### PR TITLE
Add config_flow helper to get reauth/reconfigure config entry

### DIFF
--- a/homeassistant/components/aussie_broadband/config_flow.py
+++ b/homeassistant/components/aussie_broadband/config_flow.py
@@ -99,10 +99,7 @@ class AussieBroadbandConfigFlow(ConfigFlow, domain=DOMAIN):
             }
 
             if not (errors := await self.async_auth(data)):
-                entry = self.hass.config_entries.async_get_entry(
-                    self.context["entry_id"]
-                )
-                assert entry
+                entry = self._get_entry_from_context()
                 return self.async_update_reload_and_abort(entry, data=data)
 
         return self.async_show_form(

--- a/homeassistant/components/aussie_broadband/config_flow.py
+++ b/homeassistant/components/aussie_broadband/config_flow.py
@@ -99,7 +99,7 @@ class AussieBroadbandConfigFlow(ConfigFlow, domain=DOMAIN):
             }
 
             if not (errors := await self.async_auth(data)):
-                entry = self._get_context_entry()
+                entry = self._get_reauth_entry()
                 return self.async_update_reload_and_abort(entry, data=data)
 
         return self.async_show_form(

--- a/homeassistant/components/aussie_broadband/config_flow.py
+++ b/homeassistant/components/aussie_broadband/config_flow.py
@@ -99,7 +99,7 @@ class AussieBroadbandConfigFlow(ConfigFlow, domain=DOMAIN):
             }
 
             if not (errors := await self.async_auth(data)):
-                entry = self._get_entry_from_context()
+                entry = self._get_context_entry()
                 return self.async_update_reload_and_abort(entry, data=data)
 
         return self.async_show_form(

--- a/homeassistant/components/bryant_evolution/config_flow.py
+++ b/homeassistant/components/bryant_evolution/config_flow.py
@@ -68,7 +68,7 @@ class BryantConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             system_zone = await _enumerate_sz(user_input[CONF_FILENAME])
             if len(system_zone) != 0:
-                our_entry = self._get_context_entry()
+                our_entry = self._get_reconfigure_entry()
                 return self.async_update_reload_and_abort(
                     entry=our_entry,
                     data={

--- a/homeassistant/components/bryant_evolution/config_flow.py
+++ b/homeassistant/components/bryant_evolution/config_flow.py
@@ -68,10 +68,7 @@ class BryantConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             system_zone = await _enumerate_sz(user_input[CONF_FILENAME])
             if len(system_zone) != 0:
-                our_entry = self.hass.config_entries.async_get_entry(
-                    self.context["entry_id"]
-                )
-                assert our_entry is not None, "Could not find own entry"
+                our_entry = self._get_entry_from_context()
                 return self.async_update_reload_and_abort(
                     entry=our_entry,
                     data={

--- a/homeassistant/components/bryant_evolution/config_flow.py
+++ b/homeassistant/components/bryant_evolution/config_flow.py
@@ -68,7 +68,7 @@ class BryantConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             system_zone = await _enumerate_sz(user_input[CONF_FILENAME])
             if len(system_zone) != 0:
-                our_entry = self._get_entry_from_context()
+                our_entry = self._get_context_entry()
                 return self.async_update_reload_and_abort(
                     entry=our_entry,
                     data={

--- a/homeassistant/components/powerwall/config_flow.py
+++ b/homeassistant/components/powerwall/config_flow.py
@@ -253,13 +253,12 @@ class PowerwallConfigFlow(ConfigFlow, domain=DOMAIN):
         description_placeholders: dict[str, str] = {}
         if user_input is not None:
             reauth_entry = self._get_entry_from_context()
-            entry_data = reauth_entry.data
             errors, _, description_placeholders = await self._async_try_connect(
-                {CONF_IP_ADDRESS: entry_data[CONF_IP_ADDRESS], **user_input}
+                {CONF_IP_ADDRESS: reauth_entry.data[CONF_IP_ADDRESS], **user_input}
             )
             if not errors:
                 return self.async_update_reload_and_abort(
-                    reauth_entry, data={**entry_data, **user_input}
+                    reauth_entry, data={**reauth_entry.data, **user_input}
                 )
 
         return self.async_show_form(

--- a/homeassistant/components/powerwall/config_flow.py
+++ b/homeassistant/components/powerwall/config_flow.py
@@ -99,6 +99,7 @@ class PowerwallConfigFlow(ConfigFlow, domain=DOMAIN):
         """Initialize the powerwall flow."""
         self.ip_address: str | None = None
         self.title: str | None = None
+        self.reauth_entry: ConfigEntry | None = None
 
     async def _async_powerwall_is_offline(self, entry: ConfigEntry) -> bool:
         """Check if the power wall is offline.
@@ -249,16 +250,17 @@ class PowerwallConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle reauth confirmation."""
+        assert self.reauth_entry is not None
         errors: dict[str, str] | None = {}
         description_placeholders: dict[str, str] = {}
         if user_input is not None:
-            reauth_entry = self._get_entry_from_context()
+            entry_data = self.reauth_entry.data
             errors, _, description_placeholders = await self._async_try_connect(
-                {CONF_IP_ADDRESS: reauth_entry.data[CONF_IP_ADDRESS], **user_input}
+                {CONF_IP_ADDRESS: entry_data[CONF_IP_ADDRESS], **user_input}
             )
             if not errors:
                 return self.async_update_reload_and_abort(
-                    reauth_entry, data={**reauth_entry.data, **user_input}
+                    self.reauth_entry, data={**entry_data, **user_input}
                 )
 
         return self.async_show_form(
@@ -272,6 +274,9 @@ class PowerwallConfigFlow(ConfigFlow, domain=DOMAIN):
         self, entry_data: Mapping[str, Any]
     ) -> ConfigFlowResult:
         """Handle configuration by re-auth."""
+        self.reauth_entry = self.hass.config_entries.async_get_entry(
+            self.context["entry_id"]
+        )
         return await self.async_step_reauth_confirm()
 
 

--- a/homeassistant/components/powerwall/config_flow.py
+++ b/homeassistant/components/powerwall/config_flow.py
@@ -99,7 +99,6 @@ class PowerwallConfigFlow(ConfigFlow, domain=DOMAIN):
         """Initialize the powerwall flow."""
         self.ip_address: str | None = None
         self.title: str | None = None
-        self.reauth_entry: ConfigEntry | None = None
 
     async def _async_powerwall_is_offline(self, entry: ConfigEntry) -> bool:
         """Check if the power wall is offline.
@@ -250,17 +249,17 @@ class PowerwallConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle reauth confirmation."""
-        assert self.reauth_entry is not None
         errors: dict[str, str] | None = {}
         description_placeholders: dict[str, str] = {}
         if user_input is not None:
-            entry_data = self.reauth_entry.data
+            reauth_entry = self._get_entry_from_context()
+            entry_data = reauth_entry.data
             errors, _, description_placeholders = await self._async_try_connect(
                 {CONF_IP_ADDRESS: entry_data[CONF_IP_ADDRESS], **user_input}
             )
             if not errors:
                 return self.async_update_reload_and_abort(
-                    self.reauth_entry, data={**entry_data, **user_input}
+                    reauth_entry, data={**entry_data, **user_input}
                 )
 
         return self.async_show_form(
@@ -274,9 +273,6 @@ class PowerwallConfigFlow(ConfigFlow, domain=DOMAIN):
         self, entry_data: Mapping[str, Any]
     ) -> ConfigFlowResult:
         """Handle configuration by re-auth."""
-        self.reauth_entry = self.hass.config_entries.async_get_entry(
-            self.context["entry_id"]
-        )
         return await self.async_step_reauth_confirm()
 
 

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -2728,7 +2728,7 @@ class ConfigFlow(ConfigEntryBaseFlow):
 
     @callback
     def _get_entry_from_context(self) -> ConfigEntry:
-        """Return current entry from if other_flow is matching this flow."""
+        """Return current config entry, based on context['entry_id']."""
         config_entry_id = self.context["entry_id"]
         entry = self.hass.config_entries.async_get_entry(config_entry_id)
         if entry is None:

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -2736,11 +2736,9 @@ class ConfigFlow(ConfigEntryBaseFlow):
     @callback
     def _get_reauth_entry(self) -> ConfigEntry:
         """Return the reauth config entry linked to the current context."""
-        if self.source != SOURCE_REAUTH:
-            raise ValueError(f"Source is {self.source}, expected {SOURCE_REAUTH}")
-        return cast(
-            ConfigEntry, self.hass.config_entries.async_get_entry(self._reauth_entry_id)
-        )
+        if entry := self.hass.config_entries.async_get_entry(self._reauth_entry_id):
+            return entry
+        raise UnknownEntry
 
     @property
     def _reconfigure_entry_id(self) -> str:
@@ -2752,12 +2750,11 @@ class ConfigFlow(ConfigEntryBaseFlow):
     @callback
     def _get_reconfigure_entry(self) -> ConfigEntry:
         """Return the reconfigure config entry linked to the current context."""
-        if self.source != SOURCE_RECONFIGURE:
-            raise ValueError(f"Source is {self.source}, expected {SOURCE_RECONFIGURE}")
-        return cast(
-            ConfigEntry,
-            self.hass.config_entries.async_get_entry(self._reconfigure_entry_id),
-        )
+        if entry := self.hass.config_entries.async_get_entry(
+            self._reconfigure_entry_id
+        ):
+            return entry
+        raise UnknownEntry
 
 
 class OptionsFlowManager(data_entry_flow.FlowManager[ConfigFlowResult]):

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -2377,6 +2377,20 @@ class ConfigFlow(ConfigEntryBaseFlow):
             HANDLERS.register(domain)(cls)
 
     @property
+    def _reauth_entry_id(self) -> str | None:
+        """Return reauth entry id."""
+        if self.source == SOURCE_REAUTH:
+            return self.context.get("entry_id")
+        return None
+
+    @property
+    def _reconfigure_entry_id(self) -> str | None:
+        """Return reconfigure entry id."""
+        if self.source == SOURCE_RECONFIGURE:
+            return self.context.get("entry_id")
+        return None
+
+    @property
     def unique_id(self) -> str | None:
         """Return unique ID if available."""
         if not self.context:
@@ -2727,15 +2741,30 @@ class ConfigFlow(ConfigEntryBaseFlow):
         raise NotImplementedError
 
     @callback
-    def _get_context_entry(self) -> ConfigEntry:
-        """Return the config entry linked to the current context.
+    def _get_reauth_entry(self) -> ConfigEntry:
+        """Return the reauth config entry linked to the current context.
 
-        This can be used to access the underlying entry in reauth and
-        reconfigure flows, and will fail if `entry_id` is not part of
-        the context.
+        Note: to check if you are within a reauth flow, check if
+        `self.source == SOURCE_REAUTH`.
         """
-        if "entry_id" in self.context and (
-            entry := self.hass.config_entries.async_get_entry(self.context["entry_id"])
+        if self._reauth_entry_id and (
+            entry := self.hass.config_entries.async_get_entry(self._reauth_entry_id)
+        ):
+            return entry
+
+        raise UnknownEntry
+
+    @callback
+    def _get_reconfigure_entry(self) -> ConfigEntry:
+        """Return the reconfigure config entry linked to the current context.
+
+        Note: to check if you are within a reauth flow, check if
+        `self.source == SOURCE_RECONFIGURE`.
+        """
+        if self._reconfigure_entry_id and (
+            entry := self.hass.config_entries.async_get_entry(
+                self._reconfigure_entry_id
+            )
         ):
             return entry
 

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -2377,18 +2377,18 @@ class ConfigFlow(ConfigEntryBaseFlow):
             HANDLERS.register(domain)(cls)
 
     @property
-    def _reauth_entry_id(self) -> str | None:
+    def _reauth_entry_id(self) -> str:
         """Return reauth entry id."""
         if self.source == SOURCE_REAUTH:
-            return self.context.get("entry_id")
-        return None
+            return self.context["entry_id"]  # type: ignore[no-any-return]
+        raise ValueError(f"Invalid source: {self.source}")
 
     @property
-    def _reconfigure_entry_id(self) -> str | None:
+    def _reconfigure_entry_id(self) -> str:
         """Return reconfigure entry id."""
         if self.source == SOURCE_RECONFIGURE:
-            return self.context.get("entry_id")
-        return None
+            return self.context["entry_id"]  # type: ignore[no-any-return]
+        raise ValueError(f"Invalid source: {self.source}")
 
     @property
     def unique_id(self) -> str | None:
@@ -2747,7 +2747,7 @@ class ConfigFlow(ConfigEntryBaseFlow):
         Note: to check if you are within a reauth flow, check if
         `self.source == SOURCE_REAUTH`.
         """
-        if self._reauth_entry_id and (
+        if self.source == SOURCE_REAUTH and (
             entry := self.hass.config_entries.async_get_entry(self._reauth_entry_id)
         ):
             return entry
@@ -2758,10 +2758,10 @@ class ConfigFlow(ConfigEntryBaseFlow):
     def _get_reconfigure_entry(self) -> ConfigEntry:
         """Return the reconfigure config entry linked to the current context.
 
-        Note: to check if you are within a reauth flow, check if
+        Note: to check if you are within a reconfigure flow, check if
         `self.source == SOURCE_RECONFIGURE`.
         """
-        if self._reconfigure_entry_id and (
+        if self.source == SOURCE_RECONFIGURE and (
             entry := self.hass.config_entries.async_get_entry(
                 self._reconfigure_entry_id
             )

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -2726,6 +2726,16 @@ class ConfigFlow(ConfigEntryBaseFlow):
         """Return True if other_flow is matching this flow."""
         raise NotImplementedError
 
+    @callback
+    def _get_entry_from_context(self) -> ConfigEntry:
+        """Return current entry from if other_flow is matching this flow."""
+        config_entry_id = self.context["entry_id"]
+        entry = self.hass.config_entries.async_get_entry(config_entry_id)
+        if entry is None:
+            raise UnknownEntry(config_entry_id)
+
+        return entry
+
 
 class OptionsFlowManager(data_entry_flow.FlowManager[ConfigFlowResult]):
     """Flow to set options for a configuration entry."""

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -2727,8 +2727,13 @@ class ConfigFlow(ConfigEntryBaseFlow):
         raise NotImplementedError
 
     @callback
-    def _get_entry_from_context(self) -> ConfigEntry:
-        """Return current config entry, based on context['entry_id']."""
+    def _get_context_entry(self) -> ConfigEntry:
+        """Return the config entry linked to the current context.
+
+        This can be used to access the underlying entry in reauth and
+        reconfigure flows, and will fail if `entry_id` is not part of
+        the context.
+        """
         config_entry_id = self.context["entry_id"]
         entry = self.hass.config_entries.async_get_entry(config_entry_id)
         if entry is None:

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -2381,14 +2381,14 @@ class ConfigFlow(ConfigEntryBaseFlow):
         """Return reauth entry id."""
         if self.source == SOURCE_REAUTH:
             return self.context["entry_id"]  # type: ignore[no-any-return]
-        raise ValueError(f"Invalid source: {self.source}")
+        raise AttributeError
 
     @property
     def _reconfigure_entry_id(self) -> str:
         """Return reconfigure entry id."""
         if self.source == SOURCE_RECONFIGURE:
             return self.context["entry_id"]  # type: ignore[no-any-return]
-        raise ValueError(f"Invalid source: {self.source}")
+        raise AttributeError
 
     @property
     def unique_id(self) -> str | None:

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -2734,12 +2734,12 @@ class ConfigFlow(ConfigEntryBaseFlow):
         reconfigure flows, and will fail if `entry_id` is not part of
         the context.
         """
-        config_entry_id = self.context["entry_id"]
-        entry = self.hass.config_entries.async_get_entry(config_entry_id)
-        if entry is None:
-            raise UnknownEntry(config_entry_id)
+        if "entry_id" in self.context and (
+            entry := self.hass.config_entries.async_get_entry(self.context["entry_id"])
+        ):
+            return entry
 
-        return entry
+        raise UnknownEntry
 
 
 class OptionsFlowManager(data_entry_flow.FlowManager[ConfigFlowResult]):

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -18,7 +18,7 @@ from syrupy.assertion import SnapshotAssertion
 from homeassistant import config_entries, data_entry_flow, loader
 from homeassistant.components import dhcp
 from homeassistant.components.hassio import HassioServiceInfo
-from homeassistant.config_entries import ConfigEntry, UnknownEntry
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     EVENT_COMPONENT_LOADED,
     EVENT_HOMEASSISTANT_STARTED,
@@ -6418,16 +6418,16 @@ async def test_get_reauth_entry(
             """Confirm input."""
             try:
                 entry = self._get_reauth_entry()
-            except UnknownEntry:
+            except ValueError:
                 reason = "Entry not found"
             else:
                 reason = f"Found entry {entry.title}"
             try:
                 entry_id = self._reauth_entry_id
-            except AttributeError:
+            except ValueError:
                 reason = f"{reason}: -"
             else:
-                reason = f"Found entry {entry.title}: {entry_id}"
+                reason = f"{reason}: {entry_id}"
             return self.async_abort(reason=reason)
 
     # A reauth flow finds the config entry from context
@@ -6483,16 +6483,16 @@ async def test_get_reconfigure_entry(
             """Confirm input."""
             try:
                 entry = self._get_reconfigure_entry()
-            except UnknownEntry:
+            except ValueError:
                 reason = "Entry not found"
             else:
                 reason = f"Found entry {entry.title}"
             try:
                 entry_id = self._reconfigure_entry_id
-            except AttributeError:
+            except ValueError:
                 reason = f"{reason}: -"
             else:
-                reason = f"Found entry {entry.title}: {entry_id}"
+                reason = f"{reason}: {entry_id}"
             return self.async_abort(reason=reason)
 
     # A reauth flow does not have access to the config entry from context

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -6424,7 +6424,7 @@ async def test_get_reauth_entry(
                 reason = f"Found entry {entry.title}"
             try:
                 entry_id = self._reauth_entry_id
-            except ValueError:
+            except AttributeError:
                 reason = f"{reason}: -"
             else:
                 reason = f"Found entry {entry.title}: {entry_id}"
@@ -6489,7 +6489,7 @@ async def test_get_reconfigure_entry(
                 reason = f"Found entry {entry.title}"
             try:
                 entry_id = self._reconfigure_entry_id
-            except ValueError:
+            except AttributeError:
                 reason = f"{reason}: -"
             else:
                 reason = f"Found entry {entry.title}: {entry_id}"

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -6422,24 +6422,30 @@ async def test_get_reauth_entry(
                 reason = "Entry not found"
             else:
                 reason = f"Found entry {entry.title}"
+            try:
+                entry_id = self._reauth_entry_id
+            except ValueError:
+                reason = f"{reason}: -"
+            else:
+                reason = f"Found entry {entry.title}: {entry_id}"
             return self.async_abort(reason=reason)
 
     # A reauth flow finds the config entry from context
     with mock_config_flow("test", TestFlow):
         result = await entry.start_reauth_flow(hass)
-        assert result["reason"] == "Found entry test_title"
+        assert result["reason"] == "Found entry test_title: 01J915Q6T9F6G5V0QJX6HBC94T"
 
     # A reconfigure flow does not have access to the config entry
     with mock_config_flow("test", TestFlow):
         result = await entry.start_reconfigure_flow(hass)
-        assert result["reason"] == "Entry not found"
+        assert result["reason"] == "Entry not found: -"
 
     # A user flow does not have access to the config entry
     with mock_config_flow("test", TestFlow):
         result = await manager.flow.async_init(
             "test", context={"source": config_entries.SOURCE_USER}
         )
-        assert result["reason"] == "Entry not found"
+        assert result["reason"] == "Entry not found: -"
 
 
 async def test_get_reconfigure_entry(
@@ -6481,24 +6487,30 @@ async def test_get_reconfigure_entry(
                 reason = "Entry not found"
             else:
                 reason = f"Found entry {entry.title}"
+            try:
+                entry_id = self._reconfigure_entry_id
+            except ValueError:
+                reason = f"{reason}: -"
+            else:
+                reason = f"Found entry {entry.title}: {entry_id}"
             return self.async_abort(reason=reason)
 
     # A reauth flow does not have access to the config entry from context
     with mock_config_flow("test", TestFlow):
         result = await entry.start_reauth_flow(hass)
-        assert result["reason"] == "Entry not found"
+        assert result["reason"] == "Entry not found: -"
 
     # A reconfigure flow finds the config entry
     with mock_config_flow("test", TestFlow):
         result = await entry.start_reconfigure_flow(hass)
-        assert result["reason"] == "Found entry test_title"
+        assert result["reason"] == "Found entry test_title: 01J915Q6T9F6G5V0QJX6HBC94T"
 
     # A user flow does not have access to the config entry
     with mock_config_flow("test", TestFlow):
         result = await manager.flow.async_init(
             "test", context={"source": config_entries.SOURCE_USER}
         )
-        assert result["reason"] == "Entry not found"
+        assert result["reason"] == "Entry not found: -"
 
 
 async def test_reauth_helper_alignment(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
It is quite often the case in reauth (and probably reconfigure) that we need to access the original config entry, and we end up with lots of `assert entry` or unnecessary `if entry` in the code.

This adds a helper on the config flow to simplify this.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/2347

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
