### PR TITLE
Remove dead reconfigure code

### DIFF
--- a/homeassistant/components/homeassistant/strings.json
+++ b/homeassistant/components/homeassistant/strings.json
@@ -1,7 +1,7 @@
 {
   "config": {
     "abort": {
-      "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
+      "reauth_already_in_progress": "Re-authentication flow is already in progress",
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
     },
     "step": {}

--- a/homeassistant/components/homeassistant/strings.json
+++ b/homeassistant/components/homeassistant/strings.json
@@ -1,6 +1,7 @@
 {
   "config": {
     "abort": {
+      "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
     },
     "step": {}

--- a/homeassistant/components/homeassistant/strings.json
+++ b/homeassistant/components/homeassistant/strings.json
@@ -1,7 +1,6 @@
 {
   "config": {
     "abort": {
-      "reauth_already_in_progress": "Re-authentication flow is already in progress",
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
     },
     "step": {}

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1256,6 +1256,23 @@ class ConfigEntriesFlowManager(
                 translation_domain=HOMEASSISTANT_DOMAIN,
             )
 
+        if context.get("source") == SOURCE_RECONFIGURE and any(
+            flow
+            for flow in self.hass.config_entries.flow.async_progress_by_handler(
+                handler,
+                match_context={"entry_id": context["entry_id"]},
+                include_uninitialized=True,
+            )
+            if flow["context"].get("source") in {SOURCE_REAUTH, SOURCE_RECONFIGURE}
+        ):
+            return ConfigFlowResult(
+                type=data_entry_flow.FlowResultType.ABORT,
+                flow_id=flow_id,
+                handler=handler,
+                reason="already_in_progress",
+                translation_domain=HOMEASSISTANT_DOMAIN,
+            )
+
         loop = self.hass.loop
 
         if context["source"] == SOURCE_IMPORT:

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1263,7 +1263,7 @@ class ConfigEntriesFlowManager(
                 match_context={"entry_id": context["entry_id"]},
                 include_uninitialized=True,
             )
-            if flow["context"].get("source") in {SOURCE_REAUTH, SOURCE_RECONFIGURE}
+            if flow["context"].get("source") == SOURCE_REAUTH
         ):
             return ConfigFlowResult(
                 type=data_entry_flow.FlowResultType.ABORT,

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1256,23 +1256,6 @@ class ConfigEntriesFlowManager(
                 translation_domain=HOMEASSISTANT_DOMAIN,
             )
 
-        if context.get("source") == SOURCE_RECONFIGURE and any(
-            flow
-            for flow in self.hass.config_entries.flow.async_progress_by_handler(
-                handler,
-                match_context={"entry_id": context["entry_id"]},
-                include_uninitialized=True,
-            )
-            if flow["context"].get("source") == SOURCE_REAUTH
-        ):
-            return ConfigFlowResult(
-                type=data_entry_flow.FlowResultType.ABORT,
-                flow_id=flow_id,
-                handler=handler,
-                reason="reauth_already_in_progress",
-                translation_domain=HOMEASSISTANT_DOMAIN,
-            )
-
         loop = self.hass.loop
 
         if context["source"] == SOURCE_IMPORT:

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1269,7 +1269,7 @@ class ConfigEntriesFlowManager(
                 type=data_entry_flow.FlowResultType.ABORT,
                 flow_id=flow_id,
                 handler=handler,
-                reason="already_in_progress",
+                reason="reauth_already_in_progress",
                 translation_domain=HOMEASSISTANT_DOMAIN,
             )
 

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -5413,16 +5413,12 @@ async def test_starting_config_flow_on_single_config_entry(
 
     mock_platform(hass, "comp.config_flow", None)
 
-    context = {"source": source}
-    if source in {config_entries.SOURCE_REAUTH, config_entries.SOURCE_RECONFIGURE}:
-        context["entry_id"] = entry.entry_id
-
     with patch(
         "homeassistant.loader.async_get_integration",
         return_value=integration,
     ):
         result = await hass.config_entries.flow.async_init(
-            "comp", context=context, data=user_input
+            "comp", context={"source": source}, data=user_input
         )
 
     for key in expected_result:
@@ -5489,16 +5485,12 @@ async def test_starting_config_flow_on_single_config_entry_2(
 
     mock_platform(hass, "comp.config_flow", None)
 
-    context = {"source": source}
-    if source in {config_entries.SOURCE_REAUTH, config_entries.SOURCE_RECONFIGURE}:
-        context["entry_id"] = ignored_entry.entry_id
-
     with patch(
         "homeassistant.loader.async_get_integration",
         return_value=integration,
     ):
         result = await hass.config_entries.flow.async_init(
-            "comp", context=context, data=user_input
+            "comp", context={"source": source}, data=user_input
         )
 
     for key in expected_result:

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -989,7 +989,6 @@ async def test_as_dict(snapshot: SnapshotAssertion) -> None:
         "_tries",
         "_setup_again_job",
         "_supports_options",
-        "_reconfigure_lock",
         "supports_reconfigure",
     }
 

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -5410,12 +5410,16 @@ async def test_starting_config_flow_on_single_config_entry(
 
     mock_platform(hass, "comp.config_flow", None)
 
+    context = {"source": source}
+    if source in {config_entries.SOURCE_REAUTH, config_entries.SOURCE_RECONFIGURE}:
+        context["entry_id"] = entry.entry_id
+
     with patch(
         "homeassistant.loader.async_get_integration",
         return_value=integration,
     ):
         result = await hass.config_entries.flow.async_init(
-            "comp", context={"source": source}, data=user_input
+            "comp", context=context, data=user_input
         )
 
     for key in expected_result:
@@ -5482,12 +5486,16 @@ async def test_starting_config_flow_on_single_config_entry_2(
 
     mock_platform(hass, "comp.config_flow", None)
 
+    context = {"source": source}
+    if source in {config_entries.SOURCE_REAUTH, config_entries.SOURCE_RECONFIGURE}:
+        context["entry_id"] = ignored_entry.entry_id
+
     with patch(
         "homeassistant.loader.async_get_integration",
         return_value=integration,
     ):
         result = await hass.config_entries.flow.async_init(
-            "comp", context={"source": source}, data=user_input
+            "comp", context=context, data=user_input
         )
 
     for key in expected_result:

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -4787,29 +4787,29 @@ async def test_reconfigure(
 
     assert entry.entry_id != entry2.entry_id
 
-    # Check that we can't start duplicate reconfigure flows
+    # Check that we can start duplicate reconfigure flows
     _async_start_reconfigure(entry)
     await hass.async_block_till_done()
-    assert len(hass.config_entries.flow.async_progress()) == 1
+    assert len(hass.config_entries.flow.async_progress()) == 2
 
     # Check that we can start a reconfigure flow for a different entry
     _async_start_reconfigure(entry2)
     await hass.async_block_till_done()
-    assert len(hass.config_entries.flow.async_progress()) == 2
+    assert len(hass.config_entries.flow.async_progress()) == 3
 
     # Abort all existing flows
     for flow in hass.config_entries.flow.async_progress():
         hass.config_entries.flow.async_abort(flow["flow_id"])
     await hass.async_block_till_done()
 
-    # Check that we can't start duplicate reconfigure flows
+    # Check that we can start duplicate reconfigure flows
     # without blocking between flows
     _async_start_reconfigure(entry)
     _async_start_reconfigure(entry)
     _async_start_reconfigure(entry)
     _async_start_reconfigure(entry)
     await hass.async_block_till_done()
-    assert len(hass.config_entries.flow.async_progress()) == 1
+    assert len(hass.config_entries.flow.async_progress()) == 4
 
     # Abort all existing flows
     for flow in hass.config_entries.flow.async_progress():

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -4788,6 +4788,7 @@ async def test_reconfigure(
     assert entry.entry_id != entry2.entry_id
 
     # Check that we can start duplicate reconfigure flows
+    # (may need revisiting)
     _async_start_reconfigure(entry)
     await hass.async_block_till_done()
     assert len(hass.config_entries.flow.async_progress()) == 2
@@ -4804,6 +4805,7 @@ async def test_reconfigure(
 
     # Check that we can start duplicate reconfigure flows
     # without blocking between flows
+    # (may need revisiting)
     _async_start_reconfigure(entry)
     _async_start_reconfigure(entry)
     _async_start_reconfigure(entry)
@@ -4816,13 +4818,14 @@ async def test_reconfigure(
         hass.config_entries.flow.async_abort(flow["flow_id"])
     await hass.async_block_till_done()
 
-    # Check that we can't start reconfigure flows with active reauth flow
+    # Check that we can start reconfigure flows with active reauth flow
+    # (may need revisiting)
     entry.async_start_reauth(hass, {"extra_context": "some_extra_context"})
     await hass.async_block_till_done()
     assert len(hass.config_entries.flow.async_progress()) == 1
     _async_start_reconfigure(entry)
     await hass.async_block_till_done()
-    assert len(hass.config_entries.flow.async_progress()) == 1
+    assert len(hass.config_entries.flow.async_progress()) == 2
 
     # Abort all existing flows
     for flow in hass.config_entries.flow.async_progress():


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Whilst investigating #127329 I found some dead code, which incorrectly made assumptions about the way reconfigure flows were triggered.

This removes the said dead code ~and moves the checks to the correct location~.

~To prevent a reconfigure flow sitting in a tab on my laptop from indefinitely blocking reconfiguring the config entry, the check has been adjusted to allow multiple reconfigure (but still prevent reconfigure with active reauth flow and prevent reauth with active reconfigure flow)~

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
