### PR TITLE
Fix Shelly update entity names

### DIFF
--- a/homeassistant/components/shelly/update.py
+++ b/homeassistant/components/shelly/update.py
@@ -59,7 +59,7 @@ class RestUpdateDescription(RestEntityDescription, UpdateEntityDescription):
 
 REST_UPDATES: Final = {
     "fwupdate": RestUpdateDescription(
-        name="Firmware update",
+        name="Firmware",
         key="fwupdate",
         latest_version=lambda status: status["update"]["new_version"],
         beta=False,
@@ -68,7 +68,7 @@ REST_UPDATES: Final = {
         entity_registry_enabled_default=False,
     ),
     "fwupdate_beta": RestUpdateDescription(
-        name="Beta firmware update",
+        name="Beta firmware",
         key="fwupdate",
         latest_version=lambda status: status["update"].get("beta_version"),
         beta=True,
@@ -80,7 +80,7 @@ REST_UPDATES: Final = {
 
 RPC_UPDATES: Final = {
     "fwupdate": RpcUpdateDescription(
-        name="Firmware update",
+        name="Firmware",
         key="sys",
         sub_key="available_updates",
         latest_version=lambda status: status.get("stable", {"version": ""})["version"],
@@ -89,7 +89,7 @@ RPC_UPDATES: Final = {
         entity_category=EntityCategory.CONFIG,
     ),
     "fwupdate_beta": RpcUpdateDescription(
-        name="Beta firmware update",
+        name="Beta firmware",
         key="sys",
         sub_key="available_updates",
         latest_version=lambda status: status.get("beta", {"version": ""})["version"],

--- a/tests/components/shelly/test_update.py
+++ b/tests/components/shelly/test_update.py
@@ -53,7 +53,7 @@ async def test_block_update(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test block device update entity."""
-    entity_id = "update.test_name_firmware_update"
+    entity_id = "update.test_name_firmware"
     monkeypatch.setitem(mock_block_device.status["update"], "old_version", "1.0.0")
     monkeypatch.setitem(mock_block_device.status["update"], "new_version", "2.0.0")
     monkeypatch.setitem(mock_block_device.status, "cloud", {"connected": False})
@@ -105,7 +105,7 @@ async def test_block_beta_update(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test block device beta update entity."""
-    entity_id = "update.test_name_beta_firmware_update"
+    entity_id = "update.test_name_beta_firmware"
     monkeypatch.setitem(mock_block_device.status["update"], "old_version", "1.0.0")
     monkeypatch.setitem(mock_block_device.status["update"], "new_version", "2.0.0")
     monkeypatch.setitem(mock_block_device.status["update"], "beta_version", "")
@@ -179,7 +179,7 @@ async def test_block_update_connection_error(
         await hass.services.async_call(
             UPDATE_DOMAIN,
             SERVICE_INSTALL,
-            {ATTR_ENTITY_ID: "update.test_name_firmware_update"},
+            {ATTR_ENTITY_ID: "update.test_name_firmware"},
             blocking=True,
         )
     assert "Error starting OTA update" in str(excinfo.value)
@@ -206,7 +206,7 @@ async def test_block_update_auth_error(
     await hass.services.async_call(
         UPDATE_DOMAIN,
         SERVICE_INSTALL,
-        {ATTR_ENTITY_ID: "update.test_name_firmware_update"},
+        {ATTR_ENTITY_ID: "update.test_name_firmware"},
         blocking=True,
     )
 
@@ -237,8 +237,8 @@ async def test_block_version_compare(
     STABLE = "20230913-111730/v1.14.0-gcb84623"
     BETA = "20231107-162609/v1.14.1-rc1-g0617c15"
 
-    entity_id_beta = "update.test_name_beta_firmware_update"
-    entity_id_latest = "update.test_name_firmware_update"
+    entity_id_beta = "update.test_name_beta_firmware"
+    entity_id_latest = "update.test_name_firmware"
     monkeypatch.setitem(mock_block_device.status["update"], "old_version", STABLE)
     monkeypatch.setitem(mock_block_device.status["update"], "new_version", "")
     monkeypatch.setitem(mock_block_device.status["update"], "beta_version", BETA)
@@ -276,7 +276,7 @@ async def test_rpc_update(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test RPC device update entity."""
-    entity_id = "update.test_name_firmware_update"
+    entity_id = "update.test_name_firmware"
     monkeypatch.setitem(mock_rpc_device.shelly, "ver", "1")
     monkeypatch.setitem(
         mock_rpc_device.status["sys"],
@@ -391,7 +391,7 @@ async def test_rpc_sleeping_update(
             "stable": {"version": "2"},
         },
     )
-    entity_id = f"{UPDATE_DOMAIN}.test_name_firmware_update"
+    entity_id = f"{UPDATE_DOMAIN}.test_name_firmware"
     await init_integration(hass, 2, sleep_period=1000)
 
     # Entity should be created when device is online
@@ -436,7 +436,7 @@ async def test_rpc_restored_sleeping_update(
     entity_id = register_entity(
         hass,
         UPDATE_DOMAIN,
-        "test_name_firmware_update",
+        "test_name_firmware",
         "sys-fwupdate",
         entry,
         device_id=device.id,
@@ -495,7 +495,7 @@ async def test_rpc_restored_sleeping_update_no_last_state(
     entity_id = register_entity(
         hass,
         UPDATE_DOMAIN,
-        "test_name_firmware_update",
+        "test_name_firmware",
         "sys-fwupdate",
         entry,
         device_id=device.id,
@@ -534,7 +534,7 @@ async def test_rpc_beta_update(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test RPC device beta update entity."""
-    entity_id = "update.test_name_beta_firmware_update"
+    entity_id = "update.test_name_beta_firmware"
     monkeypatch.setitem(mock_rpc_device.shelly, "ver", "1")
     monkeypatch.setitem(
         mock_rpc_device.status["sys"],
@@ -679,7 +679,7 @@ async def test_rpc_update_errors(
         await hass.services.async_call(
             UPDATE_DOMAIN,
             SERVICE_INSTALL,
-            {ATTR_ENTITY_ID: "update.test_name_firmware_update"},
+            {ATTR_ENTITY_ID: "update.test_name_firmware"},
             blocking=True,
         )
     assert error in str(excinfo.value)
@@ -714,7 +714,7 @@ async def test_rpc_update_auth_error(
     await hass.services.async_call(
         UPDATE_DOMAIN,
         SERVICE_INSTALL,
-        {ATTR_ENTITY_ID: "update.test_name_firmware_update"},
+        {ATTR_ENTITY_ID: "update.test_name_firmware"},
         blocking=True,
     )
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
**Before:**
Currently, the default entity names for `update` platform contain the word "update" which is not consistent with the default name for the `device_class` `firmware` and generates chaos in the descriptions of device automation triggers.

![obraz](https://github.com/user-attachments/assets/8d788293-7897-4406-a119-1f3a2d97d38b)


**After:**
After removing the word "update" from the names, everything looks better

![obraz](https://github.com/user-attachments/assets/6611bb93-f75a-476f-bc5c-04d710a4b1ad)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
