### PR TITLE
Allow nested schema validation in event automation trigger

### DIFF
--- a/homeassistant/components/homeassistant/triggers/event.py
+++ b/homeassistant/components/homeassistant/triggers/event.py
@@ -75,15 +75,23 @@ async def async_attach_trigger(
         event_data.update(
             template.render_complex(config[CONF_EVENT_DATA], variables, limited=True)
         )
-        # Build the schema or a an items view if the schema is simple
-        # and does not contain sub-dicts. We explicitly do not check for
-        # list like the context data below since lists are a special case
-        # only for context data. (see test test_event_data_with_list)
+
+        def build_schema(data: dict[str, Any]) -> vol.Schema:
+            schema = {}
+            for key, value in data.items():
+                if isinstance(value, dict):
+                    schema[vol.Required(key)] = build_schema(value)
+                else:
+                    schema[vol.Required(key)] = value
+            return vol.Schema(schema, extra=vol.ALLOW_EXTRA)
+
+        # For performance reasons, we want to avoid using a voluptuous schema here unless required
+        # Thus, if possible, we try to use a simple items comparison
+        # For that, we explicitly do not check for list like the context data below since lists are
+        # a special case only used for context data. (see test test_event_data_with_list)
+        # Otherwise, we recursively build the schema (see test test_event_data_with_list_nested)
         if any(isinstance(value, dict) for value in event_data.values()):
-            event_data_schema = vol.Schema(
-                {vol.Required(key): value for key, value in event_data.items()},
-                extra=vol.ALLOW_EXTRA,
-            )
+            event_data_schema = build_schema(event_data)
         else:
             # Use a simple items comparison if possible
             event_data_items = event_data.items()

--- a/homeassistant/components/homeassistant/triggers/event.py
+++ b/homeassistant/components/homeassistant/triggers/event.py
@@ -88,8 +88,6 @@ async def async_attach_trigger(
                 extra=vol.ALLOW_EXTRA,
                 required=True
             )
-         else:
-             # Use a simple items comparison if possible
         else:
             # Use a simple items comparison if possible
             event_data_items = event_data.items()

--- a/homeassistant/components/homeassistant/triggers/event.py
+++ b/homeassistant/components/homeassistant/triggers/event.py
@@ -86,7 +86,7 @@ async def async_attach_trigger(
             event_data_schema = vol.Schema(
                 event_data,
                 extra=vol.ALLOW_EXTRA,
-                required=True
+                required=True,
             )
         else:
             # Use a simple items comparison if possible

--- a/homeassistant/components/rfxtrx/device_trigger.py
+++ b/homeassistant/components/rfxtrx/device_trigger.py
@@ -97,7 +97,7 @@ async def async_attach_trigger(
     if config[CONF_TYPE] == CONF_TYPE_COMMAND:
         event_data["values"] = {"Command": config[CONF_SUBTYPE]}
     elif config[CONF_TYPE] == CONF_TYPE_STATUS:
-        event_data["values"] = {"Status": config[CONF_SUBTYPE]}
+        event_data["values"] = {"Sensor Status": config[CONF_SUBTYPE]}
 
     event_config = event_trigger.TRIGGER_SCHEMA(
         {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

While trying to build an automation for motion controlled lights that disables itself if some other source changes a light entity, I stumbled upon something unexpected.

```yaml
platform: event
event_type: call_service
id: light_turn_on_call_two
event_data:
  domain: light
  service: turn_on
  service_data:
    entity_id:
      - light.decke_bad
```
^ This trigger triggered on the following event (taken from the trace):

```yaml
trigger:
  id: light_turn_on_call_two
  idx: '6'
  alias: null
  platform: event
  event:
    event_type: call_service
    data:
      domain: light
      service: turn_on
      service_data:
        transition: 0.1
        profile: lmao
        device_id:
          - 0115a5bba8da927df1c1a164cf059429
    origin: LOCAL
    time_fired: '2024-09-25T16:00:09.232550+00:00'
```

It did so, because the schema built by the trigger does not care about nested dicts.

Not being a nested schema might be intentional so this might introduce a performance penalty and might not be desired.
If that is the case, maybe it would make sense to limit the nesting depth, though if not, I think I'd keep it without a depth limit.

An alternative solution could be to update the docs, warn about this caveat and instead further validate with a template condition. Though then you get an automation that triggers _all the time_ so might also not be desirable.

I would argue that you'd want the `event` trigger to work with at least the `call_service` events for core services

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue:  N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
