### PR TITLE
Improve handling of call deflection switches in AVM Fritz!Tools

### DIFF
--- a/homeassistant/components/fritz/switch.py
+++ b/homeassistant/components/fritz/switch.py
@@ -46,9 +46,7 @@ async def _async_deflection_entities_list(
 
     _LOGGER.debug("Setting up %s switches", SWITCH_TYPE_DEFLECTION)
 
-    if (
-        call_deflections := avm_wrapper.data.get("call_deflections")
-    ) is None or not isinstance(call_deflections, dict):
+    if not (call_deflections := avm_wrapper.data["call_deflections"]):
         _LOGGER.debug("The FRITZ!Box has no %s options", SWITCH_TYPE_DEFLECTION)
         return []
 
@@ -72,7 +70,7 @@ async def _async_port_entities_list(
     # Query port forwardings and setup a switch for each forward for the current device
     resp = await avm_wrapper.async_get_num_port_mapping(avm_wrapper.device_conn_type)
     if not resp:
-        _LOGGER.debug("The FRITZ!Box has no %s options", SWITCH_TYPE_DEFLECTION)
+        _LOGGER.debug("The FRITZ!Box has no %s options", SWITCH_TYPE_PORTFORWARD)
         return []
 
     port_forwards_count: int = resp["NewPortMappingNumberOfEntries"]

--- a/tests/components/fritz/const.py
+++ b/tests/components/fritz/const.py
@@ -904,6 +904,14 @@ MOCK_HOST_ATTRIBUTES_DATA = [
     },
 ]
 
+MOCK_CALL_DEFLECTION_DATA = {
+    "X_AVM-DE_OnTel1": {
+        "GetDeflections": {
+            "NewDeflectionList": "<List><Item><DeflectionId>0</DeflectionId><Enable>0</Enable><Type>fromAll</Type><Number></Number><DeflectionToNumber>+1234657890</DeflectionToNumber><Mode>eImmediately</Mode><Outgoing></Outgoing><PhonebookID></PhonebookID></Item></List>"
+        }
+    }
+}
+
 MOCK_USER_DATA = MOCK_CONFIG[DOMAIN][CONF_DEVICES][0]
 MOCK_USER_INPUT_ADVANCED = MOCK_USER_DATA
 MOCK_USER_INPUT_SIMPLE = {

--- a/tests/components/fritz/snapshots/test_switch.ambr
+++ b/tests/components/fritz/snapshots/test_switch.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_switch_setup[fc_data0-expected_wifi_names0][switch.mock_title_wi_fi_wifi_2_4ghz-entry]
+# name: test_switch_setup[fc_data0][switch.mock_title_wi_fi_wifi_2_4ghz-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -32,7 +32,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_switch_setup[fc_data0-expected_wifi_names0][switch.mock_title_wi_fi_wifi_2_4ghz-state]
+# name: test_switch_setup[fc_data0][switch.mock_title_wi_fi_wifi_2_4ghz-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock Title Wi-Fi WiFi (2.4Ghz)',
@@ -46,7 +46,7 @@
     'state': 'on',
   })
 # ---
-# name: test_switch_setup[fc_data0-expected_wifi_names0][switch.mock_title_wi_fi_wifi_5ghz-entry]
+# name: test_switch_setup[fc_data0][switch.mock_title_wi_fi_wifi_5ghz-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -79,7 +79,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_switch_setup[fc_data0-expected_wifi_names0][switch.mock_title_wi_fi_wifi_5ghz-state]
+# name: test_switch_setup[fc_data0][switch.mock_title_wi_fi_wifi_5ghz-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock Title Wi-Fi WiFi (5Ghz)',
@@ -93,7 +93,7 @@
     'state': 'on',
   })
 # ---
-# name: test_switch_setup[fc_data0-expected_wifi_names0][switch.printer_internet_access-entry]
+# name: test_switch_setup[fc_data0][switch.printer_internet_access-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -126,7 +126,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_switch_setup[fc_data0-expected_wifi_names0][switch.printer_internet_access-state]
+# name: test_switch_setup[fc_data0][switch.printer_internet_access-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'printer Internet Access',
@@ -140,7 +140,7 @@
     'state': 'on',
   })
 # ---
-# name: test_switch_setup[fc_data1-expected_wifi_names1][switch.mock_title_wi_fi_wifi-entry]
+# name: test_switch_setup[fc_data1][switch.mock_title_wi_fi_wifi-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -173,7 +173,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_switch_setup[fc_data1-expected_wifi_names1][switch.mock_title_wi_fi_wifi-state]
+# name: test_switch_setup[fc_data1][switch.mock_title_wi_fi_wifi-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock Title Wi-Fi WiFi',
@@ -187,7 +187,7 @@
     'state': 'on',
   })
 # ---
-# name: test_switch_setup[fc_data1-expected_wifi_names1][switch.mock_title_wi_fi_wifi2-entry]
+# name: test_switch_setup[fc_data1][switch.mock_title_wi_fi_wifi2-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -220,7 +220,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_switch_setup[fc_data1-expected_wifi_names1][switch.mock_title_wi_fi_wifi2-state]
+# name: test_switch_setup[fc_data1][switch.mock_title_wi_fi_wifi2-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock Title Wi-Fi WiFi2',
@@ -234,7 +234,7 @@
     'state': 'on',
   })
 # ---
-# name: test_switch_setup[fc_data1-expected_wifi_names1][switch.printer_internet_access-entry]
+# name: test_switch_setup[fc_data1][switch.printer_internet_access-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -267,7 +267,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_switch_setup[fc_data1-expected_wifi_names1][switch.printer_internet_access-state]
+# name: test_switch_setup[fc_data1][switch.printer_internet_access-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'printer Internet Access',
@@ -281,7 +281,7 @@
     'state': 'on',
   })
 # ---
-# name: test_switch_setup[fc_data2-expected_wifi_names2][switch.mock_title_wi_fi_wifi_2_4ghz-entry]
+# name: test_switch_setup[fc_data2][switch.mock_title_wi_fi_wifi_2_4ghz-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -314,7 +314,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_switch_setup[fc_data2-expected_wifi_names2][switch.mock_title_wi_fi_wifi_2_4ghz-state]
+# name: test_switch_setup[fc_data2][switch.mock_title_wi_fi_wifi_2_4ghz-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock Title Wi-Fi WiFi (2.4Ghz)',
@@ -328,7 +328,7 @@
     'state': 'on',
   })
 # ---
-# name: test_switch_setup[fc_data2-expected_wifi_names2][switch.mock_title_wi_fi_wifi_5ghz-entry]
+# name: test_switch_setup[fc_data2][switch.mock_title_wi_fi_wifi_5ghz-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -361,7 +361,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_switch_setup[fc_data2-expected_wifi_names2][switch.mock_title_wi_fi_wifi_5ghz-state]
+# name: test_switch_setup[fc_data2][switch.mock_title_wi_fi_wifi_5ghz-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock Title Wi-Fi WiFi+ (5Ghz)',
@@ -375,7 +375,7 @@
     'state': 'on',
   })
 # ---
-# name: test_switch_setup[fc_data2-expected_wifi_names2][switch.printer_internet_access-entry]
+# name: test_switch_setup[fc_data2][switch.printer_internet_access-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -408,7 +408,154 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_switch_setup[fc_data2-expected_wifi_names2][switch.printer_internet_access-state]
+# name: test_switch_setup[fc_data2][switch.printer_internet_access-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'printer Internet Access',
+      'icon': 'mdi:router-wireless-settings',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.printer_internet_access',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_switch_setup[fc_data3][switch.mock_title_call_deflection_0-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.mock_title_call_deflection_0',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:phone-forward',
+    'original_name': 'Call deflection 0',
+    'platform': 'fritz',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '1C:ED:6F:12:34:11-call_deflection_0',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switch_setup[fc_data3][switch.mock_title_call_deflection_0-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'deflection_to_number': '+1234657890',
+      'friendly_name': 'Mock Title Call deflection 0',
+      'icon': 'mdi:phone-forward',
+      'mode': 'Immediately',
+      'number': None,
+      'outgoing': None,
+      'phonebook_id': None,
+      'type': 'fromAll',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.mock_title_call_deflection_0',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_switch_setup[fc_data3][switch.mock_title_wi_fi_mywifi-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.mock_title_wi_fi_mywifi',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:wifi',
+    'original_name': 'Mock Title Wi-Fi MyWifi',
+    'platform': 'fritz',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '1C:ED:6F:12:34:11-wi_fi_mywifi',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switch_setup[fc_data3][switch.mock_title_wi_fi_mywifi-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Mock Title Wi-Fi MyWifi',
+      'icon': 'mdi:wifi',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.mock_title_wi_fi_mywifi',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_switch_setup[fc_data3][switch.printer_internet_access-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.printer_internet_access',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:router-wireless-settings',
+    'original_name': 'printer Internet Access',
+    'platform': 'fritz',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'AA:BB:CC:00:11:22_internet_access',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switch_setup[fc_data3][switch.printer_internet_access-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'printer Internet Access',

--- a/tests/components/fritz/test_switch.py
+++ b/tests/components/fritz/test_switch.py
@@ -12,7 +12,7 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from .const import MOCK_FB_SERVICES, MOCK_USER_DATA
+from .const import MOCK_CALL_DEFLECTION_DATA, MOCK_FB_SERVICES, MOCK_USER_DATA
 
 from tests.common import MockConfigEntry, snapshot_platform
 
@@ -169,24 +169,18 @@ MOCK_WLANCONFIGS_DIFF2_SSID: dict[str, dict] = {
 
 
 @pytest.mark.parametrize(
-    ("fc_data", "expected_wifi_names"),
+    ("fc_data"),
     [
-        (
-            {**MOCK_FB_SERVICES, **MOCK_WLANCONFIGS_SAME_SSID},
-            ["WiFi (2.4Ghz)", "WiFi (5Ghz)"],
-        ),
-        ({**MOCK_FB_SERVICES, **MOCK_WLANCONFIGS_DIFF_SSID}, ["WiFi", "WiFi2"]),
-        (
-            {**MOCK_FB_SERVICES, **MOCK_WLANCONFIGS_DIFF2_SSID},
-            ["WiFi (2.4Ghz)", "WiFi+ (5Ghz)"],
-        ),
+        ({**MOCK_FB_SERVICES, **MOCK_WLANCONFIGS_SAME_SSID}),
+        ({**MOCK_FB_SERVICES, **MOCK_WLANCONFIGS_DIFF_SSID}),
+        ({**MOCK_FB_SERVICES, **MOCK_WLANCONFIGS_DIFF2_SSID}),
+        ({**MOCK_FB_SERVICES, **MOCK_CALL_DEFLECTION_DATA}),
     ],
 )
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_switch_setup(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
-    expected_wifi_names: list[str],
     fc_class_mock,
     fh_class_mock,
     snapshot: SnapshotAssertion,
@@ -198,8 +192,5 @@ async def test_switch_setup(
     with patch("homeassistant.components.fritz.PLATFORMS", [Platform.SWITCH]):
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done(wait_background_tasks=True)
-
-    states = hass.states.async_all()
-    assert len(states) == 3
 
     await snapshot_platform(hass, entity_registry, snapshot, entry.entry_id)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The `call_deflections` key of coordinator data is always initiated as an empty dict `{}` to the existing check for existing call deflections would never result in `"The FRITZ!Box has no %s options", SWITCH_TYPE_DEFLECTION`. This is fixed.
Further some tests around call deflection switches has been added and a small copy&paste error on a later debug message has been fixed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
