### PR TITLE
Avoid creating Prometheus metrics for non-numeric states

### DIFF
--- a/homeassistant/components/prometheus/__init__.py
+++ b/homeassistant/components/prometheus/__init__.py
@@ -343,8 +343,8 @@ class PrometheusMetrics:
         )
 
     @staticmethod
-    def state_as_number(state: State) -> float:
-        """Return a state casted to a float."""
+    def state_as_number(state: State) -> float | None:
+        """Return state as a float, or None if state cannot be converted."""
         try:
             if state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.TIMESTAMP:
                 value = as_timestamp(state.state)
@@ -352,7 +352,7 @@ class PrometheusMetrics:
                 value = state_helper.state_as_number(state)
         except ValueError:
             _LOGGER.debug("Could not convert %s to float", state)
-            value = 0
+            value = None
         return value
 
     @staticmethod
@@ -382,8 +382,8 @@ class PrometheusMetrics:
             prometheus_client.Gauge,
             "State of the binary sensor (0/1)",
         )
-        value = self.state_as_number(state)
-        metric.labels(**self._labels(state)).set(value)
+        if (value := self.state_as_number(state)) is not None:
+            metric.labels(**self._labels(state)).set(value)
 
     def _handle_input_boolean(self, state: State) -> None:
         metric = self._metric(
@@ -391,8 +391,8 @@ class PrometheusMetrics:
             prometheus_client.Gauge,
             "State of the input boolean (0/1)",
         )
-        value = self.state_as_number(state)
-        metric.labels(**self._labels(state)).set(value)
+        if (value := self.state_as_number(state)) is not None:
+            metric.labels(**self._labels(state)).set(value)
 
     def _numeric_handler(self, state: State, domain: str, title: str) -> None:
         if unit := self._unit_string(state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)):
@@ -408,8 +408,7 @@ class PrometheusMetrics:
                 f"State of the {title}",
             )
 
-        with suppress(ValueError):
-            value = self.state_as_number(state)
+        if (value := self.state_as_number(state)) is not None:
             if (
                 state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
                 == UnitOfTemperature.FAHRENHEIT
@@ -431,15 +430,15 @@ class PrometheusMetrics:
             prometheus_client.Gauge,
             "State of the device tracker (0/1)",
         )
-        value = self.state_as_number(state)
-        metric.labels(**self._labels(state)).set(value)
+        if (value := self.state_as_number(state)) is not None:
+            metric.labels(**self._labels(state)).set(value)
 
     def _handle_person(self, state: State) -> None:
         metric = self._metric(
             "person_state", prometheus_client.Gauge, "State of the person (0/1)"
         )
-        value = self.state_as_number(state)
-        metric.labels(**self._labels(state)).set(value)
+        if (value := self.state_as_number(state)) is not None:
+            metric.labels(**self._labels(state)).set(value)
 
     def _handle_cover(self, state: State) -> None:
         metric = self._metric(
@@ -480,23 +479,19 @@ class PrometheusMetrics:
             "Light brightness percentage (0..100)",
         )
 
-        try:
+        if (value := self.state_as_number(state)) is not None:
             brightness = state.attributes.get(ATTR_BRIGHTNESS)
             if state.state == STATE_ON and brightness is not None:
-                value = brightness / 255.0
-            else:
-                value = self.state_as_number(state)
+                value = float(brightness) / 255.0
             value = value * 100
             metric.labels(**self._labels(state)).set(value)
-        except ValueError:
-            pass
 
     def _handle_lock(self, state: State) -> None:
         metric = self._metric(
             "lock_state", prometheus_client.Gauge, "State of the lock (0/1)"
         )
-        value = self.state_as_number(state)
-        metric.labels(**self._labels(state)).set(value)
+        if (value := self.state_as_number(state)) is not None:
+            metric.labels(**self._labels(state)).set(value)
 
     def _handle_climate_temp(
         self, state: State, attr: str, metric_name: str, metric_description: str
@@ -608,11 +603,8 @@ class PrometheusMetrics:
             prometheus_client.Gauge,
             "State of the humidifier (0/1)",
         )
-        try:
-            value = self.state_as_number(state)
+        if (value := self.state_as_number(state)) is not None:
             metric.labels(**self._labels(state)).set(value)
-        except ValueError:
-            pass
 
         current_mode = state.attributes.get(ATTR_MODE)
         available_modes = state.attributes.get(ATTR_AVAILABLE_MODES)
@@ -643,8 +635,7 @@ class PrometheusMetrics:
 
             _metric = self._metric(metric, prometheus_client.Gauge, documentation)
 
-            try:
-                value = self.state_as_number(state)
+            if (value := self.state_as_number(state)) is not None:
                 if (
                     state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
                     == UnitOfTemperature.FAHRENHEIT
@@ -653,8 +644,6 @@ class PrometheusMetrics:
                         value, UnitOfTemperature.FAHRENHEIT, UnitOfTemperature.CELSIUS
                     )
                 _metric.labels(**self._labels(state)).set(value)
-            except ValueError:
-                pass
 
         self._battery(state)
 
@@ -693,14 +682,9 @@ class PrometheusMetrics:
     @staticmethod
     def _sensor_fallback_metric(state: State, unit: str | None) -> str | None:
         """Get metric from fallback logic for compatibility."""
-        if unit in (None, ""):
-            try:
-                state_helper.state_as_number(state)
-            except ValueError:
-                _LOGGER.debug("Unsupported sensor: %s", state.entity_id)
-                return None
-            return "sensor_state"
-        return f"sensor_unit_{unit}"
+        if unit not in (None, ""):
+            return f"sensor_unit_{unit}"
+        return "sensor_state"
 
     @staticmethod
     def _unit_string(unit: str | None) -> str | None:
@@ -722,11 +706,8 @@ class PrometheusMetrics:
             "switch_state", prometheus_client.Gauge, "State of the switch (0/1)"
         )
 
-        try:
-            value = self.state_as_number(state)
+        if (value := self.state_as_number(state)) is not None:
             metric.labels(**self._labels(state)).set(value)
-        except ValueError:
-            pass
 
         self._handle_attributes(state)
 
@@ -735,11 +716,8 @@ class PrometheusMetrics:
             "fan_state", prometheus_client.Gauge, "State of the fan (0/1)"
         )
 
-        try:
-            value = self.state_as_number(state)
+        if (value := self.state_as_number(state)) is not None:
             metric.labels(**self._labels(state)).set(value)
-        except ValueError:
-            pass
 
         fan_speed_percent = state.attributes.get(ATTR_PERCENTAGE)
         if fan_speed_percent is not None:
@@ -805,8 +783,8 @@ class PrometheusMetrics:
             prometheus_client.Gauge,
             "Value of counter entities",
         )
-
-        metric.labels(**self._labels(state)).set(self.state_as_number(state))
+        if (value := self.state_as_number(state)) is not None:
+            metric.labels(**self._labels(state)).set(value)
 
     def _handle_update(self, state: State) -> None:
         metric = self._metric(
@@ -814,8 +792,8 @@ class PrometheusMetrics:
             prometheus_client.Gauge,
             "Update state, indicating if an update is available (0/1)",
         )
-        value = self.state_as_number(state)
-        metric.labels(**self._labels(state)).set(value)
+        if (value := self.state_as_number(state)) is not None:
+            metric.labels(**self._labels(state)).set(value)
 
     def _handle_alarm_control_panel(self, state: State) -> None:
         current_state = state.state

--- a/tests/components/prometheus/test_init.py
+++ b/tests/components/prometheus/test_init.py
@@ -643,7 +643,7 @@ async def test_sensor_without_unit(
         domain="sensor",
         friendly_name="Text Unit",
         entity="sensor.text_unit",
-    ).withValue(0.0).assert_in_metrics(body)
+    ).assert_not_in_metrics(body)
 
 
 @pytest.mark.parametrize("namespace", [""])
@@ -716,6 +716,13 @@ async def test_input_number(
         friendly_name="Target temperature",
         entity="input_number.target_temperature",
     ).withValue(22.7).assert_in_metrics(body)
+
+    EntityMetric(
+        metric_name="input_number_state_celsius",
+        domain="input_number",
+        friendly_name="Converted temperature",
+        entity="input_number.converted_temperature",
+    ).withValue(100).assert_in_metrics(body)
 
 
 @pytest.mark.parametrize("namespace", [""])
@@ -2207,6 +2214,17 @@ async def input_number_fixture(
     )
     set_state_with_entry(hass, input_number_3, 22.7)
     data["input_number_3"] = input_number_3
+
+    input_number_4 = entity_registry.async_get_or_create(
+        domain=input_number.DOMAIN,
+        platform="test",
+        unique_id="input_number_4",
+        suggested_object_id="converted_temperature",
+        original_name="Converted temperature",
+        unit_of_measurement=UnitOfTemperature.FAHRENHEIT,
+    )
+    set_state_with_entry(hass, input_number_4, 212)
+    data["input_number_4"] = input_number_4
 
     await hass.async_block_till_done()
     return data


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

If the state cannot be converted to a number, avoid creating a metric with a zero value for it. We had some entity-specific logic for this (e.g. for unit-less sensors), but there's no reason to not do this for all entities.

The existing test for this was broken, which we've discovered in #113849

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #128671
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
