### PR TITLE
Add config flow validation that calibration factor is not zero

### DIFF
--- a/homeassistant/components/mold_indicator/config_flow.py
+++ b/homeassistant/components/mold_indicator/config_flow.py
@@ -15,6 +15,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.schema_config_entry_flow import (
     SchemaCommonFlowHandler,
     SchemaConfigFlowHandler,
+    SchemaFlowError,
     SchemaFlowFormStep,
 )
 from homeassistant.helpers.selector import (
@@ -38,11 +39,13 @@ from .const import (
 from .sensor import MoldIndicator
 
 
-async def validate_duplicate(
+async def validate_input(
     handler: SchemaCommonFlowHandler, user_input: dict[str, Any]
 ) -> dict[str, Any]:
     """Validate already existing entry."""
     handler.parent_handler._async_abort_entries_match({**handler.options, **user_input})  # noqa: SLF001
+    if user_input[CONF_CALIBRATION_FACTOR] == 0.0:
+        raise SchemaFlowError("calibration_is_zero")
     return user_input
 
 
@@ -79,14 +82,14 @@ DATA_SCHEMA_CONFIG = vol.Schema(
 CONFIG_FLOW = {
     "user": SchemaFlowFormStep(
         schema=DATA_SCHEMA_CONFIG,
-        validate_user_input=validate_duplicate,
+        validate_user_input=validate_input,
         preview="mold_indicator",
     ),
 }
 OPTIONS_FLOW = {
     "init": SchemaFlowFormStep(
         DATA_SCHEMA_OPTIONS,
-        validate_user_input=validate_duplicate,
+        validate_user_input=validate_input,
         preview="mold_indicator",
     )
 }

--- a/homeassistant/components/mold_indicator/strings.json
+++ b/homeassistant/components/mold_indicator/strings.json
@@ -3,6 +3,9 @@
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
     },
+    "error": {
+      "calibration_is_zero": "Calibration factor can't be zero."
+    },
     "step": {
       "user": {
         "description": "Add Mold indicator helper",
@@ -26,6 +29,9 @@
   "options": {
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+    },
+    "error": {
+      "calibration_is_zero": "Calibration factor can't be zero."
     },
     "step": {
       "init": {

--- a/tests/components/mold_indicator/test_config_flow.py
+++ b/tests/components/mold_indicator/test_config_flow.py
@@ -94,6 +94,52 @@ async def test_options_flow(hass: HomeAssistant, loaded_entry: MockConfigEntry) 
     assert state is not None
 
 
+async def test_calibration_factor_not_zero(hass: HomeAssistant) -> None:
+    """Test calibration factor is not zero."""
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["step_id"] == "user"
+    assert result["type"] is FlowResultType.FORM
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_NAME: DEFAULT_NAME,
+            CONF_INDOOR_TEMP: "sensor.indoor_temp",
+            CONF_INDOOR_HUMIDITY: "sensor.indoor_humidity",
+            CONF_OUTDOOR_TEMP: "sensor.outdoor_temp",
+            CONF_CALIBRATION_FACTOR: 0.0,
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "calibration_is_zero"}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_NAME: DEFAULT_NAME,
+            CONF_INDOOR_TEMP: "sensor.indoor_temp",
+            CONF_INDOOR_HUMIDITY: "sensor.indoor_humidity",
+            CONF_OUTDOOR_TEMP: "sensor.outdoor_temp",
+            CONF_CALIBRATION_FACTOR: 1.0,
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["options"] == {
+        CONF_NAME: DEFAULT_NAME,
+        CONF_INDOOR_TEMP: "sensor.indoor_temp",
+        CONF_INDOOR_HUMIDITY: "sensor.indoor_humidity",
+        CONF_OUTDOOR_TEMP: "sensor.outdoor_temp",
+        CONF_CALIBRATION_FACTOR: 1.0,
+    }
+
+
 async def test_entry_already_exist(
     hass: HomeAssistant, loaded_entry: MockConfigEntry
 ) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add validation to config flow in `mold_indicator` that the calibration factor can't be zero (0.0)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 