### PR TITLE
Fix config entry unique_id collision in lamarzocco tests

### DIFF
--- a/tests/components/lamarzocco/conftest.py
+++ b/tests/components/lamarzocco/conftest.py
@@ -24,7 +24,7 @@ def mock_config_entry(
     hass: HomeAssistant, mock_lamarzocco: MagicMock
 ) -> MockConfigEntry:
     """Return the default mocked config entry."""
-    entry = MockConfigEntry(
+    return MockConfigEntry(
         title="My LaMarzocco",
         domain=DOMAIN,
         version=2,
@@ -37,8 +37,25 @@ def mock_config_entry(
         },
         unique_id=mock_lamarzocco.serial_number,
     )
-    entry.add_to_hass(hass)
-    return entry
+
+
+@pytest.fixture
+def mock_config_entry_no_local_connection(
+    hass: HomeAssistant, mock_lamarzocco: MagicMock
+) -> MockConfigEntry:
+    """Return the default mocked config entry."""
+    return MockConfigEntry(
+        title="My LaMarzocco",
+        domain=DOMAIN,
+        version=2,
+        data=USER_INPUT
+        | {
+            CONF_MODEL: mock_lamarzocco.model,
+            CONF_TOKEN: "token",
+            CONF_NAME: "GS3",
+        },
+        unique_id=mock_lamarzocco.serial_number,
+    )
 
 
 @pytest.fixture
@@ -129,17 +146,6 @@ def mock_lamarzocco(device_fixture: MachineModel) -> Generator[MagicMock]:
         lamarzocco.firmware[FirmwareType.MACHINE].latest_version = "1.55"
 
         yield lamarzocco
-
-
-@pytest.fixture
-def remove_local_connection(
-    hass: HomeAssistant, mock_config_entry: MockConfigEntry
-) -> MockConfigEntry:
-    """Remove the local connection."""
-    data = mock_config_entry.data.copy()
-    del data[CONF_HOST]
-    hass.config_entries.async_update_entry(mock_config_entry, data=data)
-    return mock_config_entry
 
 
 @pytest.fixture(autouse=True)

--- a/tests/components/lamarzocco/test_binary_sensor.py
+++ b/tests/components/lamarzocco/test_binary_sensor.py
@@ -5,7 +5,6 @@ from unittest.mock import MagicMock
 
 from freezegun.api import FrozenDateTimeFactory
 from lmcloud.exceptions import RequestNotSuccessful
-import pytest
 from syrupy import SnapshotAssertion
 
 from homeassistant.const import STATE_UNAVAILABLE
@@ -47,15 +46,14 @@ async def test_binary_sensors(
         assert entry == snapshot(name=f"{serial_number}_{binary_sensor}-entry")
 
 
-@pytest.mark.usefixtures("remove_local_connection")
 async def test_brew_active_does_not_exists(
     hass: HomeAssistant,
     mock_lamarzocco: MagicMock,
-    mock_config_entry: MockConfigEntry,
+    mock_config_entry_no_local_connection: MockConfigEntry,
 ) -> None:
     """Test the La Marzocco currently_making_coffee doesn't exist if host not set."""
 
-    await async_init_integration(hass, mock_config_entry)
+    await async_init_integration(hass, mock_config_entry_no_local_connection)
     state = hass.states.get(f"sensor.{mock_lamarzocco.serial_number}_brewing_active")
     assert state is None
 

--- a/tests/components/lamarzocco/test_sensor.py
+++ b/tests/components/lamarzocco/test_sensor.py
@@ -47,15 +47,14 @@ async def test_sensors(
         assert entry == snapshot(name=f"{serial_number}_{sensor}-entry")
 
 
-@pytest.mark.usefixtures("remove_local_connection")
 async def test_shot_timer_not_exists(
     hass: HomeAssistant,
     mock_lamarzocco: MagicMock,
-    mock_config_entry: MockConfigEntry,
+    mock_config_entry_no_local_connection: MockConfigEntry,
 ) -> None:
     """Test the La Marzocco shot timer doesn't exist if host not set."""
 
-    await async_init_integration(hass, mock_config_entry)
+    await async_init_integration(hass, mock_config_entry_no_local_connection)
     state = hass.states.get(f"sensor.{mock_lamarzocco.serial_number}_shot_timer")
     assert state is None
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix config entry unique_id collision in lamarzocco tests

The collision happened in tests of config entry migration

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
