### PR TITLE
Move yamaha_musiccast base entity to separate module

### DIFF
--- a/homeassistant/components/yamaha_musiccast/__init__.py
+++ b/homeassistant/components/yamaha_musiccast/__init__.py
@@ -4,35 +4,22 @@ from __future__ import annotations
 
 from datetime import timedelta
 import logging
+from typing import TYPE_CHECKING
 
 from aiomusiccast import MusicCastConnectionException
-from aiomusiccast.capabilities import Capability
 from aiomusiccast.musiccast_device import MusicCastData, MusicCastDevice
 
 from homeassistant.components import ssdp
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_CONNECTIONS, ATTR_VIA_DEVICE, CONF_HOST, Platform
+from homeassistant.const import CONF_HOST, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.device_registry import (
-    CONNECTION_NETWORK_MAC,
-    DeviceInfo,
-    format_mac,
-)
-from homeassistant.helpers.update_coordinator import (
-    CoordinatorEntity,
-    DataUpdateCoordinator,
-    UpdateFailed,
-)
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import (
-    BRAND,
-    CONF_SERIAL,
-    CONF_UPNP_DESC,
-    DEFAULT_ZONE,
-    DOMAIN,
-    ENTITY_CATEGORY_MAPPING,
-)
+from .const import CONF_SERIAL, CONF_UPNP_DESC, DOMAIN
+
+if TYPE_CHECKING:
+    from .entity import MusicCastDeviceEntity
 
 PLATFORMS = [Platform.MEDIA_PLAYER, Platform.NUMBER, Platform.SELECT, Platform.SWITCH]
 
@@ -122,99 +109,3 @@ class MusicCastDataUpdateCoordinator(DataUpdateCoordinator[MusicCastData]):  # p
         except MusicCastConnectionException as exception:
             raise UpdateFailed from exception
         return self.musiccast.data
-
-
-class MusicCastEntity(CoordinatorEntity[MusicCastDataUpdateCoordinator]):
-    """Defines a base MusicCast entity."""
-
-    def __init__(
-        self,
-        *,
-        name: str,
-        icon: str,
-        coordinator: MusicCastDataUpdateCoordinator,
-        enabled_default: bool = True,
-    ) -> None:
-        """Initialize the MusicCast entity."""
-        super().__init__(coordinator)
-        self._attr_entity_registry_enabled_default = enabled_default
-        self._attr_icon = icon
-        self._attr_name = name
-
-
-class MusicCastDeviceEntity(MusicCastEntity):
-    """Defines a MusicCast device entity."""
-
-    _zone_id: str = DEFAULT_ZONE
-
-    @property
-    def device_id(self):
-        """Return the ID of the current device."""
-        if self._zone_id == DEFAULT_ZONE:
-            return self.coordinator.data.device_id
-        return f"{self.coordinator.data.device_id}_{self._zone_id}"
-
-    @property
-    def device_name(self):
-        """Return the name of the current device."""
-        return self.coordinator.data.zones[self._zone_id].name
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return device information about this MusicCast device."""
-
-        device_info = DeviceInfo(
-            name=self.device_name,
-            identifiers={
-                (
-                    DOMAIN,
-                    self.device_id,
-                )
-            },
-            manufacturer=BRAND,
-            model=self.coordinator.data.model_name,
-            sw_version=self.coordinator.data.system_version,
-        )
-
-        if self._zone_id == DEFAULT_ZONE:
-            device_info[ATTR_CONNECTIONS] = {
-                (CONNECTION_NETWORK_MAC, format_mac(mac))
-                for mac in self.coordinator.data.mac_addresses.values()
-            }
-        else:
-            device_info[ATTR_VIA_DEVICE] = (DOMAIN, self.coordinator.data.device_id)
-
-        return device_info
-
-    async def async_added_to_hass(self):
-        """Run when this Entity has been added to HA."""
-        await super().async_added_to_hass()
-        # All entities should register callbacks to update HA when their state changes
-        self.coordinator.musiccast.register_callback(self.async_write_ha_state)
-
-    async def async_will_remove_from_hass(self):
-        """Entity being removed from hass."""
-        await super().async_will_remove_from_hass()
-        self.coordinator.musiccast.remove_callback(self.async_write_ha_state)
-
-
-class MusicCastCapabilityEntity(MusicCastDeviceEntity):
-    """Base Entity type for all capabilities."""
-
-    def __init__(
-        self,
-        coordinator: MusicCastDataUpdateCoordinator,
-        capability: Capability,
-        zone_id: str | None = None,
-    ) -> None:
-        """Initialize a capability based entity."""
-        if zone_id is not None:
-            self._zone_id = zone_id
-        self.capability = capability
-        super().__init__(name=capability.name, icon="", coordinator=coordinator)
-        self._attr_entity_category = ENTITY_CATEGORY_MAPPING.get(capability.entity_type)
-
-    @property
-    def unique_id(self) -> str:
-        """Return the unique ID for this entity."""
-        return f"{self.device_id}_{self.capability.id}"

--- a/homeassistant/components/yamaha_musiccast/entity.py
+++ b/homeassistant/components/yamaha_musiccast/entity.py
@@ -1,0 +1,112 @@
+"""The MusicCast integration."""
+
+from __future__ import annotations
+
+from aiomusiccast.capabilities import Capability
+
+from homeassistant.const import ATTR_CONNECTIONS, ATTR_VIA_DEVICE
+from homeassistant.helpers.device_registry import (
+    CONNECTION_NETWORK_MAC,
+    DeviceInfo,
+    format_mac,
+)
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from . import MusicCastDataUpdateCoordinator
+from .const import BRAND, DEFAULT_ZONE, DOMAIN, ENTITY_CATEGORY_MAPPING
+
+
+class MusicCastEntity(CoordinatorEntity[MusicCastDataUpdateCoordinator]):
+    """Defines a base MusicCast entity."""
+
+    def __init__(
+        self,
+        *,
+        name: str,
+        icon: str,
+        coordinator: MusicCastDataUpdateCoordinator,
+        enabled_default: bool = True,
+    ) -> None:
+        """Initialize the MusicCast entity."""
+        super().__init__(coordinator)
+        self._attr_entity_registry_enabled_default = enabled_default
+        self._attr_icon = icon
+        self._attr_name = name
+
+
+class MusicCastDeviceEntity(MusicCastEntity):
+    """Defines a MusicCast device entity."""
+
+    _zone_id: str = DEFAULT_ZONE
+
+    @property
+    def device_id(self):
+        """Return the ID of the current device."""
+        if self._zone_id == DEFAULT_ZONE:
+            return self.coordinator.data.device_id
+        return f"{self.coordinator.data.device_id}_{self._zone_id}"
+
+    @property
+    def device_name(self):
+        """Return the name of the current device."""
+        return self.coordinator.data.zones[self._zone_id].name
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device information about this MusicCast device."""
+
+        device_info = DeviceInfo(
+            name=self.device_name,
+            identifiers={
+                (
+                    DOMAIN,
+                    self.device_id,
+                )
+            },
+            manufacturer=BRAND,
+            model=self.coordinator.data.model_name,
+            sw_version=self.coordinator.data.system_version,
+        )
+
+        if self._zone_id == DEFAULT_ZONE:
+            device_info[ATTR_CONNECTIONS] = {
+                (CONNECTION_NETWORK_MAC, format_mac(mac))
+                for mac in self.coordinator.data.mac_addresses.values()
+            }
+        else:
+            device_info[ATTR_VIA_DEVICE] = (DOMAIN, self.coordinator.data.device_id)
+
+        return device_info
+
+    async def async_added_to_hass(self):
+        """Run when this Entity has been added to HA."""
+        await super().async_added_to_hass()
+        # All entities should register callbacks to update HA when their state changes
+        self.coordinator.musiccast.register_callback(self.async_write_ha_state)
+
+    async def async_will_remove_from_hass(self):
+        """Entity being removed from hass."""
+        await super().async_will_remove_from_hass()
+        self.coordinator.musiccast.remove_callback(self.async_write_ha_state)
+
+
+class MusicCastCapabilityEntity(MusicCastDeviceEntity):
+    """Base Entity type for all capabilities."""
+
+    def __init__(
+        self,
+        coordinator: MusicCastDataUpdateCoordinator,
+        capability: Capability,
+        zone_id: str | None = None,
+    ) -> None:
+        """Initialize a capability based entity."""
+        if zone_id is not None:
+            self._zone_id = zone_id
+        self.capability = capability
+        super().__init__(name=capability.name, icon="", coordinator=coordinator)
+        self._attr_entity_category = ENTITY_CATEGORY_MAPPING.get(capability.entity_type)
+
+    @property
+    def unique_id(self) -> str:
+        """Return the unique ID for this entity."""
+        return f"{self.device_id}_{self.capability.id}"

--- a/homeassistant/components/yamaha_musiccast/media_player.py
+++ b/homeassistant/components/yamaha_musiccast/media_player.py
@@ -27,7 +27,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util import uuid
 
-from . import MusicCastDataUpdateCoordinator, MusicCastDeviceEntity
+from . import MusicCastDataUpdateCoordinator
 from .const import (
     ATTR_MAIN_SYNC,
     ATTR_MC_LINK,
@@ -38,6 +38,7 @@ from .const import (
     MEDIA_CLASS_MAPPING,
     NULL_GROUP,
 )
+from .entity import MusicCastDeviceEntity
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/yamaha_musiccast/number.py
+++ b/homeassistant/components/yamaha_musiccast/number.py
@@ -9,7 +9,8 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import DOMAIN, MusicCastCapabilityEntity, MusicCastDataUpdateCoordinator
+from . import DOMAIN, MusicCastDataUpdateCoordinator
+from .entity import MusicCastCapabilityEntity
 
 
 async def async_setup_entry(

--- a/homeassistant/components/yamaha_musiccast/select.py
+++ b/homeassistant/components/yamaha_musiccast/select.py
@@ -9,8 +9,9 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import DOMAIN, MusicCastCapabilityEntity, MusicCastDataUpdateCoordinator
+from . import DOMAIN, MusicCastDataUpdateCoordinator
 from .const import TRANSLATION_KEY_MAPPING
+from .entity import MusicCastCapabilityEntity
 
 
 async def async_setup_entry(

--- a/homeassistant/components/yamaha_musiccast/switch.py
+++ b/homeassistant/components/yamaha_musiccast/switch.py
@@ -9,7 +9,8 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import DOMAIN, MusicCastCapabilityEntity, MusicCastDataUpdateCoordinator
+from . import DOMAIN, MusicCastDataUpdateCoordinator
+from .entity import MusicCastCapabilityEntity
 
 
 async def async_setup_entry(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #126473

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
