### PR TITLE
Handle the correct exception type when subscribing to the router service returns an error in the upnp component

### DIFF
--- a/homeassistant/components/upnp/device.py
+++ b/homeassistant/components/upnp/device.py
@@ -11,7 +11,7 @@ from urllib.parse import urlparse
 from async_upnp_client.aiohttp import AiohttpNotifyServer, AiohttpSessionRequester
 from async_upnp_client.client_factory import UpnpFactory
 from async_upnp_client.const import AddressTupleVXType
-from async_upnp_client.exceptions import UpnpConnectionError
+from async_upnp_client.exceptions import UpnpCommunicationError
 from async_upnp_client.profiles.igd import IgdDevice, IgdStateItem
 from async_upnp_client.utils import async_get_local_ip
 from getmac import get_mac_address
@@ -206,7 +206,7 @@ class Device:
         """Subscribe to services."""
         try:
             await self._igd_device.async_subscribe_services(auto_resubscribe=True)
-        except UpnpConnectionError as ex:
+        except UpnpCommunicationError as ex:
             _LOGGER.debug(
                 "Error subscribing to services, falling back to forced polling: %s", ex
             )
@@ -214,7 +214,10 @@ class Device:
 
     async def async_unsubscribe_services(self) -> None:
         """Unsubscribe from services."""
-        await self._igd_device.async_unsubscribe_services()
+        try:
+            await self._igd_device.async_unsubscribe_services()
+        except UpnpCommunicationError as ex:
+            _LOGGER.debug("Error unsubscribing to services: %s", ex)
 
     async def async_get_data(
         self, entity_description_keys: list[str] | None

--- a/tests/components/upnp/test_init.py
+++ b/tests/components/upnp/test_init.py
@@ -202,6 +202,11 @@ async def test_async_setup_entry_force_poll(
 
     mock_igd_device.async_subscribe_services.assert_not_called()
 
+    # Ensure that the device is forced to poll.
+    mock_igd_device.async_get_traffic_and_status_data.assert_called_with(
+        None, force_poll=True
+    )
+
 
 @pytest.mark.usefixtures(
     "ssdp_instant_discovery",
@@ -235,3 +240,8 @@ async def test_async_setup_entry_force_poll_subscribe_error(
     # Load config_entry, should still be able to load, falling back to polling/the old functionality.
     entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(entry.entry_id) is True
+
+    # Ensure that the device is forced to poll.
+    mock_igd_device.async_get_traffic_and_status_data.assert_called_with(
+        None, force_poll=True
+    )

--- a/tests/components/upnp/test_init.py
+++ b/tests/components/upnp/test_init.py
@@ -7,6 +7,7 @@ import copy
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from async_upnp_client.exceptions import UpnpCommunicationError
 from async_upnp_client.profiles.igd import IgdDevice
 import pytest
 
@@ -179,7 +180,7 @@ async def test_async_setup_udn_mismatch(
 async def test_async_setup_entry_force_poll(
     hass: HomeAssistant, mock_igd_device: IgdDevice
 ) -> None:
-    """Test async_setup_entry."""
+    """Test async_setup_entry with forced polling."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         unique_id=TEST_USN,
@@ -200,3 +201,37 @@ async def test_async_setup_entry_force_poll(
     assert await hass.config_entries.async_setup(entry.entry_id) is True
 
     mock_igd_device.async_subscribe_services.assert_not_called()
+
+
+@pytest.mark.usefixtures(
+    "ssdp_instant_discovery",
+    "mock_get_source_ip",
+    "mock_mac_address_from_host",
+)
+async def test_async_setup_entry_force_poll_subscribe_error(
+    hass: HomeAssistant, mock_igd_device: IgdDevice
+) -> None:
+    """Test async_setup_entry where subscribing fails."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=TEST_USN,
+        data={
+            CONFIG_ENTRY_ST: TEST_ST,
+            CONFIG_ENTRY_UDN: TEST_UDN,
+            CONFIG_ENTRY_ORIGINAL_UDN: TEST_UDN,
+            CONFIG_ENTRY_LOCATION: TEST_LOCATION,
+            CONFIG_ENTRY_MAC_ADDRESS: TEST_MAC_ADDRESS,
+        },
+        options={
+            CONFIG_ENTRY_FORCE_POLL: False,
+        },
+    )
+
+    # Subscribing partially succeeds, but not completely.
+    # Unsubscribing will fail for the subscribed services afterwards.
+    mock_igd_device.async_subscribe_services.side_effect = UpnpCommunicationError
+    mock_igd_device.async_unsubscribe_services.side_effect = UpnpCommunicationError
+
+    # Load config_entry, should still be able to load, falling back to polling/the old functionality.
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id) is True


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Some routers give an error when "subscribing" to UPnP its services. The component did handle connection errors (e.g., not connectable), but not the response errors (i.e., when the router is connectable, but the request returns a 400-error.) This catches the correct error type.

Note that this improves the error handling. It does not fix the error itself, yet (needs more information from the issue.)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #125462
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
