### PR TITLE
Bump aioautomower to 2024.9.2

### DIFF
--- a/homeassistant/components/husqvarna_automower/calendar.py
+++ b/homeassistant/components/husqvarna_automower/calendar.py
@@ -7,7 +7,6 @@ from aioautomower.model import make_name_string
 
 from homeassistant.components.calendar import CalendarEntity, CalendarEvent
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util import dt as dt_util
 
@@ -49,8 +48,6 @@ class AutomowerCalendarEntity(AutomowerBaseEntity, CalendarEntity):
     def event(self) -> CalendarEvent | None:
         """Return the current or next upcoming event."""
         schedule = self.mower_attributes.calendar
-        if schedule.timeline is None:
-            return None
         cursor = schedule.timeline.active_after(dt_util.now())
         program_event = next(cursor, None)
         _LOGGER.debug("program_event %s", program_event)
@@ -76,8 +73,6 @@ class AutomowerCalendarEntity(AutomowerBaseEntity, CalendarEntity):
         This is only called when opening the calendar in the UI.
         """
         schedule = self.mower_attributes.calendar
-        if schedule.timeline is None:
-            raise HomeAssistantError("Unable to get events: No schedule set")
         cursor = schedule.timeline.overlapping(
             start_date,
             end_date,

--- a/homeassistant/components/husqvarna_automower/device_tracker.py
+++ b/homeassistant/components/husqvarna_automower/device_tracker.py
@@ -1,7 +1,5 @@
 """Creates the device tracker entity for the mower."""
 
-from typing import TYPE_CHECKING
-
 from homeassistant.components.device_tracker import SourceType, TrackerEntity
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -47,13 +45,9 @@ class AutomowerDeviceTrackerEntity(AutomowerBaseEntity, TrackerEntity):
     @property
     def latitude(self) -> float:
         """Return latitude value of the device."""
-        if TYPE_CHECKING:
-            assert self.mower_attributes.positions is not None
         return self.mower_attributes.positions[0].latitude
 
     @property
     def longitude(self) -> float:
         """Return longitude value of the device."""
-        if TYPE_CHECKING:
-            assert self.mower_attributes.positions is not None
         return self.mower_attributes.positions[0].longitude

--- a/homeassistant/components/husqvarna_automower/manifest.json
+++ b/homeassistant/components/husqvarna_automower/manifest.json
@@ -7,5 +7,5 @@
   "documentation": "https://www.home-assistant.io/integrations/husqvarna_automower",
   "iot_class": "cloud_push",
   "loggers": ["aioautomower"],
-  "requirements": ["aioautomower==2024.9.1"]
+  "requirements": ["aioautomower==2024.9.2"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -198,7 +198,7 @@ aioaseko==1.0.0
 aioasuswrt==1.4.0
 
 # homeassistant.components.husqvarna_automower
-aioautomower==2024.9.1
+aioautomower==2024.9.2
 
 # homeassistant.components.azure_devops
 aioazuredevops==2.2.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -186,7 +186,7 @@ aioaseko==1.0.0
 aioasuswrt==1.4.0
 
 # homeassistant.components.husqvarna_automower
-aioautomower==2024.9.1
+aioautomower==2024.9.2
 
 # homeassistant.components.azure_devops
 aioazuredevops==2.2.1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Diff: https://github.com/Thomas55555/aioautomower/compare/2024.9.1...2024.9.2
RN: https://github.com/Thomas55555/aioautomower/releases/tag/2024.9.2

Improves typing and fixes an issue with the current active work area. Background: Active work area is only submitted by polling, so it has to be filtered out in the websocket message.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #125449
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
