### PR TITLE
Align config flow reconfigure step test helper with frontend

### DIFF
--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1104,11 +1104,9 @@ class ConfigEntry(Generic[_DataT]):
                 context={
                     "source": SOURCE_RECONFIGURE,
                     "entry_id": self.entry_id,
-                    "title_placeholders": {"name": self.title},
-                    "unique_id": self.unique_id,
                 }
                 | (context or {}),
-                data=data or {},
+                data=data,
             )
 
     @callback

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1104,9 +1104,11 @@ class ConfigEntry(Generic[_DataT]):
                 context={
                     "source": SOURCE_RECONFIGURE,
                     "entry_id": self.entry_id,
+                    "title_placeholders": {"name": self.title},
+                    "unique_id": self.unique_id,
                 }
                 | (context or {}),
-                data=data,
+                data=self.data | (data or {}),
             )
 
     @callback

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1108,7 +1108,7 @@ class ConfigEntry(Generic[_DataT]):
                     "unique_id": self.unique_id,
                 }
                 | (context or {}),
-                data=self.data | (data or {}),
+                data=data or {},
             )
 
     @callback

--- a/tests/common.py
+++ b/tests/common.py
@@ -1069,8 +1069,8 @@ class MockConfigEntry(config_entries.ConfigEntry):
     async def start_reconfigure_flow(
         self,
         hass: HomeAssistant,
-        context: dict[str, Any] | None = None,
-        data: dict[str, Any] | None = None,
+        *,
+        show_advanced_options: bool = False,
     ) -> ConfigFlowResult:
         """Start a reconfiguration flow."""
         return await hass.config_entries.flow.async_init(
@@ -1078,9 +1078,8 @@ class MockConfigEntry(config_entries.ConfigEntry):
             context={
                 "source": config_entries.SOURCE_RECONFIGURE,
                 "entry_id": self.entry_id,
-            }
-            | (context or {}),
-            data=data,
+                "show_advanced_options": show_advanced_options,
+            },
         )
 
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -1070,7 +1070,6 @@ class MockConfigEntry(config_entries.ConfigEntry):
         self,
         hass: HomeAssistant,
         context: dict[str, Any] | None = None,
-        data: dict[str, Any] | None = None,
     ) -> ConfigFlowResult:
         """Start a reconfiguration flow."""
         return await hass.config_entries.flow.async_init(
@@ -1082,7 +1081,7 @@ class MockConfigEntry(config_entries.ConfigEntry):
                 "unique_id": self.unique_id,
             }
             | (context or {}),
-            data=data,
+            data=None,
         )
 
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -1082,7 +1082,7 @@ class MockConfigEntry(config_entries.ConfigEntry):
                 "unique_id": self.unique_id,
             }
             | (context or {}),
-            data=self.data | (data or {}),
+            data=data or {},
         )
 
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -1070,6 +1070,7 @@ class MockConfigEntry(config_entries.ConfigEntry):
         self,
         hass: HomeAssistant,
         context: dict[str, Any] | None = None,
+        data: dict[str, Any] | None = None,
     ) -> ConfigFlowResult:
         """Start a reconfiguration flow."""
         return await hass.config_entries.flow.async_init(
@@ -1077,11 +1078,9 @@ class MockConfigEntry(config_entries.ConfigEntry):
             context={
                 "source": config_entries.SOURCE_RECONFIGURE,
                 "entry_id": self.entry_id,
-                "title_placeholders": {"name": self.title},
-                "unique_id": self.unique_id,
             }
             | (context or {}),
-            data=None,
+            data=data,
         )
 
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -1082,7 +1082,7 @@ class MockConfigEntry(config_entries.ConfigEntry):
                 "unique_id": self.unique_id,
             }
             | (context or {}),
-            data=data or {},
+            data=data,
         )
 
 

--- a/tests/components/fritz/test_config_flow.py
+++ b/tests/components/fritz/test_config_flow.py
@@ -454,7 +454,7 @@ async def test_reconfigure_successful(
 
         result = await mock_config.start_reconfigure_flow(
             hass,
-            context={"show_advanced_options": show_advanced_options},
+            show_advanced_options=show_advanced_options,
         )
 
         assert result["type"] is FlowResultType.FORM

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -4741,7 +4741,7 @@ async def test_reconfigure(
     assert len(flows) == 1
     assert flows[0]["context"]["entry_id"] == entry.entry_id
     assert flows[0]["context"]["source"] == config_entries.SOURCE_RECONFIGURE
-    assert flows[0]["context"]["title_placeholders"] == {"name": "test_title"}
+    assert "title_placeholders" not in flows[0]["context"]
     assert flows[0]["context"]["extra_context"] == "some_extra_context"
 
     assert mock_init.call_args.kwargs["data"]["extra_data"] == 1234

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -80,7 +80,7 @@ def mock_handlers() -> Generator[None]:
                 return self.async_show_form(step_id="reauth_confirm")
             return self.async_abort(reason="test")
 
-        async def async_step_reconfigure(self, data):
+        async def async_step_reconfigure(self, user_input=None):
             """Mock Reauth."""
             return await self.async_step_reauth_confirm()
 
@@ -6410,7 +6410,7 @@ async def test_get_reauth_entry(
             """Test reauth step."""
             return await self._async_step_confirm()
 
-        async def async_step_reconfigure(self, entry_data):
+        async def async_step_reconfigure(self, user_input=None):
             """Test reauth step."""
             return await self._async_step_confirm()
 
@@ -6482,7 +6482,7 @@ async def test_get_reconfigure_entry(
             """Test reauth step."""
             return await self._async_step_confirm()
 
-        async def async_step_reconfigure(self, entry_data):
+        async def async_step_reconfigure(self, user_input=None):
             """Test reauth step."""
             return await self._async_step_confirm()
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As spotted by @starkillerOG in https://github.com/home-assistant/core/pull/127307#pullrequestreview-2343081537

Contrary to what `_async_init_reconfigure` implies, the original config entry data is NOT passed up when called from the UI.
This makes sure that both are aligned.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/2351

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
