### PR TITLE
Allow smlight device to reboot before updating firmware data coordinator

### DIFF
--- a/homeassistant/components/smlight/update.py
+++ b/homeassistant/components/smlight/update.py
@@ -159,7 +159,6 @@ class SmUpdateEntity(SmEntity, UpdateEntity):
     def _update_done(self) -> None:
         """Handle cleanup for update done."""
         self._finished_event.set()
-        self.coordinator.in_progress = False
 
         for remove_cb in self._unload:
             remove_cb()
@@ -178,7 +177,7 @@ class SmUpdateEntity(SmEntity, UpdateEntity):
     @callback
     def _update_failed(self, event: MessageEvent) -> None:
         self._update_done()
-
+        self.coordinator.in_progress = False
         raise HomeAssistantError(f"Update failed for {self.name}")
 
     async def async_install(
@@ -197,5 +196,13 @@ class SmUpdateEntity(SmEntity, UpdateEntity):
             # block until update finished event received
             await self._finished_event.wait()
 
-            await self.coordinator.async_refresh()
+            # allow time for SLZB-06 to reboot before updating coordinator data
+            while (
+                self.coordinator.in_progress
+                and self.installed_version != self._firmware.ver
+            ):
+                await self.coordinator.async_refresh()
+                await asyncio.sleep(0)
+
+            self.coordinator.in_progress = False
             self._finished_event.clear()

--- a/homeassistant/components/smlight/update.py
+++ b/homeassistant/components/smlight/update.py
@@ -202,7 +202,7 @@ class SmUpdateEntity(SmEntity, UpdateEntity):
                 and self.installed_version != self._firmware.ver
             ):
                 await self.coordinator.async_refresh()
-                await asyncio.sleep(0)
+                await asyncio.sleep(1)
 
             self.coordinator.in_progress = False
             self._finished_event.clear()

--- a/homeassistant/components/smlight/update.py
+++ b/homeassistant/components/smlight/update.py
@@ -207,7 +207,10 @@ class SmUpdateEntity(SmEntity, UpdateEntity):
                         await self.coordinator.async_refresh()
                         await asyncio.sleep(1)
             except TimeoutError:
-                LOGGER.warning("Timeout waiting for SLZB-06 to reboot after update")
+                LOGGER.warning(
+                    "Timeout waiting for %s to reboot after update",
+                    self.coordinator.data.info.hostname,
+                )
 
             self.coordinator.in_progress = False
             self._finished_event.clear()

--- a/tests/components/smlight/test_update.py
+++ b/tests/components/smlight/test_update.py
@@ -1,5 +1,6 @@
 """Tests for the SMLIGHT update platform."""
 
+from datetime import timedelta
 from unittest.mock import MagicMock
 
 from freezegun.api import FrozenDateTimeFactory
@@ -126,7 +127,7 @@ async def test_update_firmware(
         sw_version="v2.5.2",
     )
 
-    freezer.tick(SCAN_FIRMWARE_INTERVAL)
+    freezer.tick(timedelta(seconds=5))
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 

--- a/tests/components/smlight/test_update.py
+++ b/tests/components/smlight/test_update.py
@@ -1,7 +1,7 @@
 """Tests for the SMLIGHT update platform."""
 
 from datetime import timedelta
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from freezegun.api import FrozenDateTimeFactory
 from pysmlight import Firmware, Info
@@ -89,7 +89,9 @@ async def test_update_setup(
     await hass.config_entries.async_unload(entry.entry_id)
 
 
+@patch("homeassistant.components.smlight.update.asyncio.sleep", return_value=None)
 async def test_update_firmware(
+    mock_sleep: MagicMock,
     hass: HomeAssistant,
     freezer: FrozenDateTimeFactory,
     mock_config_entry: MockConfigEntry,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Seems there is a race condition between data coordinator update and SLZB-06 device reboot. If update occurs before reboot it will return old version and makes it look like update didn't complete. Add a small delay to allow SLZB-06 device time to reboot before coordinator update.

Can we pick this bug fix for next stable release.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes # 127422
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
