### PR TITLE
Cache serialization of config entry storage

### DIFF
--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -481,10 +481,10 @@ class ConfigEntry(Generic[_DataT]):
     def as_json_fragment(self) -> json_fragment:
         """Return JSON fragment of a config entry that is used for the API."""
         json_repr = {
-            "created_at": self.created_at,
+            "created_at": self.created_at.timestamp(),
             "entry_id": self.entry_id,
             "domain": self.domain,
-            "modified_at": self.modified_at,
+            "modified_at": self.modified_at.timestamp(),
             "title": self.title,
             "source": self.source,
             "state": self.state.value,

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -2334,7 +2334,7 @@ class ConfigEntries:
         self._store.async_delay_save(self._data_to_save, SAVE_DELAY)
 
     @callback
-    def _data_to_save(self) -> dict[str, list[dict[str, Any]]]:
+    def _data_to_save(self) -> dict[str, list[json_fragment]]:
         """Return data to save."""
         return {
             "entries": [entry.as_storage_fragment for entry in self._entries.values()]

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -57,7 +57,7 @@ from .helpers.event import (
     async_call_later,
 )
 from .helpers.frame import report
-from .helpers.json import json_bytes, json_fragment
+from .helpers.json import json_bytes, json_bytes_sorted, json_fragment
 from .helpers.typing import UNDEFINED, ConfigType, DiscoveryInfoType, UndefinedType
 from .loader import async_suggest_report_issue
 from .setup import (
@@ -247,14 +247,13 @@ type UpdateListenerType = Callable[
     [HomeAssistant, ConfigEntry], Coroutine[Any, Any, None]
 ]
 
-FROZEN_CONFIG_ENTRY_ATTRS = {
-    "entry_id",
-    "domain",
+STATE_KEYS = {
     "state",
     "reason",
     "error_reason_translation_key",
     "error_reason_translation_placeholders",
 }
+FROZEN_CONFIG_ENTRY_ATTRS = {"entry_id", "domain", *STATE_KEYS}
 UPDATE_ENTRY_CONFIG_ENTRY_ATTRS = {
     "unique_id",
     "title",
@@ -447,7 +446,8 @@ class ConfigEntry(Generic[_DataT]):
             raise AttributeError(f"{key} cannot be changed")
 
         super().__setattr__(key, value)
-        self.clear_cache()
+        self.clear_state_cache()
+        self.clear_storage_cache()
 
     @property
     def supports_options(self) -> bool:
@@ -473,18 +473,18 @@ class ConfigEntry(Generic[_DataT]):
             )
         return self._supports_reconfigure or False
 
-    def clear_cache(self) -> None:
-        """Clear cached properties."""
+    def clear_state_cache(self) -> None:
+        """Clear cached properties that are included in as_json_fragment."""
         self.__dict__.pop("as_json_fragment", None)
 
     @cached_property
     def as_json_fragment(self) -> json_fragment:
-        """Return JSON fragment of a config entry."""
+        """Return JSON fragment of a config entry that is used for the API."""
         json_repr = {
-            "created_at": self.created_at.timestamp(),
+            "created_at": self.created_at,
             "entry_id": self.entry_id,
             "domain": self.domain,
-            "modified_at": self.modified_at.timestamp(),
+            "modified_at": self.modified_at,
             "title": self.title,
             "source": self.source,
             "state": self.state.value,
@@ -500,6 +500,15 @@ class ConfigEntry(Generic[_DataT]):
             "error_reason_translation_placeholders": self.error_reason_translation_placeholders,
         }
         return json_fragment(json_bytes(json_repr))
+
+    def clear_storage_cache(self) -> None:
+        """Clear cached properties that are included in as_storage_fragment."""
+        self.__dict__.pop("as_storage_fragment", None)
+
+    @cached_property
+    def as_storage_fragment(self) -> json_fragment:
+        """Return a storage fragment for this entry."""
+        return json_fragment(json_bytes_sorted(self.as_dict()))
 
     async def async_setup(
         self,
@@ -833,7 +842,8 @@ class ConfigEntry(Generic[_DataT]):
         """Invoke remove callback on component."""
         old_modified_at = self.modified_at
         object.__setattr__(self, "modified_at", utcnow())
-        self.clear_cache()
+        self.clear_state_cache()
+        self.clear_storage_cache()
 
         if self.source == SOURCE_IGNORE:
             return
@@ -890,7 +900,10 @@ class ConfigEntry(Generic[_DataT]):
             "error_reason_translation_placeholders",
             error_reason_translation_placeholders,
         )
-        self.clear_cache()
+        self.clear_state_cache()
+        # Storage cache is not cleared here because the state is not stored
+        # in storage and we do not want to clear the cache on every state change
+        # since state changes are frequent.
         async_dispatcher_send_internal(
             hass, SIGNAL_CONFIG_ENTRY_CHANGED, ConfigEntryChange.UPDATED, self
         )
@@ -1663,7 +1676,8 @@ class ConfigEntryItems(UserDict[str, ConfigEntry]):
         self._unindex_entry(entry_id)
         object.__setattr__(entry, "unique_id", new_unique_id)
         self._index_entry(entry)
-        entry.clear_cache()
+        entry.clear_state_cache()
+        entry.clear_storage_cache()
 
     def get_entries_for_domain(self, domain: str) -> list[ConfigEntry]:
         """Get entries for a domain."""
@@ -2138,7 +2152,8 @@ class ConfigEntries:
             )
 
         self._async_schedule_save()
-        entry.clear_cache()
+        entry.clear_state_cache()
+        entry.clear_storage_cache()
         self._async_dispatch(ConfigEntryChange.UPDATED, entry)
         return True
 
@@ -2321,7 +2336,9 @@ class ConfigEntries:
     @callback
     def _data_to_save(self) -> dict[str, list[dict[str, Any]]]:
         """Return data to save."""
-        return {"entries": [entry.as_dict() for entry in self._entries.values()]}
+        return {
+            "entries": [entry.as_storage_fragment for entry in self._entries.values()]
+        }
 
     async def async_wait_component(self, entry: ConfigEntry) -> bool:
         """Wait for an entry's component to load and return if the entry is loaded.

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -2334,7 +2334,7 @@ class ConfigEntries:
         self._store.async_delay_save(self._data_to_save, SAVE_DELAY)
 
     @callback
-    def _data_to_save(self) -> dict[str, list[json_fragment]]:
+    def _data_to_save(self) -> dict[str, list[dict[str, Any]]]:
         """Return data to save."""
         return {
             "entries": [entry.as_storage_fragment for entry in self._entries.values()]

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1693,7 +1693,7 @@ class ConfigEntryItems(UserDict[str, ConfigEntry]):
         return self._domain_unique_id_index.get(domain, {}).get(unique_id)
 
 
-class ConfigEntryStore(storage.Store[dict[str, list[dict[str, Any]]]]):
+class ConfigEntryStore(storage.Store[dict[str, list[json_fragment]]]):
     """Class to help storing config entry data."""
 
     def __init__(self, hass: HomeAssistant) -> None:

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -2336,8 +2336,9 @@ class ConfigEntries:
     @callback
     def _data_to_save(self) -> dict[str, list[dict[str, Any]]]:
         """Return data to save."""
+        # typing does not know that the storage fragment will serialize to a dict
         return {
-            "entries": [entry.as_storage_fragment for entry in self._entries.values()]
+            "entries": [entry.as_storage_fragment for entry in self._entries.values()]  # type: ignore[misc]
         }
 
     async def async_wait_component(self, entry: ConfigEntry) -> bool:

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1693,7 +1693,7 @@ class ConfigEntryItems(UserDict[str, ConfigEntry]):
         return self._domain_unique_id_index.get(domain, {}).get(unique_id)
 
 
-class ConfigEntryStore(storage.Store[dict[str, list[json_fragment]]]):
+class ConfigEntryStore(storage.Store[dict[str, list[dict[str, Any]]]]):
     """Class to help storing config entry data."""
 
     def __init__(self, hass: HomeAssistant) -> None:

--- a/homeassistant/helpers/json.py
+++ b/homeassistant/helpers/json.py
@@ -162,13 +162,17 @@ def json_dumps(data: Any) -> str:
     return json_bytes(data).decode("utf-8")
 
 
+json_bytes_sorted = partial(
+    orjson.dumps,
+    option=orjson.OPT_NON_STR_KEYS | orjson.OPT_SORT_KEYS,
+    default=json_encoder_default,
+)
+"""Dump json bytes with keys sorted."""
+
+
 def json_dumps_sorted(data: Any) -> str:
     """Dump json string with keys sorted."""
-    return orjson.dumps(
-        data,
-        option=orjson.OPT_NON_STR_KEYS | orjson.OPT_SORT_KEYS,
-        default=json_encoder_default,
-    ).decode("utf-8")
+    return json_bytes_sorted(data).decode("utf-8")
 
 
 JSON_DUMP: Final = json_dumps

--- a/tests/helpers/test_json.py
+++ b/tests/helpers/test_json.py
@@ -18,6 +18,7 @@ from homeassistant.helpers.json import (
     ExtendedJSONEncoder,
     JSONEncoder as DefaultHASSJSONEncoder,
     find_paths_unserializable_data,
+    json_bytes_sorted,
     json_bytes_strip_null,
     json_dumps,
     json_dumps_sorted,
@@ -105,6 +106,14 @@ def test_json_dumps_sorted() -> None:
     assert json_dumps_sorted(data) == json.dumps(
         data, sort_keys=True, separators=(",", ":")
     )
+
+
+def test_json_bytes_sorted() -> None:
+    """Test the json bytes sorted function."""
+    data = {"c": 3, "a": 1, "b": 2}
+    assert json_bytes_sorted(data) == json.dumps(
+        data, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
 
 
 def test_json_dumps_float_subclass() -> None:

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -40,11 +40,13 @@ from homeassistant.exceptions import (
 from homeassistant.helpers import entity_registry as er, issue_registry as ir
 from homeassistant.helpers.discovery_flow import DiscoveryKey
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.json import json_dumps
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.setup import async_set_domains_to_be_loaded, async_setup_component
 from homeassistant.util.async_ import create_eager_task
 import homeassistant.util.dt as dt_util
+from homeassistant.util.json import json_loads
 
 from .common import (
     MockConfigEntry,
@@ -6590,3 +6592,50 @@ async def test_reauth_helper_alignment(
     # Ensure context and init data are aligned
     assert helper_flow_context == reauth_flow_context
     assert helper_flow_init_data == reauth_flow_init_data
+
+
+def test_state_not_stored_in_storage() -> None:
+    """Test that state is not stored in storage.
+
+    Verify we don't start accidentally storing state in storage.
+    """
+    entry = MockConfigEntry(
+        domain="test",
+    )
+    loaded = json_loads(json_dumps(entry.as_storage_fragment))
+    for key in config_entries.STATE_KEYS:
+        assert key not in loaded
+
+
+def test_storage_cache_is_cleared_on_entry_update(hass: HomeAssistant) -> None:
+    """Test that the storage cache is cleared when an entry is updated."""
+    entry = MockConfigEntry(domain="test")
+    entry.add_to_hass(hass)
+    _ = entry.as_storage_fragment
+    hass.config_entries.async_update_entry(entry, data={"new": "data"})
+    loaded = json_loads(json_dumps(entry.as_storage_fragment))
+    assert "new" in loaded["data"]
+
+
+async def test_storage_cache_is_cleared_on_entry_disable(hass: HomeAssistant) -> None:
+    """Test that the storage cache is cleared when an entry is disabled."""
+    entry = MockConfigEntry(domain="test")
+    entry.add_to_hass(hass)
+    _ = entry.as_storage_fragment
+    await hass.config_entries.async_set_disabled_by(
+        entry.entry_id, config_entries.ConfigEntryDisabler.USER
+    )
+    loaded = json_loads(json_dumps(entry.as_storage_fragment))
+    assert loaded["disabled_by"] == "user"
+
+
+async def test_state_cache_is_cleared_on_entry_disable(hass: HomeAssistant) -> None:
+    """Test that the state cache is cleared when an entry is disabled."""
+    entry = MockConfigEntry(domain="test")
+    entry.add_to_hass(hass)
+    _ = entry.as_storage_fragment
+    await hass.config_entries.async_set_disabled_by(
+        entry.entry_id, config_entries.ConfigEntryDisabler.USER
+    )
+    loaded = json_loads(json_dumps(entry.as_json_fragment))
+    assert loaded["disabled_by"] == "user"

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -6599,9 +6599,7 @@ def test_state_not_stored_in_storage() -> None:
 
     Verify we don't start accidentally storing state in storage.
     """
-    entry = MockConfigEntry(
-        domain="test",
-    )
+    entry = MockConfigEntry(domain="test")
     loaded = json_loads(json_dumps(entry.as_storage_fragment))
     for key in config_entries.STATE_KEYS:
         assert key not in loaded


### PR DESCRIPTION



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently we only cache the serialization of the highly active registries, however with the addition of discovery_key to config entries, we end up saving them an order of magnitude more often (sometime more). The same technique we use for the registries has been applied to config entries to avoid having to reserialize all the entries that have not changed since in most cases its only a single entry changing


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
