### PR TITLE
Use pytest.mark.usefixtures for start_ha in template tests

### DIFF
--- a/tests/components/template/conftest.py
+++ b/tests/components/template/conftest.py
@@ -3,6 +3,7 @@
 import pytest
 
 from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.helpers.typing import ConfigType
 from homeassistant.setup import async_setup_component
 
 from tests.common import assert_setup_component, async_mock_service
@@ -16,8 +17,8 @@ def calls(hass: HomeAssistant) -> list[ServiceCall]:
 
 @pytest.fixture
 async def start_ha(
-    hass: HomeAssistant, count, domain, config, caplog: pytest.LogCaptureFixture
-):
+    hass: HomeAssistant, count: int, domain: str, config: ConfigType
+) -> None:
     """Do setup of integration."""
     with assert_setup_component(count, domain):
         assert await async_setup_component(

--- a/tests/components/template/test_alarm_control_panel.py
+++ b/tests/components/template/test_alarm_control_panel.py
@@ -107,7 +107,8 @@ TEMPLATE_ALARM_CONFIG = {
         },
     ],
 )
-async def test_template_state_text(hass: HomeAssistant, start_ha) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_template_state_text(hass: HomeAssistant) -> None:
     """Test the state text of a template."""
 
     for set_state in (
@@ -179,7 +180,8 @@ async def test_setup_config_entry(
         },
     ],
 )
-async def test_optimistic_states(hass: HomeAssistant, start_ha) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_optimistic_states(hass: HomeAssistant) -> None:
     """Test the optimistic state."""
 
     state = hass.states.get(TEMPLATE_NAME)
@@ -269,8 +271,9 @@ async def test_optimistic_states(hass: HomeAssistant, start_ha) -> None:
         ),
     ],
 )
+@pytest.mark.usefixtures("start_ha")
 async def test_template_syntax_error(
-    hass: HomeAssistant, msg, start_ha, caplog_setup_text
+    hass: HomeAssistant, msg, caplog_setup_text
 ) -> None:
     """Test templating syntax error."""
     assert len(hass.states.async_all("alarm_control_panel")) == 0
@@ -295,7 +298,8 @@ async def test_template_syntax_error(
         },
     ],
 )
-async def test_name(hass: HomeAssistant, start_ha) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_name(hass: HomeAssistant) -> None:
     """Test the accessibility of the name attribute."""
     state = hass.states.get(TEMPLATE_NAME)
     assert state is not None
@@ -326,8 +330,9 @@ async def test_name(hass: HomeAssistant, start_ha) -> None:
         "alarm_trigger",
     ],
 )
+@pytest.mark.usefixtures("start_ha")
 async def test_actions(
-    hass: HomeAssistant, service, start_ha, call_service_events: list[Event]
+    hass: HomeAssistant, service, call_service_events: list[Event]
 ) -> None:
     """Test alarm actions."""
     await hass.services.async_call(
@@ -363,7 +368,8 @@ async def test_actions(
         },
     ],
 )
-async def test_unique_id(hass: HomeAssistant, start_ha) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_unique_id(hass: HomeAssistant) -> None:
     """Test unique_id option only creates one alarm control panel per id."""
     assert len(hass.states.async_all()) == 1
 
@@ -435,9 +441,8 @@ async def test_unique_id(hass: HomeAssistant, start_ha) -> None:
         ),
     ],
 )
-async def test_code_config(
-    hass: HomeAssistant, code_format, code_arm_required, start_ha
-) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_code_config(hass: HomeAssistant, code_format, code_arm_required) -> None:
     """Test configuration options related to alarm code."""
     state = hass.states.get(TEMPLATE_NAME)
     assert state.attributes.get("code_format") == code_format

--- a/tests/components/template/test_binary_sensor.py
+++ b/tests/components/template/test_binary_sensor.py
@@ -72,9 +72,8 @@ OFF = "off"
         ),
     ],
 )
-async def test_setup_minimal(
-    hass: HomeAssistant, start_ha, entity_id, name, attributes
-) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_setup_minimal(hass: HomeAssistant, entity_id, name, attributes) -> None:
     """Test the setup."""
     state = hass.states.get(entity_id)
     assert state is not None
@@ -118,7 +117,8 @@ async def test_setup_minimal(
         ),
     ],
 )
-async def test_setup(hass: HomeAssistant, start_ha, entity_id) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_setup(hass: HomeAssistant, entity_id) -> None:
     """Test the setup."""
     state = hass.states.get(entity_id)
     assert state is not None
@@ -234,7 +234,8 @@ async def test_setup_config_entry(
         ),
     ],
 )
-async def test_setup_invalid_sensors(hass: HomeAssistant, count, start_ha) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_setup_invalid_sensors(hass: HomeAssistant, count) -> None:
     """Test setup with no sensors."""
     assert len(hass.states.async_entity_ids("binary_sensor")) == count
 
@@ -280,7 +281,8 @@ async def test_setup_invalid_sensors(hass: HomeAssistant, count, start_ha) -> No
         ),
     ],
 )
-async def test_icon_template(hass: HomeAssistant, start_ha, entity_id) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_icon_template(hass: HomeAssistant, entity_id) -> None:
     """Test icon template."""
     state = hass.states.get(entity_id)
     assert state.attributes.get("icon") == ""
@@ -332,9 +334,8 @@ async def test_icon_template(hass: HomeAssistant, start_ha, entity_id) -> None:
         ),
     ],
 )
-async def test_entity_picture_template(
-    hass: HomeAssistant, start_ha, entity_id
-) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_entity_picture_template(hass: HomeAssistant, entity_id) -> None:
     """Test entity_picture template."""
     state = hass.states.get(entity_id)
     assert state.attributes.get("entity_picture") == ""
@@ -382,7 +383,8 @@ async def test_entity_picture_template(
         ),
     ],
 )
-async def test_attribute_templates(hass: HomeAssistant, start_ha, entity_id) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_attribute_templates(hass: HomeAssistant, entity_id) -> None:
     """Test attribute_templates template."""
     state = hass.states.get(entity_id)
     assert state.attributes.get("test_attribute") == "It ."
@@ -426,7 +428,8 @@ async def setup_mock():
         },
     ],
 )
-async def test_match_all(hass: HomeAssistant, setup_mock, start_ha) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_match_all(hass: HomeAssistant, setup_mock) -> None:
     """Test template that is rerendered on any state lifecycle."""
     init_calls = len(setup_mock.mock_calls)
 
@@ -453,7 +456,8 @@ async def test_match_all(hass: HomeAssistant, setup_mock, start_ha) -> None:
         },
     ],
 )
-async def test_event(hass: HomeAssistant, start_ha) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_event(hass: HomeAssistant) -> None:
     """Test the event."""
     state = hass.states.get("binary_sensor.test")
     assert state.state == OFF
@@ -563,7 +567,8 @@ async def test_event(hass: HomeAssistant, start_ha) -> None:
         ),
     ],
 )
-async def test_template_delay_on_off(hass: HomeAssistant, start_ha) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_template_delay_on_off(hass: HomeAssistant) -> None:
     """Test binary sensor template delay on."""
     # Ensure the initial state is not on
     assert hass.states.get("binary_sensor.test_on").state != ON
@@ -641,8 +646,9 @@ async def test_template_delay_on_off(hass: HomeAssistant, start_ha) -> None:
         ),
     ],
 )
+@pytest.mark.usefixtures("start_ha")
 async def test_available_without_availability_template(
-    hass: HomeAssistant, start_ha, entity_id
+    hass: HomeAssistant, entity_id
 ) -> None:
     """Ensure availability is true without an availability_template."""
     state = hass.states.get(entity_id)
@@ -690,7 +696,8 @@ async def test_available_without_availability_template(
         ),
     ],
 )
-async def test_availability_template(hass: HomeAssistant, start_ha, entity_id) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_availability_template(hass: HomeAssistant, entity_id) -> None:
     """Test availability template."""
     hass.states.async_set("sensor.test_state", STATE_OFF)
     await hass.async_block_till_done()
@@ -725,8 +732,9 @@ async def test_availability_template(hass: HomeAssistant, start_ha, entity_id) -
         },
     ],
 )
+@pytest.mark.usefixtures("start_ha")
 async def test_invalid_attribute_template(
-    hass: HomeAssistant, start_ha, caplog_setup_text
+    hass: HomeAssistant, caplog_setup_text
 ) -> None:
     """Test that errors are logged if rendering template fails."""
     hass.states.async_set("binary_sensor.test_sensor", "true")
@@ -752,8 +760,9 @@ async def test_invalid_attribute_template(
         },
     ],
 )
+@pytest.mark.usefixtures("start_ha")
 async def test_invalid_availability_template_keeps_component_available(
-    hass: HomeAssistant, start_ha, caplog_setup_text
+    hass: HomeAssistant, caplog_setup_text
 ) -> None:
     """Test that an invalid availability keeps the device available."""
 
@@ -858,8 +867,9 @@ async def test_no_update_template_match_all(
         },
     ],
 )
+@pytest.mark.usefixtures("start_ha")
 async def test_unique_id(
-    hass: HomeAssistant, start_ha, entity_registry: er.EntityRegistry
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:
     """Test unique_id option only creates one binary sensor per id."""
     assert len(hass.states.async_all()) == 2
@@ -893,8 +903,9 @@ async def test_unique_id(
         },
     ],
 )
+@pytest.mark.usefixtures("start_ha")
 async def test_template_validation_error(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, start_ha
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test binary sensor template delay on."""
     caplog.set_level(logging.ERROR)
@@ -957,9 +968,8 @@ async def test_template_validation_error(
         ),
     ],
 )
-async def test_availability_icon_picture(
-    hass: HomeAssistant, start_ha, entity_id
-) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_availability_icon_picture(hass: HomeAssistant, entity_id) -> None:
     """Test name, icon and picture templates are rendered at setup."""
     state = hass.states.get(entity_id)
     assert state.state == "unavailable"
@@ -1116,8 +1126,9 @@ async def test_restore_state(
         },
     ],
 )
+@pytest.mark.usefixtures("start_ha")
 async def test_trigger_entity(
-    hass: HomeAssistant, start_ha, entity_registry: er.EntityRegistry
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:
     """Test trigger entity works."""
     await hass.async_block_till_done()
@@ -1186,9 +1197,8 @@ async def test_trigger_entity(
         },
     ],
 )
-async def test_template_with_trigger_templated_delay_on(
-    hass: HomeAssistant, start_ha
-) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_template_with_trigger_templated_delay_on(hass: HomeAssistant) -> None:
     """Test binary sensor template with template delay on."""
     state = hass.states.get("binary_sensor.test")
     assert state.state == STATE_UNKNOWN

--- a/tests/components/template/test_cover.py
+++ b/tests/components/template/test_cover.py
@@ -139,8 +139,9 @@ OPEN_CLOSE_COVER_CONFIG = {
         ),
     ],
 )
+@pytest.mark.usefixtures("start_ha")
 async def test_template_state_text(
-    hass: HomeAssistant, states, start_ha, caplog: pytest.LogCaptureFixture
+    hass: HomeAssistant, states, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test the state text of a template."""
     state = hass.states.get("cover.test_template_cover")
@@ -202,13 +203,13 @@ async def test_template_state_text(
         ),
     ],
 )
+@pytest.mark.usefixtures("start_ha")
 async def test_template_state_text_ignored_if_none_or_empty(
     hass: HomeAssistant,
     entity: str,
     set_state: str,
     test_state: str,
     attr: dict[str, Any],
-    start_ha,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test ignoring an empty state text of a template."""
@@ -239,7 +240,8 @@ async def test_template_state_text_ignored_if_none_or_empty(
         },
     ],
 )
-async def test_template_state_boolean(hass: HomeAssistant, start_ha) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_template_state_boolean(hass: HomeAssistant) -> None:
     """Test the value_template attribute."""
     state = hass.states.get("cover.test_template_cover")
     assert state.state == STATE_OPEN
@@ -264,8 +266,9 @@ async def test_template_state_boolean(hass: HomeAssistant, start_ha) -> None:
         },
     ],
 )
+@pytest.mark.usefixtures("start_ha")
 async def test_template_position(
-    hass: HomeAssistant, start_ha, caplog: pytest.LogCaptureFixture
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test the position_template attribute."""
     hass.states.async_set("cover.test", STATE_OPEN)
@@ -302,7 +305,8 @@ async def test_template_position(
         },
     ],
 )
-async def test_template_not_optimistic(hass: HomeAssistant, start_ha) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_template_not_optimistic(hass: HomeAssistant) -> None:
     """Test the is_closed attribute."""
     state = hass.states.get("cover.test_template_cover")
     assert state.state == STATE_UNKNOWN
@@ -344,9 +348,8 @@ async def test_template_not_optimistic(hass: HomeAssistant, start_ha) -> None:
         ),
     ],
 )
-async def test_template_tilt(
-    hass: HomeAssistant, tilt_position: float | None, start_ha
-) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_template_tilt(hass: HomeAssistant, tilt_position: float | None) -> None:
     """Test the tilt_template attribute."""
     state = hass.states.get("cover.test_template_cover")
     assert state.attributes.get("current_tilt_position") == tilt_position
@@ -388,7 +391,8 @@ async def test_template_tilt(
         },
     ],
 )
-async def test_template_out_of_bounds(hass: HomeAssistant, start_ha) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_template_out_of_bounds(hass: HomeAssistant) -> None:
     """Test template out-of-bounds condition."""
     state = hass.states.get("cover.test_template_cover")
     assert state.attributes.get("current_tilt_position") is None
@@ -424,8 +428,9 @@ async def test_template_out_of_bounds(hass: HomeAssistant, start_ha) -> None:
         },
     ],
 )
+@pytest.mark.usefixtures("start_ha")
 async def test_template_open_or_position(
-    hass: HomeAssistant, start_ha, caplog_setup_text
+    hass: HomeAssistant, caplog_setup_text
 ) -> None:
     """Test that at least one of open_cover or set_position is used."""
     assert hass.states.async_all("cover") == []
@@ -449,9 +454,8 @@ async def test_template_open_or_position(
         },
     ],
 )
-async def test_open_action(
-    hass: HomeAssistant, start_ha, calls: list[ServiceCall]
-) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_open_action(hass: HomeAssistant, calls: list[ServiceCall]) -> None:
     """Test the open_cover command."""
     state = hass.states.get("cover.test_template_cover")
     assert state.state == STATE_CLOSED
@@ -490,9 +494,8 @@ async def test_open_action(
         },
     ],
 )
-async def test_close_stop_action(
-    hass: HomeAssistant, start_ha, calls: list[ServiceCall]
-) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_close_stop_action(hass: HomeAssistant, calls: list[ServiceCall]) -> None:
     """Test the close-cover and stop_cover commands."""
     state = hass.states.get("cover.test_template_cover")
     assert state.state == STATE_OPEN
@@ -521,9 +524,8 @@ async def test_close_stop_action(
         {"input_number": {"test": {"min": "0", "max": "100", "initial": "42"}}},
     ],
 )
-async def test_set_position(
-    hass: HomeAssistant, start_ha, calls: list[ServiceCall]
-) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_set_position(hass: HomeAssistant, calls: list[ServiceCall]) -> None:
     """Test the set_position command."""
     with assert_setup_component(1, "cover"):
         assert await setup.async_setup_component(
@@ -652,11 +654,11 @@ async def test_set_position(
         (SERVICE_CLOSE_COVER_TILT, {ATTR_ENTITY_ID: ENTITY_COVER}, 0),
     ],
 )
+@pytest.mark.usefixtures("start_ha")
 async def test_set_tilt_position(
     hass: HomeAssistant,
     service,
     attr,
-    start_ha,
     calls: list[ServiceCall],
     tilt_position,
 ) -> None:
@@ -691,8 +693,9 @@ async def test_set_tilt_position(
         },
     ],
 )
+@pytest.mark.usefixtures("start_ha")
 async def test_set_position_optimistic(
-    hass: HomeAssistant, start_ha, calls: list[ServiceCall]
+    hass: HomeAssistant, calls: list[ServiceCall]
 ) -> None:
     """Test optimistic position mode."""
     state = hass.states.get("cover.test_template_cover")
@@ -740,8 +743,9 @@ async def test_set_position_optimistic(
         },
     ],
 )
+@pytest.mark.usefixtures("calls", "start_ha")
 async def test_set_tilt_position_optimistic(
-    hass: HomeAssistant, start_ha, calls: list[ServiceCall]
+    hass: HomeAssistant, calls: list[ServiceCall]
 ) -> None:
     """Test the optimistic tilt_position mode."""
     state = hass.states.get("cover.test_template_cover")
@@ -791,7 +795,8 @@ async def test_set_tilt_position_optimistic(
         },
     ],
 )
-async def test_icon_template(hass: HomeAssistant, start_ha) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_icon_template(hass: HomeAssistant) -> None:
     """Test icon template."""
     state = hass.states.get("cover.test_template_cover")
     assert state.attributes.get("icon") == ""
@@ -826,7 +831,8 @@ async def test_icon_template(hass: HomeAssistant, start_ha) -> None:
         },
     ],
 )
-async def test_entity_picture_template(hass: HomeAssistant, start_ha) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_entity_picture_template(hass: HomeAssistant) -> None:
     """Test icon template."""
     state = hass.states.get("cover.test_template_cover")
     assert state.attributes.get("entity_picture") == ""
@@ -859,7 +865,8 @@ async def test_entity_picture_template(hass: HomeAssistant, start_ha) -> None:
         },
     ],
 )
-async def test_availability_template(hass: HomeAssistant, start_ha) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_availability_template(hass: HomeAssistant) -> None:
     """Test availability template."""
     hass.states.async_set("availability_state.state", STATE_OFF)
     await hass.async_block_till_done()
@@ -889,9 +896,8 @@ async def test_availability_template(hass: HomeAssistant, start_ha) -> None:
         },
     ],
 )
-async def test_availability_without_availability_template(
-    hass: HomeAssistant, start_ha
-) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_availability_without_availability_template(hass: HomeAssistant) -> None:
     """Test that component is available if there is no."""
     state = hass.states.get("cover.test_template_cover")
     assert state.state != STATE_UNAVAILABLE
@@ -915,8 +921,9 @@ async def test_availability_without_availability_template(
         },
     ],
 )
+@pytest.mark.usefixtures("start_ha")
 async def test_invalid_availability_template_keeps_component_available(
-    hass: HomeAssistant, start_ha, caplog_setup_text
+    hass: HomeAssistant, caplog_setup_text
 ) -> None:
     """Test that an invalid availability keeps the device available."""
     assert hass.states.get("cover.test_template_cover") != STATE_UNAVAILABLE
@@ -941,7 +948,8 @@ async def test_invalid_availability_template_keeps_component_available(
         },
     ],
 )
-async def test_device_class(hass: HomeAssistant, start_ha) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_device_class(hass: HomeAssistant) -> None:
     """Test device class."""
     state = hass.states.get("cover.test_template_cover")
     assert state.attributes.get("device_class") == "door"
@@ -965,7 +973,8 @@ async def test_device_class(hass: HomeAssistant, start_ha) -> None:
         },
     ],
 )
-async def test_invalid_device_class(hass: HomeAssistant, start_ha) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_invalid_device_class(hass: HomeAssistant) -> None:
     """Test device class."""
     state = hass.states.get("cover.test_template_cover")
     assert not state
@@ -994,7 +1003,8 @@ async def test_invalid_device_class(hass: HomeAssistant, start_ha) -> None:
         },
     ],
 )
-async def test_unique_id(hass: HomeAssistant, start_ha) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_unique_id(hass: HomeAssistant) -> None:
     """Test unique_id option only creates one cover per id."""
     assert len(hass.states.async_all()) == 1
 
@@ -1019,7 +1029,8 @@ async def test_unique_id(hass: HomeAssistant, start_ha) -> None:
         },
     ],
 )
-async def test_state_gets_lowercased(hass: HomeAssistant, start_ha) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_state_gets_lowercased(hass: HomeAssistant) -> None:
     """Test True/False is lowercased."""
 
     hass.states.async_set("binary_sensor.garage_door_sensor", "off")
@@ -1065,8 +1076,9 @@ async def test_state_gets_lowercased(hass: HomeAssistant, start_ha) -> None:
         },
     ],
 )
+@pytest.mark.usefixtures("start_ha")
 async def test_self_referencing_icon_with_no_template_is_not_a_loop(
-    hass: HomeAssistant, start_ha, caplog: pytest.LogCaptureFixture
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test a self referencing icon with no value template is not a loop."""
     assert len(hass.states.async_all()) == 1

--- a/tests/components/template/test_fan.py
+++ b/tests/components/template/test_fan.py
@@ -54,7 +54,8 @@ _DIRECTION_INPUT_SELECT = "input_select.direction"
         },
     ],
 )
-async def test_missing_optional_config(hass: HomeAssistant, start_ha) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_missing_optional_config(hass: HomeAssistant) -> None:
     """Test: missing optional template is ok."""
     _verify(hass, STATE_ON, None, None, None, None)
 
@@ -107,7 +108,8 @@ async def test_missing_optional_config(hass: HomeAssistant, start_ha) -> None:
         },
     ],
 )
-async def test_wrong_template_config(hass: HomeAssistant, start_ha) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_wrong_template_config(hass: HomeAssistant) -> None:
     """Test: missing 'value_template' will fail."""
     assert hass.states.async_all("fan") == []
 
@@ -149,7 +151,8 @@ async def test_wrong_template_config(hass: HomeAssistant, start_ha) -> None:
         },
     ],
 )
-async def test_templates_with_entities(hass: HomeAssistant, start_ha) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_templates_with_entities(hass: HomeAssistant) -> None:
     """Test tempalates with values from other entities."""
     _verify(hass, STATE_OFF, 0, None, None, None)
 
@@ -229,9 +232,8 @@ async def test_templates_with_entities(hass: HomeAssistant, start_ha) -> None:
         ),
     ],
 )
-async def test_templates_with_entities2(
-    hass: HomeAssistant, entity, tests, start_ha
-) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_templates_with_entities2(hass: HomeAssistant, entity, tests) -> None:
     """Test templates with values from other entities."""
     for set_percentage, test_percentage, test_type in tests:
         hass.states.async_set(entity, set_percentage)
@@ -262,9 +264,8 @@ async def test_templates_with_entities2(
         },
     ],
 )
-async def test_availability_template_with_entities(
-    hass: HomeAssistant, start_ha
-) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_availability_template_with_entities(hass: HomeAssistant) -> None:
     """Test availability tempalates with values from other entities."""
     for state, test_assert in ((STATE_ON, True), (STATE_OFF, False)):
         hass.states.async_set(_STATE_AVAILABILITY_BOOLEAN, state)
@@ -347,9 +348,8 @@ async def test_availability_template_with_entities(
         ),
     ],
 )
-async def test_template_with_unavailable_entities(
-    hass: HomeAssistant, states, start_ha
-) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_template_with_unavailable_entities(hass: HomeAssistant, states) -> None:
     """Test unavailability with value_template."""
     _verify(hass, states[0], states[1], states[2], states[3], None)
 
@@ -378,8 +378,9 @@ async def test_template_with_unavailable_entities(
         },
     ],
 )
+@pytest.mark.usefixtures("start_ha")
 async def test_invalid_availability_template_keeps_component_available(
-    hass: HomeAssistant, start_ha, caplog_setup_text
+    hass: HomeAssistant, caplog_setup_text
 ) -> None:
     """Test that an invalid availability keeps the device available."""
     assert hass.states.get("fan.test_fan").state != STATE_UNAVAILABLE
@@ -940,7 +941,8 @@ async def _register_components(
         },
     ],
 )
-async def test_unique_id(hass: HomeAssistant, start_ha) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_unique_id(hass: HomeAssistant) -> None:
     """Test unique_id option only creates one fan per id."""
     assert len(hass.states.async_all()) == 1
 
@@ -1082,7 +1084,8 @@ async def test_implemented_percentage(
         },
     ],
 )
-async def test_implemented_preset_mode(hass: HomeAssistant, start_ha) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_implemented_preset_mode(hass: HomeAssistant) -> None:
     """Test a fan that implements preset_mode."""
     assert len(hass.states.async_all()) == 1
 

--- a/tests/components/template/test_init.py
+++ b/tests/components/template/test_init.py
@@ -51,7 +51,8 @@ from tests.common import MockConfigEntry, async_fire_time_changed, get_fixture_p
         },
     ],
 )
-async def test_reloadable(hass: HomeAssistant, start_ha) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_reloadable(hass: HomeAssistant) -> None:
     """Test that we can reload."""
     hass.states.async_set("sensor.test_sensor", "mytest")
     await hass.async_block_till_done()
@@ -102,7 +103,8 @@ async def test_reloadable(hass: HomeAssistant, start_ha) -> None:
         },
     ],
 )
-async def test_reloadable_can_remove(hass: HomeAssistant, start_ha) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_reloadable_can_remove(hass: HomeAssistant) -> None:
     """Test that we can reload and remove all template sensors."""
     hass.states.async_set("sensor.test_sensor", "mytest")
     await hass.async_block_till_done()
@@ -132,9 +134,8 @@ async def test_reloadable_can_remove(hass: HomeAssistant, start_ha) -> None:
         },
     ],
 )
-async def test_reloadable_stops_on_invalid_config(
-    hass: HomeAssistant, start_ha
-) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_reloadable_stops_on_invalid_config(hass: HomeAssistant) -> None:
     """Test we stop the reload if configuration.yaml is completely broken."""
     hass.states.async_set("sensor.test_sensor", "mytest")
     await hass.async_block_till_done()
@@ -162,9 +163,8 @@ async def test_reloadable_stops_on_invalid_config(
         },
     ],
 )
-async def test_reloadable_handles_partial_valid_config(
-    hass: HomeAssistant, start_ha
-) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_reloadable_handles_partial_valid_config(hass: HomeAssistant) -> None:
     """Test we can still setup valid sensors when configuration.yaml has a broken entry."""
     hass.states.async_set("sensor.test_sensor", "mytest")
     await hass.async_block_till_done()
@@ -195,7 +195,8 @@ async def test_reloadable_handles_partial_valid_config(
         },
     ],
 )
-async def test_reloadable_multiple_platforms(hass: HomeAssistant, start_ha) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_reloadable_multiple_platforms(hass: HomeAssistant) -> None:
     """Test that we can reload."""
     hass.states.async_set("sensor.test_sensor", "mytest")
     await async_setup_component(
@@ -239,8 +240,9 @@ async def test_reloadable_multiple_platforms(hass: HomeAssistant, start_ha) -> N
         },
     ],
 )
+@pytest.mark.usefixtures("start_ha")
 async def test_reload_sensors_that_reference_other_template_sensors(
-    hass: HomeAssistant, start_ha
+    hass: HomeAssistant,
 ) -> None:
     """Test that we can reload sensor that reference other template sensors."""
     await async_yaml_patch_helper(hass, "ref_configuration.yaml")

--- a/tests/components/template/test_lock.py
+++ b/tests/components/template/test_lock.py
@@ -66,7 +66,8 @@ OPTIMISTIC_CODED_LOCK_CONFIG = {
         },
     ],
 )
-async def test_template_state(hass: HomeAssistant, start_ha) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_template_state(hass: HomeAssistant) -> None:
     """Test template."""
     hass.states.async_set("switch.test_state", STATE_ON)
     await hass.async_block_till_done()
@@ -93,7 +94,8 @@ async def test_template_state(hass: HomeAssistant, start_ha) -> None:
         },
     ],
 )
-async def test_template_state_boolean_on(hass: HomeAssistant, start_ha) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_template_state_boolean_on(hass: HomeAssistant) -> None:
     """Test the setting of the state with boolean on."""
     state = hass.states.get("lock.template_lock")
     assert state.state == LockState.LOCKED
@@ -111,7 +113,8 @@ async def test_template_state_boolean_on(hass: HomeAssistant, start_ha) -> None:
         },
     ],
 )
-async def test_template_state_boolean_off(hass: HomeAssistant, start_ha) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_template_state_boolean_off(hass: HomeAssistant) -> None:
     """Test the setting of the state with off."""
     state = hass.states.get("lock.template_lock")
     assert state.state == LockState.UNLOCKED
@@ -181,7 +184,8 @@ async def test_template_state_boolean_off(hass: HomeAssistant, start_ha) -> None
         },
     ],
 )
-async def test_template_syntax_error(hass: HomeAssistant, start_ha) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_template_syntax_error(hass: HomeAssistant) -> None:
     """Test templating syntax errors don't create entities."""
     assert hass.states.async_all("lock") == []
 
@@ -198,7 +202,8 @@ async def test_template_syntax_error(hass: HomeAssistant, start_ha) -> None:
         },
     ],
 )
-async def test_template_static(hass: HomeAssistant, start_ha) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_template_static(hass: HomeAssistant) -> None:
     """Test that we allow static templates."""
     state = hass.states.get("lock.template_lock")
     assert state.state == LockState.UNLOCKED
@@ -221,9 +226,8 @@ async def test_template_static(hass: HomeAssistant, start_ha) -> None:
         },
     ],
 )
-async def test_lock_action(
-    hass: HomeAssistant, start_ha, calls: list[ServiceCall]
-) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_lock_action(hass: HomeAssistant, calls: list[ServiceCall]) -> None:
     """Test lock action."""
     await setup.async_setup_component(hass, "switch", {})
     hass.states.async_set("switch.test_state", STATE_OFF)
@@ -256,9 +260,8 @@ async def test_lock_action(
         },
     ],
 )
-async def test_unlock_action(
-    hass: HomeAssistant, start_ha, calls: list[ServiceCall]
-) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_unlock_action(hass: HomeAssistant, calls: list[ServiceCall]) -> None:
     """Test unlock action."""
     await setup.async_setup_component(hass, "switch", {})
     hass.states.async_set("switch.test_state", STATE_ON)
@@ -292,8 +295,9 @@ async def test_unlock_action(
         },
     ],
 )
+@pytest.mark.usefixtures("start_ha")
 async def test_lock_action_with_code(
-    hass: HomeAssistant, start_ha, calls: list[ServiceCall]
+    hass: HomeAssistant, calls: list[ServiceCall]
 ) -> None:
     """Test lock action with defined code format and supplied lock code."""
     await setup.async_setup_component(hass, "switch", {})
@@ -329,8 +333,9 @@ async def test_lock_action_with_code(
         },
     ],
 )
+@pytest.mark.usefixtures("start_ha")
 async def test_unlock_action_with_code(
-    hass: HomeAssistant, start_ha, calls: list[ServiceCall]
+    hass: HomeAssistant, calls: list[ServiceCall]
 ) -> None:
     """Test unlock action with code format and supplied unlock code."""
     await setup.async_setup_component(hass, "switch", {})
@@ -373,8 +378,9 @@ async def test_unlock_action_with_code(
         lock.SERVICE_UNLOCK,
     ],
 )
+@pytest.mark.usefixtures("start_ha")
 async def test_lock_actions_fail_with_invalid_code(
-    hass: HomeAssistant, start_ha, calls: list[ServiceCall], test_action
+    hass: HomeAssistant, calls: list[ServiceCall], test_action
 ) -> None:
     """Test invalid lock codes."""
     await hass.services.async_call(
@@ -405,8 +411,9 @@ async def test_lock_actions_fail_with_invalid_code(
         },
     ],
 )
+@pytest.mark.usefixtures("start_ha")
 async def test_lock_actions_dont_execute_with_code_template_rendering_error(
-    hass: HomeAssistant, start_ha, calls: list[ServiceCall]
+    hass: HomeAssistant, calls: list[ServiceCall]
 ) -> None:
     """Test lock code format rendering fails block lock/unlock actions."""
     await hass.services.async_call(
@@ -438,8 +445,9 @@ async def test_lock_actions_dont_execute_with_code_template_rendering_error(
         },
     ],
 )
+@pytest.mark.usefixtures("start_ha")
 async def test_actions_with_none_as_codeformat_ignores_code(
-    hass: HomeAssistant, action, start_ha, calls: list[ServiceCall]
+    hass: HomeAssistant, action, calls: list[ServiceCall]
 ) -> None:
     """Test lock actions with supplied lock code."""
     await setup.async_setup_component(hass, "switch", {})
@@ -476,8 +484,9 @@ async def test_actions_with_none_as_codeformat_ignores_code(
         },
     ],
 )
+@pytest.mark.usefixtures("start_ha")
 async def test_actions_with_invalid_regexp_as_codeformat_never_execute(
-    hass: HomeAssistant, action, start_ha, calls: list[ServiceCall]
+    hass: HomeAssistant, action, calls: list[ServiceCall]
 ) -> None:
     """Test lock actions don't execute with invalid regexp."""
     await setup.async_setup_component(hass, "switch", {})
@@ -522,7 +531,8 @@ async def test_actions_with_invalid_regexp_as_codeformat_never_execute(
 @pytest.mark.parametrize(
     "test_state", [LockState.UNLOCKING, LockState.LOCKING, LockState.JAMMED]
 )
-async def test_lock_state(hass: HomeAssistant, test_state, start_ha) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_lock_state(hass: HomeAssistant, test_state) -> None:
     """Test value template."""
     hass.states.async_set("input_select.test_state", test_state)
     await hass.async_block_till_done()
@@ -544,7 +554,8 @@ async def test_lock_state(hass: HomeAssistant, test_state, start_ha) -> None:
         },
     ],
 )
-async def test_available_template_with_entities(hass: HomeAssistant, start_ha) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_available_template_with_entities(hass: HomeAssistant) -> None:
     """Test availability templates with values from other entities."""
     # When template returns true..
     hass.states.async_set("availability_state.state", STATE_ON)
@@ -574,8 +585,9 @@ async def test_available_template_with_entities(hass: HomeAssistant, start_ha) -
         },
     ],
 )
+@pytest.mark.usefixtures("start_ha")
 async def test_invalid_availability_template_keeps_component_available(
-    hass: HomeAssistant, start_ha, caplog_setup_text
+    hass: HomeAssistant, caplog_setup_text
 ) -> None:
     """Test that an invalid availability keeps the device available."""
     assert hass.states.get("lock.template_lock").state != STATE_UNAVAILABLE
@@ -596,7 +608,8 @@ async def test_invalid_availability_template_keeps_component_available(
         },
     ],
 )
-async def test_unique_id(hass: HomeAssistant, start_ha) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_unique_id(hass: HomeAssistant) -> None:
     """Test unique_id option only creates one lock per id."""
     await setup.async_setup_component(
         hass,

--- a/tests/components/template/test_sensor.py
+++ b/tests/components/template/test_sensor.py
@@ -106,7 +106,8 @@ async def test_setup_config_entry(
         },
     ],
 )
-async def test_template_legacy(hass: HomeAssistant, start_ha) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_template_legacy(hass: HomeAssistant) -> None:
     """Test template."""
     assert hass.states.get(TEST_NAME).state == "It ."
 
@@ -135,7 +136,8 @@ async def test_template_legacy(hass: HomeAssistant, start_ha) -> None:
         },
     ],
 )
-async def test_icon_template(hass: HomeAssistant, start_ha) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_icon_template(hass: HomeAssistant) -> None:
     """Test icon template."""
     assert hass.states.get(TEST_NAME).attributes.get("icon") == ""
 
@@ -164,7 +166,8 @@ async def test_icon_template(hass: HomeAssistant, start_ha) -> None:
         },
     ],
 )
-async def test_entity_picture_template(hass: HomeAssistant, start_ha) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_entity_picture_template(hass: HomeAssistant) -> None:
     """Test entity_picture template."""
     assert hass.states.get(TEST_NAME).attributes.get("entity_picture") == ""
 
@@ -243,9 +246,8 @@ async def test_entity_picture_template(hass: HomeAssistant, start_ha) -> None:
         ),
     ],
 )
-async def test_friendly_name_template(
-    hass: HomeAssistant, attribute, expected, start_ha
-) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_friendly_name_template(hass: HomeAssistant, attribute, expected) -> None:
     """Test friendly_name template with an unknown value_template."""
     assert hass.states.get(TEST_NAME).attributes.get(attribute) == expected[0]
 
@@ -314,7 +316,8 @@ async def test_friendly_name_template(
         },
     ],
 )
-async def test_template_syntax_error(hass: HomeAssistant, start_ha) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_template_syntax_error(hass: HomeAssistant) -> None:
     """Test setup with invalid device_class."""
     assert hass.states.async_all("sensor") == []
 
@@ -336,7 +339,8 @@ async def test_template_syntax_error(hass: HomeAssistant, start_ha) -> None:
         },
     ],
 )
-async def test_template_attribute_missing(hass: HomeAssistant, start_ha) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_template_attribute_missing(hass: HomeAssistant) -> None:
     """Test missing attribute template."""
     assert hass.states.get(TEST_NAME).state == STATE_UNAVAILABLE
 
@@ -362,7 +366,8 @@ async def test_template_attribute_missing(hass: HomeAssistant, start_ha) -> None
         },
     ],
 )
-async def test_setup_valid_device_class(hass: HomeAssistant, start_ha) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_setup_valid_device_class(hass: HomeAssistant) -> None:
     """Test setup with valid device_class."""
     hass.states.async_set("sensor.test_sensor", "75")
     await hass.async_block_till_done()
@@ -434,7 +439,8 @@ async def test_creating_sensor_loads_group(hass: HomeAssistant) -> None:
         },
     ],
 )
-async def test_available_template_with_entities(hass: HomeAssistant, start_ha) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_available_template_with_entities(hass: HomeAssistant) -> None:
     """Test availability tempalates with values from other entities."""
     hass.states.async_set("sensor.availability_sensor", STATE_OFF)
 
@@ -472,8 +478,9 @@ async def test_available_template_with_entities(hass: HomeAssistant, start_ha) -
         },
     ],
 )
+@pytest.mark.usefixtures("start_ha")
 async def test_invalid_attribute_template(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, start_ha, caplog_setup_text
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, caplog_setup_text
 ) -> None:
     """Test that errors are logged if rendering template fails."""
     hass.states.async_set("sensor.test_sensor", "startup")
@@ -508,8 +515,9 @@ async def test_invalid_attribute_template(
         },
     ],
 )
+@pytest.mark.usefixtures("start_ha")
 async def test_invalid_availability_template_keeps_component_available(
-    hass: HomeAssistant, start_ha, caplog_setup_text
+    hass: HomeAssistant, caplog_setup_text
 ) -> None:
     """Test that an invalid availability keeps the device available."""
     assert hass.states.get("sensor.my_sensor").state != STATE_UNAVAILABLE
@@ -625,8 +633,9 @@ async def test_no_template_match_all(
         },
     ],
 )
+@pytest.mark.usefixtures("start_ha")
 async def test_unique_id(
-    hass: HomeAssistant, start_ha, entity_registry: er.EntityRegistry
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:
     """Test unique_id option only creates one sensor per id."""
     assert len(hass.states.async_all()) == 2
@@ -661,7 +670,8 @@ async def test_unique_id(
         },
     ],
 )
-async def test_sun_renders_once_per_sensor(hass: HomeAssistant, start_ha) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_sun_renders_once_per_sensor(hass: HomeAssistant) -> None:
     """Test sun change renders the template only once per sensor."""
 
     now = dt_util.utcnow()
@@ -730,7 +740,8 @@ async def test_sun_renders_once_per_sensor(hass: HomeAssistant, start_ha) -> Non
         },
     ],
 )
-async def test_this_variable(hass: HomeAssistant, start_ha) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_this_variable(hass: HomeAssistant) -> None:
     """Test template."""
     assert hass.states.get(TEST_NAME).state == "It: " + TEST_NAME
 
@@ -875,8 +886,9 @@ async def test_this_variable_early_hass_running(
         },
     ],
 )
+@pytest.mark.usefixtures("start_ha")
 async def test_self_referencing_sensor_loop(
-    hass: HomeAssistant, start_ha, caplog_setup_text
+    hass: HomeAssistant, caplog_setup_text
 ) -> None:
     """Test a self referencing sensor does not loop forever."""
     assert len(hass.states.async_all()) == 1
@@ -905,8 +917,9 @@ async def test_self_referencing_sensor_loop(
         },
     ],
 )
+@pytest.mark.usefixtures("start_ha")
 async def test_self_referencing_sensor_with_icon_loop(
-    hass: HomeAssistant, start_ha, caplog_setup_text
+    hass: HomeAssistant, caplog_setup_text
 ) -> None:
     """Test a self referencing sensor loops forever with a valid self referencing icon."""
     assert len(hass.states.async_all()) == 1
@@ -940,8 +953,9 @@ async def test_self_referencing_sensor_with_icon_loop(
         },
     ],
 )
+@pytest.mark.usefixtures("start_ha")
 async def test_self_referencing_sensor_with_icon_and_picture_entity_loop(
-    hass: HomeAssistant, start_ha, caplog_setup_text
+    hass: HomeAssistant, caplog_setup_text
 ) -> None:
     """Test a self referencing sensor loop forevers with a valid self referencing icon."""
     assert len(hass.states.async_all()) == 1
@@ -975,8 +989,9 @@ async def test_self_referencing_sensor_with_icon_and_picture_entity_loop(
         },
     ],
 )
+@pytest.mark.usefixtures("start_ha")
 async def test_self_referencing_entity_picture_loop(
-    hass: HomeAssistant, start_ha, caplog_setup_text
+    hass: HomeAssistant, caplog_setup_text
 ) -> None:
     """Test a self referencing sensor does not loop forever with a looping self referencing entity picture."""
     assert len(hass.states.async_all()) == 1
@@ -1092,7 +1107,8 @@ async def test_self_referencing_icon_with_no_loop(
         },
     ],
 )
-async def test_duplicate_templates(hass: HomeAssistant, start_ha) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_duplicate_templates(hass: HomeAssistant) -> None:
     """Test template entity where the value and friendly name as the same template."""
     hass.states.async_set("sensor.test_state", "Abc")
     await hass.async_block_till_done()
@@ -1161,8 +1177,9 @@ async def test_duplicate_templates(hass: HomeAssistant, start_ha) -> None:
         },
     ],
 )
+@pytest.mark.usefixtures("start_ha")
 async def test_trigger_entity(
-    hass: HomeAssistant, start_ha, entity_registry: er.EntityRegistry
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:
     """Test trigger entity works."""
     state = hass.states.get("sensor.hello_name")
@@ -1234,7 +1251,8 @@ async def test_trigger_entity(
         },
     ],
 )
-async def test_trigger_conditional_entity(hass: HomeAssistant, start_ha) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_trigger_conditional_entity(hass: HomeAssistant) -> None:
     """Test conditional trigger entity works."""
     state = hass.states.get("sensor.enough_name")
     assert state is not None
@@ -1280,8 +1298,9 @@ async def test_trigger_conditional_entity(hass: HomeAssistant, start_ha) -> None
         },
     ],
 )
+@pytest.mark.usefixtures("start_ha")
 async def test_trigger_conditional_entity_evaluation_error(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, start_ha
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test trigger entity is not updated when condition evaluation fails."""
     hass.bus.async_fire("test_event", {"beer": 1})
@@ -1317,8 +1336,9 @@ async def test_trigger_conditional_entity_evaluation_error(
         },
     ],
 )
+@pytest.mark.usefixtures("start_ha")
 async def test_trigger_conditional_entity_invalid_condition(
-    hass: HomeAssistant, start_ha
+    hass: HomeAssistant,
 ) -> None:
     """Test trigger entity is not created when condition is invalid."""
     state = hass.states.get("sensor.will_not_exist_name")
@@ -1350,9 +1370,8 @@ async def test_trigger_conditional_entity_invalid_condition(
         },
     ],
 )
-async def test_trigger_entity_runs_once(
-    hass: HomeAssistant, start_ha, entity_registry: er.EntityRegistry
-) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_trigger_entity_runs_once(hass: HomeAssistant) -> None:
     """Test trigger entity handles a trigger once."""
     state = hass.states.get("sensor.hello_name")
     assert state is not None
@@ -1385,8 +1404,9 @@ async def test_trigger_entity_runs_once(
         },
     ],
 )
+@pytest.mark.usefixtures("start_ha")
 async def test_trigger_entity_render_error(
-    hass: HomeAssistant, start_ha, entity_registry: er.EntityRegistry
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:
     """Test trigger entity handles render error."""
     state = hass.states.get("sensor.hello")
@@ -1422,8 +1442,9 @@ async def test_trigger_entity_render_error(
         },
     ],
 )
+@pytest.mark.usefixtures("start_ha")
 async def test_trigger_not_allowed_platform_config(
-    hass: HomeAssistant, start_ha, caplog_setup_text
+    hass: HomeAssistant, caplog_setup_text
 ) -> None:
     """Test we throw a helpful warning if a trigger is configured in platform config."""
     state = hass.states.get(TEST_NAME)
@@ -1451,7 +1472,8 @@ async def test_trigger_not_allowed_platform_config(
         },
     ],
 )
-async def test_config_top_level(hass: HomeAssistant, start_ha) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_config_top_level(hass: HomeAssistant) -> None:
     """Test unique_id option only creates one sensor per id."""
     assert len(hass.states.async_all()) == 1
     state = hass.states.get("sensor.top_level")
@@ -1997,9 +2019,8 @@ async def test_trigger_entity_restore_state(
         },
     ],
 )
-async def test_trigger_action(
-    hass: HomeAssistant, start_ha, entity_registry: er.EntityRegistry
-) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_trigger_action(hass: HomeAssistant) -> None:
     """Test trigger entity with an action works."""
     event = "test_event2"
     context = Context()
@@ -2050,7 +2071,8 @@ async def test_trigger_action(
         },
     ],
 )
-async def test_trigger_conditional_action(hass: HomeAssistant, start_ha) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_trigger_conditional_action(hass: HomeAssistant) -> None:
     """Test conditional trigger entity with an action works."""
 
     event = "test_event_by_action"

--- a/tests/components/template/test_trigger.py
+++ b/tests/components/template/test_trigger.py
@@ -48,8 +48,9 @@ def setup_comp(hass: HomeAssistant, calls: list[ServiceCall]) -> None:
         },
     ],
 )
+@pytest.mark.usefixtures("start_ha")
 async def test_if_fires_on_change_bool(
-    hass: HomeAssistant, start_ha, calls: list[ServiceCall]
+    hass: HomeAssistant, calls: list[ServiceCall]
 ) -> None:
     """Test for firing on boolean change."""
     assert len(calls) == 0
@@ -271,8 +272,9 @@ async def test_if_fires_on_change_bool(
         ),
     ],
 )
+@pytest.mark.usefixtures("start_ha")
 async def test_general(
-    hass: HomeAssistant, call_setup, start_ha, calls: list[ServiceCall]
+    hass: HomeAssistant, call_setup, calls: list[ServiceCall]
 ) -> None:
     """Test for firing on change."""
     assert len(calls) == 0
@@ -308,8 +310,9 @@ async def test_general(
         ),
     ],
 )
+@pytest.mark.usefixtures("start_ha")
 async def test_if_not_fires_because_fail(
-    hass: HomeAssistant, call_setup, start_ha, calls: list[ServiceCall]
+    hass: HomeAssistant, call_setup, calls: list[ServiceCall]
 ) -> None:
     """Test for not firing after TemplateError."""
     assert len(calls) == 0
@@ -346,8 +349,9 @@ async def test_if_not_fires_because_fail(
         },
     ],
 )
+@pytest.mark.usefixtures("start_ha")
 async def test_if_fires_on_change_with_template_advanced(
-    hass: HomeAssistant, start_ha, calls: list[ServiceCall]
+    hass: HomeAssistant, calls: list[ServiceCall]
 ) -> None:
     """Test for firing on change with template advanced."""
     context = Context()
@@ -378,9 +382,8 @@ async def test_if_fires_on_change_with_template_advanced(
         },
     ],
 )
-async def test_if_action(
-    hass: HomeAssistant, start_ha, calls: list[ServiceCall]
-) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_if_action(hass: HomeAssistant, calls: list[ServiceCall]) -> None:
     """Test for firing if action."""
     # Condition is not true yet
     hass.bus.async_fire("test_event")
@@ -410,8 +413,9 @@ async def test_if_action(
         },
     ],
 )
+@pytest.mark.usefixtures("start_ha")
 async def test_if_fires_on_change_with_bad_template(
-    hass: HomeAssistant, start_ha, calls: list[ServiceCall]
+    hass: HomeAssistant, calls: list[ServiceCall]
 ) -> None:
     """Test for firing on change with bad template."""
     assert hass.states.get("automation.automation_0").state == STATE_UNAVAILABLE
@@ -447,8 +451,9 @@ async def test_if_fires_on_change_with_bad_template(
         },
     ],
 )
+@pytest.mark.usefixtures("start_ha")
 async def test_wait_template_with_trigger(
-    hass: HomeAssistant, start_ha, calls: list[ServiceCall]
+    hass: HomeAssistant, calls: list[ServiceCall]
 ) -> None:
     """Test using wait template with 'trigger.entity_id'."""
     await hass.async_block_till_done()
@@ -519,8 +524,9 @@ async def test_if_fires_on_change_with_for(
         },
     ],
 )
+@pytest.mark.usefixtures("start_ha")
 async def test_if_fires_on_change_with_for_advanced(
-    hass: HomeAssistant, start_ha, calls: list[ServiceCall]
+    hass: HomeAssistant, calls: list[ServiceCall]
 ) -> None:
     """Test for firing on change with for advanced."""
     context = Context()
@@ -563,8 +569,9 @@ async def test_if_fires_on_change_with_for_advanced(
         },
     ],
 )
+@pytest.mark.usefixtures("start_ha")
 async def test_if_fires_on_change_with_for_0_advanced(
-    hass: HomeAssistant, start_ha, calls: list[ServiceCall]
+    hass: HomeAssistant, calls: list[ServiceCall]
 ) -> None:
     """Test for firing on change with for: 0 advanced."""
     context = Context()
@@ -604,8 +611,9 @@ async def test_if_fires_on_change_with_for_0_advanced(
         },
     ],
 )
+@pytest.mark.usefixtures("start_ha")
 async def test_if_fires_on_change_with_for_2(
-    hass: HomeAssistant, start_ha, calls: list[ServiceCall]
+    hass: HomeAssistant, calls: list[ServiceCall]
 ) -> None:
     """Test for firing on change with for."""
     context = Context()
@@ -635,8 +643,9 @@ async def test_if_fires_on_change_with_for_2(
         },
     ],
 )
+@pytest.mark.usefixtures("start_ha")
 async def test_if_not_fires_on_change_with_for(
-    hass: HomeAssistant, start_ha, calls: list[ServiceCall]
+    hass: HomeAssistant, calls: list[ServiceCall]
 ) -> None:
     """Test for firing on change with for."""
     hass.states.async_set("test.entity", "world")
@@ -669,8 +678,9 @@ async def test_if_not_fires_on_change_with_for(
         },
     ],
 )
+@pytest.mark.usefixtures("start_ha")
 async def test_if_not_fires_when_turned_off_with_for(
-    hass: HomeAssistant, start_ha, calls: list[ServiceCall]
+    hass: HomeAssistant, calls: list[ServiceCall]
 ) -> None:
     """Test for firing on change with for."""
     hass.states.async_set("test.entity", "world")
@@ -707,8 +717,9 @@ async def test_if_not_fires_when_turned_off_with_for(
         },
     ],
 )
+@pytest.mark.usefixtures("start_ha")
 async def test_if_fires_on_change_with_for_template_1(
-    hass: HomeAssistant, start_ha, calls: list[ServiceCall]
+    hass: HomeAssistant, calls: list[ServiceCall]
 ) -> None:
     """Test for firing on change with for template."""
     hass.states.async_set("test.entity", "world")
@@ -735,8 +746,9 @@ async def test_if_fires_on_change_with_for_template_1(
         },
     ],
 )
+@pytest.mark.usefixtures("start_ha")
 async def test_if_fires_on_change_with_for_template_2(
-    hass: HomeAssistant, start_ha, calls: list[ServiceCall]
+    hass: HomeAssistant, calls: list[ServiceCall]
 ) -> None:
     """Test for firing on change with for template."""
     hass.states.async_set("test.entity", "world")
@@ -763,8 +775,9 @@ async def test_if_fires_on_change_with_for_template_2(
         },
     ],
 )
+@pytest.mark.usefixtures("start_ha")
 async def test_if_fires_on_change_with_for_template_3(
-    hass: HomeAssistant, start_ha, calls: list[ServiceCall]
+    hass: HomeAssistant, calls: list[ServiceCall]
 ) -> None:
     """Test for firing on change with for template."""
     hass.states.async_set("test.entity", "world")
@@ -791,8 +804,9 @@ async def test_if_fires_on_change_with_for_template_3(
         },
     ],
 )
+@pytest.mark.usefixtures("start_ha")
 async def test_invalid_for_template_1(
-    hass: HomeAssistant, start_ha, calls: list[ServiceCall]
+    hass: HomeAssistant, calls: list[ServiceCall]
 ) -> None:
     """Test for invalid for template."""
     with mock.patch.object(template_trigger, "_LOGGER") as mock_logger:

--- a/tests/components/template/test_vacuum.py
+++ b/tests/components/template/test_vacuum.py
@@ -94,9 +94,8 @@ _BATTERY_LEVEL_INPUT_NUMBER = "input_number.battery_level"
         ),
     ],
 )
-async def test_valid_configs(
-    hass: HomeAssistant, count, parm1, parm2, start_ha
-) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_valid_configs(hass: HomeAssistant, count, parm1, parm2) -> None:
     """Test: configs."""
     assert len(hass.states.async_all("vacuum")) == count
     _verify(hass, parm1, parm2)
@@ -118,7 +117,8 @@ async def test_valid_configs(
         },
     ],
 )
-async def test_invalid_configs(hass: HomeAssistant, count, start_ha) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_invalid_configs(hass: HomeAssistant, count) -> None:
     """Test: configs."""
     assert len(hass.states.async_all("vacuum")) == count
 
@@ -144,7 +144,8 @@ async def test_invalid_configs(hass: HomeAssistant, count, start_ha) -> None:
         )
     ],
 )
-async def test_templates_with_entities(hass: HomeAssistant, start_ha) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_templates_with_entities(hass: HomeAssistant) -> None:
     """Test templates with values from other entities."""
     _verify(hass, STATE_UNKNOWN, None)
 
@@ -174,7 +175,8 @@ async def test_templates_with_entities(hass: HomeAssistant, start_ha) -> None:
         )
     ],
 )
-async def test_available_template_with_entities(hass: HomeAssistant, start_ha) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_available_template_with_entities(hass: HomeAssistant) -> None:
     """Test availability templates with values from other entities."""
 
     # When template returns true..
@@ -212,8 +214,9 @@ async def test_available_template_with_entities(hass: HomeAssistant, start_ha) -
         )
     ],
 )
+@pytest.mark.usefixtures("start_ha")
 async def test_invalid_availability_template_keeps_component_available(
-    hass: HomeAssistant, start_ha, caplog_setup_text
+    hass: HomeAssistant, caplog_setup_text
 ) -> None:
     """Test that an invalid availability keeps the device available."""
     assert hass.states.get("vacuum.test_template_vacuum") != STATE_UNAVAILABLE
@@ -243,7 +246,8 @@ async def test_invalid_availability_template_keeps_component_available(
         )
     ],
 )
-async def test_attribute_templates(hass: HomeAssistant, start_ha) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_attribute_templates(hass: HomeAssistant) -> None:
     """Test attribute_templates template."""
     state = hass.states.get("vacuum.test_template_vacuum")
     assert state.attributes["test_attribute"] == "It ."
@@ -278,8 +282,9 @@ async def test_attribute_templates(hass: HomeAssistant, start_ha) -> None:
         )
     ],
 )
+@pytest.mark.usefixtures("start_ha")
 async def test_invalid_attribute_template(
-    hass: HomeAssistant, start_ha, caplog_setup_text
+    hass: HomeAssistant, caplog_setup_text
 ) -> None:
     """Test that errors are logged if rendering template fails."""
     assert len(hass.states.async_all("vacuum")) == 1
@@ -313,7 +318,8 @@ async def test_invalid_attribute_template(
         ),
     ],
 )
-async def test_unique_id(hass: HomeAssistant, start_ha) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_unique_id(hass: HomeAssistant) -> None:
     """Test unique_id option only creates one vacuum per id."""
     assert len(hass.states.async_all("vacuum")) == 1
 

--- a/tests/components/template/test_weather.py
+++ b/tests/components/template/test_weather.py
@@ -23,7 +23,6 @@ from homeassistant.components.weather import (
 )
 from homeassistant.const import ATTR_ATTRIBUTION, STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import Context, HomeAssistant, State
-from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.restore_state import STORAGE_KEY as RESTORE_STATE_KEY
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
@@ -65,7 +64,8 @@ ATTR_FORECAST = "forecast"
         },
     ],
 )
-async def test_template_state_text(hass: HomeAssistant, start_ha) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_template_state_text(hass: HomeAssistant) -> None:
     """Test the state text of a template."""
     for attr, v_attr, value in (
         (
@@ -117,8 +117,9 @@ async def test_template_state_text(hass: HomeAssistant, start_ha) -> None:
         },
     ],
 )
+@pytest.mark.usefixtures("start_ha")
 async def test_forecasts(
-    hass: HomeAssistant, start_ha, snapshot: SnapshotAssertion, service: str
+    hass: HomeAssistant, snapshot: SnapshotAssertion, service: str
 ) -> None:
     """Test forecast service."""
     for attr, _v_attr, value in (
@@ -241,9 +242,9 @@ async def test_forecasts(
         },
     ],
 )
+@pytest.mark.usefixtures("start_ha")
 async def test_forecast_invalid(
     hass: HomeAssistant,
-    start_ha,
     caplog: pytest.LogCaptureFixture,
     service: str,
     expected: dict[str, Any],
@@ -323,9 +324,9 @@ async def test_forecast_invalid(
         },
     ],
 )
+@pytest.mark.usefixtures("start_ha")
 async def test_forecast_invalid_is_daytime_missing_in_twice_daily(
     hass: HomeAssistant,
-    start_ha,
     caplog: pytest.LogCaptureFixture,
     service: str,
     expected: dict[str, Any],
@@ -391,9 +392,9 @@ async def test_forecast_invalid_is_daytime_missing_in_twice_daily(
         },
     ],
 )
+@pytest.mark.usefixtures("start_ha")
 async def test_forecast_invalid_datetime_missing(
     hass: HomeAssistant,
-    start_ha,
     caplog: pytest.LogCaptureFixture,
     service: str,
     expected: dict[str, Any],
@@ -458,8 +459,9 @@ async def test_forecast_invalid_datetime_missing(
         },
     ],
 )
+@pytest.mark.usefixtures("start_ha")
 async def test_forecast_format_error(
-    hass: HomeAssistant, start_ha, caplog: pytest.LogCaptureFixture, service: str
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, service: str
 ) -> None:
     """Test forecast service invalid on incorrect format."""
     for attr, _v_attr, value in (
@@ -649,9 +651,8 @@ async def test_trigger_entity_restore_state(
         },
     ],
 )
-async def test_trigger_action(
-    hass: HomeAssistant, start_ha, entity_registry: er.EntityRegistry
-) -> None:
+@pytest.mark.usefixtures("start_ha")
+async def test_trigger_action(hass: HomeAssistant) -> None:
     """Test trigger entity with an action works."""
     state = hass.states.get("weather.hello_name")
     assert state is not None
@@ -720,11 +721,10 @@ async def test_trigger_action(
         },
     ],
 )
+@pytest.mark.usefixtures("start_ha")
 @pytest.mark.freeze_time("2023-10-19 13:50:05")
 async def test_trigger_weather_services(
     hass: HomeAssistant,
-    start_ha,
-    entity_registry: er.EntityRegistry,
     snapshot: SnapshotAssertion,
     service: str,
 ) -> None:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, spotted whilst working on #126806

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
