### PR TITLE
Reinitialize zeroconf discovery flow on config entry removal

### DIFF
--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -398,14 +398,12 @@ class ZeroconfDiscovery:
         entry: config_entries.ConfigEntry,
     ) -> None:
         """Handle config entry changes."""
-        if entry.source != config_entries.SOURCE_IGNORE:
-            return
         for discovery_key in entry.discovery_keys[DOMAIN]:
             if discovery_key.version != 1:
                 continue
             _type = discovery_key.key[0]
             name = discovery_key.key[1]
-            _LOGGER.debug("Rediscover unignored service %s.%s", _type, name)
+            _LOGGER.debug("Rediscover service %s.%s", _type, name)
             self._async_service_update(self.zeroconf, _type, name)
 
     def _async_dismiss_discoveries(self, name: str) -> None:

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1388,7 +1388,6 @@ class ConfigEntriesFlowManager(data_entry_flow.FlowManager[ConfigFlowResult]):
                         result["handler"], unique_id
                     )
                 )
-                and entry.source == SOURCE_IGNORE
                 and discovery_key
                 not in (
                     known_discovery_keys := entry.discovery_keys.get(

--- a/tests/components/zeroconf/test_init.py
+++ b/tests/components/zeroconf/test_init.py
@@ -1456,10 +1456,12 @@ async def test_zeroconf_removed(hass: HomeAssistant) -> None:
         ),
     ],
 )
+@pytest.mark.parametrize("entry_source", [config_entries.SOURCE_IGNORE])
 async def test_zeroconf_rediscover(
     hass: HomeAssistant,
     entry_domain: str,
     entry_discovery_keys: tuple,
+    entry_source: str,
 ) -> None:
     """Test we reinitiate flows when an ignored config entry is removed."""
 
@@ -1477,7 +1479,7 @@ async def test_zeroconf_rediscover(
         discovery_keys=entry_discovery_keys,
         unique_id="mock-unique-id",
         state=config_entries.ConfigEntryState.LOADED,
-        source=config_entries.SOURCE_IGNORE,
+        source=entry_source,
     )
     entry.add_to_hass(hass)
 
@@ -1532,6 +1534,145 @@ async def test_zeroconf_rediscover(
         }
         assert mock_config_flow.mock_calls[2][1][0] == "shelly"
         assert mock_config_flow.mock_calls[2][2]["context"] == expected_context
+
+
+@pytest.mark.usefixtures("mock_async_zeroconf")
+@pytest.mark.parametrize(
+    (
+        "entry_domain",
+        "entry_discovery_keys",
+    ),
+    [
+        # Matching discovery key
+        (
+            "shelly",
+            {
+                "zeroconf": (
+                    DiscoveryKey(
+                        domain="zeroconf",
+                        key=("_http._tcp.local.", "Shelly108._http._tcp.local."),
+                        version=1,
+                    ),
+                )
+            },
+        ),
+        # Matching discovery key
+        (
+            "shelly",
+            {
+                "zeroconf": (
+                    DiscoveryKey(
+                        domain="zeroconf",
+                        key=("_http._tcp.local.", "Shelly108._http._tcp.local."),
+                        version=1,
+                    ),
+                ),
+                "other": (
+                    DiscoveryKey(
+                        domain="other",
+                        key="blah",
+                        version=1,
+                    ),
+                ),
+            },
+        ),
+        # Matching discovery key, other domain
+        # Note: Rediscovery is not currently restricted to the domain of the removed
+        # entry. Such a check can be added if needed.
+        (
+            "comp",
+            {
+                "zeroconf": (
+                    DiscoveryKey(
+                        domain="zeroconf",
+                        key=("_http._tcp.local.", "Shelly108._http._tcp.local."),
+                        version=1,
+                    ),
+                )
+            },
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "entry_source", [config_entries.SOURCE_USER, config_entries.SOURCE_ZEROCONF]
+)
+async def test_zeroconf_rediscover_2(
+    hass: HomeAssistant,
+    entry_domain: str,
+    entry_discovery_keys: tuple,
+    entry_source: str,
+) -> None:
+    """Test we reinitiate flows when an ignored config entry is removed.
+
+    This test can be merged with test_zeroconf_rediscover when
+    async_step_unignore has been removed from the ConfigFlow base class.
+    """
+
+    def http_only_service_update_mock(zeroconf, services, handlers):
+        """Call service update handler."""
+        handlers[0](
+            zeroconf,
+            "_http._tcp.local.",
+            "Shelly108._http._tcp.local.",
+            ServiceStateChange.Added,
+        )
+
+    entry = MockConfigEntry(
+        domain=entry_domain,
+        discovery_keys=entry_discovery_keys,
+        unique_id="mock-unique-id",
+        state=config_entries.ConfigEntryState.LOADED,
+        source=entry_source,
+    )
+    entry.add_to_hass(hass)
+
+    with (
+        patch.dict(
+            zc_gen.ZEROCONF,
+            {
+                "_http._tcp.local.": [
+                    {
+                        "domain": "shelly",
+                        "name": "shelly*",
+                        "properties": {"macaddress": "ffaadd*"},
+                    }
+                ]
+            },
+            clear=True,
+        ),
+        patch.object(hass.config_entries.flow, "async_init") as mock_config_flow,
+        patch.object(
+            zeroconf, "AsyncServiceBrowser", side_effect=http_only_service_update_mock
+        ) as mock_service_browser,
+        patch(
+            "homeassistant.components.zeroconf.AsyncServiceInfo",
+            side_effect=get_zeroconf_info_mock("FFAADDCC11DD"),
+        ),
+    ):
+        assert await async_setup_component(hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {}})
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+        await hass.async_block_till_done()
+
+        expected_context = {
+            "discovery_key": DiscoveryKey(
+                domain="zeroconf",
+                key=("_http._tcp.local.", "Shelly108._http._tcp.local."),
+                version=1,
+            ),
+            "source": "zeroconf",
+        }
+        assert len(mock_service_browser.mock_calls) == 1
+        assert len(mock_config_flow.mock_calls) == 1
+        assert mock_config_flow.mock_calls[0][1][0] == "shelly"
+        assert mock_config_flow.mock_calls[0][2]["context"] == expected_context
+
+        await hass.config_entries.async_remove(entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert len(mock_service_browser.mock_calls) == 1
+        assert len(mock_config_flow.mock_calls) == 2
+        assert mock_config_flow.mock_calls[1][1][0] == "shelly"
+        assert mock_config_flow.mock_calls[1][2]["context"] == expected_context
 
 
 @pytest.mark.usefixtures("mock_async_zeroconf")
@@ -1654,110 +1795,3 @@ async def test_zeroconf_rediscover_no_match(
         assert mock_config_flow.mock_calls[1][2]["context"] == {
             "source": "unignore",
         }
-
-
-@pytest.mark.usefixtures("mock_async_zeroconf")
-@pytest.mark.parametrize(
-    (
-        "entry_domain",
-        "entry_discovery_keys",
-        "entry_source",
-        "entry_unique_id",
-    ),
-    [
-        # Source not SOURCE_IGNORE
-        (
-            "shelly",
-            {
-                "zeroconf": (
-                    DiscoveryKey(
-                        domain="zeroconf",
-                        key=("_http._tcp.local.", "Shelly108._http._tcp.local."),
-                        version=1,
-                    ),
-                )
-            },
-            config_entries.SOURCE_ZEROCONF,
-            "mock-unique-id",
-        ),
-    ],
-)
-async def test_zeroconf_rediscover_no_match_2(
-    hass: HomeAssistant,
-    entry_domain: str,
-    entry_discovery_keys: tuple,
-    entry_source: str,
-    entry_unique_id: str,
-) -> None:
-    """Test we don't reinitiate flows when a non matching config entry is removed.
-
-    This test can be merged with test_zeroconf_rediscover_no_match when
-    async_step_unignore has been removed from the ConfigFlow base class.
-    """
-
-    def http_only_service_update_mock(zeroconf, services, handlers):
-        """Call service update handler."""
-        handlers[0](
-            zeroconf,
-            "_http._tcp.local.",
-            "Shelly108._http._tcp.local.",
-            ServiceStateChange.Added,
-        )
-
-    hass.config.components.add(entry_domain)
-    mock_integration(hass, MockModule(entry_domain))
-
-    entry = MockConfigEntry(
-        domain=entry_domain,
-        discovery_keys=entry_discovery_keys,
-        unique_id=entry_unique_id,
-        state=config_entries.ConfigEntryState.LOADED,
-        source=entry_source,
-    )
-    entry.add_to_hass(hass)
-
-    with (
-        patch.dict(
-            zc_gen.ZEROCONF,
-            {
-                "_http._tcp.local.": [
-                    {
-                        "domain": "shelly",
-                        "name": "shelly*",
-                        "properties": {"macaddress": "ffaadd*"},
-                    }
-                ]
-            },
-            clear=True,
-        ),
-        patch.object(hass.config_entries.flow, "async_init") as mock_config_flow,
-        patch.object(
-            zeroconf, "AsyncServiceBrowser", side_effect=http_only_service_update_mock
-        ) as mock_service_browser,
-        patch(
-            "homeassistant.components.zeroconf.AsyncServiceInfo",
-            side_effect=get_zeroconf_info_mock("FFAADDCC11DD"),
-        ),
-    ):
-        assert await async_setup_component(hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {}})
-        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
-        await hass.async_block_till_done()
-
-        expected_context = {
-            "discovery_key": DiscoveryKey(
-                domain="zeroconf",
-                key=("_http._tcp.local.", "Shelly108._http._tcp.local."),
-                version=1,
-            ),
-            "source": "zeroconf",
-        }
-        assert len(mock_service_browser.mock_calls) == 1
-        assert len(mock_config_flow.mock_calls) == 1
-        assert mock_config_flow.mock_calls[0][1][0] == "shelly"
-        assert mock_config_flow.mock_calls[0][2]["context"] == expected_context
-
-        await hass.config_entries.async_remove(entry.entry_id)
-        await hass.async_block_till_done()
-
-        assert len(mock_service_browser.mock_calls) == 1
-        assert len(mock_config_flow.mock_calls) == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Reinitialize zeroconf discovery flow on any config entry removal instead of only when removing an ignored zeroconf discovery

This is a follow up to PR https://github.com/home-assistant/core/pull/125753

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
