### PR TITLE
Add tests for evohome water_heater entities

### DIFF
--- a/tests/components/evohome/conftest.py
+++ b/tests/components/evohome/conftest.py
@@ -14,7 +14,12 @@ from evohomeasync2.broker import Broker
 import pytest
 
 from homeassistant.components.evohome import CONF_PASSWORD, CONF_USERNAME, DOMAIN
+from homeassistant.components.evohome.coordinator import EvoBroker
+from homeassistant.components.evohome.water_heater import EvoDHW
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 from homeassistant.util.json import JsonArrayType, JsonObjectType
@@ -153,3 +158,20 @@ async def setup_evohome(
         assert mock_client.account_info is not None
 
         yield mock_client
+
+
+def get_dhw_entity(hass: HomeAssistant) -> EvoDHW | None:
+    """Return the DHW entity of the evohome system."""
+
+    broker: EvoBroker = hass.data[DOMAIN]["broker"]
+
+    if (dhw := broker.tcs.hotwater) is None:
+        return None
+
+    entity_registry = er.async_get(hass)
+    entity_id = entity_registry.async_get_entity_id(
+        Platform.WATER_HEATER, DOMAIN, dhw._id
+    )
+
+    component: EntityComponent = hass.data.get(Platform.WATER_HEATER)  # type: ignore[assignment]
+    return next(e for e in component.entities if e.entity_id == entity_id)  # type: ignore[return-value]

--- a/tests/components/evohome/conftest.py
+++ b/tests/components/evohome/conftest.py
@@ -14,12 +14,7 @@ from evohomeasync2.broker import Broker
 import pytest
 
 from homeassistant.components.evohome import CONF_PASSWORD, CONF_USERNAME, DOMAIN
-from homeassistant.components.evohome.coordinator import EvoBroker
-from homeassistant.components.evohome.water_heater import EvoDHW
-from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 from homeassistant.util.json import JsonArrayType, JsonObjectType
@@ -158,20 +153,3 @@ async def setup_evohome(
         assert mock_client.account_info is not None
 
         yield mock_client
-
-
-def get_dhw_entity(hass: HomeAssistant) -> EvoDHW | None:
-    """Return the DHW entity of the evohome system."""
-
-    broker: EvoBroker = hass.data[DOMAIN]["broker"]
-
-    if (dhw := broker.tcs.hotwater) is None:
-        return None
-
-    entity_registry = er.async_get(hass)
-    entity_id = entity_registry.async_get_entity_id(
-        Platform.WATER_HEATER, DOMAIN, dhw._id
-    )
-
-    component: EntityComponent = hass.data.get(Platform.WATER_HEATER)  # type: ignore[assignment]
-    return next(e for e in component.entities if e.entity_id == entity_id)  # type: ignore[return-value]

--- a/tests/components/evohome/const.py
+++ b/tests/components/evohome/const.py
@@ -18,3 +18,5 @@ TEST_INSTALLS: Final = (
     "sys_004",  # RoundModulation
 )
 #   "botched",  # as default: but with activeFaults, ghost zones & unknown types
+
+TEST_INSTALLS_WITH_DHW: Final = ("default",)

--- a/tests/components/evohome/snapshots/test_water_heater.ambr
+++ b/tests/components/evohome/snapshots/test_water_heater.ambr
@@ -1,0 +1,19 @@
+# serializer version: 1
+# name: test_set_operation_mode[default]
+  list([
+    tuple(
+      dict({
+        'mode': <ZoneMode.TEMPORARY_OVERRIDE: 'TemporaryOverride'>,
+        'state': <DhwState.OFF: 'Off'>,
+        'untilTime': '2024-07-10T12:00:00Z',
+      }),
+    ),
+    tuple(
+      dict({
+        'mode': <ZoneMode.TEMPORARY_OVERRIDE: 'TemporaryOverride'>,
+        'state': <DhwState.ON: 'On'>,
+        'untilTime': '2024-07-10T12:00:00Z',
+      }),
+    ),
+  ])
+# ---

--- a/tests/components/evohome/test_water_heater.py
+++ b/tests/components/evohome/test_water_heater.py
@@ -20,7 +20,7 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_component import EntityComponent
 
 from .conftest import setup_evohome
-from .const import TEST_INSTALLS
+from .const import TEST_INSTALLS_WITH_DHW
 
 
 def get_dhw_entity(hass: HomeAssistant) -> EvoDHW | None:
@@ -40,7 +40,7 @@ def get_dhw_entity(hass: HomeAssistant) -> EvoDHW | None:
     return next(e for e in component.entities if e.entity_id == entity_id)  # type: ignore[return-value]
 
 
-@pytest.mark.parametrize("install", TEST_INSTALLS)
+@pytest.mark.parametrize("install", TEST_INSTALLS_WITH_DHW)
 async def test_set_operation_mode(
     hass: HomeAssistant,
     config: dict[str, str],
@@ -106,7 +106,7 @@ async def test_set_operation_mode(
     assert results == snapshot
 
 
-@pytest.mark.parametrize("install", TEST_INSTALLS)
+@pytest.mark.parametrize("install", TEST_INSTALLS_WITH_DHW)
 async def test_turn_away_mode_off(
     hass: HomeAssistant,
     config: dict[str, str],
@@ -133,7 +133,7 @@ async def test_turn_away_mode_off(
             assert mock_fcn.await_args.kwargs == {}
 
 
-@pytest.mark.parametrize("install", TEST_INSTALLS)
+@pytest.mark.parametrize("install", TEST_INSTALLS_WITH_DHW)
 async def test_turn_away_mode_on(
     hass: HomeAssistant,
     config: dict[str, str],
@@ -160,7 +160,7 @@ async def test_turn_away_mode_on(
             assert mock_fcn.await_args.kwargs == {}
 
 
-@pytest.mark.parametrize("install", TEST_INSTALLS)
+@pytest.mark.parametrize("install", TEST_INSTALLS_WITH_DHW)
 async def test_turn_off(
     hass: HomeAssistant,
     config: dict[str, str],
@@ -187,7 +187,7 @@ async def test_turn_off(
             assert mock_fcn.await_args.kwargs == {}
 
 
-@pytest.mark.parametrize("install", TEST_INSTALLS)
+@pytest.mark.parametrize("install", TEST_INSTALLS_WITH_DHW)
 async def test_turn_on(
     hass: HomeAssistant,
     config: dict[str, str],

--- a/tests/components/evohome/test_water_heater.py
+++ b/tests/components/evohome/test_water_heater.py
@@ -54,8 +54,7 @@ async def test_set_operation_mode(
     results = []
 
     async for _ in setup_evohome(hass, config, install=install):
-        if (dhw := get_dhw_entity(hass)) is None:
-            pytest.skip("this installation has no DHW to test")
+        dhw = get_dhw_entity(hass)
 
         # set_operation_mode(auto): FollowSchedule
         with patch("evohomeasync2.hotwater.HotWater._set_mode") as mock_fcn:
@@ -115,8 +114,7 @@ async def test_turn_away_mode_off(
     """Test water_heater services of a evohome-compatible DHW zone."""
 
     async for _ in setup_evohome(hass, config, install=install):
-        if (dhw := get_dhw_entity(hass)) is None:
-            pytest.skip("this installation has no DHW to test")
+        dhw = get_dhw_entity(hass)
 
         # turn_away_mode_off(): FollowSchedule
         with patch("evohomeasync2.hotwater.HotWater._set_mode") as mock_fcn:
@@ -142,8 +140,7 @@ async def test_turn_away_mode_on(
     """Test water_heater services of a evohome-compatible DHW zone."""
 
     async for _ in setup_evohome(hass, config, install=install):
-        if (dhw := get_dhw_entity(hass)) is None:
-            pytest.skip("this installation has no DHW to test")
+        dhw = get_dhw_entity(hass)
 
         # turn_away_mode_on(): PermanentOverride, Off
         with patch("evohomeasync2.hotwater.HotWater._set_mode") as mock_fcn:
@@ -169,8 +166,7 @@ async def test_turn_off(
     """Test water_heater services of a evohome-compatible DHW zone."""
 
     async for _ in setup_evohome(hass, config, install=install):
-        if (dhw := get_dhw_entity(hass)) is None:
-            pytest.skip("this installation has no DHW to test")
+        dhw = get_dhw_entity(hass)
 
         # turn_off(): PermanentOverride, Off
         with patch("evohomeasync2.hotwater.HotWater._set_mode") as mock_fcn:
@@ -196,8 +192,7 @@ async def test_turn_on(
     """Test water_heater services of a evohome-compatible DHW zone."""
 
     async for _ in setup_evohome(hass, config, install=install):
-        if (dhw := get_dhw_entity(hass)) is None:
-            pytest.skip("this installation has no DHW to test")
+        dhw = get_dhw_entity(hass)
 
         # turn_on(): PermanentOverride, On
         with patch("evohomeasync2.hotwater.HotWater._set_mode") as mock_fcn:

--- a/tests/components/evohome/test_water_heater.py
+++ b/tests/components/evohome/test_water_heater.py
@@ -1,0 +1,191 @@
+"""The tests for water_heater entities of evohome.
+
+Not all evohome systems will have a DHW zone.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from freezegun.api import FrozenDateTimeFactory
+import pytest
+from syrupy import SnapshotAssertion
+
+from homeassistant.core import HomeAssistant
+
+from .conftest import get_dhw_entity, setup_evohome
+from .const import TEST_INSTALLS
+
+
+@pytest.mark.parametrize("install", TEST_INSTALLS)
+async def test_set_operation_mode(
+    hass: HomeAssistant,
+    config: dict[str, str],
+    install: str,
+    freezer: FrozenDateTimeFactory,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test water_heater services of a evohome-compatible DHW zone."""
+
+    freezer.move_to("2024-07-10T11:55:00Z")
+    results = []
+
+    async for _ in setup_evohome(hass, config, install=install):
+        if (dhw := get_dhw_entity(hass)) is None:
+            pytest.skip("this installation has no DHW to test")
+
+        # set_operation_mode(auto): FollowSchedule
+        with patch("evohomeasync2.hotwater.HotWater._set_mode") as mock_fcn:
+            await dhw.async_set_operation_mode("auto")
+
+            assert mock_fcn.await_count == 1
+            assert mock_fcn.await_args.args == (
+                {
+                    "mode": "FollowSchedule",
+                    "state": None,
+                    "untilTime": None,
+                },
+            )
+            assert mock_fcn.await_args.kwargs == {}
+
+        # set_operation_mode(off): TemporaryOverride, advanced
+        with patch("evohomeasync2.hotwater.HotWater._set_mode") as mock_fcn:
+            await dhw.async_set_operation_mode("off")
+
+            assert mock_fcn.await_count == 1
+            assert install != "default" or mock_fcn.await_args.args == (
+                {
+                    "mode": "TemporaryOverride",
+                    "state": "Off",
+                    "untilTime": "2024-07-10T12:00:00Z",  # varies by install
+                },
+            )
+            assert mock_fcn.await_args.kwargs == {}
+
+            results.append(mock_fcn.await_args.args)
+
+        # set_operation_mode(on): TemporaryOverride, advanced
+        with patch("evohomeasync2.hotwater.HotWater._set_mode") as mock_fcn:
+            await dhw.async_set_operation_mode("on")
+
+            assert mock_fcn.await_count == 1
+            assert install != "default" or mock_fcn.await_args.args == (
+                {
+                    "mode": "TemporaryOverride",
+                    "state": "On",
+                    "untilTime": "2024-07-10T12:00:00Z",  # varies by install
+                },
+            )
+            assert mock_fcn.await_args.kwargs == {}
+
+            results.append(mock_fcn.await_args.args)
+
+    assert results == snapshot
+
+
+@pytest.mark.parametrize("install", TEST_INSTALLS)
+async def test_turn_away_mode_off(
+    hass: HomeAssistant,
+    config: dict[str, str],
+    install: str,
+) -> None:
+    """Test water_heater services of a evohome-compatible DHW zone."""
+
+    async for _ in setup_evohome(hass, config, install=install):
+        if (dhw := get_dhw_entity(hass)) is None:
+            pytest.skip("this installation has no DHW to test")
+
+        # turn_away_mode_off(): FollowSchedule
+        with patch("evohomeasync2.hotwater.HotWater._set_mode") as mock_fcn:
+            await dhw.async_turn_away_mode_off()
+
+            assert mock_fcn.await_count == 1
+            assert mock_fcn.await_args.args == (
+                {
+                    "mode": "FollowSchedule",
+                    "state": None,
+                    "untilTime": None,
+                },
+            )
+            assert mock_fcn.await_args.kwargs == {}
+
+
+@pytest.mark.parametrize("install", TEST_INSTALLS)
+async def test_turn_away_mode_on(
+    hass: HomeAssistant,
+    config: dict[str, str],
+    install: str,
+) -> None:
+    """Test water_heater services of a evohome-compatible DHW zone."""
+
+    async for _ in setup_evohome(hass, config, install=install):
+        if (dhw := get_dhw_entity(hass)) is None:
+            pytest.skip("this installation has no DHW to test")
+
+        # turn_away_mode_on(): PermanentOverride, Off
+        with patch("evohomeasync2.hotwater.HotWater._set_mode") as mock_fcn:
+            await dhw.async_turn_away_mode_on()
+
+            assert mock_fcn.await_count == 1
+            assert mock_fcn.await_args.args == (
+                {
+                    "mode": "PermanentOverride",
+                    "state": "Off",
+                    "untilTime": None,
+                },
+            )
+            assert mock_fcn.await_args.kwargs == {}
+
+
+@pytest.mark.parametrize("install", TEST_INSTALLS)
+async def test_turn_off(
+    hass: HomeAssistant,
+    config: dict[str, str],
+    install: str,
+) -> None:
+    """Test water_heater services of a evohome-compatible DHW zone."""
+
+    async for _ in setup_evohome(hass, config, install=install):
+        if (dhw := get_dhw_entity(hass)) is None:
+            pytest.skip("this installation has no DHW to test")
+
+        # turn_off(): PermanentOverride, Off
+        with patch("evohomeasync2.hotwater.HotWater._set_mode") as mock_fcn:
+            await dhw.async_turn_off()
+
+            assert mock_fcn.await_count == 1
+            assert mock_fcn.await_args.args == (
+                {
+                    "mode": "PermanentOverride",
+                    "state": "Off",
+                    "untilTime": None,
+                },
+            )
+            assert mock_fcn.await_args.kwargs == {}
+
+
+@pytest.mark.parametrize("install", TEST_INSTALLS)
+async def test_turn_on(
+    hass: HomeAssistant,
+    config: dict[str, str],
+    install: str,
+) -> None:
+    """Test water_heater services of a evohome-compatible DHW zone."""
+
+    async for _ in setup_evohome(hass, config, install=install):
+        if (dhw := get_dhw_entity(hass)) is None:
+            pytest.skip("this installation has no DHW to test")
+
+        # turn_on(): PermanentOverride, On
+        with patch("evohomeasync2.hotwater.HotWater._set_mode") as mock_fcn:
+            await dhw.async_turn_on()
+
+            assert mock_fcn.await_count == 1
+            assert mock_fcn.await_args.args == (
+                {
+                    "mode": "PermanentOverride",
+                    "state": "On",
+                    "untilTime": None,
+                },
+            )
+            assert mock_fcn.await_args.kwargs == {}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Test the following methods of the evohome integration's water_heater entities:
 - `async_set_operation_mode`
 - `async_turn_away_mode_off`
 - `async_turn_away_mode_on`
 - `async_turn_off`
 - `async_turn_on`

The test asserts that the methods invoke a client library API with the correct parameters.
 
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
