### PR TITLE
Use common reconfigure string in bryant_evolution

### DIFF
--- a/homeassistant/components/bryant_evolution/config_flow.py
+++ b/homeassistant/components/bryant_evolution/config_flow.py
@@ -10,7 +10,6 @@ import voluptuous as vol
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_FILENAME
-from homeassistant.helpers.typing import UNDEFINED
 
 from .const import CONF_SYSTEM_ZONE, DOMAIN
 
@@ -74,15 +73,13 @@ class BryantConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             system_zone = await _enumerate_sz(user_input[CONF_FILENAME])
             if len(system_zone) != 0:
-                our_entry = self._get_reconfigure_entry()
                 return self.async_update_reload_and_abort(
-                    entry=our_entry,
+                    self._get_reconfigure_entry(),
                     data={
                         CONF_FILENAME: user_input[CONF_FILENAME],
                         CONF_SYSTEM_ZONE: system_zone,
                     },
-                    unique_id=UNDEFINED,
-                    reason="reconfigured",
+                    reason="reconfigure_successful",
                 )
             errors["base"] = "cannot_connect"
         return self.async_show_form(

--- a/homeassistant/components/bryant_evolution/strings.json
+++ b/homeassistant/components/bryant_evolution/strings.json
@@ -18,7 +18,8 @@
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
     }
   },
   "exceptions": {

--- a/tests/components/bryant_evolution/test_config_flow.py
+++ b/tests/components/bryant_evolution/test_config_flow.py
@@ -154,7 +154,7 @@ async def test_reconfigure(
         )
     await hass.async_block_till_done()
     assert result["type"] is FlowResultType.ABORT, result
-    assert result["reason"] == "reconfigured"
+    assert result["reason"] == "reconfigure_successful"
     config_entry = hass.config_entries.async_entries()[0]
     assert config_entry.data[CONF_SYSTEM_ZONE] == [
         (1, 1),


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I spotted this whilst investigating correctness of reconfigure flows.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
