### PR TITLE
Start mqtt integration discovery config flow only once if config has not changed

### DIFF
--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -191,7 +191,7 @@ async def async_start(  # noqa: C901
     """Start MQTT Discovery."""
     mqtt_data = hass.data[DATA_MQTT]
     platform_setup_lock: dict[str, asyncio.Lock] = {}
-    integration_discovery_discovered: dict[str, int] = {}
+    integration_discovery_messages: dict[str, int] = {}
 
     @callback
     def _async_add_component(discovery_payload: MQTTDiscoveryPayload) -> None:
@@ -369,8 +369,8 @@ async def async_start(  # noqa: C901
     ) -> None:
         """Process the received message."""
         if (
-            msg.topic in integration_discovery_discovered
-            and integration_discovery_discovered[msg.topic] == hash(msg.payload)
+            msg.topic in integration_discovery_messages
+            and integration_discovery_messages[msg.topic] == hash(msg.payload)
         ):
             _LOGGER.debug(
                 "Ignoring already processed discovery message for '%s' on topic %s: %s",
@@ -398,10 +398,10 @@ async def async_start(  # noqa: C901
             )
             if msg.payload:
                 # Update the last discovered config message
-                integration_discovery_discovered[msg.topic] = hash(msg.payload)
-            elif msg.topic in integration_discovery_discovered:
+                integration_discovery_messages[msg.topic] = hash(msg.payload)
+            elif msg.topic in integration_discovery_messages:
                 # Cleanup hash if discovery payload is empty
-                del integration_discovery_discovered[msg.topic]
+                del integration_discovery_messages[msg.topic]
 
     integration_unsubscribe.update(
         {

--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -14,7 +14,6 @@ from typing import TYPE_CHECKING, Any
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_DEVICE, CONF_PLATFORM
 from homeassistant.core import HassJobType, HomeAssistant, callback
-from homeassistant.data_entry_flow import FlowResultType
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect,
@@ -382,15 +381,10 @@ async def async_start(  # noqa: C901
             return
         if TYPE_CHECKING:
             assert mqtt_data.data_config_flow_lock
-        key = f"{integration}_{msg.subscribed_topic}"
 
         # Lock to prevent initiating many parallel config flows.
         # Note: The lock is not intended to prevent a race, only for performance
         async with mqtt_data.data_config_flow_lock:
-            # Already unsubscribed
-            if key not in integration_unsubscribe:
-                return
-
             data = MqttServiceInfo(
                 topic=msg.topic,
                 payload=msg.payload,
@@ -399,18 +393,15 @@ async def async_start(  # noqa: C901
                 subscribed_topic=msg.subscribed_topic,
                 timestamp=msg.timestamp,
             )
-            result = await hass.config_entries.flow.async_init(
+            await hass.config_entries.flow.async_init(
                 integration, context={"source": DOMAIN}, data=data
             )
-            if (
-                result
-                and result["type"] == FlowResultType.ABORT
-                and result["reason"] == "single_instance_allowed"
-            ):
-                integration_unsubscribe.pop(key)()
-            else:
+            if msg.payload:
                 # Update the last discovered config message
                 integration_discovery_discovered[msg.topic] = hash(msg.payload)
+            elif msg.topic in integration_discovery_discovered:
+                # Cleanup hash if discovery payload is empty
+                del integration_discovery_discovered[msg.topic]
 
     integration_unsubscribe.update(
         {

--- a/tests/components/mqtt/test_discovery.py
+++ b/tests/components/mqtt/test_discovery.py
@@ -1503,7 +1503,7 @@ async def test_mqtt_integration_discovery_flow_fitering_on_redundant_payload(
         await hass.async_block_till_done(wait_background_tasks=True)
         assert len(flow_calls) == 1
 
-        # A updated message gets starts a new flow
+        # An updated message gets starts a new flow
         await hass.async_block_till_done(wait_background_tasks=True)
         async_fire_mqtt_message(hass, "comp/discovery/bla/config", "update message")
         await hass.async_block_till_done(wait_background_tasks=True)
@@ -1589,7 +1589,7 @@ async def test_mqtt_discovery_flow_starts_once(
         assert flow_calls[2].topic == "comp/discovery/bla/config2"
         assert flow_calls[2].payload == "update message"
 
-        # And empty message triggers a flow to allow cleanup
+        # An empty message triggers a flow to allow cleanup
         async_fire_mqtt_message(hass, "comp/discovery/bla/config2", "")
         await hass.async_block_till_done(wait_background_tasks=True)
 

--- a/tests/components/mqtt/test_discovery.py
+++ b/tests/components/mqtt/test_discovery.py
@@ -1448,26 +1448,20 @@ async def test_complex_discovery_topic_prefix(
 @patch("homeassistant.components.mqtt.client.SUBSCRIBE_COOLDOWN", 0.0)
 @patch("homeassistant.components.mqtt.client.UNSUBSCRIBE_COOLDOWN", 0.0)
 @pytest.mark.parametrize(
-    ("reason", "unsubscribes"),
-    [
-        ("single_instance_allowed", True),
-        ("already_configured", False),
-        ("some_abort_error", False),
-    ],
+    "reason", ["single_instance_allowed", "already_configured", "some_abort_error"]
 )
-async def test_mqtt_integration_discovery_subscribe_unsubscribe(
-    hass: HomeAssistant,
-    mqtt_client_mock: MqttMockPahoClient,
-    reason: str,
-    unsubscribes: bool,
+async def test_mqtt_integration_discovery_flow_fitering_on_redundant_payload(
+    hass: HomeAssistant, mqtt_client_mock: MqttMockPahoClient, reason: str
 ) -> None:
-    """Check MQTT integration discovery subscribe and unsubscribe."""
+    """Check MQTT integration discovery starts a flow once."""
+    flow_calls: list[MqttServiceInfo] = []
 
     class TestFlow(config_entries.ConfigFlow):
         """Test flow."""
 
         async def async_step_mqtt(self, discovery_info: MqttServiceInfo) -> FlowResult:
             """Test mqtt step."""
+            flow_calls.append(discovery_info)
             return self.async_abort(reason=reason)
 
     mock_platform(hass, "comp.config_flow", None)
@@ -1496,82 +1490,24 @@ async def test_mqtt_integration_discovery_subscribe_unsubscribe(
         assert ("comp/discovery/#", 0) in help_all_subscribe_calls(mqtt_client_mock)
         assert not mqtt_client_mock.unsubscribe.called
         mqtt_client_mock.reset_mock()
+        assert len(flow_calls) == 0
 
         await hass.async_block_till_done(wait_background_tasks=True)
-        async_fire_mqtt_message(hass, "comp/discovery/bla/config", "")
-        await hass.async_block_till_done()
+        async_fire_mqtt_message(hass, "comp/discovery/bla/config", "initial message")
         await hass.async_block_till_done(wait_background_tasks=True)
+        assert len(flow_calls) == 1
 
-        assert (
-            unsubscribes
-            and call(["comp/discovery/#"]) in mqtt_client_mock.unsubscribe.mock_calls
-            or not unsubscribes
-            and call(["comp/discovery/#"])
-            not in mqtt_client_mock.unsubscribe.mock_calls
-        )
+        # A redundant message gets does not start a new flow
         await hass.async_block_till_done(wait_background_tasks=True)
-
-
-@patch("homeassistant.components.mqtt.client.DISCOVERY_COOLDOWN", 0.0)
-@patch("homeassistant.components.mqtt.client.INITIAL_SUBSCRIBE_COOLDOWN", 0.0)
-@patch("homeassistant.components.mqtt.client.SUBSCRIBE_COOLDOWN", 0.0)
-@patch("homeassistant.components.mqtt.client.UNSUBSCRIBE_COOLDOWN", 0.0)
-async def test_mqtt_discovery_unsubscribe_once(
-    hass: HomeAssistant, mqtt_client_mock: MqttMockPahoClient
-) -> None:
-    """Check MQTT integration discovery unsubscribe once."""
-
-    class TestFlow(config_entries.ConfigFlow):
-        """Test flow."""
-
-        async def async_step_mqtt(self, discovery_info: MqttServiceInfo) -> FlowResult:
-            """Test mqtt step."""
-            await asyncio.sleep(0)
-            return self.async_abort(reason="single_instance_allowed")
-
-    mock_platform(hass, "comp.config_flow", None)
-
-    birth = asyncio.Event()
-
-    @callback
-    def wait_birth(msg: ReceiveMessage) -> None:
-        """Handle birth message."""
-        birth.set()
-
-    wait_unsub = asyncio.Event()
-
-    @callback
-    def _mock_unsubscribe(topics: list[str]) -> tuple[int, int]:
-        wait_unsub.set()
-        return (0, 0)
-
-    entry = MockConfigEntry(domain=mqtt.DOMAIN, data=ENTRY_DEFAULT_BIRTH_MESSAGE)
-    entry.add_to_hass(hass)
-
-    with (
-        patch(
-            "homeassistant.components.mqtt.discovery.async_get_mqtt",
-            return_value={"comp": ["comp/discovery/#"]},
-        ),
-        mock_config_flow("comp", TestFlow),
-        patch.object(mqtt_client_mock, "unsubscribe", side_effect=_mock_unsubscribe),
-    ):
-        assert await hass.config_entries.async_setup(entry.entry_id)
-        await mqtt.async_subscribe(hass, "homeassistant/status", wait_birth)
-        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
-        await birth.wait()
-
-        assert ("comp/discovery/#", 0) in help_all_subscribe_calls(mqtt_client_mock)
-        assert not mqtt_client_mock.unsubscribe.called
-
+        async_fire_mqtt_message(hass, "comp/discovery/bla/config", "initial message")
         await hass.async_block_till_done(wait_background_tasks=True)
-        async_fire_mqtt_message(hass, "comp/discovery/bla/config", "")
-        async_fire_mqtt_message(hass, "comp/discovery/bla/config", "")
-        await wait_unsub.wait()
-        await asyncio.sleep(0)
+        assert len(flow_calls) == 1
+
+        # A updated message gets starts a new flow
         await hass.async_block_till_done(wait_background_tasks=True)
-        mqtt_client_mock.unsubscribe.assert_called_once_with(["comp/discovery/#"])
+        async_fire_mqtt_message(hass, "comp/discovery/bla/config", "update message")
         await hass.async_block_till_done(wait_background_tasks=True)
+        assert len(flow_calls) == 2
 
 
 @patch("homeassistant.components.mqtt.client.DISCOVERY_COOLDOWN", 0.0)
@@ -1652,6 +1588,14 @@ async def test_mqtt_discovery_flow_starts_once(
         assert len(flow_calls) == 3
         assert flow_calls[2].topic == "comp/discovery/bla/config2"
         assert flow_calls[2].payload == "update message"
+
+        # And empty message triggers a flow to allow cleanup
+        async_fire_mqtt_message(hass, "comp/discovery/bla/config2", "")
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+        assert len(flow_calls) == 4
+        assert flow_calls[3].topic == "comp/discovery/bla/config2"
+        assert flow_calls[3].payload == ""
 
         assert not mqtt_client_mock.unsubscribe.called
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
After an initial mqtt integration discovery config flow, redundant discovery payloads do not start a new flow unless the config message has changed, or an empty message is removed.
If a single entry is allowed, the integration topic is no longer unsubscribed to, but requests are filtered out.

This allows to recover discovery after a config entry is removed. The integration is responsible for publishing an empty payload to avoid unintended re-discovery after a config entry is removed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
