### PR TITLE
Fix telegram_bot tests for Python 3.13

### DIFF
--- a/tests/components/telegram_bot/conftest.py
+++ b/tests/components/telegram_bot/conftest.py
@@ -6,7 +6,7 @@ from typing import Any
 from unittest.mock import patch
 
 import pytest
-from telegram import Chat, Message, User
+from telegram import Bot, Chat, Message, User
 from telegram.constants import ChatType
 
 from homeassistant.components.telegram_bot import (
@@ -89,23 +89,22 @@ def mock_external_calls() -> Generator[None]:
         date=datetime.now(),
         chat=Chat(id=123456, type=ChatType.PRIVATE),
     )
+
+    class BotMock(Bot):
+        """Mock bot class."""
+
+        __slots__ = ()
+
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            """Initialize BotMock instance."""
+            super().__init__(*args, **kwargs)
+            self._bot_user = test_user
+
     with (
-        patch(
-            "telegram.Bot.get_me",
-            return_value=test_user,
-        ),
-        patch(
-            "telegram.Bot._bot_user",
-            test_user,
-        ),
-        patch(
-            "telegram.Bot.bot",
-            test_user,
-        ),
-        patch(
-            "telegram.Bot.send_message",
-            return_value=message,
-        ),
+        patch("homeassistant.components.telegram_bot.Bot", BotMock),
+        patch.object(BotMock, "get_me", return_value=test_user),
+        patch.object(BotMock, "bot", test_user),
+        patch.object(BotMock, "send_message", return_value=message),
         patch("telegram.ext.Updater._bootstrap"),
     ):
         yield


### PR DESCRIPTION
## Proposed change
Python 3.13 will add `__slots__` to `AbstractAsyncContextManager`. With that the `telegram.Bot` class will no longer have a `__dict__`. Subsequently patching the attribute `Bot._bot_user` will fail.

```
AttributeError: 'Bot' object attribute '_bot_user' is read-only
```

Adjust the tests to work around that.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
