### PR TITLE
Clean up Tibber service tests

### DIFF
--- a/tests/components/tibber/conftest.py
+++ b/tests/components/tibber/conftest.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 import pytest
 
+from homeassistant.components.recorder import Recorder
 from homeassistant.components.tibber.const import DOMAIN
 from homeassistant.const import CONF_ACCESS_TOKEN
 from homeassistant.core import HomeAssistant
@@ -26,7 +27,7 @@ def config_entry(hass: HomeAssistant) -> MockConfigEntry:
 
 @pytest.fixture
 async def mock_tibber_setup(
-    config_entry: MockConfigEntry, hass: HomeAssistant
+    recorder_mock: Recorder, config_entry: MockConfigEntry, hass: HomeAssistant
 ) -> AsyncGenerator[MagicMock]:
     """Mock tibber entry setup."""
     unique_user_id = "unique_user_id"

--- a/tests/components/tibber/test_services.py
+++ b/tests/components/tibber/test_services.py
@@ -11,12 +11,12 @@ from homeassistant.components.tibber.services import PRICE_SERVICE_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
 
-STARTTIME = dt.datetime.fromtimestamp(1615766400).replace(tzinfo=dt.UTC)
+START_TIME = dt.datetime.fromtimestamp(1615766400).replace(tzinfo=dt.UTC)
 
 
 def generate_mock_home_data():
     """Create mock data from the tibber connection."""
-    tomorrow = STARTTIME + dt.timedelta(days=1)
+    tomorrow = START_TIME + dt.timedelta(days=1)
     mock_homes = [
         MagicMock(
             name="first_home",
@@ -27,13 +27,13 @@ def generate_mock_home_data():
                             "priceInfo": {
                                 "today": [
                                     {
-                                        "startsAt": STARTTIME.isoformat(),
+                                        "startsAt": START_TIME.isoformat(),
                                         "total": 0.36914,
                                         "level": "VERY_EXPENSIVE",
                                     },
                                     {
                                         "startsAt": (
-                                            STARTTIME + dt.timedelta(hours=1)
+                                            START_TIME + dt.timedelta(hours=1)
                                         ).isoformat(),
                                         "total": 0.36914,
                                         "level": "VERY_EXPENSIVE",
@@ -68,13 +68,13 @@ def generate_mock_home_data():
                             "priceInfo": {
                                 "today": [
                                     {
-                                        "startsAt": STARTTIME.isoformat(),
+                                        "startsAt": START_TIME.isoformat(),
                                         "total": 0.36914,
                                         "level": "VERY_EXPENSIVE",
                                     },
                                     {
                                         "startsAt": (
-                                            STARTTIME + dt.timedelta(hours=1)
+                                            START_TIME + dt.timedelta(hours=1)
                                         ).isoformat(),
                                         "total": 0.36914,
                                         "level": "VERY_EXPENSIVE",
@@ -101,6 +101,8 @@ def generate_mock_home_data():
             },
         ),
     ]
+    # set name again, as the name is special in mock objects
+    # see documentation: https://docs.python.org/3/library/unittest.mock.html#mock-names-and-the-name-attribute
     mock_homes[0].name = "first_home"
     mock_homes[1].name = "second_home"
     return mock_homes
@@ -110,10 +112,10 @@ def generate_mock_home_data():
     "data",
     [
         {},
-        {"start": STARTTIME.isoformat()},
+        {"start": START_TIME.isoformat()},
         {
-            "start": STARTTIME.isoformat(),
-            "end": (STARTTIME + dt.timedelta(days=1)).isoformat(),
+            "start": START_TIME.isoformat(),
+            "end": (START_TIME + dt.timedelta(days=1)).isoformat(),
         },
     ],
 )
@@ -123,8 +125,8 @@ async def test_get_prices(
     freezer: FrozenDateTimeFactory,
     data,
 ) -> None:
-    """Test __get_prices with mock data."""
-    freezer.move_to(STARTTIME)
+    """Test get_prices with mock data."""
+    freezer.move_to(START_TIME)
     mock_tibber_setup.get_homes.return_value = generate_mock_home_data()
 
     result = await hass.services.async_call(
@@ -136,14 +138,14 @@ async def test_get_prices(
         "prices": {
             "first_home": [
                 {
-                    "start_time": dt.datetime.fromisoformat(STARTTIME.isoformat()),
+                    "start_time": dt.datetime.fromisoformat(START_TIME.isoformat()),
                     # back and forth conversion to deal with HAFakeDatetime vs real datetime being different types
                     "price": 0.36914,
                     "level": "VERY_EXPENSIVE",
                 },
                 {
                     "start_time": dt.datetime.fromisoformat(
-                        (STARTTIME + dt.timedelta(hours=1)).isoformat()
+                        (START_TIME + dt.timedelta(hours=1)).isoformat()
                     ),
                     "price": 0.36914,
                     "level": "VERY_EXPENSIVE",
@@ -151,13 +153,13 @@ async def test_get_prices(
             ],
             "second_home": [
                 {
-                    "start_time": dt.datetime.fromisoformat(STARTTIME.isoformat()),
+                    "start_time": dt.datetime.fromisoformat(START_TIME.isoformat()),
                     "price": 0.36914,
                     "level": "VERY_EXPENSIVE",
                 },
                 {
                     "start_time": dt.datetime.fromisoformat(
-                        (STARTTIME + dt.timedelta(hours=1)).isoformat()
+                        (START_TIME + dt.timedelta(hours=1)).isoformat()
                     ),
                     "price": 0.36914,
                     "level": "VERY_EXPENSIVE",
@@ -172,9 +174,9 @@ async def test_get_prices_start_tomorrow(
     hass: HomeAssistant,
     freezer: FrozenDateTimeFactory,
 ) -> None:
-    """Test __get_prices with start date tomorrow."""
-    freezer.move_to(STARTTIME)
-    tomorrow = STARTTIME + dt.timedelta(days=1)
+    """Test get_prices with start date tomorrow."""
+    freezer.move_to(START_TIME)
+    tomorrow = START_TIME + dt.timedelta(days=1)
 
     mock_tibber_setup.get_homes.return_value = generate_mock_home_data()
 
@@ -220,8 +222,8 @@ async def test_get_prices_start_tomorrow(
 @pytest.mark.parametrize(
     "start_time",
     [
-        STARTTIME.isoformat(),
-        (STARTTIME + dt.timedelta(hours=4))
+        START_TIME.isoformat(),
+        (START_TIME + dt.timedelta(hours=4))
         .replace(tzinfo=dt.timezone(dt.timedelta(hours=4)))
         .isoformat(),
     ],
@@ -232,8 +234,8 @@ async def test_get_prices_with_timezones(
     freezer: FrozenDateTimeFactory,
     start_time: str,
 ) -> None:
-    """Test __get_prices with timezone and without."""
-    freezer.move_to(STARTTIME)
+    """Test get_prices with timezone and without."""
+    freezer.move_to(START_TIME)
 
     mock_tibber_setup.get_homes.return_value = generate_mock_home_data()
 
@@ -250,24 +252,24 @@ async def test_get_prices_with_timezones(
         "prices": {
             "first_home": [
                 {
-                    "start_time": STARTTIME,
+                    "start_time": START_TIME,
                     "price": 0.36914,
                     "level": "VERY_EXPENSIVE",
                 },
                 {
-                    "start_time": STARTTIME + dt.timedelta(hours=1),
+                    "start_time": START_TIME + dt.timedelta(hours=1),
                     "price": 0.36914,
                     "level": "VERY_EXPENSIVE",
                 },
             ],
             "second_home": [
                 {
-                    "start_time": STARTTIME,
+                    "start_time": START_TIME,
                     "price": 0.36914,
                     "level": "VERY_EXPENSIVE",
                 },
                 {
-                    "start_time": STARTTIME + dt.timedelta(hours=1),
+                    "start_time": START_TIME + dt.timedelta(hours=1),
                     "price": 0.36914,
                     "level": "VERY_EXPENSIVE",
                 },
@@ -279,14 +281,14 @@ async def test_get_prices_with_timezones(
 @pytest.mark.parametrize(
     "start_time",
     [
-        (STARTTIME + dt.timedelta(hours=2)).isoformat(),
-        (STARTTIME + dt.timedelta(hours=2))
+        (START_TIME + dt.timedelta(hours=2)).isoformat(),
+        (START_TIME + dt.timedelta(hours=2))
         .astimezone(tz=dt.timezone(dt.timedelta(hours=5)))
         .isoformat(),
-        (STARTTIME + dt.timedelta(hours=2))
+        (START_TIME + dt.timedelta(hours=2))
         .astimezone(tz=dt.timezone(dt.timedelta(hours=8)))
         .isoformat(),
-        (STARTTIME + dt.timedelta(hours=2))
+        (START_TIME + dt.timedelta(hours=2))
         .astimezone(tz=dt.timezone(dt.timedelta(hours=-8)))
         .isoformat(),
     ],
@@ -297,9 +299,9 @@ async def test_get_prices_with_wrong_timezones(
     freezer: FrozenDateTimeFactory,
     start_time: str,
 ) -> None:
-    """Test __get_prices with timezone and without, while expecting it to fail."""
-    freezer.move_to(STARTTIME)
-    tomorrow = STARTTIME + dt.timedelta(days=1)
+    """Test get_prices with incorrect time and/or timezone. We expect an empty list."""
+    freezer.move_to(START_TIME)
+    tomorrow = START_TIME + dt.timedelta(days=1)
 
     mock_tibber_setup.get_homes.return_value = generate_mock_home_data()
 
@@ -319,7 +321,7 @@ async def test_get_prices_invalid_input(
     mock_tibber_setup: MagicMock,
     hass: HomeAssistant,
 ) -> None:
-    """Test __get_prices with invalid input."""
+    """Test get_prices with invalid input."""
 
     with pytest.raises(ServiceValidationError):
         await hass.services.async_call(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Cleanup service tests (now known as actions) for tibber.
This was requested by @MartinHjelmare here: https://github.com/home-assistant/core/pull/123289#discussion_r1783919396

The tests now use the recommended way to call services.
Additionally, pricing was made more diverse in the mock data. This causes "today" and "tomorrow" tests to verify the correct data was returned.

Unfortunately, the test environment seems to use US/Pacific as timezone, and this information is not available when `pytest.parametrize` is evaluated. For this reason, all tests now specify a timezone, as I did not want tests to rely on the arbitrary number -7.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
