### PR TITLE
Use exposed error messages in Assist

### DIFF
--- a/homeassistant/components/conversation/default_agent.py
+++ b/homeassistant/components/conversation/default_agent.py
@@ -875,11 +875,6 @@ class DefaultAgent(ConversationEntity):
         start = time.monotonic()
 
         entity_registry = er.async_get(self.hass)
-        # states = [
-        #     state
-        #     for state in self.hass.states.async_all()
-        #     if async_should_expose(self.hass, DOMAIN, state.entity_id)
-        # ]
 
         # Gather entity names, keeping track of exposed names.
         # We try intent recognition with only exposed names first, then all names.

--- a/homeassistant/helpers/intent.py
+++ b/homeassistant/helpers/intent.py
@@ -647,6 +647,12 @@ def async_match_targets(  # noqa: C901
                     False, MatchFailedReason.AREA, areas=targeted_areas
                 )
 
+    if constraints.assistant:
+        # Check exposure
+        candidates = [c for c in candidates if c.is_exposed]
+        if not candidates:
+            return MatchTargetsResult(False, MatchFailedReason.ASSISTANT)
+
     if constraints.name and (not constraints.allow_duplicate_names):
         # Check for duplicates
         if not areas_added:
@@ -691,13 +697,6 @@ def async_match_targets(  # noqa: C901
                     final_candidates.extend(group_candidates)
                     continue
 
-            # Try to disambiguate by exposure
-            exposed_candidates = [c for c in group_candidates if c.is_exposed]
-            if len(exposed_candidates) < 2:
-                # Only one candidate was exposed
-                final_candidates.extend(exposed_candidates)
-                continue
-
             # Couldn't disambiguate duplicate names
             return MatchTargetsResult(
                 False,
@@ -716,12 +715,6 @@ def async_match_targets(  # noqa: C901
             )
 
         candidates = final_candidates
-
-    if constraints.assistant:
-        # Check exposure
-        candidates = [c for c in candidates if c.is_exposed]
-        if not candidates:
-            return MatchTargetsResult(False, MatchFailedReason.ASSISTANT)
 
     return MatchTargetsResult(
         True,

--- a/homeassistant/helpers/intent.py
+++ b/homeassistant/helpers/intent.py
@@ -23,7 +23,6 @@ from homeassistant.const import (
 )
 from homeassistant.core import Context, HomeAssistant, State, callback
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import entity as entity_helper
 from homeassistant.loader import bind_hass
 from homeassistant.util.hass_dict import HassKey
 
@@ -31,6 +30,7 @@ from . import (
     area_registry,
     config_validation as cv,
     device_registry,
+    entity as entity_helper,
     entity_registry,
     floor_registry,
 )

--- a/homeassistant/helpers/intent.py
+++ b/homeassistant/helpers/intent.py
@@ -518,25 +518,14 @@ def async_match_targets(  # noqa: C901
     candidates = [
         MatchTargetsCandidate(
             state=state,
-            is_exposed=async_should_expose(
-                hass, constraints.assistant, state.entity_id
+            is_exposed=(
+                async_should_expose(hass, constraints.assistant, state.entity_id)
+                if constraints.assistant
+                else True
             ),
         )
         for state in states
     ]
-
-    # if constraints.assistant:
-    #     # Filter by exposure
-    #     exposed_states: list[State] = []
-    #     for state in states:
-    #         if async_should_expose(hass, constraints.assistant, state.entity_id):
-    #             exposed_states.append(state)
-    #         else:
-    #             unexposed_states.append(state)
-
-    #     states = exposed_states
-    #     if not states:
-    #         return MatchTargetsResult(False, MatchFailedReason.ASSISTANT)
 
     if constraints.domains and (not filtered_by_domain):
         # Filter by domain (if we didn't already do it)

--- a/tests/components/climate/test_intent.py
+++ b/tests/components/climate/test_intent.py
@@ -371,7 +371,7 @@ async def test_not_exposed(
             {"name": {"value": climate_1.name}},
             assistant=conversation.DOMAIN,
         )
-    assert err.value.result.no_match_reason == intent.MatchFailedReason.NAME
+    assert err.value.result.no_match_reason == intent.MatchFailedReason.ASSISTANT
 
     # Expose first, hide second
     async_expose_entity(hass, conversation.DOMAIN, climate_1.entity_id, True)

--- a/tests/components/conversation/snapshots/test_default_agent.ambr
+++ b/tests/components/conversation/snapshots/test_default_agent.ambr
@@ -168,7 +168,7 @@
       'speech': dict({
         'plain': dict({
           'extra_data': None,
-          'speech': 'Sorry, I am not aware of any device called kitchen light',
+          'speech': 'Sorry, kitchen light is not exposed',
         }),
       }),
     }),
@@ -358,7 +358,7 @@
       'speech': dict({
         'plain': dict({
           'extra_data': None,
-          'speech': 'Sorry, I am not aware of any device called kitchen light',
+          'speech': 'Sorry, kitchen light is not exposed',
         }),
       }),
     }),

--- a/tests/components/conversation/test_default_agent.py
+++ b/tests/components/conversation/test_default_agent.py
@@ -1249,12 +1249,48 @@ async def test_error_duplicate_names(
 
 
 @pytest.mark.usefixtures("init_components")
-async def test_error_duplicate_names_in_area(
+async def test_duplicate_names_but_one_is_exposed(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
+    """Test when multiple devices have the same name (or alias), but only one of them is exposed."""
+    kitchen_light_1 = entity_registry.async_get_or_create("light", "demo", "1234")
+    kitchen_light_2 = entity_registry.async_get_or_create("light", "demo", "5678")
+
+    # Same name and alias
+    for light in (kitchen_light_1, kitchen_light_2):
+        light = entity_registry.async_update_entity(
+            light.entity_id,
+            name="kitchen light",
+            aliases={"overhead light"},
+        )
+        hass.states.async_set(
+            light.entity_id,
+            "off",
+            attributes={ATTR_FRIENDLY_NAME: light.name},
+        )
+
+    # Only expose one
+    expose_entity(hass, kitchen_light_1.entity_id, True)
+    expose_entity(hass, kitchen_light_2.entity_id, False)
+
+    # Check name and alias
+    async_mock_service(hass, "light", "turn_on")
+    for name in ("kitchen light", "overhead light"):
+        # command
+        result = await conversation.async_converse(
+            hass, f"turn on {name}", None, Context(), None
+        )
+        assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+        assert result.response.matched_states[0].entity_id == kitchen_light_1.entity_id
+
+
+@pytest.mark.usefixtures("init_components")
+async def test_error_duplicate_names_same_area(
     hass: HomeAssistant,
     area_registry: ar.AreaRegistry,
     entity_registry: er.EntityRegistry,
 ) -> None:
-    """Test error message when multiple devices have the same name (or alias)."""
+    """Test error message when multiple devices have the same name (or alias) in the same area."""
     area_kitchen = area_registry.async_get_or_create("kitchen_id")
     area_kitchen = area_registry.async_update(area_kitchen.id, name="kitchen")
 
@@ -1304,6 +1340,127 @@ async def test_error_duplicate_names_in_area(
             result.response.speech["plain"]["speech"]
             == f"Sorry, there are multiple devices called {name} in the {area_kitchen.name} area"
         )
+
+
+@pytest.mark.usefixtures("init_components")
+async def test_duplicate_names_same_area_but_one_is_exposed(
+    hass: HomeAssistant,
+    area_registry: ar.AreaRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test when multiple devices have the same name (or alias) in the same area but only one is exposed."""
+    area_kitchen = area_registry.async_get_or_create("kitchen_id")
+    area_kitchen = area_registry.async_update(area_kitchen.id, name="kitchen")
+
+    kitchen_light_1 = entity_registry.async_get_or_create("light", "demo", "1234")
+    kitchen_light_2 = entity_registry.async_get_or_create("light", "demo", "5678")
+
+    # Same name and alias
+    for light in (kitchen_light_1, kitchen_light_2):
+        light = entity_registry.async_update_entity(
+            light.entity_id,
+            name="kitchen light",
+            area_id=area_kitchen.id,
+            aliases={"overhead light"},
+        )
+        hass.states.async_set(
+            light.entity_id,
+            "off",
+            attributes={ATTR_FRIENDLY_NAME: light.name},
+        )
+
+    # Only expose one
+    expose_entity(hass, kitchen_light_1.entity_id, True)
+    expose_entity(hass, kitchen_light_2.entity_id, False)
+
+    # Check name and alias
+    async_mock_service(hass, "light", "turn_on")
+    for name in ("kitchen light", "overhead light"):
+        # command
+        result = await conversation.async_converse(
+            hass, f"turn on {name} in {area_kitchen.name}", None, Context(), None
+        )
+        assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+        assert result.response.matched_states[0].entity_id == kitchen_light_1.entity_id
+
+
+@pytest.mark.usefixtures("init_components")
+async def test_duplicate_names_different_areas(
+    hass: HomeAssistant,
+    area_registry: ar.AreaRegistry,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test preferred area when multiple devices have the same name (or alias) in different areas."""
+    area_kitchen = area_registry.async_get_or_create("kitchen_id")
+    area_kitchen = area_registry.async_update(area_kitchen.id, name="kitchen")
+
+    area_bedroom = area_registry.async_get_or_create("bedroom_id")
+    area_bedroom = area_registry.async_update(area_bedroom.id, name="bedroom")
+
+    kitchen_light = entity_registry.async_get_or_create("light", "demo", "1234")
+    kitchen_light = entity_registry.async_update_entity(
+        kitchen_light.entity_id, area_id=area_kitchen.id
+    )
+    bedroom_light = entity_registry.async_get_or_create("light", "demo", "5678")
+    bedroom_light = entity_registry.async_update_entity(
+        bedroom_light.entity_id, area_id=area_bedroom.id
+    )
+
+    # Same name and alias
+    for light in (kitchen_light, bedroom_light):
+        light = entity_registry.async_update_entity(
+            light.entity_id,
+            name="test light",
+            aliases={"overhead light"},
+        )
+        hass.states.async_set(
+            light.entity_id,
+            "off",
+            attributes={ATTR_FRIENDLY_NAME: light.name},
+        )
+
+    # Add a satellite in the kitchen and bedroom
+    kitchen_entry = MockConfigEntry()
+    kitchen_entry.add_to_hass(hass)
+    device_kitchen = device_registry.async_get_or_create(
+        config_entry_id=kitchen_entry.entry_id,
+        connections=set(),
+        identifiers={("demo", "device-kitchen")},
+    )
+    device_registry.async_update_device(device_kitchen.id, area_id=area_kitchen.id)
+
+    bedroom_entry = MockConfigEntry()
+    bedroom_entry.add_to_hass(hass)
+    device_bedroom = device_registry.async_get_or_create(
+        config_entry_id=bedroom_entry.entry_id,
+        connections=set(),
+        identifiers={("demo", "device-bedroom")},
+    )
+    device_registry.async_update_device(device_bedroom.id, area_id=area_bedroom.id)
+
+    # Check name and alias
+    async_mock_service(hass, "light", "turn_on")
+    for name in ("test light", "overhead light"):
+        # Should fail without a preferred area
+        result = await conversation.async_converse(
+            hass, f"turn on {name}", None, Context(), None
+        )
+        assert result.response.response_type == intent.IntentResponseType.ERROR
+
+        # Target kitchen light by using kitchen device
+        result = await conversation.async_converse(
+            hass, f"turn on {name}", None, Context(), None, device_id=device_kitchen.id
+        )
+        assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+        assert result.response.matched_states[0].entity_id == kitchen_light.entity_id
+
+        # Target bedroom light by using bedroom device
+        result = await conversation.async_converse(
+            hass, f"turn on {name}", None, Context(), None, device_id=device_bedroom.id
+        )
+        assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+        assert result.response.matched_states[0].entity_id == bedroom_light.entity_id
 
 
 @pytest.mark.usefixtures("init_components")

--- a/tests/components/conversation/test_default_agent.py
+++ b/tests/components/conversation/test_default_agent.py
@@ -581,7 +581,7 @@ async def test_device_area_context(
 
 @pytest.mark.usefixtures("init_components")
 async def test_error_no_device(hass: HomeAssistant) -> None:
-    """Test error message when device/entity is missing."""
+    """Test error message when device/entity doesn't exist."""
     result = await conversation.async_converse(
         hass, "turn on missing entity", None, Context(), None
     )
@@ -595,8 +595,26 @@ async def test_error_no_device(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.usefixtures("init_components")
+async def test_error_no_device_exposed(hass: HomeAssistant) -> None:
+    """Test error message when device/entity exists but is not exposed."""
+    hass.states.async_set("light.kitchen_light", "off")
+    expose_entity(hass, "light.kitchen_light", False)
+
+    result = await conversation.async_converse(
+        hass, "turn on kitchen light", None, Context(), None
+    )
+
+    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.error_code == intent.IntentResponseErrorCode.NO_VALID_TARGETS
+    assert (
+        result.response.speech["plain"]["speech"]
+        == "Sorry, kitchen light is not exposed"
+    )
+
+
+@pytest.mark.usefixtures("init_components")
 async def test_error_no_area(hass: HomeAssistant) -> None:
-    """Test error message when area is missing."""
+    """Test error message when area doesn't exist."""
     result = await conversation.async_converse(
         hass, "turn on the lights in missing area", None, Context(), None
     )
@@ -611,7 +629,7 @@ async def test_error_no_area(hass: HomeAssistant) -> None:
 
 @pytest.mark.usefixtures("init_components")
 async def test_error_no_floor(hass: HomeAssistant) -> None:
-    """Test error message when floor is missing."""
+    """Test error message when floor doesn't exist."""
     result = await conversation.async_converse(
         hass, "turn on all the lights on missing floor", None, Context(), None
     )
@@ -628,7 +646,7 @@ async def test_error_no_floor(hass: HomeAssistant) -> None:
 async def test_error_no_device_in_area(
     hass: HomeAssistant, area_registry: ar.AreaRegistry
 ) -> None:
-    """Test error message when area is missing a device/entity."""
+    """Test error message when area exists but is does not contain a device/entity."""
     area_kitchen = area_registry.async_get_or_create("kitchen_id")
     area_kitchen = area_registry.async_update(area_kitchen.id, name="kitchen")
     result = await conversation.async_converse(
@@ -640,6 +658,119 @@ async def test_error_no_device_in_area(
     assert (
         result.response.speech["plain"]["speech"]
         == "Sorry, I am not aware of any device called missing entity in the kitchen area"
+    )
+
+
+@pytest.mark.usefixtures("init_components")
+async def test_error_no_device_on_floor(
+    hass: HomeAssistant,
+    floor_registry: fr.FloorRegistry,
+) -> None:
+    """Test error message when floor exists but is does not contain a device/entity."""
+    floor_registry.async_create("ground")
+    result = await conversation.async_converse(
+        hass, "turn on missing entity on ground floor", None, Context(), None
+    )
+
+    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.error_code == intent.IntentResponseErrorCode.NO_VALID_TARGETS
+    assert (
+        result.response.speech["plain"]["speech"]
+        == "Sorry, I am not aware of any device called missing entity on ground floor"
+    )
+
+
+@pytest.mark.usefixtures("init_components")
+async def test_error_no_device_on_floor_exposed(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    area_registry: ar.AreaRegistry,
+    floor_registry: fr.FloorRegistry,
+) -> None:
+    """Test error message when a device/entity exists on a floor but isn't exposed."""
+    floor_ground = floor_registry.async_create("ground")
+
+    area_kitchen = area_registry.async_get_or_create("kitchen_id")
+    area_kitchen = area_registry.async_update(
+        area_kitchen.id, name="kitchen", floor_id=floor_ground.floor_id
+    )
+
+    kitchen_light = entity_registry.async_get_or_create("light", "demo", "1234")
+    kitchen_light = entity_registry.async_update_entity(
+        kitchen_light.entity_id,
+        name="test light",
+        area_id=area_kitchen.id,
+    )
+    hass.states.async_set(
+        kitchen_light.entity_id,
+        "off",
+        attributes={ATTR_FRIENDLY_NAME: kitchen_light.name},
+    )
+    expose_entity(hass, kitchen_light.entity_id, False)
+    await hass.async_block_till_done()
+
+    # We don't have a sentence for turning on devices by floor
+    name = MatchEntity(name="name", value=kitchen_light.name, text=kitchen_light.name)
+    floor = MatchEntity(name="floor", value=floor_ground.name, text=floor_ground.name)
+    recognize_result = RecognizeResult(
+        intent=Intent("HassTurnOn"),
+        intent_data=IntentData([]),
+        entities={"name": name, "floor": floor},
+        entities_list=[name, floor],
+    )
+
+    with patch(
+        "homeassistant.components.conversation.default_agent.recognize_all",
+        return_value=[recognize_result],
+    ):
+        result = await conversation.async_converse(
+            hass, "turn on test light on the ground floor", None, Context(), None
+        )
+
+        assert result.response.response_type == intent.IntentResponseType.ERROR
+        assert (
+            result.response.error_code
+            == intent.IntentResponseErrorCode.NO_VALID_TARGETS
+        )
+        assert (
+            result.response.speech["plain"]["speech"]
+            == "Sorry, test light in the ground floor is not exposed"
+        )
+
+
+@pytest.mark.usefixtures("init_components")
+async def test_error_no_device_in_area_exposed(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    area_registry: ar.AreaRegistry,
+) -> None:
+    """Test error message when a device/entity exists in an area but isn't exposed."""
+    area_kitchen = area_registry.async_get_or_create("kitchen_id")
+    area_kitchen = area_registry.async_update(area_kitchen.id, name="kitchen")
+
+    kitchen_light = entity_registry.async_get_or_create("light", "demo", "1234")
+    kitchen_light = entity_registry.async_update_entity(
+        kitchen_light.entity_id,
+        name="test light",
+        area_id=area_kitchen.id,
+    )
+    hass.states.async_set(
+        kitchen_light.entity_id,
+        "off",
+        attributes={ATTR_FRIENDLY_NAME: kitchen_light.name},
+    )
+    expose_entity(hass, kitchen_light.entity_id, False)
+    await hass.async_block_till_done()
+
+    result = await conversation.async_converse(
+        hass, "turn on test light in the kitchen", None, Context(), None
+    )
+
+    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.error_code == intent.IntentResponseErrorCode.NO_VALID_TARGETS
+    assert (
+        result.response.speech["plain"]["speech"]
+        == "Sorry, test light in the kitchen area is not exposed"
     )
 
 
@@ -676,6 +807,38 @@ async def test_error_no_domain(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.usefixtures("init_components")
+async def test_error_no_domain_exposed(hass: HomeAssistant) -> None:
+    """Test error message when devices/entities exist for a domain but are not exposed."""
+    hass.states.async_set("fan.test_fan", "off")
+    expose_entity(hass, "fan.test_fan", False)
+    await hass.async_block_till_done()
+
+    # We don't have a sentence for turning on all fans
+    fan_domain = MatchEntity(name="domain", value="fan", text="fans")
+    recognize_result = RecognizeResult(
+        intent=Intent("HassTurnOn"),
+        intent_data=IntentData([]),
+        entities={"domain": fan_domain},
+        entities_list=[fan_domain],
+    )
+
+    with patch(
+        "homeassistant.components.conversation.default_agent.recognize_all",
+        return_value=[recognize_result],
+    ):
+        result = await conversation.async_converse(
+            hass, "turn on the fans", None, Context(), None
+        )
+
+        assert result.response.response_type == intent.IntentResponseType.ERROR
+        assert (
+            result.response.error_code
+            == intent.IntentResponseErrorCode.NO_VALID_TARGETS
+        )
+        assert result.response.speech["plain"]["speech"] == "Sorry, no fan is exposed"
+
+
+@pytest.mark.usefixtures("init_components")
 async def test_error_no_domain_in_area(
     hass: HomeAssistant, area_registry: ar.AreaRegistry
 ) -> None:
@@ -695,7 +858,43 @@ async def test_error_no_domain_in_area(
 
 
 @pytest.mark.usefixtures("init_components")
-async def test_error_no_domain_in_floor(
+async def test_error_no_domain_in_area_exposed(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    area_registry: ar.AreaRegistry,
+) -> None:
+    """Test error message when devices/entities for a domain exist in an area but are not exposed."""
+    area_kitchen = area_registry.async_get_or_create("kitchen_id")
+    area_kitchen = area_registry.async_update(area_kitchen.id, name="kitchen")
+
+    kitchen_light = entity_registry.async_get_or_create("light", "demo", "1234")
+    kitchen_light = entity_registry.async_update_entity(
+        kitchen_light.entity_id,
+        name="test light",
+        area_id=area_kitchen.id,
+    )
+    hass.states.async_set(
+        kitchen_light.entity_id,
+        "off",
+        attributes={ATTR_FRIENDLY_NAME: kitchen_light.name},
+    )
+    expose_entity(hass, kitchen_light.entity_id, False)
+    await hass.async_block_till_done()
+
+    result = await conversation.async_converse(
+        hass, "turn on the lights in the kitchen", None, Context(), None
+    )
+
+    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.error_code == intent.IntentResponseErrorCode.NO_VALID_TARGETS
+    assert (
+        result.response.speech["plain"]["speech"]
+        == "Sorry, no light in the kitchen area is exposed"
+    )
+
+
+@pytest.mark.usefixtures("init_components")
+async def test_error_no_domain_on_floor(
     hass: HomeAssistant,
     area_registry: ar.AreaRegistry,
     floor_registry: fr.FloorRegistry,
@@ -733,6 +932,45 @@ async def test_error_no_domain_in_floor(
     assert (
         result.response.speech["plain"]["speech"]
         == "Sorry, I am not aware of any light on the upstairs floor"
+    )
+
+
+@pytest.mark.usefixtures("init_components")
+async def test_error_no_domain_on_floor_exposed(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    area_registry: ar.AreaRegistry,
+    floor_registry: fr.FloorRegistry,
+) -> None:
+    """Test error message when devices/entities for a domain exist on a floor but are not exposed."""
+    floor_ground = floor_registry.async_create("ground")
+    area_kitchen = area_registry.async_get_or_create("kitchen_id")
+    area_kitchen = area_registry.async_update(
+        area_kitchen.id, name="kitchen", floor_id=floor_ground.floor_id
+    )
+    kitchen_light = entity_registry.async_get_or_create("light", "demo", "1234")
+    kitchen_light = entity_registry.async_update_entity(
+        kitchen_light.entity_id,
+        name="test light",
+        area_id=area_kitchen.id,
+    )
+    hass.states.async_set(
+        kitchen_light.entity_id,
+        "off",
+        attributes={ATTR_FRIENDLY_NAME: kitchen_light.name},
+    )
+    expose_entity(hass, kitchen_light.entity_id, False)
+    await hass.async_block_till_done()
+
+    result = await conversation.async_converse(
+        hass, "turn on all lights on the ground floor", None, Context(), None
+    )
+
+    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.error_code == intent.IntentResponseErrorCode.NO_VALID_TARGETS
+    assert (
+        result.response.speech["plain"]["speech"]
+        == "Sorry, no light in the ground floor is exposed"
     )
 
 
@@ -778,6 +1016,54 @@ async def test_error_no_device_class(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.usefixtures("init_components")
+async def test_error_no_device_class_exposed(hass: HomeAssistant) -> None:
+    """Test error message when entities of a device class exist but aren't exposed."""
+    # Create a cover entity that is not a window.
+    # This ensures that the filtering below won't exit early because there are
+    # no entities in the cover domain.
+    hass.states.async_set(
+        "cover.garage_door",
+        STATE_CLOSED,
+        attributes={ATTR_DEVICE_CLASS: cover.CoverDeviceClass.GARAGE},
+    )
+
+    # Create a window an ensure it's not exposed
+    hass.states.async_set(
+        "cover.test_window",
+        STATE_CLOSED,
+        attributes={ATTR_DEVICE_CLASS: cover.CoverDeviceClass.WINDOW},
+    )
+    expose_entity(hass, "cover.test_window", False)
+
+    # We don't have a sentence for opening all windows
+    cover_domain = MatchEntity(name="domain", value="cover", text="cover")
+    window_class = MatchEntity(name="device_class", value="window", text="windows")
+    recognize_result = RecognizeResult(
+        intent=Intent("HassTurnOn"),
+        intent_data=IntentData([]),
+        entities={"domain": cover_domain, "device_class": window_class},
+        entities_list=[cover_domain, window_class],
+    )
+
+    with patch(
+        "homeassistant.components.conversation.default_agent.recognize_all",
+        return_value=[recognize_result],
+    ):
+        result = await conversation.async_converse(
+            hass, "open all the windows", None, Context(), None
+        )
+
+        assert result.response.response_type == intent.IntentResponseType.ERROR
+        assert (
+            result.response.error_code
+            == intent.IntentResponseErrorCode.NO_VALID_TARGETS
+        )
+        assert (
+            result.response.speech["plain"]["speech"] == "Sorry, no window is exposed"
+        )
+
+
+@pytest.mark.usefixtures("init_components")
 async def test_error_no_device_class_in_area(
     hass: HomeAssistant, area_registry: ar.AreaRegistry
 ) -> None:
@@ -794,6 +1080,99 @@ async def test_error_no_device_class_in_area(
         result.response.speech["plain"]["speech"]
         == "Sorry, I am not aware of any window in the bedroom area"
     )
+
+
+@pytest.mark.usefixtures("init_components")
+async def test_error_no_device_class_in_area_exposed(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    area_registry: ar.AreaRegistry,
+) -> None:
+    """Test error message when entities of a device class exist in an area but are not exposed."""
+    area_bedroom = area_registry.async_get_or_create("bedroom_id")
+    area_bedroom = area_registry.async_update(area_bedroom.id, name="bedroom")
+    bedroom_window = entity_registry.async_get_or_create("cover", "demo", "1234")
+    bedroom_window = entity_registry.async_update_entity(
+        bedroom_window.entity_id,
+        name="test cover",
+        area_id=area_bedroom.id,
+    )
+    hass.states.async_set(
+        bedroom_window.entity_id,
+        "off",
+        attributes={ATTR_DEVICE_CLASS: cover.CoverDeviceClass.WINDOW},
+    )
+    expose_entity(hass, bedroom_window.entity_id, False)
+    await hass.async_block_till_done()
+
+    result = await conversation.async_converse(
+        hass, "open bedroom windows", None, Context(), None
+    )
+
+    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.error_code == intent.IntentResponseErrorCode.NO_VALID_TARGETS
+    assert (
+        result.response.speech["plain"]["speech"]
+        == "Sorry, no window in the bedroom area is exposed"
+    )
+
+
+@pytest.mark.usefixtures("init_components")
+async def test_error_no_device_class_on_floor_exposed(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    area_registry: ar.AreaRegistry,
+    floor_registry: fr.FloorRegistry,
+) -> None:
+    """Test error message when entities of a device class exist in on a floor but are not exposed."""
+    floor_ground = floor_registry.async_create("ground")
+
+    area_bedroom = area_registry.async_get_or_create("bedroom_id")
+    area_bedroom = area_registry.async_update(
+        area_bedroom.id, name="bedroom", floor_id=floor_ground.floor_id
+    )
+    bedroom_window = entity_registry.async_get_or_create("cover", "demo", "1234")
+    bedroom_window = entity_registry.async_update_entity(
+        bedroom_window.entity_id,
+        name="test cover",
+        area_id=area_bedroom.id,
+    )
+    hass.states.async_set(
+        bedroom_window.entity_id,
+        "off",
+        attributes={ATTR_DEVICE_CLASS: cover.CoverDeviceClass.WINDOW},
+    )
+    expose_entity(hass, bedroom_window.entity_id, False)
+    await hass.async_block_till_done()
+
+    # We don't have a sentence for opening all windows on a floor
+    cover_domain = MatchEntity(name="domain", value="cover", text="cover")
+    window_class = MatchEntity(name="device_class", value="window", text="windows")
+    floor = MatchEntity(name="floor", value=floor_ground.name, text=floor_ground.name)
+    recognize_result = RecognizeResult(
+        intent=Intent("HassTurnOn"),
+        intent_data=IntentData([]),
+        entities={"domain": cover_domain, "device_class": window_class, "floor": floor},
+        entities_list=[cover_domain, window_class, floor],
+    )
+
+    with patch(
+        "homeassistant.components.conversation.default_agent.recognize_all",
+        return_value=[recognize_result],
+    ):
+        result = await conversation.async_converse(
+            hass, "open ground floor windows", None, Context(), None
+        )
+
+        assert result.response.response_type == intent.IntentResponseType.ERROR
+        assert (
+            result.response.error_code
+            == intent.IntentResponseErrorCode.NO_VALID_TARGETS
+        )
+        assert (
+            result.response.speech["plain"]["speech"]
+            == "Sorry, no window in the ground floor is exposed"
+        )
 
 
 @pytest.mark.usefixtures("init_components")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Assist includes error messages for 9 different cases where having an entity not exposed causes an intent match failure:
1. "turn on standing light" - entity named "standing light" is not exposed
2. "turn on lamp in living room" - entity named "lamp" is in living room, but not exposed
3. "turn on downstairs TV" - entity named "TV" is on the downstairs floor, but not exposed
4. "turn on all the lights" - no lights are exposed
5. "turn on lights in the kitchen" - no lights in the kitchen are exposed
6. "turn on lights upstairs" - no lights on the upstairs floor are exposed
7. "open all windows" - no covers with window device class are exposed
8. "open windows in the kitchen" - no windows in the kitchen are exposed
9. "open main floor windows" - no windows on the main floor are exposed

(**NOTE:** We don't have sentences for all of these cases yet)

This PR reports the correct error message for each case, and includes a test for each one. This required one large change, and several smaller changes.

The large change is that intent recognition now has 3 phrases instead of just 2. Previously, a strict match was attempted first and a fuzzy match second. Now, two strict matches are tried, one with only exposed entities, and the other with all entities. This is for cases 1-3 above, where we need to know that a device/entity exists, but is not exposed.

**QUESTION:** For the second strict match will all entities, can we filter down this list (for example, remove diagnostic entities or domains that Assist can't handle)?

The smaller changes were in `async_match_targets` keeping track of unexposed entities so that we could distinguish between a name/area/domain/device class not existing and not being exposed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
