### PR TITLE
Refactoring : Duplicate String Literal "Setting operation mode of the miio device failed." - homeassistant/components/xiaomi_miio/fan.py

### DIFF
--- a/homeassistant/components/xiaomi_miio/const.py
+++ b/homeassistant/components/xiaomi_miio/const.py
@@ -500,3 +500,5 @@ FEATURE_FLAGS_FAN_P10_P11 = (
     | FEATURE_SET_LED
     | FEATURE_SET_DELAY_OFF_COUNTDOWN
 )
+# Device Actions Failure Messages
+SET_OP_MODE_FAIL_MSG = "Setting operation mode of the miio device failed."

--- a/homeassistant/components/xiaomi_miio/fan.py
+++ b/homeassistant/components/xiaomi_miio/fan.py
@@ -90,6 +90,7 @@ from .const import (
     MODELS_PURIFIER_MIOT,
     SERVICE_RESET_FILTER,
     SERVICE_SET_EXTRA_FEATURES,
+    SET_OP_MODE_FAIL_MSG,
 )
 from .device import XiaomiCoordinatedMiioEntity
 from .typing import ServiceMethodDetails
@@ -525,7 +526,7 @@ class XiaomiAirPurifier(XiaomiGenericAirPurifier):
         )
         if speed_mode:
             await self._try_command(
-                "Setting operation mode of the miio device failed.",
+                SET_OP_MODE_FAIL_MSG,
                 self._device.set_mode,
                 self.operation_mode_class(self.SPEED_MODE_MAPPING[speed_mode]),
             )
@@ -536,7 +537,7 @@ class XiaomiAirPurifier(XiaomiGenericAirPurifier):
         This method is a coroutine.
         """
         if await self._try_command(
-            "Setting operation mode of the miio device failed.",
+            SET_OP_MODE_FAIL_MSG,
             self._device.set_mode,
             self.operation_mode_class[preset_mode],
         ):
@@ -630,7 +631,7 @@ class XiaomiAirPurifierMB4(XiaomiGenericAirPurifier):
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set the preset mode of the fan."""
         if await self._try_command(
-            "Setting operation mode of the miio device failed.",
+            SET_OP_MODE_FAIL_MSG,
             self._device.set_mode,
             self.operation_mode_class[preset_mode],
         ):
@@ -713,7 +714,7 @@ class XiaomiAirFresh(XiaomiGenericAirPurifier):
         )
         if speed_mode:
             if await self._try_command(
-                "Setting operation mode of the miio device failed.",
+                SET_OP_MODE_FAIL_MSG,
                 self._device.set_mode,
                 AirfreshOperationMode(self.SPEED_MODE_MAPPING[speed_mode]),
             ):
@@ -728,7 +729,7 @@ class XiaomiAirFresh(XiaomiGenericAirPurifier):
         This method is a coroutine.
         """
         if await self._try_command(
-            "Setting operation mode of the miio device failed.",
+            SET_OP_MODE_FAIL_MSG,
             self._device.set_mode,
             self.operation_mode_class[preset_mode],
         ):
@@ -816,7 +817,7 @@ class XiaomiAirFreshA1(XiaomiGenericAirPurifier):
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set the preset mode of the fan. This method is a coroutine."""
         if await self._try_command(
-            "Setting operation mode of the miio device failed.",
+            SET_OP_MODE_FAIL_MSG,
             self._device.set_mode,
             self.operation_mode_class[preset_mode],
         ):
@@ -1038,7 +1039,7 @@ class XiaomiFanP5(XiaomiGenericFan):
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set the preset mode of the fan."""
         await self._try_command(
-            "Setting operation mode of the miio device failed.",
+            SET_OP_MODE_FAIL_MSG,
             self._device.set_mode,
             self.operation_mode_class[preset_mode],
         )
@@ -1094,7 +1095,7 @@ class XiaomiFanMiot(XiaomiGenericFan):
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set the preset mode of the fan."""
         await self._try_command(
-            "Setting operation mode of the miio device failed.",
+            SET_OP_MODE_FAIL_MSG,
             self._device.set_mode,
             self.operation_mode_class[preset_mode],
         )


### PR DESCRIPTION

## Proposed change

**Code Smell:** Duplicate String Literals

**Relevance and Importance:**  
When the same string literal duplicates, it affects the maintainability of the code and possible to create inconsistencies and errors when changes need to be done. For example, if an error message (same one) is used 15 times in the same class and a new developer wants to change the message slightly. It takes a considerable amount of time, even if it is a simple “find and replace”. Sometimes this message can be written with slight differences which leads to inconsistency. Moreover code duplication, violates DRY (Do not Repeat Yourself) principle which is not a decent practice in coding.

The change merged in this pull request, contains the fix for the issue which got the most priority at our analysis based on “maintenance overhead” criteria. All the issues identified in the selected directory (homeassistant/components/xiaomi_miio), had the same persistence, all the files had the same change frequency (commit history was analyzed), same future extensibility probability. So the only prioritization criteria to proceed with was, “maintenance overhead”. The length/ complexity of the string literal and the number of occurrences were sub criterion which were taken into account to rank the maintenance overhead of the issues. . For detailed analysis, [Codesmell_Analysis_Group2](https://docs.google.com/spreadsheets/d/1YfGB-CDQo4AqEH7aRehcnklAPJTkYxky2nWttA79BYY/edit?usp=sharing) can be referred to.

The selected string literal was the longest and had the most number of duplications.

**How the Issue was addressed and how does it solve the Issue:**

1.	Defined a constant in xiaomi_miio/const.py to keep the duplicated message.
2.	Imported the defined constant to in xiaomi_miio/fan.py
3.	Replaced the duplicated long message with the imported constant

String literal duplication, in the selected issue disappears with the change. Now when a developer needs to change the message he/she just have to change it in const.py. This is a slight improvement of maintainability in homeassistant. The fix, promotes DRY principle and reduces the risk of inconsistency in the code.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [\/ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ x] The code change is tested and works locally.
- [ x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x ] There is no commented out code in this PR.
- [x ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
