### PR TITLE
Prevent `async_create_entry` from reauth/reconfigure flows

### DIFF
--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -2732,9 +2732,9 @@ class ConfigFlow(ConfigEntryBaseFlow):
             )
             _LOGGER.warning(
                 (
-                    "Detected %s config flow using `async_create_entry`, which "
-                    "can cause unexpected behavior and will stop working in %s. "
-                    "Please %s"
+                    "Detected %s config flow creating a new entry, "
+                    "when it is expected to update an existing entry and abort. "
+                    "This will stop working in %s, please %s"
                 ),
                 self.source,
                 "2025.11",

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -2726,6 +2726,12 @@ class ConfigFlow(ConfigEntryBaseFlow):
         options: Mapping[str, Any] | None = None,
     ) -> ConfigFlowResult:
         """Finish config flow and create a config entry."""
+        if self.source in {SOURCE_REAUTH, SOURCE_RECONFIGURE}:
+            raise ValueError(
+                f"Creating a new config entry from {self.source} is invalid, "
+                "please use `async_update_reload_and_abort` or `async_abort` "
+                f'with `reason="{self.source}_successful"'
+            )
         result = super().async_create_entry(
             title=title,
             data=data,

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -2727,10 +2727,18 @@ class ConfigFlow(ConfigEntryBaseFlow):
     ) -> ConfigFlowResult:
         """Finish config flow and create a config entry."""
         if self.source in {SOURCE_REAUTH, SOURCE_RECONFIGURE}:
-            raise ValueError(
-                f"Creating a new config entry from {self.source} can cause "
-                "unexpected behavior, please use `async_update_reload_and_abort` "
-                f'or `async_abort` with `reason="{self.source}_successful"'
+            report_issue = async_suggest_report_issue(
+                self.hass, integration_domain=self.handler
+            )
+            _LOGGER.warning(
+                (
+                    "Detected %s config flow using `async_create_entry`, which "
+                    "can cause unexpected behavior and will stop working in %s. "
+                    "Please %s"
+                ),
+                self.source,
+                "2025.11",
+                report_issue,
             )
         result = super().async_create_entry(
             title=title,

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -2728,9 +2728,9 @@ class ConfigFlow(ConfigEntryBaseFlow):
         """Finish config flow and create a config entry."""
         if self.source in {SOURCE_REAUTH, SOURCE_RECONFIGURE}:
             raise ValueError(
-                f"Creating a new config entry from {self.source} is invalid, "
-                "please use `async_update_reload_and_abort` or `async_abort` "
-                f'with `reason="{self.source}_successful"'
+                f"Creating a new config entry from {self.source} can cause "
+                "unexpected behavior, please use `async_update_reload_and_abort` "
+                f'or `async_abort` with `reason="{self.source}_successful"'
             )
         result = super().async_create_entry(
             title=title,

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -6870,7 +6870,7 @@ async def test_create_entry_reauth_reconfigure(
 
     assert (
         f"Detected {source} config flow creating a new entry, when it is expected "
-        "to update an existing entry. This will stop working in "
+        "to update an existing entry and abort. This will stop working in "
         "2025.11, please create a bug report at https://github.com/home"
         "-assistant/core/issues?q=is%3Aopen+is%3Aissue+"
         "label%3A%22integration%3A+test%22"

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -6869,9 +6869,9 @@ async def test_create_entry_reauth_reconfigure(
         assert len(entries) == 2
 
     assert (
-        f"Detected {source} config flow using `async_create_entry`, "
-        "which can cause unexpected behavior and will stop working in "
-        "2025.11. Please create a bug report at https://github.com/home"
+        f"Detected {source} config flow creating a new entry, when it is expected "
+        "to update an existing entry. This will stop working in "
+        "2025.11, please create a bug report at https://github.com/home"
         "-assistant/core/issues?q=is%3Aopen+is%3Aissue+"
         "label%3A%22integration%3A+test%22"
     ) in caplog.text

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -6791,12 +6791,12 @@ async def test_state_cache_is_cleared_on_entry_disable(hass: HomeAssistant) -> N
 
 
 @pytest.mark.parametrize(
-    ("original_unique_id", "new_unique_id"),
+    ("original_unique_id", "new_unique_id", "recreate"),
     [
-        ("unique", "unique"),
-        ("unique", "new"),
-        ("unique", None),
-        (None, "unique"),
+        ("unique", "unique", True),
+        ("unique", "new", False),
+        ("unique", None, False),
+        (None, "unique", False),
     ],
 )
 @pytest.mark.parametrize(
@@ -6808,6 +6808,7 @@ async def test_create_entry_reauth_reconfigure(
     source: str,
     original_unique_id: str | None,
     new_unique_id: str | None,
+    recreate: bool,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test to highlight unexpected behavior on create_entry."""
@@ -6859,7 +6860,7 @@ async def test_create_entry_reauth_reconfigure(
     assert result["type"] is FlowResultType.CREATE_ENTRY
 
     entries = hass.config_entries.async_entries("test")
-    if original_unique_id is not None and original_unique_id == new_unique_id:
+    if recreate:
         # Show that the previous entry got binned and recreated
         assert len(entries) == 1
         assert entries[0].entry_id != entry.entry_id

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -6791,12 +6791,12 @@ async def test_state_cache_is_cleared_on_entry_disable(hass: HomeAssistant) -> N
 
 
 @pytest.mark.parametrize(
-    ("original_unique_id", "new_unique_id", "recreate"),
+    ("original_unique_id", "new_unique_id", "count"),
     [
-        ("unique", "unique", True),
-        ("unique", "new", False),
-        ("unique", None, False),
-        (None, "unique", False),
+        ("unique", "unique", 1),
+        ("unique", "new", 2),
+        ("unique", None, 2),
+        (None, "unique", 2),
     ],
 )
 @pytest.mark.parametrize(
@@ -6808,7 +6808,7 @@ async def test_create_entry_reauth_reconfigure(
     source: str,
     original_unique_id: str | None,
     new_unique_id: str | None,
-    recreate: bool,
+    count: int,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test to highlight unexpected behavior on create_entry."""
@@ -6860,13 +6860,10 @@ async def test_create_entry_reauth_reconfigure(
     assert result["type"] is FlowResultType.CREATE_ENTRY
 
     entries = hass.config_entries.async_entries("test")
-    if recreate:
+    assert len(entries) == count
+    if count == 1:
         # Show that the previous entry got binned and recreated
-        assert len(entries) == 1
         assert entries[0].entry_id != entry.entry_id
-    else:
-        # Show that a new entry got created
-        assert len(entries) == 2
 
     assert (
         f"Detected {source} config flow creating a new entry, when it is expected "

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -6850,7 +6850,6 @@ async def test_create_entry_reauth_reconfigure(
 
     assert len(hass.config_entries.async_entries("test")) == 1
 
-    # A reauth flow does not have access to the config entry from context
     with mock_config_flow("test", TestFlow):
         if source == config_entries.SOURCE_REAUTH:
             result = await entry.start_reauth_flow(hass)

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -6852,10 +6852,7 @@ async def test_create_entry_reauth_reconfigure(
     assert len(hass.config_entries.async_entries("test")) == 1
 
     with mock_config_flow("test", TestFlow):
-        if source == config_entries.SOURCE_REAUTH:
-            result = await entry.start_reauth_flow(hass)
-        elif source == config_entries.SOURCE_RECONFIGURE:
-            result = await entry.start_reconfigure_flow(hass)
+        result = await getattr(entry, f"start_{source}_flow")(hass)
         await hass.async_block_till_done()
     assert result["type"] is FlowResultType.CREATE_ENTRY
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Use of `async_create_entry` within reauth and reconfigure flow causes new config entries to be created.
If an existing entry exists with the same unique_id, it will also cause the previous entry to be removed.

This invalid use of `async_create_entry` will be blocked from `2025.11`.
Please refactor to use `async_update_reload_and_abort` or `async_abort` with a valid reason (eg. `reauth_successful`, `reconfigure_successful`, ...)

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Tests have been added to highlight the behavior.

Sample run raising `ValueError` on core: https://github.com/home-assistant/core/actions/runs/11176114641

Violations fixed in:
- #127530
- #127532 
- #127534

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
