### PR TITLE
Cover state is enum

### DIFF
--- a/homeassistant/components/blebox/cover.py
+++ b/homeassistant/components/blebox/cover.py
@@ -14,9 +14,9 @@ from homeassistant.components.cover import (
     CoverDeviceClass,
     CoverEntity,
     CoverEntityFeature,
+    CoverState,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import STATE_CLOSED, STATE_CLOSING, STATE_OPEN, STATE_OPENING
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -32,15 +32,15 @@ BLEBOX_TO_COVER_DEVICE_CLASSES = {
 BLEBOX_TO_HASS_COVER_STATES = {
     None: None,
     # all blebox covers
-    BleboxCoverState.MOVING_DOWN: STATE_CLOSING,
-    BleboxCoverState.MOVING_UP: STATE_OPENING,
-    BleboxCoverState.MANUALLY_STOPPED: STATE_OPEN,
-    BleboxCoverState.LOWER_LIMIT_REACHED: STATE_CLOSED,
-    BleboxCoverState.UPPER_LIMIT_REACHED: STATE_OPEN,
+    BleboxCoverState.MOVING_DOWN: CoverState.CLOSING,
+    BleboxCoverState.MOVING_UP: CoverState.OPENING,
+    BleboxCoverState.MANUALLY_STOPPED: CoverState.OPEN,
+    BleboxCoverState.LOWER_LIMIT_REACHED: CoverState.CLOSED,
+    BleboxCoverState.UPPER_LIMIT_REACHED: CoverState.OPEN,
     # extra states of gateController product
-    BleboxCoverState.OVERLOAD: STATE_OPEN,
-    BleboxCoverState.MOTOR_FAILURE: STATE_OPEN,
-    BleboxCoverState.SAFETY_STOP: STATE_OPEN,
+    BleboxCoverState.OVERLOAD: CoverState.OPEN,
+    BleboxCoverState.MOTOR_FAILURE: CoverState.OPEN,
+    BleboxCoverState.SAFETY_STOP: CoverState.OPEN,
 }
 
 
@@ -98,17 +98,17 @@ class BleBoxCoverEntity(BleBoxEntity[blebox_uniapi.cover.Cover], CoverEntity):
     @property
     def is_opening(self) -> bool | None:
         """Return whether cover is opening."""
-        return self._is_state(STATE_OPENING)
+        return self._is_state(CoverState.OPENING)
 
     @property
     def is_closing(self) -> bool | None:
         """Return whether cover is closing."""
-        return self._is_state(STATE_CLOSING)
+        return self._is_state(CoverState.CLOSING)
 
     @property
     def is_closed(self) -> bool | None:
         """Return whether cover is closed."""
-        return self._is_state(STATE_CLOSED)
+        return self._is_state(CoverState.CLOSED)
 
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Fully open the cover position."""

--- a/homeassistant/components/comelit/cover.py
+++ b/homeassistant/components/comelit/cover.py
@@ -7,7 +7,7 @@ from typing import Any
 from aiocomelit import ComelitSerialBridgeObject
 from aiocomelit.const import COVER, STATE_COVER, STATE_OFF, STATE_ON
 
-from homeassistant.components.cover import STATE_CLOSED, CoverDeviceClass, CoverEntity
+from homeassistant.components.cover import CoverDeviceClass, CoverEntity, CoverState
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -85,7 +85,7 @@ class ComelitCoverEntity(
         if self._last_action:
             return self._last_action == STATE_COVER.index("closing")
 
-        return self._last_state == STATE_CLOSED
+        return self._last_state == CoverState.CLOSED
 
     @property
     def is_closing(self) -> bool:

--- a/homeassistant/components/cover/__init__.py
+++ b/homeassistant/components/cover/__init__.py
@@ -24,10 +24,6 @@ from homeassistant.const import (
     SERVICE_STOP_COVER_TILT,
     SERVICE_TOGGLE,
     SERVICE_TOGGLE_COVER_TILT,
-    STATE_CLOSED,
-    STATE_CLOSING,
-    STATE_OPEN,
-    STATE_OPENING,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
@@ -52,6 +48,24 @@ ENTITY_ID_FORMAT = DOMAIN + ".{}"
 PLATFORM_SCHEMA = cv.PLATFORM_SCHEMA
 PLATFORM_SCHEMA_BASE = cv.PLATFORM_SCHEMA_BASE
 SCAN_INTERVAL = timedelta(seconds=15)
+
+
+class CoverState(StrEnum):
+    """State of Cover entities."""
+
+    CLOSED = "closed"
+    CLOSING = "closing"
+    OPEN = "open"
+    OPENING = "opening"
+
+
+# STATE_* below are deprecated as of 2024.11
+# when imported from homeassistant.components.cover
+# use the CoverState enum instead.
+_DEPRECATED_STATE_CLOSED = DeprecatedConstantEnum(CoverState.CLOSED, "2025.11")
+_DEPRECATED_STATE_CLOSING = DeprecatedConstantEnum(CoverState.CLOSING, "2025.11")
+_DEPRECATED_STATE_OPEN = DeprecatedConstantEnum(CoverState.OPEN, "2025.11")
+_DEPRECATED_STATE_OPENING = DeprecatedConstantEnum(CoverState.OPENING, "2025.11")
 
 
 class CoverDeviceClass(StrEnum):
@@ -148,7 +162,7 @@ ATTR_TILT_POSITION = "tilt_position"
 @bind_hass
 def is_closed(hass: HomeAssistant, entity_id: str) -> bool:
     """Return if the cover is closed based on the statemachine."""
-    return hass.states.is_state(entity_id, STATE_CLOSED)
+    return hass.states.is_state(entity_id, CoverState.CLOSED)
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
@@ -303,15 +317,15 @@ class CoverEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
         """Return the state of the cover."""
         if self.is_opening:
             self._cover_is_last_toggle_direction_open = True
-            return STATE_OPENING
+            return CoverState.OPENING
         if self.is_closing:
             self._cover_is_last_toggle_direction_open = False
-            return STATE_CLOSING
+            return CoverState.CLOSING
 
         if (closed := self.is_closed) is None:
             return None
 
-        return STATE_CLOSED if closed else STATE_OPEN
+        return CoverState.CLOSED if closed else CoverState.OPEN
 
     @final
     @property

--- a/homeassistant/components/cover/__init__.py
+++ b/homeassistant/components/cover/__init__.py
@@ -13,7 +13,7 @@ from propcache import cached_property
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
+from homeassistant.const import (  # noqa: F401
     SERVICE_CLOSE_COVER,
     SERVICE_CLOSE_COVER_TILT,
     SERVICE_OPEN_COVER,
@@ -24,6 +24,10 @@ from homeassistant.const import (
     SERVICE_STOP_COVER_TILT,
     SERVICE_TOGGLE,
     SERVICE_TOGGLE_COVER_TILT,
+    STATE_CLOSED,
+    STATE_CLOSING,
+    STATE_OPEN,
+    STATE_OPENING,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv

--- a/homeassistant/components/cover/device_condition.py
+++ b/homeassistant/components/cover/device_condition.py
@@ -12,10 +12,6 @@ from homeassistant.const import (
     CONF_DOMAIN,
     CONF_ENTITY_ID,
     CONF_TYPE,
-    STATE_CLOSED,
-    STATE_CLOSING,
-    STATE_OPEN,
-    STATE_OPENING,
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import (
@@ -27,7 +23,7 @@ from homeassistant.helpers.config_validation import DEVICE_CONDITION_BASE_SCHEMA
 from homeassistant.helpers.entity import get_supported_features
 from homeassistant.helpers.typing import ConfigType, TemplateVarsType
 
-from . import DOMAIN, CoverEntityFeature
+from . import DOMAIN, CoverEntityFeature, CoverState
 
 # mypy: disallow-any-generics
 
@@ -128,13 +124,13 @@ def async_condition_from_config(
 
     if config[CONF_TYPE] in STATE_CONDITION_TYPES:
         if config[CONF_TYPE] == "is_open":
-            state = STATE_OPEN
+            state = CoverState.OPEN
         elif config[CONF_TYPE] == "is_closed":
-            state = STATE_CLOSED
+            state = CoverState.CLOSED
         elif config[CONF_TYPE] == "is_opening":
-            state = STATE_OPENING
+            state = CoverState.OPENING
         elif config[CONF_TYPE] == "is_closing":
-            state = STATE_CLOSING
+            state = CoverState.CLOSING
 
         def test_is_state(hass: HomeAssistant, variables: TemplateVarsType) -> bool:
             """Test if an entity is a certain state."""

--- a/homeassistant/components/cover/device_trigger.py
+++ b/homeassistant/components/cover/device_trigger.py
@@ -19,10 +19,6 @@ from homeassistant.const import (
     CONF_PLATFORM,
     CONF_TYPE,
     CONF_VALUE_TEMPLATE,
-    STATE_CLOSED,
-    STATE_CLOSING,
-    STATE_OPEN,
-    STATE_OPENING,
 )
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant
 from homeassistant.helpers import config_validation as cv, entity_registry as er
@@ -30,7 +26,7 @@ from homeassistant.helpers.entity import get_supported_features
 from homeassistant.helpers.trigger import TriggerActionType, TriggerInfo
 from homeassistant.helpers.typing import ConfigType
 
-from . import DOMAIN, CoverEntityFeature
+from . import DOMAIN, CoverEntityFeature, CoverState
 
 POSITION_TRIGGER_TYPES = {"position", "tilt_position"}
 STATE_TRIGGER_TYPES = {"opened", "closed", "opening", "closing"}
@@ -147,13 +143,13 @@ async def async_attach_trigger(
     """Attach a trigger."""
     if config[CONF_TYPE] in STATE_TRIGGER_TYPES:
         if config[CONF_TYPE] == "opened":
-            to_state = STATE_OPEN
+            to_state = CoverState.OPEN
         elif config[CONF_TYPE] == "closed":
-            to_state = STATE_CLOSED
+            to_state = CoverState.CLOSED
         elif config[CONF_TYPE] == "opening":
-            to_state = STATE_OPENING
+            to_state = CoverState.OPENING
         elif config[CONF_TYPE] == "closing":
-            to_state = STATE_CLOSING
+            to_state = CoverState.CLOSING
 
         state_config = {
             CONF_PLATFORM: "state",

--- a/homeassistant/components/cover/reproduce_state.py
+++ b/homeassistant/components/cover/reproduce_state.py
@@ -15,10 +15,6 @@ from homeassistant.const import (
     SERVICE_OPEN_COVER_TILT,
     SERVICE_SET_COVER_POSITION,
     SERVICE_SET_COVER_TILT_POSITION,
-    STATE_CLOSED,
-    STATE_CLOSING,
-    STATE_OPEN,
-    STATE_OPENING,
 )
 from homeassistant.core import Context, HomeAssistant, State
 
@@ -28,11 +24,17 @@ from . import (
     ATTR_POSITION,
     ATTR_TILT_POSITION,
     DOMAIN,
+    CoverState,
 )
 
 _LOGGER = logging.getLogger(__name__)
 
-VALID_STATES = {STATE_CLOSED, STATE_CLOSING, STATE_OPEN, STATE_OPENING}
+VALID_STATES = {
+    CoverState.CLOSED,
+    CoverState.CLOSING,
+    CoverState.OPEN,
+    CoverState.OPENING,
+}
 
 
 async def _async_reproduce_state(
@@ -72,9 +74,9 @@ async def _async_reproduce_state(
         == state.attributes.get(ATTR_CURRENT_POSITION)
     ):
         # Open/Close
-        if state.state in [STATE_CLOSED, STATE_CLOSING]:
+        if state.state in [CoverState.CLOSED, CoverState.CLOSING]:
             service = SERVICE_CLOSE_COVER
-        elif state.state in [STATE_OPEN, STATE_OPENING]:
+        elif state.state in [CoverState.OPEN, CoverState.OPENING]:
             if (
                 ATTR_CURRENT_POSITION in cur_state.attributes
                 and ATTR_CURRENT_POSITION in state.attributes

--- a/homeassistant/components/garadget/cover.py
+++ b/homeassistant/components/garadget/cover.py
@@ -12,6 +12,7 @@ from homeassistant.components.cover import (
     PLATFORM_SCHEMA as COVER_PLATFORM_SCHEMA,
     CoverDeviceClass,
     CoverEntity,
+    CoverState,
 )
 from homeassistant.const import (
     CONF_ACCESS_TOKEN,
@@ -20,8 +21,6 @@ from homeassistant.const import (
     CONF_NAME,
     CONF_PASSWORD,
     CONF_USERNAME,
-    STATE_CLOSED,
-    STATE_OPEN,
 )
 from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
@@ -38,16 +37,14 @@ ATTR_TIME_IN_STATE = "time_in_state"
 
 DEFAULT_NAME = "Garadget"
 
-STATE_CLOSING = "closing"
 STATE_OFFLINE = "offline"
-STATE_OPENING = "opening"
 STATE_STOPPED = "stopped"
 
 STATES_MAP = {
-    "open": STATE_OPEN,
-    "opening": STATE_OPENING,
-    "closed": STATE_CLOSED,
-    "closing": STATE_CLOSING,
+    "open": CoverState.OPEN,
+    "opening": CoverState.OPENING,
+    "closed": CoverState.CLOSED,
+    "closing": CoverState.CLOSING,
     "stopped": STATE_STOPPED,
 }
 
@@ -175,7 +172,7 @@ class GaradgetCover(CoverEntity):
         """Return if the cover is closed."""
         if self._state is None:
             return None
-        return self._state == STATE_CLOSED
+        return self._state == CoverState.CLOSED
 
     def get_token(self):
         """Get new token for usage during this session."""
@@ -249,7 +246,7 @@ class GaradgetCover(CoverEntity):
             self._state = STATE_OFFLINE
 
         if (
-            self._state not in [STATE_CLOSING, STATE_OPENING]
+            self._state not in [CoverState.CLOSING, CoverState.OPENING]
             and self._unsub_listener_cover is not None
         ):
             self._unsub_listener_cover()

--- a/homeassistant/components/group/cover.py
+++ b/homeassistant/components/group/cover.py
@@ -15,6 +15,7 @@ from homeassistant.components.cover import (
     PLATFORM_SCHEMA as COVER_PLATFORM_SCHEMA,
     CoverEntity,
     CoverEntityFeature,
+    CoverState,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
@@ -31,10 +32,6 @@ from homeassistant.const import (
     SERVICE_SET_COVER_TILT_POSITION,
     SERVICE_STOP_COVER,
     SERVICE_STOP_COVER_TILT,
-    STATE_CLOSED,
-    STATE_CLOSING,
-    STATE_OPEN,
-    STATE_OPENING,
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
 )
@@ -285,15 +282,15 @@ class CoverGroup(GroupEntity, CoverEntity):
         for entity_id in self._entity_ids:
             if not (state := self.hass.states.get(entity_id)):
                 continue
-            if state.state == STATE_OPEN:
+            if state.state == CoverState.OPEN:
                 self._attr_is_closed = False
                 continue
-            if state.state == STATE_CLOSED:
+            if state.state == CoverState.CLOSED:
                 continue
-            if state.state == STATE_CLOSING:
+            if state.state == CoverState.CLOSING:
                 self._attr_is_closing = True
                 continue
-            if state.state == STATE_OPENING:
+            if state.state == CoverState.OPENING:
                 self._attr_is_opening = True
                 continue
         if not valid_state:

--- a/homeassistant/components/homekit_controller/cover.py
+++ b/homeassistant/components/homekit_controller/cover.py
@@ -14,15 +14,10 @@ from homeassistant.components.cover import (
     CoverDeviceClass,
     CoverEntity,
     CoverEntityFeature,
+    CoverState,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
-    STATE_CLOSED,
-    STATE_CLOSING,
-    STATE_OPEN,
-    STATE_OPENING,
-    Platform,
-)
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -33,16 +28,24 @@ from .entity import HomeKitEntity
 STATE_STOPPED = "stopped"
 
 CURRENT_GARAGE_STATE_MAP = {
-    0: STATE_OPEN,
-    1: STATE_CLOSED,
-    2: STATE_OPENING,
-    3: STATE_CLOSING,
+    0: CoverState.OPEN,
+    1: CoverState.CLOSED,
+    2: CoverState.OPENING,
+    3: CoverState.CLOSING,
     4: STATE_STOPPED,
 }
 
-TARGET_GARAGE_STATE_MAP = {STATE_OPEN: 0, STATE_CLOSED: 1, STATE_STOPPED: 2}
+TARGET_GARAGE_STATE_MAP = {
+    CoverState.OPEN: 0,
+    CoverState.CLOSED: 1,
+    STATE_STOPPED: 2,
+}
 
-CURRENT_WINDOW_STATE_MAP = {0: STATE_CLOSING, 1: STATE_OPENING, 2: STATE_STOPPED}
+CURRENT_WINDOW_STATE_MAP = {
+    0: CoverState.CLOSING,
+    1: CoverState.OPENING,
+    2: STATE_STOPPED,
+}
 
 
 async def async_setup_entry(
@@ -92,25 +95,25 @@ class HomeKitGarageDoorCover(HomeKitEntity, CoverEntity):
     @property
     def is_closed(self) -> bool:
         """Return true if cover is closed, else False."""
-        return self._state == STATE_CLOSED
+        return self._state == CoverState.CLOSED
 
     @property
     def is_closing(self) -> bool:
         """Return if the cover is closing or not."""
-        return self._state == STATE_CLOSING
+        return self._state == CoverState.CLOSING
 
     @property
     def is_opening(self) -> bool:
         """Return if the cover is opening or not."""
-        return self._state == STATE_OPENING
+        return self._state == CoverState.OPENING
 
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Send open command."""
-        await self.set_door_state(STATE_OPEN)
+        await self.set_door_state(CoverState.OPEN)
 
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Send close command."""
-        await self.set_door_state(STATE_CLOSED)
+        await self.set_door_state(CoverState.CLOSED)
 
     async def set_door_state(self, state: str) -> None:
         """Send state command."""
@@ -188,14 +191,14 @@ class HomeKitWindowCover(HomeKitEntity, CoverEntity):
         """Return if the cover is closing or not."""
         value = self.service.value(CharacteristicsTypes.POSITION_STATE)
         state = CURRENT_WINDOW_STATE_MAP[value]
-        return state == STATE_CLOSING
+        return state == CoverState.CLOSING
 
     @property
     def is_opening(self) -> bool:
         """Return if the cover is opening or not."""
         value = self.service.value(CharacteristicsTypes.POSITION_STATE)
         state = CURRENT_WINDOW_STATE_MAP[value]
-        return state == STATE_OPENING
+        return state == CoverState.OPENING
 
     @property
     def is_horizontal_tilt(self) -> bool:

--- a/homeassistant/components/modbus/cover.py
+++ b/homeassistant/components/modbus/cover.py
@@ -5,17 +5,8 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any
 
-from homeassistant.components.cover import CoverEntity, CoverEntityFeature
-from homeassistant.const import (
-    CONF_COVERS,
-    CONF_NAME,
-    STATE_CLOSED,
-    STATE_CLOSING,
-    STATE_OPEN,
-    STATE_OPENING,
-    STATE_UNAVAILABLE,
-    STATE_UNKNOWN,
-)
+from homeassistant.components.cover import CoverEntity, CoverEntityFeature, CoverState
+from homeassistant.const import CONF_COVERS, CONF_NAME, STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
@@ -105,10 +96,10 @@ class ModbusCover(BasePlatform, CoverEntity, RestoreEntity):
         await self.async_base_added_to_hass()
         if state := await self.async_get_last_state():
             convert = {
-                STATE_CLOSED: self._state_closed,
-                STATE_CLOSING: self._state_closing,
-                STATE_OPENING: self._state_opening,
-                STATE_OPEN: self._state_open,
+                CoverState.CLOSED: self._state_closed,
+                CoverState.CLOSING: self._state_closing,
+                CoverState.OPENING: self._state_opening,
+                CoverState.OPEN: self._state_open,
                 STATE_UNAVAILABLE: None,
                 STATE_UNKNOWN: None,
             }

--- a/homeassistant/components/opengarage/cover.py
+++ b/homeassistant/components/opengarage/cover.py
@@ -9,9 +9,9 @@ from homeassistant.components.cover import (
     CoverDeviceClass,
     CoverEntity,
     CoverEntityFeature,
+    CoverState,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import STATE_CLOSED, STATE_CLOSING, STATE_OPEN, STATE_OPENING
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -21,7 +21,7 @@ from .entity import OpenGarageEntity
 
 _LOGGER = logging.getLogger(__name__)
 
-STATES_MAP = {0: STATE_CLOSED, 1: STATE_OPEN}
+STATES_MAP = {0: CoverState.CLOSED, 1: CoverState.OPEN}
 
 
 async def async_setup_entry(
@@ -54,36 +54,36 @@ class OpenGarageCover(OpenGarageEntity, CoverEntity):
         """Return if the cover is closed."""
         if self._state is None:
             return None
-        return self._state == STATE_CLOSED
+        return self._state == CoverState.CLOSED
 
     @property
     def is_closing(self) -> bool | None:
         """Return if the cover is closing."""
         if self._state is None:
             return None
-        return self._state == STATE_CLOSING
+        return self._state == CoverState.CLOSING
 
     @property
     def is_opening(self) -> bool | None:
         """Return if the cover is opening."""
         if self._state is None:
             return None
-        return self._state == STATE_OPENING
+        return self._state == CoverState.OPENING
 
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close the cover."""
-        if self._state in [STATE_CLOSED, STATE_CLOSING]:
+        if self._state in [CoverState.CLOSED, CoverState.CLOSING]:
             return
         self._state_before_move = self._state
-        self._state = STATE_CLOSING
+        self._state = CoverState.CLOSING
         await self._push_button()
 
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""
-        if self._state in [STATE_OPEN, STATE_OPENING]:
+        if self._state in [CoverState.OPEN, CoverState.OPENING]:
             return
         self._state_before_move = self._state
-        self._state = STATE_OPENING
+        self._state = CoverState.OPENING
         await self._push_button()
 
     @callback

--- a/homeassistant/components/rflink/cover.py
+++ b/homeassistant/components/rflink/cover.py
@@ -10,8 +10,9 @@ import voluptuous as vol
 from homeassistant.components.cover import (
     PLATFORM_SCHEMA as COVER_PLATFORM_SCHEMA,
     CoverEntity,
+    CoverState,
 )
-from homeassistant.const import CONF_DEVICES, CONF_NAME, CONF_TYPE, STATE_OPEN
+from homeassistant.const import CONF_DEVICES, CONF_NAME, CONF_TYPE
 from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -133,7 +134,7 @@ class RflinkCover(RflinkCommand, CoverEntity, RestoreEntity):
         """Restore RFLink cover state (OPEN/CLOSE)."""
         await super().async_added_to_hass()
         if (old_state := await self.async_get_last_state()) is not None:
-            self._state = old_state.state == STATE_OPEN
+            self._state = old_state.state == CoverState.OPEN
 
     def _handle_event(self, event):
         """Adjust state if Rflink picks up a remote command for this device."""

--- a/homeassistant/components/rfxtrx/cover.py
+++ b/homeassistant/components/rfxtrx/cover.py
@@ -7,9 +7,8 @@ from typing import Any
 
 import RFXtrx as rfxtrxmod
 
-from homeassistant.components.cover import CoverEntity, CoverEntityFeature
+from homeassistant.components.cover import CoverEntity, CoverEntityFeature, CoverState
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import STATE_OPEN
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -97,7 +96,7 @@ class RfxtrxCover(RfxtrxCommandEntity, CoverEntity):
         if self._event is None:
             old_state = await self.async_get_last_state()
             if old_state is not None:
-                self._attr_is_closed = old_state.state != STATE_OPEN
+                self._attr_is_closed = old_state.state != CoverState.OPEN
 
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Move the cover up."""

--- a/homeassistant/components/smartthings/cover.py
+++ b/homeassistant/components/smartthings/cover.py
@@ -10,13 +10,10 @@ from pysmartthings import Attribute, Capability
 from homeassistant.components.cover import (
     ATTR_POSITION,
     DOMAIN as COVER_DOMAIN,
-    STATE_CLOSED,
-    STATE_CLOSING,
-    STATE_OPEN,
-    STATE_OPENING,
     CoverDeviceClass,
     CoverEntity,
     CoverEntityFeature,
+    CoverState,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_BATTERY_LEVEL
@@ -27,11 +24,11 @@ from .const import DATA_BROKERS, DOMAIN
 from .entity import SmartThingsEntity
 
 VALUE_TO_STATE = {
-    "closed": STATE_CLOSED,
-    "closing": STATE_CLOSING,
-    "open": STATE_OPEN,
-    "opening": STATE_OPENING,
-    "partially open": STATE_OPEN,
+    "closed": CoverState.CLOSED,
+    "closing": CoverState.CLOSING,
+    "open": CoverState.OPEN,
+    "opening": CoverState.OPENING,
+    "partially open": CoverState.OPEN,
     "unknown": None,
 }
 
@@ -147,16 +144,16 @@ class SmartThingsCover(SmartThingsEntity, CoverEntity):
     @property
     def is_opening(self) -> bool:
         """Return if the cover is opening or not."""
-        return self._state == STATE_OPENING
+        return self._state == CoverState.OPENING
 
     @property
     def is_closing(self) -> bool:
         """Return if the cover is closing or not."""
-        return self._state == STATE_CLOSING
+        return self._state == CoverState.CLOSING
 
     @property
     def is_closed(self) -> bool | None:
         """Return if the cover is closed or not."""
-        if self._state == STATE_CLOSED:
+        if self._state == CoverState.CLOSED:
             return True
         return None if self._state is None else False

--- a/homeassistant/components/somfy_mylink/cover.py
+++ b/homeassistant/components/somfy_mylink/cover.py
@@ -3,9 +3,8 @@
 import logging
 from typing import Any
 
-from homeassistant.components.cover import CoverDeviceClass, CoverEntity
+from homeassistant.components.cover import CoverDeviceClass, CoverEntity, CoverState
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import STATE_CLOSED, STATE_OPEN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -131,7 +130,7 @@ class SomfyShade(RestoreEntity, CoverEntity):
         last_state = await self.async_get_last_state()
 
         if last_state is not None and last_state.state in (
-            STATE_OPEN,
-            STATE_CLOSED,
+            CoverState.OPEN,
+            CoverState.CLOSED,
         ):
-            self._attr_is_closed = last_state.state == STATE_CLOSED
+            self._attr_is_closed = last_state.state == CoverState.CLOSED

--- a/homeassistant/components/template/cover.py
+++ b/homeassistant/components/template/cover.py
@@ -15,6 +15,7 @@ from homeassistant.components.cover import (
     PLATFORM_SCHEMA as COVER_PLATFORM_SCHEMA,
     CoverEntity,
     CoverEntityFeature,
+    CoverState,
 )
 from homeassistant.const import (
     CONF_COVERS,
@@ -234,8 +235,8 @@ class CoverTemplate(TemplateEntity, CoverEntity):
                 else:
                     self._position = 0
 
-            self._is_opening = state == OPENING_STATE
-            self._is_closing = state == CLOSING_STATE
+            self._is_opening = state == CoverState.OPENING
+            self._is_closing = state == CoverState.CLOSING
         else:
             _LOGGER.error(
                 "Received invalid cover is_on state: %s for entity %s. Expected: %s",

--- a/homeassistant/components/template/cover.py
+++ b/homeassistant/components/template/cover.py
@@ -15,7 +15,6 @@ from homeassistant.components.cover import (
     PLATFORM_SCHEMA as COVER_PLATFORM_SCHEMA,
     CoverEntity,
     CoverEntityFeature,
-    CoverState,
 )
 from homeassistant.const import (
     CONF_COVERS,
@@ -235,8 +234,8 @@ class CoverTemplate(TemplateEntity, CoverEntity):
                 else:
                     self._position = 0
 
-            self._is_opening = state == CoverState.OPENING
-            self._is_closing = state == CoverState.CLOSING
+            self._is_opening = state == OPENING_STATE
+            self._is_closing = state == CLOSING_STATE
         else:
             _LOGGER.error(
                 "Received invalid cover is_on state: %s for entity %s. Expected: %s",

--- a/tests/components/abode/test_cover.py
+++ b/tests/components/abode/test_cover.py
@@ -3,13 +3,12 @@
 from unittest.mock import patch
 
 from homeassistant.components.abode import ATTR_DEVICE_ID
-from homeassistant.components.cover import DOMAIN as COVER_DOMAIN
+from homeassistant.components.cover import DOMAIN as COVER_DOMAIN, CoverState
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     ATTR_FRIENDLY_NAME,
     SERVICE_CLOSE_COVER,
     SERVICE_OPEN_COVER,
-    STATE_CLOSED,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -34,7 +33,7 @@ async def test_attributes(hass: HomeAssistant) -> None:
     await setup_platform(hass, COVER_DOMAIN)
 
     state = hass.states.get(DEVICE_ID)
-    assert state.state == STATE_CLOSED
+    assert state.state == CoverState.CLOSED
     assert state.attributes.get(ATTR_DEVICE_ID) == "ZW:00000007"
     assert not state.attributes.get("battery_low")
     assert not state.attributes.get("no_response")

--- a/tests/components/advantage_air/test_cover.py
+++ b/tests/components/advantage_air/test_cover.py
@@ -9,8 +9,9 @@ from homeassistant.components.cover import (
     SERVICE_OPEN_COVER,
     SERVICE_SET_COVER_POSITION,
     CoverDeviceClass,
+    CoverState,
 )
-from homeassistant.const import ATTR_ENTITY_ID, STATE_OPEN
+from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -31,7 +32,7 @@ async def test_ac_cover(
     entity_id = "cover.myauto_zone_y"
     state = hass.states.get(entity_id)
     assert state
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
     assert state.attributes.get("device_class") == CoverDeviceClass.DAMPER
     assert state.attributes.get("current_position") == 100
 
@@ -120,7 +121,7 @@ async def test_things_cover(
     thing_id = "200"
     state = hass.states.get(entity_id)
     assert state
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
     assert state.attributes.get("device_class") == CoverDeviceClass.BLIND
 
     entry = entity_registry.async_get(entity_id)

--- a/tests/components/airtouch5/test_cover.py
+++ b/tests/components/airtouch5/test_cover.py
@@ -17,9 +17,9 @@ from homeassistant.components.cover import (
     SERVICE_CLOSE_COVER,
     SERVICE_OPEN_COVER,
     SERVICE_SET_COVER_POSITION,
-    STATE_OPEN,
+    CoverState,
 )
-from homeassistant.const import ATTR_ENTITY_ID, STATE_CLOSED, Platform
+from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -118,26 +118,26 @@ async def test_cover_callbacks(
     await _call_zone_status_callback(0.7)
     state = hass.states.get(COVER_ENTITY_ID)
     assert state
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
     assert state.attributes.get(ATTR_CURRENT_POSITION) == 70
 
     # Fully open
     await _call_zone_status_callback(1)
     state = hass.states.get(COVER_ENTITY_ID)
     assert state
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
     assert state.attributes.get(ATTR_CURRENT_POSITION) == 100
 
     # Fully closed
     await _call_zone_status_callback(0.0)
     state = hass.states.get(COVER_ENTITY_ID)
     assert state
-    assert state.state == STATE_CLOSED
+    assert state.state == CoverState.CLOSED
     assert state.attributes.get(ATTR_CURRENT_POSITION) == 0
 
     # Partly reopened
     await _call_zone_status_callback(0.3)
     state = hass.states.get(COVER_ENTITY_ID)
     assert state
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
     assert state.attributes.get(ATTR_CURRENT_POSITION) == 30

--- a/tests/components/blebox/test_cover.py
+++ b/tests/components/blebox/test_cover.py
@@ -11,12 +11,9 @@ from homeassistant.components.cover import (
     ATTR_CURRENT_TILT_POSITION,
     ATTR_POSITION,
     ATTR_TILT_POSITION,
-    STATE_CLOSED,
-    STATE_CLOSING,
-    STATE_OPEN,
-    STATE_OPENING,
     CoverDeviceClass,
     CoverEntityFeature,
+    CoverState,
 )
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
@@ -212,7 +209,7 @@ async def test_open(feature, hass: HomeAssistant) -> None:
     feature_mock.async_open = AsyncMock(side_effect=open_gate)
 
     await async_setup_entity(hass, entity_id)
-    assert hass.states.get(entity_id).state == STATE_CLOSED
+    assert hass.states.get(entity_id).state == CoverState.CLOSED
 
     feature_mock.async_update = AsyncMock()
     await hass.services.async_call(
@@ -221,7 +218,7 @@ async def test_open(feature, hass: HomeAssistant) -> None:
         {"entity_id": entity_id},
         blocking=True,
     )
-    assert hass.states.get(entity_id).state == STATE_OPENING
+    assert hass.states.get(entity_id).state == CoverState.OPENING
 
 
 @pytest.mark.parametrize("feature", ALL_COVER_FIXTURES, indirect=["feature"])
@@ -240,13 +237,13 @@ async def test_close(feature, hass: HomeAssistant) -> None:
     feature_mock.async_close = AsyncMock(side_effect=close)
 
     await async_setup_entity(hass, entity_id)
-    assert hass.states.get(entity_id).state == STATE_OPEN
+    assert hass.states.get(entity_id).state == CoverState.OPEN
 
     feature_mock.async_update = AsyncMock()
     await hass.services.async_call(
         "cover", SERVICE_CLOSE_COVER, {"entity_id": entity_id}, blocking=True
     )
-    assert hass.states.get(entity_id).state == STATE_CLOSING
+    assert hass.states.get(entity_id).state == CoverState.CLOSING
 
 
 def opening_to_stop_feature_mock(feature_mock):
@@ -270,13 +267,13 @@ async def test_stop(feature, hass: HomeAssistant) -> None:
     opening_to_stop_feature_mock(feature_mock)
 
     await async_setup_entity(hass, entity_id)
-    assert hass.states.get(entity_id).state == STATE_OPENING
+    assert hass.states.get(entity_id).state == CoverState.OPENING
 
     feature_mock.async_update = AsyncMock()
     await hass.services.async_call(
         "cover", SERVICE_STOP_COVER, {"entity_id": entity_id}, blocking=True
     )
-    assert hass.states.get(entity_id).state == STATE_OPEN
+    assert hass.states.get(entity_id).state == CoverState.OPEN
 
 
 @pytest.mark.parametrize("feature", ALL_COVER_FIXTURES, indirect=["feature"])
@@ -295,7 +292,7 @@ async def test_update(feature, hass: HomeAssistant) -> None:
 
     state = hass.states.get(entity_id)
     assert state.attributes[ATTR_CURRENT_POSITION] == 71  # 100 - 29
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
 
 
 @pytest.mark.parametrize(
@@ -318,7 +315,7 @@ async def test_set_position(feature, hass: HomeAssistant) -> None:
     feature_mock.async_set_position = AsyncMock(side_effect=set_position)
 
     await async_setup_entity(hass, entity_id)
-    assert hass.states.get(entity_id).state == STATE_CLOSED
+    assert hass.states.get(entity_id).state == CoverState.CLOSED
 
     feature_mock.async_update = AsyncMock()
     await hass.services.async_call(
@@ -327,7 +324,7 @@ async def test_set_position(feature, hass: HomeAssistant) -> None:
         {"entity_id": entity_id, ATTR_POSITION: 1},
         blocking=True,
     )  # almost closed
-    assert hass.states.get(entity_id).state == STATE_OPENING
+    assert hass.states.get(entity_id).state == CoverState.OPENING
 
 
 async def test_unknown_position(shutterbox, hass: HomeAssistant) -> None:
@@ -344,7 +341,7 @@ async def test_unknown_position(shutterbox, hass: HomeAssistant) -> None:
     await async_setup_entity(hass, entity_id)
 
     state = hass.states.get(entity_id)
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
     assert ATTR_CURRENT_POSITION not in state.attributes
 
 
@@ -402,7 +399,7 @@ async def test_opening_state(feature, hass: HomeAssistant) -> None:
 
     feature_mock.async_update = AsyncMock(side_effect=initial_update)
     await async_setup_entity(hass, entity_id)
-    assert hass.states.get(entity_id).state == STATE_OPENING
+    assert hass.states.get(entity_id).state == CoverState.OPENING
 
 
 @pytest.mark.parametrize("feature", ALL_COVER_FIXTURES, indirect=["feature"])
@@ -416,7 +413,7 @@ async def test_closing_state(feature, hass: HomeAssistant) -> None:
 
     feature_mock.async_update = AsyncMock(side_effect=initial_update)
     await async_setup_entity(hass, entity_id)
-    assert hass.states.get(entity_id).state == STATE_CLOSING
+    assert hass.states.get(entity_id).state == CoverState.CLOSING
 
 
 @pytest.mark.parametrize("feature", ALL_COVER_FIXTURES, indirect=["feature"])
@@ -430,7 +427,7 @@ async def test_closed_state(feature, hass: HomeAssistant) -> None:
 
     feature_mock.async_update = AsyncMock(side_effect=initial_update)
     await async_setup_entity(hass, entity_id)
-    assert hass.states.get(entity_id).state == STATE_CLOSED
+    assert hass.states.get(entity_id).state == CoverState.CLOSED
 
 
 async def test_tilt_position(shutterbox, hass: HomeAssistant) -> None:
@@ -465,7 +462,7 @@ async def test_set_tilt_position(shutterbox, hass: HomeAssistant) -> None:
     feature_mock.async_set_tilt_position = AsyncMock(side_effect=set_tilt)
 
     await async_setup_entity(hass, entity_id)
-    assert hass.states.get(entity_id).state == STATE_CLOSED
+    assert hass.states.get(entity_id).state == CoverState.CLOSED
 
     feature_mock.async_update = AsyncMock()
     await hass.services.async_call(
@@ -474,7 +471,7 @@ async def test_set_tilt_position(shutterbox, hass: HomeAssistant) -> None:
         {"entity_id": entity_id, ATTR_TILT_POSITION: 80},
         blocking=True,
     )
-    assert hass.states.get(entity_id).state == STATE_OPENING
+    assert hass.states.get(entity_id).state == CoverState.OPENING
 
 
 async def test_open_tilt(shutterbox, hass: HomeAssistant) -> None:

--- a/tests/components/bond/test_cover.py
+++ b/tests/components/bond/test_cover.py
@@ -8,7 +8,7 @@ from homeassistant.components.cover import (
     ATTR_CURRENT_POSITION,
     ATTR_POSITION,
     DOMAIN as COVER_DOMAIN,
-    STATE_CLOSED,
+    CoverState,
 )
 from homeassistant.const import (
     ATTR_ENTITY_ID,
@@ -19,7 +19,6 @@ from homeassistant.const import (
     SERVICE_SET_COVER_POSITION,
     SERVICE_STOP_COVER,
     SERVICE_STOP_COVER_TILT,
-    STATE_OPEN,
     STATE_UNKNOWN,
 )
 from homeassistant.core import HomeAssistant
@@ -224,7 +223,7 @@ async def test_tilt_and_open(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     mock_open.assert_called_once_with("test-device-id", Action.tilt_open())
-    assert hass.states.get("cover.name_1").state == STATE_CLOSED
+    assert hass.states.get("cover.name_1").state == CoverState.CLOSED
 
 
 async def test_update_reports_open_cover(hass: HomeAssistant) -> None:
@@ -280,7 +279,7 @@ async def test_set_position_cover(hass: HomeAssistant) -> None:
 
     mock_hold.assert_called_once_with("test-device-id", Action.set_position(0))
     entity_state = hass.states.get("cover.name_1")
-    assert entity_state.state == STATE_OPEN
+    assert entity_state.state == CoverState.OPEN
     assert entity_state.attributes[ATTR_CURRENT_POSITION] == 100
 
     with (
@@ -298,7 +297,7 @@ async def test_set_position_cover(hass: HomeAssistant) -> None:
 
     mock_hold.assert_called_once_with("test-device-id", Action.set_position(100))
     entity_state = hass.states.get("cover.name_1")
-    assert entity_state.state == STATE_CLOSED
+    assert entity_state.state == CoverState.CLOSED
     assert entity_state.attributes[ATTR_CURRENT_POSITION] == 0
 
     with (
@@ -316,5 +315,5 @@ async def test_set_position_cover(hass: HomeAssistant) -> None:
 
     mock_hold.assert_called_once_with("test-device-id", Action.set_position(40))
     entity_state = hass.states.get("cover.name_1")
-    assert entity_state.state == STATE_OPEN
+    assert entity_state.state == CoverState.OPEN
     assert entity_state.attributes[ATTR_CURRENT_POSITION] == 60

--- a/tests/components/chacon_dio/test_cover.py
+++ b/tests/components/chacon_dio/test_cover.py
@@ -13,9 +13,7 @@ from homeassistant.components.cover import (
     SERVICE_OPEN_COVER,
     SERVICE_SET_COVER_POSITION,
     SERVICE_STOP_COVER,
-    STATE_CLOSING,
-    STATE_OPEN,
-    STATE_OPENING,
+    CoverState,
 )
 from homeassistant.components.homeassistant import SERVICE_UPDATE_ENTITY
 from homeassistant.const import ATTR_ENTITY_ID
@@ -73,7 +71,7 @@ async def test_update(
     state = hass.states.get(COVER_ENTITY_ID)
     assert state
     assert state.attributes.get(ATTR_CURRENT_POSITION) == 51
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
 
 
 async def test_cover_actions(
@@ -95,7 +93,7 @@ async def test_cover_actions(
     )
     await hass.async_block_till_done()
     state = hass.states.get(COVER_ENTITY_ID)
-    assert state.state == STATE_CLOSING
+    assert state.state == CoverState.CLOSING
 
     await hass.services.async_call(
         COVER_DOMAIN,
@@ -105,7 +103,7 @@ async def test_cover_actions(
     )
     await hass.async_block_till_done()
     state = hass.states.get(COVER_ENTITY_ID)
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
 
     await hass.services.async_call(
         COVER_DOMAIN,
@@ -115,7 +113,7 @@ async def test_cover_actions(
     )
     await hass.async_block_till_done()
     state = hass.states.get(COVER_ENTITY_ID)
-    assert state.state == STATE_OPENING
+    assert state.state == CoverState.OPENING
 
     await hass.services.async_call(
         COVER_DOMAIN,
@@ -125,7 +123,7 @@ async def test_cover_actions(
     )
     await hass.async_block_till_done()
     state = hass.states.get(COVER_ENTITY_ID)
-    assert state.state == STATE_OPENING
+    assert state.state == CoverState.OPENING
 
 
 async def test_cover_callbacks(
@@ -161,19 +159,19 @@ async def test_cover_callbacks(
     state = hass.states.get(COVER_ENTITY_ID)
     assert state
     assert state.attributes.get(ATTR_CURRENT_POSITION) == 79
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
 
     await _callback_device_state_function(90, "up")
     state = hass.states.get(COVER_ENTITY_ID)
     assert state
     assert state.attributes.get(ATTR_CURRENT_POSITION) == 90
-    assert state.state == STATE_OPENING
+    assert state.state == CoverState.OPENING
 
     await _callback_device_state_function(60, "down")
     state = hass.states.get(COVER_ENTITY_ID)
     assert state
     assert state.attributes.get(ATTR_CURRENT_POSITION) == 60
-    assert state.state == STATE_CLOSING
+    assert state.state == CoverState.CLOSING
 
 
 async def test_no_cover_found(

--- a/tests/components/command_line/test_cover.py
+++ b/tests/components/command_line/test_cover.py
@@ -14,7 +14,11 @@ import pytest
 from homeassistant import setup
 from homeassistant.components.command_line import DOMAIN
 from homeassistant.components.command_line.cover import CommandCover
-from homeassistant.components.cover import DOMAIN as COVER_DOMAIN, SCAN_INTERVAL
+from homeassistant.components.cover import (
+    DOMAIN as COVER_DOMAIN,
+    SCAN_INTERVAL,
+    CoverState,
+)
 from homeassistant.components.homeassistant import (
     DOMAIN as HA_DOMAIN,
     SERVICE_UPDATE_ENTITY,
@@ -24,7 +28,6 @@ from homeassistant.const import (
     SERVICE_CLOSE_COVER,
     SERVICE_OPEN_COVER,
     SERVICE_STOP_COVER,
-    STATE_OPEN,
     STATE_UNAVAILABLE,
 )
 from homeassistant.core import HomeAssistant
@@ -389,7 +392,7 @@ async def test_availability(
 
     entity_state = hass.states.get("cover.test")
     assert entity_state
-    assert entity_state.state == STATE_OPEN
+    assert entity_state.state == CoverState.OPEN
 
     hass.states.async_set("sensor.input1", "off")
     await hass.async_block_till_done()

--- a/tests/components/cover/common.py
+++ b/tests/components/cover/common.py
@@ -2,8 +2,7 @@
 
 from typing import Any
 
-from homeassistant.components.cover import CoverEntity, CoverEntityFeature
-from homeassistant.const import STATE_CLOSED, STATE_CLOSING, STATE_OPEN, STATE_OPENING
+from homeassistant.components.cover import CoverEntity, CoverEntityFeature, CoverState
 
 from tests.common import MockEntity
 
@@ -26,7 +25,7 @@ class MockCover(MockEntity, CoverEntity):
     @property
     def is_closed(self):
         """Return if the cover is closed or not."""
-        if "state" in self._values and self._values["state"] == STATE_CLOSED:
+        if "state" in self._values and self._values["state"] == CoverState.CLOSED:
             return True
 
         return self.current_cover_position == 0
@@ -35,7 +34,7 @@ class MockCover(MockEntity, CoverEntity):
     def is_opening(self):
         """Return if the cover is opening or not."""
         if "state" in self._values:
-            return self._values["state"] == STATE_OPENING
+            return self._values["state"] == CoverState.OPENING
 
         return False
 
@@ -43,28 +42,28 @@ class MockCover(MockEntity, CoverEntity):
     def is_closing(self):
         """Return if the cover is closing or not."""
         if "state" in self._values:
-            return self._values["state"] == STATE_CLOSING
+            return self._values["state"] == CoverState.CLOSING
 
         return False
 
     def open_cover(self, **kwargs) -> None:
         """Open cover."""
         if self._reports_opening_closing:
-            self._values["state"] = STATE_OPENING
+            self._values["state"] = CoverState.OPENING
         else:
-            self._values["state"] = STATE_OPEN
+            self._values["state"] = CoverState.OPEN
 
     def close_cover(self, **kwargs) -> None:
         """Close cover."""
         if self._reports_opening_closing:
-            self._values["state"] = STATE_CLOSING
+            self._values["state"] = CoverState.CLOSING
         else:
-            self._values["state"] = STATE_CLOSED
+            self._values["state"] = CoverState.CLOSED
 
     def stop_cover(self, **kwargs) -> None:
         """Stop cover."""
         assert CoverEntityFeature.STOP in self.supported_features
-        self._values["state"] = STATE_CLOSED if self.is_closed else STATE_OPEN
+        self._values["state"] = CoverState.CLOSED if self.is_closed else CoverState.OPEN
 
     @property
     def current_cover_position(self):

--- a/tests/components/cover/test_device_condition.py
+++ b/tests/components/cover/test_device_condition.py
@@ -4,17 +4,9 @@ import pytest
 from pytest_unordered import unordered
 
 from homeassistant.components import automation
-from homeassistant.components.cover import DOMAIN, CoverEntityFeature
+from homeassistant.components.cover import DOMAIN, CoverEntityFeature, CoverState
 from homeassistant.components.device_automation import DeviceAutomationType
-from homeassistant.const import (
-    CONF_PLATFORM,
-    STATE_CLOSED,
-    STATE_CLOSING,
-    STATE_OPEN,
-    STATE_OPENING,
-    STATE_UNAVAILABLE,
-    EntityCategory,
-)
+from homeassistant.const import CONF_PLATFORM, STATE_UNAVAILABLE, EntityCategory
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import RegistryEntryHider
@@ -365,7 +357,7 @@ async def test_if_state(
         DOMAIN, "test", "5678", device_id=device_entry.id
     )
 
-    hass.states.async_set(entry.entity_id, STATE_OPEN)
+    hass.states.async_set(entry.entity_id, CoverState.OPEN)
 
     assert await async_setup_component(
         hass,
@@ -469,21 +461,21 @@ async def test_if_state(
     assert len(service_calls) == 1
     assert service_calls[0].data["some"] == "is_open - event - test_event1"
 
-    hass.states.async_set(entry.entity_id, STATE_CLOSED)
+    hass.states.async_set(entry.entity_id, CoverState.CLOSED)
     hass.bus.async_fire("test_event1")
     hass.bus.async_fire("test_event2")
     await hass.async_block_till_done()
     assert len(service_calls) == 2
     assert service_calls[1].data["some"] == "is_closed - event - test_event2"
 
-    hass.states.async_set(entry.entity_id, STATE_OPENING)
+    hass.states.async_set(entry.entity_id, CoverState.OPENING)
     hass.bus.async_fire("test_event1")
     hass.bus.async_fire("test_event3")
     await hass.async_block_till_done()
     assert len(service_calls) == 3
     assert service_calls[2].data["some"] == "is_opening - event - test_event3"
 
-    hass.states.async_set(entry.entity_id, STATE_CLOSING)
+    hass.states.async_set(entry.entity_id, CoverState.CLOSING)
     hass.bus.async_fire("test_event1")
     hass.bus.async_fire("test_event4")
     await hass.async_block_till_done()
@@ -508,7 +500,7 @@ async def test_if_state_legacy(
         DOMAIN, "test", "5678", device_id=device_entry.id
     )
 
-    hass.states.async_set(entry.entity_id, STATE_OPEN)
+    hass.states.async_set(entry.entity_id, CoverState.OPEN)
 
     assert await async_setup_component(
         hass,
@@ -675,7 +667,7 @@ async def test_if_position(
     assert service_calls[2].data["some"] == "is_pos_gt_45_lt_90 - event - test_event3"
 
     hass.states.async_set(
-        ent.entity_id, STATE_CLOSED, attributes={"current_position": 45}
+        ent.entity_id, CoverState.CLOSED, attributes={"current_position": 45}
     )
     hass.bus.async_fire("test_event1")
     await hass.async_block_till_done()
@@ -688,7 +680,7 @@ async def test_if_position(
     assert service_calls[4].data["some"] == "is_pos_lt_90 - event - test_event2"
 
     hass.states.async_set(
-        ent.entity_id, STATE_CLOSED, attributes={"current_position": 90}
+        ent.entity_id, CoverState.CLOSED, attributes={"current_position": 90}
     )
     hass.bus.async_fire("test_event1")
     hass.bus.async_fire("test_event2")
@@ -835,7 +827,7 @@ async def test_if_tilt_position(
     assert service_calls[2].data["some"] == "is_pos_gt_45_lt_90 - event - test_event3"
 
     hass.states.async_set(
-        ent.entity_id, STATE_CLOSED, attributes={"current_tilt_position": 45}
+        ent.entity_id, CoverState.CLOSED, attributes={"current_tilt_position": 45}
     )
     hass.bus.async_fire("test_event1")
     await hass.async_block_till_done()
@@ -848,7 +840,7 @@ async def test_if_tilt_position(
     assert service_calls[4].data["some"] == "is_pos_lt_90 - event - test_event2"
 
     hass.states.async_set(
-        ent.entity_id, STATE_CLOSED, attributes={"current_tilt_position": 90}
+        ent.entity_id, CoverState.CLOSED, attributes={"current_tilt_position": 90}
     )
     hass.bus.async_fire("test_event1")
     await hass.async_block_till_done()

--- a/tests/components/cover/test_device_trigger.py
+++ b/tests/components/cover/test_device_trigger.py
@@ -6,16 +6,9 @@ import pytest
 from pytest_unordered import unordered
 
 from homeassistant.components import automation
-from homeassistant.components.cover import DOMAIN, CoverEntityFeature
+from homeassistant.components.cover import DOMAIN, CoverEntityFeature, CoverState
 from homeassistant.components.device_automation import DeviceAutomationType
-from homeassistant.const import (
-    CONF_PLATFORM,
-    STATE_CLOSED,
-    STATE_CLOSING,
-    STATE_OPEN,
-    STATE_OPENING,
-    EntityCategory,
-)
+from homeassistant.const import CONF_PLATFORM, EntityCategory
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import RegistryEntryHider
@@ -387,7 +380,7 @@ async def test_if_fires_on_state_change(
         DOMAIN, "test", "5678", device_id=device_entry.id
     )
 
-    hass.states.async_set(entry.entity_id, STATE_CLOSED)
+    hass.states.async_set(entry.entity_id, CoverState.CLOSED)
 
     assert await async_setup_component(
         hass,
@@ -487,7 +480,7 @@ async def test_if_fires_on_state_change(
     )
 
     # Fake that the entity is opened.
-    hass.states.async_set(entry.entity_id, STATE_OPEN)
+    hass.states.async_set(entry.entity_id, CoverState.OPEN)
     await hass.async_block_till_done()
     assert len(service_calls) == 1
     assert (
@@ -496,7 +489,7 @@ async def test_if_fires_on_state_change(
     )
 
     # Fake that the entity is closed.
-    hass.states.async_set(entry.entity_id, STATE_CLOSED)
+    hass.states.async_set(entry.entity_id, CoverState.CLOSED)
     await hass.async_block_till_done()
     assert len(service_calls) == 2
     assert (
@@ -505,7 +498,7 @@ async def test_if_fires_on_state_change(
     )
 
     # Fake that the entity is opening.
-    hass.states.async_set(entry.entity_id, STATE_OPENING)
+    hass.states.async_set(entry.entity_id, CoverState.OPENING)
     await hass.async_block_till_done()
     assert len(service_calls) == 3
     assert (
@@ -514,7 +507,7 @@ async def test_if_fires_on_state_change(
     )
 
     # Fake that the entity is closing.
-    hass.states.async_set(entry.entity_id, STATE_CLOSING)
+    hass.states.async_set(entry.entity_id, CoverState.CLOSING)
     await hass.async_block_till_done()
     assert len(service_calls) == 4
     assert (
@@ -540,7 +533,7 @@ async def test_if_fires_on_state_change_legacy(
         DOMAIN, "test", "5678", device_id=device_entry.id
     )
 
-    hass.states.async_set(entry.entity_id, STATE_CLOSED)
+    hass.states.async_set(entry.entity_id, CoverState.CLOSED)
 
     assert await async_setup_component(
         hass,
@@ -574,7 +567,7 @@ async def test_if_fires_on_state_change_legacy(
     )
 
     # Fake that the entity is opened.
-    hass.states.async_set(entry.entity_id, STATE_OPEN)
+    hass.states.async_set(entry.entity_id, CoverState.OPEN)
     await hass.async_block_till_done()
     assert len(service_calls) == 1
     assert (
@@ -600,7 +593,7 @@ async def test_if_fires_on_state_change_with_for(
         DOMAIN, "test", "5678", device_id=device_entry.id
     )
 
-    hass.states.async_set(entry.entity_id, STATE_CLOSED)
+    hass.states.async_set(entry.entity_id, CoverState.CLOSED)
 
     assert await async_setup_component(
         hass,
@@ -635,7 +628,7 @@ async def test_if_fires_on_state_change_with_for(
     await hass.async_block_till_done()
     assert len(service_calls) == 0
 
-    hass.states.async_set(entry.entity_id, STATE_OPEN)
+    hass.states.async_set(entry.entity_id, CoverState.OPEN)
     await hass.async_block_till_done()
     assert len(service_calls) == 0
     async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=10))
@@ -754,12 +747,14 @@ async def test_if_fires_on_position(
             ]
         },
     )
-    hass.states.async_set(ent.entity_id, STATE_OPEN, attributes={"current_position": 1})
     hass.states.async_set(
-        ent.entity_id, STATE_CLOSED, attributes={"current_position": 95}
+        ent.entity_id, CoverState.OPEN, attributes={"current_position": 1}
     )
     hass.states.async_set(
-        ent.entity_id, STATE_OPEN, attributes={"current_position": 50}
+        ent.entity_id, CoverState.CLOSED, attributes={"current_position": 95}
+    )
+    hass.states.async_set(
+        ent.entity_id, CoverState.OPEN, attributes={"current_position": 50}
     )
     await hass.async_block_till_done()
     assert len(service_calls) == 3
@@ -781,11 +776,11 @@ async def test_if_fires_on_position(
     )
 
     hass.states.async_set(
-        ent.entity_id, STATE_CLOSED, attributes={"current_position": 95}
+        ent.entity_id, CoverState.CLOSED, attributes={"current_position": 95}
     )
     await hass.async_block_till_done()
     hass.states.async_set(
-        ent.entity_id, STATE_CLOSED, attributes={"current_position": 45}
+        ent.entity_id, CoverState.CLOSED, attributes={"current_position": 45}
     )
     await hass.async_block_till_done()
     assert len(service_calls) == 4
@@ -795,7 +790,7 @@ async def test_if_fires_on_position(
     )
 
     hass.states.async_set(
-        ent.entity_id, STATE_CLOSED, attributes={"current_position": 90}
+        ent.entity_id, CoverState.CLOSED, attributes={"current_position": 90}
     )
     await hass.async_block_till_done()
     assert len(service_calls) == 5
@@ -912,13 +907,13 @@ async def test_if_fires_on_tilt_position(
         },
     )
     hass.states.async_set(
-        ent.entity_id, STATE_OPEN, attributes={"current_tilt_position": 1}
+        ent.entity_id, CoverState.OPEN, attributes={"current_tilt_position": 1}
     )
     hass.states.async_set(
-        ent.entity_id, STATE_CLOSED, attributes={"current_tilt_position": 95}
+        ent.entity_id, CoverState.CLOSED, attributes={"current_tilt_position": 95}
     )
     hass.states.async_set(
-        ent.entity_id, STATE_OPEN, attributes={"current_tilt_position": 50}
+        ent.entity_id, CoverState.OPEN, attributes={"current_tilt_position": 50}
     )
     await hass.async_block_till_done()
     assert len(service_calls) == 3
@@ -940,11 +935,11 @@ async def test_if_fires_on_tilt_position(
     )
 
     hass.states.async_set(
-        ent.entity_id, STATE_CLOSED, attributes={"current_tilt_position": 95}
+        ent.entity_id, CoverState.CLOSED, attributes={"current_tilt_position": 95}
     )
     await hass.async_block_till_done()
     hass.states.async_set(
-        ent.entity_id, STATE_CLOSED, attributes={"current_tilt_position": 45}
+        ent.entity_id, CoverState.CLOSED, attributes={"current_tilt_position": 45}
     )
     await hass.async_block_till_done()
     assert len(service_calls) == 4
@@ -954,7 +949,7 @@ async def test_if_fires_on_tilt_position(
     )
 
     hass.states.async_set(
-        ent.entity_id, STATE_CLOSED, attributes={"current_tilt_position": 90}
+        ent.entity_id, CoverState.CLOSED, attributes={"current_tilt_position": 90}
     )
     await hass.async_block_till_done()
     assert len(service_calls) == 5

--- a/tests/components/cover/test_init.py
+++ b/tests/components/cover/test_init.py
@@ -5,15 +5,8 @@ from enum import Enum
 import pytest
 
 from homeassistant.components import cover
-from homeassistant.const import (
-    ATTR_ENTITY_ID,
-    CONF_PLATFORM,
-    SERVICE_TOGGLE,
-    STATE_CLOSED,
-    STATE_CLOSING,
-    STATE_OPEN,
-    STATE_OPENING,
-)
+from homeassistant.components.cover import CoverState
+from homeassistant.const import ATTR_ENTITY_ID, CONF_PLATFORM, SERVICE_TOGGLE
 from homeassistant.core import HomeAssistant, ServiceResponse
 from homeassistant.helpers.entity import Entity
 from homeassistant.setup import async_setup_component
@@ -106,15 +99,17 @@ async def test_services(
     assert is_closing(hass, ent6)
 
     # Without STOP but still reports opening/closing has a 4th possible toggle state
-    set_state(ent6, STATE_CLOSED)
+    set_state(ent6, CoverState.CLOSED)
     await call_service(hass, SERVICE_TOGGLE, ent6)
     assert is_opening(hass, ent6)
 
     # After the unusual state transition: closing -> fully open, toggle should close
-    set_state(ent5, STATE_OPEN)
+    set_state(ent5, CoverState.OPEN)
     await call_service(hass, SERVICE_TOGGLE, ent5)  # Start closing
     assert is_closing(hass, ent5)
-    set_state(ent5, STATE_OPEN)  # Unusual state transition from closing -> fully open
+    set_state(
+        ent5, CoverState.OPEN
+    )  # Unusual state transition from closing -> fully open
     set_cover_position(ent5, 100)
     await call_service(hass, SERVICE_TOGGLE, ent5)  # Should close, not open
     assert is_closing(hass, ent5)
@@ -139,22 +134,22 @@ def set_state(ent, state) -> None:
 
 def is_open(hass: HomeAssistant, ent: Entity) -> bool:
     """Return if the cover is closed based on the statemachine."""
-    return hass.states.is_state(ent.entity_id, STATE_OPEN)
+    return hass.states.is_state(ent.entity_id, CoverState.OPEN)
 
 
 def is_opening(hass: HomeAssistant, ent: Entity) -> bool:
     """Return if the cover is closed based on the statemachine."""
-    return hass.states.is_state(ent.entity_id, STATE_OPENING)
+    return hass.states.is_state(ent.entity_id, CoverState.OPENING)
 
 
 def is_closed(hass: HomeAssistant, ent: Entity) -> bool:
     """Return if the cover is closed based on the statemachine."""
-    return hass.states.is_state(ent.entity_id, STATE_CLOSED)
+    return hass.states.is_state(ent.entity_id, CoverState.CLOSED)
 
 
 def is_closing(hass: HomeAssistant, ent: Entity) -> bool:
     """Return if the cover is closed based on the statemachine."""
-    return hass.states.is_state(ent.entity_id, STATE_CLOSING)
+    return hass.states.is_state(ent.entity_id, CoverState.CLOSING)
 
 
 def _create_tuples(enum: type[Enum], constant_prefix: str) -> list[tuple[Enum, str]]:

--- a/tests/components/cover/test_intent.py
+++ b/tests/components/cover/test_intent.py
@@ -10,9 +10,9 @@ from homeassistant.components.cover import (
     SERVICE_CLOSE_COVER,
     SERVICE_OPEN_COVER,
     SERVICE_SET_COVER_POSITION,
+    CoverState,
     intent as cover_intent,
 )
-from homeassistant.const import STATE_CLOSED, STATE_OPEN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import intent
 from homeassistant.setup import async_setup_component
@@ -32,7 +32,9 @@ async def test_open_cover_intent(hass: HomeAssistant, slots: dict[str, Any]) -> 
     await cover_intent.async_setup_intents(hass)
 
     hass.states.async_set(
-        f"{DOMAIN}.garage_door", STATE_CLOSED, attributes={"device_class": "garage"}
+        f"{DOMAIN}.garage_door",
+        CoverState.CLOSED,
+        attributes={"device_class": "garage"},
     )
     calls = async_mock_service(hass, DOMAIN, SERVICE_OPEN_COVER)
 
@@ -61,7 +63,7 @@ async def test_close_cover_intent(hass: HomeAssistant, slots: dict[str, Any]) ->
     await cover_intent.async_setup_intents(hass)
 
     hass.states.async_set(
-        f"{DOMAIN}.garage_door", STATE_OPEN, attributes={"device_class": "garage"}
+        f"{DOMAIN}.garage_door", CoverState.OPEN, attributes={"device_class": "garage"}
     )
     calls = async_mock_service(hass, DOMAIN, SERVICE_CLOSE_COVER)
 
@@ -95,7 +97,7 @@ async def test_set_cover_position(hass: HomeAssistant, slots: dict[str, Any]) ->
     entity_id = f"{DOMAIN}.test_cover"
     hass.states.async_set(
         entity_id,
-        STATE_CLOSED,
+        CoverState.CLOSED,
         attributes={ATTR_CURRENT_POSITION: 0, "device_class": "shade"},
     )
     calls = async_mock_service(hass, DOMAIN, SERVICE_SET_COVER_POSITION)

--- a/tests/components/cover/test_reproduce_state.py
+++ b/tests/components/cover/test_reproduce_state.py
@@ -7,6 +7,7 @@ from homeassistant.components.cover import (
     ATTR_CURRENT_TILT_POSITION,
     ATTR_POSITION,
     ATTR_TILT_POSITION,
+    CoverState,
 )
 from homeassistant.const import (
     SERVICE_CLOSE_COVER,
@@ -15,8 +16,6 @@ from homeassistant.const import (
     SERVICE_OPEN_COVER_TILT,
     SERVICE_SET_COVER_POSITION,
     SERVICE_SET_COVER_TILT_POSITION,
-    STATE_CLOSED,
-    STATE_OPEN,
 )
 from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers.state import async_reproduce_state
@@ -28,32 +27,32 @@ async def test_reproducing_states(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test reproducing Cover states."""
-    hass.states.async_set("cover.entity_close", STATE_CLOSED, {})
+    hass.states.async_set("cover.entity_close", CoverState.CLOSED, {})
     hass.states.async_set(
         "cover.entity_close_attr",
-        STATE_CLOSED,
+        CoverState.CLOSED,
         {ATTR_CURRENT_POSITION: 0, ATTR_CURRENT_TILT_POSITION: 0},
     )
     hass.states.async_set(
-        "cover.entity_close_tilt", STATE_CLOSED, {ATTR_CURRENT_TILT_POSITION: 50}
+        "cover.entity_close_tilt", CoverState.CLOSED, {ATTR_CURRENT_TILT_POSITION: 50}
     )
-    hass.states.async_set("cover.entity_open", STATE_OPEN, {})
+    hass.states.async_set("cover.entity_open", CoverState.OPEN, {})
     hass.states.async_set(
-        "cover.entity_slightly_open", STATE_OPEN, {ATTR_CURRENT_POSITION: 50}
+        "cover.entity_slightly_open", CoverState.OPEN, {ATTR_CURRENT_POSITION: 50}
     )
     hass.states.async_set(
         "cover.entity_open_attr",
-        STATE_OPEN,
+        CoverState.OPEN,
         {ATTR_CURRENT_POSITION: 100, ATTR_CURRENT_TILT_POSITION: 0},
     )
     hass.states.async_set(
         "cover.entity_open_tilt",
-        STATE_OPEN,
+        CoverState.OPEN,
         {ATTR_CURRENT_POSITION: 50, ATTR_CURRENT_TILT_POSITION: 50},
     )
     hass.states.async_set(
         "cover.entity_entirely_open",
-        STATE_OPEN,
+        CoverState.OPEN,
         {ATTR_CURRENT_POSITION: 100, ATTR_CURRENT_TILT_POSITION: 100},
     )
 
@@ -70,34 +69,36 @@ async def test_reproducing_states(
     await async_reproduce_state(
         hass,
         [
-            State("cover.entity_close", STATE_CLOSED),
+            State("cover.entity_close", CoverState.CLOSED),
             State(
                 "cover.entity_close_attr",
-                STATE_CLOSED,
+                CoverState.CLOSED,
                 {ATTR_CURRENT_POSITION: 0, ATTR_CURRENT_TILT_POSITION: 0},
             ),
             State(
                 "cover.entity_close_tilt",
-                STATE_CLOSED,
+                CoverState.CLOSED,
                 {ATTR_CURRENT_TILT_POSITION: 50},
             ),
-            State("cover.entity_open", STATE_OPEN),
+            State("cover.entity_open", CoverState.OPEN),
             State(
-                "cover.entity_slightly_open", STATE_OPEN, {ATTR_CURRENT_POSITION: 50}
+                "cover.entity_slightly_open",
+                CoverState.OPEN,
+                {ATTR_CURRENT_POSITION: 50},
             ),
             State(
                 "cover.entity_open_attr",
-                STATE_OPEN,
+                CoverState.OPEN,
                 {ATTR_CURRENT_POSITION: 100, ATTR_CURRENT_TILT_POSITION: 0},
             ),
             State(
                 "cover.entity_open_tilt",
-                STATE_OPEN,
+                CoverState.OPEN,
                 {ATTR_CURRENT_POSITION: 50, ATTR_CURRENT_TILT_POSITION: 50},
             ),
             State(
                 "cover.entity_entirely_open",
-                STATE_OPEN,
+                CoverState.OPEN,
                 {ATTR_CURRENT_POSITION: 100, ATTR_CURRENT_TILT_POSITION: 100},
             ),
         ],
@@ -125,26 +126,28 @@ async def test_reproducing_states(
     await async_reproduce_state(
         hass,
         [
-            State("cover.entity_close", STATE_OPEN),
+            State("cover.entity_close", CoverState.OPEN),
             State(
                 "cover.entity_close_attr",
-                STATE_OPEN,
+                CoverState.OPEN,
                 {ATTR_CURRENT_POSITION: 50, ATTR_CURRENT_TILT_POSITION: 50},
             ),
             State(
                 "cover.entity_close_tilt",
-                STATE_CLOSED,
+                CoverState.CLOSED,
                 {ATTR_CURRENT_TILT_POSITION: 100},
             ),
-            State("cover.entity_open", STATE_CLOSED),
-            State("cover.entity_slightly_open", STATE_OPEN, {}),
-            State("cover.entity_open_attr", STATE_CLOSED, {}),
+            State("cover.entity_open", CoverState.CLOSED),
+            State("cover.entity_slightly_open", CoverState.OPEN, {}),
+            State("cover.entity_open_attr", CoverState.CLOSED, {}),
             State(
-                "cover.entity_open_tilt", STATE_OPEN, {ATTR_CURRENT_TILT_POSITION: 0}
+                "cover.entity_open_tilt",
+                CoverState.OPEN,
+                {ATTR_CURRENT_TILT_POSITION: 0},
             ),
             State(
                 "cover.entity_entirely_open",
-                STATE_CLOSED,
+                CoverState.CLOSED,
                 {ATTR_CURRENT_POSITION: 0, ATTR_CURRENT_TILT_POSITION: 0},
             ),
             # Should not raise

--- a/tests/components/deconz/test_cover.py
+++ b/tests/components/deconz/test_cover.py
@@ -19,8 +19,9 @@ from homeassistant.components.cover import (
     SERVICE_SET_COVER_TILT_POSITION,
     SERVICE_STOP_COVER,
     SERVICE_STOP_COVER_TILT,
+    CoverState,
 )
-from homeassistant.const import ATTR_ENTITY_ID, STATE_OPEN, Platform
+from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -67,7 +68,7 @@ async def test_cover(
 
     await light_ws_data({"state": {"lift": 0, "open": True}})
     cover = hass.states.get("cover.window_covering_device")
-    assert cover.state == STATE_OPEN
+    assert cover.state == CoverState.OPEN
     assert cover.attributes[ATTR_CURRENT_POSITION] == 100
 
     # Verify service calls for cover

--- a/tests/components/demo/test_cover.py
+++ b/tests/components/demo/test_cover.py
@@ -12,6 +12,7 @@ from homeassistant.components.cover import (
     ATTR_POSITION,
     ATTR_TILT_POSITION,
     DOMAIN as COVER_DOMAIN,
+    CoverState,
 )
 from homeassistant.const import (
     ATTR_ENTITY_ID,
@@ -26,10 +27,6 @@ from homeassistant.const import (
     SERVICE_STOP_COVER_TILT,
     SERVICE_TOGGLE,
     SERVICE_TOGGLE_COVER_TILT,
-    STATE_CLOSED,
-    STATE_CLOSING,
-    STATE_OPEN,
-    STATE_OPENING,
     Platform,
 )
 from homeassistant.core import HomeAssistant
@@ -75,41 +72,41 @@ async def test_supported_features(hass: HomeAssistant) -> None:
 async def test_close_cover(hass: HomeAssistant) -> None:
     """Test closing the cover."""
     state = hass.states.get(ENTITY_COVER)
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
     assert state.attributes[ATTR_CURRENT_POSITION] == 70
 
     await hass.services.async_call(
         COVER_DOMAIN, SERVICE_CLOSE_COVER, {ATTR_ENTITY_ID: ENTITY_COVER}, blocking=True
     )
     state = hass.states.get(ENTITY_COVER)
-    assert state.state == STATE_CLOSING
+    assert state.state == CoverState.CLOSING
     for _ in range(7):
         future = dt_util.utcnow() + timedelta(seconds=1)
         async_fire_time_changed(hass, future)
         await hass.async_block_till_done()
 
     state = hass.states.get(ENTITY_COVER)
-    assert state.state == STATE_CLOSED
+    assert state.state == CoverState.CLOSED
     assert state.attributes[ATTR_CURRENT_POSITION] == 0
 
 
 async def test_open_cover(hass: HomeAssistant) -> None:
     """Test opening the cover."""
     state = hass.states.get(ENTITY_COVER)
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
     assert state.attributes[ATTR_CURRENT_POSITION] == 70
     await hass.services.async_call(
         COVER_DOMAIN, SERVICE_OPEN_COVER, {ATTR_ENTITY_ID: ENTITY_COVER}, blocking=True
     )
     state = hass.states.get(ENTITY_COVER)
-    assert state.state == STATE_OPENING
+    assert state.state == CoverState.OPENING
     for _ in range(7):
         future = dt_util.utcnow() + timedelta(seconds=1)
         async_fire_time_changed(hass, future)
         await hass.async_block_till_done()
 
     state = hass.states.get(ENTITY_COVER)
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
     assert state.attributes[ATTR_CURRENT_POSITION] == 100
 
 
@@ -125,7 +122,7 @@ async def test_toggle_cover(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     state = hass.states.get(ENTITY_COVER)
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
     assert state.attributes["current_position"] == 100
     # Toggle closed
     await hass.services.async_call(
@@ -137,7 +134,7 @@ async def test_toggle_cover(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     state = hass.states.get(ENTITY_COVER)
-    assert state.state == STATE_CLOSED
+    assert state.state == CoverState.CLOSED
     assert state.attributes[ATTR_CURRENT_POSITION] == 0
     # Toggle open
     await hass.services.async_call(
@@ -149,7 +146,7 @@ async def test_toggle_cover(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     state = hass.states.get(ENTITY_COVER)
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
     assert state.attributes[ATTR_CURRENT_POSITION] == 100
 
 

--- a/tests/components/devolo_home_control/test_cover.py
+++ b/tests/components/devolo_home_control/test_cover.py
@@ -8,13 +8,13 @@ from homeassistant.components.cover import (
     ATTR_CURRENT_POSITION,
     ATTR_POSITION,
     DOMAIN as COVER_DOMAIN,
+    CoverState,
 )
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     SERVICE_CLOSE_COVER,
     SERVICE_OPEN_COVER,
     SERVICE_SET_COVER_POSITION,
-    STATE_CLOSED,
     STATE_UNAVAILABLE,
 )
 from homeassistant.core import HomeAssistant
@@ -46,7 +46,7 @@ async def test_cover(
     test_gateway.publisher.dispatch("Test", ("devolo.Blinds", 0.0))
     await hass.async_block_till_done()
     state = hass.states.get(f"{COVER_DOMAIN}.test")
-    assert state.state == STATE_CLOSED
+    assert state.state == CoverState.CLOSED
     assert state.attributes[ATTR_CURRENT_POSITION] == 0.0
 
     # Test setting position

--- a/tests/components/dynalite/test_cover.py
+++ b/tests/components/dynalite/test_cover.py
@@ -13,15 +13,9 @@ from homeassistant.components.cover import (
     ATTR_POSITION,
     ATTR_TILT_POSITION,
     CoverDeviceClass,
+    CoverState,
 )
-from homeassistant.const import (
-    ATTR_DEVICE_CLASS,
-    ATTR_FRIENDLY_NAME,
-    STATE_CLOSED,
-    STATE_CLOSING,
-    STATE_OPEN,
-    STATE_OPENING,
-)
+from homeassistant.const import ATTR_DEVICE_CLASS, ATTR_FRIENDLY_NAME
 from homeassistant.core import HomeAssistant, State
 from homeassistant.exceptions import HomeAssistantError
 
@@ -130,16 +124,16 @@ async def test_cover_positions(hass: HomeAssistant, mock_device: Mock) -> None:
     """Test that the state updates in the various positions."""
     update_func = await create_entity_from_device(hass, mock_device)
     await check_cover_position(
-        hass, update_func, mock_device, True, False, False, STATE_CLOSING
+        hass, update_func, mock_device, True, False, False, CoverState.CLOSING
     )
     await check_cover_position(
-        hass, update_func, mock_device, False, True, False, STATE_OPENING
+        hass, update_func, mock_device, False, True, False, CoverState.OPENING
     )
     await check_cover_position(
-        hass, update_func, mock_device, False, False, True, STATE_CLOSED
+        hass, update_func, mock_device, False, False, True, CoverState.CLOSED
     )
     await check_cover_position(
-        hass, update_func, mock_device, False, False, False, STATE_OPEN
+        hass, update_func, mock_device, False, False, False, CoverState.OPEN
     )
 
 
@@ -147,12 +141,12 @@ async def test_cover_restore_state(hass: HomeAssistant, mock_device: Mock) -> No
     """Test restore from cache."""
     mock_restore_cache(
         hass,
-        [State("cover.name", STATE_OPEN, attributes={ATTR_CURRENT_POSITION: 77})],
+        [State("cover.name", CoverState.OPEN, attributes={ATTR_CURRENT_POSITION: 77})],
     )
     await create_entity_from_device(hass, mock_device)
     mock_device.init_level.assert_called_once_with(77)
     entity_state = hass.states.get("cover.name")
-    assert entity_state.state == STATE_OPEN
+    assert entity_state.state == CoverState.OPEN
 
 
 async def test_cover_restore_state_bad_cache(
@@ -161,9 +155,9 @@ async def test_cover_restore_state_bad_cache(
     """Test restore from a cache without the attribute."""
     mock_restore_cache(
         hass,
-        [State("cover.name", STATE_OPEN, attributes={"bla bla": 77})],
+        [State("cover.name", CoverState.OPEN, attributes={"bla bla": 77})],
     )
     await create_entity_from_device(hass, mock_device)
     mock_device.init_level.assert_not_called()
     entity_state = hass.states.get("cover.name")
-    assert entity_state.state == STATE_CLOSED
+    assert entity_state.state == CoverState.CLOSED

--- a/tests/components/esphome/test_cover.py
+++ b/tests/components/esphome/test_cover.py
@@ -7,7 +7,7 @@ from aioesphomeapi import (
     APIClient,
     CoverInfo,
     CoverOperation,
-    CoverState,
+    CoverState as ESPHomeCoverState,
     EntityInfo,
     EntityState,
     UserService,
@@ -26,10 +26,7 @@ from homeassistant.components.cover import (
     SERVICE_SET_COVER_POSITION,
     SERVICE_SET_COVER_TILT_POSITION,
     SERVICE_STOP_COVER,
-    STATE_CLOSED,
-    STATE_CLOSING,
-    STATE_OPEN,
-    STATE_OPENING,
+    CoverState,
 )
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
@@ -58,7 +55,7 @@ async def test_cover_entity(
         )
     ]
     states = [
-        CoverState(
+        ESPHomeCoverState(
             key=1,
             position=0.5,
             tilt=0.5,
@@ -74,7 +71,7 @@ async def test_cover_entity(
     )
     state = hass.states.get("cover.test_mycover")
     assert state is not None
-    assert state.state == STATE_OPENING
+    assert state.state == CoverState.OPENING
     assert state.attributes[ATTR_CURRENT_POSITION] == 50
     assert state.attributes[ATTR_CURRENT_TILT_POSITION] == 50
 
@@ -142,28 +139,30 @@ async def test_cover_entity(
     mock_client.cover_command.reset_mock()
 
     mock_device.set_state(
-        CoverState(key=1, position=0.0, current_operation=CoverOperation.IDLE)
+        ESPHomeCoverState(key=1, position=0.0, current_operation=CoverOperation.IDLE)
     )
     await hass.async_block_till_done()
     state = hass.states.get("cover.test_mycover")
     assert state is not None
-    assert state.state == STATE_CLOSED
+    assert state.state == CoverState.CLOSED
 
     mock_device.set_state(
-        CoverState(key=1, position=0.5, current_operation=CoverOperation.IS_CLOSING)
+        ESPHomeCoverState(
+            key=1, position=0.5, current_operation=CoverOperation.IS_CLOSING
+        )
     )
     await hass.async_block_till_done()
     state = hass.states.get("cover.test_mycover")
     assert state is not None
-    assert state.state == STATE_CLOSING
+    assert state.state == CoverState.CLOSING
 
     mock_device.set_state(
-        CoverState(key=1, position=1.0, current_operation=CoverOperation.IDLE)
+        ESPHomeCoverState(key=1, position=1.0, current_operation=CoverOperation.IDLE)
     )
     await hass.async_block_till_done()
     state = hass.states.get("cover.test_mycover")
     assert state is not None
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
 
 
 async def test_cover_entity_without_position(
@@ -187,7 +186,7 @@ async def test_cover_entity_without_position(
         )
     ]
     states = [
-        CoverState(
+        ESPHomeCoverState(
             key=1,
             position=0.5,
             tilt=0.5,
@@ -203,6 +202,6 @@ async def test_cover_entity_without_position(
     )
     state = hass.states.get("cover.test_mycover")
     assert state is not None
-    assert state.state == STATE_OPENING
+    assert state.state == CoverState.OPENING
     assert ATTR_CURRENT_TILT_POSITION not in state.attributes
     assert ATTR_CURRENT_POSITION not in state.attributes

--- a/tests/components/freedompro/test_cover.py
+++ b/tests/components/freedompro/test_cover.py
@@ -5,14 +5,16 @@ from unittest.mock import ANY, patch
 
 import pytest
 
-from homeassistant.components.cover import ATTR_POSITION, DOMAIN as COVER_DOMAIN
+from homeassistant.components.cover import (
+    ATTR_POSITION,
+    DOMAIN as COVER_DOMAIN,
+    CoverState,
+)
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     SERVICE_CLOSE_COVER,
     SERVICE_OPEN_COVER,
     SERVICE_SET_COVER_POSITION,
-    STATE_CLOSED,
-    STATE_OPEN,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
@@ -56,7 +58,7 @@ async def test_cover_get_state(
 
     state = hass.states.get(entity_id)
     assert state
-    assert state.state == STATE_CLOSED
+    assert state.state == CoverState.CLOSED
     assert state.attributes.get("friendly_name") == name
 
     entry = entity_registry.async_get(entity_id)
@@ -80,7 +82,7 @@ async def test_cover_get_state(
         assert entry
         assert entry.unique_id == uid
 
-        assert state.state == STATE_OPEN
+        assert state.state == CoverState.OPEN
 
 
 @pytest.mark.parametrize(
@@ -107,7 +109,7 @@ async def test_cover_set_position(
 
     state = hass.states.get(entity_id)
     assert state
-    assert state.state == STATE_CLOSED
+    assert state.state == CoverState.CLOSED
     assert state.attributes.get("friendly_name") == name
 
     entry = entity_registry.async_get(entity_id)
@@ -133,7 +135,7 @@ async def test_cover_set_position(
         await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
     assert state.attributes["current_position"] == 33
 
 
@@ -171,7 +173,7 @@ async def test_cover_close(
 
     state = hass.states.get(entity_id)
     assert state
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
     assert state.attributes.get("friendly_name") == name
 
     entry = entity_registry.async_get(entity_id)
@@ -196,7 +198,7 @@ async def test_cover_close(
         await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)
-    assert state.state == STATE_CLOSED
+    assert state.state == CoverState.CLOSED
 
 
 @pytest.mark.parametrize(
@@ -223,7 +225,7 @@ async def test_cover_open(
 
     state = hass.states.get(entity_id)
     assert state
-    assert state.state == STATE_CLOSED
+    assert state.state == CoverState.CLOSED
     assert state.attributes.get("friendly_name") == name
 
     entry = entity_registry.async_get(entity_id)
@@ -249,4 +251,4 @@ async def test_cover_open(
         await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN

--- a/tests/components/fritzbox/test_cover.py
+++ b/tests/components/fritzbox/test_cover.py
@@ -7,7 +7,7 @@ from homeassistant.components.cover import (
     ATTR_CURRENT_POSITION,
     ATTR_POSITION,
     DOMAIN as COVER_DOMAIN,
-    STATE_OPEN,
+    CoverState,
 )
 from homeassistant.components.fritzbox.const import DOMAIN as FB_DOMAIN
 from homeassistant.const import (
@@ -44,7 +44,7 @@ async def test_setup(hass: HomeAssistant, fritz: Mock) -> None:
 
     state = hass.states.get(ENTITY_ID)
     assert state
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
     assert state.attributes[ATTR_CURRENT_POSITION] == 100
 
 

--- a/tests/components/gogogate2/test_cover.py
+++ b/tests/components/gogogate2/test_cover.py
@@ -20,6 +20,7 @@ from homeassistant.components.cover import (
     DOMAIN as COVER_DOMAIN,
     CoverDeviceClass,
     CoverEntityFeature,
+    CoverState,
 )
 from homeassistant.components.gogogate2.const import (
     DEVICE_TYPE_GOGOGATE2,
@@ -34,10 +35,6 @@ from homeassistant.const import (
     CONF_IP_ADDRESS,
     CONF_PASSWORD,
     CONF_USERNAME,
-    STATE_CLOSED,
-    STATE_CLOSING,
-    STATE_OPEN,
-    STATE_OPENING,
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
 )
@@ -144,7 +141,7 @@ async def test_open_close_update(gogogate2api_mock, hass: HomeAssistant) -> None
     assert hass.states.get("cover.door1") is None
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
-    assert hass.states.get("cover.door1").state == STATE_OPEN
+    assert hass.states.get("cover.door1").state == CoverState.OPEN
     assert dict(hass.states.get("cover.door1").attributes) == expected_attributes
 
     api.async_info.return_value = info_response(DoorStatus.CLOSED)
@@ -163,12 +160,12 @@ async def test_open_close_update(gogogate2api_mock, hass: HomeAssistant) -> None
     }
     async_fire_time_changed(hass, utcnow() + timedelta(hours=2))
     await hass.async_block_till_done()
-    assert hass.states.get("cover.door1").state == STATE_CLOSING
+    assert hass.states.get("cover.door1").state == CoverState.CLOSING
     api.async_close_door.assert_called_with(1)
 
     async_fire_time_changed(hass, utcnow() + timedelta(seconds=10))
     await hass.async_block_till_done()
-    assert hass.states.get("cover.door1").state == STATE_CLOSING
+    assert hass.states.get("cover.door1").state == CoverState.CLOSING
 
     api.async_info.return_value = info_response(DoorStatus.CLOSED)
     api.async_get_door_statuses_from_info.return_value = {
@@ -177,7 +174,7 @@ async def test_open_close_update(gogogate2api_mock, hass: HomeAssistant) -> None
     }
     async_fire_time_changed(hass, utcnow() + timedelta(hours=2))
     await hass.async_block_till_done()
-    assert hass.states.get("cover.door1").state == STATE_CLOSED
+    assert hass.states.get("cover.door1").state == CoverState.CLOSED
 
     api.async_info.return_value = info_response(DoorStatus.OPENED)
     api.async_get_door_statuses_from_info.return_value = {
@@ -195,12 +192,12 @@ async def test_open_close_update(gogogate2api_mock, hass: HomeAssistant) -> None
     }
     async_fire_time_changed(hass, utcnow() + timedelta(hours=2))
     await hass.async_block_till_done()
-    assert hass.states.get("cover.door1").state == STATE_OPENING
+    assert hass.states.get("cover.door1").state == CoverState.OPENING
     api.async_open_door.assert_called_with(1)
 
     async_fire_time_changed(hass, utcnow() + timedelta(seconds=10))
     await hass.async_block_till_done()
-    assert hass.states.get("cover.door1").state == STATE_OPENING
+    assert hass.states.get("cover.door1").state == CoverState.OPENING
 
     api.async_info.return_value = info_response(DoorStatus.OPENED)
     api.async_get_door_statuses_from_info.return_value = {
@@ -209,7 +206,7 @@ async def test_open_close_update(gogogate2api_mock, hass: HomeAssistant) -> None
     }
     async_fire_time_changed(hass, utcnow() + timedelta(hours=2))
     await hass.async_block_till_done()
-    assert hass.states.get("cover.door1").state == STATE_OPEN
+    assert hass.states.get("cover.door1").state == CoverState.OPEN
 
     api.async_info.return_value = info_response(DoorStatus.UNDEFINED)
     api.async_get_door_statuses_from_info.return_value = {
@@ -241,7 +238,7 @@ async def test_open_close_update(gogogate2api_mock, hass: HomeAssistant) -> None
     }
     async_fire_time_changed(hass, utcnow() + timedelta(hours=2))
     await hass.async_block_till_done()
-    assert hass.states.get("cover.door1").state == STATE_OPENING
+    assert hass.states.get("cover.door1").state == CoverState.OPENING
     api.async_open_door.assert_called_with(1)
 
     assert await hass.config_entries.async_unload(config_entry.entry_id)
@@ -303,7 +300,7 @@ async def test_availability(ismartgateapi_mock, hass: HomeAssistant) -> None:
     }
     async_fire_time_changed(hass, utcnow() + timedelta(hours=2))
     await hass.async_block_till_done()
-    assert hass.states.get("cover.door1").state == STATE_CLOSED
+    assert hass.states.get("cover.door1").state == CoverState.CLOSED
     assert dict(hass.states.get("cover.door1").attributes) == expected_attributes
 
 

--- a/tests/components/group/test_cover.py
+++ b/tests/components/group/test_cover.py
@@ -12,6 +12,7 @@ from homeassistant.components.cover import (
     ATTR_POSITION,
     ATTR_TILT_POSITION,
     DOMAIN as COVER_DOMAIN,
+    CoverState,
 )
 from homeassistant.components.group.cover import DEFAULT_NAME
 from homeassistant.const import (
@@ -31,10 +32,6 @@ from homeassistant.const import (
     SERVICE_STOP_COVER_TILT,
     SERVICE_TOGGLE,
     SERVICE_TOGGLE_COVER_TILT,
-    STATE_CLOSED,
-    STATE_CLOSING,
-    STATE_OPEN,
-    STATE_OPENING,
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
 )
@@ -158,90 +155,105 @@ async def test_state(hass: HomeAssistant) -> None:
 
     # At least one member opening -> group opening
     for state_1 in (
-        STATE_CLOSED,
-        STATE_CLOSING,
-        STATE_OPEN,
-        STATE_OPENING,
+        CoverState.CLOSED,
+        CoverState.CLOSING,
+        CoverState.OPEN,
+        CoverState.OPENING,
         STATE_UNAVAILABLE,
         STATE_UNKNOWN,
     ):
         for state_2 in (
-            STATE_CLOSED,
-            STATE_CLOSING,
-            STATE_OPEN,
-            STATE_OPENING,
+            CoverState.CLOSED,
+            CoverState.CLOSING,
+            CoverState.OPEN,
+            CoverState.OPENING,
             STATE_UNAVAILABLE,
             STATE_UNKNOWN,
         ):
             for state_3 in (
-                STATE_CLOSED,
-                STATE_CLOSING,
-                STATE_OPEN,
-                STATE_OPENING,
+                CoverState.CLOSED,
+                CoverState.CLOSING,
+                CoverState.OPEN,
+                CoverState.OPENING,
                 STATE_UNAVAILABLE,
                 STATE_UNKNOWN,
             ):
                 hass.states.async_set(DEMO_COVER, state_1, {})
                 hass.states.async_set(DEMO_COVER_POS, state_2, {})
                 hass.states.async_set(DEMO_COVER_TILT, state_3, {})
-                hass.states.async_set(DEMO_TILT, STATE_OPENING, {})
+                hass.states.async_set(DEMO_TILT, CoverState.OPENING, {})
                 await hass.async_block_till_done()
                 state = hass.states.get(COVER_GROUP)
-                assert state.state == STATE_OPENING
+                assert state.state == CoverState.OPENING
 
     # At least one member closing -> group closing
     for state_1 in (
-        STATE_CLOSED,
-        STATE_CLOSING,
-        STATE_OPEN,
+        CoverState.CLOSED,
+        CoverState.CLOSING,
+        CoverState.OPEN,
         STATE_UNAVAILABLE,
         STATE_UNKNOWN,
     ):
         for state_2 in (
-            STATE_CLOSED,
-            STATE_CLOSING,
-            STATE_OPEN,
+            CoverState.CLOSED,
+            CoverState.CLOSING,
+            CoverState.OPEN,
             STATE_UNAVAILABLE,
             STATE_UNKNOWN,
         ):
             for state_3 in (
-                STATE_CLOSED,
-                STATE_CLOSING,
-                STATE_OPEN,
+                CoverState.CLOSED,
+                CoverState.CLOSING,
+                CoverState.OPEN,
                 STATE_UNAVAILABLE,
                 STATE_UNKNOWN,
             ):
                 hass.states.async_set(DEMO_COVER, state_1, {})
                 hass.states.async_set(DEMO_COVER_POS, state_2, {})
                 hass.states.async_set(DEMO_COVER_TILT, state_3, {})
-                hass.states.async_set(DEMO_TILT, STATE_CLOSING, {})
+                hass.states.async_set(DEMO_TILT, CoverState.CLOSING, {})
                 await hass.async_block_till_done()
                 state = hass.states.get(COVER_GROUP)
-                assert state.state == STATE_CLOSING
+                assert state.state == CoverState.CLOSING
 
     # At least one member open -> group open
-    for state_1 in (STATE_CLOSED, STATE_OPEN, STATE_UNAVAILABLE, STATE_UNKNOWN):
-        for state_2 in (STATE_CLOSED, STATE_OPEN, STATE_UNAVAILABLE, STATE_UNKNOWN):
-            for state_3 in (STATE_CLOSED, STATE_OPEN, STATE_UNAVAILABLE, STATE_UNKNOWN):
+    for state_1 in (
+        CoverState.CLOSED,
+        CoverState.OPEN,
+        STATE_UNAVAILABLE,
+        STATE_UNKNOWN,
+    ):
+        for state_2 in (
+            CoverState.CLOSED,
+            CoverState.OPEN,
+            STATE_UNAVAILABLE,
+            STATE_UNKNOWN,
+        ):
+            for state_3 in (
+                CoverState.CLOSED,
+                CoverState.OPEN,
+                STATE_UNAVAILABLE,
+                STATE_UNKNOWN,
+            ):
                 hass.states.async_set(DEMO_COVER, state_1, {})
                 hass.states.async_set(DEMO_COVER_POS, state_2, {})
                 hass.states.async_set(DEMO_COVER_TILT, state_3, {})
-                hass.states.async_set(DEMO_TILT, STATE_OPEN, {})
+                hass.states.async_set(DEMO_TILT, CoverState.OPEN, {})
                 await hass.async_block_till_done()
                 state = hass.states.get(COVER_GROUP)
-                assert state.state == STATE_OPEN
+                assert state.state == CoverState.OPEN
 
     # At least one member closed -> group closed
-    for state_1 in (STATE_CLOSED, STATE_UNAVAILABLE, STATE_UNKNOWN):
-        for state_2 in (STATE_CLOSED, STATE_UNAVAILABLE, STATE_UNKNOWN):
-            for state_3 in (STATE_CLOSED, STATE_UNAVAILABLE, STATE_UNKNOWN):
+    for state_1 in (CoverState.CLOSED, STATE_UNAVAILABLE, STATE_UNKNOWN):
+        for state_2 in (CoverState.CLOSED, STATE_UNAVAILABLE, STATE_UNKNOWN):
+            for state_3 in (CoverState.CLOSED, STATE_UNAVAILABLE, STATE_UNKNOWN):
                 hass.states.async_set(DEMO_COVER, state_1, {})
                 hass.states.async_set(DEMO_COVER_POS, state_2, {})
                 hass.states.async_set(DEMO_COVER_TILT, state_3, {})
-                hass.states.async_set(DEMO_TILT, STATE_CLOSED, {})
+                hass.states.async_set(DEMO_TILT, CoverState.CLOSED, {})
                 await hass.async_block_till_done()
                 state = hass.states.get(COVER_GROUP)
-                assert state.state == STATE_CLOSED
+                assert state.state == CoverState.CLOSED
 
     # All group members removed from the state machine -> unavailable
     hass.states.async_remove(DEMO_COVER)
@@ -269,11 +281,11 @@ async def test_attributes(
     assert ATTR_CURRENT_TILT_POSITION not in state.attributes
 
     # Set entity as closed
-    hass.states.async_set(DEMO_COVER, STATE_CLOSED, {})
+    hass.states.async_set(DEMO_COVER, CoverState.CLOSED, {})
     await hass.async_block_till_done()
 
     state = hass.states.get(COVER_GROUP)
-    assert state.state == STATE_CLOSED
+    assert state.state == CoverState.CLOSED
     assert state.attributes[ATTR_ENTITY_ID] == [
         DEMO_COVER,
         DEMO_COVER_POS,
@@ -282,18 +294,18 @@ async def test_attributes(
     ]
 
     # Set entity as opening
-    hass.states.async_set(DEMO_COVER, STATE_OPENING, {})
+    hass.states.async_set(DEMO_COVER, CoverState.OPENING, {})
     await hass.async_block_till_done()
 
     state = hass.states.get(COVER_GROUP)
-    assert state.state == STATE_OPENING
+    assert state.state == CoverState.OPENING
 
     # Set entity as closing
-    hass.states.async_set(DEMO_COVER, STATE_CLOSING, {})
+    hass.states.async_set(DEMO_COVER, CoverState.CLOSING, {})
     await hass.async_block_till_done()
 
     state = hass.states.get(COVER_GROUP)
-    assert state.state == STATE_CLOSING
+    assert state.state == CoverState.CLOSING
 
     # Set entity as unknown again
     hass.states.async_set(DEMO_COVER, STATE_UNKNOWN, {})
@@ -303,11 +315,11 @@ async def test_attributes(
     assert state.state == STATE_UNKNOWN
 
     # Add Entity that supports open / close / stop
-    hass.states.async_set(DEMO_COVER, STATE_OPEN, {ATTR_SUPPORTED_FEATURES: 11})
+    hass.states.async_set(DEMO_COVER, CoverState.OPEN, {ATTR_SUPPORTED_FEATURES: 11})
     await hass.async_block_till_done()
 
     state = hass.states.get(COVER_GROUP)
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
     assert ATTR_ASSUMED_STATE not in state.attributes
     assert state.attributes[ATTR_SUPPORTED_FEATURES] == 11
     assert ATTR_CURRENT_POSITION not in state.attributes
@@ -316,24 +328,24 @@ async def test_attributes(
     # Add Entity that supports set_cover_position
     hass.states.async_set(
         DEMO_COVER_POS,
-        STATE_OPEN,
+        CoverState.OPEN,
         {ATTR_SUPPORTED_FEATURES: 4, ATTR_CURRENT_POSITION: 70},
     )
     await hass.async_block_till_done()
 
     state = hass.states.get(COVER_GROUP)
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
     assert ATTR_ASSUMED_STATE not in state.attributes
     assert state.attributes[ATTR_SUPPORTED_FEATURES] == 15
     assert state.attributes[ATTR_CURRENT_POSITION] == 70
     assert ATTR_CURRENT_TILT_POSITION not in state.attributes
 
     # Add Entity that supports open tilt / close tilt / stop tilt
-    hass.states.async_set(DEMO_TILT, STATE_OPEN, {ATTR_SUPPORTED_FEATURES: 112})
+    hass.states.async_set(DEMO_TILT, CoverState.OPEN, {ATTR_SUPPORTED_FEATURES: 112})
     await hass.async_block_till_done()
 
     state = hass.states.get(COVER_GROUP)
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
     assert ATTR_ASSUMED_STATE not in state.attributes
     assert state.attributes[ATTR_SUPPORTED_FEATURES] == 127
     assert state.attributes[ATTR_CURRENT_POSITION] == 70
@@ -342,13 +354,13 @@ async def test_attributes(
     # Add Entity that supports set_tilt_position
     hass.states.async_set(
         DEMO_COVER_TILT,
-        STATE_OPEN,
+        CoverState.OPEN,
         {ATTR_SUPPORTED_FEATURES: 128, ATTR_CURRENT_TILT_POSITION: 60},
     )
     await hass.async_block_till_done()
 
     state = hass.states.get(COVER_GROUP)
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
     assert ATTR_ASSUMED_STATE not in state.attributes
     assert state.attributes[ATTR_SUPPORTED_FEATURES] == 255
     assert state.attributes[ATTR_CURRENT_POSITION] == 70
@@ -359,12 +371,14 @@ async def test_attributes(
 
     # Covers
     hass.states.async_set(
-        DEMO_COVER, STATE_OPEN, {ATTR_SUPPORTED_FEATURES: 4, ATTR_CURRENT_POSITION: 100}
+        DEMO_COVER,
+        CoverState.OPEN,
+        {ATTR_SUPPORTED_FEATURES: 4, ATTR_CURRENT_POSITION: 100},
     )
     await hass.async_block_till_done()
 
     state = hass.states.get(COVER_GROUP)
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
     assert ATTR_ASSUMED_STATE not in state.attributes
     assert state.attributes[ATTR_SUPPORTED_FEATURES] == 244
     assert state.attributes[ATTR_CURRENT_POSITION] == 85  # (70 + 100) / 2
@@ -375,7 +389,7 @@ async def test_attributes(
     await hass.async_block_till_done()
 
     state = hass.states.get(COVER_GROUP)
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
     assert ATTR_ASSUMED_STATE not in state.attributes
     assert state.attributes[ATTR_SUPPORTED_FEATURES] == 240
     assert ATTR_CURRENT_POSITION not in state.attributes
@@ -384,31 +398,31 @@ async def test_attributes(
     # Tilts
     hass.states.async_set(
         DEMO_TILT,
-        STATE_OPEN,
+        CoverState.OPEN,
         {ATTR_SUPPORTED_FEATURES: 128, ATTR_CURRENT_TILT_POSITION: 100},
     )
     await hass.async_block_till_done()
 
     state = hass.states.get(COVER_GROUP)
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
     assert ATTR_ASSUMED_STATE not in state.attributes
     assert state.attributes[ATTR_SUPPORTED_FEATURES] == 128
     assert ATTR_CURRENT_POSITION not in state.attributes
     assert state.attributes[ATTR_CURRENT_TILT_POSITION] == 80  # (60 + 100) / 2
 
     hass.states.async_remove(DEMO_COVER_TILT)
-    hass.states.async_set(DEMO_TILT, STATE_CLOSED)
+    hass.states.async_set(DEMO_TILT, CoverState.CLOSED)
     await hass.async_block_till_done()
 
     state = hass.states.get(COVER_GROUP)
-    assert state.state == STATE_CLOSED
+    assert state.state == CoverState.CLOSED
     assert ATTR_ASSUMED_STATE not in state.attributes
     assert state.attributes[ATTR_SUPPORTED_FEATURES] == 0
     assert ATTR_CURRENT_POSITION not in state.attributes
     assert ATTR_CURRENT_TILT_POSITION not in state.attributes
 
     # Group member has set assumed_state
-    hass.states.async_set(DEMO_TILT, STATE_CLOSED, {ATTR_ASSUMED_STATE: True})
+    hass.states.async_set(DEMO_TILT, CoverState.CLOSED, {ATTR_ASSUMED_STATE: True})
     await hass.async_block_till_done()
 
     state = hass.states.get(COVER_GROUP)
@@ -426,16 +440,16 @@ async def test_cover_that_only_supports_tilt_removed(hass: HomeAssistant) -> Non
     """Test removing a cover that support tilt."""
     hass.states.async_set(
         DEMO_COVER_TILT,
-        STATE_OPEN,
+        CoverState.OPEN,
         {ATTR_SUPPORTED_FEATURES: 128, ATTR_CURRENT_TILT_POSITION: 60},
     )
     hass.states.async_set(
         DEMO_TILT,
-        STATE_OPEN,
+        CoverState.OPEN,
         {ATTR_SUPPORTED_FEATURES: 128, ATTR_CURRENT_TILT_POSITION: 60},
     )
     state = hass.states.get(COVER_GROUP)
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
     assert state.attributes[ATTR_FRIENDLY_NAME] == DEFAULT_NAME
     assert state.attributes[ATTR_ENTITY_ID] == [
         DEMO_COVER_TILT,
@@ -445,7 +459,7 @@ async def test_cover_that_only_supports_tilt_removed(hass: HomeAssistant) -> Non
     assert ATTR_CURRENT_TILT_POSITION in state.attributes
 
     hass.states.async_remove(DEMO_COVER_TILT)
-    hass.states.async_set(DEMO_TILT, STATE_CLOSED)
+    hass.states.async_set(DEMO_TILT, CoverState.CLOSED)
     await hass.async_block_till_done()
 
 
@@ -463,10 +477,10 @@ async def test_open_covers(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     state = hass.states.get(COVER_GROUP)
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
     assert state.attributes[ATTR_CURRENT_POSITION] == 100
 
-    assert hass.states.get(DEMO_COVER).state == STATE_OPEN
+    assert hass.states.get(DEMO_COVER).state == CoverState.OPEN
     assert hass.states.get(DEMO_COVER_POS).attributes[ATTR_CURRENT_POSITION] == 100
     assert hass.states.get(DEMO_COVER_TILT).attributes[ATTR_CURRENT_POSITION] == 100
 
@@ -485,10 +499,10 @@ async def test_close_covers(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     state = hass.states.get(COVER_GROUP)
-    assert state.state == STATE_CLOSED
+    assert state.state == CoverState.CLOSED
     assert state.attributes[ATTR_CURRENT_POSITION] == 0
 
-    assert hass.states.get(DEMO_COVER).state == STATE_CLOSED
+    assert hass.states.get(DEMO_COVER).state == CoverState.CLOSED
     assert hass.states.get(DEMO_COVER_POS).attributes[ATTR_CURRENT_POSITION] == 0
     assert hass.states.get(DEMO_COVER_TILT).attributes[ATTR_CURRENT_POSITION] == 0
 
@@ -507,7 +521,7 @@ async def test_toggle_covers(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     state = hass.states.get(COVER_GROUP)
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
 
     # Toggle will close covers
     await hass.services.async_call(
@@ -519,10 +533,10 @@ async def test_toggle_covers(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     state = hass.states.get(COVER_GROUP)
-    assert state.state == STATE_CLOSED
+    assert state.state == CoverState.CLOSED
     assert state.attributes[ATTR_CURRENT_POSITION] == 0
 
-    assert hass.states.get(DEMO_COVER).state == STATE_CLOSED
+    assert hass.states.get(DEMO_COVER).state == CoverState.CLOSED
     assert hass.states.get(DEMO_COVER_POS).attributes[ATTR_CURRENT_POSITION] == 0
     assert hass.states.get(DEMO_COVER_TILT).attributes[ATTR_CURRENT_POSITION] == 0
 
@@ -536,10 +550,10 @@ async def test_toggle_covers(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     state = hass.states.get(COVER_GROUP)
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
     assert state.attributes[ATTR_CURRENT_POSITION] == 100
 
-    assert hass.states.get(DEMO_COVER).state == STATE_OPEN
+    assert hass.states.get(DEMO_COVER).state == CoverState.OPEN
     assert hass.states.get(DEMO_COVER_POS).attributes[ATTR_CURRENT_POSITION] == 100
     assert hass.states.get(DEMO_COVER_TILT).attributes[ATTR_CURRENT_POSITION] == 100
 
@@ -563,10 +577,10 @@ async def test_stop_covers(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
     state = hass.states.get(COVER_GROUP)
-    assert state.state == STATE_OPENING
+    assert state.state == CoverState.OPENING
     assert state.attributes[ATTR_CURRENT_POSITION] == 50  # (20 + 80) / 2
 
-    assert hass.states.get(DEMO_COVER).state == STATE_OPEN
+    assert hass.states.get(DEMO_COVER).state == CoverState.OPEN
     assert hass.states.get(DEMO_COVER_POS).attributes[ATTR_CURRENT_POSITION] == 20
     assert hass.states.get(DEMO_COVER_TILT).attributes[ATTR_CURRENT_POSITION] == 80
 
@@ -587,10 +601,10 @@ async def test_set_cover_position(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     state = hass.states.get(COVER_GROUP)
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
     assert state.attributes[ATTR_CURRENT_POSITION] == 50
 
-    assert hass.states.get(DEMO_COVER).state == STATE_CLOSED
+    assert hass.states.get(DEMO_COVER).state == CoverState.CLOSED
     assert hass.states.get(DEMO_COVER_POS).attributes[ATTR_CURRENT_POSITION] == 50
     assert hass.states.get(DEMO_COVER_TILT).attributes[ATTR_CURRENT_POSITION] == 50
 
@@ -611,7 +625,7 @@ async def test_open_tilts(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     state = hass.states.get(COVER_GROUP)
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
     assert state.attributes[ATTR_CURRENT_TILT_POSITION] == 100
 
     assert (
@@ -635,7 +649,7 @@ async def test_close_tilts(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     state = hass.states.get(COVER_GROUP)
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
     assert state.attributes[ATTR_CURRENT_TILT_POSITION] == 0
 
     assert hass.states.get(DEMO_COVER_TILT).attributes[ATTR_CURRENT_TILT_POSITION] == 0
@@ -658,7 +672,7 @@ async def test_toggle_tilts(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     state = hass.states.get(COVER_GROUP)
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
     assert state.attributes[ATTR_CURRENT_TILT_POSITION] == 100
 
     assert (
@@ -678,7 +692,7 @@ async def test_toggle_tilts(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     state = hass.states.get(COVER_GROUP)
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
     assert state.attributes[ATTR_CURRENT_TILT_POSITION] == 0
 
     assert hass.states.get(DEMO_COVER_TILT).attributes[ATTR_CURRENT_TILT_POSITION] == 0
@@ -696,7 +710,7 @@ async def test_toggle_tilts(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     state = hass.states.get(COVER_GROUP)
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
     assert state.attributes[ATTR_CURRENT_TILT_POSITION] == 100
 
     assert (
@@ -729,7 +743,7 @@ async def test_stop_tilts(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
     state = hass.states.get(COVER_GROUP)
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
     assert state.attributes[ATTR_CURRENT_TILT_POSITION] == 60
 
     assert hass.states.get(DEMO_COVER_TILT).attributes[ATTR_CURRENT_TILT_POSITION] == 60
@@ -751,7 +765,7 @@ async def test_set_tilt_positions(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     state = hass.states.get(COVER_GROUP)
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
     assert state.attributes[ATTR_CURRENT_TILT_POSITION] == 80
 
     assert hass.states.get(DEMO_COVER_TILT).attributes[ATTR_CURRENT_TILT_POSITION] == 80
@@ -767,9 +781,9 @@ async def test_is_opening_closing(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
     # Both covers opening -> opening
-    assert hass.states.get(DEMO_COVER_POS).state == STATE_OPENING
-    assert hass.states.get(DEMO_COVER_TILT).state == STATE_OPENING
-    assert hass.states.get(COVER_GROUP).state == STATE_OPENING
+    assert hass.states.get(DEMO_COVER_POS).state == CoverState.OPENING
+    assert hass.states.get(DEMO_COVER_TILT).state == CoverState.OPENING
+    assert hass.states.get(COVER_GROUP).state == CoverState.OPENING
 
     for _ in range(10):
         future = dt_util.utcnow() + timedelta(seconds=1)
@@ -781,54 +795,68 @@ async def test_is_opening_closing(hass: HomeAssistant) -> None:
     )
 
     # Both covers closing -> closing
-    assert hass.states.get(DEMO_COVER_POS).state == STATE_CLOSING
-    assert hass.states.get(DEMO_COVER_TILT).state == STATE_CLOSING
-    assert hass.states.get(COVER_GROUP).state == STATE_CLOSING
+    assert hass.states.get(DEMO_COVER_POS).state == CoverState.CLOSING
+    assert hass.states.get(DEMO_COVER_TILT).state == CoverState.CLOSING
+    assert hass.states.get(COVER_GROUP).state == CoverState.CLOSING
 
-    hass.states.async_set(DEMO_COVER_POS, STATE_OPENING, {ATTR_SUPPORTED_FEATURES: 11})
+    hass.states.async_set(
+        DEMO_COVER_POS, CoverState.OPENING, {ATTR_SUPPORTED_FEATURES: 11}
+    )
     await hass.async_block_till_done()
 
     # Closing + Opening -> Opening
-    assert hass.states.get(DEMO_COVER_TILT).state == STATE_CLOSING
-    assert hass.states.get(DEMO_COVER_POS).state == STATE_OPENING
-    assert hass.states.get(COVER_GROUP).state == STATE_OPENING
+    assert hass.states.get(DEMO_COVER_TILT).state == CoverState.CLOSING
+    assert hass.states.get(DEMO_COVER_POS).state == CoverState.OPENING
+    assert hass.states.get(COVER_GROUP).state == CoverState.OPENING
 
-    hass.states.async_set(DEMO_COVER_POS, STATE_CLOSING, {ATTR_SUPPORTED_FEATURES: 11})
+    hass.states.async_set(
+        DEMO_COVER_POS, CoverState.CLOSING, {ATTR_SUPPORTED_FEATURES: 11}
+    )
     await hass.async_block_till_done()
 
     # Both covers closing -> closing
-    assert hass.states.get(DEMO_COVER_TILT).state == STATE_CLOSING
-    assert hass.states.get(DEMO_COVER_POS).state == STATE_CLOSING
-    assert hass.states.get(COVER_GROUP).state == STATE_CLOSING
+    assert hass.states.get(DEMO_COVER_TILT).state == CoverState.CLOSING
+    assert hass.states.get(DEMO_COVER_POS).state == CoverState.CLOSING
+    assert hass.states.get(COVER_GROUP).state == CoverState.CLOSING
 
     # Closed + Closing -> Closing
-    hass.states.async_set(DEMO_COVER_POS, STATE_CLOSED, {ATTR_SUPPORTED_FEATURES: 11})
+    hass.states.async_set(
+        DEMO_COVER_POS, CoverState.CLOSED, {ATTR_SUPPORTED_FEATURES: 11}
+    )
     await hass.async_block_till_done()
-    assert hass.states.get(DEMO_COVER_TILT).state == STATE_CLOSING
-    assert hass.states.get(DEMO_COVER_POS).state == STATE_CLOSED
-    assert hass.states.get(COVER_GROUP).state == STATE_CLOSING
+    assert hass.states.get(DEMO_COVER_TILT).state == CoverState.CLOSING
+    assert hass.states.get(DEMO_COVER_POS).state == CoverState.CLOSED
+    assert hass.states.get(COVER_GROUP).state == CoverState.CLOSING
 
     # Open + Closing -> Closing
-    hass.states.async_set(DEMO_COVER_POS, STATE_OPEN, {ATTR_SUPPORTED_FEATURES: 11})
+    hass.states.async_set(
+        DEMO_COVER_POS, CoverState.OPEN, {ATTR_SUPPORTED_FEATURES: 11}
+    )
     await hass.async_block_till_done()
-    assert hass.states.get(DEMO_COVER_TILT).state == STATE_CLOSING
-    assert hass.states.get(DEMO_COVER_POS).state == STATE_OPEN
-    assert hass.states.get(COVER_GROUP).state == STATE_CLOSING
+    assert hass.states.get(DEMO_COVER_TILT).state == CoverState.CLOSING
+    assert hass.states.get(DEMO_COVER_POS).state == CoverState.OPEN
+    assert hass.states.get(COVER_GROUP).state == CoverState.CLOSING
 
     # Closed + Opening -> Closing
-    hass.states.async_set(DEMO_COVER_TILT, STATE_OPENING, {ATTR_SUPPORTED_FEATURES: 11})
-    hass.states.async_set(DEMO_COVER_POS, STATE_CLOSED, {ATTR_SUPPORTED_FEATURES: 11})
+    hass.states.async_set(
+        DEMO_COVER_TILT, CoverState.OPENING, {ATTR_SUPPORTED_FEATURES: 11}
+    )
+    hass.states.async_set(
+        DEMO_COVER_POS, CoverState.CLOSED, {ATTR_SUPPORTED_FEATURES: 11}
+    )
     await hass.async_block_till_done()
-    assert hass.states.get(DEMO_COVER_TILT).state == STATE_OPENING
-    assert hass.states.get(DEMO_COVER_POS).state == STATE_CLOSED
-    assert hass.states.get(COVER_GROUP).state == STATE_OPENING
+    assert hass.states.get(DEMO_COVER_TILT).state == CoverState.OPENING
+    assert hass.states.get(DEMO_COVER_POS).state == CoverState.CLOSED
+    assert hass.states.get(COVER_GROUP).state == CoverState.OPENING
 
     # Open + Opening -> Closing
-    hass.states.async_set(DEMO_COVER_POS, STATE_OPEN, {ATTR_SUPPORTED_FEATURES: 11})
+    hass.states.async_set(
+        DEMO_COVER_POS, CoverState.OPEN, {ATTR_SUPPORTED_FEATURES: 11}
+    )
     await hass.async_block_till_done()
-    assert hass.states.get(DEMO_COVER_TILT).state == STATE_OPENING
-    assert hass.states.get(DEMO_COVER_POS).state == STATE_OPEN
-    assert hass.states.get(COVER_GROUP).state == STATE_OPENING
+    assert hass.states.get(DEMO_COVER_TILT).state == CoverState.OPENING
+    assert hass.states.get(DEMO_COVER_POS).state == CoverState.OPEN
+    assert hass.states.get(COVER_GROUP).state == CoverState.OPENING
 
 
 async def test_nested_group(hass: HomeAssistant) -> None:
@@ -858,12 +886,12 @@ async def test_nested_group(hass: HomeAssistant) -> None:
 
     state = hass.states.get("cover.bedroom_group")
     assert state is not None
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
     assert state.attributes.get(ATTR_ENTITY_ID) == [DEMO_COVER_POS, DEMO_COVER_TILT]
 
     state = hass.states.get("cover.nested_group")
     assert state is not None
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
     assert state.attributes.get(ATTR_ENTITY_ID) == ["cover.bedroom_group"]
 
     # Test controlling the nested group
@@ -874,7 +902,7 @@ async def test_nested_group(hass: HomeAssistant) -> None:
             {ATTR_ENTITY_ID: "cover.nested_group"},
             blocking=True,
         )
-    assert hass.states.get(DEMO_COVER_POS).state == STATE_CLOSING
-    assert hass.states.get(DEMO_COVER_TILT).state == STATE_CLOSING
-    assert hass.states.get("cover.bedroom_group").state == STATE_CLOSING
-    assert hass.states.get("cover.nested_group").state == STATE_CLOSING
+    assert hass.states.get(DEMO_COVER_POS).state == CoverState.CLOSING
+    assert hass.states.get(DEMO_COVER_TILT).state == CoverState.CLOSING
+    assert hass.states.get("cover.bedroom_group").state == CoverState.CLOSING
+    assert hass.states.get("cover.nested_group").state == CoverState.CLOSING

--- a/tests/components/homematicip_cloud/test_cover.py
+++ b/tests/components/homematicip_cloud/test_cover.py
@@ -6,9 +6,10 @@ from homeassistant.components.cover import (
     ATTR_CURRENT_POSITION,
     ATTR_CURRENT_TILT_POSITION,
     DOMAIN as COVER_DOMAIN,
+    CoverState,
 )
 from homeassistant.components.homematicip_cloud import DOMAIN as HMIPC_DOMAIN
-from homeassistant.const import STATE_CLOSED, STATE_OPEN, STATE_UNKNOWN
+from homeassistant.const import STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
@@ -50,7 +51,7 @@ async def test_hmip_cover_shutter(
     assert hmip_device.mock_calls[-1][1] == (0, 1)
     await async_manipulate_test_data(hass, hmip_device, "shutterLevel", 0)
     ha_state = hass.states.get(entity_id)
-    assert ha_state.state == STATE_OPEN
+    assert ha_state.state == CoverState.OPEN
     assert ha_state.attributes[ATTR_CURRENT_POSITION] == 100
 
     await hass.services.async_call(
@@ -64,7 +65,7 @@ async def test_hmip_cover_shutter(
     assert hmip_device.mock_calls[-1][1] == (0.5, 1)
     await async_manipulate_test_data(hass, hmip_device, "shutterLevel", 0.5)
     ha_state = hass.states.get(entity_id)
-    assert ha_state.state == STATE_OPEN
+    assert ha_state.state == CoverState.OPEN
     assert ha_state.attributes[ATTR_CURRENT_POSITION] == 50
 
     await hass.services.async_call(
@@ -75,7 +76,7 @@ async def test_hmip_cover_shutter(
     assert hmip_device.mock_calls[-1][1] == (1, 1)
     await async_manipulate_test_data(hass, hmip_device, "shutterLevel", 1)
     ha_state = hass.states.get(entity_id)
-    assert ha_state.state == STATE_CLOSED
+    assert ha_state.state == CoverState.CLOSED
     assert ha_state.attributes[ATTR_CURRENT_POSITION] == 0
 
     await hass.services.async_call(
@@ -105,7 +106,7 @@ async def test_hmip_cover_slats(
         hass, mock_hap, entity_id, entity_name, device_model
     )
 
-    assert ha_state.state == STATE_CLOSED
+    assert ha_state.state == CoverState.CLOSED
     assert ha_state.attributes[ATTR_CURRENT_POSITION] == 0
     assert ha_state.attributes[ATTR_CURRENT_TILT_POSITION] == 0
     service_call_counter = len(hmip_device.mock_calls)
@@ -119,7 +120,7 @@ async def test_hmip_cover_slats(
     await async_manipulate_test_data(hass, hmip_device, "shutterLevel", 0)
     await async_manipulate_test_data(hass, hmip_device, "slatsLevel", 0)
     ha_state = hass.states.get(entity_id)
-    assert ha_state.state == STATE_OPEN
+    assert ha_state.state == CoverState.OPEN
     assert ha_state.attributes[ATTR_CURRENT_POSITION] == 100
     assert ha_state.attributes[ATTR_CURRENT_TILT_POSITION] == 100
 
@@ -134,7 +135,7 @@ async def test_hmip_cover_slats(
     assert hmip_device.mock_calls[-1][2] == {"channelIndex": 1, "slatsLevel": 0.5}
     await async_manipulate_test_data(hass, hmip_device, "slatsLevel", 0.5)
     ha_state = hass.states.get(entity_id)
-    assert ha_state.state == STATE_OPEN
+    assert ha_state.state == CoverState.OPEN
     assert ha_state.attributes[ATTR_CURRENT_POSITION] == 100
     assert ha_state.attributes[ATTR_CURRENT_TILT_POSITION] == 50
 
@@ -146,7 +147,7 @@ async def test_hmip_cover_slats(
     assert hmip_device.mock_calls[-1][2] == {"channelIndex": 1, "slatsLevel": 1}
     await async_manipulate_test_data(hass, hmip_device, "slatsLevel", 1)
     ha_state = hass.states.get(entity_id)
-    assert ha_state.state == STATE_OPEN
+    assert ha_state.state == CoverState.OPEN
     assert ha_state.attributes[ATTR_CURRENT_POSITION] == 100
     assert ha_state.attributes[ATTR_CURRENT_TILT_POSITION] == 0
 
@@ -185,7 +186,7 @@ async def test_hmip_multi_cover_slats(
     await async_manipulate_test_data(hass, hmip_device, "slatsLevel", 1, channel=4)
     ha_state = hass.states.get(entity_id)
 
-    assert ha_state.state == STATE_CLOSED
+    assert ha_state.state == CoverState.CLOSED
     assert ha_state.attributes[ATTR_CURRENT_POSITION] == 0
     assert ha_state.attributes[ATTR_CURRENT_TILT_POSITION] == 0
     service_call_counter = len(hmip_device.mock_calls)
@@ -199,7 +200,7 @@ async def test_hmip_multi_cover_slats(
     await async_manipulate_test_data(hass, hmip_device, "shutterLevel", 0, channel=4)
     await async_manipulate_test_data(hass, hmip_device, "slatsLevel", 0, channel=4)
     ha_state = hass.states.get(entity_id)
-    assert ha_state.state == STATE_OPEN
+    assert ha_state.state == CoverState.OPEN
     assert ha_state.attributes[ATTR_CURRENT_POSITION] == 100
     assert ha_state.attributes[ATTR_CURRENT_TILT_POSITION] == 100
 
@@ -214,7 +215,7 @@ async def test_hmip_multi_cover_slats(
     assert hmip_device.mock_calls[-1][2] == {"channelIndex": 4, "slatsLevel": 0.5}
     await async_manipulate_test_data(hass, hmip_device, "slatsLevel", 0.5, channel=4)
     ha_state = hass.states.get(entity_id)
-    assert ha_state.state == STATE_OPEN
+    assert ha_state.state == CoverState.OPEN
     assert ha_state.attributes[ATTR_CURRENT_POSITION] == 100
     assert ha_state.attributes[ATTR_CURRENT_TILT_POSITION] == 50
 
@@ -226,7 +227,7 @@ async def test_hmip_multi_cover_slats(
     assert hmip_device.mock_calls[-1][2] == {"channelIndex": 4, "slatsLevel": 1}
     await async_manipulate_test_data(hass, hmip_device, "slatsLevel", 1, channel=4)
     ha_state = hass.states.get(entity_id)
-    assert ha_state.state == STATE_OPEN
+    assert ha_state.state == CoverState.OPEN
     assert ha_state.attributes[ATTR_CURRENT_POSITION] == 100
     assert ha_state.attributes[ATTR_CURRENT_TILT_POSITION] == 0
 
@@ -261,7 +262,7 @@ async def test_hmip_blind_module(
         hass, mock_hap, entity_id, entity_name, device_model
     )
 
-    assert ha_state.state == STATE_OPEN
+    assert ha_state.state == CoverState.OPEN
     assert ha_state.attributes[ATTR_CURRENT_POSITION] == 5
     assert ha_state.attributes[ATTR_CURRENT_TILT_POSITION] == 100
     service_call_counter = len(hmip_device.mock_calls)
@@ -287,7 +288,7 @@ async def test_hmip_blind_module(
     assert hmip_device.mock_calls[-1][2] == {"primaryShadingLevel": 0}
 
     ha_state = hass.states.get(entity_id)
-    assert ha_state.state == STATE_OPEN
+    assert ha_state.state == CoverState.OPEN
     assert ha_state.attributes[ATTR_CURRENT_POSITION] == 100
     assert ha_state.attributes[ATTR_CURRENT_TILT_POSITION] == 100
 
@@ -310,7 +311,7 @@ async def test_hmip_blind_module(
     assert hmip_device.mock_calls[-1][0] == "set_primary_shading_level"
     assert hmip_device.mock_calls[-1][2] == {"primaryShadingLevel": 0.5}
     ha_state = hass.states.get(entity_id)
-    assert ha_state.state == STATE_OPEN
+    assert ha_state.state == CoverState.OPEN
     assert ha_state.attributes[ATTR_CURRENT_POSITION] == 50
     assert ha_state.attributes[ATTR_CURRENT_TILT_POSITION] == 50
 
@@ -331,7 +332,7 @@ async def test_hmip_blind_module(
     }
 
     ha_state = hass.states.get(entity_id)
-    assert ha_state.state == STATE_CLOSED
+    assert ha_state.state == CoverState.CLOSED
     assert ha_state.attributes[ATTR_CURRENT_POSITION] == 0
     assert ha_state.attributes[ATTR_CURRENT_TILT_POSITION] == 0
 
@@ -385,7 +386,7 @@ async def test_hmip_garage_door_tormatic(
     assert hmip_device.mock_calls[-1][1] == (DoorCommand.OPEN,)
     await async_manipulate_test_data(hass, hmip_device, "doorState", DoorState.OPEN)
     ha_state = hass.states.get(entity_id)
-    assert ha_state.state == STATE_OPEN
+    assert ha_state.state == CoverState.OPEN
     assert ha_state.attributes[ATTR_CURRENT_POSITION] == 100
 
     await hass.services.async_call(
@@ -396,7 +397,7 @@ async def test_hmip_garage_door_tormatic(
     assert hmip_device.mock_calls[-1][1] == (DoorCommand.CLOSE,)
     await async_manipulate_test_data(hass, hmip_device, "doorState", DoorState.CLOSED)
     ha_state = hass.states.get(entity_id)
-    assert ha_state.state == STATE_CLOSED
+    assert ha_state.state == CoverState.CLOSED
     assert ha_state.attributes[ATTR_CURRENT_POSITION] == 0
 
     await hass.services.async_call(
@@ -434,7 +435,7 @@ async def test_hmip_garage_door_hoermann(
     assert hmip_device.mock_calls[-1][1] == (DoorCommand.OPEN,)
     await async_manipulate_test_data(hass, hmip_device, "doorState", DoorState.OPEN)
     ha_state = hass.states.get(entity_id)
-    assert ha_state.state == STATE_OPEN
+    assert ha_state.state == CoverState.OPEN
     assert ha_state.attributes[ATTR_CURRENT_POSITION] == 100
 
     await hass.services.async_call(
@@ -445,7 +446,7 @@ async def test_hmip_garage_door_hoermann(
     assert hmip_device.mock_calls[-1][1] == (DoorCommand.CLOSE,)
     await async_manipulate_test_data(hass, hmip_device, "doorState", DoorState.CLOSED)
     ha_state = hass.states.get(entity_id)
-    assert ha_state.state == STATE_CLOSED
+    assert ha_state.state == CoverState.CLOSED
     assert ha_state.attributes[ATTR_CURRENT_POSITION] == 0
 
     await hass.services.async_call(
@@ -481,7 +482,7 @@ async def test_hmip_cover_shutter_group(
     assert hmip_device.mock_calls[-1][1] == (0,)
     await async_manipulate_test_data(hass, hmip_device, "shutterLevel", 0)
     ha_state = hass.states.get(entity_id)
-    assert ha_state.state == STATE_OPEN
+    assert ha_state.state == CoverState.OPEN
     assert ha_state.attributes[ATTR_CURRENT_POSITION] == 100
 
     await hass.services.async_call(
@@ -495,7 +496,7 @@ async def test_hmip_cover_shutter_group(
     assert hmip_device.mock_calls[-1][1] == (0.5,)
     await async_manipulate_test_data(hass, hmip_device, "shutterLevel", 0.5)
     ha_state = hass.states.get(entity_id)
-    assert ha_state.state == STATE_OPEN
+    assert ha_state.state == CoverState.OPEN
     assert ha_state.attributes[ATTR_CURRENT_POSITION] == 50
 
     await hass.services.async_call(
@@ -506,7 +507,7 @@ async def test_hmip_cover_shutter_group(
     assert hmip_device.mock_calls[-1][1] == (1,)
     await async_manipulate_test_data(hass, hmip_device, "shutterLevel", 1)
     ha_state = hass.states.get(entity_id)
-    assert ha_state.state == STATE_CLOSED
+    assert ha_state.state == CoverState.CLOSED
     assert ha_state.attributes[ATTR_CURRENT_POSITION] == 0
 
     await hass.services.async_call(
@@ -536,7 +537,7 @@ async def test_hmip_cover_slats_group(
     await async_manipulate_test_data(hass, hmip_device, "slatsLevel", 1)
     ha_state = hass.states.get(entity_id)
 
-    assert ha_state.state == STATE_CLOSED
+    assert ha_state.state == CoverState.CLOSED
     assert ha_state.attributes[ATTR_CURRENT_POSITION] == 0
     assert ha_state.attributes[ATTR_CURRENT_TILT_POSITION] == 0
     service_call_counter = len(hmip_device.mock_calls)
@@ -557,7 +558,7 @@ async def test_hmip_cover_slats_group(
     await async_manipulate_test_data(hass, hmip_device, "shutterLevel", 0.5)
     await async_manipulate_test_data(hass, hmip_device, "slatsLevel", 0)
     ha_state = hass.states.get(entity_id)
-    assert ha_state.state == STATE_OPEN
+    assert ha_state.state == CoverState.OPEN
     assert ha_state.attributes[ATTR_CURRENT_POSITION] == 50
     assert ha_state.attributes[ATTR_CURRENT_TILT_POSITION] == 100
 
@@ -572,7 +573,7 @@ async def test_hmip_cover_slats_group(
     assert hmip_device.mock_calls[-1][1] == (0.5,)
     await async_manipulate_test_data(hass, hmip_device, "slatsLevel", 0.5)
     ha_state = hass.states.get(entity_id)
-    assert ha_state.state == STATE_OPEN
+    assert ha_state.state == CoverState.OPEN
     assert ha_state.attributes[ATTR_CURRENT_POSITION] == 50
     assert ha_state.attributes[ATTR_CURRENT_TILT_POSITION] == 50
 
@@ -584,7 +585,7 @@ async def test_hmip_cover_slats_group(
     assert hmip_device.mock_calls[-1][1] == (1,)
     await async_manipulate_test_data(hass, hmip_device, "slatsLevel", 1)
     ha_state = hass.states.get(entity_id)
-    assert ha_state.state == STATE_OPEN
+    assert ha_state.state == CoverState.OPEN
     assert ha_state.attributes[ATTR_CURRENT_POSITION] == 50
     assert ha_state.attributes[ATTR_CURRENT_TILT_POSITION] == 0
 

--- a/tests/components/idasen_desk/test_cover.py
+++ b/tests/components/idasen_desk/test_cover.py
@@ -10,14 +10,13 @@ from homeassistant.components.cover import (
     ATTR_CURRENT_POSITION,
     ATTR_POSITION,
     DOMAIN as COVER_DOMAIN,
+    CoverState,
 )
 from homeassistant.const import (
     SERVICE_CLOSE_COVER,
     SERVICE_OPEN_COVER,
     SERVICE_SET_COVER_POSITION,
     SERVICE_STOP_COVER,
-    STATE_CLOSED,
-    STATE_OPEN,
     STATE_UNAVAILABLE,
 )
 from homeassistant.core import HomeAssistant
@@ -36,7 +35,7 @@ async def test_cover_available(
 
     state = hass.states.get(entity_id)
     assert state
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
     assert state.attributes[ATTR_CURRENT_POSITION] == 60
 
     mock_desk_api.connect = AsyncMock()
@@ -51,11 +50,11 @@ async def test_cover_available(
 @pytest.mark.parametrize(
     ("service", "service_data", "expected_state", "expected_position"),
     [
-        (SERVICE_SET_COVER_POSITION, {ATTR_POSITION: 100}, STATE_OPEN, 100),
-        (SERVICE_SET_COVER_POSITION, {ATTR_POSITION: 0}, STATE_CLOSED, 0),
-        (SERVICE_OPEN_COVER, {}, STATE_OPEN, 100),
-        (SERVICE_CLOSE_COVER, {}, STATE_CLOSED, 0),
-        (SERVICE_STOP_COVER, {}, STATE_OPEN, 60),
+        (SERVICE_SET_COVER_POSITION, {ATTR_POSITION: 100}, CoverState.OPEN, 100),
+        (SERVICE_SET_COVER_POSITION, {ATTR_POSITION: 0}, CoverState.CLOSED, 0),
+        (SERVICE_OPEN_COVER, {}, CoverState.OPEN, 100),
+        (SERVICE_CLOSE_COVER, {}, CoverState.CLOSED, 0),
+        (SERVICE_STOP_COVER, {}, CoverState.OPEN, 60),
     ],
 )
 async def test_cover_services(
@@ -71,7 +70,7 @@ async def test_cover_services(
     await init_integration(hass)
     state = hass.states.get(entity_id)
     assert state
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
     assert state.attributes[ATTR_CURRENT_POSITION] == 60
     await hass.services.async_call(
         COVER_DOMAIN,

--- a/tests/components/iotty/test_cover.py
+++ b/tests/components/iotty/test_cover.py
@@ -18,10 +18,7 @@ from homeassistant.components.cover import (
     SERVICE_OPEN_COVER,
     SERVICE_SET_COVER_POSITION,
     SERVICE_STOP_COVER,
-    STATE_CLOSED,
-    STATE_CLOSING,
-    STATE_OPEN,
-    STATE_OPENING,
+    CoverState,
 )
 from homeassistant.components.iotty.const import DOMAIN
 from homeassistant.components.iotty.coordinator import UPDATE_INTERVAL
@@ -55,7 +52,7 @@ async def test_open_ok(
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
 
     assert (state := hass.states.get(entity_id))
-    assert state.state == STATE_CLOSED
+    assert state.state == CoverState.CLOSED
 
     mock_get_status_filled_stationary_0.return_value = {
         RESULT: {STATUS: STATUS_OPENING, OPEN_PERCENTAGE: 10}
@@ -72,7 +69,7 @@ async def test_open_ok(
     mock_command_fn.assert_called_once()
 
     assert (state := hass.states.get(entity_id))
-    assert state.state == STATE_OPENING
+    assert state.state == CoverState.OPENING
 
 
 async def test_close_ok(
@@ -96,7 +93,7 @@ async def test_close_ok(
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
 
     assert (state := hass.states.get(entity_id))
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
 
     mock_get_status_filled_stationary_100.return_value = {
         RESULT: {STATUS: STATUS_CLOSING, OPEN_PERCENTAGE: 90}
@@ -113,7 +110,7 @@ async def test_close_ok(
     mock_command_fn.assert_called_once()
 
     assert (state := hass.states.get(entity_id))
-    assert state.state == STATE_CLOSING
+    assert state.state == CoverState.CLOSING
 
 
 async def test_stop_ok(
@@ -137,7 +134,7 @@ async def test_stop_ok(
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
 
     assert (state := hass.states.get(entity_id))
-    assert state.state == STATE_OPENING
+    assert state.state == CoverState.OPENING
 
     mock_get_status_filled_opening_50.return_value = {
         RESULT: {STATUS: STATUS_STATIONATRY, OPEN_PERCENTAGE: 60}
@@ -154,7 +151,7 @@ async def test_stop_ok(
     mock_command_fn.assert_called_once()
 
     assert (state := hass.states.get(entity_id))
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
 
 
 async def test_set_position_ok(
@@ -178,7 +175,7 @@ async def test_set_position_ok(
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
 
     assert (state := hass.states.get(entity_id))
-    assert state.state == STATE_CLOSED
+    assert state.state == CoverState.CLOSED
 
     mock_get_status_filled_stationary_0.return_value = {
         RESULT: {STATUS: STATUS_OPENING, OPEN_PERCENTAGE: 50}
@@ -195,7 +192,7 @@ async def test_set_position_ok(
     mock_command_fn.assert_called_once()
 
     assert (state := hass.states.get(entity_id))
-    assert state.state == STATE_OPENING
+    assert state.state == CoverState.OPENING
 
 
 async def test_devices_insertion_ok(

--- a/tests/components/knx/test_cover.py
+++ b/tests/components/knx/test_cover.py
@@ -1,7 +1,8 @@
 """Test KNX cover."""
 
+from homeassistant.components.cover import CoverState
 from homeassistant.components.knx.schema import CoverSchema
-from homeassistant.const import CONF_NAME, STATE_CLOSING
+from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant
 
 from .conftest import KNXTestKit
@@ -72,7 +73,7 @@ async def test_cover_basic(hass: HomeAssistant, knx: KNXTestKit) -> None:
 
     knx.assert_state(
         "cover.test",
-        STATE_CLOSING,
+        CoverState.CLOSING,
     )
 
     assert len(events) == 1

--- a/tests/components/lcn/test_cover.py
+++ b/tests/components/lcn/test_cover.py
@@ -7,17 +7,13 @@ from pypck.lcn_addr import LcnAddr
 from pypck.lcn_defs import MotorReverseTime, MotorStateModifier
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.components.cover import DOMAIN as DOMAIN_COVER
+from homeassistant.components.cover import DOMAIN as DOMAIN_COVER, CoverState
 from homeassistant.components.lcn.helpers import get_device_connection
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     SERVICE_CLOSE_COVER,
     SERVICE_OPEN_COVER,
     SERVICE_STOP_COVER,
-    STATE_CLOSED,
-    STATE_CLOSING,
-    STATE_OPEN,
-    STATE_OPENING,
     STATE_UNAVAILABLE,
     Platform,
 )
@@ -53,7 +49,7 @@ async def test_outputs_open(hass: HomeAssistant, entry: MockConfigEntry) -> None
         MockModuleConnection, "control_motors_outputs"
     ) as control_motors_outputs:
         state = hass.states.get(COVER_OUTPUTS)
-        state.state = STATE_CLOSED
+        state.state = CoverState.CLOSED
 
         # command failed
         control_motors_outputs.return_value = False
@@ -71,7 +67,7 @@ async def test_outputs_open(hass: HomeAssistant, entry: MockConfigEntry) -> None
 
         state = hass.states.get(COVER_OUTPUTS)
         assert state is not None
-        assert state.state != STATE_OPENING
+        assert state.state != CoverState.OPENING
 
         # command success
         control_motors_outputs.reset_mock(return_value=True)
@@ -90,7 +86,7 @@ async def test_outputs_open(hass: HomeAssistant, entry: MockConfigEntry) -> None
 
         state = hass.states.get(COVER_OUTPUTS)
         assert state is not None
-        assert state.state == STATE_OPENING
+        assert state.state == CoverState.OPENING
 
 
 async def test_outputs_close(hass: HomeAssistant, entry: MockConfigEntry) -> None:
@@ -101,7 +97,7 @@ async def test_outputs_close(hass: HomeAssistant, entry: MockConfigEntry) -> Non
         MockModuleConnection, "control_motors_outputs"
     ) as control_motors_outputs:
         state = hass.states.get(COVER_OUTPUTS)
-        state.state = STATE_OPEN
+        state.state = CoverState.OPEN
 
         # command failed
         control_motors_outputs.return_value = False
@@ -119,7 +115,7 @@ async def test_outputs_close(hass: HomeAssistant, entry: MockConfigEntry) -> Non
 
         state = hass.states.get(COVER_OUTPUTS)
         assert state is not None
-        assert state.state != STATE_CLOSING
+        assert state.state != CoverState.CLOSING
 
         # command success
         control_motors_outputs.reset_mock(return_value=True)
@@ -138,7 +134,7 @@ async def test_outputs_close(hass: HomeAssistant, entry: MockConfigEntry) -> Non
 
         state = hass.states.get(COVER_OUTPUTS)
         assert state is not None
-        assert state.state == STATE_CLOSING
+        assert state.state == CoverState.CLOSING
 
 
 async def test_outputs_stop(hass: HomeAssistant, entry: MockConfigEntry) -> None:
@@ -149,7 +145,7 @@ async def test_outputs_stop(hass: HomeAssistant, entry: MockConfigEntry) -> None
         MockModuleConnection, "control_motors_outputs"
     ) as control_motors_outputs:
         state = hass.states.get(COVER_OUTPUTS)
-        state.state = STATE_CLOSING
+        state.state = CoverState.CLOSING
 
         # command failed
         control_motors_outputs.return_value = False
@@ -165,7 +161,7 @@ async def test_outputs_stop(hass: HomeAssistant, entry: MockConfigEntry) -> None
 
         state = hass.states.get(COVER_OUTPUTS)
         assert state is not None
-        assert state.state == STATE_CLOSING
+        assert state.state == CoverState.CLOSING
 
         # command success
         control_motors_outputs.reset_mock(return_value=True)
@@ -182,7 +178,7 @@ async def test_outputs_stop(hass: HomeAssistant, entry: MockConfigEntry) -> None
 
         state = hass.states.get(COVER_OUTPUTS)
         assert state is not None
-        assert state.state not in (STATE_CLOSING, STATE_OPENING)
+        assert state.state not in (CoverState.CLOSING, CoverState.OPENING)
 
 
 async def test_relays_open(hass: HomeAssistant, entry: MockConfigEntry) -> None:
@@ -196,7 +192,7 @@ async def test_relays_open(hass: HomeAssistant, entry: MockConfigEntry) -> None:
         states[0] = MotorStateModifier.UP
 
         state = hass.states.get(COVER_RELAYS)
-        state.state = STATE_CLOSED
+        state.state = CoverState.CLOSED
 
         # command failed
         control_motors_relays.return_value = False
@@ -212,7 +208,7 @@ async def test_relays_open(hass: HomeAssistant, entry: MockConfigEntry) -> None:
 
         state = hass.states.get(COVER_RELAYS)
         assert state is not None
-        assert state.state != STATE_OPENING
+        assert state.state != CoverState.OPENING
 
         # command success
         control_motors_relays.reset_mock(return_value=True)
@@ -229,7 +225,7 @@ async def test_relays_open(hass: HomeAssistant, entry: MockConfigEntry) -> None:
 
         state = hass.states.get(COVER_RELAYS)
         assert state is not None
-        assert state.state == STATE_OPENING
+        assert state.state == CoverState.OPENING
 
 
 async def test_relays_close(hass: HomeAssistant, entry: MockConfigEntry) -> None:
@@ -243,7 +239,7 @@ async def test_relays_close(hass: HomeAssistant, entry: MockConfigEntry) -> None
         states[0] = MotorStateModifier.DOWN
 
         state = hass.states.get(COVER_RELAYS)
-        state.state = STATE_OPEN
+        state.state = CoverState.OPEN
 
         # command failed
         control_motors_relays.return_value = False
@@ -259,7 +255,7 @@ async def test_relays_close(hass: HomeAssistant, entry: MockConfigEntry) -> None
 
         state = hass.states.get(COVER_RELAYS)
         assert state is not None
-        assert state.state != STATE_CLOSING
+        assert state.state != CoverState.CLOSING
 
         # command success
         control_motors_relays.reset_mock(return_value=True)
@@ -276,7 +272,7 @@ async def test_relays_close(hass: HomeAssistant, entry: MockConfigEntry) -> None
 
         state = hass.states.get(COVER_RELAYS)
         assert state is not None
-        assert state.state == STATE_CLOSING
+        assert state.state == CoverState.CLOSING
 
 
 async def test_relays_stop(hass: HomeAssistant, entry: MockConfigEntry) -> None:
@@ -290,7 +286,7 @@ async def test_relays_stop(hass: HomeAssistant, entry: MockConfigEntry) -> None:
         states[0] = MotorStateModifier.STOP
 
         state = hass.states.get(COVER_RELAYS)
-        state.state = STATE_CLOSING
+        state.state = CoverState.CLOSING
 
         # command failed
         control_motors_relays.return_value = False
@@ -306,7 +302,7 @@ async def test_relays_stop(hass: HomeAssistant, entry: MockConfigEntry) -> None:
 
         state = hass.states.get(COVER_RELAYS)
         assert state is not None
-        assert state.state == STATE_CLOSING
+        assert state.state == CoverState.CLOSING
 
         # command success
         control_motors_relays.reset_mock(return_value=True)
@@ -323,7 +319,7 @@ async def test_relays_stop(hass: HomeAssistant, entry: MockConfigEntry) -> None:
 
         state = hass.states.get(COVER_RELAYS)
         assert state is not None
-        assert state.state not in (STATE_CLOSING, STATE_OPENING)
+        assert state.state not in (CoverState.CLOSING, CoverState.OPENING)
 
 
 async def test_pushed_outputs_status_change(
@@ -336,7 +332,7 @@ async def test_pushed_outputs_status_change(
     address = LcnAddr(0, 7, False)
 
     state = hass.states.get(COVER_OUTPUTS)
-    state.state = STATE_CLOSED
+    state.state = CoverState.CLOSED
 
     # push status "open"
     inp = ModStatusOutput(address, 0, 100)
@@ -345,7 +341,7 @@ async def test_pushed_outputs_status_change(
 
     state = hass.states.get(COVER_OUTPUTS)
     assert state is not None
-    assert state.state == STATE_OPENING
+    assert state.state == CoverState.OPENING
 
     # push status "stop"
     inp = ModStatusOutput(address, 0, 0)
@@ -354,7 +350,7 @@ async def test_pushed_outputs_status_change(
 
     state = hass.states.get(COVER_OUTPUTS)
     assert state is not None
-    assert state.state not in (STATE_OPENING, STATE_CLOSING)
+    assert state.state not in (CoverState.OPENING, CoverState.CLOSING)
 
     # push status "close"
     inp = ModStatusOutput(address, 1, 100)
@@ -363,7 +359,7 @@ async def test_pushed_outputs_status_change(
 
     state = hass.states.get(COVER_OUTPUTS)
     assert state is not None
-    assert state.state == STATE_CLOSING
+    assert state.state == CoverState.CLOSING
 
 
 async def test_pushed_relays_status_change(
@@ -377,7 +373,7 @@ async def test_pushed_relays_status_change(
     states = [False] * 8
 
     state = hass.states.get(COVER_RELAYS)
-    state.state = STATE_CLOSED
+    state.state = CoverState.CLOSED
 
     # push status "open"
     states[0:2] = [True, False]
@@ -387,7 +383,7 @@ async def test_pushed_relays_status_change(
 
     state = hass.states.get(COVER_RELAYS)
     assert state is not None
-    assert state.state == STATE_OPENING
+    assert state.state == CoverState.OPENING
 
     # push status "stop"
     states[0] = False
@@ -397,7 +393,7 @@ async def test_pushed_relays_status_change(
 
     state = hass.states.get(COVER_RELAYS)
     assert state is not None
-    assert state.state not in (STATE_OPENING, STATE_CLOSING)
+    assert state.state not in (CoverState.OPENING, CoverState.CLOSING)
 
     # push status "close"
     states[0:2] = [True, True]
@@ -407,7 +403,7 @@ async def test_pushed_relays_status_change(
 
     state = hass.states.get(COVER_RELAYS)
     assert state is not None
-    assert state.state == STATE_CLOSING
+    assert state.state == CoverState.CLOSING
 
 
 async def test_unload_config_entry(hass: HomeAssistant, entry: MockConfigEntry) -> None:

--- a/tests/components/linear_garage_door/test_cover.py
+++ b/tests/components/linear_garage_door/test_cover.py
@@ -10,16 +10,10 @@ from homeassistant.components.cover import (
     DOMAIN as COVER_DOMAIN,
     SERVICE_CLOSE_COVER,
     SERVICE_OPEN_COVER,
+    CoverState,
 )
 from homeassistant.components.linear_garage_door import DOMAIN
-from homeassistant.const import (
-    ATTR_ENTITY_ID,
-    STATE_CLOSED,
-    STATE_CLOSING,
-    STATE_OPEN,
-    STATE_OPENING,
-    Platform,
-)
+from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -109,8 +103,8 @@ async def test_update_cover_state(
 
     await setup_integration(hass, mock_config_entry, [Platform.COVER])
 
-    assert hass.states.get("cover.test_garage_1").state == STATE_OPEN
-    assert hass.states.get("cover.test_garage_2").state == STATE_CLOSED
+    assert hass.states.get("cover.test_garage_1").state == CoverState.OPEN
+    assert hass.states.get("cover.test_garage_2").state == CoverState.CLOSED
 
     device_states = load_json_object_fixture("get_device_state_1.json", DOMAIN)
     mock_linear.get_device_state.side_effect = lambda device_id: device_states[
@@ -120,5 +114,5 @@ async def test_update_cover_state(
     freezer.tick(timedelta(seconds=60))
     async_fire_time_changed(hass)
 
-    assert hass.states.get("cover.test_garage_1").state == STATE_CLOSING
-    assert hass.states.get("cover.test_garage_2").state == STATE_OPENING
+    assert hass.states.get("cover.test_garage_1").state == CoverState.CLOSING
+    assert hass.states.get("cover.test_garage_2").state == CoverState.OPENING

--- a/tests/components/matter/test_cover.py
+++ b/tests/components/matter/test_cover.py
@@ -8,13 +8,7 @@ from matter_server.client.models.node import MatterNode
 import pytest
 from syrupy import SnapshotAssertion
 
-from homeassistant.components.cover import (
-    STATE_CLOSED,
-    STATE_CLOSING,
-    STATE_OPEN,
-    STATE_OPENING,
-    CoverEntityFeature,
-)
+from homeassistant.components.cover import CoverEntityFeature, CoverState
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -144,14 +138,14 @@ async def test_cover_lift(
 
     state = hass.states.get(entity_id)
     assert state
-    assert state.state == STATE_CLOSING
+    assert state.state == CoverState.CLOSING
 
     set_node_attribute(matter_node, 1, 258, 10, 0b000101)
     await trigger_subscription_callback(hass, matter_client)
 
     state = hass.states.get(entity_id)
     assert state
-    assert state.state == STATE_OPENING
+    assert state.state == CoverState.OPENING
 
 
 @pytest.mark.parametrize(
@@ -223,7 +217,7 @@ async def test_cover_position_aware_lift(
         state = hass.states.get(entity_id)
         assert state
         assert state.attributes["current_position"] == 100 - floor(position / 100)
-        assert state.state == STATE_OPEN
+        assert state.state == CoverState.OPEN
 
     set_node_attribute(matter_node, 1, 258, 14, 10000)
     set_node_attribute(matter_node, 1, 258, 10, 0b000000)
@@ -232,7 +226,7 @@ async def test_cover_position_aware_lift(
     state = hass.states.get(entity_id)
     assert state
     assert state.attributes["current_position"] == 0
-    assert state.state == STATE_CLOSED
+    assert state.state == CoverState.CLOSED
 
 
 @pytest.mark.parametrize(
@@ -275,14 +269,14 @@ async def test_cover_tilt(
     await trigger_subscription_callback(hass, matter_client)
     state = hass.states.get(entity_id)
     assert state
-    assert state.state == STATE_CLOSING
+    assert state.state == CoverState.CLOSING
 
     set_node_attribute(matter_node, 1, 258, 10, 0b010001)
     await trigger_subscription_callback(hass, matter_client)
 
     state = hass.states.get(entity_id)
     assert state
-    assert state.state == STATE_OPENING
+    assert state.state == CoverState.OPENING
 
 
 @pytest.mark.parametrize(
@@ -383,7 +377,7 @@ async def test_cover_full_features(
 
     state = hass.states.get(entity_id)
     assert state
-    assert state.state == STATE_CLOSED
+    assert state.state == CoverState.CLOSED
 
     set_node_attribute(matter_node, 1, 258, 14, 5000)
     set_node_attribute(matter_node, 1, 258, 15, 10000)
@@ -392,7 +386,7 @@ async def test_cover_full_features(
 
     state = hass.states.get(entity_id)
     assert state
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
 
     set_node_attribute(matter_node, 1, 258, 14, 10000)
     set_node_attribute(matter_node, 1, 258, 15, 5000)
@@ -401,7 +395,7 @@ async def test_cover_full_features(
 
     state = hass.states.get(entity_id)
     assert state
-    assert state.state == STATE_CLOSED
+    assert state.state == CoverState.CLOSED
 
     set_node_attribute(matter_node, 1, 258, 14, 5000)
     set_node_attribute(matter_node, 1, 258, 15, 5000)
@@ -410,7 +404,7 @@ async def test_cover_full_features(
 
     state = hass.states.get(entity_id)
     assert state
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
 
     set_node_attribute(matter_node, 1, 258, 14, 5000)
     set_node_attribute(matter_node, 1, 258, 15, None)
@@ -418,7 +412,7 @@ async def test_cover_full_features(
     await trigger_subscription_callback(hass, matter_client)
     state = hass.states.get(entity_id)
     assert state
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
 
     set_node_attribute(matter_node, 1, 258, 14, None)
     set_node_attribute(matter_node, 1, 258, 15, 5000)
@@ -434,7 +428,7 @@ async def test_cover_full_features(
     await trigger_subscription_callback(hass, matter_client)
     state = hass.states.get(entity_id)
     assert state
-    assert state.state == STATE_CLOSED
+    assert state.state == CoverState.CLOSED
 
     set_node_attribute(matter_node, 1, 258, 14, None)
     set_node_attribute(matter_node, 1, 258, 15, 10000)

--- a/tests/components/motionblinds_ble/test_cover.py
+++ b/tests/components/motionblinds_ble/test_cover.py
@@ -18,10 +18,7 @@ from homeassistant.components.cover import (
     SERVICE_SET_COVER_TILT_POSITION,
     SERVICE_STOP_COVER,
     SERVICE_STOP_COVER_TILT,
-    STATE_CLOSED,
-    STATE_CLOSING,
-    STATE_OPEN,
-    STATE_OPENING,
+    CoverState,
 )
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
@@ -74,8 +71,8 @@ async def test_cover_service(
     [
         (None, "unknown"),
         (MotionRunningType.STILL, "unknown"),
-        (MotionRunningType.OPENING, STATE_OPENING),
-        (MotionRunningType.CLOSING, STATE_CLOSING),
+        (MotionRunningType.OPENING, CoverState.OPENING),
+        (MotionRunningType.CLOSING, CoverState.CLOSING),
     ],
 )
 async def test_cover_update_running(
@@ -101,9 +98,9 @@ async def test_cover_update_running(
     ("position", "tilt", "state"),
     [
         (None, None, "unknown"),
-        (0, 0, STATE_OPEN),
-        (50, 90, STATE_OPEN),
-        (100, 180, STATE_CLOSED),
+        (0, 0, CoverState.OPEN),
+        (50, 90, CoverState.OPEN),
+        (100, 180, CoverState.CLOSED),
     ],
 )
 async def test_cover_update_position(

--- a/tests/components/mqtt/test_cover.py
+++ b/tests/components/mqtt/test_cover.py
@@ -12,6 +12,7 @@ from homeassistant.components.cover import (
     ATTR_CURRENT_TILT_POSITION,
     ATTR_POSITION,
     ATTR_TILT_POSITION,
+    CoverState,
 )
 from homeassistant.components.mqtt.const import CONF_STATE_TOPIC
 from homeassistant.components.mqtt.cover import (
@@ -39,9 +40,7 @@ from homeassistant.const import (
     SERVICE_TOGGLE,
     SERVICE_TOGGLE_COVER_TILT,
     STATE_CLOSED,
-    STATE_CLOSING,
     STATE_OPEN,
-    STATE_OPENING,
     STATE_UNKNOWN,
 )
 from homeassistant.core import HomeAssistant
@@ -116,12 +115,12 @@ async def test_state_via_state_topic(
     async_fire_mqtt_message(hass, "state-topic", STATE_CLOSED)
 
     state = hass.states.get("cover.test")
-    assert state.state == STATE_CLOSED
+    assert state.state == CoverState.CLOSED
 
     async_fire_mqtt_message(hass, "state-topic", STATE_OPEN)
 
     state = hass.states.get("cover.test")
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
 
     async_fire_mqtt_message(hass, "state-topic", "None")
 
@@ -162,17 +161,17 @@ async def test_opening_and_closing_state_via_custom_state_payload(
     async_fire_mqtt_message(hass, "state-topic", "34")
 
     state = hass.states.get("cover.test")
-    assert state.state == STATE_OPENING
+    assert state.state == CoverState.OPENING
 
     async_fire_mqtt_message(hass, "state-topic", "--43")
 
     state = hass.states.get("cover.test")
-    assert state.state == STATE_CLOSING
+    assert state.state == CoverState.CLOSING
 
     async_fire_mqtt_message(hass, "state-topic", STATE_CLOSED)
 
     state = hass.states.get("cover.test")
-    assert state.state == STATE_CLOSED
+    assert state.state == CoverState.CLOSED
 
 
 @pytest.mark.parametrize(
@@ -197,11 +196,11 @@ async def test_opening_and_closing_state_via_custom_state_payload(
 @pytest.mark.parametrize(
     ("position", "assert_state"),
     [
-        (0, STATE_CLOSED),
-        (1, STATE_OPEN),
-        (30, STATE_OPEN),
-        (99, STATE_OPEN),
-        (100, STATE_OPEN),
+        (0, CoverState.CLOSED),
+        (1, CoverState.OPEN),
+        (30, CoverState.OPEN),
+        (99, CoverState.OPEN),
+        (100, CoverState.OPEN),
     ],
 )
 async def test_open_closed_state_from_position_optimistic(
@@ -253,13 +252,13 @@ async def test_open_closed_state_from_position_optimistic(
 @pytest.mark.parametrize(
     ("position", "assert_state"),
     [
-        (0, STATE_CLOSED),
-        (1, STATE_CLOSED),
-        (10, STATE_CLOSED),
-        (11, STATE_OPEN),
-        (30, STATE_OPEN),
-        (99, STATE_OPEN),
-        (100, STATE_OPEN),
+        (0, CoverState.CLOSED),
+        (1, CoverState.CLOSED),
+        (10, CoverState.CLOSED),
+        (11, CoverState.OPEN),
+        (30, CoverState.OPEN),
+        (99, CoverState.OPEN),
+        (100, CoverState.OPEN),
     ],
 )
 async def test_open_closed_state_from_position_optimistic_alt_positions(
@@ -449,12 +448,12 @@ async def test_position_via_position_topic(
     async_fire_mqtt_message(hass, "get-position-topic", "0")
 
     state = hass.states.get("cover.test")
-    assert state.state == STATE_CLOSED
+    assert state.state == CoverState.CLOSED
 
     async_fire_mqtt_message(hass, "get-position-topic", "100")
 
     state = hass.states.get("cover.test")
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
 
 
 @pytest.mark.parametrize(
@@ -490,12 +489,12 @@ async def test_state_via_template(
     async_fire_mqtt_message(hass, "state-topic", "10000")
 
     state = hass.states.get("cover.test")
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
 
     async_fire_mqtt_message(hass, "state-topic", "99")
 
     state = hass.states.get("cover.test")
-    assert state.state == STATE_CLOSED
+    assert state.state == CoverState.CLOSED
 
 
 @pytest.mark.parametrize(
@@ -532,13 +531,13 @@ async def test_state_via_template_and_entity_id(
     async_fire_mqtt_message(hass, "state-topic", "invalid")
 
     state = hass.states.get("cover.test")
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
 
     async_fire_mqtt_message(hass, "state-topic", "closed")
     async_fire_mqtt_message(hass, "state-topic", "invalid")
 
     state = hass.states.get("cover.test")
-    assert state.state == STATE_CLOSED
+    assert state.state == CoverState.CLOSED
 
 
 @pytest.mark.parametrize(
@@ -571,14 +570,14 @@ async def test_state_via_template_with_json_value(
     async_fire_mqtt_message(hass, "state-topic", '{ "Var1": "open", "Var2": "other" }')
 
     state = hass.states.get("cover.test")
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
 
     async_fire_mqtt_message(
         hass, "state-topic", '{ "Var1": "closed", "Var2": "other" }'
     )
 
     state = hass.states.get("cover.test")
-    assert state.state == STATE_CLOSED
+    assert state.state == CoverState.CLOSED
 
     async_fire_mqtt_message(hass, "state-topic", '{ "Var2": "other" }')
     assert (
@@ -741,7 +740,7 @@ async def test_optimistic_state_change(
     mqtt_mock.async_publish.assert_called_once_with("command-topic", "OPEN", 0, False)
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get("cover.test")
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
 
     await hass.services.async_call(
         cover.DOMAIN, SERVICE_CLOSE_COVER, {ATTR_ENTITY_ID: "cover.test"}, blocking=True
@@ -750,7 +749,7 @@ async def test_optimistic_state_change(
     mqtt_mock.async_publish.assert_called_once_with("command-topic", "CLOSE", 0, False)
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get("cover.test")
-    assert state.state == STATE_CLOSED
+    assert state.state == CoverState.CLOSED
 
     await hass.services.async_call(
         cover.DOMAIN, SERVICE_TOGGLE, {ATTR_ENTITY_ID: "cover.test"}, blocking=True
@@ -759,7 +758,7 @@ async def test_optimistic_state_change(
     mqtt_mock.async_publish.assert_called_once_with("command-topic", "OPEN", 0, False)
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get("cover.test")
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
 
     await hass.services.async_call(
         cover.DOMAIN, SERVICE_TOGGLE, {ATTR_ENTITY_ID: "cover.test"}, blocking=True
@@ -767,7 +766,7 @@ async def test_optimistic_state_change(
 
     mqtt_mock.async_publish.assert_called_once_with("command-topic", "CLOSE", 0, False)
     state = hass.states.get("cover.test")
-    assert state.state == STATE_CLOSED
+    assert state.state == CoverState.CLOSED
 
 
 @pytest.mark.parametrize(
@@ -804,7 +803,7 @@ async def test_optimistic_state_change_with_position(
     mqtt_mock.async_publish.assert_called_once_with("command-topic", "OPEN", 0, False)
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get("cover.test")
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
     assert state.attributes.get(ATTR_CURRENT_POSITION) == 100
 
     await hass.services.async_call(
@@ -814,7 +813,7 @@ async def test_optimistic_state_change_with_position(
     mqtt_mock.async_publish.assert_called_once_with("command-topic", "CLOSE", 0, False)
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get("cover.test")
-    assert state.state == STATE_CLOSED
+    assert state.state == CoverState.CLOSED
     assert state.attributes.get(ATTR_CURRENT_POSITION) == 0
 
     await hass.services.async_call(
@@ -824,7 +823,7 @@ async def test_optimistic_state_change_with_position(
     mqtt_mock.async_publish.assert_called_once_with("command-topic", "OPEN", 0, False)
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get("cover.test")
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
     assert state.attributes.get(ATTR_CURRENT_POSITION) == 100
 
     await hass.services.async_call(
@@ -833,7 +832,7 @@ async def test_optimistic_state_change_with_position(
 
     mqtt_mock.async_publish.assert_called_once_with("command-topic", "CLOSE", 0, False)
     state = hass.states.get("cover.test")
-    assert state.state == STATE_CLOSED
+    assert state.state == CoverState.CLOSED
     assert state.attributes.get(ATTR_CURRENT_POSITION) == 0
 
 
@@ -1026,35 +1025,35 @@ async def test_current_cover_position_inverted(
         ATTR_CURRENT_POSITION
     ]
     assert current_percentage_cover_position == 0
-    assert hass.states.get("cover.test").state == STATE_CLOSED
+    assert hass.states.get("cover.test").state == CoverState.CLOSED
 
     async_fire_mqtt_message(hass, "get-position-topic", "0")
     current_percentage_cover_position = hass.states.get("cover.test").attributes[
         ATTR_CURRENT_POSITION
     ]
     assert current_percentage_cover_position == 100
-    assert hass.states.get("cover.test").state == STATE_OPEN
+    assert hass.states.get("cover.test").state == CoverState.OPEN
 
     async_fire_mqtt_message(hass, "get-position-topic", "50")
     current_percentage_cover_position = hass.states.get("cover.test").attributes[
         ATTR_CURRENT_POSITION
     ]
     assert current_percentage_cover_position == 50
-    assert hass.states.get("cover.test").state == STATE_OPEN
+    assert hass.states.get("cover.test").state == CoverState.OPEN
 
     async_fire_mqtt_message(hass, "get-position-topic", "non-numeric")
     current_percentage_cover_position = hass.states.get("cover.test").attributes[
         ATTR_CURRENT_POSITION
     ]
     assert current_percentage_cover_position == 50
-    assert hass.states.get("cover.test").state == STATE_OPEN
+    assert hass.states.get("cover.test").state == CoverState.OPEN
 
     async_fire_mqtt_message(hass, "get-position-topic", "101")
     current_percentage_cover_position = hass.states.get("cover.test").attributes[
         ATTR_CURRENT_POSITION
     ]
     assert current_percentage_cover_position == 0
-    assert hass.states.get("cover.test").state == STATE_CLOSED
+    assert hass.states.get("cover.test").state == CoverState.CLOSED
 
 
 @pytest.mark.parametrize(
@@ -2738,32 +2737,32 @@ async def test_state_and_position_topics_state_not_set_via_position_topic(
     async_fire_mqtt_message(hass, "state-topic", "OPEN")
 
     state = hass.states.get("cover.test")
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
 
     async_fire_mqtt_message(hass, "get-position-topic", "0")
 
     state = hass.states.get("cover.test")
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
 
     async_fire_mqtt_message(hass, "get-position-topic", "100")
 
     state = hass.states.get("cover.test")
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
 
     async_fire_mqtt_message(hass, "state-topic", "CLOSE")
 
     state = hass.states.get("cover.test")
-    assert state.state == STATE_CLOSED
+    assert state.state == CoverState.CLOSED
 
     async_fire_mqtt_message(hass, "get-position-topic", "0")
 
     state = hass.states.get("cover.test")
-    assert state.state == STATE_CLOSED
+    assert state.state == CoverState.CLOSED
 
     async_fire_mqtt_message(hass, "get-position-topic", "100")
 
     state = hass.states.get("cover.test")
-    assert state.state == STATE_CLOSED
+    assert state.state == CoverState.CLOSED
 
 
 @pytest.mark.parametrize(
@@ -2800,27 +2799,27 @@ async def test_set_state_via_position_using_stopped_state(
     async_fire_mqtt_message(hass, "state-topic", "OPEN")
 
     state = hass.states.get("cover.test")
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
 
     async_fire_mqtt_message(hass, "get-position-topic", "0")
 
     state = hass.states.get("cover.test")
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
 
     async_fire_mqtt_message(hass, "state-topic", "STOPPED")
 
     state = hass.states.get("cover.test")
-    assert state.state == STATE_CLOSED
+    assert state.state == CoverState.CLOSED
 
     async_fire_mqtt_message(hass, "get-position-topic", "100")
 
     state = hass.states.get("cover.test")
-    assert state.state == STATE_CLOSED
+    assert state.state == CoverState.CLOSED
 
     async_fire_mqtt_message(hass, "state-topic", "STOPPED")
 
     state = hass.states.get("cover.test")
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
 
 
 @pytest.mark.parametrize(
@@ -3136,32 +3135,32 @@ async def test_set_state_via_stopped_state_no_position_topic(
     async_fire_mqtt_message(hass, "state-topic", "OPEN")
 
     state = hass.states.get("cover.test")
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
 
     async_fire_mqtt_message(hass, "state-topic", "OPENING")
 
     state = hass.states.get("cover.test")
-    assert state.state == STATE_OPENING
+    assert state.state == CoverState.OPENING
 
     async_fire_mqtt_message(hass, "state-topic", "STOPPED")
 
     state = hass.states.get("cover.test")
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
 
     async_fire_mqtt_message(hass, "state-topic", "CLOSING")
 
     state = hass.states.get("cover.test")
-    assert state.state == STATE_CLOSING
+    assert state.state == CoverState.CLOSING
 
     async_fire_mqtt_message(hass, "state-topic", "STOPPED")
 
     state = hass.states.get("cover.test")
-    assert state.state == STATE_CLOSED
+    assert state.state == CoverState.CLOSED
 
     async_fire_mqtt_message(hass, "state-topic", "STOPPED")
 
     state = hass.states.get("cover.test")
-    assert state.state == STATE_CLOSED
+    assert state.state == CoverState.CLOSED
 
 
 @pytest.mark.parametrize(

--- a/tests/components/mysensors/test_cover.py
+++ b/tests/components/mysensors/test_cover.py
@@ -15,10 +15,7 @@ from homeassistant.components.cover import (
     SERVICE_OPEN_COVER,
     SERVICE_SET_COVER_POSITION,
     SERVICE_STOP_COVER,
-    STATE_CLOSED,
-    STATE_CLOSING,
-    STATE_OPEN,
-    STATE_OPENING,
+    CoverState,
 )
 from homeassistant.const import ATTR_BATTERY_LEVEL, ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
@@ -36,7 +33,7 @@ async def test_cover_node_percentage(
     state = hass.states.get(entity_id)
 
     assert state
-    assert state.state == STATE_CLOSED
+    assert state.state == CoverState.CLOSED
     assert state.attributes[ATTR_CURRENT_POSITION] == 0
     assert state.attributes[ATTR_BATTERY_LEVEL] == 0
 
@@ -57,7 +54,7 @@ async def test_cover_node_percentage(
     state = hass.states.get(entity_id)
 
     assert state
-    assert state.state == STATE_OPENING
+    assert state.state == CoverState.OPENING
     assert state.attributes[ATTR_CURRENT_POSITION] == 50
 
     transport_write.reset_mock()
@@ -79,7 +76,7 @@ async def test_cover_node_percentage(
     state = hass.states.get(entity_id)
 
     assert state
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
     assert state.attributes[ATTR_CURRENT_POSITION] == 50
 
     transport_write.reset_mock()
@@ -102,7 +99,7 @@ async def test_cover_node_percentage(
     state = hass.states.get(entity_id)
 
     assert state
-    assert state.state == STATE_OPENING
+    assert state.state == CoverState.OPENING
     assert state.attributes[ATTR_CURRENT_POSITION] == 75
 
     receive_message("1;1;1;0;29;0\n")
@@ -112,7 +109,7 @@ async def test_cover_node_percentage(
     state = hass.states.get(entity_id)
 
     assert state
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
     assert state.attributes[ATTR_CURRENT_POSITION] == 100
 
     transport_write.reset_mock()
@@ -134,7 +131,7 @@ async def test_cover_node_percentage(
     state = hass.states.get(entity_id)
 
     assert state
-    assert state.state == STATE_CLOSING
+    assert state.state == CoverState.CLOSING
     assert state.attributes[ATTR_CURRENT_POSITION] == 50
 
     receive_message("1;1;1;0;30;0\n")
@@ -144,7 +141,7 @@ async def test_cover_node_percentage(
     state = hass.states.get(entity_id)
 
     assert state
-    assert state.state == STATE_CLOSED
+    assert state.state == CoverState.CLOSED
     assert state.attributes[ATTR_CURRENT_POSITION] == 0
 
     transport_write.reset_mock()
@@ -165,7 +162,7 @@ async def test_cover_node_percentage(
     state = hass.states.get(entity_id)
 
     assert state
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
     assert state.attributes[ATTR_CURRENT_POSITION] == 25
 
 
@@ -181,7 +178,7 @@ async def test_cover_node_binary(
     state = hass.states.get(entity_id)
 
     assert state
-    assert state.state == STATE_CLOSED
+    assert state.state == CoverState.CLOSED
 
     await hass.services.async_call(
         COVER_DOMAIN,
@@ -200,7 +197,7 @@ async def test_cover_node_binary(
     state = hass.states.get(entity_id)
 
     assert state
-    assert state.state == STATE_OPENING
+    assert state.state == CoverState.OPENING
 
     transport_write.reset_mock()
 
@@ -220,7 +217,7 @@ async def test_cover_node_binary(
     state = hass.states.get(entity_id)
 
     assert state
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
 
     transport_write.reset_mock()
 
@@ -241,7 +238,7 @@ async def test_cover_node_binary(
     state = hass.states.get(entity_id)
 
     assert state
-    assert state.state == STATE_OPENING
+    assert state.state == CoverState.OPENING
 
     receive_message("1;1;1;0;29;0\n")
     receive_message("1;1;1;0;2;1\n")
@@ -250,7 +247,7 @@ async def test_cover_node_binary(
     state = hass.states.get(entity_id)
 
     assert state
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
 
     transport_write.reset_mock()
 
@@ -270,7 +267,7 @@ async def test_cover_node_binary(
     state = hass.states.get(entity_id)
 
     assert state
-    assert state.state == STATE_CLOSING
+    assert state.state == CoverState.CLOSING
 
     receive_message("1;1;1;0;30;0\n")
     receive_message("1;1;1;0;2;0\n")
@@ -279,4 +276,4 @@ async def test_cover_node_binary(
     state = hass.states.get(entity_id)
 
     assert state
-    assert state.state == STATE_CLOSED
+    assert state.state == CoverState.CLOSED

--- a/tests/components/nice_go/test_cover.py
+++ b/tests/components/nice_go/test_cover.py
@@ -12,16 +12,10 @@ from homeassistant.components.cover import (
     DOMAIN as COVER_DOMAIN,
     SERVICE_CLOSE_COVER,
     SERVICE_OPEN_COVER,
+    CoverState,
 )
 from homeassistant.components.nice_go.const import DOMAIN
-from homeassistant.const import (
-    ATTR_ENTITY_ID,
-    STATE_CLOSED,
-    STATE_CLOSING,
-    STATE_OPEN,
-    STATE_OPENING,
-    Platform,
-)
+from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
@@ -107,16 +101,16 @@ async def test_update_cover_state(
 
     await setup_integration(hass, mock_config_entry, [Platform.COVER])
 
-    assert hass.states.get("cover.test_garage_1").state == STATE_CLOSED
-    assert hass.states.get("cover.test_garage_2").state == STATE_OPEN
+    assert hass.states.get("cover.test_garage_1").state == CoverState.CLOSED
+    assert hass.states.get("cover.test_garage_2").state == CoverState.OPEN
 
     device_update = load_json_object_fixture("device_state_update.json", DOMAIN)
     await mock_config_entry.runtime_data.on_data(device_update)
     device_update_1 = load_json_object_fixture("device_state_update_1.json", DOMAIN)
     await mock_config_entry.runtime_data.on_data(device_update_1)
 
-    assert hass.states.get("cover.test_garage_1").state == STATE_OPENING
-    assert hass.states.get("cover.test_garage_2").state == STATE_CLOSING
+    assert hass.states.get("cover.test_garage_1").state == CoverState.OPENING
+    assert hass.states.get("cover.test_garage_2").state == CoverState.CLOSING
 
 
 @pytest.mark.parametrize(

--- a/tests/components/rflink/test_cover.py
+++ b/tests/components/rflink/test_cover.py
@@ -7,14 +7,9 @@ control of RFLink cover devices.
 
 import pytest
 
+from homeassistant.components.cover import CoverState
 from homeassistant.components.rflink.entity import EVENT_BUTTON_PRESSED
-from homeassistant.const import (
-    ATTR_ENTITY_ID,
-    SERVICE_CLOSE_COVER,
-    SERVICE_OPEN_COVER,
-    STATE_CLOSED,
-    STATE_OPEN,
-)
+from homeassistant.const import ATTR_ENTITY_ID, SERVICE_CLOSE_COVER, SERVICE_OPEN_COVER
 from homeassistant.core import CoreState, HomeAssistant, State, callback
 
 from .test_init import mock_rflink
@@ -53,7 +48,7 @@ async def test_default_setup(
 
     # test default state of cover loaded from config
     cover_initial = hass.states.get(f"{DOMAIN}.test")
-    assert cover_initial.state == STATE_CLOSED
+    assert cover_initial.state == CoverState.CLOSED
     assert cover_initial.attributes["assumed_state"]
 
     # cover should follow state of the hardware device by interpreting
@@ -64,7 +59,7 @@ async def test_default_setup(
     await hass.async_block_till_done()
 
     cover_after_first_command = hass.states.get(f"{DOMAIN}.test")
-    assert cover_after_first_command.state == STATE_OPEN
+    assert cover_after_first_command.state == CoverState.OPEN
     # not sure why, but cover have always assumed_state=true
     assert cover_after_first_command.attributes.get("assumed_state")
 
@@ -72,34 +67,34 @@ async def test_default_setup(
     event_callback({"id": "protocol_0_0", "command": "down"})
     await hass.async_block_till_done()
 
-    assert hass.states.get(f"{DOMAIN}.test").state == STATE_CLOSED
+    assert hass.states.get(f"{DOMAIN}.test").state == CoverState.CLOSED
 
     # should respond to group command
     event_callback({"id": "protocol_0_0", "command": "allon"})
     await hass.async_block_till_done()
 
     cover_after_first_command = hass.states.get(f"{DOMAIN}.test")
-    assert cover_after_first_command.state == STATE_OPEN
+    assert cover_after_first_command.state == CoverState.OPEN
 
     # should respond to group command
     event_callback({"id": "protocol_0_0", "command": "alloff"})
     await hass.async_block_till_done()
 
-    assert hass.states.get(f"{DOMAIN}.test").state == STATE_CLOSED
+    assert hass.states.get(f"{DOMAIN}.test").state == CoverState.CLOSED
 
     # test following aliases
     # mock incoming command event for this device alias
     event_callback({"id": "test_alias_0_0", "command": "up"})
     await hass.async_block_till_done()
 
-    assert hass.states.get(f"{DOMAIN}.test").state == STATE_OPEN
+    assert hass.states.get(f"{DOMAIN}.test").state == CoverState.OPEN
 
     # test changing state from HA propagates to RFLink
     await hass.services.async_call(
         DOMAIN, SERVICE_CLOSE_COVER, {ATTR_ENTITY_ID: f"{DOMAIN}.test"}
     )
     await hass.async_block_till_done()
-    assert hass.states.get(f"{DOMAIN}.test").state == STATE_CLOSED
+    assert hass.states.get(f"{DOMAIN}.test").state == CoverState.CLOSED
     assert protocol.send_command_ack.call_args_list[0][0][0] == "protocol_0_0"
     assert protocol.send_command_ack.call_args_list[0][0][1] == "DOWN"
 
@@ -107,7 +102,7 @@ async def test_default_setup(
         DOMAIN, SERVICE_OPEN_COVER, {ATTR_ENTITY_ID: f"{DOMAIN}.test"}
     )
     await hass.async_block_till_done()
-    assert hass.states.get(f"{DOMAIN}.test").state == STATE_OPEN
+    assert hass.states.get(f"{DOMAIN}.test").state == CoverState.OPEN
     assert protocol.send_command_ack.call_args_list[1][0][1] == "UP"
 
 
@@ -269,19 +264,19 @@ async def test_group_alias(
     # setup mocking rflink module
     event_callback, _, _, _ = await mock_rflink(hass, config, DOMAIN, monkeypatch)
 
-    assert hass.states.get(f"{DOMAIN}.test").state == STATE_CLOSED
+    assert hass.states.get(f"{DOMAIN}.test").state == CoverState.CLOSED
 
     # test sending group command to group alias
     event_callback({"id": "test_group_0_0", "command": "allon"})
     await hass.async_block_till_done()
 
-    assert hass.states.get(f"{DOMAIN}.test").state == STATE_OPEN
+    assert hass.states.get(f"{DOMAIN}.test").state == CoverState.OPEN
 
     # test sending group command to group alias
     event_callback({"id": "test_group_0_0", "command": "down"})
     await hass.async_block_till_done()
 
-    assert hass.states.get(f"{DOMAIN}.test").state == STATE_OPEN
+    assert hass.states.get(f"{DOMAIN}.test").state == CoverState.OPEN
 
 
 async def test_nogroup_alias(
@@ -304,19 +299,19 @@ async def test_nogroup_alias(
     # setup mocking rflink module
     event_callback, _, _, _ = await mock_rflink(hass, config, DOMAIN, monkeypatch)
 
-    assert hass.states.get(f"{DOMAIN}.test").state == STATE_CLOSED
+    assert hass.states.get(f"{DOMAIN}.test").state == CoverState.CLOSED
 
     # test sending group command to nogroup alias
     event_callback({"id": "test_nogroup_0_0", "command": "allon"})
     await hass.async_block_till_done()
     # should not affect state
-    assert hass.states.get(f"{DOMAIN}.test").state == STATE_CLOSED
+    assert hass.states.get(f"{DOMAIN}.test").state == CoverState.CLOSED
 
     # test sending group command to nogroup alias
     event_callback({"id": "test_nogroup_0_0", "command": "up"})
     await hass.async_block_till_done()
     # should affect state
-    assert hass.states.get(f"{DOMAIN}.test").state == STATE_OPEN
+    assert hass.states.get(f"{DOMAIN}.test").state == CoverState.OPEN
 
 
 async def test_nogroup_device_id(
@@ -334,19 +329,19 @@ async def test_nogroup_device_id(
     # setup mocking rflink module
     event_callback, _, _, _ = await mock_rflink(hass, config, DOMAIN, monkeypatch)
 
-    assert hass.states.get(f"{DOMAIN}.test").state == STATE_CLOSED
+    assert hass.states.get(f"{DOMAIN}.test").state == CoverState.CLOSED
 
     # test sending group command to nogroup
     event_callback({"id": "test_nogroup_0_0", "command": "allon"})
     await hass.async_block_till_done()
     # should not affect state
-    assert hass.states.get(f"{DOMAIN}.test").state == STATE_CLOSED
+    assert hass.states.get(f"{DOMAIN}.test").state == CoverState.CLOSED
 
     # test sending group command to nogroup
     event_callback({"id": "test_nogroup_0_0", "command": "up"})
     await hass.async_block_till_done()
     # should affect state
-    assert hass.states.get(f"{DOMAIN}.test").state == STATE_OPEN
+    assert hass.states.get(f"{DOMAIN}.test").state == CoverState.OPEN
 
 
 async def test_restore_state(
@@ -367,7 +362,11 @@ async def test_restore_state(
     }
 
     mock_restore_cache(
-        hass, (State(f"{DOMAIN}.c1", STATE_OPEN), State(f"{DOMAIN}.c2", STATE_CLOSED))
+        hass,
+        (
+            State(f"{DOMAIN}.c1", CoverState.OPEN),
+            State(f"{DOMAIN}.c2", CoverState.CLOSED),
+        ),
     )
 
     hass.set_state(CoreState.starting)
@@ -377,20 +376,20 @@ async def test_restore_state(
 
     state = hass.states.get(f"{DOMAIN}.c1")
     assert state
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
 
     state = hass.states.get(f"{DOMAIN}.c2")
     assert state
-    assert state.state == STATE_CLOSED
+    assert state.state == CoverState.CLOSED
 
     state = hass.states.get(f"{DOMAIN}.c3")
     assert state
-    assert state.state == STATE_CLOSED
+    assert state.state == CoverState.CLOSED
 
     # not cached cover must default values
     state = hass.states.get(f"{DOMAIN}.c4")
     assert state
-    assert state.state == STATE_CLOSED
+    assert state.state == CoverState.CLOSED
     assert state.attributes["assumed_state"]
 
 
@@ -435,7 +434,7 @@ async def test_inverted_cover(
 
     # test default state of cover loaded from config
     standard_cover = hass.states.get(f"{DOMAIN}.nonkaku_type_standard")
-    assert standard_cover.state == STATE_CLOSED
+    assert standard_cover.state == CoverState.CLOSED
     assert standard_cover.attributes["assumed_state"]
 
     # mock incoming up command event for nonkaku_device_1
@@ -443,7 +442,7 @@ async def test_inverted_cover(
     await hass.async_block_till_done()
 
     standard_cover = hass.states.get(f"{DOMAIN}.nonkaku_type_standard")
-    assert standard_cover.state == STATE_OPEN
+    assert standard_cover.state == CoverState.OPEN
     assert standard_cover.attributes.get("assumed_state")
 
     # mock incoming up command event for nonkaku_device_2
@@ -451,7 +450,7 @@ async def test_inverted_cover(
     await hass.async_block_till_done()
 
     standard_cover = hass.states.get(f"{DOMAIN}.nonkaku_type_none")
-    assert standard_cover.state == STATE_OPEN
+    assert standard_cover.state == CoverState.OPEN
     assert standard_cover.attributes.get("assumed_state")
 
     # mock incoming up command event for nonkaku_device_3
@@ -460,7 +459,7 @@ async def test_inverted_cover(
     await hass.async_block_till_done()
 
     inverted_cover = hass.states.get(f"{DOMAIN}.nonkaku_type_inverted")
-    assert inverted_cover.state == STATE_OPEN
+    assert inverted_cover.state == CoverState.OPEN
     assert inverted_cover.attributes.get("assumed_state")
 
     # mock incoming up command event for newkaku_device_4
@@ -469,7 +468,7 @@ async def test_inverted_cover(
     await hass.async_block_till_done()
 
     inverted_cover = hass.states.get(f"{DOMAIN}.newkaku_type_standard")
-    assert inverted_cover.state == STATE_OPEN
+    assert inverted_cover.state == CoverState.OPEN
     assert inverted_cover.attributes.get("assumed_state")
 
     # mock incoming up command event for newkaku_device_5
@@ -478,7 +477,7 @@ async def test_inverted_cover(
     await hass.async_block_till_done()
 
     inverted_cover = hass.states.get(f"{DOMAIN}.newkaku_type_none")
-    assert inverted_cover.state == STATE_OPEN
+    assert inverted_cover.state == CoverState.OPEN
     assert inverted_cover.attributes.get("assumed_state")
 
     # mock incoming up command event for newkaku_device_6
@@ -487,7 +486,7 @@ async def test_inverted_cover(
     await hass.async_block_till_done()
 
     inverted_cover = hass.states.get(f"{DOMAIN}.newkaku_type_inverted")
-    assert inverted_cover.state == STATE_OPEN
+    assert inverted_cover.state == CoverState.OPEN
     assert inverted_cover.attributes.get("assumed_state")
 
     # mock incoming down command event for nonkaku_device_1
@@ -496,7 +495,7 @@ async def test_inverted_cover(
     await hass.async_block_till_done()
 
     standard_cover = hass.states.get(f"{DOMAIN}.nonkaku_type_standard")
-    assert standard_cover.state == STATE_CLOSED
+    assert standard_cover.state == CoverState.CLOSED
     assert standard_cover.attributes.get("assumed_state")
 
     # mock incoming down command event for nonkaku_device_2
@@ -505,7 +504,7 @@ async def test_inverted_cover(
     await hass.async_block_till_done()
 
     standard_cover = hass.states.get(f"{DOMAIN}.nonkaku_type_none")
-    assert standard_cover.state == STATE_CLOSED
+    assert standard_cover.state == CoverState.CLOSED
     assert standard_cover.attributes.get("assumed_state")
 
     # mock incoming down command event for nonkaku_device_3
@@ -514,7 +513,7 @@ async def test_inverted_cover(
     await hass.async_block_till_done()
 
     inverted_cover = hass.states.get(f"{DOMAIN}.nonkaku_type_inverted")
-    assert inverted_cover.state == STATE_CLOSED
+    assert inverted_cover.state == CoverState.CLOSED
     assert inverted_cover.attributes.get("assumed_state")
 
     # mock incoming down command event for newkaku_device_4
@@ -523,7 +522,7 @@ async def test_inverted_cover(
     await hass.async_block_till_done()
 
     inverted_cover = hass.states.get(f"{DOMAIN}.newkaku_type_standard")
-    assert inverted_cover.state == STATE_CLOSED
+    assert inverted_cover.state == CoverState.CLOSED
     assert inverted_cover.attributes.get("assumed_state")
 
     # mock incoming down command event for newkaku_device_5
@@ -532,7 +531,7 @@ async def test_inverted_cover(
     await hass.async_block_till_done()
 
     inverted_cover = hass.states.get(f"{DOMAIN}.newkaku_type_none")
-    assert inverted_cover.state == STATE_CLOSED
+    assert inverted_cover.state == CoverState.CLOSED
     assert inverted_cover.attributes.get("assumed_state")
 
     # mock incoming down command event for newkaku_device_6
@@ -541,7 +540,7 @@ async def test_inverted_cover(
     await hass.async_block_till_done()
 
     inverted_cover = hass.states.get(f"{DOMAIN}.newkaku_type_inverted")
-    assert inverted_cover.state == STATE_CLOSED
+    assert inverted_cover.state == CoverState.CLOSED
     assert inverted_cover.attributes.get("assumed_state")
 
     # We are only testing the 'inverted' devices, the 'standard' devices
@@ -553,7 +552,7 @@ async def test_inverted_cover(
     await hass.async_block_till_done()
 
     inverted_cover = hass.states.get(f"{DOMAIN}.nonkaku_type_inverted")
-    assert inverted_cover.state == STATE_CLOSED
+    assert inverted_cover.state == CoverState.CLOSED
 
     # should respond to group command
     event_callback({"id": "nonkaku_device_3", "command": "allon"})
@@ -561,7 +560,7 @@ async def test_inverted_cover(
     await hass.async_block_till_done()
 
     inverted_cover = hass.states.get(f"{DOMAIN}.nonkaku_type_inverted")
-    assert inverted_cover.state == STATE_OPEN
+    assert inverted_cover.state == CoverState.OPEN
 
     # should respond to group command
     event_callback({"id": "newkaku_device_4", "command": "alloff"})
@@ -569,7 +568,7 @@ async def test_inverted_cover(
     await hass.async_block_till_done()
 
     inverted_cover = hass.states.get(f"{DOMAIN}.newkaku_type_standard")
-    assert inverted_cover.state == STATE_CLOSED
+    assert inverted_cover.state == CoverState.CLOSED
 
     # should respond to group command
     event_callback({"id": "newkaku_device_4", "command": "allon"})
@@ -577,7 +576,7 @@ async def test_inverted_cover(
     await hass.async_block_till_done()
 
     inverted_cover = hass.states.get(f"{DOMAIN}.newkaku_type_standard")
-    assert inverted_cover.state == STATE_OPEN
+    assert inverted_cover.state == CoverState.OPEN
 
     # should respond to group command
     event_callback({"id": "newkaku_device_5", "command": "alloff"})
@@ -585,7 +584,7 @@ async def test_inverted_cover(
     await hass.async_block_till_done()
 
     inverted_cover = hass.states.get(f"{DOMAIN}.newkaku_type_none")
-    assert inverted_cover.state == STATE_CLOSED
+    assert inverted_cover.state == CoverState.CLOSED
 
     # should respond to group command
     event_callback({"id": "newkaku_device_5", "command": "allon"})
@@ -593,7 +592,7 @@ async def test_inverted_cover(
     await hass.async_block_till_done()
 
     inverted_cover = hass.states.get(f"{DOMAIN}.newkaku_type_none")
-    assert inverted_cover.state == STATE_OPEN
+    assert inverted_cover.state == CoverState.OPEN
 
     # should respond to group command
     event_callback({"id": "newkaku_device_6", "command": "alloff"})
@@ -601,7 +600,7 @@ async def test_inverted_cover(
     await hass.async_block_till_done()
 
     inverted_cover = hass.states.get(f"{DOMAIN}.newkaku_type_inverted")
-    assert inverted_cover.state == STATE_CLOSED
+    assert inverted_cover.state == CoverState.CLOSED
 
     # should respond to group command
     event_callback({"id": "newkaku_device_6", "command": "allon"})
@@ -609,7 +608,7 @@ async def test_inverted_cover(
     await hass.async_block_till_done()
 
     inverted_cover = hass.states.get(f"{DOMAIN}.newkaku_type_inverted")
-    assert inverted_cover.state == STATE_OPEN
+    assert inverted_cover.state == CoverState.OPEN
 
     # Sending the close command from HA should result
     # in an 'DOWN' command sent to a non-newkaku device
@@ -622,7 +621,7 @@ async def test_inverted_cover(
 
     await hass.async_block_till_done()
 
-    assert hass.states.get(f"{DOMAIN}.nonkaku_type_standard").state == STATE_CLOSED
+    assert hass.states.get(f"{DOMAIN}.nonkaku_type_standard").state == CoverState.CLOSED
     assert protocol.send_command_ack.call_args_list[0][0][0] == "nonkaku_device_1"
     assert protocol.send_command_ack.call_args_list[0][0][1] == "DOWN"
 
@@ -637,7 +636,7 @@ async def test_inverted_cover(
 
     await hass.async_block_till_done()
 
-    assert hass.states.get(f"{DOMAIN}.nonkaku_type_standard").state == STATE_OPEN
+    assert hass.states.get(f"{DOMAIN}.nonkaku_type_standard").state == CoverState.OPEN
     assert protocol.send_command_ack.call_args_list[1][0][0] == "nonkaku_device_1"
     assert protocol.send_command_ack.call_args_list[1][0][1] == "UP"
 
@@ -650,7 +649,7 @@ async def test_inverted_cover(
 
     await hass.async_block_till_done()
 
-    assert hass.states.get(f"{DOMAIN}.nonkaku_type_none").state == STATE_CLOSED
+    assert hass.states.get(f"{DOMAIN}.nonkaku_type_none").state == CoverState.CLOSED
     assert protocol.send_command_ack.call_args_list[2][0][0] == "nonkaku_device_2"
     assert protocol.send_command_ack.call_args_list[2][0][1] == "DOWN"
 
@@ -663,7 +662,7 @@ async def test_inverted_cover(
 
     await hass.async_block_till_done()
 
-    assert hass.states.get(f"{DOMAIN}.nonkaku_type_none").state == STATE_OPEN
+    assert hass.states.get(f"{DOMAIN}.nonkaku_type_none").state == CoverState.OPEN
     assert protocol.send_command_ack.call_args_list[3][0][0] == "nonkaku_device_2"
     assert protocol.send_command_ack.call_args_list[3][0][1] == "UP"
 
@@ -678,7 +677,7 @@ async def test_inverted_cover(
 
     await hass.async_block_till_done()
 
-    assert hass.states.get(f"{DOMAIN}.nonkaku_type_inverted").state == STATE_CLOSED
+    assert hass.states.get(f"{DOMAIN}.nonkaku_type_inverted").state == CoverState.CLOSED
     assert protocol.send_command_ack.call_args_list[4][0][0] == "nonkaku_device_3"
     assert protocol.send_command_ack.call_args_list[4][0][1] == "UP"
 
@@ -693,7 +692,7 @@ async def test_inverted_cover(
 
     await hass.async_block_till_done()
 
-    assert hass.states.get(f"{DOMAIN}.nonkaku_type_inverted").state == STATE_OPEN
+    assert hass.states.get(f"{DOMAIN}.nonkaku_type_inverted").state == CoverState.OPEN
     assert protocol.send_command_ack.call_args_list[5][0][0] == "nonkaku_device_3"
     assert protocol.send_command_ack.call_args_list[5][0][1] == "DOWN"
 
@@ -708,7 +707,7 @@ async def test_inverted_cover(
 
     await hass.async_block_till_done()
 
-    assert hass.states.get(f"{DOMAIN}.newkaku_type_standard").state == STATE_CLOSED
+    assert hass.states.get(f"{DOMAIN}.newkaku_type_standard").state == CoverState.CLOSED
     assert protocol.send_command_ack.call_args_list[6][0][0] == "newkaku_device_4"
     assert protocol.send_command_ack.call_args_list[6][0][1] == "DOWN"
 
@@ -723,7 +722,7 @@ async def test_inverted_cover(
 
     await hass.async_block_till_done()
 
-    assert hass.states.get(f"{DOMAIN}.newkaku_type_standard").state == STATE_OPEN
+    assert hass.states.get(f"{DOMAIN}.newkaku_type_standard").state == CoverState.OPEN
     assert protocol.send_command_ack.call_args_list[7][0][0] == "newkaku_device_4"
     assert protocol.send_command_ack.call_args_list[7][0][1] == "UP"
 
@@ -736,7 +735,7 @@ async def test_inverted_cover(
 
     await hass.async_block_till_done()
 
-    assert hass.states.get(f"{DOMAIN}.newkaku_type_none").state == STATE_CLOSED
+    assert hass.states.get(f"{DOMAIN}.newkaku_type_none").state == CoverState.CLOSED
     assert protocol.send_command_ack.call_args_list[8][0][0] == "newkaku_device_5"
     assert protocol.send_command_ack.call_args_list[8][0][1] == "UP"
 
@@ -749,7 +748,7 @@ async def test_inverted_cover(
 
     await hass.async_block_till_done()
 
-    assert hass.states.get(f"{DOMAIN}.newkaku_type_none").state == STATE_OPEN
+    assert hass.states.get(f"{DOMAIN}.newkaku_type_none").state == CoverState.OPEN
     assert protocol.send_command_ack.call_args_list[9][0][0] == "newkaku_device_5"
     assert protocol.send_command_ack.call_args_list[9][0][1] == "DOWN"
 
@@ -764,7 +763,7 @@ async def test_inverted_cover(
 
     await hass.async_block_till_done()
 
-    assert hass.states.get(f"{DOMAIN}.newkaku_type_inverted").state == STATE_CLOSED
+    assert hass.states.get(f"{DOMAIN}.newkaku_type_inverted").state == CoverState.CLOSED
     assert protocol.send_command_ack.call_args_list[10][0][0] == "newkaku_device_6"
     assert protocol.send_command_ack.call_args_list[10][0][1] == "UP"
 
@@ -779,6 +778,6 @@ async def test_inverted_cover(
 
     await hass.async_block_till_done()
 
-    assert hass.states.get(f"{DOMAIN}.newkaku_type_inverted").state == STATE_OPEN
+    assert hass.states.get(f"{DOMAIN}.newkaku_type_inverted").state == CoverState.OPEN
     assert protocol.send_command_ack.call_args_list[11][0][0] == "newkaku_device_6"
     assert protocol.send_command_ack.call_args_list[11][0][1] == "DOWN"

--- a/tests/components/shelly/test_cover.py
+++ b/tests/components/shelly/test_cover.py
@@ -19,10 +19,7 @@ from homeassistant.components.cover import (
     SERVICE_SET_COVER_TILT_POSITION,
     SERVICE_STOP_COVER,
     SERVICE_STOP_COVER_TILT,
-    STATE_CLOSED,
-    STATE_CLOSING,
-    STATE_OPEN,
-    STATE_OPENING,
+    CoverState,
 )
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
@@ -59,7 +56,7 @@ async def test_block_device_services(
         {ATTR_ENTITY_ID: entity_id},
         blocking=True,
     )
-    assert hass.states.get(entity_id).state == STATE_OPENING
+    assert hass.states.get(entity_id).state == CoverState.OPENING
 
     await hass.services.async_call(
         COVER_DOMAIN,
@@ -67,7 +64,7 @@ async def test_block_device_services(
         {ATTR_ENTITY_ID: entity_id},
         blocking=True,
     )
-    assert hass.states.get(entity_id).state == STATE_CLOSING
+    assert hass.states.get(entity_id).state == CoverState.CLOSING
 
     await hass.services.async_call(
         COVER_DOMAIN,
@@ -75,7 +72,7 @@ async def test_block_device_services(
         {ATTR_ENTITY_ID: entity_id},
         blocking=True,
     )
-    assert hass.states.get(entity_id).state == STATE_CLOSED
+    assert hass.states.get(entity_id).state == CoverState.CLOSED
 
     entry = entity_registry.async_get(entity_id)
     assert entry
@@ -89,11 +86,11 @@ async def test_block_device_update(
     monkeypatch.setattr(mock_block_device.blocks[ROLLER_BLOCK_ID], "rollerPos", 0)
     await init_integration(hass, 1)
 
-    assert hass.states.get("cover.test_name").state == STATE_CLOSED
+    assert hass.states.get("cover.test_name").state == CoverState.CLOSED
 
     monkeypatch.setattr(mock_block_device.blocks[ROLLER_BLOCK_ID], "rollerPos", 100)
     mock_block_device.mock_update()
-    assert hass.states.get("cover.test_name").state == STATE_OPEN
+    assert hass.states.get("cover.test_name").state == CoverState.OPEN
 
 
 async def test_block_device_no_roller_blocks(
@@ -134,7 +131,7 @@ async def test_rpc_device_services(
         blocking=True,
     )
     mock_rpc_device.mock_update()
-    assert hass.states.get(entity_id).state == STATE_OPENING
+    assert hass.states.get(entity_id).state == CoverState.OPENING
 
     mutate_rpc_device_status(
         monkeypatch, mock_rpc_device, "cover:0", "state", "closing"
@@ -146,7 +143,7 @@ async def test_rpc_device_services(
         blocking=True,
     )
     mock_rpc_device.mock_update()
-    assert hass.states.get(entity_id).state == STATE_CLOSING
+    assert hass.states.get(entity_id).state == CoverState.CLOSING
 
     mutate_rpc_device_status(monkeypatch, mock_rpc_device, "cover:0", "state", "closed")
     await hass.services.async_call(
@@ -156,7 +153,7 @@ async def test_rpc_device_services(
         blocking=True,
     )
     mock_rpc_device.mock_update()
-    assert hass.states.get(entity_id).state == STATE_CLOSED
+    assert hass.states.get(entity_id).state == CoverState.CLOSED
 
     entry = entity_registry.async_get(entity_id)
     assert entry
@@ -178,11 +175,11 @@ async def test_rpc_device_update(
     """Test RPC device update."""
     mutate_rpc_device_status(monkeypatch, mock_rpc_device, "cover:0", "state", "closed")
     await init_integration(hass, 2)
-    assert hass.states.get("cover.test_cover_0").state == STATE_CLOSED
+    assert hass.states.get("cover.test_cover_0").state == CoverState.CLOSED
 
     mutate_rpc_device_status(monkeypatch, mock_rpc_device, "cover:0", "state", "open")
     mock_rpc_device.mock_update()
-    assert hass.states.get("cover.test_cover_0").state == STATE_OPEN
+    assert hass.states.get("cover.test_cover_0").state == CoverState.OPEN
 
 
 async def test_rpc_device_no_position_control(
@@ -193,7 +190,7 @@ async def test_rpc_device_no_position_control(
         monkeypatch, mock_rpc_device, "cover:0", "pos_control", False
     )
     await init_integration(hass, 2)
-    assert hass.states.get("cover.test_cover_0").state == STATE_OPEN
+    assert hass.states.get("cover.test_cover_0").state == CoverState.OPEN
 
 
 async def test_rpc_cover_tilt(

--- a/tests/components/smartthings/test_cover.py
+++ b/tests/components/smartthings/test_cover.py
@@ -13,10 +13,7 @@ from homeassistant.components.cover import (
     SERVICE_CLOSE_COVER,
     SERVICE_OPEN_COVER,
     SERVICE_SET_COVER_POSITION,
-    STATE_CLOSED,
-    STATE_CLOSING,
-    STATE_OPEN,
-    STATE_OPENING,
+    CoverState,
 )
 from homeassistant.components.smartthings.const import DOMAIN, SIGNAL_SMARTTHINGS_UPDATE
 from homeassistant.config_entries import ConfigEntryState
@@ -87,7 +84,7 @@ async def test_open(hass: HomeAssistant, device_factory) -> None:
     for entity_id in entity_ids:
         state = hass.states.get(entity_id)
         assert state is not None
-        assert state.state == STATE_OPENING
+        assert state.state == CoverState.OPENING
 
 
 async def test_close(hass: HomeAssistant, device_factory) -> None:
@@ -112,7 +109,7 @@ async def test_close(hass: HomeAssistant, device_factory) -> None:
     for entity_id in entity_ids:
         state = hass.states.get(entity_id)
         assert state is not None
-        assert state.state == STATE_CLOSING
+        assert state.state == CoverState.CLOSING
 
 
 async def test_set_cover_position_switch_level(
@@ -136,7 +133,7 @@ async def test_set_cover_position_switch_level(
 
     state = hass.states.get("cover.shade")
     # Result of call does not update state
-    assert state.state == STATE_OPENING
+    assert state.state == CoverState.OPENING
     assert state.attributes[ATTR_BATTERY_LEVEL] == 95
     assert state.attributes[ATTR_CURRENT_POSITION] == 10
     # Ensure API called
@@ -167,7 +164,7 @@ async def test_set_cover_position(hass: HomeAssistant, device_factory) -> None:
 
     state = hass.states.get("cover.shade")
     # Result of call does not update state
-    assert state.state == STATE_OPENING
+    assert state.state == CoverState.OPENING
     assert state.attributes[ATTR_BATTERY_LEVEL] == 95
     assert state.attributes[ATTR_CURRENT_POSITION] == 10
     # Ensure API called
@@ -208,14 +205,14 @@ async def test_update_to_open_from_signal(hass: HomeAssistant, device_factory) -
     )
     await setup_platform(hass, COVER_DOMAIN, devices=[device])
     device.status.update_attribute_value(Attribute.door, "open")
-    assert hass.states.get("cover.garage").state == STATE_OPENING
+    assert hass.states.get("cover.garage").state == CoverState.OPENING
     # Act
     async_dispatcher_send(hass, SIGNAL_SMARTTHINGS_UPDATE, [device.device_id])
     # Assert
     await hass.async_block_till_done()
     state = hass.states.get("cover.garage")
     assert state is not None
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
 
 
 async def test_update_to_closed_from_signal(
@@ -228,14 +225,14 @@ async def test_update_to_closed_from_signal(
     )
     await setup_platform(hass, COVER_DOMAIN, devices=[device])
     device.status.update_attribute_value(Attribute.door, "closed")
-    assert hass.states.get("cover.garage").state == STATE_CLOSING
+    assert hass.states.get("cover.garage").state == CoverState.CLOSING
     # Act
     async_dispatcher_send(hass, SIGNAL_SMARTTHINGS_UPDATE, [device.device_id])
     # Assert
     await hass.async_block_till_done()
     state = hass.states.get("cover.garage")
     assert state is not None
-    assert state.state == STATE_CLOSED
+    assert state.state == CoverState.CLOSED
 
 
 async def test_unload_config_entry(hass: HomeAssistant, device_factory) -> None:

--- a/tests/components/switch_as_x/test_cover.py
+++ b/tests/components/switch_as_x/test_cover.py
@@ -1,6 +1,6 @@
 """Tests for the Switch as X Cover platform."""
 
-from homeassistant.components.cover import DOMAIN as COVER_DOMAIN
+from homeassistant.components.cover import DOMAIN as COVER_DOMAIN, CoverState
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.components.switch_as_x.config_flow import SwitchAsXConfigFlowHandler
 from homeassistant.components.switch_as_x.const import (
@@ -15,10 +15,8 @@ from homeassistant.const import (
     SERVICE_TOGGLE,
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
-    STATE_CLOSED,
     STATE_OFF,
     STATE_ON,
-    STATE_OPEN,
     Platform,
 )
 from homeassistant.core import HomeAssistant
@@ -71,7 +69,7 @@ async def test_service_calls(hass: HomeAssistant) -> None:
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert hass.states.get("cover.decorative_lights").state == STATE_OPEN
+    assert hass.states.get("cover.decorative_lights").state == CoverState.OPEN
 
     await hass.services.async_call(
         COVER_DOMAIN,
@@ -81,7 +79,7 @@ async def test_service_calls(hass: HomeAssistant) -> None:
     )
 
     assert hass.states.get("switch.decorative_lights").state == STATE_OFF
-    assert hass.states.get("cover.decorative_lights").state == STATE_CLOSED
+    assert hass.states.get("cover.decorative_lights").state == CoverState.CLOSED
 
     await hass.services.async_call(
         COVER_DOMAIN,
@@ -91,7 +89,7 @@ async def test_service_calls(hass: HomeAssistant) -> None:
     )
 
     assert hass.states.get("switch.decorative_lights").state == STATE_ON
-    assert hass.states.get("cover.decorative_lights").state == STATE_OPEN
+    assert hass.states.get("cover.decorative_lights").state == CoverState.OPEN
 
     await hass.services.async_call(
         COVER_DOMAIN,
@@ -101,7 +99,7 @@ async def test_service_calls(hass: HomeAssistant) -> None:
     )
 
     assert hass.states.get("switch.decorative_lights").state == STATE_OFF
-    assert hass.states.get("cover.decorative_lights").state == STATE_CLOSED
+    assert hass.states.get("cover.decorative_lights").state == CoverState.CLOSED
 
     await hass.services.async_call(
         SWITCH_DOMAIN,
@@ -111,7 +109,7 @@ async def test_service_calls(hass: HomeAssistant) -> None:
     )
 
     assert hass.states.get("switch.decorative_lights").state == STATE_ON
-    assert hass.states.get("cover.decorative_lights").state == STATE_OPEN
+    assert hass.states.get("cover.decorative_lights").state == CoverState.OPEN
 
     await hass.services.async_call(
         SWITCH_DOMAIN,
@@ -121,7 +119,7 @@ async def test_service_calls(hass: HomeAssistant) -> None:
     )
 
     assert hass.states.get("switch.decorative_lights").state == STATE_OFF
-    assert hass.states.get("cover.decorative_lights").state == STATE_CLOSED
+    assert hass.states.get("cover.decorative_lights").state == CoverState.CLOSED
 
     await hass.services.async_call(
         SWITCH_DOMAIN,
@@ -131,7 +129,7 @@ async def test_service_calls(hass: HomeAssistant) -> None:
     )
 
     assert hass.states.get("switch.decorative_lights").state == STATE_ON
-    assert hass.states.get("cover.decorative_lights").state == STATE_OPEN
+    assert hass.states.get("cover.decorative_lights").state == CoverState.OPEN
 
 
 async def test_service_calls_inverted(hass: HomeAssistant) -> None:
@@ -154,7 +152,7 @@ async def test_service_calls_inverted(hass: HomeAssistant) -> None:
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert hass.states.get("cover.decorative_lights").state == STATE_CLOSED
+    assert hass.states.get("cover.decorative_lights").state == CoverState.CLOSED
 
     await hass.services.async_call(
         COVER_DOMAIN,
@@ -164,7 +162,7 @@ async def test_service_calls_inverted(hass: HomeAssistant) -> None:
     )
 
     assert hass.states.get("switch.decorative_lights").state == STATE_OFF
-    assert hass.states.get("cover.decorative_lights").state == STATE_OPEN
+    assert hass.states.get("cover.decorative_lights").state == CoverState.OPEN
 
     await hass.services.async_call(
         COVER_DOMAIN,
@@ -174,7 +172,7 @@ async def test_service_calls_inverted(hass: HomeAssistant) -> None:
     )
 
     assert hass.states.get("switch.decorative_lights").state == STATE_OFF
-    assert hass.states.get("cover.decorative_lights").state == STATE_OPEN
+    assert hass.states.get("cover.decorative_lights").state == CoverState.OPEN
 
     await hass.services.async_call(
         COVER_DOMAIN,
@@ -184,7 +182,7 @@ async def test_service_calls_inverted(hass: HomeAssistant) -> None:
     )
 
     assert hass.states.get("switch.decorative_lights").state == STATE_ON
-    assert hass.states.get("cover.decorative_lights").state == STATE_CLOSED
+    assert hass.states.get("cover.decorative_lights").state == CoverState.CLOSED
 
     await hass.services.async_call(
         SWITCH_DOMAIN,
@@ -194,7 +192,7 @@ async def test_service_calls_inverted(hass: HomeAssistant) -> None:
     )
 
     assert hass.states.get("switch.decorative_lights").state == STATE_ON
-    assert hass.states.get("cover.decorative_lights").state == STATE_CLOSED
+    assert hass.states.get("cover.decorative_lights").state == CoverState.CLOSED
 
     await hass.services.async_call(
         SWITCH_DOMAIN,
@@ -204,7 +202,7 @@ async def test_service_calls_inverted(hass: HomeAssistant) -> None:
     )
 
     assert hass.states.get("switch.decorative_lights").state == STATE_OFF
-    assert hass.states.get("cover.decorative_lights").state == STATE_OPEN
+    assert hass.states.get("cover.decorative_lights").state == CoverState.OPEN
 
     await hass.services.async_call(
         SWITCH_DOMAIN,
@@ -214,4 +212,4 @@ async def test_service_calls_inverted(hass: HomeAssistant) -> None:
     )
 
     assert hass.states.get("switch.decorative_lights").state == STATE_ON
-    assert hass.states.get("cover.decorative_lights").state == STATE_CLOSED
+    assert hass.states.get("cover.decorative_lights").state == CoverState.CLOSED

--- a/tests/components/switcher_kis/test_cover.py
+++ b/tests/components/switcher_kis/test_cover.py
@@ -14,10 +14,7 @@ from homeassistant.components.cover import (
     SERVICE_OPEN_COVER,
     SERVICE_SET_COVER_POSITION,
     SERVICE_STOP_COVER,
-    STATE_CLOSED,
-    STATE_CLOSING,
-    STATE_OPEN,
-    STATE_OPENING,
+    CoverState,
 )
 from homeassistant.const import ATTR_ENTITY_ID, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
@@ -58,7 +55,7 @@ async def test_cover(
 
     # Test initial state - open
     state = hass.states.get(entity_id)
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
 
     # Test set position
     with patch(
@@ -78,7 +75,7 @@ async def test_cover(
         assert mock_api.call_count == 2
         mock_control_device.assert_called_once_with(77, 0)
         state = hass.states.get(entity_id)
-        assert state.state == STATE_OPEN
+        assert state.state == CoverState.OPEN
         assert state.attributes[ATTR_CURRENT_POSITION] == 77
 
     # Test open
@@ -99,7 +96,7 @@ async def test_cover(
         assert mock_api.call_count == 4
         mock_control_device.assert_called_once_with(100, 0)
         state = hass.states.get(entity_id)
-        assert state.state == STATE_OPENING
+        assert state.state == CoverState.OPENING
 
     # Test close
     with patch(
@@ -119,7 +116,7 @@ async def test_cover(
         assert mock_api.call_count == 6
         mock_control_device.assert_called_once_with(0, 0)
         state = hass.states.get(entity_id)
-        assert state.state == STATE_CLOSING
+        assert state.state == CoverState.CLOSING
 
     # Test stop
     with patch(
@@ -139,7 +136,7 @@ async def test_cover(
         assert mock_api.call_count == 8
         mock_control_device.assert_called_once_with(0)
         state = hass.states.get(entity_id)
-        assert state.state == STATE_OPEN
+        assert state.state == CoverState.OPEN
 
     # Test closed on position == 0
     monkeypatch.setattr(device, "position", 0)
@@ -147,7 +144,7 @@ async def test_cover(
     await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)
-    assert state.state == STATE_CLOSED
+    assert state.state == CoverState.CLOSED
     assert state.attributes[ATTR_CURRENT_POSITION] == 0
 
 
@@ -172,7 +169,7 @@ async def test_cover_control_fail(
 
     # Test initial state - open
     state = hass.states.get(entity_id)
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
 
     # Test exception during set position
     with patch(
@@ -197,7 +194,7 @@ async def test_cover_control_fail(
     await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
 
     # Test error response during set position
     with patch(

--- a/tests/components/tesla_fleet/test_cover.py
+++ b/tests/components/tesla_fleet/test_cover.py
@@ -11,14 +11,9 @@ from homeassistant.components.cover import (
     SERVICE_CLOSE_COVER,
     SERVICE_OPEN_COVER,
     SERVICE_STOP_COVER,
+    CoverState,
 )
-from homeassistant.const import (
-    ATTR_ENTITY_ID,
-    STATE_CLOSED,
-    STATE_OPEN,
-    STATE_UNKNOWN,
-    Platform,
-)
+from homeassistant.const import ATTR_ENTITY_ID, STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -106,7 +101,7 @@ async def test_cover_services(
         call.assert_called_once()
         state = hass.states.get(entity_id)
         assert state
-        assert state.state is STATE_OPEN
+        assert state.state is CoverState.OPEN
 
         call.reset_mock()
         await hass.services.async_call(
@@ -118,7 +113,7 @@ async def test_cover_services(
         call.assert_called_once()
         state = hass.states.get(entity_id)
         assert state
-        assert state.state is STATE_CLOSED
+        assert state.state is CoverState.CLOSED
 
     # Charge Port Door
     entity_id = "cover.test_charge_port_door"
@@ -135,7 +130,7 @@ async def test_cover_services(
         call.assert_called_once()
         state = hass.states.get(entity_id)
         assert state
-        assert state.state is STATE_OPEN
+        assert state.state is CoverState.OPEN
 
     with patch(
         "homeassistant.components.teslemetry.VehicleSpecific.charge_port_door_close",
@@ -150,7 +145,7 @@ async def test_cover_services(
         call.assert_called_once()
         state = hass.states.get(entity_id)
         assert state
-        assert state.state is STATE_CLOSED
+        assert state.state is CoverState.CLOSED
 
     # Frunk
     entity_id = "cover.test_frunk"
@@ -167,7 +162,7 @@ async def test_cover_services(
         call.assert_called_once()
         state = hass.states.get(entity_id)
         assert state
-        assert state.state is STATE_OPEN
+        assert state.state is CoverState.OPEN
 
     # Trunk
     entity_id = "cover.test_trunk"
@@ -184,7 +179,7 @@ async def test_cover_services(
         call.assert_called_once()
         state = hass.states.get(entity_id)
         assert state
-        assert state.state is STATE_OPEN
+        assert state.state is CoverState.OPEN
 
         call.reset_mock()
         await hass.services.async_call(
@@ -196,7 +191,7 @@ async def test_cover_services(
         call.assert_called_once()
         state = hass.states.get(entity_id)
         assert state
-        assert state.state is STATE_CLOSED
+        assert state.state is CoverState.CLOSED
 
     # Sunroof
     entity_id = "cover.test_sunroof"
@@ -213,7 +208,7 @@ async def test_cover_services(
         call.assert_called_once()
         state = hass.states.get(entity_id)
         assert state
-        assert state.state is STATE_OPEN
+        assert state.state is CoverState.OPEN
 
         call.reset_mock()
         await hass.services.async_call(
@@ -225,7 +220,7 @@ async def test_cover_services(
         call.assert_called_once()
         state = hass.states.get(entity_id)
         assert state
-        assert state.state is STATE_OPEN
+        assert state.state is CoverState.OPEN
 
         call.reset_mock()
         await hass.services.async_call(
@@ -237,4 +232,4 @@ async def test_cover_services(
         call.assert_called_once()
         state = hass.states.get(entity_id)
         assert state
-        assert state.state is STATE_CLOSED
+        assert state.state is CoverState.CLOSED

--- a/tests/components/tesla_fleet/test_cover.py
+++ b/tests/components/tesla_fleet/test_cover.py
@@ -101,7 +101,7 @@ async def test_cover_services(
         call.assert_called_once()
         state = hass.states.get(entity_id)
         assert state
-        assert state.state is CoverState.OPEN
+        assert state.state == CoverState.OPEN
 
         call.reset_mock()
         await hass.services.async_call(
@@ -113,7 +113,7 @@ async def test_cover_services(
         call.assert_called_once()
         state = hass.states.get(entity_id)
         assert state
-        assert state.state is CoverState.CLOSED
+        assert state.state == CoverState.CLOSED
 
     # Charge Port Door
     entity_id = "cover.test_charge_port_door"
@@ -130,7 +130,7 @@ async def test_cover_services(
         call.assert_called_once()
         state = hass.states.get(entity_id)
         assert state
-        assert state.state is CoverState.OPEN
+        assert state.state == CoverState.OPEN
 
     with patch(
         "homeassistant.components.teslemetry.VehicleSpecific.charge_port_door_close",
@@ -145,7 +145,7 @@ async def test_cover_services(
         call.assert_called_once()
         state = hass.states.get(entity_id)
         assert state
-        assert state.state is CoverState.CLOSED
+        assert state.state == CoverState.CLOSED
 
     # Frunk
     entity_id = "cover.test_frunk"
@@ -162,7 +162,7 @@ async def test_cover_services(
         call.assert_called_once()
         state = hass.states.get(entity_id)
         assert state
-        assert state.state is CoverState.OPEN
+        assert state.state == CoverState.OPEN
 
     # Trunk
     entity_id = "cover.test_trunk"
@@ -179,7 +179,7 @@ async def test_cover_services(
         call.assert_called_once()
         state = hass.states.get(entity_id)
         assert state
-        assert state.state is CoverState.OPEN
+        assert state.state == CoverState.OPEN
 
         call.reset_mock()
         await hass.services.async_call(
@@ -191,7 +191,7 @@ async def test_cover_services(
         call.assert_called_once()
         state = hass.states.get(entity_id)
         assert state
-        assert state.state is CoverState.CLOSED
+        assert state.state == CoverState.CLOSED
 
     # Sunroof
     entity_id = "cover.test_sunroof"
@@ -208,7 +208,7 @@ async def test_cover_services(
         call.assert_called_once()
         state = hass.states.get(entity_id)
         assert state
-        assert state.state is CoverState.OPEN
+        assert state.state == CoverState.OPEN
 
         call.reset_mock()
         await hass.services.async_call(
@@ -220,7 +220,7 @@ async def test_cover_services(
         call.assert_called_once()
         state = hass.states.get(entity_id)
         assert state
-        assert state.state is CoverState.OPEN
+        assert state.state == CoverState.OPEN
 
         call.reset_mock()
         await hass.services.async_call(
@@ -232,4 +232,4 @@ async def test_cover_services(
         call.assert_called_once()
         state = hass.states.get(entity_id)
         assert state
-        assert state.state is CoverState.CLOSED
+        assert state.state == CoverState.CLOSED

--- a/tests/components/teslemetry/test_cover.py
+++ b/tests/components/teslemetry/test_cover.py
@@ -96,7 +96,7 @@ async def test_cover_services(
         call.assert_called_once()
         state = hass.states.get(entity_id)
         assert state
-        assert state.state is CoverState.OPEN
+        assert state.state == CoverState.OPEN
 
         call.reset_mock()
         await hass.services.async_call(
@@ -108,7 +108,7 @@ async def test_cover_services(
         call.assert_called_once()
         state = hass.states.get(entity_id)
         assert state
-        assert state.state is CoverState.CLOSED
+        assert state.state == CoverState.CLOSED
 
     # Charge Port Door
     entity_id = "cover.test_charge_port_door"
@@ -125,7 +125,7 @@ async def test_cover_services(
         call.assert_called_once()
         state = hass.states.get(entity_id)
         assert state
-        assert state.state is CoverState.OPEN
+        assert state.state == CoverState.OPEN
 
     with patch(
         "homeassistant.components.teslemetry.VehicleSpecific.charge_port_door_close",
@@ -140,7 +140,7 @@ async def test_cover_services(
         call.assert_called_once()
         state = hass.states.get(entity_id)
         assert state
-        assert state.state is CoverState.CLOSED
+        assert state.state == CoverState.CLOSED
 
     # Frunk
     entity_id = "cover.test_frunk"
@@ -157,7 +157,7 @@ async def test_cover_services(
         call.assert_called_once()
         state = hass.states.get(entity_id)
         assert state
-        assert state.state is CoverState.OPEN
+        assert state.state == CoverState.OPEN
 
     # Trunk
     entity_id = "cover.test_trunk"
@@ -174,7 +174,7 @@ async def test_cover_services(
         call.assert_called_once()
         state = hass.states.get(entity_id)
         assert state
-        assert state.state is CoverState.OPEN
+        assert state.state == CoverState.OPEN
 
         call.reset_mock()
         await hass.services.async_call(
@@ -186,7 +186,7 @@ async def test_cover_services(
         call.assert_called_once()
         state = hass.states.get(entity_id)
         assert state
-        assert state.state is CoverState.CLOSED
+        assert state.state == CoverState.CLOSED
 
     # Sunroof
     entity_id = "cover.test_sunroof"
@@ -203,7 +203,7 @@ async def test_cover_services(
         call.assert_called_once()
         state = hass.states.get(entity_id)
         assert state
-        assert state.state is CoverState.OPEN
+        assert state.state == CoverState.OPEN
 
         call.reset_mock()
         await hass.services.async_call(
@@ -215,7 +215,7 @@ async def test_cover_services(
         call.assert_called_once()
         state = hass.states.get(entity_id)
         assert state
-        assert state.state is CoverState.OPEN
+        assert state.state == CoverState.OPEN
 
         call.reset_mock()
         await hass.services.async_call(
@@ -227,4 +227,4 @@ async def test_cover_services(
         call.assert_called_once()
         state = hass.states.get(entity_id)
         assert state
-        assert state.state is CoverState.CLOSED
+        assert state.state == CoverState.CLOSED

--- a/tests/components/teslemetry/test_cover.py
+++ b/tests/components/teslemetry/test_cover.py
@@ -11,14 +11,9 @@ from homeassistant.components.cover import (
     SERVICE_CLOSE_COVER,
     SERVICE_OPEN_COVER,
     SERVICE_STOP_COVER,
+    CoverState,
 )
-from homeassistant.const import (
-    ATTR_ENTITY_ID,
-    STATE_CLOSED,
-    STATE_OPEN,
-    STATE_UNKNOWN,
-    Platform,
-)
+from homeassistant.const import ATTR_ENTITY_ID, STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -101,7 +96,7 @@ async def test_cover_services(
         call.assert_called_once()
         state = hass.states.get(entity_id)
         assert state
-        assert state.state is STATE_OPEN
+        assert state.state is CoverState.OPEN
 
         call.reset_mock()
         await hass.services.async_call(
@@ -113,7 +108,7 @@ async def test_cover_services(
         call.assert_called_once()
         state = hass.states.get(entity_id)
         assert state
-        assert state.state is STATE_CLOSED
+        assert state.state is CoverState.CLOSED
 
     # Charge Port Door
     entity_id = "cover.test_charge_port_door"
@@ -130,7 +125,7 @@ async def test_cover_services(
         call.assert_called_once()
         state = hass.states.get(entity_id)
         assert state
-        assert state.state is STATE_OPEN
+        assert state.state is CoverState.OPEN
 
     with patch(
         "homeassistant.components.teslemetry.VehicleSpecific.charge_port_door_close",
@@ -145,7 +140,7 @@ async def test_cover_services(
         call.assert_called_once()
         state = hass.states.get(entity_id)
         assert state
-        assert state.state is STATE_CLOSED
+        assert state.state is CoverState.CLOSED
 
     # Frunk
     entity_id = "cover.test_frunk"
@@ -162,7 +157,7 @@ async def test_cover_services(
         call.assert_called_once()
         state = hass.states.get(entity_id)
         assert state
-        assert state.state is STATE_OPEN
+        assert state.state is CoverState.OPEN
 
     # Trunk
     entity_id = "cover.test_trunk"
@@ -179,7 +174,7 @@ async def test_cover_services(
         call.assert_called_once()
         state = hass.states.get(entity_id)
         assert state
-        assert state.state is STATE_OPEN
+        assert state.state is CoverState.OPEN
 
         call.reset_mock()
         await hass.services.async_call(
@@ -191,7 +186,7 @@ async def test_cover_services(
         call.assert_called_once()
         state = hass.states.get(entity_id)
         assert state
-        assert state.state is STATE_CLOSED
+        assert state.state is CoverState.CLOSED
 
     # Sunroof
     entity_id = "cover.test_sunroof"
@@ -208,7 +203,7 @@ async def test_cover_services(
         call.assert_called_once()
         state = hass.states.get(entity_id)
         assert state
-        assert state.state is STATE_OPEN
+        assert state.state is CoverState.OPEN
 
         call.reset_mock()
         await hass.services.async_call(
@@ -220,7 +215,7 @@ async def test_cover_services(
         call.assert_called_once()
         state = hass.states.get(entity_id)
         assert state
-        assert state.state is STATE_OPEN
+        assert state.state is CoverState.OPEN
 
         call.reset_mock()
         await hass.services.async_call(
@@ -232,4 +227,4 @@ async def test_cover_services(
         call.assert_called_once()
         state = hass.states.get(entity_id)
         assert state
-        assert state.state is STATE_CLOSED
+        assert state.state is CoverState.CLOSED

--- a/tests/components/tessie/test_cover.py
+++ b/tests/components/tessie/test_cover.py
@@ -9,8 +9,7 @@ from homeassistant.components.cover import (
     DOMAIN as COVER_DOMAIN,
     SERVICE_CLOSE_COVER,
     SERVICE_OPEN_COVER,
-    STATE_CLOSED,
-    STATE_OPEN,
+    CoverState,
 )
 from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
@@ -57,7 +56,7 @@ async def test_covers(
                     blocking=True,
                 )
                 mock_open.assert_called_once()
-            assert hass.states.get(entity_id).state == STATE_OPEN
+            assert hass.states.get(entity_id).state == CoverState.OPEN
 
         # Test close windows
         if closefunc:
@@ -72,7 +71,7 @@ async def test_covers(
                     blocking=True,
                 )
                 mock_close.assert_called_once()
-            assert hass.states.get(entity_id).state == STATE_CLOSED
+            assert hass.states.get(entity_id).state == CoverState.CLOSED
 
 
 async def test_errors(hass: HomeAssistant) -> None:

--- a/tests/components/tradfri/test_cover.py
+++ b/tests/components/tradfri/test_cover.py
@@ -8,8 +8,12 @@ import pytest
 from pytradfri.const import ATTR_REACHABLE_STATE
 from pytradfri.device import Device
 
-from homeassistant.components.cover import ATTR_CURRENT_POSITION, DOMAIN as COVER_DOMAIN
-from homeassistant.const import STATE_CLOSED, STATE_OPEN, STATE_UNAVAILABLE
+from homeassistant.components.cover import (
+    ATTR_CURRENT_POSITION,
+    DOMAIN as COVER_DOMAIN,
+    CoverState,
+)
+from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 
 from .common import CommandStore, setup_integration
@@ -27,7 +31,7 @@ async def test_cover_available(
 
     state = hass.states.get(entity_id)
     assert state
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
     assert state.attributes[ATTR_CURRENT_POSITION] == 60
     assert state.attributes["model"] == "FYRTUR block-out roller blind"
 
@@ -44,11 +48,11 @@ async def test_cover_available(
 @pytest.mark.parametrize(
     ("service", "service_data", "expected_state", "expected_position"),
     [
-        ("set_cover_position", {"position": 100}, STATE_OPEN, 100),
-        ("set_cover_position", {"position": 0}, STATE_CLOSED, 0),
-        ("open_cover", {}, STATE_OPEN, 100),
-        ("close_cover", {}, STATE_CLOSED, 0),
-        ("stop_cover", {}, STATE_OPEN, 60),
+        ("set_cover_position", {"position": 100}, CoverState.OPEN, 100),
+        ("set_cover_position", {"position": 0}, CoverState.CLOSED, 0),
+        ("open_cover", {}, CoverState.OPEN, 100),
+        ("close_cover", {}, CoverState.CLOSED, 0),
+        ("stop_cover", {}, CoverState.OPEN, 60),
     ],
 )
 async def test_cover_services(
@@ -66,7 +70,7 @@ async def test_cover_services(
 
     state = hass.states.get(entity_id)
     assert state
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
     assert state.attributes[ATTR_CURRENT_POSITION] == 60
 
     await hass.services.async_call(

--- a/tests/components/wilight/test_cover.py
+++ b/tests/components/wilight/test_cover.py
@@ -9,6 +9,7 @@ from homeassistant.components.cover import (
     ATTR_CURRENT_POSITION,
     ATTR_POSITION,
     DOMAIN as COVER_DOMAIN,
+    CoverState,
 )
 from homeassistant.const import (
     ATTR_ENTITY_ID,
@@ -16,10 +17,6 @@ from homeassistant.const import (
     SERVICE_OPEN_COVER,
     SERVICE_SET_COVER_POSITION,
     SERVICE_STOP_COVER,
-    STATE_CLOSED,
-    STATE_CLOSING,
-    STATE_OPEN,
-    STATE_OPENING,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -70,7 +67,7 @@ async def test_loading_cover(
     # First segment of the strip
     state = hass.states.get("cover.wl000000000099_1")
     assert state
-    assert state.state == STATE_CLOSED
+    assert state.state == CoverState.CLOSED
 
     entry = entity_registry.async_get("cover.wl000000000099_1")
     assert entry
@@ -94,7 +91,7 @@ async def test_open_close_cover_state(
     await hass.async_block_till_done()
     state = hass.states.get("cover.wl000000000099_1")
     assert state
-    assert state.state == STATE_OPENING
+    assert state.state == CoverState.OPENING
 
     # Close
     await hass.services.async_call(
@@ -107,7 +104,7 @@ async def test_open_close_cover_state(
     await hass.async_block_till_done()
     state = hass.states.get("cover.wl000000000099_1")
     assert state
-    assert state.state == STATE_CLOSING
+    assert state.state == CoverState.CLOSING
 
     # Set position
     await hass.services.async_call(
@@ -120,7 +117,7 @@ async def test_open_close_cover_state(
     await hass.async_block_till_done()
     state = hass.states.get("cover.wl000000000099_1")
     assert state
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
     assert state.attributes.get(ATTR_CURRENT_POSITION) == 50
 
     # Stop
@@ -134,4 +131,4 @@ async def test_open_close_cover_state(
     await hass.async_block_till_done()
     state = hass.states.get("cover.wl000000000099_1")
     assert state
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN

--- a/tests/components/zwave_js/test_cover.py
+++ b/tests/components/zwave_js/test_cover.py
@@ -26,6 +26,7 @@ from homeassistant.components.cover import (
     SERVICE_STOP_COVER_TILT,
     CoverDeviceClass,
     CoverEntityFeature,
+    CoverState,
 )
 from homeassistant.components.zwave_js.const import LOGGER
 from homeassistant.components.zwave_js.helpers import ZwaveValueMatcher
@@ -33,10 +34,6 @@ from homeassistant.const import (
     ATTR_DEVICE_CLASS,
     ATTR_ENTITY_ID,
     ATTR_SUPPORTED_FEATURES,
-    STATE_CLOSED,
-    STATE_CLOSING,
-    STATE_OPEN,
-    STATE_OPENING,
     STATE_UNKNOWN,
 )
 from homeassistant.core import HomeAssistant
@@ -63,7 +60,7 @@ async def test_window_cover(
     assert state
     assert state.attributes[ATTR_DEVICE_CLASS] == CoverDeviceClass.WINDOW
 
-    assert state.state == STATE_CLOSED
+    assert state.state == CoverState.CLOSED
     assert state.attributes[ATTR_CURRENT_POSITION] == 0
 
     # Test setting position
@@ -170,7 +167,7 @@ async def test_window_cover(
     client.async_send_command.reset_mock()
 
     state = hass.states.get(WINDOW_COVER_ENTITY)
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
 
     # Test closing
     await hass.services.async_call(
@@ -233,7 +230,7 @@ async def test_window_cover(
     node.receive_event(event)
 
     state = hass.states.get(WINDOW_COVER_ENTITY)
-    assert state.state == STATE_CLOSED
+    assert state.state == CoverState.CLOSED
 
 
 async def test_fibaro_fgr222_shutter_cover(
@@ -244,7 +241,7 @@ async def test_fibaro_fgr222_shutter_cover(
     assert state
     assert state.attributes[ATTR_DEVICE_CLASS] == CoverDeviceClass.SHUTTER
 
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
     assert state.attributes[ATTR_CURRENT_TILT_POSITION] == 0
 
     # Test opening tilts
@@ -345,7 +342,7 @@ async def test_fibaro_fgr223_shutter_cover(
     assert state
     assert state.attributes[ATTR_DEVICE_CLASS] == CoverDeviceClass.SHUTTER
 
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
     assert state.attributes[ATTR_CURRENT_TILT_POSITION] == 0
 
     # Test opening tilts
@@ -441,7 +438,7 @@ async def test_aeotec_nano_shutter_cover(
     assert state
     assert state.attributes[ATTR_DEVICE_CLASS] == CoverDeviceClass.WINDOW
 
-    assert state.state == STATE_CLOSED
+    assert state.state == CoverState.CLOSED
     assert state.attributes[ATTR_CURRENT_POSITION] == 0
 
     # Test opening
@@ -507,7 +504,7 @@ async def test_aeotec_nano_shutter_cover(
     client.async_send_command.reset_mock()
 
     state = hass.states.get(AEOTEC_SHUTTER_COVER_ENTITY)
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
 
     # Test closing
     await hass.services.async_call(
@@ -579,7 +576,7 @@ async def test_motor_barrier_cover(
     assert state
     assert state.attributes[ATTR_DEVICE_CLASS] == CoverDeviceClass.GARAGE
 
-    assert state.state == STATE_CLOSED
+    assert state.state == CoverState.CLOSED
 
     # Test open
     await hass.services.async_call(
@@ -602,7 +599,7 @@ async def test_motor_barrier_cover(
 
     # state doesn't change until currentState value update is received
     state = hass.states.get(GDC_COVER_ENTITY)
-    assert state.state == STATE_CLOSED
+    assert state.state == CoverState.CLOSED
 
     client.async_send_command.reset_mock()
 
@@ -627,7 +624,7 @@ async def test_motor_barrier_cover(
 
     # state doesn't change until currentState value update is received
     state = hass.states.get(GDC_COVER_ENTITY)
-    assert state.state == STATE_CLOSED
+    assert state.state == CoverState.CLOSED
 
     client.async_send_command.reset_mock()
 
@@ -652,7 +649,7 @@ async def test_motor_barrier_cover(
     node.receive_event(event)
 
     state = hass.states.get(GDC_COVER_ENTITY)
-    assert state.state == STATE_OPENING
+    assert state.state == CoverState.OPENING
 
     # Barrier sends an opened state
     event = Event(
@@ -675,7 +672,7 @@ async def test_motor_barrier_cover(
     node.receive_event(event)
 
     state = hass.states.get(GDC_COVER_ENTITY)
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
 
     # Barrier sends a closing state
     event = Event(
@@ -698,7 +695,7 @@ async def test_motor_barrier_cover(
     node.receive_event(event)
 
     state = hass.states.get(GDC_COVER_ENTITY)
-    assert state.state == STATE_CLOSING
+    assert state.state == CoverState.CLOSING
 
     # Barrier sends a closed state
     event = Event(
@@ -721,7 +718,7 @@ async def test_motor_barrier_cover(
     node.receive_event(event)
 
     state = hass.states.get(GDC_COVER_ENTITY)
-    assert state.state == STATE_CLOSED
+    assert state.state == CoverState.CLOSED
 
     # Barrier sends a stopped state
     event = Event(
@@ -827,7 +824,7 @@ async def test_fibaro_fgr223_shutter_cover_no_tilt(
 
     state = hass.states.get(FIBARO_FGR_223_SHUTTER_COVER_ENTITY)
     assert state
-    assert state.state == STATE_OPEN
+    assert state.state == CoverState.OPEN
     assert ATTR_CURRENT_POSITION in state.attributes
     assert ATTR_CURRENT_TILT_POSITION not in state.attributes
 
@@ -944,7 +941,7 @@ async def test_nice_ibt4zwave_cover(
     state = hass.states.get(entity_id)
     assert state
     # This device has no state because there is no position value
-    assert state.state == STATE_CLOSED
+    assert state.state == CoverState.CLOSED
     assert state.attributes[ATTR_SUPPORTED_FEATURES] == (
         CoverEntityFeature.CLOSE
         | CoverEntityFeature.OPEN


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Makes `cover` state into an enum `CoverState`
Previously used constants are deprecated when imported from `homeassistant.components.cover`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/2348

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 