### PR TITLE
Add language selection for entity naming in WolfLink

### DIFF
--- a/homeassistant/components/wolflink/__init__.py
+++ b/homeassistant/components/wolflink/__init__.py
@@ -8,7 +8,7 @@ from wolf_comm.token_auth import InvalidAuth
 from wolf_comm.wolf_client import FetchFailed, ParameterReadError, WolfClient
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, Platform
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME,  Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
@@ -22,6 +22,7 @@ from .const import (
     DEVICE_NAME,
     DOMAIN,
     PARAMETERS,
+    LOCALE,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -37,6 +38,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     device_name = entry.data[DEVICE_NAME]
     device_id = entry.data[DEVICE_ID]
     gateway_id = entry.data[DEVICE_GATEWAY]
+    locale = entry.data[LOCALE]
     refetch_parameters = False
     _LOGGER.debug(
         "Setting up wolflink integration for device: %s (ID: %s, gateway: %s)",
@@ -50,6 +52,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         password,
         client=get_async_client(hass=hass, verify_ssl=False),
     )
+    await wolf_client.load_localized_json(locale)
 
     parameters = await fetch_parameters_init(wolf_client, gateway_id, device_id)
 

--- a/homeassistant/components/wolflink/__init__.py
+++ b/homeassistant/components/wolflink/__init__.py
@@ -8,7 +8,7 @@ from wolf_comm.token_auth import InvalidAuth
 from wolf_comm.wolf_client import FetchFailed, ParameterReadError, WolfClient
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME,  Platform
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
@@ -21,8 +21,8 @@ from .const import (
     DEVICE_ID,
     DEVICE_NAME,
     DOMAIN,
-    PARAMETERS,
     LOCALE,
+    PARAMETERS,
 )
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/wolflink/config_flow.py
+++ b/homeassistant/components/wolflink/config_flow.py
@@ -11,12 +11,12 @@ from wolf_comm.wolf_client import WolfClient
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 
-from .const import DEVICE_GATEWAY, DEVICE_ID, DEVICE_NAME, DOMAIN
+from .const import DEVICE_GATEWAY, DEVICE_ID, DEVICE_NAME, DOMAIN, LOCALE
 
 _LOGGER = logging.getLogger(__name__)
 
 USER_SCHEMA = vol.Schema(
-    {vol.Required(CONF_USERNAME): str, vol.Required(CONF_PASSWORD): str}
+    {vol.Required(CONF_USERNAME): str, vol.Required(CONF_PASSWORD): str, vol.Required(LOCALE): str}
 )
 
 
@@ -32,6 +32,7 @@ class WolfLinkConfigFlow(ConfigFlow, domain=DOMAIN):
         """Initialize with empty username and password."""
         self.username: str | None = None
         self.password: str | None = None
+        self.locale: str = "en"
 
     async def async_step_user(
         self, user_input: dict[str, str] | None = None
@@ -42,6 +43,7 @@ class WolfLinkConfigFlow(ConfigFlow, domain=DOMAIN):
             wolf_client = WolfClient(
                 user_input[CONF_USERNAME], user_input[CONF_PASSWORD]
             )
+            await wolf_client.load_localized_json(user_input[LOCALE])
             try:
                 self.fetched_systems = await wolf_client.fetch_system_list()
             except ConnectError:
@@ -54,6 +56,7 @@ class WolfLinkConfigFlow(ConfigFlow, domain=DOMAIN):
             else:
                 self.username = user_input[CONF_USERNAME]
                 self.password = user_input[CONF_PASSWORD]
+                self.locale = user_input[LOCALE]
                 return await self.async_step_device()
         return self.async_show_form(
             step_id="user", data_schema=USER_SCHEMA, errors=errors
@@ -80,6 +83,7 @@ class WolfLinkConfigFlow(ConfigFlow, domain=DOMAIN):
                     DEVICE_NAME: device_name,
                     DEVICE_GATEWAY: system[0].gateway,
                     DEVICE_ID: device_id,
+                    LOCALE: self.locale,
                 },
             )
 

--- a/homeassistant/components/wolflink/config_flow.py
+++ b/homeassistant/components/wolflink/config_flow.py
@@ -11,7 +11,7 @@ from wolf_comm.wolf_client import WolfClient
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 
-from .const import DEVICE_GATEWAY, DEVICE_ID, DEVICE_NAME, DOMAIN, LOCALE
+from .const import DEVICE_GATEWAY, DEVICE_ID, DEVICE_NAME, DOMAIN, LANGUAGE
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -19,7 +19,7 @@ USER_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_USERNAME): str,
         vol.Required(CONF_PASSWORD): str,
-        vol.Required(LOCALE): str,
+        vol.Required(LANGUAGE): str,
     }
 )
 
@@ -47,7 +47,7 @@ class WolfLinkConfigFlow(ConfigFlow, domain=DOMAIN):
             wolf_client = WolfClient(
                 user_input[CONF_USERNAME], user_input[CONF_PASSWORD]
             )
-            await wolf_client.load_localized_json(user_input[LOCALE])
+            await wolf_client.load_localized_json(user_input[LANGUAGE])
             try:
                 self.fetched_systems = await wolf_client.fetch_system_list()
             except ConnectError:
@@ -60,7 +60,7 @@ class WolfLinkConfigFlow(ConfigFlow, domain=DOMAIN):
             else:
                 self.username = user_input[CONF_USERNAME]
                 self.password = user_input[CONF_PASSWORD]
-                self.locale = user_input[LOCALE]
+                self.locale = user_input[LANGUAGE]
                 return await self.async_step_device()
         return self.async_show_form(
             step_id="user", data_schema=USER_SCHEMA, errors=errors
@@ -87,7 +87,7 @@ class WolfLinkConfigFlow(ConfigFlow, domain=DOMAIN):
                     DEVICE_NAME: device_name,
                     DEVICE_GATEWAY: system[0].gateway,
                     DEVICE_ID: device_id,
-                    LOCALE: self.locale,
+                    LANGUAGE: self.locale,
                 },
             )
 

--- a/homeassistant/components/wolflink/config_flow.py
+++ b/homeassistant/components/wolflink/config_flow.py
@@ -16,7 +16,11 @@ from .const import DEVICE_GATEWAY, DEVICE_ID, DEVICE_NAME, DOMAIN, LOCALE
 _LOGGER = logging.getLogger(__name__)
 
 USER_SCHEMA = vol.Schema(
-    {vol.Required(CONF_USERNAME): str, vol.Required(CONF_PASSWORD): str, vol.Required(LOCALE): str}
+    {
+        vol.Required(CONF_USERNAME): str,
+        vol.Required(CONF_PASSWORD): str,
+        vol.Required(LOCALE): str,
+    }
 )
 
 

--- a/homeassistant/components/wolflink/const.py
+++ b/homeassistant/components/wolflink/const.py
@@ -8,6 +8,7 @@ DEVICE_ID = "device_id"
 DEVICE_GATEWAY = "device_gateway"
 DEVICE_NAME = "device_name"
 MANUFACTURER = "WOLF GmbH"
+LOCALE = "locale (en, de, it, fr, etc)"
 
 STATES = {
     "Ein": "ein",

--- a/homeassistant/components/wolflink/const.py
+++ b/homeassistant/components/wolflink/const.py
@@ -8,7 +8,7 @@ DEVICE_ID = "device_id"
 DEVICE_GATEWAY = "device_gateway"
 DEVICE_NAME = "device_name"
 MANUFACTURER = "WOLF GmbH"
-LOCALE = "locale (en, de, it, fr, etc)"
+LANGUAGE = "Language (en, de, it, fr, etc)"
 
 STATES = {
     "Ein": "ein",

--- a/tests/components/wolflink/const.py
+++ b/tests/components/wolflink/const.py
@@ -17,3 +17,16 @@ CONFIG = {
     CONF_PASSWORD: "test-password",
     LOCALE: "en",
 }
+
+MOCK_RESPONSE = """
+wb.addTranslation("en"
+, { messages: {
+"%":"%",
+"%r.H.":"%rel. hum.",
+"%rH":"%rH",
+"---":"---",
+"----":"----",
+"0":"0",
+"Englisch":"English"
+}});
+"""

--- a/tests/components/wolflink/const.py
+++ b/tests/components/wolflink/const.py
@@ -4,10 +4,9 @@ from homeassistant.components.wolflink.const import (
     DEVICE_GATEWAY,
     DEVICE_ID,
     DEVICE_NAME,
+    LANGUAGE,
 )
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
-
-LOCALE = "locale"
 
 CONFIG = {
     DEVICE_NAME: "test-device",
@@ -15,7 +14,7 @@ CONFIG = {
     DEVICE_GATEWAY: 5678,
     CONF_USERNAME: "test-username",
     CONF_PASSWORD: "test-password",
-    LOCALE: "en",
+    LANGUAGE: "en",
 }
 
 MOCK_RESPONSE = """

--- a/tests/components/wolflink/const.py
+++ b/tests/components/wolflink/const.py
@@ -7,10 +7,13 @@ from homeassistant.components.wolflink.const import (
 )
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 
+LOCALE = "locale"
+
 CONFIG = {
     DEVICE_NAME: "test-device",
     DEVICE_ID: 1234,
     DEVICE_GATEWAY: 5678,
     CONF_USERNAME: "test-username",
     CONF_PASSWORD: "test-password",
+    LOCALE: "en",
 }

--- a/tests/components/wolflink/test_config_flow.py
+++ b/tests/components/wolflink/test_config_flow.py
@@ -13,19 +13,20 @@ from homeassistant.components.wolflink.const import (
     DEVICE_ID,
     DEVICE_NAME,
     DOMAIN,
+    LANGUAGE,
 )
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
-from .const import CONFIG, LOCALE, MOCK_RESPONSE
+from .const import CONFIG, MOCK_RESPONSE
 
 from tests.common import MockConfigEntry
 
 INPUT_CONFIG = {
     CONF_USERNAME: CONFIG[CONF_USERNAME],
     CONF_PASSWORD: CONFIG[CONF_PASSWORD],
-    LOCALE: CONFIG[LOCALE],
+    LANGUAGE: CONFIG[LANGUAGE],
 }
 
 DEVICE = Device(CONFIG[DEVICE_ID], CONFIG[DEVICE_GATEWAY], CONFIG[DEVICE_NAME])
@@ -153,9 +154,9 @@ async def test_locale(hass: HomeAssistant) -> None:
     with patch.object(
         WolfClient, "fetch_localized_text", return_value=MOCK_RESPONSE
     ) as mock_fetch_localized_text:
-        await wolf_client.load_localized_json(LOCALE)
+        await wolf_client.load_localized_json(LANGUAGE)
 
-    mock_fetch_localized_text.assert_called_once_with(LOCALE)
+    mock_fetch_localized_text.assert_called_once_with(LANGUAGE)
 
     messages = WolfClient.extract_messages_json(mock_fetch_localized_text.return_value)
     wolf_client.language = messages

--- a/tests/components/wolflink/test_config_flow.py
+++ b/tests/components/wolflink/test_config_flow.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 from httpcore import ConnectError
 from wolf_comm.models import Device
 from wolf_comm.token_auth import InvalidAuth
+from wolf_comm.wolf_client import WolfClient
 
 from homeassistant import config_entries
 from homeassistant.components.wolflink.const import (
@@ -17,13 +18,14 @@ from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
-from .const import CONFIG
+from .const import CONFIG, LOCALE
 
 from tests.common import MockConfigEntry
 
 INPUT_CONFIG = {
     CONF_USERNAME: CONFIG[CONF_USERNAME],
     CONF_PASSWORD: CONFIG[CONF_PASSWORD],
+    LOCALE: CONFIG[LOCALE],
 }
 
 DEVICE = Device(CONFIG[DEVICE_ID], CONFIG[DEVICE_GATEWAY], CONFIG[DEVICE_NAME])
@@ -142,3 +144,11 @@ async def test_already_configured_error(hass: HomeAssistant) -> None:
 
     assert result_create_entry["type"] is FlowResultType.ABORT
     assert result_create_entry["reason"] == "already_configured"
+
+
+async def test_locale(hass: HomeAssistant) -> None:
+    wolf_client = WolfClient(INPUT_CONFIG[CONF_USERNAME], INPUT_CONFIG[CONF_PASSWORD])
+    print(INPUT_CONFIG)
+    await wolf_client.load_localized_json(LOCALE)
+    print("Language: ", wolf_client.language)
+    assert wolf_client.language["Englisch"] == "English"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
This pr uses the new locale system of wolf-comm 0.0.10, so it's recommended to reinstall the integration

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
A new locale input parameter is now asked when logging in into the integration, it can be something like (en, es, de, it, etc)
The locale format doesn't follow a common standard for locales, it uses Wolf's website language system.
Entities names are now also translated based on the locale. 
If there are 2 entities with the same name but different group. now both of them will be loaded. Previously only one of them was loaded.
![image](https://github.com/user-attachments/assets/09de242a-d3a8-4fbd-a22e-fc7b23391899)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR introduces some changes based on the new wolf-comm version https://github.com/home-assistant/core/pull/126342

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
