### PR TITLE
Use config entry runtime_data in aussie broadband

### DIFF
--- a/homeassistant/components/aussie_broadband/const.py
+++ b/homeassistant/components/aussie_broadband/const.py
@@ -1,6 +1,8 @@
 """Constants for the Aussie Broadband integration."""
 
+from typing import Final
+
 DEFAULT_UPDATE_INTERVAL = 30
 DOMAIN = "aussie_broadband"
-SERVICE_ID = "service_id"
+SERVICE_ID: Final = "service_id"
 CONF_SERVICES = "services"

--- a/homeassistant/components/aussie_broadband/coordinator.py
+++ b/homeassistant/components/aussie_broadband/coordinator.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 from datetime import timedelta
 import logging
-from typing import Any
+from typing import Any, TypedDict
 
 from aussiebb.asyncio import AussieBB
 from aussiebb.exceptions import UnrecognisedServiceType
 
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
@@ -17,7 +18,20 @@ from .const import DEFAULT_UPDATE_INTERVAL
 _LOGGER = logging.getLogger(__name__)
 
 
-class AussieBroadandDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
+class AussieBroadbandServiceData(TypedDict, total=False):
+    """Aussie Broadband service information, extended with the coordinator."""
+
+    coordinator: AussieBroadbandDataUpdateCoordinator
+    description: str
+    name: str
+    service_id: str
+    type: str
+
+
+type AussieBroadbandConfigEntry = ConfigEntry[list[AussieBroadbandServiceData]]
+
+
+class AussieBroadbandDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     """Aussie Broadand data update coordinator."""
 
     def __init__(self, hass: HomeAssistant, client: AussieBB, service_id: str) -> None:

--- a/homeassistant/components/aussie_broadband/diagnostics.py
+++ b/homeassistant/components/aussie_broadband/diagnostics.py
@@ -5,16 +5,15 @@ from __future__ import annotations
 from typing import Any
 
 from homeassistant.components.diagnostics import async_redact_data
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from .const import DOMAIN
+from .coordinator import AussieBroadbandConfigEntry
 
 TO_REDACT = ["address", "ipAddresses", "description", "discounts", "coordinator"]
 
 
 async def async_get_config_entry_diagnostics(
-    hass: HomeAssistant, config_entry: ConfigEntry
+    hass: HomeAssistant, config_entry: AussieBroadbandConfigEntry
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
     return {
@@ -23,6 +22,6 @@ async def async_get_config_entry_diagnostics(
                 "service": async_redact_data(service, TO_REDACT),
                 "usage": async_redact_data(service["coordinator"].data, ["historical"]),
             }
-            for service in hass.data[DOMAIN][config_entry.entry_id]["services"]
+            for service in config_entry.runtime_data
         ]
     }

--- a/homeassistant/components/aussie_broadband/sensor.py
+++ b/homeassistant/components/aussie_broadband/sensor.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass
 import re
-from typing import Any, cast
+from typing import cast
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -13,7 +13,6 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfInformation, UnitOfTime
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
@@ -22,7 +21,11 @@ from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, SERVICE_ID
-from .coordinator import AussieBroadandDataUpdateCoordinator
+from .coordinator import (
+    AussieBroadbandConfigEntry,
+    AussieBroadbandDataUpdateCoordinator,
+    AussieBroadbandServiceData,
+)
 
 
 @dataclass(frozen=True)
@@ -118,14 +121,16 @@ SENSOR_DESCRIPTIONS: tuple[SensorValueEntityDescription, ...] = (
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+    hass: HomeAssistant,
+    entry: AussieBroadbandConfigEntry,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the Aussie Broadband sensor platform from a config entry."""
 
     async_add_entities(
         [
             AussieBroadandSensorEntity(service, description)
-            for service in hass.data[DOMAIN][entry.entry_id]["services"]
+            for service in entry.runtime_data
             for description in SENSOR_DESCRIPTIONS
             if description.key in service["coordinator"].data
         ]
@@ -133,7 +138,7 @@ async def async_setup_entry(
 
 
 class AussieBroadandSensorEntity(
-    CoordinatorEntity[AussieBroadandDataUpdateCoordinator], SensorEntity
+    CoordinatorEntity[AussieBroadbandDataUpdateCoordinator], SensorEntity
 ):
     """Base class for Aussie Broadband metric sensors."""
 
@@ -141,7 +146,9 @@ class AussieBroadandSensorEntity(
     entity_description: SensorValueEntityDescription
 
     def __init__(
-        self, service: dict[str, Any], description: SensorValueEntityDescription
+        self,
+        service: AussieBroadbandServiceData,
+        description: SensorValueEntityDescription,
     ) -> None:
         """Initialize the sensor."""
         super().__init__(service["coordinator"])


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, follow-up to #127081

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
