### PR TITLE
Add sensor platform to Bring integration

### DIFF
--- a/homeassistant/components/bring/__init__.py
+++ b/homeassistant/components/bring/__init__.py
@@ -20,7 +20,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from .const import DOMAIN
 from .coordinator import BringDataUpdateCoordinator
 
-PLATFORMS: list[Platform] = [Platform.TODO]
+PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.TODO]
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/bring/const.py
+++ b/homeassistant/components/bring/const.py
@@ -9,3 +9,4 @@ ATTR_ITEM_NAME: Final = "item"
 ATTR_NOTIFICATION_TYPE: Final = "message"
 
 SERVICE_PUSH_NOTIFICATION = "send_message"
+UNIT_ITEMS = "Items"

--- a/homeassistant/components/bring/const.py
+++ b/homeassistant/components/bring/const.py
@@ -9,4 +9,4 @@ ATTR_ITEM_NAME: Final = "item"
 ATTR_NOTIFICATION_TYPE: Final = "message"
 
 SERVICE_PUSH_NOTIFICATION = "send_message"
-UNIT_ITEMS = "Items"
+UNIT_ITEMS = "items"

--- a/homeassistant/components/bring/coordinator.py
+++ b/homeassistant/components/bring/coordinator.py
@@ -11,7 +11,7 @@ from bring_api import (
     BringParseException,
     BringRequestException,
 )
-from bring_api.types import BringItemsResponse, BringList
+from bring_api.types import BringItemsResponse, BringList, BringUserSettingsResponse
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_EMAIL
@@ -32,6 +32,7 @@ class BringDataUpdateCoordinator(DataUpdateCoordinator[dict[str, BringData]]):
     """A Bring Data Update Coordinator."""
 
     config_entry: ConfigEntry
+    user_settings: BringUserSettingsResponse
 
     def __init__(self, hass: HomeAssistant, bring: Bring) -> None:
         """Initialize the Bring data coordinator."""
@@ -81,3 +82,17 @@ class BringDataUpdateCoordinator(DataUpdateCoordinator[dict[str, BringData]]):
                 list_dict[lst["listUuid"]] = BringData(**lst, **items)
 
         return list_dict
+
+    async def _async_setup(self) -> None:
+        """Set up coordinator."""
+
+        await self.async_refresh_user_settings()
+
+    async def async_refresh_user_settings(self) -> None:
+        """Refresh user settings."""
+        try:
+            self.user_settings = await self.bring.get_all_user_settings()
+        except (BringAuthException, BringRequestException, BringParseException) as e:
+            raise UpdateFailed(
+                "Unable to connect and retrieve user settings from bring"
+            ) from e

--- a/homeassistant/components/bring/entity.py
+++ b/homeassistant/components/bring/entity.py
@@ -25,6 +25,9 @@ class BringBaseEntity(CoordinatorEntity[BringDataUpdateCoordinator]):
         self._list_uuid = bring_list["listUuid"]
         self._attr_unique_id = f"{coordinator.config_entry.unique_id}_{self._list_uuid}"
 
+        if hasattr(self, "entity_description"):
+            self._attr_unique_id += f"_{self.entity_description.key}"
+
         self.device_info = DeviceInfo(
             entry_type=DeviceEntryType.SERVICE,
             name=bring_list["name"],

--- a/homeassistant/components/bring/entity.py
+++ b/homeassistant/components/bring/entity.py
@@ -23,10 +23,6 @@ class BringBaseEntity(CoordinatorEntity[BringDataUpdateCoordinator]):
         super().__init__(coordinator)
 
         self._list_uuid = bring_list["listUuid"]
-        self._attr_unique_id = f"{coordinator.config_entry.unique_id}_{self._list_uuid}"
-
-        if hasattr(self, "entity_description"):
-            self._attr_unique_id += f"_{self.entity_description.key}"
 
         self.device_info = DeviceInfo(
             entry_type=DeviceEntryType.SERVICE,

--- a/homeassistant/components/bring/icons.json
+++ b/homeassistant/components/bring/icons.json
@@ -1,5 +1,19 @@
 {
   "entity": {
+    "sensor": {
+      "urgent": {
+        "default": "mdi:run-fast"
+      },
+      "discounted": {
+        "default": "mdi:brightness-percent"
+      },
+      "convenient": {
+        "default": "mdi:fridge-outline"
+      },
+      "list_language": {
+        "default": "mdi:translate"
+      }
+    },
     "todo": {
       "shopping_list": {
         "default": "mdi:cart"

--- a/homeassistant/components/bring/icons.json
+++ b/homeassistant/components/bring/icons.json
@@ -11,7 +11,7 @@
         "default": "mdi:fridge-outline"
       },
       "list_language": {
-        "default": "mdi:translate"
+        "default": "mdi:earth"
       }
     },
     "todo": {

--- a/homeassistant/components/bring/sensor.py
+++ b/homeassistant/components/bring/sensor.py
@@ -60,9 +60,13 @@ SENSOR_DESCRIPTIONS: tuple[BringSensorEntityDescription, ...] = (
     BringSensorEntityDescription(
         key=BringSensor.LIST_LANGUAGE,
         translation_key=BringSensor.LIST_LANGUAGE,
-        value_fn=(lambda lst, settings: list_language(lst["listUuid"], settings)),
+        value_fn=(
+            lambda lst, settings: x.lower()
+            if (x := list_language(lst["listUuid"], settings))
+            else None
+        ),
         entity_category=EntityCategory.DIAGNOSTIC,
-        options=BRING_SUPPORTED_LOCALES,
+        options=[x.lower() for x in BRING_SUPPORTED_LOCALES],
         device_class=SensorDeviceClass.ENUM,
     ),
 )

--- a/homeassistant/components/bring/sensor.py
+++ b/homeassistant/components/bring/sensor.py
@@ -80,17 +80,15 @@ async def async_setup_entry(
     """Set up the sensor platform."""
     coordinator = config_entry.runtime_data
 
-    entities: list[BringSensorEntity] = []
-    for bring_list in coordinator.data.values():
-        entities.extend(
-            BringSensorEntity(
-                coordinator,
-                bring_list,
-                description,
-            )
-            for description in SENSOR_DESCRIPTIONS
+    async_add_entities(
+        BringSensorEntity(
+            coordinator,
+            bring_list,
+            description,
         )
-    async_add_entities(entities)
+        for description in SENSOR_DESCRIPTIONS
+        for bring_list in coordinator.data.values()
+    )
 
 
 class BringSensorEntity(BringBaseEntity, SensorEntity):

--- a/homeassistant/components/bring/sensor.py
+++ b/homeassistant/components/bring/sensor.py
@@ -80,8 +80,9 @@ async def async_setup_entry(
     """Set up the sensor platform."""
     coordinator = config_entry.runtime_data
 
+    entities: list[BringSensorEntity] = []
     for bring_list in coordinator.data.values():
-        async_add_entities(
+        entities.extend(
             BringSensorEntity(
                 coordinator,
                 bring_list,
@@ -89,6 +90,7 @@ async def async_setup_entry(
             )
             for description in SENSOR_DESCRIPTIONS
         )
+    async_add_entities(entities)
 
 
 class BringSensorEntity(BringBaseEntity, SensorEntity):
@@ -103,9 +105,9 @@ class BringSensorEntity(BringBaseEntity, SensorEntity):
         entity_description: BringSensorEntityDescription,
     ) -> None:
         """Initialize the entity."""
-        self.entity_description = entity_description
-
         super().__init__(coordinator, bring_list)
+        self.entity_description = entity_description
+        self._attr_unique_id = f"{coordinator.config_entry.unique_id}_{self._list_uuid}_{self.entity_description.key}"
 
     @property
     def native_value(self) -> StateType:

--- a/homeassistant/components/bring/sensor.py
+++ b/homeassistant/components/bring/sensor.py
@@ -20,6 +20,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
 
 from . import BringConfigEntry
+from .const import UNIT_ITEMS
 from .coordinator import BringData, BringDataUpdateCoordinator
 from .entity import BringBaseEntity
 from .util import list_language, sum_attributes
@@ -46,16 +47,19 @@ SENSOR_DESCRIPTIONS: tuple[BringSensorEntityDescription, ...] = (
         key=BringSensor.URGENT,
         translation_key=BringSensor.URGENT,
         value_fn=lambda lst, _: sum_attributes(lst, "urgent"),
+        native_unit_of_measurement=UNIT_ITEMS,
     ),
     BringSensorEntityDescription(
         key=BringSensor.CONVENIENT,
         translation_key=BringSensor.CONVENIENT,
         value_fn=lambda lst, _: sum_attributes(lst, "convenient"),
+        native_unit_of_measurement=UNIT_ITEMS,
     ),
     BringSensorEntityDescription(
         key=BringSensor.DISCOUNTED,
         translation_key=BringSensor.DISCOUNTED,
         value_fn=lambda lst, _: sum_attributes(lst, "discounted"),
+        native_unit_of_measurement=UNIT_ITEMS,
     ),
     BringSensorEntityDescription(
         key=BringSensor.LIST_LANGUAGE,

--- a/homeassistant/components/bring/sensor.py
+++ b/homeassistant/components/bring/sensor.py
@@ -1,0 +1,113 @@
+"""Sensor platform for the Bring! integration."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from enum import StrEnum
+
+from bring_api import BringUserSettingsResponse
+from bring_api.const import BRING_SUPPORTED_LOCALES
+
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorEntityDescription,
+)
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import StateType
+
+from . import BringConfigEntry
+from .coordinator import BringData, BringDataUpdateCoordinator
+from .entity import BringBaseEntity
+from .util import list_language, sum_attributes
+
+
+@dataclass(kw_only=True, frozen=True)
+class BringSensorEntityDescription(SensorEntityDescription):
+    """Bring Sensor Description."""
+
+    value_fn: Callable[[BringData, BringUserSettingsResponse], StateType]
+
+
+class BringSensor(StrEnum):
+    """Bring sensors."""
+
+    URGENT = "urgent"
+    CONVENIENT = "convenient"
+    DISCOUNTED = "discounted"
+    LIST_LANGUAGE = "list_language"
+
+
+SENSOR_DESCRIPTIONS: tuple[BringSensorEntityDescription, ...] = (
+    BringSensorEntityDescription(
+        key=BringSensor.URGENT,
+        translation_key=BringSensor.URGENT,
+        value_fn=lambda lst, _: sum_attributes(lst, "urgent"),
+    ),
+    BringSensorEntityDescription(
+        key=BringSensor.CONVENIENT,
+        translation_key=BringSensor.CONVENIENT,
+        value_fn=lambda lst, _: sum_attributes(lst, "convenient"),
+    ),
+    BringSensorEntityDescription(
+        key=BringSensor.DISCOUNTED,
+        translation_key=BringSensor.DISCOUNTED,
+        value_fn=lambda lst, _: sum_attributes(lst, "discounted"),
+    ),
+    BringSensorEntityDescription(
+        key=BringSensor.LIST_LANGUAGE,
+        translation_key=BringSensor.LIST_LANGUAGE,
+        value_fn=(lambda lst, settings: list_language(lst["listUuid"], settings)),
+        entity_category=EntityCategory.DIAGNOSTIC,
+        options=BRING_SUPPORTED_LOCALES,
+        device_class=SensorDeviceClass.ENUM,
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: BringConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the sensor platform."""
+    coordinator = config_entry.runtime_data
+
+    for bring_list in coordinator.data.values():
+        async_add_entities(
+            BringSensorEntity(
+                coordinator,
+                bring_list,
+                description,
+            )
+            for description in SENSOR_DESCRIPTIONS
+        )
+
+
+class BringSensorEntity(BringBaseEntity, SensorEntity):
+    """A sensor entity."""
+
+    entity_description: BringSensorEntityDescription
+
+    def __init__(
+        self,
+        coordinator: BringDataUpdateCoordinator,
+        bring_list: BringData,
+        entity_description: BringSensorEntityDescription,
+    ) -> None:
+        """Initialize the entity."""
+        self.entity_description = entity_description
+
+        super().__init__(coordinator, bring_list)
+
+    @property
+    def native_value(self) -> StateType:
+        """Return the state of the sensor."""
+
+        return self.entity_description.value_fn(
+            self.coordinator.data[self._list_uuid],
+            self.coordinator.user_settings,
+        )

--- a/homeassistant/components/bring/strings.json
+++ b/homeassistant/components/bring/strings.json
@@ -26,6 +26,22 @@
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     }
   },
+  "entity": {
+    "sensor": {
+      "urgent": {
+        "name": "Urgent"
+      },
+      "convenient": {
+        "name": "On occasion"
+      },
+      "discounted": {
+        "name": "Discount only"
+      },
+      "list_language": {
+        "name": "Language"
+      }
+    }
+  },
   "exceptions": {
     "todo_save_item_failed": {
       "message": "Failed to save item {name} to Bring! list"

--- a/homeassistant/components/bring/strings.json
+++ b/homeassistant/components/bring/strings.json
@@ -38,7 +38,29 @@
         "name": "Discount only"
       },
       "list_language": {
-        "name": "Language"
+        "name": "Region & language",
+        "state": {
+          "de-at": "Austria",
+          "de-ch": "Switzerland (German)",
+          "de-de": "Germany",
+          "en-au": "Australia",
+          "en-ca": "Canada",
+          "en-gb": "United Kingdom",
+          "en-us": "United States",
+          "es-es": "Spain",
+          "fr-ch": "Switzerland (French)",
+          "fr-fr": "France",
+          "hu-hu": "Hungary",
+          "it-ch": "Switzerland (Italian)",
+          "it-it": "Italy",
+          "nb-no": "Norway",
+          "nl-nl": "Netherlands",
+          "pl-pl": "Poland",
+          "pt-br": "Portugal",
+          "ru-ru": "Russia",
+          "sv-se": "Sweden",
+          "tr-tr": "Turkey"
+        }
       }
     }
   },

--- a/homeassistant/components/bring/todo.py
+++ b/homeassistant/components/bring/todo.py
@@ -31,7 +31,7 @@ from .const import (
     DOMAIN,
     SERVICE_PUSH_NOTIFICATION,
 )
-from .coordinator import BringData
+from .coordinator import BringData, BringDataUpdateCoordinator
 from .entity import BringBaseEntity
 
 
@@ -76,6 +76,13 @@ class BringTodoListEntity(BringBaseEntity, TodoListEntity):
         | TodoListEntityFeature.DELETE_TODO_ITEM
         | TodoListEntityFeature.SET_DESCRIPTION_ON_ITEM
     )
+
+    def __init__(
+        self, coordinator: BringDataUpdateCoordinator, bring_list: BringData
+    ) -> None:
+        """Initialize the entity."""
+        super().__init__(coordinator, bring_list)
+        self._attr_unique_id = f"{coordinator.config_entry.unique_id}_{self._list_uuid}"
 
     @property
     def todo_items(self) -> list[TodoItem]:

--- a/homeassistant/components/bring/util.py
+++ b/homeassistant/components/bring/util.py
@@ -1,0 +1,40 @@
+"""Utility functions for Bring."""
+
+from __future__ import annotations
+
+from bring_api import BringUserSettingsResponse
+
+from .coordinator import BringData
+
+
+def list_language(
+    list_uuid: str,
+    user_settings: BringUserSettingsResponse,
+) -> str | None:
+    """Get the lists language setting."""
+    try:
+        list_settings = next(
+            filter(
+                lambda x: x["listUuid"] == list_uuid,
+                user_settings["userlistsettings"],
+            )
+        )
+
+        return next(
+            filter(
+                lambda x: x["key"] == "listArticleLanguage",
+                list_settings["usersettings"],
+            )
+        )["value"]
+
+    except (StopIteration, KeyError):
+        return None
+
+
+def sum_attributes(bring_list: BringData, attribute: str) -> int:
+    """Count items with given attribute set."""
+    return sum(
+        item["attributes"][0]["content"][attribute]  # type: ignore[typeddict-item]
+        for item in bring_list["purchase"]
+        if len(item.get("attributes", []))  # type: ignore[arg-type]
+    )

--- a/homeassistant/components/bring/util.py
+++ b/homeassistant/components/bring/util.py
@@ -34,7 +34,7 @@ def list_language(
 def sum_attributes(bring_list: BringData, attribute: str) -> int:
     """Count items with given attribute set."""
     return sum(
-        item["attributes"][0]["content"][attribute]  # type: ignore[typeddict-item]
+        item["attributes"][0]["content"][attribute]
         for item in bring_list["purchase"]
-        if len(item.get("attributes", []))  # type: ignore[arg-type]
+        if len(item.get("attributes", []))
     )

--- a/tests/components/bring/conftest.py
+++ b/tests/components/bring/conftest.py
@@ -46,6 +46,9 @@ def mock_bring_client() -> Generator[AsyncMock]:
         client.login.return_value = cast(BringAuthResponse, {"name": "Bring"})
         client.load_lists.return_value = load_json_object_fixture("lists.json", DOMAIN)
         client.get_list.return_value = load_json_object_fixture("items.json", DOMAIN)
+        client.get_all_user_settings.return_value = load_json_object_fixture(
+            "usersettings.json", DOMAIN
+        )
         yield client
 
 

--- a/tests/components/bring/fixtures/items.json
+++ b/tests/components/bring/fixtures/items.json
@@ -6,13 +6,31 @@
       "uuid": "b5d0790b-5f32-4d5c-91da-e29066f167de",
       "itemId": "Paprika",
       "specification": "Rot",
-      "attributes": []
+      "attributes": [
+        {
+          "type": "PURCHASE_CONDITIONS",
+          "content": {
+            "urgent": true,
+            "convenient": true,
+            "discounted": true
+          }
+        }
+      ]
     },
     {
       "uuid": "72d370ab-d8ca-4e41-b956-91df94795b4e",
       "itemId": "Pouletbrüstli",
       "specification": "Bio",
-      "attributes": []
+      "attributes": [
+        {
+          "type": "PURCHASE_CONDITIONS",
+          "content": {
+            "urgent": true,
+            "convenient": true,
+            "discounted": true
+          }
+        }
+      ]
     }
   ],
   "recently": [

--- a/tests/components/bring/fixtures/usersettings.json
+++ b/tests/components/bring/fixtures/usersettings.json
@@ -1,0 +1,60 @@
+{
+  "userlistsettings": [
+    {
+      "listUuid": "e542eef6-dba7-4c31-a52c-29e6ab9d83a5",
+      "usersettings": [
+        {
+          "key": "listSectionOrder",
+          "value": "[\"Früchte & Gemüse\",\"Brot & Gebäck\",\"Milch & Käse\",\"Fleisch & Fisch\",\"Zutaten & Gewürze\",\"Fertig- & Tiefkühlprodukte\",\"Getreideprodukte\",\"Snacks & Süsswaren\",\"Getränke & Tabak\",\"Haushalt & Gesundheit\",\"Pflege & Gesundheit\",\"Tierbedarf\",\"Baumarkt & Garten\",\"Eigene Artikel\"]"
+        },
+        {
+          "key": "listArticleLanguage",
+          "value": "de-DE"
+        }
+      ]
+    },
+    {
+      "listUuid": "b4776778-7f6c-496e-951b-92a35d3db0dd",
+      "usersettings": [
+        {
+          "key": "listSectionOrder",
+          "value": "[\"Früchte & Gemüse\",\"Brot & Gebäck\",\"Milch & Käse\",\"Fleisch & Fisch\",\"Zutaten & Gewürze\",\"Fertig- & Tiefkühlprodukte\",\"Getreideprodukte\",\"Snacks & Süsswaren\",\"Getränke & Tabak\",\"Haushalt & Gesundheit\",\"Pflege & Gesundheit\",\"Tierbedarf\",\"Baumarkt & Garten\",\"Eigene Artikel\"]"
+        },
+        {
+          "key": "listArticleLanguage",
+          "value": "en-US"
+        }
+      ]
+    }
+  ],
+  "usersettings": [
+    {
+      "key": "autoPush",
+      "value": "ON"
+    },
+    {
+      "key": "premiumHideOffersBadge",
+      "value": "ON"
+    },
+    {
+      "key": "premiumHideSponsoredCategories",
+      "value": "ON"
+    },
+    {
+      "key": "premiumHideInspirationsBadge",
+      "value": "ON"
+    },
+    {
+      "key": "onboardClient",
+      "value": "android"
+    },
+    {
+      "key": "premiumHideOffersOnMain",
+      "value": "ON"
+    },
+    {
+      "key": "defaultListUUID",
+      "value": "e542eef6-dba7-4c31-a52c-29e6ab9d83a5"
+    }
+  ]
+}

--- a/tests/components/bring/snapshots/test_sensor.ambr
+++ b/tests/components/bring/snapshots/test_sensor.ambr
@@ -29,13 +29,14 @@
     'supported_features': 0,
     'translation_key': <BringSensor.DISCOUNTED: 'discounted'>,
     'unique_id': '00000000-00000000-00000000-00000000_b4776778-7f6c-496e-951b-92a35d3db0dd_discounted',
-    'unit_of_measurement': None,
+    'unit_of_measurement': 'Items',
   })
 # ---
 # name: test_setup[sensor.baumarkt_discount_only-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Baumarkt Discount only',
+      'unit_of_measurement': 'Items',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.baumarkt_discount_only',
@@ -167,13 +168,14 @@
     'supported_features': 0,
     'translation_key': <BringSensor.CONVENIENT: 'convenient'>,
     'unique_id': '00000000-00000000-00000000-00000000_b4776778-7f6c-496e-951b-92a35d3db0dd_convenient',
-    'unit_of_measurement': None,
+    'unit_of_measurement': 'Items',
   })
 # ---
 # name: test_setup[sensor.baumarkt_on_occasion-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Baumarkt On occasion',
+      'unit_of_measurement': 'Items',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.baumarkt_on_occasion',
@@ -305,13 +307,14 @@
     'supported_features': 0,
     'translation_key': <BringSensor.URGENT: 'urgent'>,
     'unique_id': '00000000-00000000-00000000-00000000_b4776778-7f6c-496e-951b-92a35d3db0dd_urgent',
-    'unit_of_measurement': None,
+    'unit_of_measurement': 'Items',
   })
 # ---
 # name: test_setup[sensor.baumarkt_urgent-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Baumarkt Urgent',
+      'unit_of_measurement': 'Items',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.baumarkt_urgent',
@@ -351,13 +354,14 @@
     'supported_features': 0,
     'translation_key': <BringSensor.DISCOUNTED: 'discounted'>,
     'unique_id': '00000000-00000000-00000000-00000000_e542eef6-dba7-4c31-a52c-29e6ab9d83a5_discounted',
-    'unit_of_measurement': None,
+    'unit_of_measurement': 'Items',
   })
 # ---
 # name: test_setup[sensor.einkauf_discount_only-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Einkauf Discount only',
+      'unit_of_measurement': 'Items',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.einkauf_discount_only',
@@ -489,13 +493,14 @@
     'supported_features': 0,
     'translation_key': <BringSensor.CONVENIENT: 'convenient'>,
     'unique_id': '00000000-00000000-00000000-00000000_e542eef6-dba7-4c31-a52c-29e6ab9d83a5_convenient',
-    'unit_of_measurement': None,
+    'unit_of_measurement': 'Items',
   })
 # ---
 # name: test_setup[sensor.einkauf_on_occasion-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Einkauf On occasion',
+      'unit_of_measurement': 'Items',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.einkauf_on_occasion',
@@ -627,13 +632,14 @@
     'supported_features': 0,
     'translation_key': <BringSensor.URGENT: 'urgent'>,
     'unique_id': '00000000-00000000-00000000-00000000_e542eef6-dba7-4c31-a52c-29e6ab9d83a5_urgent',
-    'unit_of_measurement': None,
+    'unit_of_measurement': 'Items',
   })
 # ---
 # name: test_setup[sensor.einkauf_urgent-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Einkauf Urgent',
+      'unit_of_measurement': 'Items',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.einkauf_urgent',

--- a/tests/components/bring/snapshots/test_sensor.ambr
+++ b/tests/components/bring/snapshots/test_sensor.ambr
@@ -138,6 +138,239 @@
     'state': 'en-US',
   })
 # ---
+# name: test_setup[sensor.baumarkt_none-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.baumarkt_none',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'bring',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': <BringSensor.URGENT: 'urgent'>,
+    'unique_id': '00000000-00000000-00000000-00000000_b4776778-7f6c-496e-951b-92a35d3db0dd_urgent',
+    'unit_of_measurement': 'items',
+  })
+# ---
+# name: test_setup[sensor.baumarkt_none-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Baumarkt None',
+      'unit_of_measurement': 'items',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.baumarkt_none',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2',
+  })
+# ---
+# name: test_setup[sensor.baumarkt_none_2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.baumarkt_none_2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'bring',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': <BringSensor.CONVENIENT: 'convenient'>,
+    'unique_id': '00000000-00000000-00000000-00000000_b4776778-7f6c-496e-951b-92a35d3db0dd_convenient',
+    'unit_of_measurement': 'items',
+  })
+# ---
+# name: test_setup[sensor.baumarkt_none_2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Baumarkt None',
+      'unit_of_measurement': 'items',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.baumarkt_none_2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2',
+  })
+# ---
+# name: test_setup[sensor.baumarkt_none_3-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.baumarkt_none_3',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'bring',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': <BringSensor.DISCOUNTED: 'discounted'>,
+    'unique_id': '00000000-00000000-00000000-00000000_b4776778-7f6c-496e-951b-92a35d3db0dd_discounted',
+    'unit_of_measurement': 'items',
+  })
+# ---
+# name: test_setup[sensor.baumarkt_none_3-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Baumarkt None',
+      'unit_of_measurement': 'items',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.baumarkt_none_3',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2',
+  })
+# ---
+# name: test_setup[sensor.baumarkt_none_4-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'de-at',
+        'de-ch',
+        'de-de',
+        'en-au',
+        'en-ca',
+        'en-gb',
+        'en-us',
+        'es-es',
+        'fr-ch',
+        'fr-fr',
+        'hu-hu',
+        'it-ch',
+        'it-it',
+        'nb-no',
+        'nl-nl',
+        'pl-pl',
+        'pt-br',
+        'ru-ru',
+        'sv-se',
+        'tr-tr',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.baumarkt_none_4',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'bring',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': <BringSensor.LIST_LANGUAGE: 'list_language'>,
+    'unique_id': '00000000-00000000-00000000-00000000_b4776778-7f6c-496e-951b-92a35d3db0dd_list_language',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup[sensor.baumarkt_none_4-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'enum',
+      'friendly_name': 'Baumarkt None',
+      'options': list([
+        'de-at',
+        'de-ch',
+        'de-de',
+        'en-au',
+        'en-ca',
+        'en-gb',
+        'en-us',
+        'es-es',
+        'fr-ch',
+        'fr-fr',
+        'hu-hu',
+        'it-ch',
+        'it-it',
+        'nb-no',
+        'nl-nl',
+        'pl-pl',
+        'pt-br',
+        'ru-ru',
+        'sv-se',
+        'tr-tr',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.baumarkt_none_4',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'en-us',
+  })
+# ---
 # name: test_setup[sensor.baumarkt_on_occasion-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -461,6 +694,239 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'de-DE',
+  })
+# ---
+# name: test_setup[sensor.einkauf_none-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.einkauf_none',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'bring',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': <BringSensor.URGENT: 'urgent'>,
+    'unique_id': '00000000-00000000-00000000-00000000_e542eef6-dba7-4c31-a52c-29e6ab9d83a5_urgent',
+    'unit_of_measurement': 'items',
+  })
+# ---
+# name: test_setup[sensor.einkauf_none-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Einkauf None',
+      'unit_of_measurement': 'items',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.einkauf_none',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2',
+  })
+# ---
+# name: test_setup[sensor.einkauf_none_2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.einkauf_none_2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'bring',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': <BringSensor.CONVENIENT: 'convenient'>,
+    'unique_id': '00000000-00000000-00000000-00000000_e542eef6-dba7-4c31-a52c-29e6ab9d83a5_convenient',
+    'unit_of_measurement': 'items',
+  })
+# ---
+# name: test_setup[sensor.einkauf_none_2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Einkauf None',
+      'unit_of_measurement': 'items',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.einkauf_none_2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2',
+  })
+# ---
+# name: test_setup[sensor.einkauf_none_3-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.einkauf_none_3',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'bring',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': <BringSensor.DISCOUNTED: 'discounted'>,
+    'unique_id': '00000000-00000000-00000000-00000000_e542eef6-dba7-4c31-a52c-29e6ab9d83a5_discounted',
+    'unit_of_measurement': 'items',
+  })
+# ---
+# name: test_setup[sensor.einkauf_none_3-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Einkauf None',
+      'unit_of_measurement': 'items',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.einkauf_none_3',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2',
+  })
+# ---
+# name: test_setup[sensor.einkauf_none_4-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'de-at',
+        'de-ch',
+        'de-de',
+        'en-au',
+        'en-ca',
+        'en-gb',
+        'en-us',
+        'es-es',
+        'fr-ch',
+        'fr-fr',
+        'hu-hu',
+        'it-ch',
+        'it-it',
+        'nb-no',
+        'nl-nl',
+        'pl-pl',
+        'pt-br',
+        'ru-ru',
+        'sv-se',
+        'tr-tr',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.einkauf_none_4',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'bring',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': <BringSensor.LIST_LANGUAGE: 'list_language'>,
+    'unique_id': '00000000-00000000-00000000-00000000_e542eef6-dba7-4c31-a52c-29e6ab9d83a5_list_language',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup[sensor.einkauf_none_4-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'enum',
+      'friendly_name': 'Einkauf None',
+      'options': list([
+        'de-at',
+        'de-ch',
+        'de-de',
+        'en-au',
+        'en-ca',
+        'en-gb',
+        'en-us',
+        'es-es',
+        'fr-ch',
+        'fr-fr',
+        'hu-hu',
+        'it-ch',
+        'it-it',
+        'nb-no',
+        'nl-nl',
+        'pl-pl',
+        'pt-br',
+        'ru-ru',
+        'sv-se',
+        'tr-tr',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.einkauf_none_4',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'de-de',
   })
 # ---
 # name: test_setup[sensor.einkauf_on_occasion-entry]

--- a/tests/components/bring/snapshots/test_sensor.ambr
+++ b/tests/components/bring/snapshots/test_sensor.ambr
@@ -29,14 +29,14 @@
     'supported_features': 0,
     'translation_key': <BringSensor.DISCOUNTED: 'discounted'>,
     'unique_id': '00000000-00000000-00000000-00000000_b4776778-7f6c-496e-951b-92a35d3db0dd_discounted',
-    'unit_of_measurement': 'Items',
+    'unit_of_measurement': 'items',
   })
 # ---
 # name: test_setup[sensor.baumarkt_discount_only-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Baumarkt Discount only',
-      'unit_of_measurement': 'Items',
+      'unit_of_measurement': 'items',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.baumarkt_discount_only',
@@ -44,331 +44,6 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '2',
-  })
-# ---
-# name: test_setup[sensor.baumarkt_language-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': dict({
-      'options': list([
-        'de-AT',
-        'de-CH',
-        'de-DE',
-        'en-AU',
-        'en-CA',
-        'en-GB',
-        'en-US',
-        'es-ES',
-        'fr-CH',
-        'fr-FR',
-        'hu-HU',
-        'it-CH',
-        'it-IT',
-        'nb-NO',
-        'nl-NL',
-        'pl-PL',
-        'pt-BR',
-        'ru-RU',
-        'sv-SE',
-        'tr-TR',
-      ]),
-    }),
-    'config_entry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.baumarkt_language',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
-    'original_icon': None,
-    'original_name': 'Language',
-    'platform': 'bring',
-    'previous_unique_id': None,
-    'supported_features': 0,
-    'translation_key': <BringSensor.LIST_LANGUAGE: 'list_language'>,
-    'unique_id': '00000000-00000000-00000000-00000000_b4776778-7f6c-496e-951b-92a35d3db0dd_list_language',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_setup[sensor.baumarkt_language-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'enum',
-      'friendly_name': 'Baumarkt Language',
-      'options': list([
-        'de-AT',
-        'de-CH',
-        'de-DE',
-        'en-AU',
-        'en-CA',
-        'en-GB',
-        'en-US',
-        'es-ES',
-        'fr-CH',
-        'fr-FR',
-        'hu-HU',
-        'it-CH',
-        'it-IT',
-        'nb-NO',
-        'nl-NL',
-        'pl-PL',
-        'pt-BR',
-        'ru-RU',
-        'sv-SE',
-        'tr-TR',
-      ]),
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.baumarkt_language',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'en-US',
-  })
-# ---
-# name: test_setup[sensor.baumarkt_none-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.baumarkt_none',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': None,
-    'platform': 'bring',
-    'previous_unique_id': None,
-    'supported_features': 0,
-    'translation_key': <BringSensor.URGENT: 'urgent'>,
-    'unique_id': '00000000-00000000-00000000-00000000_b4776778-7f6c-496e-951b-92a35d3db0dd_urgent',
-    'unit_of_measurement': 'items',
-  })
-# ---
-# name: test_setup[sensor.baumarkt_none-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Baumarkt None',
-      'unit_of_measurement': 'items',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.baumarkt_none',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '2',
-  })
-# ---
-# name: test_setup[sensor.baumarkt_none_2-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.baumarkt_none_2',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': None,
-    'platform': 'bring',
-    'previous_unique_id': None,
-    'supported_features': 0,
-    'translation_key': <BringSensor.CONVENIENT: 'convenient'>,
-    'unique_id': '00000000-00000000-00000000-00000000_b4776778-7f6c-496e-951b-92a35d3db0dd_convenient',
-    'unit_of_measurement': 'items',
-  })
-# ---
-# name: test_setup[sensor.baumarkt_none_2-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Baumarkt None',
-      'unit_of_measurement': 'items',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.baumarkt_none_2',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '2',
-  })
-# ---
-# name: test_setup[sensor.baumarkt_none_3-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.baumarkt_none_3',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': None,
-    'platform': 'bring',
-    'previous_unique_id': None,
-    'supported_features': 0,
-    'translation_key': <BringSensor.DISCOUNTED: 'discounted'>,
-    'unique_id': '00000000-00000000-00000000-00000000_b4776778-7f6c-496e-951b-92a35d3db0dd_discounted',
-    'unit_of_measurement': 'items',
-  })
-# ---
-# name: test_setup[sensor.baumarkt_none_3-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Baumarkt None',
-      'unit_of_measurement': 'items',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.baumarkt_none_3',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '2',
-  })
-# ---
-# name: test_setup[sensor.baumarkt_none_4-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': dict({
-      'options': list([
-        'de-at',
-        'de-ch',
-        'de-de',
-        'en-au',
-        'en-ca',
-        'en-gb',
-        'en-us',
-        'es-es',
-        'fr-ch',
-        'fr-fr',
-        'hu-hu',
-        'it-ch',
-        'it-it',
-        'nb-no',
-        'nl-nl',
-        'pl-pl',
-        'pt-br',
-        'ru-ru',
-        'sv-se',
-        'tr-tr',
-      ]),
-    }),
-    'config_entry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.baumarkt_none_4',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
-    'original_icon': None,
-    'original_name': None,
-    'platform': 'bring',
-    'previous_unique_id': None,
-    'supported_features': 0,
-    'translation_key': <BringSensor.LIST_LANGUAGE: 'list_language'>,
-    'unique_id': '00000000-00000000-00000000-00000000_b4776778-7f6c-496e-951b-92a35d3db0dd_list_language',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_setup[sensor.baumarkt_none_4-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'enum',
-      'friendly_name': 'Baumarkt None',
-      'options': list([
-        'de-at',
-        'de-ch',
-        'de-de',
-        'en-au',
-        'en-ca',
-        'en-gb',
-        'en-us',
-        'es-es',
-        'fr-ch',
-        'fr-fr',
-        'hu-hu',
-        'it-ch',
-        'it-it',
-        'nb-no',
-        'nl-nl',
-        'pl-pl',
-        'pt-br',
-        'ru-ru',
-        'sv-se',
-        'tr-tr',
-      ]),
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.baumarkt_none_4',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'en-us',
   })
 # ---
 # name: test_setup[sensor.baumarkt_on_occasion-entry]
@@ -401,14 +76,14 @@
     'supported_features': 0,
     'translation_key': <BringSensor.CONVENIENT: 'convenient'>,
     'unique_id': '00000000-00000000-00000000-00000000_b4776778-7f6c-496e-951b-92a35d3db0dd_convenient',
-    'unit_of_measurement': 'Items',
+    'unit_of_measurement': 'items',
   })
 # ---
 # name: test_setup[sensor.baumarkt_on_occasion-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Baumarkt On occasion',
-      'unit_of_measurement': 'Items',
+      'unit_of_measurement': 'items',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.baumarkt_on_occasion',
@@ -540,14 +215,14 @@
     'supported_features': 0,
     'translation_key': <BringSensor.URGENT: 'urgent'>,
     'unique_id': '00000000-00000000-00000000-00000000_b4776778-7f6c-496e-951b-92a35d3db0dd_urgent',
-    'unit_of_measurement': 'Items',
+    'unit_of_measurement': 'items',
   })
 # ---
 # name: test_setup[sensor.baumarkt_urgent-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Baumarkt Urgent',
-      'unit_of_measurement': 'Items',
+      'unit_of_measurement': 'items',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.baumarkt_urgent',
@@ -587,14 +262,14 @@
     'supported_features': 0,
     'translation_key': <BringSensor.DISCOUNTED: 'discounted'>,
     'unique_id': '00000000-00000000-00000000-00000000_e542eef6-dba7-4c31-a52c-29e6ab9d83a5_discounted',
-    'unit_of_measurement': 'Items',
+    'unit_of_measurement': 'items',
   })
 # ---
 # name: test_setup[sensor.einkauf_discount_only-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Einkauf Discount only',
-      'unit_of_measurement': 'Items',
+      'unit_of_measurement': 'items',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.einkauf_discount_only',
@@ -602,331 +277,6 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '2',
-  })
-# ---
-# name: test_setup[sensor.einkauf_language-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': dict({
-      'options': list([
-        'de-AT',
-        'de-CH',
-        'de-DE',
-        'en-AU',
-        'en-CA',
-        'en-GB',
-        'en-US',
-        'es-ES',
-        'fr-CH',
-        'fr-FR',
-        'hu-HU',
-        'it-CH',
-        'it-IT',
-        'nb-NO',
-        'nl-NL',
-        'pl-PL',
-        'pt-BR',
-        'ru-RU',
-        'sv-SE',
-        'tr-TR',
-      ]),
-    }),
-    'config_entry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.einkauf_language',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
-    'original_icon': None,
-    'original_name': 'Language',
-    'platform': 'bring',
-    'previous_unique_id': None,
-    'supported_features': 0,
-    'translation_key': <BringSensor.LIST_LANGUAGE: 'list_language'>,
-    'unique_id': '00000000-00000000-00000000-00000000_e542eef6-dba7-4c31-a52c-29e6ab9d83a5_list_language',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_setup[sensor.einkauf_language-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'enum',
-      'friendly_name': 'Einkauf Language',
-      'options': list([
-        'de-AT',
-        'de-CH',
-        'de-DE',
-        'en-AU',
-        'en-CA',
-        'en-GB',
-        'en-US',
-        'es-ES',
-        'fr-CH',
-        'fr-FR',
-        'hu-HU',
-        'it-CH',
-        'it-IT',
-        'nb-NO',
-        'nl-NL',
-        'pl-PL',
-        'pt-BR',
-        'ru-RU',
-        'sv-SE',
-        'tr-TR',
-      ]),
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.einkauf_language',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'de-DE',
-  })
-# ---
-# name: test_setup[sensor.einkauf_none-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.einkauf_none',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': None,
-    'platform': 'bring',
-    'previous_unique_id': None,
-    'supported_features': 0,
-    'translation_key': <BringSensor.URGENT: 'urgent'>,
-    'unique_id': '00000000-00000000-00000000-00000000_e542eef6-dba7-4c31-a52c-29e6ab9d83a5_urgent',
-    'unit_of_measurement': 'items',
-  })
-# ---
-# name: test_setup[sensor.einkauf_none-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Einkauf None',
-      'unit_of_measurement': 'items',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.einkauf_none',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '2',
-  })
-# ---
-# name: test_setup[sensor.einkauf_none_2-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.einkauf_none_2',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': None,
-    'platform': 'bring',
-    'previous_unique_id': None,
-    'supported_features': 0,
-    'translation_key': <BringSensor.CONVENIENT: 'convenient'>,
-    'unique_id': '00000000-00000000-00000000-00000000_e542eef6-dba7-4c31-a52c-29e6ab9d83a5_convenient',
-    'unit_of_measurement': 'items',
-  })
-# ---
-# name: test_setup[sensor.einkauf_none_2-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Einkauf None',
-      'unit_of_measurement': 'items',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.einkauf_none_2',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '2',
-  })
-# ---
-# name: test_setup[sensor.einkauf_none_3-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.einkauf_none_3',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': None,
-    'platform': 'bring',
-    'previous_unique_id': None,
-    'supported_features': 0,
-    'translation_key': <BringSensor.DISCOUNTED: 'discounted'>,
-    'unique_id': '00000000-00000000-00000000-00000000_e542eef6-dba7-4c31-a52c-29e6ab9d83a5_discounted',
-    'unit_of_measurement': 'items',
-  })
-# ---
-# name: test_setup[sensor.einkauf_none_3-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Einkauf None',
-      'unit_of_measurement': 'items',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.einkauf_none_3',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '2',
-  })
-# ---
-# name: test_setup[sensor.einkauf_none_4-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': dict({
-      'options': list([
-        'de-at',
-        'de-ch',
-        'de-de',
-        'en-au',
-        'en-ca',
-        'en-gb',
-        'en-us',
-        'es-es',
-        'fr-ch',
-        'fr-fr',
-        'hu-hu',
-        'it-ch',
-        'it-it',
-        'nb-no',
-        'nl-nl',
-        'pl-pl',
-        'pt-br',
-        'ru-ru',
-        'sv-se',
-        'tr-tr',
-      ]),
-    }),
-    'config_entry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.einkauf_none_4',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
-    'original_icon': None,
-    'original_name': None,
-    'platform': 'bring',
-    'previous_unique_id': None,
-    'supported_features': 0,
-    'translation_key': <BringSensor.LIST_LANGUAGE: 'list_language'>,
-    'unique_id': '00000000-00000000-00000000-00000000_e542eef6-dba7-4c31-a52c-29e6ab9d83a5_list_language',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_setup[sensor.einkauf_none_4-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'enum',
-      'friendly_name': 'Einkauf None',
-      'options': list([
-        'de-at',
-        'de-ch',
-        'de-de',
-        'en-au',
-        'en-ca',
-        'en-gb',
-        'en-us',
-        'es-es',
-        'fr-ch',
-        'fr-fr',
-        'hu-hu',
-        'it-ch',
-        'it-it',
-        'nb-no',
-        'nl-nl',
-        'pl-pl',
-        'pt-br',
-        'ru-ru',
-        'sv-se',
-        'tr-tr',
-      ]),
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.einkauf_none_4',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'de-de',
   })
 # ---
 # name: test_setup[sensor.einkauf_on_occasion-entry]
@@ -959,14 +309,14 @@
     'supported_features': 0,
     'translation_key': <BringSensor.CONVENIENT: 'convenient'>,
     'unique_id': '00000000-00000000-00000000-00000000_e542eef6-dba7-4c31-a52c-29e6ab9d83a5_convenient',
-    'unit_of_measurement': 'Items',
+    'unit_of_measurement': 'items',
   })
 # ---
 # name: test_setup[sensor.einkauf_on_occasion-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Einkauf On occasion',
-      'unit_of_measurement': 'Items',
+      'unit_of_measurement': 'items',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.einkauf_on_occasion',
@@ -1098,14 +448,14 @@
     'supported_features': 0,
     'translation_key': <BringSensor.URGENT: 'urgent'>,
     'unique_id': '00000000-00000000-00000000-00000000_e542eef6-dba7-4c31-a52c-29e6ab9d83a5_urgent',
-    'unit_of_measurement': 'Items',
+    'unit_of_measurement': 'items',
   })
 # ---
 # name: test_setup[sensor.einkauf_urgent-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Einkauf Urgent',
-      'unit_of_measurement': 'Items',
+      'unit_of_measurement': 'items',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.einkauf_urgent',

--- a/tests/components/bring/snapshots/test_sensor.ambr
+++ b/tests/components/bring/snapshots/test_sensor.ambr
@@ -1,0 +1,461 @@
+# serializer version: 1
+# name: test_setup[sensor.baumarkt_discount_only-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.baumarkt_discount_only',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Discount only',
+    'platform': 'bring',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': <BringSensor.DISCOUNTED: 'discounted'>,
+    'unique_id': '00000000-00000000-00000000-00000000_b4776778-7f6c-496e-951b-92a35d3db0dd_discounted',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup[sensor.baumarkt_discount_only-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Baumarkt Discount only',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.baumarkt_discount_only',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2',
+  })
+# ---
+# name: test_setup[sensor.baumarkt_language-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'de-AT',
+        'de-CH',
+        'de-DE',
+        'en-AU',
+        'en-CA',
+        'en-GB',
+        'en-US',
+        'es-ES',
+        'fr-CH',
+        'fr-FR',
+        'hu-HU',
+        'it-CH',
+        'it-IT',
+        'nb-NO',
+        'nl-NL',
+        'pl-PL',
+        'pt-BR',
+        'ru-RU',
+        'sv-SE',
+        'tr-TR',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.baumarkt_language',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': 'Language',
+    'platform': 'bring',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': <BringSensor.LIST_LANGUAGE: 'list_language'>,
+    'unique_id': '00000000-00000000-00000000-00000000_b4776778-7f6c-496e-951b-92a35d3db0dd_list_language',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup[sensor.baumarkt_language-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'enum',
+      'friendly_name': 'Baumarkt Language',
+      'options': list([
+        'de-AT',
+        'de-CH',
+        'de-DE',
+        'en-AU',
+        'en-CA',
+        'en-GB',
+        'en-US',
+        'es-ES',
+        'fr-CH',
+        'fr-FR',
+        'hu-HU',
+        'it-CH',
+        'it-IT',
+        'nb-NO',
+        'nl-NL',
+        'pl-PL',
+        'pt-BR',
+        'ru-RU',
+        'sv-SE',
+        'tr-TR',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.baumarkt_language',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'en-US',
+  })
+# ---
+# name: test_setup[sensor.baumarkt_on_occasion-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.baumarkt_on_occasion',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'On occasion',
+    'platform': 'bring',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': <BringSensor.CONVENIENT: 'convenient'>,
+    'unique_id': '00000000-00000000-00000000-00000000_b4776778-7f6c-496e-951b-92a35d3db0dd_convenient',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup[sensor.baumarkt_on_occasion-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Baumarkt On occasion',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.baumarkt_on_occasion',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2',
+  })
+# ---
+# name: test_setup[sensor.baumarkt_urgent-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.baumarkt_urgent',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Urgent',
+    'platform': 'bring',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': <BringSensor.URGENT: 'urgent'>,
+    'unique_id': '00000000-00000000-00000000-00000000_b4776778-7f6c-496e-951b-92a35d3db0dd_urgent',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup[sensor.baumarkt_urgent-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Baumarkt Urgent',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.baumarkt_urgent',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2',
+  })
+# ---
+# name: test_setup[sensor.einkauf_discount_only-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.einkauf_discount_only',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Discount only',
+    'platform': 'bring',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': <BringSensor.DISCOUNTED: 'discounted'>,
+    'unique_id': '00000000-00000000-00000000-00000000_e542eef6-dba7-4c31-a52c-29e6ab9d83a5_discounted',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup[sensor.einkauf_discount_only-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Einkauf Discount only',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.einkauf_discount_only',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2',
+  })
+# ---
+# name: test_setup[sensor.einkauf_language-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'de-AT',
+        'de-CH',
+        'de-DE',
+        'en-AU',
+        'en-CA',
+        'en-GB',
+        'en-US',
+        'es-ES',
+        'fr-CH',
+        'fr-FR',
+        'hu-HU',
+        'it-CH',
+        'it-IT',
+        'nb-NO',
+        'nl-NL',
+        'pl-PL',
+        'pt-BR',
+        'ru-RU',
+        'sv-SE',
+        'tr-TR',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.einkauf_language',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': 'Language',
+    'platform': 'bring',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': <BringSensor.LIST_LANGUAGE: 'list_language'>,
+    'unique_id': '00000000-00000000-00000000-00000000_e542eef6-dba7-4c31-a52c-29e6ab9d83a5_list_language',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup[sensor.einkauf_language-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'enum',
+      'friendly_name': 'Einkauf Language',
+      'options': list([
+        'de-AT',
+        'de-CH',
+        'de-DE',
+        'en-AU',
+        'en-CA',
+        'en-GB',
+        'en-US',
+        'es-ES',
+        'fr-CH',
+        'fr-FR',
+        'hu-HU',
+        'it-CH',
+        'it-IT',
+        'nb-NO',
+        'nl-NL',
+        'pl-PL',
+        'pt-BR',
+        'ru-RU',
+        'sv-SE',
+        'tr-TR',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.einkauf_language',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'de-DE',
+  })
+# ---
+# name: test_setup[sensor.einkauf_on_occasion-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.einkauf_on_occasion',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'On occasion',
+    'platform': 'bring',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': <BringSensor.CONVENIENT: 'convenient'>,
+    'unique_id': '00000000-00000000-00000000-00000000_e542eef6-dba7-4c31-a52c-29e6ab9d83a5_convenient',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup[sensor.einkauf_on_occasion-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Einkauf On occasion',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.einkauf_on_occasion',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2',
+  })
+# ---
+# name: test_setup[sensor.einkauf_urgent-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.einkauf_urgent',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Urgent',
+    'platform': 'bring',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': <BringSensor.URGENT: 'urgent'>,
+    'unique_id': '00000000-00000000-00000000-00000000_e542eef6-dba7-4c31-a52c-29e6ab9d83a5_urgent',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup[sensor.einkauf_urgent-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Einkauf Urgent',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.einkauf_urgent',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2',
+  })
+# ---

--- a/tests/components/bring/snapshots/test_sensor.ambr
+++ b/tests/components/bring/snapshots/test_sensor.ambr
@@ -183,6 +183,98 @@
     'state': '2',
   })
 # ---
+# name: test_setup[sensor.baumarkt_region_language-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'de-at',
+        'de-ch',
+        'de-de',
+        'en-au',
+        'en-ca',
+        'en-gb',
+        'en-us',
+        'es-es',
+        'fr-ch',
+        'fr-fr',
+        'hu-hu',
+        'it-ch',
+        'it-it',
+        'nb-no',
+        'nl-nl',
+        'pl-pl',
+        'pt-br',
+        'ru-ru',
+        'sv-se',
+        'tr-tr',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.baumarkt_region_language',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': 'Region & language',
+    'platform': 'bring',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': <BringSensor.LIST_LANGUAGE: 'list_language'>,
+    'unique_id': '00000000-00000000-00000000-00000000_b4776778-7f6c-496e-951b-92a35d3db0dd_list_language',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup[sensor.baumarkt_region_language-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'enum',
+      'friendly_name': 'Baumarkt Region & language',
+      'options': list([
+        'de-at',
+        'de-ch',
+        'de-de',
+        'en-au',
+        'en-ca',
+        'en-gb',
+        'en-us',
+        'es-es',
+        'fr-ch',
+        'fr-fr',
+        'hu-hu',
+        'it-ch',
+        'it-it',
+        'nb-no',
+        'nl-nl',
+        'pl-pl',
+        'pt-br',
+        'ru-ru',
+        'sv-se',
+        'tr-tr',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.baumarkt_region_language',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'en-us',
+  })
+# ---
 # name: test_setup[sensor.baumarkt_urgent-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -411,6 +503,98 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '2',
+  })
+# ---
+# name: test_setup[sensor.einkauf_region_language-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'de-at',
+        'de-ch',
+        'de-de',
+        'en-au',
+        'en-ca',
+        'en-gb',
+        'en-us',
+        'es-es',
+        'fr-ch',
+        'fr-fr',
+        'hu-hu',
+        'it-ch',
+        'it-it',
+        'nb-no',
+        'nl-nl',
+        'pl-pl',
+        'pt-br',
+        'ru-ru',
+        'sv-se',
+        'tr-tr',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.einkauf_region_language',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': 'Region & language',
+    'platform': 'bring',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': <BringSensor.LIST_LANGUAGE: 'list_language'>,
+    'unique_id': '00000000-00000000-00000000-00000000_e542eef6-dba7-4c31-a52c-29e6ab9d83a5_list_language',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup[sensor.einkauf_region_language-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'enum',
+      'friendly_name': 'Einkauf Region & language',
+      'options': list([
+        'de-at',
+        'de-ch',
+        'de-de',
+        'en-au',
+        'en-ca',
+        'en-gb',
+        'en-us',
+        'es-es',
+        'fr-ch',
+        'fr-fr',
+        'hu-hu',
+        'it-ch',
+        'it-it',
+        'nb-no',
+        'nl-nl',
+        'pl-pl',
+        'pt-br',
+        'ru-ru',
+        'sv-se',
+        'tr-tr',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.einkauf_region_language',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'de-de',
   })
 # ---
 # name: test_setup[sensor.einkauf_urgent-entry]

--- a/tests/components/bring/test_init.py
+++ b/tests/components/bring/test_init.py
@@ -90,7 +90,14 @@ async def test_init_exceptions(
 
 
 @pytest.mark.parametrize("exception", [BringRequestException, BringParseException])
-@pytest.mark.parametrize("bring_method", ["load_lists", "get_list"])
+@pytest.mark.parametrize(
+    "bring_method",
+    [
+        "load_lists",
+        "get_list",
+        "get_all_user_settings",
+    ],
+)
 async def test_config_entry_not_ready(
     hass: HomeAssistant,
     bring_config_entry: MockConfigEntry,

--- a/tests/components/bring/test_sensor.py
+++ b/tests/components/bring/test_sensor.py
@@ -1,0 +1,44 @@
+"""Test for sensor platform of the Bring! integration."""
+
+from collections.abc import Generator
+from unittest.mock import patch
+
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+
+@pytest.fixture(autouse=True)
+def sensor_only() -> Generator[None]:
+    """Enable only the sensor platform."""
+    with patch(
+        "homeassistant.components.bring.PLATFORMS",
+        [Platform.SENSOR],
+    ):
+        yield
+
+
+@pytest.mark.usefixtures("mock_bring_client")
+async def test_setup(
+    hass: HomeAssistant,
+    bring_config_entry: MockConfigEntry,
+    snapshot: SnapshotAssertion,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Snapshot test states of sensor platform."""
+
+    bring_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(bring_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert bring_config_entry.state is ConfigEntryState.LOADED
+
+    await snapshot_platform(
+        hass, entity_registry, snapshot, bring_config_entry.entry_id
+    )

--- a/tests/components/bring/test_todo.py
+++ b/tests/components/bring/test_todo.py
@@ -1,7 +1,8 @@
 """Test for todo platform of the Bring! integration."""
 
+from collections.abc import Generator
 import re
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 from bring_api import BringItemOperation, BringRequestException
 import pytest
@@ -15,12 +16,22 @@ from homeassistant.components.todo import (
     TodoServices,
 )
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 
 from tests.common import MockConfigEntry, snapshot_platform
+
+
+@pytest.fixture(autouse=True)
+def todo_only() -> Generator[None]:
+    """Enable only the todo platform."""
+    with patch(
+        "homeassistant.components.bring.PLATFORMS",
+        [Platform.TODO],
+    ):
+        yield
 
 
 @pytest.mark.usefixtures("mock_bring_client")

--- a/tests/components/bring/test_util.py
+++ b/tests/components/bring/test_util.py
@@ -1,0 +1,56 @@
+"""Test for utility functions of the Bring! integration."""
+
+from typing import cast
+
+from bring_api import BringUserSettingsResponse
+import pytest
+
+from homeassistant.components.bring import DOMAIN
+from homeassistant.components.bring.coordinator import BringData
+from homeassistant.components.bring.util import list_language, sum_attributes
+
+from tests.common import load_json_object_fixture
+
+
+@pytest.mark.parametrize(
+    ("list_uuid", "expected"),
+    [
+        ("e542eef6-dba7-4c31-a52c-29e6ab9d83a5", "de-DE"),
+        ("b4776778-7f6c-496e-951b-92a35d3db0dd", "en-US"),
+        ("00000000-0000-0000-0000-00000000", None),
+    ],
+)
+def test_list_language(list_uuid: str, expected: str | None) -> None:
+    """Test function list_language."""
+
+    result = list_language(
+        list_uuid,
+        cast(
+            BringUserSettingsResponse,
+            load_json_object_fixture("usersettings.json", DOMAIN),
+        ),
+    )
+
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    ("attribute", "expected"),
+    [
+        ("urgent", 2),
+        ("convenient", 2),
+        ("discounted", 2),
+    ],
+)
+def test_sum_attributes(attribute: str, expected: int) -> None:
+    """Test function sum_attributes."""
+
+    result = sum_attributes(
+        cast(
+            BringData,
+            load_json_object_fixture("items.json", DOMAIN),
+        ),
+        attribute,
+    )
+
+    assert result == expected


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


Adds the sensor platform and 4 sensors to the Bring integration.

Adds support for a new feature in the Bring app, items on the list can be marked with 3 attributes. 3 sensors display the number of items marked with these attributes on the list. Can be used for example for sending notifications if an item was marked as urgent.

The last sensor is for diagnostics, it shows the language of the shopping list that was configured in the app.

P.S.: Coderabbit suggests renaming the sensor `On occasion` to `Occasionally` or `Non-urgent`. I didn't use some of the english translations used in the Bring app, because I think they are not good, but also I'm not a native english speaker, so some feedback would be  welcome.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/34898

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
