### PR TITLE
Store instance name in Thread router discovery

### DIFF
--- a/homeassistant/components/thread/discovery.py
+++ b/homeassistant/components/thread/discovery.py
@@ -37,6 +37,7 @@ TYPE_PTR = 12
 class ThreadRouterDiscoveryData:
     """Thread router discovery data."""
 
+    instance_name: str
     addresses: list[str]
     border_agent_id: str | None
     brand: str | None
@@ -89,6 +90,7 @@ def async_discovery_data_from_service(
             unconfigured = True
 
     return ThreadRouterDiscoveryData(
+        instance_name=service.name.split(".")[0],
         addresses=service.parsed_addresses(),
         border_agent_id=border_agent_id.hex() if border_agent_id is not None else None,
         brand=brand,

--- a/homeassistant/components/thread/discovery.py
+++ b/homeassistant/components/thread/discovery.py
@@ -8,7 +8,13 @@ import logging
 from typing import cast
 
 from python_otbr_api.mdns import StateBitmap
-from zeroconf import BadTypeInNameException, DNSPointer, ServiceListener, Zeroconf
+from zeroconf import (
+    BadTypeInNameException,
+    DNSPointer,
+    ServiceListener,
+    Zeroconf,
+    instance_name_from_service_info,
+)
 from zeroconf.asyncio import AsyncServiceInfo, AsyncZeroconf
 
 from homeassistant.components import zeroconf
@@ -90,7 +96,7 @@ def async_discovery_data_from_service(
             unconfigured = True
 
     return ThreadRouterDiscoveryData(
-        instance_name=service.name.split(".")[0],
+        instance_name=instance_name_from_service_info(service),
         addresses=service.parsed_addresses(),
         border_agent_id=border_agent_id.hex() if border_agent_id is not None else None,
         brand=brand,

--- a/tests/components/thread/test_discovery.py
+++ b/tests/components/thread/test_discovery.py
@@ -74,6 +74,7 @@ async def test_discover_routers(
     assert discovered[-1] == (
         "aeeb2f594b570bbf",
         discovery.ThreadRouterDiscoveryData(
+            instance_name="HomeAssistant OpenThreadBorderRouter #0BBF",
             addresses=["192.168.0.115"],
             border_agent_id="230c6a1ac57f6f4be262acf32e5ef52c",
             brand="homeassistant",
@@ -101,6 +102,7 @@ async def test_discover_routers(
     assert discovered[-1] == (
         "f6a99b425a67abed",
         discovery.ThreadRouterDiscoveryData(
+            instance_name="Google-Nest-Hub-#ABED",
             addresses=["192.168.0.124"],
             border_agent_id="bc3740c3e963aa8735bebecd7cc503c7",
             brand="google",
@@ -180,6 +182,7 @@ async def test_discover_routers_unconfigured(
     router_discovered_removed.assert_called_once_with(
         "aeeb2f594b570bbf",
         discovery.ThreadRouterDiscoveryData(
+            instance_name="HomeAssistant OpenThreadBorderRouter #0BBF",
             addresses=["192.168.0.115"],
             border_agent_id="230c6a1ac57f6f4be262acf32e5ef52c",
             brand="homeassistant",
@@ -226,6 +229,7 @@ async def test_discover_routers_bad_or_missing_optional_data(
     router_discovered_removed.assert_called_once_with(
         "aeeb2f594b570bbf",
         discovery.ThreadRouterDiscoveryData(
+            instance_name="HomeAssistant OpenThreadBorderRouter #0BBF",
             addresses=["192.168.0.115"],
             border_agent_id="230c6a1ac57f6f4be262acf32e5ef52c",
             brand=None,

--- a/tests/components/thread/test_websocket_api.py
+++ b/tests/components/thread/test_websocket_api.py
@@ -353,6 +353,7 @@ async def test_discover_routers(
     assert msg == {
         "event": {
             "data": {
+                "instance_name": "HomeAssistant OpenThreadBorderRouter #0BBF",
                 "addresses": ["192.168.0.115"],
                 "border_agent_id": "230c6a1ac57f6f4be262acf32e5ef52c",
                 "brand": "homeassistant",
@@ -388,6 +389,7 @@ async def test_discover_routers(
                 "brand": "google",
                 "extended_address": "f6a99b425a67abed",
                 "extended_pan_id": "9e75e256f61409a3",
+                "instance_name": "Google-Nest-Hub-#ABED",
                 "model_name": "Google Nest Hub",
                 "network_name": "NEST-PAN-E1AF",
                 "server": "2d99f293-cd8e-2770-8dd2-6675de9fa000.local.",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Store the DNS-SD instance name in the Thread router discovery message. The instance name is the actual name given to a Thread border router, e.g. when configuring the name of a Thread border router in Apple Home the name appears as the DNS-SD instance name. This will allow to make the Thread border router list more user friendly.

Currently the model name is shown, which is often the same for each border router instance which leads to a not very useful Thread router list.

![image](https://github.com/user-attachments/assets/1d34486a-2ed5-4aac-b553-2797eb922ed7)

With this change

![image](https://github.com/user-attachments/assets/6b014c4e-5a47-4ad2-be7f-6b400ef86f82)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
