### PR TITLE
Change Assist satellite state names

### DIFF
--- a/homeassistant/components/assist_satellite/strings.json
+++ b/homeassistant/components/assist_satellite/strings.json
@@ -4,7 +4,7 @@
     "_": {
       "name": "Assist satellite",
       "state": {
-        "idle": "Idle",
+        "idle": "[%key:common::state::idle%]",
         "listening": "Listening",
         "responding": "Responding",
         "processing": "Processing"

--- a/homeassistant/components/assist_satellite/strings.json
+++ b/homeassistant/components/assist_satellite/strings.json
@@ -4,8 +4,8 @@
     "_": {
       "name": "Assist satellite",
       "state": {
-        "listening_wake_word": "Wake word",
-        "listening_command": "Voice command",
+        "idle": "Idle",
+        "listening": "Listening",
         "responding": "Responding",
         "processing": "Processing"
       }

--- a/tests/components/assist_satellite/test_entity.py
+++ b/tests/components/assist_satellite/test_entity.py
@@ -37,7 +37,7 @@ async def test_entity_state(
 
     state = hass.states.get(ENTITY_ID)
     assert state is not None
-    assert state.state == AssistSatelliteState.LISTENING_WAKE_WORD
+    assert state.state == AssistSatelliteState.IDLE
 
     context = Context()
     audio_stream = object()
@@ -73,18 +73,18 @@ async def test_entity_state(
     assert kwargs["end_stage"] == PipelineStage.TTS
 
     for event_type, event_data, expected_state in (
-        (PipelineEventType.RUN_START, {}, AssistSatelliteState.LISTENING_WAKE_WORD),
-        (PipelineEventType.RUN_END, {}, AssistSatelliteState.LISTENING_WAKE_WORD),
+        (PipelineEventType.RUN_START, {}, AssistSatelliteState.IDLE),
+        (PipelineEventType.RUN_END, {}, AssistSatelliteState.IDLE),
         (
             PipelineEventType.WAKE_WORD_START,
             {},
-            AssistSatelliteState.LISTENING_WAKE_WORD,
+            AssistSatelliteState.IDLE,
         ),
-        (PipelineEventType.WAKE_WORD_END, {}, AssistSatelliteState.LISTENING_WAKE_WORD),
-        (PipelineEventType.STT_START, {}, AssistSatelliteState.LISTENING_COMMAND),
-        (PipelineEventType.STT_VAD_START, {}, AssistSatelliteState.LISTENING_COMMAND),
-        (PipelineEventType.STT_VAD_END, {}, AssistSatelliteState.LISTENING_COMMAND),
-        (PipelineEventType.STT_END, {}, AssistSatelliteState.LISTENING_COMMAND),
+        (PipelineEventType.WAKE_WORD_END, {}, AssistSatelliteState.IDLE),
+        (PipelineEventType.STT_START, {}, AssistSatelliteState.LISTENING),
+        (PipelineEventType.STT_VAD_START, {}, AssistSatelliteState.LISTENING),
+        (PipelineEventType.STT_VAD_END, {}, AssistSatelliteState.LISTENING),
+        (PipelineEventType.STT_END, {}, AssistSatelliteState.LISTENING),
         (PipelineEventType.INTENT_START, {}, AssistSatelliteState.PROCESSING),
         (
             PipelineEventType.INTENT_END,
@@ -105,7 +105,7 @@ async def test_entity_state(
 
     entity.tts_response_finished()
     state = hass.states.get(ENTITY_ID)
-    assert state.state == AssistSatelliteState.LISTENING_WAKE_WORD
+    assert state.state == AssistSatelliteState.IDLE
 
 
 async def test_new_pipeline_cancels_pipeline(
@@ -241,7 +241,7 @@ async def test_announce(
             target={"entity_id": "assist_satellite.test_entity"},
             blocking=True,
         )
-        assert entity.state == AssistSatelliteState.LISTENING_WAKE_WORD
+        assert entity.state == AssistSatelliteState.IDLE
 
     assert entity.announcements[0] == expected_params
 

--- a/tests/components/esphome/test_assist_satellite.py
+++ b/tests/components/esphome/test_assist_satellite.py
@@ -187,7 +187,7 @@ async def test_pipeline_api_audio(
         )
 
         # Wake word
-        assert satellite.state == AssistSatelliteState.LISTENING_WAKE_WORD
+        assert satellite.state == AssistSatelliteState.IDLE
 
         event_callback(
             PipelineEvent(
@@ -242,7 +242,7 @@ async def test_pipeline_api_audio(
             VoiceAssistantEventType.VOICE_ASSISTANT_STT_START,
             {},
         )
-        assert satellite.state == AssistSatelliteState.LISTENING_COMMAND
+        assert satellite.state == AssistSatelliteState.LISTENING
 
         event_callback(
             PipelineEvent(
@@ -761,7 +761,7 @@ async def test_pipeline_media_player(
             )
             await tts_finished.wait()
 
-            assert satellite.state == AssistSatelliteState.LISTENING_WAKE_WORD
+            assert satellite.state == AssistSatelliteState.IDLE
 
 
 async def test_timer_events(
@@ -1214,7 +1214,7 @@ async def test_announce_message(
                 blocking=True,
             )
             await done.wait()
-            assert satellite.state == AssistSatelliteState.LISTENING_WAKE_WORD
+            assert satellite.state == AssistSatelliteState.IDLE
 
 
 async def test_announce_media_id(
@@ -1297,7 +1297,7 @@ async def test_announce_media_id(
                 blocking=True,
             )
             await done.wait()
-            assert satellite.state == AssistSatelliteState.LISTENING_WAKE_WORD
+            assert satellite.state == AssistSatelliteState.IDLE
 
         mock_async_create_proxy_url.assert_called_once_with(
             hass,

--- a/tests/components/voip/test_voip.py
+++ b/tests/components/voip/test_voip.py
@@ -199,7 +199,7 @@ async def test_pipeline(
     assert voip_user_id
 
     # Satellite is muted until a call begins
-    assert satellite.state == AssistSatelliteState.LISTENING_WAKE_WORD
+    assert satellite.state == AssistSatelliteState.IDLE
 
     done = asyncio.Event()
 
@@ -251,7 +251,7 @@ async def test_pipeline(
             )
         )
 
-        assert satellite.state == AssistSatelliteState.LISTENING_COMMAND
+        assert satellite.state == AssistSatelliteState.LISTENING
 
         # Fake STT result
         event_callback(
@@ -345,7 +345,7 @@ async def test_pipeline(
         satellite.transport = Mock()
 
         satellite.connection_made(satellite.transport)
-        assert satellite.state == AssistSatelliteState.LISTENING_WAKE_WORD
+        assert satellite.state == AssistSatelliteState.IDLE
 
         # Ensure audio queue is cleared before pipeline starts
         satellite._audio_queue.put_nowait(bad_chunk)
@@ -370,7 +370,7 @@ async def test_pipeline(
             await done.wait()
 
         # Finished speaking
-        assert satellite.state == AssistSatelliteState.LISTENING_WAKE_WORD
+        assert satellite.state == AssistSatelliteState.IDLE
 
 
 async def test_stt_stream_timeout(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Change some of the Assist satellite state names to be more in line with the original proposal, specifically:

* `listening_wake_word` becomes `idle`
* `listening_voice_command` becomes just `listening`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
