### PR TITLE
Update A. O. Smith integration to reflect upstream API changes

### DIFF
--- a/homeassistant/components/aosmith/manifest.json
+++ b/homeassistant/components/aosmith/manifest.json
@@ -5,5 +5,5 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/aosmith",
   "iot_class": "cloud_polling",
-  "requirements": ["py-aosmith==1.0.8"]
+  "requirements": ["py-aosmith==1.0.10"]
 }

--- a/homeassistant/components/aosmith/sensor.py
+++ b/homeassistant/components/aosmith/sensor.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 
-from py_aosmith.models import Device as AOSmithDevice, HotWaterStatus
+from py_aosmith.models import Device as AOSmithDevice
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -11,7 +11,7 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.const import UnitOfEnergy
+from homeassistant.const import PERCENTAGE, UnitOfEnergy
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -31,19 +31,10 @@ STATUS_ENTITY_DESCRIPTIONS: tuple[AOSmithStatusSensorEntityDescription, ...] = (
     AOSmithStatusSensorEntityDescription(
         key="hot_water_availability",
         translation_key="hot_water_availability",
-        device_class=SensorDeviceClass.ENUM,
-        options=["low", "medium", "high"],
-        value_fn=lambda device: HOT_WATER_STATUS_MAP.get(
-            device.status.hot_water_status
-        ),
+        native_unit_of_measurement=PERCENTAGE,
+        value_fn=lambda device: device.status.hot_water_status,
     ),
 )
-
-HOT_WATER_STATUS_MAP: dict[HotWaterStatus, str] = {
-    HotWaterStatus.LOW: "low",
-    HotWaterStatus.MEDIUM: "medium",
-    HotWaterStatus.HIGH: "high",
-}
 
 
 async def async_setup_entry(

--- a/homeassistant/components/aosmith/strings.json
+++ b/homeassistant/components/aosmith/strings.json
@@ -28,12 +28,7 @@
   "entity": {
     "sensor": {
       "hot_water_availability": {
-        "name": "Hot water availability",
-        "state": {
-          "low": "Low",
-          "medium": "Medium",
-          "high": "High"
-        }
+        "name": "Hot water availability"
       },
       "energy_usage": {
         "name": "Energy usage"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1662,7 +1662,7 @@ pushover_complete==1.1.1
 pvo==2.1.1
 
 # homeassistant.components.aosmith
-py-aosmith==1.0.8
+py-aosmith==1.0.10
 
 # homeassistant.components.canary
 py-canary==0.5.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1357,7 +1357,7 @@ pushover_complete==1.1.1
 pvo==2.1.1
 
 # homeassistant.components.aosmith
-py-aosmith==1.0.8
+py-aosmith==1.0.10
 
 # homeassistant.components.canary
 py-canary==0.5.4

--- a/tests/components/aosmith/conftest.py
+++ b/tests/components/aosmith/conftest.py
@@ -10,7 +10,6 @@ from py_aosmith.models import (
     DeviceType,
     EnergyUseData,
     EnergyUseHistoryEntry,
-    HotWaterStatus,
     OperationMode,
     SupportedOperationModeInfo,
 )
@@ -93,7 +92,7 @@ def build_device_fixture(
             temperature_setpoint_pending=setpoint_pending,
             temperature_setpoint_previous=130,
             temperature_setpoint_maximum=130,
-            hot_water_status=HotWaterStatus.LOW,
+            hot_water_status=90,
         ),
     )
 

--- a/tests/components/aosmith/fixtures/get_all_device_info.json
+++ b/tests/components/aosmith/fixtures/get_all_device_info.json
@@ -103,7 +103,7 @@
           }
         ],
         "firmwareVersion": "2.14",
-        "hotWaterStatus": "HIGH",
+        "hotWaterStatus": 10,
         "isAdvancedLoadUpMore": false,
         "isCtaUcmPresent": false,
         "isDemandResponsePaused": false,

--- a/tests/components/aosmith/snapshots/test_diagnostics.ambr
+++ b/tests/components/aosmith/snapshots/test_diagnostics.ambr
@@ -43,7 +43,7 @@
           'error': '',
           'firmwareVersion': '2.14',
           'heaterSsid': '**REDACTED**',
-          'hotWaterStatus': 'HIGH',
+          'hotWaterStatus': 10,
           'isAdvancedLoadUpMore': False,
           'isCtaUcmPresent': False,
           'isDemandResponsePaused': False,

--- a/tests/components/aosmith/snapshots/test_sensor.ambr
+++ b/tests/components/aosmith/snapshots/test_sensor.ambr
@@ -58,13 +58,7 @@
     'aliases': set({
     }),
     'area_id': None,
-    'capabilities': dict({
-      'options': list([
-        'low',
-        'medium',
-        'high',
-      ]),
-    }),
+    'capabilities': None,
     'config_entry_id': <ANY>,
     'device_class': None,
     'device_id': <ANY>,
@@ -81,7 +75,7 @@
     'name': None,
     'options': dict({
     }),
-    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_device_class': None,
     'original_icon': None,
     'original_name': 'Hot water availability',
     'platform': 'aosmith',
@@ -89,25 +83,20 @@
     'supported_features': 0,
     'translation_key': 'hot_water_availability',
     'unique_id': 'hot_water_availability_junctionId',
-    'unit_of_measurement': None,
+    'unit_of_measurement': '%',
   })
 # ---
 # name: test_state[sensor.my_water_heater_hot_water_availability-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'enum',
       'friendly_name': 'My water heater Hot water availability',
-      'options': list([
-        'low',
-        'medium',
-        'high',
-      ]),
+      'unit_of_measurement': '%',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.my_water_heater_hot_water_availability',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'low',
+    'state': '90',
   })
 # ---


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
A. O. Smith now provides the hot water status as a percentage rather than low, medium, or high. The hot water status entity has been updated accordingly.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update the A. O. Smith integration to reflect new changes to the upstream API.

https://github.com/bdr99/py-aosmith/compare/1.0.8...1.0.10


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/bdr99/py-aosmith/issues/3
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/35091

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
