### PR TITLE
Add BackupMode to Fronius integration

### DIFF
--- a/homeassistant/components/fronius/__init__.py
+++ b/homeassistant/components/fronius/__init__.py
@@ -37,7 +37,7 @@ from .coordinator import (
 )
 
 _LOGGER: Final = logging.getLogger(__name__)
-PLATFORMS: Final = [Platform.SENSOR]
+PLATFORMS: Final = [Platform.BINARY_SENSOR, Platform.SENSOR]
 
 type FroniusConfigEntry = ConfigEntry[FroniusSolarNet]
 

--- a/homeassistant/components/fronius/binary_sensor.py
+++ b/homeassistant/components/fronius/binary_sensor.py
@@ -1,0 +1,117 @@
+"""Binary sensors for Fronius devices."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorEntity,
+    BinarySensorEntityDescription,
+)
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+if TYPE_CHECKING:
+    from . import FroniusConfigEntry
+    from .coordinator import FroniusCoordinatorBase, FroniusPowerFlowUpdateCoordinator
+
+
+@dataclass(frozen=True)
+class FroniusBinarySensorEntityDescription(BinarySensorEntityDescription):
+    """Describes Fronius binary_sensor entity."""
+
+    default_value: bool | None = None
+    response_key: str | None = None
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: FroniusConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Fronius binary_sensor entities based on a config entry."""
+    solar_net = config_entry.runtime_data
+
+    if solar_net.power_flow_coordinator is not None:
+        solar_net.power_flow_coordinator.add_binary_entities_for_seen_keys(
+            async_add_entities, PowerFlowBinarySensor
+        )
+
+
+POWER_FLOW_BINARY_ENTITY_DESCRIPTIONS: list[FroniusBinarySensorEntityDescription] = [
+    FroniusBinarySensorEntityDescription(
+        name="Backup mode",
+        key="backup_mode",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    FroniusBinarySensorEntityDescription(
+        name="Battery standby",
+        key="battery_standby",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+]
+
+
+class _FroniusBinarySensorEntity(
+    CoordinatorEntity["FroniusCoordinatorBase"], BinarySensorEntity
+):
+    """Defines a Fronius binary_sensor entity."""
+
+    entity_description: FroniusBinarySensorEntityDescription
+
+    def __init__(
+        self,
+        coordinator: FroniusCoordinatorBase,
+        description: FroniusBinarySensorEntityDescription,
+        solar_net_id: str,
+    ) -> None:
+        """Set up an individual Fronius meter sensor."""
+        super().__init__(coordinator)
+        self.entity_description = description
+        self.response_key = description.response_key or description.key
+        self.solar_net_id = solar_net_id
+        self._attr_native_value = self._get_entity_value()
+        self._attr_translation_key = description.key
+
+    def _device_data(self) -> dict[str, Any]:
+        """Extract information for SolarNet device from coordinator data."""
+        return self.coordinator.data[self.solar_net_id]
+
+    def _get_entity_value(self) -> bool | None:
+        """Extract entity value from coordinator. Raises KeyError if not included in latest update."""
+        new_value = self.coordinator.data[self.solar_net_id][self.response_key]["value"]
+        if new_value is None:
+            return self.entity_description.default_value
+        return bool(new_value)
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        try:
+            self._attr_is_on = self._get_entity_value()
+        except KeyError:
+            # sets state to `None` if no default_value is defined in entity description
+            # KeyError: raised when omitted in response - eg. at night when no production
+            self._attr_native_value = self.entity_description.default_value
+        self.async_write_ha_state()
+
+
+class PowerFlowBinarySensor(_FroniusBinarySensorEntity):
+    """Defines a Fronius power flow binary_sensor entity."""
+
+    def __init__(
+        self,
+        coordinator: FroniusPowerFlowUpdateCoordinator,
+        description: FroniusBinarySensorEntityDescription,
+        solar_net_id: str,
+    ) -> None:
+        """Set up an individual Fronius power flow binary_sensor."""
+        super().__init__(coordinator, description, solar_net_id)
+        # SolarNet device is already created in FroniusSolarNet._create_solar_net_device
+        self._attr_device_info = coordinator.solar_net.system_device_info
+        self._attr_unique_id = (
+            f"{coordinator.solar_net.solar_net_device_id}-power_flow-{description.key}"
+        )

--- a/homeassistant/components/fronius/binary_sensor.py
+++ b/homeassistant/components/fronius/binary_sensor.py
@@ -39,12 +39,14 @@ async def async_setup_entry(
     solar_net = config_entry.runtime_data
 
     if solar_net.power_flow_coordinator is not None:
-        solar_net.power_flow_coordinator.add_binary_entities_for_seen_keys(
-            async_add_entities, PowerFlowBinarySensor
+        solar_net.power_flow_coordinator.add_entities_for_seen_keys(
+            async_add_entities,
+            PowerFlowBinarySensor,
+            FroniusBinarySensorEntityDescription,
         )
 
 
-POWER_FLOW_BINARY_ENTITY_DESCRIPTIONS: list[FroniusBinarySensorEntityDescription] = [
+POWER_FLOW_BINARY_ENTITY_DESCRIPTIONS: list[FroniusEntityDescription] = [
     FroniusBinarySensorEntityDescription(
         name="Backup mode",
         key="backup_mode",

--- a/homeassistant/components/fronius/binary_sensor.py
+++ b/homeassistant/components/fronius/binary_sensor.py
@@ -9,7 +9,7 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
     BinarySensorEntityDescription,
 )
-from homeassistant.const import EntityCategory
+from homeassistant.const import EntityCategory, Platform
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -41,8 +41,8 @@ async def async_setup_entry(
     if solar_net.power_flow_coordinator is not None:
         solar_net.power_flow_coordinator.add_entities_for_seen_keys(
             async_add_entities,
+            Platform.BINARY_SENSOR,
             PowerFlowBinarySensor,
-            FroniusBinarySensorEntityDescription,
         )
 
 

--- a/homeassistant/components/fronius/binary_sensor.py
+++ b/homeassistant/components/fronius/binary_sensor.py
@@ -13,7 +13,7 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .entity import FroniusEntityDescription, _FroniusEntity
+from .entity import FroniusEntity, FroniusEntityDescription
 
 if TYPE_CHECKING:
     from . import FroniusConfigEntry
@@ -55,7 +55,7 @@ POWER_FLOW_BINARY_ENTITY_DESCRIPTIONS: list[FroniusEntityDescription] = [
 ]
 
 
-class _FroniusBinarySensorEntity(_FroniusEntity, BinarySensorEntity):
+class _FroniusBinarySensorEntity(FroniusEntity, BinarySensorEntity):
     """Defines a Fronius binary_sensor entity."""
 
     entity_description: FroniusBinarySensorEntityDescription

--- a/homeassistant/components/fronius/binary_sensor.py
+++ b/homeassistant/components/fronius/binary_sensor.py
@@ -66,6 +66,10 @@ class _FroniusBinarySensorEntity(_FroniusEntity, BinarySensorEntity):
             self.coordinator.data[self.solar_net_id][self.response_key]["value"]
         )
 
+    def _set_entity_value(self) -> None:
+        """binary_sensor requires a boolean value in _attr_is_on."""
+        self._attr_is_on = self._get_entity_value()
+
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""

--- a/homeassistant/components/fronius/coordinator.py
+++ b/homeassistant/components/fronius/coordinator.py
@@ -94,7 +94,7 @@ class FroniusCoordinatorBase(
 
         Called from a platforms `async_setup_entry`.
 
-        Only those descriptions who are a subclass of the filter_to argument will be added.
+        Only those descriptions matching the supplied platform will be added.
         """
 
         @callback

--- a/homeassistant/components/fronius/entity.py
+++ b/homeassistant/components/fronius/entity.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.helpers.entity import Entity, EntityDescription
@@ -18,7 +19,7 @@ if TYPE_CHECKING:
     from .coordinator import FroniusCoordinatorBase
 
 
-class _FroniusEntity(CoordinatorEntity["FroniusCoordinatorBase"], Entity):
+class FroniusEntity(ABC, CoordinatorEntity["FroniusCoordinatorBase"], Entity):
     """Defines a Fronius coordinator entity."""
 
     entity_description: FroniusEntityDescription
@@ -43,17 +44,17 @@ class _FroniusEntity(CoordinatorEntity["FroniusCoordinatorBase"], Entity):
         """Extract information for SolarNet device from coordinator data."""
         return self.coordinator.data[self.solar_net_id]
 
+    @abstractmethod
     def _get_entity_value(self) -> Any:
         """Extract entity value from coordinator.
-
-        Subclasses must implement.
 
         Raises KeyError if not included in latest update.
         """
 
-        raise NotImplementedError
-
+    @abstractmethod
     def _set_entity_value(self) -> None:
         """Set the entity value correctly based on the platform."""
 
-        raise NotImplementedError
+    @abstractmethod
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""

--- a/homeassistant/components/fronius/entity.py
+++ b/homeassistant/components/fronius/entity.py
@@ -1,0 +1,54 @@
+"""Support for Fronius devices."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from homeassistant.helpers.entity import Entity, EntityDescription
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+
+class FroniusEntityDescription(EntityDescription):
+    """Base class for Fronius entity descriptions."""
+
+    response_key: str | None = None
+
+
+if TYPE_CHECKING:
+    from .coordinator import FroniusCoordinatorBase
+
+
+class _FroniusEntity(CoordinatorEntity["FroniusCoordinatorBase"], Entity):
+    """Defines a Fronius coordinator entity."""
+
+    entity_description: FroniusEntityDescription
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: FroniusCoordinatorBase,
+        description: FroniusEntityDescription,
+        solar_net_id: str,
+    ) -> None:
+        """Set up an individual Fronius meter sensor."""
+        super().__init__(coordinator)
+        self.entity_description = description
+        self.response_key = description.response_key or description.key
+        self.solar_net_id = solar_net_id
+        self._attr_native_value = self._get_entity_value()
+        self._attr_translation_key = description.key
+
+    def _device_data(self) -> dict[str, Any]:
+        """Extract information for SolarNet device from coordinator data."""
+        return self.coordinator.data[self.solar_net_id]
+
+    def _get_entity_value(self) -> Any:
+        """Extract entity value from coordinator.
+
+        Subclasses must implement.
+
+        Raises KeyError if not included in latest update.
+        """
+
+        raise NotImplementedError

--- a/homeassistant/components/fronius/entity.py
+++ b/homeassistant/components/fronius/entity.py
@@ -36,7 +36,7 @@ class _FroniusEntity(CoordinatorEntity["FroniusCoordinatorBase"], Entity):
         self.entity_description = description
         self.response_key = description.response_key or description.key
         self.solar_net_id = solar_net_id
-        self._attr_native_value = self._get_entity_value()
+        self._set_entity_value()
         self._attr_translation_key = description.key
 
     def _device_data(self) -> dict[str, Any]:
@@ -50,5 +50,10 @@ class _FroniusEntity(CoordinatorEntity["FroniusCoordinatorBase"], Entity):
 
         Raises KeyError if not included in latest update.
         """
+
+        raise NotImplementedError
+
+    def _set_entity_value(self) -> None:
+        """Set the entity value correctly based on the platform."""
 
         raise NotImplementedError

--- a/homeassistant/components/fronius/sensor.py
+++ b/homeassistant/components/fronius/sensor.py
@@ -114,7 +114,6 @@ class FroniusSensorEntityDescription(FroniusEntityDescription, SensorEntityDescr
     # Gen24 devices may report 0 for total energy while doing firmware updates.
     # Handling such values shall mitigate spikes in delta calculations.
     invalid_when_falsy: bool = False
-    response_key: str | None = None
     value_fn: Callable[[StateType], StateType] | None = None
 
 

--- a/homeassistant/components/fronius/sensor.py
+++ b/homeassistant/components/fronius/sensor.py
@@ -641,10 +641,6 @@ POWER_FLOW_ENTITY_DESCRIPTIONS: list[FroniusSensorEntityDescription] = [
         native_unit_of_measurement=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    FroniusSensorEntityDescription(
-        key="backup_mode",
-        entity_category=EntityCategory.DIAGNOSTIC,
-    ),
 ]
 
 STORAGE_ENTITY_DESCRIPTIONS: list[FroniusSensorEntityDescription] = [

--- a/homeassistant/components/fronius/sensor.py
+++ b/homeassistant/components/fronius/sensor.py
@@ -15,6 +15,7 @@ from homeassistant.components.sensor import (
 from homeassistant.const import (
     PERCENTAGE,
     EntityCategory,
+    Platform,
     UnitOfApparentPower,
     UnitOfElectricCurrent,
     UnitOfElectricPotential,
@@ -66,34 +67,34 @@ async def async_setup_entry(
 
     for inverter_coordinator in solar_net.inverter_coordinators:
         inverter_coordinator.add_entities_for_seen_keys(
-            async_add_entities, InverterSensor, FroniusSensorEntityDescription
+            async_add_entities, Platform.SENSOR, InverterSensor
         )
     if solar_net.logger_coordinator is not None:
         solar_net.logger_coordinator.add_entities_for_seen_keys(
-            async_add_entities, LoggerSensor, FroniusSensorEntityDescription
+            async_add_entities, Platform.SENSOR, LoggerSensor
         )
     if solar_net.meter_coordinator is not None:
         solar_net.meter_coordinator.add_entities_for_seen_keys(
-            async_add_entities, MeterSensor, FroniusSensorEntityDescription
+            async_add_entities, Platform.SENSOR, MeterSensor
         )
     if solar_net.ohmpilot_coordinator is not None:
         solar_net.ohmpilot_coordinator.add_entities_for_seen_keys(
-            async_add_entities, OhmpilotSensor, FroniusSensorEntityDescription
+            async_add_entities, Platform.SENSOR, OhmpilotSensor
         )
     if solar_net.power_flow_coordinator is not None:
         solar_net.power_flow_coordinator.add_entities_for_seen_keys(
-            async_add_entities, PowerFlowSensor, FroniusSensorEntityDescription
+            async_add_entities, Platform.SENSOR, PowerFlowSensor
         )
     if solar_net.storage_coordinator is not None:
         solar_net.storage_coordinator.add_entities_for_seen_keys(
-            async_add_entities, StorageSensor, FroniusSensorEntityDescription
+            async_add_entities, Platform.SENSOR, StorageSensor
         )
 
     @callback
     def async_add_new_entities(coordinator: FroniusInverterUpdateCoordinator) -> None:
         """Add newly found inverter entities."""
         coordinator.add_entities_for_seen_keys(
-            async_add_entities, InverterSensor, FroniusEntityDescription
+            async_add_entities, Platform.SENSOR, InverterSensor
         )
 
     config_entry.async_on_unload(

--- a/homeassistant/components/fronius/sensor.py
+++ b/homeassistant/components/fronius/sensor.py
@@ -66,33 +66,35 @@ async def async_setup_entry(
 
     for inverter_coordinator in solar_net.inverter_coordinators:
         inverter_coordinator.add_entities_for_seen_keys(
-            async_add_entities, InverterSensor
+            async_add_entities, InverterSensor, FroniusSensorEntityDescription
         )
     if solar_net.logger_coordinator is not None:
         solar_net.logger_coordinator.add_entities_for_seen_keys(
-            async_add_entities, LoggerSensor
+            async_add_entities, LoggerSensor, FroniusSensorEntityDescription
         )
     if solar_net.meter_coordinator is not None:
         solar_net.meter_coordinator.add_entities_for_seen_keys(
-            async_add_entities, MeterSensor
+            async_add_entities, MeterSensor, FroniusSensorEntityDescription
         )
     if solar_net.ohmpilot_coordinator is not None:
         solar_net.ohmpilot_coordinator.add_entities_for_seen_keys(
-            async_add_entities, OhmpilotSensor
+            async_add_entities, OhmpilotSensor, FroniusSensorEntityDescription
         )
     if solar_net.power_flow_coordinator is not None:
         solar_net.power_flow_coordinator.add_entities_for_seen_keys(
-            async_add_entities, PowerFlowSensor
+            async_add_entities, PowerFlowSensor, FroniusSensorEntityDescription
         )
     if solar_net.storage_coordinator is not None:
         solar_net.storage_coordinator.add_entities_for_seen_keys(
-            async_add_entities, StorageSensor
+            async_add_entities, StorageSensor, FroniusSensorEntityDescription
         )
 
     @callback
     def async_add_new_entities(coordinator: FroniusInverterUpdateCoordinator) -> None:
         """Add newly found inverter entities."""
-        coordinator.add_entities_for_seen_keys(async_add_entities, InverterSensor)
+        coordinator.add_entities_for_seen_keys(
+            async_add_entities, InverterSensor, FroniusEntityDescription
+        )
 
     config_entry.async_on_unload(
         async_dispatcher_connect(
@@ -115,7 +117,7 @@ class FroniusSensorEntityDescription(FroniusEntityDescription, SensorEntityDescr
     value_fn: Callable[[StateType], StateType] | None = None
 
 
-INVERTER_ENTITY_DESCRIPTIONS: list[FroniusSensorEntityDescription] = [
+INVERTER_ENTITY_DESCRIPTIONS: list[FroniusEntityDescription] = [
     FroniusSensorEntityDescription(
         key="energy_day",
         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
@@ -227,7 +229,7 @@ INVERTER_ENTITY_DESCRIPTIONS: list[FroniusSensorEntityDescription] = [
     ),
 ]
 
-LOGGER_ENTITY_DESCRIPTIONS: list[FroniusSensorEntityDescription] = [
+LOGGER_ENTITY_DESCRIPTIONS: list[FroniusEntityDescription] = [
     FroniusSensorEntityDescription(
         key="co2_factor",
         state_class=SensorStateClass.MEASUREMENT,
@@ -242,7 +244,7 @@ LOGGER_ENTITY_DESCRIPTIONS: list[FroniusSensorEntityDescription] = [
     ),
 ]
 
-METER_ENTITY_DESCRIPTIONS: list[FroniusSensorEntityDescription] = [
+METER_ENTITY_DESCRIPTIONS: list[FroniusEntityDescription] = [
     FroniusSensorEntityDescription(
         key="current_ac_phase_1",
         native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
@@ -477,7 +479,7 @@ METER_ENTITY_DESCRIPTIONS: list[FroniusSensorEntityDescription] = [
     ),
 ]
 
-OHMPILOT_ENTITY_DESCRIPTIONS: list[FroniusSensorEntityDescription] = [
+OHMPILOT_ENTITY_DESCRIPTIONS: list[FroniusEntityDescription] = [
     FroniusSensorEntityDescription(
         key="energy_real_ac_consumed",
         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
@@ -515,7 +517,7 @@ OHMPILOT_ENTITY_DESCRIPTIONS: list[FroniusSensorEntityDescription] = [
     ),
 ]
 
-POWER_FLOW_ENTITY_DESCRIPTIONS: list[FroniusSensorEntityDescription] = [
+POWER_FLOW_ENTITY_DESCRIPTIONS: list[FroniusEntityDescription] = [
     FroniusSensorEntityDescription(
         key="energy_day",
         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
@@ -642,7 +644,7 @@ POWER_FLOW_ENTITY_DESCRIPTIONS: list[FroniusSensorEntityDescription] = [
     ),
 ]
 
-STORAGE_ENTITY_DESCRIPTIONS: list[FroniusSensorEntityDescription] = [
+STORAGE_ENTITY_DESCRIPTIONS: list[FroniusEntityDescription] = [
     FroniusSensorEntityDescription(
         key="capacity_maximum",
         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,

--- a/homeassistant/components/fronius/sensor.py
+++ b/homeassistant/components/fronius/sensor.py
@@ -716,11 +716,15 @@ class _FroniusSensorEntity(_FroniusEntity, SensorEntity):
             return round(new_value, 4)
         return new_value
 
+    def _set_entity_value(self) -> None:
+        """Sensor requires a value in _attr_native_value."""
+        self._attr_native_value = self._get_entity_value()
+
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         try:
-            self._attr_native_value = self._get_entity_value()
+            self._set_entity_value()
         except KeyError:
             # sets state to `None` if no default_value is defined in entity description
             # KeyError: raised when omitted in response - eg. at night when no production

--- a/homeassistant/components/fronius/sensor.py
+++ b/homeassistant/components/fronius/sensor.py
@@ -41,7 +41,7 @@ from .const import (
     get_meter_location_description,
     get_ohmpilot_state_message,
 )
-from .entity import FroniusEntityDescription, _FroniusEntity
+from .entity import FroniusEntity, FroniusEntityDescription
 
 if TYPE_CHECKING:
     from . import FroniusConfigEntry
@@ -696,7 +696,7 @@ STORAGE_ENTITY_DESCRIPTIONS: list[FroniusEntityDescription] = [
 ]
 
 
-class _FroniusSensorEntity(_FroniusEntity, SensorEntity):
+class _FroniusSensorEntity(FroniusEntity, SensorEntity):
     """Defines a Fronius coordinator entity."""
 
     entity_description: FroniusSensorEntityDescription

--- a/homeassistant/components/fronius/sensor.py
+++ b/homeassistant/components/fronius/sensor.py
@@ -641,6 +641,10 @@ POWER_FLOW_ENTITY_DESCRIPTIONS: list[FroniusSensorEntityDescription] = [
         native_unit_of_measurement=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,
     ),
+    FroniusSensorEntityDescription(
+        key="backup_mode",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
 ]
 
 STORAGE_ENTITY_DESCRIPTIONS: list[FroniusSensorEntityDescription] = [

--- a/homeassistant/components/fronius/strings.json
+++ b/homeassistant/components/fronius/strings.json
@@ -291,6 +291,9 @@
       },
       "temperature_cell": {
         "name": "[%key:component::sensor::entity_component::temperature::name%]"
+      },
+      "backup_mode": {
+        "name": "Backup Mode"
       }
     }
   }

--- a/homeassistant/components/fronius/strings.json
+++ b/homeassistant/components/fronius/strings.json
@@ -294,6 +294,9 @@
       },
       "backup_mode": {
         "name": "Backup Mode"
+      },
+      "battery_standby": {
+        "name": "Battery Standby"
       }
     }
   }

--- a/tests/components/fronius/test_sensor.py
+++ b/tests/components/fronius/test_sensor.py
@@ -360,8 +360,8 @@ async def test_gen24(
     assert_state("sensor.solarnet_meter_mode", "meter")
     assert_state("sensor.solarnet_relative_autonomy", 5.3592)
     assert_state("sensor.solarnet_total_energy", 1530193.42)
-    assert_state("binary_sensor.solarnet_backup_mode", False)
-    assert_state("binary_sensor.solarnet_battery_standby", False)
+    assert_state("binary_sensor.solarnet_backup_mode", "off")
+    assert_state("binary_sensor.solarnet_battery_standby", "off")
 
     # Gen24 devices may report 0 for total energy while doing firmware updates.
     # This should yield "unknown" state instead of 0.
@@ -473,8 +473,8 @@ async def test_gen24_storage(
     assert_state("sensor.solarnet_relative_autonomy", 7.4984)
     assert_state("sensor.solarnet_meter_mode", "bidirectional")
     assert_state("sensor.solarnet_total_energy", 7512664.4042)
-    assert_state("binary_sensor.solarnet_backup_mode", True)
-    assert_state("binary_sensor.solarnet_battery_standby", False)
+    assert_state("binary_sensor.solarnet_backup_mode", "on")
+    assert_state("binary_sensor.solarnet_battery_standby", "off")
     # storage
     assert_state("sensor.byd_battery_box_premium_hv_dc_current", 0.0)
     assert_state("sensor.byd_battery_box_premium_hv_state_of_charge", 4.6)

--- a/tests/components/fronius/test_sensor.py
+++ b/tests/components/fronius/test_sensor.py
@@ -3,6 +3,7 @@
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 
+from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
 from homeassistant.components.fronius.const import DOMAIN
 from homeassistant.components.fronius.coordinator import (
     FroniusInverterUpdateCoordinator,
@@ -300,6 +301,8 @@ async def test_gen24(
         FroniusMeterUpdateCoordinator.default_interval,
     )
     assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 58
+    assert len(hass.states.async_all(domain_filter=BINARY_SENSOR_DOMAIN)) == 2
+
     # inverter 1
     assert_state("sensor.inverter_name_ac_current", 0.1589)
     assert_state("sensor.inverter_name_dc_current_2", 0.0754)
@@ -357,6 +360,8 @@ async def test_gen24(
     assert_state("sensor.solarnet_meter_mode", "meter")
     assert_state("sensor.solarnet_relative_autonomy", 5.3592)
     assert_state("sensor.solarnet_total_energy", 1530193.42)
+    assert_state("binary_sensor.solarnet_backup_mode", False)
+    assert_state("binary_sensor.solarnet_battery_standby", False)
 
     # Gen24 devices may report 0 for total energy while doing firmware updates.
     # This should yield "unknown" state instead of 0.
@@ -401,6 +406,7 @@ async def test_gen24_storage(
         FroniusMeterUpdateCoordinator.default_interval,
     )
     assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 72
+    assert len(hass.states.async_all(domain_filter=BINARY_SENSOR_DOMAIN)) == 2
     # inverter 1
     assert_state("sensor.gen24_storage_dc_current", 0.3952)
     assert_state("sensor.gen24_storage_dc_voltage_2", 318.8103)
@@ -467,6 +473,8 @@ async def test_gen24_storage(
     assert_state("sensor.solarnet_relative_autonomy", 7.4984)
     assert_state("sensor.solarnet_meter_mode", "bidirectional")
     assert_state("sensor.solarnet_total_energy", 7512664.4042)
+    assert_state("binary_sensor.solarnet_backup_mode", True)
+    assert_state("binary_sensor.solarnet_battery_standby", False)
     # storage
     assert_state("sensor.byd_battery_box_premium_hv_dc_current", 0.0)
     assert_state("sensor.byd_battery_box_premium_hv_state_of_charge", 4.6)


### PR DESCRIPTION

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change

This adds a binary sensor that shows if the Fronius Gen24 inverter is running in "Backup Mode", which means the grid power is not available, and the device is running from battery (or using the PVPoint).



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
