### PR TITLE
Add pylint checks for fixture scope

### DIFF
--- a/pylint/plugins/hass_decorator.py
+++ b/pylint/plugins/hass_decorator.py
@@ -27,9 +27,10 @@ class HassDecoratorChecker(BaseChecker):
 
     def _get_pytest_fixture_node(self, node: nodes.FunctionDef) -> nodes.Call | None:
         for decorator in node.decorators.nodes:
-            if not isinstance(decorator, nodes.Call):
-                pass
-            if decorator.func.as_string() == "pytest.fixture":
+            if (
+                isinstance(decorator, nodes.Call)
+                and decorator.func.as_string() == "pytest.fixture"
+            ):
                 return decorator
 
         return None

--- a/pylint/plugins/hass_decorator.py
+++ b/pylint/plugins/hass_decorator.py
@@ -18,14 +18,56 @@ class HassDecoratorChecker(BaseChecker):
             "hass-async-callback-decorator",
             "Used when a coroutine function has an invalid @callback decorator",
         ),
+        "W7472": (
+            "Fixture %s is invalid here, please use %s",
+            "hass-pytest-fixture-decorator",
+            "Used when a pytest fixture is invalid",
+        ),
     }
+
+    def _get_pytest_fixture_node(self, node: nodes.FunctionDef) -> nodes.Call | None:
+        for decorator in node.decorators.nodes:
+            if not isinstance(decorator, nodes.Call):
+                pass
+            if decorator.func.as_string() == "pytest.fixture":
+                return decorator
+
+        return None
+
+    def _check_pytest_fixture(
+        self, node: nodes.FunctionDef, decoratornames: set[str]
+    ) -> None:
+        if (
+            "_pytest.fixtures.FixtureFunctionMarker" not in decoratornames
+            or (root_name := node.root().name) == "tests.components.conftest"
+            or not root_name.startswith("tests.components.")
+            or (decorator := self._get_pytest_fixture_node(node)) is None
+        ):
+            return
+
+        for keyword in decorator.keywords:
+            if (
+                keyword.arg == "scope"
+                and isinstance(keyword.value, nodes.Const)
+                and keyword.value.value == "session"
+            ):
+                self.add_message(
+                    "hass-pytest-fixture-decorator",
+                    node=node,
+                    args=(f"scope `{keyword.value.value}`", "`package` or lower"),
+                )
 
     def visit_asyncfunctiondef(self, node: nodes.AsyncFunctionDef) -> None:
         """Apply checks on an AsyncFunctionDef node."""
-        if (
-            decoratornames := node.decoratornames()
-        ) and "homeassistant.core.callback" in decoratornames:
-            self.add_message("hass-async-callback-decorator", node=node)
+        if decoratornames := node.decoratornames():
+            if "homeassistant.core.callback" in decoratornames:
+                self.add_message("hass-async-callback-decorator", node=node)
+            self._check_pytest_fixture(node, decoratornames)
+
+    def visit_functiondef(self, node: nodes.FunctionDef) -> None:
+        """Apply checks on an AsyncFunctionDef node."""
+        if decoratornames := node.decoratornames():
+            self._check_pytest_fixture(node, decoratornames)
 
 
 def register(linter: PyLinter) -> None:

--- a/pylint/plugins/hass_decorator.py
+++ b/pylint/plugins/hass_decorator.py
@@ -50,10 +50,13 @@ class HassDecoratorChecker(BaseChecker):
             "_pytest.fixtures.FixtureFunctionMarker" not in decoratornames
             or not (root_name := node.root().name).startswith("tests.")
             or (decorator := self._get_pytest_fixture_node(node)) is None
-            or (keyword := self._get_pytest_fixture_node_keyword(decorator, "scope"))
-            is None
-            or not isinstance(keyword.value, nodes.Const)
-            or not (scope := keyword.value.value)
+            or not (
+                scope_keyword := self._get_pytest_fixture_node_keyword(
+                    decorator, "scope"
+                )
+            )
+            or not isinstance(scope_keyword.value, nodes.Const)
+            or not (scope := scope_keyword.value.value)
         ):
             return
 

--- a/pylint/plugins/hass_decorator.py
+++ b/pylint/plugins/hass_decorator.py
@@ -53,7 +53,7 @@ class HassDecoratorChecker(BaseChecker):
             ):
                 self.add_message(
                     "hass-pytest-fixture-decorator",
-                    node=node,
+                    node=decorator,
                     args=(f"scope `{keyword.value.value}`", "`package` or lower"),
                 )
 

--- a/pylint/plugins/hass_decorator.py
+++ b/pylint/plugins/hass_decorator.py
@@ -73,14 +73,13 @@ class HassDecoratorChecker(BaseChecker):
                     args=("scope `session`", "use `package` or lower"),
                 )
                 return
-            if (
-                not (
-                    autouse_keyword := self._get_pytest_fixture_node_keyword(
-                        decorator, "autouse"
-                    )
+            if not (
+                autouse_keyword := self._get_pytest_fixture_node_keyword(
+                    decorator, "autouse"
                 )
-                or not isinstance(autouse_keyword.value, nodes.Const)
-                or not autouse_keyword.value.value
+            ) or (
+                isinstance(autouse_keyword.value, nodes.Const)
+                and not autouse_keyword.value.value
             ):
                 self.add_message(
                     "hass-pytest-fixture-decorator",

--- a/pylint/plugins/hass_decorator.py
+++ b/pylint/plugins/hass_decorator.py
@@ -85,7 +85,10 @@ class HassDecoratorChecker(BaseChecker):
                 self.add_message(
                     "hass-pytest-fixture-decorator",
                     node=decorator,
-                    args=("scope/autouse combination", "set `autouse=True`"),
+                    args=(
+                        "scope/autouse combination",
+                        "set `autouse=True` or reduce scope",
+                    ),
                 )
             return
 

--- a/tests/pylint/test_decorator.py
+++ b/tests/pylint/test_decorator.py
@@ -78,6 +78,10 @@ def test_bad_callback(linter: UnittestLinter, decorator_checker: BaseChecker) ->
         ('scope="module"', "tests.components.conftest"),
         ('scope="package"', "tests.components.conftest"),
         ('scope="session", autouse=True', "tests.components.conftest"),
+        (
+            'scope="session", autouse=find_spec("zeroconf") is not None',
+            "tests.components.conftest",
+        ),
         ('scope="function"', "tests.components.pylint_tests.conftest"),
         ('scope="class"', "tests.components.pylint_tests.conftest"),
         ('scope="module"', "tests.components.pylint_tests.conftest"),

--- a/tests/pylint/test_decorator.py
+++ b/tests/pylint/test_decorator.py
@@ -8,6 +8,7 @@ from pylint.interfaces import UNDEFINED
 from pylint.testutils import MessageTest
 from pylint.testutils.unittest_linter import UnittestLinter
 from pylint.utils.ast_walker import ASTWalker
+import pytest
 
 from . import assert_adds_messages, assert_no_messages
 
@@ -59,6 +60,93 @@ def test_bad_callback(linter: UnittestLinter, decorator_checker: BaseChecker) ->
             col_offset=0,
             end_line=5,
             end_col_offset=15,
+        ),
+    ):
+        walker.walk(root_node)
+
+
+@pytest.mark.parametrize(
+    ("scope", "path"),
+    [
+        ("function", "tests.test_bootstrap"),
+        ("class", "tests.test_bootstrap"),
+        ("module", "tests.test_bootstrap"),
+        ("package", "tests.test_bootstrap"),
+        ("session", "tests.test_bootstrap"),
+        ("function", "tests.components.conftest"),
+        ("class", "tests.components.conftest"),
+        ("module", "tests.components.conftest"),
+        ("package", "tests.components.conftest"),
+        ("session", "tests.components.conftest"),
+        ("function", "tests.components.pylint_test"),
+        ("class", "tests.components.pylint_test"),
+        ("module", "tests.components.pylint_test"),
+        ("package", "tests.components.pylint_test"),
+    ],
+)
+def test_good_fixture(
+    linter: UnittestLinter, decorator_checker: BaseChecker, scope: str, path: str
+) -> None:
+    """Test good `@pytest.fixture` decorator."""
+    code = f"""
+    import pytest
+
+    @pytest.fixture
+    def setup(
+        arg1, arg2
+    ):
+        pass
+
+    @pytest.fixture(scope="{scope}")
+    def setup_session(
+        arg1, arg2
+    ):
+        pass
+    """
+
+    root_node = astroid.parse(code, path)
+    walker = ASTWalker(linter)
+    walker.add_checker(decorator_checker)
+
+    with assert_no_messages(linter):
+        walker.walk(root_node)
+
+
+def test_bad_fixture_scope(
+    linter: UnittestLinter, decorator_checker: BaseChecker
+) -> None:
+    """Test bad `@pytest.fixture` decorator."""
+    code = """
+    import pytest
+
+    @pytest.fixture
+    def setup(
+        arg1, arg2
+    ):
+        pass
+
+    @pytest.fixture(scope="session")
+    def setup_session(
+        arg1, arg2
+    ):
+        pass
+    """
+
+    root_node = astroid.parse(code, "tests.components.pylint_test")
+    walker = ASTWalker(linter)
+    walker.add_checker(decorator_checker)
+
+    with assert_adds_messages(
+        linter,
+        MessageTest(
+            msg_id="hass-pytest-fixture-decorator",
+            line=11,
+            node=root_node.body[2],
+            args=("scope `session`", "`package` or lower"),
+            confidence=UNDEFINED,
+            col_offset=0,
+            end_line=11,
+            end_col_offset=17,
         ),
     ):
         walker.walk(root_node)

--- a/tests/pylint/test_decorator.py
+++ b/tests/pylint/test_decorator.py
@@ -254,7 +254,7 @@ def test_bad_fixture_autouse(
             msg_id="hass-pytest-fixture-decorator",
             line=10,
             node=root_node.body[2].decorators.nodes[0],
-            args=("scope/autouse combination", "set `autouse=True`"),
+            args=("scope/autouse combination", "set `autouse=True` or reduce scope"),
             confidence=UNDEFINED,
             col_offset=1,
             end_line=10,

--- a/tests/pylint/test_decorator.py
+++ b/tests/pylint/test_decorator.py
@@ -140,13 +140,13 @@ def test_bad_fixture_scope(
         linter,
         MessageTest(
             msg_id="hass-pytest-fixture-decorator",
-            line=11,
-            node=root_node.body[2],
+            line=10,
+            node=root_node.body[2].decorators.nodes[0],
             args=("scope `session`", "`package` or lower"),
             confidence=UNDEFINED,
-            col_offset=0,
-            end_line=11,
-            end_col_offset=17,
+            col_offset=1,
+            end_line=10,
+            end_col_offset=32,
         ),
     ):
         walker.walk(root_node)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow-up to #116197
Based on discussion with @emontnemery on discord

Sample violation:
```console
************* Module tests.conftest
tests/conftest.py:421:1: W7472: Fixture scope/autouse combination is invalid here, please set `autouse=True` or reduce scope (hass-pytest-fixture-decorator)
************* Module tests.components.blueprint.test_importer
tests/components/blueprint/test_importer.py:17:1: W7472: Fixture scope `package` is invalid here, please use `module` or lower (hass-pytest-fixture-decorator)
************* Module tests.components.doorbird.conftest
tests/components/doorbird/conftest.py:35:1: W7472: Fixture scope `session` is invalid here, please use `package` or lower (hass-pytest-fixture-decorator)
tests/components/doorbird/conftest.py:41:1: W7472: Fixture scope `session` is invalid here, please use `package` or lower (hass-pytest-fixture-decorator)
tests/components/doorbird/conftest.py:49:1: W7472: Fixture scope `session` is invalid here, please use `package` or lower (hass-pytest-fixture-decorator)
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
