### PR TITLE
Reinitialize ssdp discovery flow on config entry removal

### DIFF
--- a/homeassistant/components/ssdp/__init__.py
+++ b/homeassistant/components/ssdp/__init__.py
@@ -579,14 +579,13 @@ class Scanner:
     ) -> Mapping[str, str]:
         """Get description dict."""
         assert self._description_cache is not None
+        cache = self._description_cache
 
-        has_description, description = self._description_cache.peek_description_dict(
-            location
-        )
+        has_description, description = cache.peek_description_dict(location)
         if has_description:
             return description or {}
 
-        return await self._description_cache.async_get_description_dict(location) or {}
+        return await cache.async_get_description_dict(location) or {}
 
     async def _async_headers_to_discovery_info(
         self, ssdp_device: SsdpDevice, headers: CaseInsensitiveDict
@@ -595,8 +594,6 @@ class Scanner:
 
         Building this is a bit expensive so we only do it on demand.
         """
-        assert self._description_cache is not None
-
         location = headers["location"]
         info_desc = await self._async_get_description_dict(location)
         return discovery_info_from_headers_and_description(
@@ -640,6 +637,7 @@ class Scanner:
         """Handle config entry changes."""
         if TYPE_CHECKING:
             assert self._description_cache is not None
+        cache = self._description_cache
         for discovery_key in entry.discovery_keys[DOMAIN]:
             if discovery_key.version != 1 or not isinstance(discovery_key.key, str):
                 continue
@@ -650,10 +648,8 @@ class Scanner:
                 if ssdp_device.udn != udn:
                     continue
                 for dst in ssdp_device.all_combined_headers:
-                    has_cached_desc, info_desc = (
-                        self._description_cache.peek_description_dict(
-                            ssdp_device.location
-                        )
+                    has_cached_desc, info_desc = cache.peek_description_dict(
+                        ssdp_device.location
                     )
                     if has_cached_desc and info_desc:
                         self._ssdp_listener_process_callback(

--- a/homeassistant/components/ssdp/__init__.py
+++ b/homeassistant/components/ssdp/__init__.py
@@ -637,13 +637,11 @@ class Scanner:
         entry: config_entries.ConfigEntry,
     ) -> None:
         """Handle config entry changes."""
-        if entry.source != config_entries.SOURCE_IGNORE:
-            return
         for discovery_key in entry.discovery_keys[DOMAIN]:
             if discovery_key.version != 1 or not isinstance(discovery_key.key, str):
                 continue
             udn = discovery_key.key
-            _LOGGER.debug("Rediscover unignored service %s", udn)
+            _LOGGER.debug("Rediscover service %s", udn)
 
             for ssdp_device in self._ssdp_devices:
                 if ssdp_device.udn != udn:

--- a/homeassistant/components/ssdp/__init__.py
+++ b/homeassistant/components/ssdp/__init__.py
@@ -545,17 +545,20 @@ class Scanner:
 
         _LOGGER.debug("Discovery info: %s", discovery_info)
 
-        location = ssdp_device.location
+        if not matching_domains:
+            return  # avoid creating DiscoveryKey if there are no matches
+
+        discovery_key = discovery_flow.DiscoveryKey(
+            domain=DOMAIN, key=ssdp_device.udn, version=1
+        )
         for domain in matching_domains:
-            _LOGGER.debug("Discovered %s at %s", domain, location)
+            _LOGGER.debug("Discovered %s at %s", domain, ssdp_device.location)
             discovery_flow.async_create_flow(
                 self.hass,
                 domain,
                 {"source": config_entries.SOURCE_SSDP},
                 discovery_info,
-                discovery_key=discovery_flow.DiscoveryKey(
-                    domain=DOMAIN, key=ssdp_device.udn, version=1
-                ),
+                discovery_key=discovery_key,
             )
 
     def _async_dismiss_discoveries(

--- a/tests/components/ssdp/test_init.py
+++ b/tests/components/ssdp/test_init.py
@@ -942,6 +942,7 @@ async def test_flow_dismiss_on_byebye(
 async def test_ssdp_rediscover(
     mock_get_ssdp,
     hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
     mock_flow_init,
     entry_domain: str,
     entry_discovery_keys: tuple,
@@ -966,6 +967,17 @@ async def test_ssdp_rediscover(
             "ext": "",
             "_source": "search",
         }
+    )
+    aioclient_mock.get(
+        "http://1.1.1.1",
+        text="""
+<root>
+  <device>
+    <deviceType>Paulus</deviceType>
+    <manufacturer>Paulus</manufacturer>
+  </device>
+</root>
+    """,
     )
     ssdp_listener = await init_ssdp_component(hass)
     ssdp_listener._on_search(mock_ssdp_search_response)
@@ -1036,6 +1048,7 @@ async def test_ssdp_rediscover(
 async def test_ssdp_rediscover_2(
     mock_get_ssdp,
     hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
     mock_flow_init,
     entry_domain: str,
     entry_discovery_keys: tuple,
@@ -1064,6 +1077,17 @@ async def test_ssdp_rediscover_2(
             "ext": "",
             "_source": "search",
         }
+    )
+    aioclient_mock.get(
+        "http://1.1.1.1",
+        text="""
+<root>
+  <device>
+    <deviceType>Paulus</deviceType>
+    <manufacturer>Paulus</manufacturer>
+  </device>
+</root>
+    """,
     )
     ssdp_listener = await init_ssdp_component(hass)
     ssdp_listener._on_search(mock_ssdp_search_response)

--- a/tests/components/ssdp/test_init.py
+++ b/tests/components/ssdp/test_init.py
@@ -938,12 +938,14 @@ async def test_flow_dismiss_on_byebye(
         ),
     ],
 )
+@pytest.mark.parametrize("entry_source", [config_entries.SOURCE_IGNORE])
 async def test_ssdp_rediscover(
     mock_get_ssdp,
     hass: HomeAssistant,
     mock_flow_init,
     entry_domain: str,
     entry_discovery_keys: tuple,
+    entry_source: str,
 ) -> None:
     """Test we reinitiate flows when an ignored config entry is removed."""
     entry = MockConfigEntry(
@@ -951,7 +953,7 @@ async def test_ssdp_rediscover(
         discovery_keys=entry_discovery_keys,
         unique_id="mock-unique-id",
         state=config_entries.ConfigEntryState.LOADED,
-        source=config_entries.SOURCE_IGNORE,
+        source=entry_source,
     )
     entry.add_to_hass(hass)
 
@@ -992,6 +994,102 @@ async def test_ssdp_rediscover(
     assert mock_flow_init.mock_calls[2][2]["context"] == expected_context
     assert (
         mock_flow_init.mock_calls[2][2]["data"]
+        == mock_flow_init.mock_calls[0][2]["data"]
+    )
+
+
+@patch(
+    "homeassistant.components.ssdp.async_get_ssdp",
+    return_value={"mock-domain": [{"st": "mock-st"}]},
+)
+@pytest.mark.parametrize(
+    (
+        "entry_domain",
+        "entry_discovery_keys",
+    ),
+    [
+        # Matching discovery key
+        (
+            "mock-domain",
+            {"ssdp": (DiscoveryKey(domain="ssdp", key="uuid:mock-udn", version=1),)},
+        ),
+        # Matching discovery key
+        (
+            "mock-domain",
+            {
+                "ssdp": (DiscoveryKey(domain="ssdp", key="uuid:mock-udn", version=1),),
+                "other": (DiscoveryKey(domain="other", key="blah", version=1),),
+            },
+        ),
+        # Matching discovery key, other domain
+        # Note: Rediscovery is not currently restricted to the domain of the removed
+        # entry. Such a check can be added if needed.
+        (
+            "comp",
+            {"ssdp": (DiscoveryKey(domain="ssdp", key="uuid:mock-udn", version=1),)},
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "entry_source", [config_entries.SOURCE_USER, config_entries.SOURCE_ZEROCONF]
+)
+async def test_ssdp_rediscover_2(
+    mock_get_ssdp,
+    hass: HomeAssistant,
+    mock_flow_init,
+    entry_domain: str,
+    entry_discovery_keys: tuple,
+    entry_source: str,
+) -> None:
+    """Test we reinitiate flows when an ignored config entry is removed.
+
+    This test can be merged with test_zeroconf_rediscover when
+    async_step_unignore has been removed from the ConfigFlow base class.
+    """
+    entry = MockConfigEntry(
+        domain=entry_domain,
+        discovery_keys=entry_discovery_keys,
+        unique_id="mock-unique-id",
+        state=config_entries.ConfigEntryState.LOADED,
+        source=entry_source,
+    )
+    entry.add_to_hass(hass)
+
+    mock_ssdp_search_response = _ssdp_headers(
+        {
+            "st": "mock-st",
+            "location": "http://1.1.1.1",
+            "usn": "uuid:mock-udn::mock-st",
+            "server": "mock-server",
+            "ext": "",
+            "_source": "search",
+        }
+    )
+    ssdp_listener = await init_ssdp_component(hass)
+    ssdp_listener._on_search(mock_ssdp_search_response)
+    await hass.async_block_till_done()
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+    await hass.async_block_till_done()
+
+    expected_context = {
+        "discovery_key": DiscoveryKey(domain="ssdp", key="uuid:mock-udn", version=1),
+        "source": config_entries.SOURCE_SSDP,
+    }
+    assert len(mock_flow_init.mock_calls) == 1
+    assert mock_flow_init.mock_calls[0][1][0] == "mock-domain"
+    assert mock_flow_init.mock_calls[0][2]["context"] == expected_context
+    mock_call_data: ssdp.SsdpServiceInfo = mock_flow_init.mock_calls[0][2]["data"]
+    assert mock_call_data.ssdp_st == "mock-st"
+    assert mock_call_data.ssdp_location == "http://1.1.1.1"
+
+    await hass.config_entries.async_remove(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert len(mock_flow_init.mock_calls) == 2
+    assert mock_flow_init.mock_calls[1][1][0] == "mock-domain"
+    assert mock_flow_init.mock_calls[1][2]["context"] == expected_context
+    assert (
+        mock_flow_init.mock_calls[1][2]["data"]
         == mock_flow_init.mock_calls[0][2]["data"]
     )
 
@@ -1077,81 +1175,3 @@ async def test_ssdp_rediscover_no_match(
     assert len(mock_flow_init.mock_calls) == 2
     assert mock_flow_init.mock_calls[1][1][0] == entry_domain
     assert mock_flow_init.mock_calls[1][2]["context"] == {"source": "unignore"}
-
-
-@patch(
-    "homeassistant.components.ssdp.async_get_ssdp",
-    return_value={"mock-domain": [{"st": "mock-st"}]},
-)
-@pytest.mark.parametrize(
-    (
-        "entry_domain",
-        "entry_discovery_keys",
-        "entry_source",
-        "entry_unique_id",
-    ),
-    [
-        # Source not SOURCE_IGNORE
-        (
-            "mock-domain",
-            {"ssdp": (DiscoveryKey(domain="ssdp", key="uuid:mock-udn", version=1),)},
-            config_entries.SOURCE_SSDP,
-            "mock-unique-id",
-        ),
-    ],
-)
-async def test_ssdp_rediscover_no_match_2(
-    mock_get_ssdp,
-    hass: HomeAssistant,
-    mock_flow_init,
-    entry_domain: str,
-    entry_discovery_keys: tuple,
-    entry_source: str,
-    entry_unique_id: str,
-) -> None:
-    """Test we don't reinitiate flows when a non matching config entry is removed.
-
-    This test can be merged with test_zeroconf_rediscover_no_match when
-    async_step_unignore has been removed from the ConfigFlow base class.
-    """
-    mock_integration(hass, MockModule(entry_domain))
-    entry = MockConfigEntry(
-        domain=entry_domain,
-        discovery_keys=entry_discovery_keys,
-        unique_id=entry_unique_id,
-        state=config_entries.ConfigEntryState.LOADED,
-        source=entry_source,
-    )
-    entry.add_to_hass(hass)
-
-    mock_ssdp_search_response = _ssdp_headers(
-        {
-            "st": "mock-st",
-            "location": "http://1.1.1.1",
-            "usn": "uuid:mock-udn::mock-st",
-            "server": "mock-server",
-            "ext": "",
-            "_source": "search",
-        }
-    )
-    ssdp_listener = await init_ssdp_component(hass)
-    ssdp_listener._on_search(mock_ssdp_search_response)
-    await hass.async_block_till_done()
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
-    await hass.async_block_till_done()
-
-    expected_context = {
-        "discovery_key": DiscoveryKey(domain="ssdp", key="uuid:mock-udn", version=1),
-        "source": config_entries.SOURCE_SSDP,
-    }
-    assert len(mock_flow_init.mock_calls) == 1
-    assert mock_flow_init.mock_calls[0][1][0] == "mock-domain"
-    assert mock_flow_init.mock_calls[0][2]["context"] == expected_context
-    mock_call_data: ssdp.SsdpServiceInfo = mock_flow_init.mock_calls[0][2]["data"]
-    assert mock_call_data.ssdp_st == "mock-st"
-    assert mock_call_data.ssdp_location == "http://1.1.1.1"
-
-    await hass.config_entries.async_remove(entry.entry_id)
-    await hass.async_block_till_done()
-
-    assert len(mock_flow_init.mock_calls) == 1

--- a/tests/components/ssdp/test_init.py
+++ b/tests/components/ssdp/test_init.py
@@ -18,10 +18,16 @@ from homeassistant.const import (
     MATCH_ALL,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.discovery_flow import DiscoveryKey
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
-from tests.common import async_fire_time_changed
+from tests.common import (
+    MockConfigEntry,
+    MockModule,
+    async_fire_time_changed,
+    mock_integration,
+)
 from tests.test_util.aiohttp import AiohttpClientMocker
 
 
@@ -65,7 +71,8 @@ async def test_ssdp_flow_dispatched_on_st(
     assert len(mock_flow_init.mock_calls) == 1
     assert mock_flow_init.mock_calls[0][1][0] == "mock-domain"
     assert mock_flow_init.mock_calls[0][2]["context"] == {
-        "source": config_entries.SOURCE_SSDP
+        "discovery_key": DiscoveryKey(domain="ssdp", key="uuid:mock-udn", version=1),
+        "source": config_entries.SOURCE_SSDP,
     }
     mock_call_data: ssdp.SsdpServiceInfo = mock_flow_init.mock_calls[0][2]["data"]
     assert mock_call_data.ssdp_st == "mock-st"
@@ -108,7 +115,8 @@ async def test_ssdp_flow_dispatched_on_manufacturer_url(
     assert len(mock_flow_init.mock_calls) == 1
     assert mock_flow_init.mock_calls[0][1][0] == "mock-domain"
     assert mock_flow_init.mock_calls[0][2]["context"] == {
-        "source": config_entries.SOURCE_SSDP
+        "discovery_key": DiscoveryKey(domain="ssdp", key="uuid:mock-udn", version=1),
+        "source": config_entries.SOURCE_SSDP,
     }
     mock_call_data: ssdp.SsdpServiceInfo = mock_flow_init.mock_calls[0][2]["data"]
     assert mock_call_data.ssdp_st == "mock-st"
@@ -163,7 +171,8 @@ async def test_scan_match_upnp_devicedesc_manufacturer(
     assert len(mock_flow_init.mock_calls) == 1
     assert mock_flow_init.mock_calls[0][1][0] == "mock-domain"
     assert mock_flow_init.mock_calls[0][2]["context"] == {
-        "source": config_entries.SOURCE_SSDP
+        "discovery_key": DiscoveryKey(domain="ssdp", key="uuid:mock-udn", version=1),
+        "source": config_entries.SOURCE_SSDP,
     }
 
 
@@ -208,7 +217,8 @@ async def test_scan_match_upnp_devicedesc_devicetype(
     assert len(mock_flow_init.mock_calls) == 1
     assert mock_flow_init.mock_calls[0][1][0] == "mock-domain"
     assert mock_flow_init.mock_calls[0][2]["context"] == {
-        "source": config_entries.SOURCE_SSDP
+        "discovery_key": DiscoveryKey(domain="ssdp", key="uuid:mock-udn", version=1),
+        "source": config_entries.SOURCE_SSDP,
     }
 
 
@@ -339,7 +349,14 @@ async def test_flow_start_only_alive(
     await hass.async_block_till_done(wait_background_tasks=True)
 
     mock_flow_init.assert_awaited_once_with(
-        "mock-domain", context={"source": config_entries.SOURCE_SSDP}, data=ANY
+        "mock-domain",
+        context={
+            "discovery_key": DiscoveryKey(
+                domain="ssdp", key="uuid:mock-udn", version=1
+            ),
+            "source": config_entries.SOURCE_SSDP,
+        },
+        data=ANY,
     )
 
     # ssdp:alive advertisement should start a flow
@@ -356,7 +373,14 @@ async def test_flow_start_only_alive(
     ssdp_listener._on_alive(mock_ssdp_advertisement)
     await hass.async_block_till_done()
     mock_flow_init.assert_awaited_once_with(
-        "mock-domain", context={"source": config_entries.SOURCE_SSDP}, data=ANY
+        "mock-domain",
+        context={
+            "discovery_key": DiscoveryKey(
+                domain="ssdp", key="uuid:mock-udn", version=1
+            ),
+            "source": config_entries.SOURCE_SSDP,
+        },
+        data=ANY,
     )
 
     # ssdp:byebye advertisement should not start a flow
@@ -372,7 +396,14 @@ async def test_flow_start_only_alive(
     ssdp_listener._on_update(mock_ssdp_advertisement)
     await hass.async_block_till_done()
     mock_flow_init.assert_awaited_once_with(
-        "mock-domain", context={"source": config_entries.SOURCE_SSDP}, data=ANY
+        "mock-domain",
+        context={
+            "discovery_key": DiscoveryKey(
+                domain="ssdp", key="uuid:mock-udn", version=1
+            ),
+            "source": config_entries.SOURCE_SSDP,
+        },
+        data=ANY,
     )
 
 
@@ -824,7 +855,14 @@ async def test_flow_dismiss_on_byebye(
     await hass.async_block_till_done(wait_background_tasks=True)
 
     mock_flow_init.assert_awaited_once_with(
-        "mock-domain", context={"source": config_entries.SOURCE_SSDP}, data=ANY
+        "mock-domain",
+        context={
+            "discovery_key": DiscoveryKey(
+                domain="ssdp", key="uuid:mock-udn", version=1
+            ),
+            "source": config_entries.SOURCE_SSDP,
+        },
+        data=ANY,
     )
 
     # ssdp:alive advertisement should start a flow
@@ -841,7 +879,14 @@ async def test_flow_dismiss_on_byebye(
     ssdp_listener._on_alive(mock_ssdp_advertisement)
     await hass.async_block_till_done(wait_background_tasks=True)
     mock_flow_init.assert_awaited_once_with(
-        "mock-domain", context={"source": config_entries.SOURCE_SSDP}, data=ANY
+        "mock-domain",
+        context={
+            "discovery_key": DiscoveryKey(
+                domain="ssdp", key="uuid:mock-udn", version=1
+            ),
+            "source": config_entries.SOURCE_SSDP,
+        },
+        data=ANY,
     )
 
     mock_ssdp_advertisement["nts"] = "ssdp:byebye"
@@ -859,3 +904,254 @@ async def test_flow_dismiss_on_byebye(
 
     assert len(mock_async_progress_by_init_data_type.mock_calls) == 1
     assert mock_async_abort.mock_calls[0][1][0] == "mock_flow_id"
+
+
+@patch(
+    "homeassistant.components.ssdp.async_get_ssdp",
+    return_value={"mock-domain": [{"st": "mock-st"}]},
+)
+@pytest.mark.parametrize(
+    (
+        "entry_domain",
+        "entry_discovery_keys",
+    ),
+    [
+        # Matching discovery key
+        (
+            "mock-domain",
+            {"ssdp": (DiscoveryKey(domain="ssdp", key="uuid:mock-udn", version=1),)},
+        ),
+        # Matching discovery key
+        (
+            "mock-domain",
+            {
+                "ssdp": (DiscoveryKey(domain="ssdp", key="uuid:mock-udn", version=1),),
+                "other": (DiscoveryKey(domain="other", key="blah", version=1),),
+            },
+        ),
+        # Matching discovery key, other domain
+        # Note: Rediscovery is not currently restricted to the domain of the removed
+        # entry. Such a check can be added if needed.
+        (
+            "comp",
+            {"ssdp": (DiscoveryKey(domain="ssdp", key="uuid:mock-udn", version=1),)},
+        ),
+    ],
+)
+async def test_ssdp_rediscover(
+    mock_get_ssdp,
+    hass: HomeAssistant,
+    mock_flow_init,
+    entry_domain: str,
+    entry_discovery_keys: tuple,
+) -> None:
+    """Test we reinitiate flows when an ignored config entry is removed."""
+    entry = MockConfigEntry(
+        domain=entry_domain,
+        discovery_keys=entry_discovery_keys,
+        unique_id="mock-unique-id",
+        state=config_entries.ConfigEntryState.LOADED,
+        source=config_entries.SOURCE_IGNORE,
+    )
+    entry.add_to_hass(hass)
+
+    mock_ssdp_search_response = _ssdp_headers(
+        {
+            "st": "mock-st",
+            "location": "http://1.1.1.1",
+            "usn": "uuid:mock-udn::mock-st",
+            "server": "mock-server",
+            "ext": "",
+            "_source": "search",
+        }
+    )
+    ssdp_listener = await init_ssdp_component(hass)
+    ssdp_listener._on_search(mock_ssdp_search_response)
+    await hass.async_block_till_done()
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+    await hass.async_block_till_done()
+
+    expected_context = {
+        "discovery_key": DiscoveryKey(domain="ssdp", key="uuid:mock-udn", version=1),
+        "source": config_entries.SOURCE_SSDP,
+    }
+    assert len(mock_flow_init.mock_calls) == 1
+    assert mock_flow_init.mock_calls[0][1][0] == "mock-domain"
+    assert mock_flow_init.mock_calls[0][2]["context"] == expected_context
+    mock_call_data: ssdp.SsdpServiceInfo = mock_flow_init.mock_calls[0][2]["data"]
+    assert mock_call_data.ssdp_st == "mock-st"
+    assert mock_call_data.ssdp_location == "http://1.1.1.1"
+
+    await hass.config_entries.async_remove(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert len(mock_flow_init.mock_calls) == 3
+    assert mock_flow_init.mock_calls[1][1][0] == entry_domain
+    assert mock_flow_init.mock_calls[1][2]["context"] == {"source": "unignore"}
+    assert mock_flow_init.mock_calls[2][1][0] == "mock-domain"
+    assert mock_flow_init.mock_calls[2][2]["context"] == expected_context
+    assert (
+        mock_flow_init.mock_calls[2][2]["data"]
+        == mock_flow_init.mock_calls[0][2]["data"]
+    )
+
+
+@patch(
+    "homeassistant.components.ssdp.async_get_ssdp",
+    return_value={"mock-domain": [{"st": "mock-st"}]},
+)
+@pytest.mark.parametrize(
+    (
+        "entry_domain",
+        "entry_discovery_keys",
+        "entry_source",
+        "entry_unique_id",
+    ),
+    [
+        # Discovery key from other domain
+        (
+            "mock-domain",
+            {"dhcp": (DiscoveryKey(domain="dhcp", key="uuid:mock-udn", version=1),)},
+            config_entries.SOURCE_IGNORE,
+            "mock-unique-id",
+        ),
+        # Discovery key from the future
+        (
+            "mock-domain",
+            {"ssdp": (DiscoveryKey(domain="ssdp", key="uuid:mock-udn", version=2),)},
+            config_entries.SOURCE_IGNORE,
+            "mock-unique-id",
+        ),
+    ],
+)
+async def test_ssdp_rediscover_no_match(
+    mock_get_ssdp,
+    hass: HomeAssistant,
+    mock_flow_init,
+    entry_domain: str,
+    entry_discovery_keys: tuple,
+    entry_source: str,
+    entry_unique_id: str,
+) -> None:
+    """Test we don't reinitiate flows when a non matching config entry is removed."""
+    mock_integration(hass, MockModule(entry_domain))
+    entry = MockConfigEntry(
+        domain=entry_domain,
+        discovery_keys=entry_discovery_keys,
+        unique_id=entry_unique_id,
+        state=config_entries.ConfigEntryState.LOADED,
+        source=entry_source,
+    )
+    entry.add_to_hass(hass)
+
+    mock_ssdp_search_response = _ssdp_headers(
+        {
+            "st": "mock-st",
+            "location": "http://1.1.1.1",
+            "usn": "uuid:mock-udn::mock-st",
+            "server": "mock-server",
+            "ext": "",
+            "_source": "search",
+        }
+    )
+    ssdp_listener = await init_ssdp_component(hass)
+    ssdp_listener._on_search(mock_ssdp_search_response)
+    await hass.async_block_till_done()
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+    await hass.async_block_till_done()
+
+    expected_context = {
+        "discovery_key": DiscoveryKey(domain="ssdp", key="uuid:mock-udn", version=1),
+        "source": config_entries.SOURCE_SSDP,
+    }
+    assert len(mock_flow_init.mock_calls) == 1
+    assert mock_flow_init.mock_calls[0][1][0] == "mock-domain"
+    assert mock_flow_init.mock_calls[0][2]["context"] == expected_context
+    mock_call_data: ssdp.SsdpServiceInfo = mock_flow_init.mock_calls[0][2]["data"]
+    assert mock_call_data.ssdp_st == "mock-st"
+    assert mock_call_data.ssdp_location == "http://1.1.1.1"
+
+    await hass.config_entries.async_remove(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert len(mock_flow_init.mock_calls) == 2
+    assert mock_flow_init.mock_calls[1][1][0] == entry_domain
+    assert mock_flow_init.mock_calls[1][2]["context"] == {"source": "unignore"}
+
+
+@patch(
+    "homeassistant.components.ssdp.async_get_ssdp",
+    return_value={"mock-domain": [{"st": "mock-st"}]},
+)
+@pytest.mark.parametrize(
+    (
+        "entry_domain",
+        "entry_discovery_keys",
+        "entry_source",
+        "entry_unique_id",
+    ),
+    [
+        # Source not SOURCE_IGNORE
+        (
+            "mock-domain",
+            {"ssdp": (DiscoveryKey(domain="ssdp", key="uuid:mock-udn", version=1),)},
+            config_entries.SOURCE_SSDP,
+            "mock-unique-id",
+        ),
+    ],
+)
+async def test_ssdp_rediscover_no_match_2(
+    mock_get_ssdp,
+    hass: HomeAssistant,
+    mock_flow_init,
+    entry_domain: str,
+    entry_discovery_keys: tuple,
+    entry_source: str,
+    entry_unique_id: str,
+) -> None:
+    """Test we don't reinitiate flows when a non matching config entry is removed.
+
+    This test can be merged with test_zeroconf_rediscover_no_match when
+    async_step_unignore has been removed from the ConfigFlow base class.
+    """
+    mock_integration(hass, MockModule(entry_domain))
+    entry = MockConfigEntry(
+        domain=entry_domain,
+        discovery_keys=entry_discovery_keys,
+        unique_id=entry_unique_id,
+        state=config_entries.ConfigEntryState.LOADED,
+        source=entry_source,
+    )
+    entry.add_to_hass(hass)
+
+    mock_ssdp_search_response = _ssdp_headers(
+        {
+            "st": "mock-st",
+            "location": "http://1.1.1.1",
+            "usn": "uuid:mock-udn::mock-st",
+            "server": "mock-server",
+            "ext": "",
+            "_source": "search",
+        }
+    )
+    ssdp_listener = await init_ssdp_component(hass)
+    ssdp_listener._on_search(mock_ssdp_search_response)
+    await hass.async_block_till_done()
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+    await hass.async_block_till_done()
+
+    expected_context = {
+        "discovery_key": DiscoveryKey(domain="ssdp", key="uuid:mock-udn", version=1),
+        "source": config_entries.SOURCE_SSDP,
+    }
+    assert len(mock_flow_init.mock_calls) == 1
+    assert mock_flow_init.mock_calls[0][1][0] == "mock-domain"
+    assert mock_flow_init.mock_calls[0][2]["context"] == expected_context
+    mock_call_data: ssdp.SsdpServiceInfo = mock_flow_init.mock_calls[0][2]["data"]
+    assert mock_call_data.ssdp_st == "mock-st"
+    assert mock_call_data.ssdp_location == "http://1.1.1.1"
+
+    await hass.config_entries.async_remove(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert len(mock_flow_init.mock_calls) == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Reinitialize ssdp discovery flow on unignore

This is a follow up to PR https://github.com/home-assistant/core/pull/125753

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
