### PR TITLE
Move tesla_wall_connector base entity to separate module

### DIFF
--- a/homeassistant/components/tesla_wall_connector/__init__.py
+++ b/homeassistant/components/tesla_wall_connector/__init__.py
@@ -2,11 +2,9 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import timedelta
 import logging
-from typing import Any
 
 from tesla_wall_connector import WallConnector
 from tesla_wall_connector.exceptions import (
@@ -20,19 +18,13 @@ from homeassistant.const import CONF_HOST, CONF_SCAN_INTERVAL, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.device_registry import DeviceInfo
-from homeassistant.helpers.update_coordinator import (
-    CoordinatorEntity,
-    DataUpdateCoordinator,
-    UpdateFailed,
-)
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import (
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
     WALLCONNECTOR_DATA_LIFETIME,
     WALLCONNECTOR_DATA_VITALS,
-    WALLCONNECTOR_DEVICE_NAME,
 )
 
 PLATFORMS: list[Platform] = [Platform.BINARY_SENSOR, Platform.SENSOR]
@@ -121,43 +113,6 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok
-
-
-def get_unique_id(serial_number: str, key: str) -> str:
-    """Get a unique entity name."""
-    return f"{serial_number}-{key}"
-
-
-class WallConnectorEntity(CoordinatorEntity):
-    """Base class for Wall Connector entities."""
-
-    _attr_has_entity_name = True
-
-    def __init__(self, wall_connector_data: WallConnectorData) -> None:
-        """Initialize WallConnector Entity."""
-        self.wall_connector_data = wall_connector_data
-        self._attr_unique_id = get_unique_id(
-            wall_connector_data.serial_number, self.entity_description.key
-        )
-        super().__init__(wall_connector_data.update_coordinator)
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return information about the device."""
-        return DeviceInfo(
-            identifiers={(DOMAIN, self.wall_connector_data.serial_number)},
-            name=WALLCONNECTOR_DEVICE_NAME,
-            model=self.wall_connector_data.part_number,
-            sw_version=self.wall_connector_data.firmware_version,
-            manufacturer="Tesla",
-        )
-
-
-@dataclass(frozen=True)
-class WallConnectorLambdaValueGetterMixin:
-    """Mixin with a function pointer for getting sensor value."""
-
-    value_fn: Callable[[dict], Any]
 
 
 @dataclass

--- a/homeassistant/components/tesla_wall_connector/binary_sensor.py
+++ b/homeassistant/components/tesla_wall_connector/binary_sensor.py
@@ -13,12 +13,9 @@ from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import (
-    WallConnectorData,
-    WallConnectorEntity,
-    WallConnectorLambdaValueGetterMixin,
-)
+from . import WallConnectorData
 from .const import DOMAIN, WALLCONNECTOR_DATA_VITALS
+from .entity import WallConnectorEntity, WallConnectorLambdaValueGetterMixin
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/tesla_wall_connector/entity.py
+++ b/homeassistant/components/tesla_wall_connector/entity.py
@@ -1,0 +1,50 @@
+"""The Tesla Wall Connector integration."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from . import WallConnectorData
+from .const import DOMAIN, WALLCONNECTOR_DEVICE_NAME
+
+
+@dataclass(frozen=True)
+class WallConnectorLambdaValueGetterMixin:
+    """Mixin with a function pointer for getting sensor value."""
+
+    value_fn: Callable[[dict], Any]
+
+
+def _get_unique_id(serial_number: str, key: str) -> str:
+    """Get a unique entity name."""
+    return f"{serial_number}-{key}"
+
+
+class WallConnectorEntity(CoordinatorEntity):
+    """Base class for Wall Connector entities."""
+
+    _attr_has_entity_name = True
+
+    def __init__(self, wall_connector_data: WallConnectorData) -> None:
+        """Initialize WallConnector Entity."""
+        self.wall_connector_data = wall_connector_data
+        self._attr_unique_id = _get_unique_id(
+            wall_connector_data.serial_number, self.entity_description.key
+        )
+        super().__init__(wall_connector_data.update_coordinator)
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return information about the device."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, self.wall_connector_data.serial_number)},
+            name=WALLCONNECTOR_DEVICE_NAME,
+            model=self.wall_connector_data.part_number,
+            sw_version=self.wall_connector_data.firmware_version,
+            manufacturer="Tesla",
+        )

--- a/homeassistant/components/tesla_wall_connector/sensor.py
+++ b/homeassistant/components/tesla_wall_connector/sensor.py
@@ -21,12 +21,9 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import (
-    WallConnectorData,
-    WallConnectorEntity,
-    WallConnectorLambdaValueGetterMixin,
-)
+from . import WallConnectorData
 from .const import DOMAIN, WALLCONNECTOR_DATA_LIFETIME, WALLCONNECTOR_DATA_VITALS
+from .entity import WallConnectorEntity, WallConnectorLambdaValueGetterMixin
 
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #126473

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
