### PR TITLE
Add more Wordle sensors

### DIFF
--- a/homeassistant/components/nyt_games/icons.json
+++ b/homeassistant/components/nyt_games/icons.json
@@ -3,6 +3,15 @@
     "sensor": {
       "wordles_played": {
         "default": "mdi:text-long"
+      },
+      "wordles_won": {
+        "default": "mdi:trophy-award"
+      },
+      "wordles_streak": {
+        "default": "mdi:calendar-range"
+      },
+      "wordles_max_streak": {
+        "default": "mdi:calendar-month"
       }
     }
   }

--- a/homeassistant/components/nyt_games/sensor.py
+++ b/homeassistant/components/nyt_games/sensor.py
@@ -6,10 +6,12 @@ from dataclasses import dataclass
 from nyt_games import Wordle
 
 from homeassistant.components.sensor import (
+    SensorDeviceClass,
     SensorEntity,
     SensorEntityDescription,
     SensorStateClass,
 )
+from homeassistant.const import UnitOfTime
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
@@ -45,15 +47,17 @@ SENSOR_TYPES: tuple[NYTGamesWordleSensorEntityDescription, ...] = (
         key="wordles_streak",
         translation_key="wordles_streak",
         state_class=SensorStateClass.TOTAL,
-        native_unit_of_measurement="games",
-        value_fn=lambda wordle: wordle.games_played,
+        native_unit_of_measurement=UnitOfTime.DAYS,
+        device_class=SensorDeviceClass.DURATION,
+        value_fn=lambda wordle: wordle.current_streak,
     ),
     NYTGamesWordleSensorEntityDescription(
         key="wordles_max_streak",
         translation_key="wordles_max_streak",
         state_class=SensorStateClass.TOTAL_INCREASING,
-        native_unit_of_measurement="games",
-        value_fn=lambda wordle: wordle.games_played,
+        native_unit_of_measurement=UnitOfTime.DAYS,
+        device_class=SensorDeviceClass.DURATION,
+        value_fn=lambda wordle: wordle.max_streak,
     ),
 )
 

--- a/homeassistant/components/nyt_games/sensor.py
+++ b/homeassistant/components/nyt_games/sensor.py
@@ -34,6 +34,27 @@ SENSOR_TYPES: tuple[NYTGamesWordleSensorEntityDescription, ...] = (
         native_unit_of_measurement="games",
         value_fn=lambda wordle: wordle.games_played,
     ),
+    NYTGamesWordleSensorEntityDescription(
+        key="wordles_won",
+        translation_key="wordles_won",
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement="games",
+        value_fn=lambda wordle: wordle.games_won,
+    ),
+    NYTGamesWordleSensorEntityDescription(
+        key="wordles_streak",
+        translation_key="wordles_streak",
+        state_class=SensorStateClass.TOTAL,
+        native_unit_of_measurement="games",
+        value_fn=lambda wordle: wordle.games_played,
+    ),
+    NYTGamesWordleSensorEntityDescription(
+        key="wordles_max_streak",
+        translation_key="wordles_max_streak",
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        native_unit_of_measurement="games",
+        value_fn=lambda wordle: wordle.games_played,
+    ),
 )
 
 

--- a/homeassistant/components/nyt_games/strings.json
+++ b/homeassistant/components/nyt_games/strings.json
@@ -23,6 +23,15 @@
     "sensor": {
       "wordles_played": {
         "name": "Wordles played"
+      },
+      "wordles_won": {
+        "name": "Wordles won"
+      },
+      "wordles_streak": {
+        "name": "Current Wordle streak"
+      },
+      "wordles_max_streak": {
+        "name": "Highest Wordle streak"
       }
     }
   }

--- a/tests/components/nyt_games/snapshots/test_sensor.ambr
+++ b/tests/components/nyt_games/snapshots/test_sensor.ambr
@@ -23,7 +23,7 @@
     'name': None,
     'options': dict({
     }),
-    'original_device_class': None,
+    'original_device_class': <SensorDeviceClass.DURATION: 'duration'>,
     'original_icon': None,
     'original_name': 'Current Wordle streak',
     'platform': 'nyt_games',
@@ -31,22 +31,23 @@
     'supported_features': 0,
     'translation_key': 'wordles_streak',
     'unique_id': '218886794-wordles_streak',
-    'unit_of_measurement': 'games',
+    'unit_of_measurement': <UnitOfTime.DAYS: 'd'>,
   })
 # ---
 # name: test_all_entities[sensor.nytgames_current_wordle_streak-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'device_class': 'duration',
       'friendly_name': 'NYTGames Current Wordle streak',
       'state_class': <SensorStateClass.TOTAL: 'total'>,
-      'unit_of_measurement': 'games',
+      'unit_of_measurement': <UnitOfTime.DAYS: 'd'>,
     }),
     'context': <ANY>,
     'entity_id': 'sensor.nytgames_current_wordle_streak',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '33',
+    'state': '1',
   })
 # ---
 # name: test_all_entities[sensor.nytgames_highest_wordle_streak-entry]
@@ -73,7 +74,7 @@
     'name': None,
     'options': dict({
     }),
-    'original_device_class': None,
+    'original_device_class': <SensorDeviceClass.DURATION: 'duration'>,
     'original_icon': None,
     'original_name': 'Highest Wordle streak',
     'platform': 'nyt_games',
@@ -81,22 +82,23 @@
     'supported_features': 0,
     'translation_key': 'wordles_max_streak',
     'unique_id': '218886794-wordles_max_streak',
-    'unit_of_measurement': 'games',
+    'unit_of_measurement': <UnitOfTime.DAYS: 'd'>,
   })
 # ---
 # name: test_all_entities[sensor.nytgames_highest_wordle_streak-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'device_class': 'duration',
       'friendly_name': 'NYTGames Highest Wordle streak',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
-      'unit_of_measurement': 'games',
+      'unit_of_measurement': <UnitOfTime.DAYS: 'd'>,
     }),
     'context': <ANY>,
     'entity_id': 'sensor.nytgames_highest_wordle_streak',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '33',
+    'state': '5',
   })
 # ---
 # name: test_all_entities[sensor.nytgames_wordles_played-entry]

--- a/tests/components/nyt_games/snapshots/test_sensor.ambr
+++ b/tests/components/nyt_games/snapshots/test_sensor.ambr
@@ -1,4 +1,104 @@
 # serializer version: 1
+# name: test_all_entities[sensor.nytgames_current_wordle_streak-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL: 'total'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.nytgames_current_wordle_streak',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Current Wordle streak',
+    'platform': 'nyt_games',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'wordles_streak',
+    'unique_id': '218886794-wordles_streak',
+    'unit_of_measurement': 'games',
+  })
+# ---
+# name: test_all_entities[sensor.nytgames_current_wordle_streak-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'NYTGames Current Wordle streak',
+      'state_class': <SensorStateClass.TOTAL: 'total'>,
+      'unit_of_measurement': 'games',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.nytgames_current_wordle_streak',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '33',
+  })
+# ---
+# name: test_all_entities[sensor.nytgames_highest_wordle_streak-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.nytgames_highest_wordle_streak',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Highest Wordle streak',
+    'platform': 'nyt_games',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'wordles_max_streak',
+    'unique_id': '218886794-wordles_max_streak',
+    'unit_of_measurement': 'games',
+  })
+# ---
+# name: test_all_entities[sensor.nytgames_highest_wordle_streak-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'NYTGames Highest Wordle streak',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'unit_of_measurement': 'games',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.nytgames_highest_wordle_streak',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '33',
+  })
+# ---
 # name: test_all_entities[sensor.nytgames_wordles_played-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -47,5 +147,55 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '33',
+  })
+# ---
+# name: test_all_entities[sensor.nytgames_wordles_won-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.nytgames_wordles_won',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Wordles won',
+    'platform': 'nyt_games',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'wordles_won',
+    'unique_id': '218886794-wordles_won',
+    'unit_of_measurement': 'games',
+  })
+# ---
+# name: test_all_entities[sensor.nytgames_wordles_won-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'NYTGames Wordles won',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': 'games',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.nytgames_wordles_won',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '26',
   })
 # ---


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add more Wordle sensors

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
