### PR TITLE
Add data streaming to Teslemetry

### DIFF
--- a/homeassistant/components/teslemetry/__init__.py
+++ b/homeassistant/components/teslemetry/__init__.py
@@ -1,6 +1,7 @@
 """Teslemetry integration."""
 
 import asyncio
+from collections.abc import Callable
 from typing import Final
 
 from tesla_fleet_api import EnergySpecific, Teslemetry, VehicleSpecific
@@ -239,7 +240,7 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
     return True
 
 
-def create_handle_vehicle_stream(vin: str, coordinator):
+def create_handle_vehicle_stream(vin: str, coordinator) -> Callable[[dict], None]:
     """Create a handle vehicle stream function."""
 
     def handle_vehicle_stream(data: dict) -> None:

--- a/homeassistant/components/teslemetry/__init__.py
+++ b/homeassistant/components/teslemetry/__init__.py
@@ -91,7 +91,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
     vehicles: list[TeslemetryVehicleData] = []
     energysites: list[TeslemetryEnergyData] = []
 
-    # Create a single stream instance
+    # Create the stream
     stream = TeslemetryStream(
         session,
         access_token,

--- a/homeassistant/components/teslemetry/__init__.py
+++ b/homeassistant/components/teslemetry/__init__.py
@@ -76,15 +76,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
             teslemetry.metadata(),
             teslemetry.products(),
         )
-        scopes = calls[0]["scopes"]
-        region = calls[0]["region"]
-        products = calls[1]["response"]
     except InvalidToken as e:
         raise ConfigEntryAuthFailed from e
     except SubscriptionRequired as e:
         raise ConfigEntryAuthFailed from e
     except TeslaFleetError as e:
         raise ConfigEntryNotReady from e
+
+    scopes = calls[0]["scopes"]
+    region = calls[0]["region"]
+    products = calls[1]["response"]
 
     device_registry = dr.async_get(hass)
 

--- a/homeassistant/components/teslemetry/__init__.py
+++ b/homeassistant/components/teslemetry/__init__.py
@@ -10,6 +10,7 @@ from tesla_fleet_api.exceptions import (
     SubscriptionRequired,
     TeslaFleetError,
 )
+from teslemetry_stream import TeslemetryStream
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ACCESS_TOKEN, Platform
@@ -28,6 +29,7 @@ from .coordinator import (
     TeslemetryEnergySiteLiveCoordinator,
     TeslemetryVehicleDataCoordinator,
 )
+from .helpers import flatten
 from .models import TeslemetryData, TeslemetryEnergyData, TeslemetryVehicleData
 from .services import async_register_services
 
@@ -69,8 +71,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
         access_token=access_token,
     )
     try:
-        scopes = (await teslemetry.metadata())["scopes"]
-        products = (await teslemetry.products())["response"]
+        calls = await asyncio.gather(
+            teslemetry.metadata(),
+            teslemetry.products(),
+        )
+        scopes = calls[0]["scopes"]
+        region = calls[0]["region"]
+        products = calls[1]["response"]
     except InvalidToken as e:
         raise ConfigEntryAuthFailed from e
     except SubscriptionRequired as e:
@@ -83,6 +90,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
     # Create array of classes
     vehicles: list[TeslemetryVehicleData] = []
     energysites: list[TeslemetryEnergyData] = []
+
+    # Create a single stream instance
+    stream = TeslemetryStream(
+        session,
+        access_token,
+        server=f"{region.lower()}.teslemetry.com",
+        parse_timestamp=True,
+    )
+
     for product in products:
         if "vin" in product and Scope.VEHICLE_DEVICE_DATA in scopes:
             # Remove the protobuff 'cached_data' that we do not use to save memory
@@ -99,12 +115,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
                 serial_number=vin,
             )
 
+            remove_listener = stream.async_add_listener(
+                create_handle_vehicle_stream(vin, coordinator),
+                {"vin": vin},
+            )
+
             vehicles.append(
                 TeslemetryVehicleData(
                     api=api,
                     coordinator=coordinator,
+                    stream=stream,
                     vin=vin,
                     device=device,
+                    remove_listener=remove_listener,
                 )
             )
 
@@ -214,3 +237,20 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
             config_entry, unique_id=metadata["uid"], version=1, minor_version=2
         )
     return True
+
+
+def create_handle_vehicle_stream(vin: str, coordinator):
+    """Create a handle vehicle stream function."""
+
+    def handle_vehicle_stream(data: dict) -> None:
+        """Handle vehicle data from the stream."""
+        if "vehicle_data" in data:
+            LOGGER.debug("Streaming received vehicle data from %s", vin)
+            coordinator.updated_once = True
+            coordinator.async_set_updated_data(flatten(data["vehicle_data"]))
+        elif "state" in data:
+            LOGGER.debug("Streaming received state from %s", vin)
+            coordinator.data["state"] = data["state"]
+            coordinator.async_set_updated_data(coordinator.data)
+
+    return handle_vehicle_stream

--- a/homeassistant/components/teslemetry/coordinator.py
+++ b/homeassistant/components/teslemetry/coordinator.py
@@ -18,6 +18,7 @@ from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import ENERGY_HISTORY_FIELDS, LOGGER, TeslemetryState
+from .helpers import flatten
 
 VEHICLE_INTERVAL = timedelta(seconds=30)
 VEHICLE_WAIT = timedelta(minutes=15)
@@ -33,19 +34,6 @@ ENDPOINTS = [
     VehicleDataEndpoint.VEHICLE_STATE,
     VehicleDataEndpoint.VEHICLE_CONFIG,
 ]
-
-
-def flatten(data: dict[str, Any], parent: str | None = None) -> dict[str, Any]:
-    """Flatten the data structure."""
-    result = {}
-    for key, value in data.items():
-        if parent:
-            key = f"{parent}_{key}"
-        if isinstance(value, dict):
-            result.update(flatten(value, key))
-        else:
-            result[key] = value
-    return result
 
 
 class TeslemetryVehicleDataCoordinator(DataUpdateCoordinator[dict[str, Any]]):

--- a/homeassistant/components/teslemetry/helpers.py
+++ b/homeassistant/components/teslemetry/helpers.py
@@ -77,10 +77,7 @@ async def handle_vehicle_command(command) -> Any:
                 translation_placeholders={"error": error},
             )
         # No response without error (unexpected)
-        raise HomeAssistantError(
-            translation_domain=DOMAIN,
-            translation_key="command_no_response",
-        )
+        raise HomeAssistantError(f"Unknown response: {response}")
     if (result := response.get("result")) is not True:
         if reason := response.get("reason"):
             if reason in ("already_set", "not_charging", "requested"):

--- a/homeassistant/components/teslemetry/manifest.json
+++ b/homeassistant/components/teslemetry/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "cloud_polling",
   "loggers": ["tesla-fleet-api"],
   "quality_scale": "platinum",
-  "requirements": ["tesla-fleet-api==0.8.4", "teslemetry-stream==0.4.1"]
+  "requirements": ["tesla-fleet-api==0.8.4", "teslemetry-stream==0.4.2"]
 }

--- a/homeassistant/components/teslemetry/manifest.json
+++ b/homeassistant/components/teslemetry/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "cloud_polling",
   "loggers": ["tesla-fleet-api"],
   "quality_scale": "platinum",
-  "requirements": ["tesla-fleet-api==0.8.4"]
+  "requirements": ["tesla-fleet-api==0.8.4", "teslemetry-stream==0.4.1"]
 }

--- a/homeassistant/components/teslemetry/models.py
+++ b/homeassistant/components/teslemetry/models.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Callable
 from dataclasses import dataclass
 
 from tesla_fleet_api import EnergySpecific, VehicleSpecific
 from tesla_fleet_api.const import Scope
+from teslemetry_stream import TeslemetryStream
 
 from homeassistant.helpers.device_registry import DeviceInfo
 
@@ -33,9 +35,11 @@ class TeslemetryVehicleData:
 
     api: VehicleSpecific
     coordinator: TeslemetryVehicleDataCoordinator
+    stream: TeslemetryStream
     vin: str
     wakelock = asyncio.Lock()
     device: DeviceInfo
+    remove_listener: Callable
 
 
 @dataclass

--- a/homeassistant/components/teslemetry/strings.json
+++ b/homeassistant/components/teslemetry/strings.json
@@ -598,6 +598,9 @@
     "command_no_result": {
       "message": "Command had no result"
     },
+    "command_no_response": {
+      "message": "Command had no response"
+    },
     "wake_up_failed": {
       "message": "Failed to wake up vehicle: {message}"
     },

--- a/homeassistant/components/teslemetry/strings.json
+++ b/homeassistant/components/teslemetry/strings.json
@@ -598,9 +598,6 @@
     "command_no_result": {
       "message": "Command had no result"
     },
-    "command_no_response": {
-      "message": "Command had no response"
-    },
     "wake_up_failed": {
       "message": "Failed to wake up vehicle: {message}"
     },

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2801,7 +2801,7 @@ tesla-powerwall==0.5.2
 tesla-wall-connector==1.0.2
 
 # homeassistant.components.teslemetry
-teslemetry-stream==0.4.1
+teslemetry-stream==0.4.2
 
 # homeassistant.components.tessie
 tessie-api==0.1.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2800,6 +2800,9 @@ tesla-powerwall==0.5.2
 # homeassistant.components.tesla_wall_connector
 tesla-wall-connector==1.0.2
 
+# homeassistant.components.teslemetry
+teslemetry-stream==0.4.1
+
 # homeassistant.components.tessie
 tessie-api==0.1.1
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2228,6 +2228,9 @@ tesla-powerwall==0.5.2
 # homeassistant.components.tesla_wall_connector
 tesla-wall-connector==1.0.2
 
+# homeassistant.components.teslemetry
+teslemetry-stream==0.4.1
+
 # homeassistant.components.tessie
 tessie-api==0.1.1
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2229,7 +2229,7 @@ tesla-powerwall==0.5.2
 tesla-wall-connector==1.0.2
 
 # homeassistant.components.teslemetry
-teslemetry-stream==0.4.1
+teslemetry-stream==0.4.2
 
 # homeassistant.components.tessie
 tessie-api==0.1.1

--- a/tests/components/teslemetry/conftest.py
+++ b/tests/components/teslemetry/conftest.py
@@ -1,4 +1,4 @@
-"""Fixtures for Tessie."""
+"""Fixtures for Teslemetry."""
 
 from __future__ import annotations
 
@@ -106,3 +106,12 @@ def mock_energy_history():
         return_value=ENERGY_HISTORY,
     ) as mock_live_status:
         yield mock_live_status
+
+
+@pytest.fixture(autouse=True)
+def mock_listen():
+    """Mock Teslemetry Stream listen method."""
+    with patch(
+        "homeassistant.components.teslemetry.TeslemetryStream.listen",
+    ) as mock_listen:
+        yield mock_listen

--- a/tests/components/teslemetry/test_init.py
+++ b/tests/components/teslemetry/test_init.py
@@ -216,16 +216,15 @@ async def test_energy_history_refresh_error(
     assert entry.state is state
 
 
-# Vehicle Coordinator
 async def test_vehicle_stream(
     hass: HomeAssistant,
-    mock_vehicle: AsyncMock,
-    mock_vehicle_data: AsyncMock,
+    mock_listen: AsyncMock,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test vehicle stream events."""
 
     entry = await setup_platform(hass, [Platform.BINARY_SENSOR])
+    mock_listen.assert_called_once()
 
     state = hass.states.get("binary_sensor.test_status")
     assert state.state == STATE_ON

--- a/tests/components/teslemetry/test_init.py
+++ b/tests/components/teslemetry/test_init.py
@@ -18,7 +18,7 @@ from homeassistant.components.teslemetry.coordinator import (
 )
 from homeassistant.components.teslemetry.models import TeslemetryData
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import Platform
+from homeassistant.const import STATE_OFF, STATE_ON, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
@@ -214,3 +214,48 @@ async def test_energy_history_refresh_error(
     mock_energy_history.side_effect = side_effect
     entry = await setup_platform(hass)
     assert entry.state is state
+
+
+# Vehicle Coordinator
+async def test_vehicle_stream(
+    hass: HomeAssistant,
+    mock_vehicle: AsyncMock,
+    mock_vehicle_data: AsyncMock,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test vehicle stream events."""
+
+    entry = await setup_platform(hass, [Platform.BINARY_SENSOR])
+
+    state = hass.states.get("binary_sensor.test_status")
+    assert state.state == STATE_ON
+
+    state = hass.states.get("binary_sensor.test_user_present")
+    assert state.state == STATE_OFF
+
+    runtime_data: TeslemetryData = entry.runtime_data
+    for listener, _ in runtime_data.vehicles[0].stream._listeners.values():
+        listener(
+            {
+                "vin": VEHICLE_DATA_ALT["response"]["vin"],
+                "vehicle_data": VEHICLE_DATA_ALT["response"],
+                "createdAt": "2024-10-04T10:45:17.537Z",
+            }
+        )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test_user_present")
+    assert state.state == STATE_ON
+
+    for listener, _ in runtime_data.vehicles[0].stream._listeners.values():
+        listener(
+            {
+                "vin": VEHICLE_DATA_ALT["response"]["vin"],
+                "state": "offline",
+                "createdAt": "2024-10-04T10:45:17.537Z",
+            }
+        )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.test_status")
+    assert state.state == STATE_OFF


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Teslemetry provides a Server Sent Events stream of both realtime and server-side polled data, which allows for multiple consumers of data without adding additional API calls.

This PR adds the first part of this functionality where the stream will manually update the Vehicle coordinator,.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
