### PR TITLE
Fix climate temperature range checking does not support customization of ranges

### DIFF
--- a/homeassistant/components/climate/__init__.py
+++ b/homeassistant/components/climate/__init__.py
@@ -995,9 +995,8 @@ async def async_service_temperature_set(
     # otherwise use the default entity_id
     else:
         entity_id = entity.entity_id
-    
     # Get the min and max from the state machine in case they have been
-    # overridden through customize.
+    # overridden through customization.
     if entity_state := hass.states.get(entity_id):
         min_temp = entity_state.attributes.get(ATTR_MIN_TEMP, entity.min_temp)
         max_temp = entity_state.attributes.get(ATTR_MAX_TEMP, entity.max_temp)

--- a/homeassistant/components/climate/__init__.py
+++ b/homeassistant/components/climate/__init__.py
@@ -995,11 +995,16 @@ async def async_service_temperature_set(
     # otherwise use the default entity_id
     else:
         entity_id = entity.entity_id
-    entity_state = hass.states.get(entity_id)
+    
     # Get the min and max from the state machine in case they have been
     # overridden through customize.
-    min_temp = entity_state.attributes.get(ATTR_MIN_TEMP, entity.min_temp)
-    max_temp = entity_state.attributes.get(ATTR_MAX_TEMP, entity.max_temp)
+    if entity_state := hass.states.get(entity_id):
+        min_temp = entity_state.attributes.get(ATTR_MIN_TEMP, entity.min_temp)
+        max_temp = entity_state.attributes.get(ATTR_MAX_TEMP, entity.max_temp)
+    else:
+        min_temp = entity.min_temp
+        max_temp = entity.max_temp
+
     temp_unit = entity.temperature_unit
 
     if (

--- a/homeassistant/components/climate/__init__.py
+++ b/homeassistant/components/climate/__init__.py
@@ -995,9 +995,7 @@ async def async_service_temperature_set(
     # otherwise use the default entity_id
     else:
         entity_id = entity.entity_id
-
     entity_state = hass.states.get(entity_id)
-
     # Get the min and max from the state machine in case they have been
     # overridden through customize.
     min_temp = entity_state.attributes.get(ATTR_MIN_TEMP, entity.min_temp)

--- a/homeassistant/components/climate/__init__.py
+++ b/homeassistant/components/climate/__init__.py
@@ -989,7 +989,7 @@ async def async_service_temperature_set(
 
     # If the entity has a unique id then look it up in the registry to get its entity id.
     if er_entity_id := entity_reg.async_get_entity_id(
-        entity.platform.domain, entity.platform.platform_name, entity.unique_id
+        entity.platform.domain, entity.platform.platform_name, str(entity.unique_id)
     ):
         entity_id = er_entity_id
     # otherwise use the default entity_id

--- a/homeassistant/components/climate/__init__.py
+++ b/homeassistant/components/climate/__init__.py
@@ -987,13 +987,15 @@ async def async_service_temperature_set(
     kwargs: dict[str, Any] = {}
     entity_reg: er.EntityRegistry = er.async_get(hass)
 
-    # If the entity has a unique id then look it up in the registry
-    # to get its entity id, otherwise use the entity default entity_id
-    entity_id: str = entity.entity_id
+    # If the entity has a unique id then look it up in the registry to get its entity id.
     if er_entity_id := entity_reg.async_get_entity_id(
         entity.platform.domain, entity.platform.platform_name, entity.unique_id
     ):
         entity_id = er_entity_id
+    # otherwise use the default entity_id
+    else:
+        entity_id = entity.entity_id
+
     entity_state = hass.states.get(entity_id)
 
     # Get the min and max from the state machine in case they have been
@@ -1020,7 +1022,8 @@ async def async_service_temperature_set(
             )
 
             _LOGGER.debug(
-                "Check valid temperature %d %s (%d %s) in range %d %s - %d %s",
+                "Check valid temperature %s %d %s (%d %s) in range %d %s - %d %s",
+                entity_id,
                 check_temp,
                 entity.temperature_unit,
                 temp,

--- a/tests/components/climate/test_init.py
+++ b/tests/components/climate/test_init.py
@@ -1227,6 +1227,8 @@ async def test_temperature_validation(
     assert state.attributes.get(ATTR_TARGET_TEMP_LOW) == 10
     assert state.attributes.get(ATTR_TARGET_TEMP_HIGH) == 25
 
+    # Test that the min or max temps may be overridden in the state machine
+    # Fox example by using customize.
     attributes = state.attributes.copy()
     attributes[ATTR_MIN_TEMP] = 0.0
     attributes[ATTR_MAX_TEMP] = 45.0
@@ -1245,6 +1247,7 @@ async def test_temperature_validation(
         blocking=True,
     )
 
+    # Repeat the tests used the entity without a unique id
     with pytest.raises(
         ServiceValidationError,
         match="Provided temperature 0.0 is not valid. Accepted range is 7 to 35",


### PR DESCRIPTION
## Proposed change
PR #118649 introduced validation of climate temperature ranges in the climate platform. Prior to this change, the limits were enforced in the UI and optionally in the integration.  The climate min and max temperature ranges may be overridden using **customize** - this change updates the validation code to take this into account.

Here is a simple example using the generic thermostat.  The min limit that should be checked should be 40.

```
input_boolean:
 study_heater:
    name: study_heater

input_number:
  study_temperature:
    min: 0
    max: 80
    step: 1
    unit_of_measurement: "°F"
    mode: box


climate:
  - platform: generic_thermostat
    name: study
    heater: input_boolean.study_heater
    target_sensor: input_number.study_temperature
    min_temp: 60
    max_temp: 80
    ac_mode: false
    target_temp: 17
    cold_tolerance: 0.3
    hot_tolerance: 0
    min_cycle_duration:
      seconds: 5
    keep_alive:
      minutes: 3
    initial_hvac_mode: "off"
    away_temp: 16

homeassistant:
  customize:
    climate.study:
      min_temp: 40    
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #123612
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
