### PR TITLE
Adjust polling rate of Rituals Perfume Genie

### DIFF
--- a/homeassistant/components/rituals_perfume_genie/__init__.py
+++ b/homeassistant/components/rituals_perfume_genie/__init__.py
@@ -12,7 +12,7 @@ from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import ACCOUNT_HASH, DOMAIN
+from .const import ACCOUNT_HASH, DOMAIN, UPDATE_INTERVAL
 from .coordinator import RitualsDataUpdateCoordinator
 
 PLATFORMS = [
@@ -37,9 +37,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Migrate old unique_ids to the new format
     async_migrate_entities_unique_ids(hass, entry, account_devices)
 
+    # The API provided by Rituals is currently rate limited to 30 requests
+    # per hour per IP address. To avoid hitting this limit, we will adjust
+    # the polling interval based on the number of diffusers one has.
+    update_interval = UPDATE_INTERVAL * len(account_devices)
+
     # Create a coordinator for each diffuser
     coordinators = {
-        diffuser.hublot: RitualsDataUpdateCoordinator(hass, diffuser)
+        diffuser.hublot: RitualsDataUpdateCoordinator(hass, diffuser, update_interval)
         for diffuser in account_devices
     }
 

--- a/homeassistant/components/rituals_perfume_genie/config_flow.py
+++ b/homeassistant/components/rituals_perfume_genie/config_flow.py
@@ -45,6 +45,7 @@ class RitualsPerfumeGenieConfigFlow(ConfigFlow, domain=DOMAIN):
         try:
             await account.authenticate()
         except ClientResponseError:
+            _LOGGER.exception("Unexpected response")
             errors["base"] = "cannot_connect"
         except AuthenticationException:
             errors["base"] = "invalid_auth"

--- a/homeassistant/components/rituals_perfume_genie/const.py
+++ b/homeassistant/components/rituals_perfume_genie/const.py
@@ -6,4 +6,8 @@ DOMAIN = "rituals_perfume_genie"
 
 ACCOUNT_HASH = "account_hash"
 
-UPDATE_INTERVAL = timedelta(minutes=2)
+# The API provided by Rituals is currently rate limited to 30 requests
+# per hour per IP address. To avoid hitting this limit, the polling
+# interval is set to 3 minutes. This also gives a little room for
+# Home Assistant restarts.
+UPDATE_INTERVAL = timedelta(minutes=3)

--- a/homeassistant/components/rituals_perfume_genie/coordinator.py
+++ b/homeassistant/components/rituals_perfume_genie/coordinator.py
@@ -1,5 +1,6 @@
 """The Rituals Perfume Genie data update coordinator."""
 
+from datetime import timedelta
 import logging
 
 from pyrituals import Diffuser
@@ -7,7 +8,7 @@ from pyrituals import Diffuser
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from .const import DOMAIN, UPDATE_INTERVAL
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -15,14 +16,19 @@ _LOGGER = logging.getLogger(__name__)
 class RitualsDataUpdateCoordinator(DataUpdateCoordinator[None]):
     """Class to manage fetching Rituals Perfume Genie device data from single endpoint."""
 
-    def __init__(self, hass: HomeAssistant, diffuser: Diffuser) -> None:
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        diffuser: Diffuser,
+        update_interval: timedelta,
+    ) -> None:
         """Initialize global Rituals Perfume Genie data updater."""
         self.diffuser = diffuser
         super().__init__(
             hass,
             _LOGGER,
             name=f"{DOMAIN}-{diffuser.hublot}",
-            update_interval=UPDATE_INTERVAL,
+            update_interval=update_interval,
         )
 
     async def _async_update_data(self) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This changes the polling rate of the Rituals Perfume Genie integration.
The API is now limited to 30 polling requests per hour for all the devices combined.

To avoid hitting those limits:
- Adjusted the default polling rate to be every 3 minutes (20 calls per hour); giving a little breathing room for restarts as well.
- The polling rate is multiplied by the number of diffusers one has to avoid hitting the limits.

This adjustment isn't perfect, but it should be OK for most use cases. For a future goal, a different API should be used; but until that is in place, this will take away almost all problems people have.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #125437
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
