### PR TITLE
Use config entry runtime_data in atag

### DIFF
--- a/homeassistant/components/atag/__init__.py
+++ b/homeassistant/components/atag/__init__.py
@@ -1,22 +1,21 @@
 """The ATAG Integration."""
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 
-from .coordinator import AtagDataUpdateCoordinator
+from .coordinator import AtagConfigEntry, AtagDataUpdateCoordinator
 
 DOMAIN = "atag"
 PLATFORMS = [Platform.CLIMATE, Platform.SENSOR, Platform.WATER_HEATER]
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: AtagConfigEntry) -> bool:
     """Set up Atag integration from a config entry."""
 
     coordinator = AtagDataUpdateCoordinator(hass, entry)
     await coordinator.async_config_entry_first_refresh()
 
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
+    entry.runtime_data = coordinator
     if entry.unique_id is None:
         hass.config_entries.async_update_entry(entry, unique_id=coordinator.atag.id)
 
@@ -25,10 +24,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: AtagConfigEntry) -> bool:
     """Unload Atag config entry."""
-    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-
-    if unload_ok:
-        hass.data[DOMAIN].pop(entry.entry_id)
-    return unload_ok
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/atag/climate.py
+++ b/homeassistant/components/atag/climate.py
@@ -12,13 +12,12 @@ from homeassistant.components.climate import (
     HVACAction,
     HVACMode,
 )
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_TEMPERATURE, Platform
+from homeassistant.const import ATTR_TEMPERATURE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util.enum import try_parse_enum
 
-from . import DOMAIN
+from .coordinator import AtagConfigEntry, AtagDataUpdateCoordinator
 from .entity import AtagEntity
 
 PRESET_MAP = {
@@ -33,11 +32,10 @@ HVAC_MODES = [HVACMode.AUTO, HVACMode.HEAT]
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+    hass: HomeAssistant, entry: AtagConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Load a config entry."""
-    coordinator = hass.data[DOMAIN][entry.entry_id]
-    async_add_entities([AtagThermostat(coordinator, Platform.CLIMATE)])
+    async_add_entities([AtagThermostat(entry.runtime_data, "climate")])
 
 
 class AtagThermostat(AtagEntity, ClimateEntity):
@@ -50,7 +48,7 @@ class AtagThermostat(AtagEntity, ClimateEntity):
     )
     _enable_turn_on_off_backwards_compatibility = False
 
-    def __init__(self, coordinator, atag_id):
+    def __init__(self, coordinator: AtagDataUpdateCoordinator, atag_id: str) -> None:
         """Initialize an Atag climate device."""
         super().__init__(coordinator, atag_id)
         self._attr_temperature_unit = coordinator.atag.climate.temp_unit

--- a/homeassistant/components/atag/coordinator.py
+++ b/homeassistant/components/atag/coordinator.py
@@ -13,6 +13,8 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 
 _LOGGER = logging.getLogger(__name__)
 
+type AtagConfigEntry = ConfigEntry[AtagDataUpdateCoordinator]
+
 
 class AtagDataUpdateCoordinator(DataUpdateCoordinator[None]):
     """Atag data update coordinator."""

--- a/homeassistant/components/atag/sensor.py
+++ b/homeassistant/components/atag/sensor.py
@@ -1,7 +1,6 @@
 """Initialization of ATAG One sensor platform."""
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     PERCENTAGE,
     UnitOfPressure,
@@ -11,7 +10,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import DOMAIN
+from .coordinator import AtagConfigEntry, AtagDataUpdateCoordinator
 from .entity import AtagEntity
 
 SENSORS = {
@@ -28,18 +27,18 @@ SENSORS = {
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: AtagConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Initialize sensor platform from config entry."""
-    coordinator = hass.data[DOMAIN][config_entry.entry_id]
+    coordinator = config_entry.runtime_data
     async_add_entities([AtagSensor(coordinator, sensor) for sensor in SENSORS])
 
 
 class AtagSensor(AtagEntity, SensorEntity):
     """Representation of a AtagOne Sensor."""
 
-    def __init__(self, coordinator, sensor):
+    def __init__(self, coordinator: AtagDataUpdateCoordinator, sensor: str) -> None:
         """Initialize Atag sensor."""
         super().__init__(coordinator, SENSORS[sensor])
         self._attr_name = sensor

--- a/homeassistant/components/atag/water_heater.py
+++ b/homeassistant/components/atag/water_heater.py
@@ -7,12 +7,11 @@ from homeassistant.components.water_heater import (
     STATE_PERFORMANCE,
     WaterHeaterEntity,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_TEMPERATURE, STATE_OFF, Platform, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import DOMAIN
+from .coordinator import AtagConfigEntry
 from .entity import AtagEntity
 
 OPERATION_LIST = [STATE_OFF, STATE_ECO, STATE_PERFORMANCE]
@@ -20,12 +19,13 @@ OPERATION_LIST = [STATE_OFF, STATE_ECO, STATE_PERFORMANCE]
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: AtagConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Initialize DHW device from config entry."""
-    coordinator = hass.data[DOMAIN][config_entry.entry_id]
-    async_add_entities([AtagWaterHeater(coordinator, Platform.WATER_HEATER)])
+    async_add_entities(
+        [AtagWaterHeater(config_entry.runtime_data, Platform.WATER_HEATER)]
+    )
 
 
 class AtagWaterHeater(AtagEntity, WaterHeaterEntity):

--- a/tests/components/atag/test_climate.py
+++ b/tests/components/atag/test_climate.py
@@ -2,7 +2,8 @@
 
 from unittest.mock import PropertyMock, patch
 
-from homeassistant.components.atag.climate import DOMAIN, PRESET_MAP
+from homeassistant.components.atag import DOMAIN
+from homeassistant.components.atag.climate import PRESET_MAP
 from homeassistant.components.climate import (
     ATTR_HVAC_ACTION,
     ATTR_HVAC_MODE,
@@ -104,7 +105,7 @@ async def test_update_failed(
     entry = await init_integration(hass, aioclient_mock)
     await async_setup_component(hass, HA_DOMAIN, {})
     assert hass.states.get(CLIMATE_ID).state == HVACMode.HEAT
-    coordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator = entry.runtime_data
     with patch("pyatag.AtagOne.update", side_effect=TimeoutError) as updater:
         await coordinator.async_refresh()
         await hass.async_block_till_done()

--- a/tests/components/atag/test_init.py
+++ b/tests/components/atag/test_init.py
@@ -1,6 +1,5 @@
 """Tests for the ATAG integration."""
 
-from homeassistant.components.atag import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 
@@ -23,7 +22,7 @@ async def test_unload_config_entry(
 ) -> None:
     """Test the ATAG configuration entry unloading."""
     entry = await init_integration(hass, aioclient_mock)
-    assert hass.data[DOMAIN]
+    assert entry.runtime_data
     await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
-    assert not hass.data.get(DOMAIN)
+    assert not hasattr(entry, "runtime_data")


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, follow-up to #127071

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
