### PR TITLE
Fix-compile-english-translations-task

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -75,6 +75,18 @@
           "remoteRoot": "/usr/src/homeassistant"
         }
       ]
+    },
+    {
+      "name": "Debug - Compile English translations task",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "script.translations",
+      "console": "integratedTerminal",
+      "args": [
+        "develop",
+        "--all"
+      ],
+      "justMyCode": false
     }
   ]
 }

--- a/script/translations/develop.py
+++ b/script/translations/develop.py
@@ -4,7 +4,6 @@ import argparse
 import json
 from pathlib import Path
 import re
-from shutil import rmtree
 import sys
 
 from . import download, upload
@@ -105,10 +104,7 @@ def run_single(translations, flattened_translations, integration):
         integration_strings, flattened_translations
     )
 
-    if download.DOWNLOAD_DIR.is_dir():
-        rmtree(str(download.DOWNLOAD_DIR))
-
-    download.DOWNLOAD_DIR.mkdir(parents=True)
+    download.DOWNLOAD_DIR.mkdir(parents=True, exist_ok=True)
 
     (download.DOWNLOAD_DIR / "en.json").write_text(
         json.dumps({"component": {integration: translations["component"][integration]}})


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When attempting to launch the first two debug configs from vscode the session does not start because a failure happens in the "preLaunchTask" for compiling english translations,

the error mentions attempting to remove a symlink, the only removal attempt is on the temp folder for the translation JSON being constantly destroyed and recreated


https://github.com/user-attachments/assets/657543dd-ef0d-45e3-9aa9-5be643ec0deb


however its possible to instead let the mkdir command not error should the dir already exist plus the file write is going to override the JSON file anyway so it should not be necessary to destroy the dir and its content each time


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/127886
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
