### PR TITLE
Add RSS description to Feedreader event

### DIFF
--- a/homeassistant/components/feedreader/event.py
+++ b/homeassistant/components/feedreader/event.py
@@ -19,6 +19,7 @@ from .coordinator import FeedReaderCoordinator
 LOGGER = logging.getLogger(__name__)
 
 ATTR_CONTENT = "content"
+ATTR_DESCRIPTION = "description"
 ATTR_LINK = "link"
 ATTR_TITLE = "title"
 
@@ -40,7 +41,9 @@ class FeedReaderEvent(CoordinatorEntity[FeedReaderCoordinator], EventEntity):
     _attr_event_types = [EVENT_FEEDREADER]
     _attr_name = None
     _attr_has_entity_name = True
-    _unrecorded_attributes = frozenset({ATTR_CONTENT, ATTR_TITLE, ATTR_LINK})
+    _unrecorded_attributes = frozenset(
+        {ATTR_CONTENT, ATTR_DESCRIPTION, ATTR_TITLE, ATTR_LINK}
+    )
     coordinator: FeedReaderCoordinator
 
     def __init__(self, coordinator: FeedReaderCoordinator) -> None:
@@ -80,6 +83,7 @@ class FeedReaderEvent(CoordinatorEntity[FeedReaderCoordinator], EventEntity):
         self._trigger_event(
             EVENT_FEEDREADER,
             {
+                ATTR_DESCRIPTION: feed_data.get("description"),
                 ATTR_TITLE: feed_data.get("title"),
                 ATTR_LINK: feed_data.get("link"),
                 ATTR_CONTENT: content,

--- a/tests/components/feedreader/test_event.py
+++ b/tests/components/feedreader/test_event.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 from homeassistant.components.feedreader.event import (
     ATTR_CONTENT,
+    ATTR_DESCRIPTION,
     ATTR_LINK,
     ATTR_TITLE,
 )
@@ -35,6 +36,7 @@ async def test_event_entity(
         assert state.attributes[ATTR_TITLE] == "Title 1"
         assert state.attributes[ATTR_LINK] == "http://www.example.com/link/1"
         assert state.attributes[ATTR_CONTENT] == "Content 1"
+        assert state.attributes[ATTR_DESCRIPTION] == "Description 1"
 
         future = dt_util.utcnow() + timedelta(hours=1, seconds=1)
         async_fire_time_changed(hass, future)
@@ -45,6 +47,7 @@ async def test_event_entity(
         assert state.attributes[ATTR_TITLE] == "Title 2"
         assert state.attributes[ATTR_LINK] == "http://www.example.com/link/2"
         assert state.attributes[ATTR_CONTENT] == "Content 2"
+        assert state.attributes[ATTR_DESCRIPTION] == "Description 2"
 
         future = dt_util.utcnow() + timedelta(hours=2, seconds=2)
         async_fire_time_changed(hass, future)
@@ -55,3 +58,4 @@ async def test_event_entity(
         assert state.attributes[ATTR_TITLE] == "Title 1"
         assert state.attributes[ATTR_LINK] == "http://www.example.com/link/1"
         assert state.attributes[ATTR_CONTENT] == "This is a summary"
+        assert state.attributes[ATTR_DESCRIPTION] == "Description 1"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

The Feedreader event entity does not expose the "description" field, while it is a required element according RSS standard.
This PR adds this

Relevant spec: https://www.rssboard.org/rss-specification#requiredChannelElements

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
