### PR TITLE
Use pathlib in homeassistant core files

### DIFF
--- a/homeassistant/requirements.py
+++ b/homeassistant/requirements.py
@@ -6,7 +6,7 @@ import asyncio
 from collections.abc import Iterable
 import contextlib
 import logging
-import os
+from pathlib import Path
 from typing import Any
 
 from packaging.requirements import Requirement
@@ -85,15 +85,15 @@ def async_clear_install_history(hass: HomeAssistant) -> None:
     _async_get_manager(hass).install_failure_history.clear()
 
 
-def pip_kwargs(config_dir: str | None) -> dict[str, Any]:
+def pip_kwargs(config_dir: Path | None) -> dict[str, Any]:
     """Return keyword arguments for PIP install."""
     is_docker = pkg_util.is_docker_env()
     kwargs = {
-        "constraints": os.path.join(os.path.dirname(__file__), CONSTRAINT_FILE),
+        "constraints": str(Path(__file__).parent / CONSTRAINT_FILE),
         "timeout": PIP_TIMEOUT,
     }
     if not (config_dir is None or pkg_util.is_virtual_env()) and not is_docker:
-        kwargs["target"] = os.path.join(config_dir, "deps")
+        kwargs["target"] = str(config_dir / "deps")
     return kwargs
 
 
@@ -297,7 +297,7 @@ class RequirementsManager:
         requirements: list[str],
     ) -> None:
         """Install a requirement and save failures."""
-        kwargs = pip_kwargs(self.hass.config.config_dir)
+        kwargs = pip_kwargs(Path(self.hass.config.config_dir))
         installed, failures = await self.hass.async_add_executor_job(
             _install_requirements_if_missing, requirements, kwargs
         )

--- a/homeassistant/runner.py
+++ b/homeassistant/runner.py
@@ -7,6 +7,7 @@ from asyncio import events
 import dataclasses
 import logging
 import os
+from pathlib import Path
 import subprocess
 import threading
 from time import monotonic
@@ -41,7 +42,7 @@ _LOGGER = logging.getLogger(__name__)
 class RuntimeConfig:
     """Class to hold the information for running Home Assistant."""
 
-    config_dir: str
+    config_dir: Path
     skip_pip: bool = False
     skip_pip_packages: list[str] = dataclasses.field(default_factory=list)
     recovery_mode: bool = False
@@ -49,7 +50,7 @@ class RuntimeConfig:
     verbose: bool = False
 
     log_rotate_days: int | None = None
-    log_file: str | None = None
+    log_file: Path | None = None
     log_no_color: bool = False
 
     debug: bool = False

--- a/homeassistant/scripts/__init__.py
+++ b/homeassistant/scripts/__init__.py
@@ -8,6 +8,7 @@ from collections.abc import Sequence
 import importlib
 import logging
 import os
+from pathlib import Path
 import sys
 
 from homeassistant import runner
@@ -68,13 +69,13 @@ def run(args: list[str]) -> int:
     return script.run(args[1:])
 
 
-def extract_config_dir(args: Sequence[str] | None = None) -> str:
+def extract_config_dir(args: Sequence[str] | None = None) -> Path:
     """Extract the config dir from the arguments or get the default."""
     parser = argparse.ArgumentParser(add_help=False)
     parser.add_argument("-c", "--config", default=None)
     parsed_args = parser.parse_known_args(args)[0]
     return (
-        os.path.join(os.getcwd(), parsed_args.config)
+        Path.cwd() / parsed_args.config
         if parsed_args.config
         else get_default_config_dir()
     )

--- a/homeassistant/util/package.py
+++ b/homeassistant/util/package.py
@@ -157,13 +157,13 @@ def install_package(
     return True
 
 
-async def async_get_user_site(deps_dir: str) -> str:
+async def async_get_user_site(deps_dir: Path) -> Path:
     """Return user local library path.
 
     This function is a coroutine.
     """
     env = os.environ.copy()
-    env["PYTHONUSERBASE"] = os.path.abspath(deps_dir)
+    env["PYTHONUSERBASE"] = str(deps_dir.resolve())
     args = [sys.executable, "-m", "site", "--user-site"]
     process = await asyncio.create_subprocess_exec(
         *args,
@@ -174,4 +174,4 @@ async def async_get_user_site(deps_dir: str) -> str:
         close_fds=False,  # required for posix_spawn
     )
     stdout, _ = await process.communicate()
-    return stdout.decode().strip()
+    return Path(stdout.decode().strip())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -920,7 +920,7 @@ split-on-trailing-comma = false
 "tests/components/*/*/*" = ["TID252"]
 
 # Temporary
-"homeassistant/**" = ["PTH"]
+"homeassistant/*/**" = ["PTH"]
 "tests/**" = ["PTH"]
 
 [tool.ruff.lint.mccabe]

--- a/tests/scripts/test_init.py
+++ b/tests/scripts/test_init.py
@@ -1,15 +1,16 @@
 """Test script init."""
 
+from pathlib import Path
 from unittest.mock import patch
 
 from homeassistant import scripts
 
 
-@patch("homeassistant.scripts.get_default_config_dir", return_value="/default")
+@patch("homeassistant.scripts.get_default_config_dir", return_value=Path("/default"))
 def test_config_per_platform(mock_def) -> None:
     """Test config per platform method."""
-    assert scripts.get_default_config_dir() == "/default"
-    assert scripts.extract_config_dir() == "/default"
-    assert scripts.extract_config_dir([""]) == "/default"
-    assert scripts.extract_config_dir(["-c", "/arg"]) == "/arg"
-    assert scripts.extract_config_dir(["--config", "/a"]) == "/a"
+    assert scripts.get_default_config_dir() == Path("/default")
+    assert scripts.extract_config_dir() == Path("/default")
+    assert scripts.extract_config_dir([""]) == Path("/default")
+    assert scripts.extract_config_dir(["-c", "/arg"]) == Path("/arg")
+    assert scripts.extract_config_dir(["--config", "/a"]) == Path("/a")

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -6,6 +6,7 @@ import contextlib
 import glob
 import logging
 import os
+from pathlib import Path
 import sys
 from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
@@ -102,7 +103,7 @@ async def test_async_enable_logging(
         await bootstrap.async_enable_logging(
             hass,
             log_rotate_days=5,
-            log_file="test.log",
+            log_file=Path("test.log"),
         )
         mock_async_activate_log_queue_handler.assert_called_once()
         for f in glob.glob("test.log*"):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1922,7 +1922,7 @@ async def test_config_defaults() -> None:
     """Test config defaults."""
     hass = Mock()
     hass.data = {}
-    config = ha.Config(hass, "/test/ha-config")
+    config = ha.Config(hass, Path("/test/ha-config"))
     assert config.hass is hass
     assert config.latitude == 0
     assert config.longitude == 0
@@ -1952,7 +1952,7 @@ async def test_config_path_with_file() -> None:
     """Test get_config_path method."""
     hass = Mock()
     hass.data = {}
-    config = ha.Config(hass, "/test/ha-config")
+    config = ha.Config(hass, Path("/test/ha-config"))
     assert config.path("test.conf") == "/test/ha-config/test.conf"
 
 
@@ -1960,7 +1960,7 @@ async def test_config_path_with_dir_and_file() -> None:
     """Test get_config_path method."""
     hass = Mock()
     hass.data = {}
-    config = ha.Config(hass, "/test/ha-config")
+    config = ha.Config(hass, Path("/test/ha-config"))
     assert config.path("dir", "test.conf") == "/test/ha-config/dir/test.conf"
 
 
@@ -1968,7 +1968,7 @@ async def test_config_as_dict() -> None:
     """Test as dict."""
     hass = Mock()
     hass.data = {}
-    config = ha.Config(hass, "/test/ha-config")
+    config = ha.Config(hass, Path("/test/ha-config"))
     type(config.hass.state).value = PropertyMock(return_value="RUNNING")
     expected = {
         "latitude": 0,
@@ -2003,7 +2003,7 @@ async def test_config_is_allowed_path() -> None:
     """Test is_allowed_path method."""
     hass = Mock()
     hass.data = {}
-    config = ha.Config(hass, "/test/ha-config")
+    config = ha.Config(hass, Path("/test/ha-config"))
     with TemporaryDirectory() as tmp_dir:
         # The created dir is in /tmp. This is a symlink on OS X
         # causing this test to fail unless we resolve path first.
@@ -2038,7 +2038,7 @@ async def test_config_is_allowed_external_url() -> None:
     """Test is_allowed_external_url method."""
     hass = Mock()
     hass.data = {}
-    config = ha.Config(hass, "/test/ha-config")
+    config = ha.Config(hass, Path("/test/ha-config"))
     config.allowlist_external_urls = [
         "http://x.com/",
         "https://y.com/bla/",
@@ -2303,7 +2303,7 @@ async def test_additional_data_in_core_config(
     hass: HomeAssistant, hass_storage: dict[str, Any]
 ) -> None:
     """Test that we can handle additional data in core configuration."""
-    config = ha.Config(hass, "/test/ha-config")
+    config = ha.Config(hass, Path("/test/ha-config"))
     config.async_initialize()
     hass_storage[ha.CORE_STORAGE_KEY] = {
         "version": 1,
@@ -2317,7 +2317,7 @@ async def test_incorrect_internal_external_url(
     hass: HomeAssistant, hass_storage: dict[str, Any], caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test that we warn when detecting invalid internal/external url."""
-    config = ha.Config(hass, "/test/ha-config")
+    config = ha.Config(hass, Path("/test/ha-config"))
     config.async_initialize()
 
     hass_storage[ha.CORE_STORAGE_KEY] = {
@@ -2331,7 +2331,7 @@ async def test_incorrect_internal_external_url(
     assert "Invalid external_url set" not in caplog.text
     assert "Invalid internal_url set" not in caplog.text
 
-    config = ha.Config(hass, "/test/ha-config")
+    config = ha.Config(hass, Path("/test/ha-config"))
     config.async_initialize()
 
     hass_storage[ha.CORE_STORAGE_KEY] = {

--- a/tests/util/test_package.py
+++ b/tests/util/test_package.py
@@ -5,6 +5,7 @@ from collections.abc import Generator
 from importlib.metadata import metadata
 import logging
 import os
+from pathlib import Path
 from subprocess import PIPE
 import sys
 from unittest.mock import MagicMock, Mock, call, patch
@@ -322,9 +323,9 @@ def test_install_constraint(mock_popen, mock_env_copy) -> None:
 
 async def test_async_get_user_site(mock_env_copy) -> None:
     """Test async get user site directory."""
-    deps_dir = "/deps_dir"
+    deps_dir = Path("/deps_dir")
     env = mock_env_copy()
-    env["PYTHONUSERBASE"] = os.path.abspath(deps_dir)
+    env["PYTHONUSERBASE"] = str(deps_dir.resolve())
     args = [sys.executable, "-m", "site", "--user-site"]
     with patch(
         "homeassistant.util.package.asyncio.create_subprocess_exec",
@@ -340,7 +341,7 @@ async def test_async_get_user_site(mock_env_copy) -> None:
         env=env,
         close_fds=False,
     )
-    assert ret == os.path.join(deps_dir, "lib_dir")
+    assert ret == deps_dir / "lib_dir"
 
 
 def test_check_package_global(caplog: pytest.LogCaptureFixture) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Migrate the `homeassistant/*.py` files to pathlib.

Functions which are used by components, HACS components or other parts of core are kept to accept `str | Path` und returning `str`.

- `homeassistant.config.load_yaml_config_file()` is used by a few components
- `hass.config.path()` is used extensively everywhere. The only chance I see is to create a second function which returns a `Path` object.
- `hass.config.config_dir` is used in quite a few components and HACS components as well, so there would be the need to use another variable to have a `Path` object as well.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
