### PR TITLE
Fix problems with automatic management of Schlage locks

### DIFF
--- a/tests/components/schlage/test_init.py
+++ b/tests/components/schlage/test_init.py
@@ -12,6 +12,7 @@ from syrupy.assertion import SnapshotAssertion
 from homeassistant.components.schlage.const import DOMAIN, UPDATE_INTERVAL
 from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.core import HomeAssistant
+import homeassistant.helpers.device_registry as dr
 from homeassistant.helpers.device_registry import DeviceRegistry
 
 from tests.common import MockConfigEntry, async_fire_time_changed
@@ -125,6 +126,10 @@ async def test_auto_add_device(
     """Test new devices are auto-added to the device registry."""
     device = device_registry.async_get_device(identifiers={(DOMAIN, "test")})
     assert device is not None
+    all_devices = dr.async_entries_for_config_entry(
+        device_registry, mock_added_config_entry.entry_id
+    )
+    assert len(all_devices) == 1
 
     mock_lock_attrs["device_id"] = "test2"
     new_mock_lock = create_autospec(Lock)
@@ -139,19 +144,21 @@ async def test_auto_add_device(
     new_device = device_registry.async_get_device(identifiers={(DOMAIN, "test2")})
     assert new_device is not None
 
+    all_devices = dr.async_entries_for_config_entry(
+        device_registry, mock_added_config_entry.entry_id
+    )
+    assert len(all_devices) == 2
+
 
 async def test_auto_remove_device(
     hass: HomeAssistant,
     device_registry: DeviceRegistry,
     mock_added_config_entry: ConfigEntry,
     mock_schlage: Mock,
-    mock_lock: Mock,
-    mock_lock_attrs: dict[str, Any],
     freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test new devices are auto-added to the device registry."""
-    device = device_registry.async_get_device(identifiers={(DOMAIN, "test")})
-    assert device is not None
+    assert device_registry.async_get_device(identifiers={(DOMAIN, "test")}) is not None
 
     mock_schlage.locks.return_value = []
 
@@ -160,5 +167,8 @@ async def test_auto_remove_device(
     async_fire_time_changed(hass)
     await hass.async_block_till_done(wait_background_tasks=True)
 
-    new_device = device_registry.async_get_device(identifiers={(DOMAIN, "test")})
-    assert new_device is None
+    assert device_registry.async_get_device(identifiers={(DOMAIN, "test")}) is None
+    all_devices = dr.async_entries_for_config_entry(
+        device_registry, mock_added_config_entry.entry_id
+    )
+    assert len(all_devices) == 0


### PR DESCRIPTION
## Proposed change
Fix a problem with auto-addition and removal of Schlage locks caused by comparing the wrong identifiers. The `device_id` we save in Schlage entities is from the Schlage API and is not the same as the Home Assistant concept of a `device_id`, so when we go to compare the previously seen locks with recently refreshed, we always replace all the existing entities. This causes the entities to completely refresh on every data reload and causes manual renames to get wiped out.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #127455
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
