### PR TITLE
Revert grpcio constraint to 1.62.3

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -205,9 +205,11 @@ jobs:
           # Some dependencies still require 'cython<3'
           # and don't yet use isolated build environments.
           # Build these first.
+          # grpcio: https://github.com/grpc/grpc/issues/33918
           # pydantic: https://github.com/pydantic/pydantic/issues/7689
 
           touch requirements_old-cython.txt
+          cat homeassistant/package_constraints.txt | grep 'grpcio==' >> requirements_old-cython.txt
           cat homeassistant/package_constraints.txt | grep 'pydantic==' >> requirements_old-cython.txt
 
       - name: Build wheels (old cython)

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -77,9 +77,9 @@ httplib2>=0.19.0
 # gRPC is an implicit dependency that we want to make explicit so we manage
 # upgrades intentionally. It is a large package to build from source and we
 # want to ensure we have wheels built.
-grpcio==1.66.2
-grpcio-status==1.66.2
-grpcio-reflection==1.66.2
+grpcio==1.62.3
+grpcio-status==1.62.3
+grpcio-reflection==1.62.3
 
 # This is a old unmaintained library and is replaced with pycryptodome
 pycrypto==1000000000.0.0

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -96,9 +96,9 @@ httplib2>=0.19.0
 # gRPC is an implicit dependency that we want to make explicit so we manage
 # upgrades intentionally. It is a large package to build from source and we
 # want to ensure we have wheels built.
-grpcio==1.66.2
-grpcio-status==1.66.2
-grpcio-reflection==1.66.2
+grpcio==1.62.3
+grpcio-status==1.62.3
+grpcio-reflection==1.62.3
 
 # This is a old unmaintained library and is replaced with pycryptodome
 pycrypto==1000000000.0.0


### PR DESCRIPTION
## Proposed change
Revert grpcio back to `1.62.3`. Wheels are still up at: https://wheels.home-assistant.io/musllinux/
- #126947
- #127026

It seems as if the musl linux wheels are broken somehow. To test the issue
```bash
docker run -it --rm --entrypoint "/bin/bash" ghcr.io/home-assistant/wheels/armv7/musllinux_1_2/cp312:dev
pip install --extra-index-url https://wheels.home-assistant.io/musllinux-index/ grpcio==1.66.2
python -c "import grpc"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/local/lib/python3.12/site-packages/grpc/__init__.py", line 22, in <module>
    from grpc import _compression
  File "/usr/local/lib/python3.12/site-packages/grpc/_compression.py", line 20, in <module>
    from grpc._cython import cygrpc
ImportError: Error relocating /usr/local/lib/python3.12/site-packages/grpc/_cython/cygrpc.cpython-312-arm-linux-musleabihf.so: __wrap_memcpy: symbol not found

# Revert back to 1.62.3 is fine
pip install --extra-index-url https://wheels.home-assistant.io/musllinux-index/ grpcio==1.62.3
python -c "import grpc"
```

This could address these issues (will close them after confirmed it's working)
- #127039
- #127119


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
