### PR TITLE
Switch to using a fixture for evohome WaterHeater tests

### DIFF
--- a/tests/components/evohome/conftest.py
+++ b/tests/components/evohome/conftest.py
@@ -11,14 +11,12 @@ from unittest.mock import MagicMock, patch
 from aiohttp import ClientSession
 from evohomeasync2 import EvohomeClient
 from evohomeasync2.broker import Broker
-from evohomeasync2.hotwater import HotWater
 import pytest
 
 from homeassistant.components.evohome import CONF_PASSWORD, CONF_USERNAME, DOMAIN
-from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
-from homeassistant.util import dt as dt_util, slugify
+from homeassistant.util import dt as dt_util
 from homeassistant.util.json import JsonArrayType, JsonObjectType
 
 from .const import ACCESS_TOKEN, REFRESH_TOKEN, USERNAME
@@ -163,25 +161,3 @@ async def setup_evohome(
 
         mock_client.return_value = evo
         yield mock_client
-
-
-@pytest.fixture
-async def dhw_id(
-    hass: HomeAssistant,
-    config: dict[str, str],
-    install: str,
-) -> AsyncGenerator[str]:
-    """Return the entity_id of the evohome integration' WaterHeater.
-
-    Not all evohome systems have DHW.
-    """
-
-    dhw: HotWater | None
-
-    async for mock_client in setup_evohome(hass, config, install=install):
-        evo: EvohomeClient = mock_client.return_value
-
-        if (dhw := evo._get_single_tcs().hotwater) is None:
-            pytest.fail("DHW expected, but was not found")
-
-        yield f"{Platform.WATER_HEATER}.{slugify(dhw.name)}"

--- a/tests/components/evohome/conftest.py
+++ b/tests/components/evohome/conftest.py
@@ -161,3 +161,17 @@ async def setup_evohome(
 
         mock_client.return_value = evo
         yield mock_client
+
+
+@pytest.fixture
+async def evohome(
+    hass: HomeAssistant,
+    config: dict[str, str],
+    install: str,
+) -> AsyncGenerator[EvohomeClient]:
+    """Return the evohome client for this install fixture."""
+
+    async for mock_client in setup_evohome(hass, config, install=install):
+        evo: EvohomeClient = mock_client.return_value
+
+        yield evo

--- a/tests/components/evohome/conftest.py
+++ b/tests/components/evohome/conftest.py
@@ -168,10 +168,8 @@ async def evohome(
     hass: HomeAssistant,
     config: dict[str, str],
     install: str,
-) -> AsyncGenerator[EvohomeClient]:
-    """Return the evohome client for this install fixture."""
+) -> AsyncGenerator[MagicMock]:
+    """Return the mocked evohome client for this install fixture."""
 
     async for mock_client in setup_evohome(hass, config, install=install):
-        evo: EvohomeClient = mock_client.return_value
-
-        yield evo
+        yield mock_client

--- a/tests/components/evohome/conftest.py
+++ b/tests/components/evohome/conftest.py
@@ -11,16 +11,14 @@ from unittest.mock import MagicMock, patch
 from aiohttp import ClientSession
 from evohomeasync2 import EvohomeClient
 from evohomeasync2.broker import Broker
+from evohomeasync2.hotwater import HotWater
 import pytest
 
 from homeassistant.components.evohome import CONF_PASSWORD, CONF_USERNAME, DOMAIN
-from homeassistant.components.evohome.water_heater import EvoDHW
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.setup import async_setup_component
-from homeassistant.util import dt as dt_util
+from homeassistant.util import dt as dt_util, slugify
 from homeassistant.util.json import JsonArrayType, JsonObjectType
 
 from .const import ACCESS_TOKEN, REFRESH_TOKEN, USERNAME
@@ -167,27 +165,23 @@ async def setup_evohome(
         yield mock_client
 
 
-def get_dhw_entity(hass: HomeAssistant, evo: EvohomeClient) -> EvoDHW:
-    """Return the WaterHeater entity of the evohome integration."""
-
-    if (dhw := evo._get_single_tcs().hotwater) is None:
-        pytest.fail("DHW expected, but was not found")
-
-    entity_id = er.async_get(hass).async_get_entity_id(
-        Platform.WATER_HEATER, DOMAIN, dhw._id
-    )
-
-    component: EntityComponent = hass.data.get(Platform.WATER_HEATER)  # type: ignore[assignment]
-    return next(e for e in component.entities if e.entity_id == entity_id)  # type: ignore[return-value]
-
-
 @pytest.fixture
-async def dhw(
+async def dhw_id(
     hass: HomeAssistant,
     config: dict[str, str],
     install: str,
-) -> AsyncGenerator[EvoDHW]:
-    """Return the WaterHeater entity of the evohome integration."""
+) -> AsyncGenerator[str]:
+    """Return the entity_id of the evohome integration' WaterHeater.
+
+    Not all evohome systems have DHW.
+    """
+
+    dhw: HotWater | None
 
     async for mock_client in setup_evohome(hass, config, install=install):
-        yield get_dhw_entity(hass, mock_client.return_value)
+        evo: EvohomeClient = mock_client.return_value
+
+        if (dhw := evo._get_single_tcs().hotwater) is None:
+            pytest.fail("DHW expected, but was not found")
+
+        yield f"{Platform.WATER_HEATER}.{slugify(dhw.name)}"

--- a/tests/components/evohome/conftest.py
+++ b/tests/components/evohome/conftest.py
@@ -14,7 +14,12 @@ from evohomeasync2.broker import Broker
 import pytest
 
 from homeassistant.components.evohome import CONF_PASSWORD, CONF_USERNAME, DOMAIN
+from homeassistant.components.evohome.coordinator import EvoBroker
+from homeassistant.components.evohome.water_heater import EvoDHW
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 from homeassistant.util.json import JsonArrayType, JsonObjectType
@@ -153,3 +158,32 @@ async def setup_evohome(
         assert mock_client.account_info is not None
 
         yield mock_client
+
+
+def get_dhw_entity(hass: HomeAssistant) -> EvoDHW:
+    """Return the DHW entity of the evohome system."""
+
+    broker: EvoBroker = hass.data[DOMAIN]["broker"]
+
+    if (dhw := broker.tcs.hotwater) is None:
+        pytest.fail("DHW expected, but was not found")
+
+    entity_registry = er.async_get(hass)
+    entity_id = entity_registry.async_get_entity_id(
+        Platform.WATER_HEATER, DOMAIN, dhw._id
+    )
+
+    component: EntityComponent = hass.data.get(Platform.WATER_HEATER)  # type: ignore[assignment]
+    return next(e for e in component.entities if e.entity_id == entity_id)  # type: ignore[return-value]
+
+
+@pytest.fixture
+async def dhw(
+    hass: HomeAssistant,
+    config: dict[str, str],
+    install: str,
+) -> AsyncGenerator[EvoDHW]:
+    """Return the first heating zone (Climate entity) of the evohome system."""
+
+    async for _ in setup_evohome(hass, config, install=install):
+        yield get_dhw_entity(hass)

--- a/tests/components/evohome/conftest.py
+++ b/tests/components/evohome/conftest.py
@@ -161,7 +161,7 @@ async def setup_evohome(
 
 
 def get_dhw_entity(hass: HomeAssistant) -> EvoDHW:
-    """Return the DHW entity of the evohome system."""
+    """Return the WaterHeater entity of the evohome integration."""
 
     broker: EvoBroker = hass.data[DOMAIN]["broker"]
 
@@ -183,7 +183,7 @@ async def dhw(
     config: dict[str, str],
     install: str,
 ) -> AsyncGenerator[EvoDHW]:
-    """Return the first heating zone (Climate entity) of the evohome system."""
+    """Return the WaterHeater entity of the evohome integration."""
 
     async for _ in setup_evohome(hass, config, install=install):
         yield get_dhw_entity(hass)

--- a/tests/components/evohome/snapshots/test_water_heater.ambr
+++ b/tests/components/evohome/snapshots/test_water_heater.ambr
@@ -2,18 +2,8 @@
 # name: test_set_operation_mode[default]
   list([
     tuple(
-      dict({
-        'mode': <ZoneMode.TEMPORARY_OVERRIDE: 'TemporaryOverride'>,
-        'state': <DhwState.OFF: 'Off'>,
-        'untilTime': '2024-07-10T12:00:00Z',
-      }),
     ),
     tuple(
-      dict({
-        'mode': <ZoneMode.TEMPORARY_OVERRIDE: 'TemporaryOverride'>,
-        'state': <DhwState.ON: 'On'>,
-        'untilTime': '2024-07-10T12:00:00Z',
-      }),
     ),
   ])
 # ---

--- a/tests/components/evohome/test_water_heater.py
+++ b/tests/components/evohome/test_water_heater.py
@@ -23,13 +23,13 @@ from .conftest import setup_evohome
 from .const import TEST_INSTALLS_WITH_DHW
 
 
-def get_dhw_entity(hass: HomeAssistant) -> EvoDHW | None:
+def get_dhw_entity(hass: HomeAssistant) -> EvoDHW:
     """Return the DHW entity of the evohome system."""
 
     broker: EvoBroker = hass.data[DOMAIN]["broker"]
 
     if (dhw := broker.tcs.hotwater) is None:
-        return None
+        pytest.fail("DHW expected, but not found")
 
     entity_registry = er.async_get(hass)
     entity_id = entity_registry.async_get_entity_id(

--- a/tests/components/evohome/test_water_heater.py
+++ b/tests/components/evohome/test_water_heater.py
@@ -11,7 +11,6 @@ from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy import SnapshotAssertion
 
-from homeassistant.components.evohome.water_heater import EvoDHW
 from homeassistant.components.water_heater import (
     ATTR_AWAY_MODE,
     ATTR_OPERATION_MODE,
@@ -33,13 +32,11 @@ from .const import TEST_INSTALLS_WITH_DHW
 @pytest.mark.parametrize("install", TEST_INSTALLS_WITH_DHW)
 async def test_set_operation_mode(
     hass: HomeAssistant,
-    dhw: EvoDHW,
+    dhw_id: str,
     freezer: FrozenDateTimeFactory,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test SERVICE_SET_OPERATION_MODE of a evohome HotWater entity."""
-
-    assert dhw.operation_list == ["auto", "on", "off"]
 
     freezer.move_to("2024-07-10T11:55:00Z")
     results = []
@@ -50,7 +47,7 @@ async def test_set_operation_mode(
             Platform.WATER_HEATER,
             SERVICE_SET_OPERATION_MODE,
             {
-                ATTR_ENTITY_ID: dhw.entity_id,
+                ATTR_ENTITY_ID: dhw_id,
                 ATTR_OPERATION_MODE: "auto",
             },
             blocking=True,
@@ -66,7 +63,7 @@ async def test_set_operation_mode(
             Platform.WATER_HEATER,
             SERVICE_SET_OPERATION_MODE,
             {
-                ATTR_ENTITY_ID: dhw.entity_id,
+                ATTR_ENTITY_ID: dhw_id,
                 ATTR_OPERATION_MODE: "off",
             },
             blocking=True,
@@ -82,7 +79,7 @@ async def test_set_operation_mode(
             Platform.WATER_HEATER,
             SERVICE_SET_OPERATION_MODE,
             {
-                ATTR_ENTITY_ID: dhw.entity_id,
+                ATTR_ENTITY_ID: dhw_id,
                 ATTR_OPERATION_MODE: "on",
             },
             blocking=True,
@@ -96,7 +93,7 @@ async def test_set_operation_mode(
 
 
 @pytest.mark.parametrize("install", TEST_INSTALLS_WITH_DHW)
-async def test_set_away_mode(hass: HomeAssistant, dhw: EvoDHW) -> None:
+async def test_set_away_mode(hass: HomeAssistant, dhw_id: str) -> None:
     """Test SERVICE_SET_AWAY_MODE of a evohome HotWater entity."""
 
     # set_away_mode: off
@@ -105,7 +102,7 @@ async def test_set_away_mode(hass: HomeAssistant, dhw: EvoDHW) -> None:
             Platform.WATER_HEATER,
             SERVICE_SET_AWAY_MODE,
             {
-                ATTR_ENTITY_ID: dhw.entity_id,
+                ATTR_ENTITY_ID: dhw_id,
                 ATTR_AWAY_MODE: "off",
             },
             blocking=True,
@@ -121,7 +118,7 @@ async def test_set_away_mode(hass: HomeAssistant, dhw: EvoDHW) -> None:
             Platform.WATER_HEATER,
             SERVICE_SET_AWAY_MODE,
             {
-                ATTR_ENTITY_ID: dhw.entity_id,
+                ATTR_ENTITY_ID: dhw_id,
                 ATTR_AWAY_MODE: "on",
             },
             blocking=True,
@@ -133,7 +130,7 @@ async def test_set_away_mode(hass: HomeAssistant, dhw: EvoDHW) -> None:
 
 
 @pytest.mark.parametrize("install", TEST_INSTALLS_WITH_DHW)
-async def test_turn_off(hass: HomeAssistant, dhw: EvoDHW) -> None:
+async def test_turn_off(hass: HomeAssistant, dhw_id: str) -> None:
     """Test SERVICE_TURN_OFF of a evohome HotWater entity."""
 
     # Entity water_heater.domestic_hot_water does not support this service
@@ -142,14 +139,14 @@ async def test_turn_off(hass: HomeAssistant, dhw: EvoDHW) -> None:
             Platform.WATER_HEATER,
             SERVICE_TURN_OFF,
             {
-                ATTR_ENTITY_ID: dhw.entity_id,
+                ATTR_ENTITY_ID: dhw_id,
             },
             blocking=True,
         )
 
 
 @pytest.mark.parametrize("install", TEST_INSTALLS_WITH_DHW)
-async def test_turn_on(hass: HomeAssistant, dhw: EvoDHW) -> None:
+async def test_turn_on(hass: HomeAssistant, dhw_id: str) -> None:
     """Test SERVICE_TURN_ON of a evohome HotWater entity."""
 
     # Entity water_heater.domestic_hot_water does not support this service
@@ -158,7 +155,7 @@ async def test_turn_on(hass: HomeAssistant, dhw: EvoDHW) -> None:
             Platform.WATER_HEATER,
             SERVICE_TURN_ON,
             {
-                ATTR_ENTITY_ID: dhw.entity_id,
+                ATTR_ENTITY_ID: dhw_id,
             },
             blocking=True,
         )

--- a/tests/components/evohome/test_water_heater.py
+++ b/tests/components/evohome/test_water_heater.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
+from evohomeasync2 import EvohomeClient
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy import SnapshotAssertion
@@ -34,6 +35,7 @@ DHW_ENTITY_ID = "water_heater.domestic_hot_water"
 @pytest.mark.parametrize("install", TEST_INSTALLS_WITH_DHW)
 async def test_set_operation_mode(
     hass: HomeAssistant,
+    evohome: EvohomeClient,
     freezer: FrozenDateTimeFactory,
     snapshot: SnapshotAssertion,
 ) -> None:
@@ -94,7 +96,7 @@ async def test_set_operation_mode(
 
 
 @pytest.mark.parametrize("install", TEST_INSTALLS_WITH_DHW)
-async def test_set_away_mode(hass: HomeAssistant) -> None:
+async def test_set_away_mode(hass: HomeAssistant, evohome: EvohomeClient) -> None:
     """Test SERVICE_SET_AWAY_MODE of a evohome HotWater entity."""
 
     # set_away_mode: off
@@ -131,7 +133,7 @@ async def test_set_away_mode(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize("install", TEST_INSTALLS_WITH_DHW)
-async def test_turn_off(hass: HomeAssistant) -> None:
+async def test_turn_off(hass: HomeAssistant, evohome: EvohomeClient) -> None:
     """Test SERVICE_TURN_OFF of a evohome HotWater entity."""
 
     # Entity water_heater.domestic_hot_water does not support this service
@@ -147,7 +149,7 @@ async def test_turn_off(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize("install", TEST_INSTALLS_WITH_DHW)
-async def test_turn_on(hass: HomeAssistant) -> None:
+async def test_turn_on(hass: HomeAssistant, evohome: EvohomeClient) -> None:
     """Test SERVICE_TURN_ON of a evohome HotWater entity."""
 
     # Entity water_heater.domestic_hot_water does not support this service

--- a/tests/components/evohome/test_water_heater.py
+++ b/tests/components/evohome/test_water_heater.py
@@ -28,7 +28,7 @@ from homeassistant.exceptions import HomeAssistantError
 
 from .const import TEST_INSTALLS_WITH_DHW
 
-DHW_ID = "water_heater.domestic_hot_water"
+DHW_ENTITY_ID = "water_heater.domestic_hot_water"
 
 
 @pytest.mark.parametrize("install", TEST_INSTALLS_WITH_DHW)
@@ -48,7 +48,7 @@ async def test_set_operation_mode(
             Platform.WATER_HEATER,
             SERVICE_SET_OPERATION_MODE,
             {
-                ATTR_ENTITY_ID: DHW_ID,
+                ATTR_ENTITY_ID: DHW_ENTITY_ID,
                 ATTR_OPERATION_MODE: "auto",
             },
             blocking=True,
@@ -64,7 +64,7 @@ async def test_set_operation_mode(
             Platform.WATER_HEATER,
             SERVICE_SET_OPERATION_MODE,
             {
-                ATTR_ENTITY_ID: DHW_ID,
+                ATTR_ENTITY_ID: DHW_ENTITY_ID,
                 ATTR_OPERATION_MODE: "off",
             },
             blocking=True,
@@ -80,7 +80,7 @@ async def test_set_operation_mode(
             Platform.WATER_HEATER,
             SERVICE_SET_OPERATION_MODE,
             {
-                ATTR_ENTITY_ID: DHW_ID,
+                ATTR_ENTITY_ID: DHW_ENTITY_ID,
                 ATTR_OPERATION_MODE: "on",
             },
             blocking=True,
@@ -103,7 +103,7 @@ async def test_set_away_mode(hass: HomeAssistant) -> None:
             Platform.WATER_HEATER,
             SERVICE_SET_AWAY_MODE,
             {
-                ATTR_ENTITY_ID: DHW_ID,
+                ATTR_ENTITY_ID: DHW_ENTITY_ID,
                 ATTR_AWAY_MODE: "off",
             },
             blocking=True,
@@ -119,7 +119,7 @@ async def test_set_away_mode(hass: HomeAssistant) -> None:
             Platform.WATER_HEATER,
             SERVICE_SET_AWAY_MODE,
             {
-                ATTR_ENTITY_ID: DHW_ID,
+                ATTR_ENTITY_ID: DHW_ENTITY_ID,
                 ATTR_AWAY_MODE: "on",
             },
             blocking=True,
@@ -140,7 +140,7 @@ async def test_turn_off(hass: HomeAssistant) -> None:
             Platform.WATER_HEATER,
             SERVICE_TURN_OFF,
             {
-                ATTR_ENTITY_ID: DHW_ID,
+                ATTR_ENTITY_ID: DHW_ENTITY_ID,
             },
             blocking=True,
         )
@@ -156,7 +156,7 @@ async def test_turn_on(hass: HomeAssistant) -> None:
             Platform.WATER_HEATER,
             SERVICE_TURN_ON,
             {
-                ATTR_ENTITY_ID: DHW_ID,
+                ATTR_ENTITY_ID: DHW_ENTITY_ID,
             },
             blocking=True,
         )

--- a/tests/components/evohome/test_water_heater.py
+++ b/tests/components/evohome/test_water_heater.py
@@ -12,14 +12,12 @@ import pytest
 from syrupy import SnapshotAssertion
 
 from homeassistant.components.evohome.water_heater import EvoDHW
-from homeassistant.core import HomeAssistant
 
 from .const import TEST_INSTALLS_WITH_DHW
 
 
 @pytest.mark.parametrize("install", TEST_INSTALLS_WITH_DHW)
 async def test_set_operation_mode(
-    hass: HomeAssistant,
     install: str,
     dhw: EvoDHW,
     freezer: FrozenDateTimeFactory,
@@ -80,11 +78,7 @@ async def test_set_operation_mode(
 
 
 @pytest.mark.parametrize("install", TEST_INSTALLS_WITH_DHW)
-async def test_turn_away_mode_off(
-    hass: HomeAssistant,
-    install: str,
-    dhw: EvoDHW,
-) -> None:
+async def test_turn_away_mode_off(dhw: EvoDHW) -> None:
     """Test water_heater services of a evohome-compatible DHW zone."""
 
     # turn_away_mode_off(): FollowSchedule
@@ -103,11 +97,7 @@ async def test_turn_away_mode_off(
 
 
 @pytest.mark.parametrize("install", TEST_INSTALLS_WITH_DHW)
-async def test_turn_away_mode_on(
-    hass: HomeAssistant,
-    install: str,
-    dhw: EvoDHW,
-) -> None:
+async def test_turn_away_mode_on(dhw: EvoDHW) -> None:
     """Test water_heater services of a evohome-compatible DHW zone."""
 
     # turn_away_mode_on(): PermanentOverride, Off
@@ -126,11 +116,7 @@ async def test_turn_away_mode_on(
 
 
 @pytest.mark.parametrize("install", TEST_INSTALLS_WITH_DHW)
-async def test_turn_off(
-    hass: HomeAssistant,
-    install: str,
-    dhw: EvoDHW,
-) -> None:
+async def test_turn_off(dhw: EvoDHW) -> None:
     """Test water_heater services of a evohome-compatible DHW zone."""
 
     # turn_off(): PermanentOverride, Off
@@ -149,11 +135,7 @@ async def test_turn_off(
 
 
 @pytest.mark.parametrize("install", TEST_INSTALLS_WITH_DHW)
-async def test_turn_on(
-    hass: HomeAssistant,
-    install: str,
-    dhw: EvoDHW,
-) -> None:
+async def test_turn_on(dhw: EvoDHW) -> None:
     """Test water_heater services of a evohome-compatible DHW zone."""
 
     # turn_on(): PermanentOverride, On

--- a/tests/components/evohome/test_water_heater.py
+++ b/tests/components/evohome/test_water_heater.py
@@ -28,11 +28,12 @@ from homeassistant.exceptions import HomeAssistantError
 
 from .const import TEST_INSTALLS_WITH_DHW
 
+DHW_ID = "water_heater.domestic_hot_water"
+
 
 @pytest.mark.parametrize("install", TEST_INSTALLS_WITH_DHW)
 async def test_set_operation_mode(
     hass: HomeAssistant,
-    dhw_id: str,
     freezer: FrozenDateTimeFactory,
     snapshot: SnapshotAssertion,
 ) -> None:
@@ -47,7 +48,7 @@ async def test_set_operation_mode(
             Platform.WATER_HEATER,
             SERVICE_SET_OPERATION_MODE,
             {
-                ATTR_ENTITY_ID: dhw_id,
+                ATTR_ENTITY_ID: DHW_ID,
                 ATTR_OPERATION_MODE: "auto",
             },
             blocking=True,
@@ -63,7 +64,7 @@ async def test_set_operation_mode(
             Platform.WATER_HEATER,
             SERVICE_SET_OPERATION_MODE,
             {
-                ATTR_ENTITY_ID: dhw_id,
+                ATTR_ENTITY_ID: DHW_ID,
                 ATTR_OPERATION_MODE: "off",
             },
             blocking=True,
@@ -79,7 +80,7 @@ async def test_set_operation_mode(
             Platform.WATER_HEATER,
             SERVICE_SET_OPERATION_MODE,
             {
-                ATTR_ENTITY_ID: dhw_id,
+                ATTR_ENTITY_ID: DHW_ID,
                 ATTR_OPERATION_MODE: "on",
             },
             blocking=True,
@@ -93,7 +94,7 @@ async def test_set_operation_mode(
 
 
 @pytest.mark.parametrize("install", TEST_INSTALLS_WITH_DHW)
-async def test_set_away_mode(hass: HomeAssistant, dhw_id: str) -> None:
+async def test_set_away_mode(hass: HomeAssistant) -> None:
     """Test SERVICE_SET_AWAY_MODE of a evohome HotWater entity."""
 
     # set_away_mode: off
@@ -102,7 +103,7 @@ async def test_set_away_mode(hass: HomeAssistant, dhw_id: str) -> None:
             Platform.WATER_HEATER,
             SERVICE_SET_AWAY_MODE,
             {
-                ATTR_ENTITY_ID: dhw_id,
+                ATTR_ENTITY_ID: DHW_ID,
                 ATTR_AWAY_MODE: "off",
             },
             blocking=True,
@@ -118,7 +119,7 @@ async def test_set_away_mode(hass: HomeAssistant, dhw_id: str) -> None:
             Platform.WATER_HEATER,
             SERVICE_SET_AWAY_MODE,
             {
-                ATTR_ENTITY_ID: dhw_id,
+                ATTR_ENTITY_ID: DHW_ID,
                 ATTR_AWAY_MODE: "on",
             },
             blocking=True,
@@ -130,7 +131,7 @@ async def test_set_away_mode(hass: HomeAssistant, dhw_id: str) -> None:
 
 
 @pytest.mark.parametrize("install", TEST_INSTALLS_WITH_DHW)
-async def test_turn_off(hass: HomeAssistant, dhw_id: str) -> None:
+async def test_turn_off(hass: HomeAssistant) -> None:
     """Test SERVICE_TURN_OFF of a evohome HotWater entity."""
 
     # Entity water_heater.domestic_hot_water does not support this service
@@ -139,14 +140,14 @@ async def test_turn_off(hass: HomeAssistant, dhw_id: str) -> None:
             Platform.WATER_HEATER,
             SERVICE_TURN_OFF,
             {
-                ATTR_ENTITY_ID: dhw_id,
+                ATTR_ENTITY_ID: DHW_ID,
             },
             blocking=True,
         )
 
 
 @pytest.mark.parametrize("install", TEST_INSTALLS_WITH_DHW)
-async def test_turn_on(hass: HomeAssistant, dhw_id: str) -> None:
+async def test_turn_on(hass: HomeAssistant) -> None:
     """Test SERVICE_TURN_ON of a evohome HotWater entity."""
 
     # Entity water_heater.domestic_hot_water does not support this service
@@ -155,7 +156,7 @@ async def test_turn_on(hass: HomeAssistant, dhw_id: str) -> None:
             Platform.WATER_HEATER,
             SERVICE_TURN_ON,
             {
-                ATTR_ENTITY_ID: dhw_id,
+                ATTR_ENTITY_ID: DHW_ID,
             },
             blocking=True,
         )

--- a/tests/components/evohome/test_water_heater.py
+++ b/tests/components/evohome/test_water_heater.py
@@ -11,40 +11,17 @@ from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy import SnapshotAssertion
 
-from homeassistant.components.evohome import DOMAIN
-from homeassistant.components.evohome.coordinator import EvoBroker
 from homeassistant.components.evohome.water_heater import EvoDHW
-from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers.entity_component import EntityComponent
 
-from .conftest import setup_evohome
 from .const import TEST_INSTALLS_WITH_DHW
-
-
-def get_dhw_entity(hass: HomeAssistant) -> EvoDHW:
-    """Return the DHW entity of the evohome system."""
-
-    broker: EvoBroker = hass.data[DOMAIN]["broker"]
-
-    if (dhw := broker.tcs.hotwater) is None:
-        pytest.fail("DHW expected, but not found")
-
-    entity_registry = er.async_get(hass)
-    entity_id = entity_registry.async_get_entity_id(
-        Platform.WATER_HEATER, DOMAIN, dhw._id
-    )
-
-    component: EntityComponent = hass.data.get(Platform.WATER_HEATER)  # type: ignore[assignment]
-    return next(e for e in component.entities if e.entity_id == entity_id)  # type: ignore[return-value]
 
 
 @pytest.mark.parametrize("install", TEST_INSTALLS_WITH_DHW)
 async def test_set_operation_mode(
     hass: HomeAssistant,
-    config: dict[str, str],
     install: str,
+    dhw: EvoDHW,
     freezer: FrozenDateTimeFactory,
     snapshot: SnapshotAssertion,
 ) -> None:
@@ -53,54 +30,51 @@ async def test_set_operation_mode(
     freezer.move_to("2024-07-10T11:55:00Z")
     results = []
 
-    async for _ in setup_evohome(hass, config, install=install):
-        dhw = get_dhw_entity(hass)
+    # set_operation_mode(auto): FollowSchedule
+    with patch("evohomeasync2.hotwater.HotWater._set_mode") as mock_fcn:
+        await dhw.async_set_operation_mode("auto")
 
-        # set_operation_mode(auto): FollowSchedule
-        with patch("evohomeasync2.hotwater.HotWater._set_mode") as mock_fcn:
-            await dhw.async_set_operation_mode("auto")
+        assert mock_fcn.await_count == 1
+        assert mock_fcn.await_args.args == (
+            {
+                "mode": "FollowSchedule",
+                "state": None,
+                "untilTime": None,
+            },
+        )
+        assert mock_fcn.await_args.kwargs == {}
 
-            assert mock_fcn.await_count == 1
-            assert mock_fcn.await_args.args == (
-                {
-                    "mode": "FollowSchedule",
-                    "state": None,
-                    "untilTime": None,
-                },
-            )
-            assert mock_fcn.await_args.kwargs == {}
+    # set_operation_mode(off): TemporaryOverride, advanced
+    with patch("evohomeasync2.hotwater.HotWater._set_mode") as mock_fcn:
+        await dhw.async_set_operation_mode("off")
 
-        # set_operation_mode(off): TemporaryOverride, advanced
-        with patch("evohomeasync2.hotwater.HotWater._set_mode") as mock_fcn:
-            await dhw.async_set_operation_mode("off")
+        assert mock_fcn.await_count == 1
+        assert install != "default" or mock_fcn.await_args.args == (
+            {
+                "mode": "TemporaryOverride",
+                "state": "Off",
+                "untilTime": "2024-07-10T12:00:00Z",  # varies by install
+            },
+        )
+        assert mock_fcn.await_args.kwargs == {}
 
-            assert mock_fcn.await_count == 1
-            assert install != "default" or mock_fcn.await_args.args == (
-                {
-                    "mode": "TemporaryOverride",
-                    "state": "Off",
-                    "untilTime": "2024-07-10T12:00:00Z",  # varies by install
-                },
-            )
-            assert mock_fcn.await_args.kwargs == {}
+        results.append(mock_fcn.await_args.args)
 
-            results.append(mock_fcn.await_args.args)
+    # set_operation_mode(on): TemporaryOverride, advanced
+    with patch("evohomeasync2.hotwater.HotWater._set_mode") as mock_fcn:
+        await dhw.async_set_operation_mode("on")
 
-        # set_operation_mode(on): TemporaryOverride, advanced
-        with patch("evohomeasync2.hotwater.HotWater._set_mode") as mock_fcn:
-            await dhw.async_set_operation_mode("on")
+        assert mock_fcn.await_count == 1
+        assert install != "default" or mock_fcn.await_args.args == (
+            {
+                "mode": "TemporaryOverride",
+                "state": "On",
+                "untilTime": "2024-07-10T12:00:00Z",  # varies by install
+            },
+        )
+        assert mock_fcn.await_args.kwargs == {}
 
-            assert mock_fcn.await_count == 1
-            assert install != "default" or mock_fcn.await_args.args == (
-                {
-                    "mode": "TemporaryOverride",
-                    "state": "On",
-                    "untilTime": "2024-07-10T12:00:00Z",  # varies by install
-                },
-            )
-            assert mock_fcn.await_args.kwargs == {}
-
-            results.append(mock_fcn.await_args.args)
+        results.append(mock_fcn.await_args.args)
 
     assert results == snapshot
 
@@ -108,102 +82,90 @@ async def test_set_operation_mode(
 @pytest.mark.parametrize("install", TEST_INSTALLS_WITH_DHW)
 async def test_turn_away_mode_off(
     hass: HomeAssistant,
-    config: dict[str, str],
     install: str,
+    dhw: EvoDHW,
 ) -> None:
     """Test water_heater services of a evohome-compatible DHW zone."""
 
-    async for _ in setup_evohome(hass, config, install=install):
-        dhw = get_dhw_entity(hass)
+    # turn_away_mode_off(): FollowSchedule
+    with patch("evohomeasync2.hotwater.HotWater._set_mode") as mock_fcn:
+        await dhw.async_turn_away_mode_off()
 
-        # turn_away_mode_off(): FollowSchedule
-        with patch("evohomeasync2.hotwater.HotWater._set_mode") as mock_fcn:
-            await dhw.async_turn_away_mode_off()
-
-            assert mock_fcn.await_count == 1
-            assert mock_fcn.await_args.args == (
-                {
-                    "mode": "FollowSchedule",
-                    "state": None,
-                    "untilTime": None,
-                },
-            )
-            assert mock_fcn.await_args.kwargs == {}
+        assert mock_fcn.await_count == 1
+        assert mock_fcn.await_args.args == (
+            {
+                "mode": "FollowSchedule",
+                "state": None,
+                "untilTime": None,
+            },
+        )
+        assert mock_fcn.await_args.kwargs == {}
 
 
 @pytest.mark.parametrize("install", TEST_INSTALLS_WITH_DHW)
 async def test_turn_away_mode_on(
     hass: HomeAssistant,
-    config: dict[str, str],
     install: str,
+    dhw: EvoDHW,
 ) -> None:
     """Test water_heater services of a evohome-compatible DHW zone."""
 
-    async for _ in setup_evohome(hass, config, install=install):
-        dhw = get_dhw_entity(hass)
+    # turn_away_mode_on(): PermanentOverride, Off
+    with patch("evohomeasync2.hotwater.HotWater._set_mode") as mock_fcn:
+        await dhw.async_turn_away_mode_on()
 
-        # turn_away_mode_on(): PermanentOverride, Off
-        with patch("evohomeasync2.hotwater.HotWater._set_mode") as mock_fcn:
-            await dhw.async_turn_away_mode_on()
-
-            assert mock_fcn.await_count == 1
-            assert mock_fcn.await_args.args == (
-                {
-                    "mode": "PermanentOverride",
-                    "state": "Off",
-                    "untilTime": None,
-                },
-            )
-            assert mock_fcn.await_args.kwargs == {}
+        assert mock_fcn.await_count == 1
+        assert mock_fcn.await_args.args == (
+            {
+                "mode": "PermanentOverride",
+                "state": "Off",
+                "untilTime": None,
+            },
+        )
+        assert mock_fcn.await_args.kwargs == {}
 
 
 @pytest.mark.parametrize("install", TEST_INSTALLS_WITH_DHW)
 async def test_turn_off(
     hass: HomeAssistant,
-    config: dict[str, str],
     install: str,
+    dhw: EvoDHW,
 ) -> None:
     """Test water_heater services of a evohome-compatible DHW zone."""
 
-    async for _ in setup_evohome(hass, config, install=install):
-        dhw = get_dhw_entity(hass)
+    # turn_off(): PermanentOverride, Off
+    with patch("evohomeasync2.hotwater.HotWater._set_mode") as mock_fcn:
+        await dhw.async_turn_off()
 
-        # turn_off(): PermanentOverride, Off
-        with patch("evohomeasync2.hotwater.HotWater._set_mode") as mock_fcn:
-            await dhw.async_turn_off()
-
-            assert mock_fcn.await_count == 1
-            assert mock_fcn.await_args.args == (
-                {
-                    "mode": "PermanentOverride",
-                    "state": "Off",
-                    "untilTime": None,
-                },
-            )
-            assert mock_fcn.await_args.kwargs == {}
+        assert mock_fcn.await_count == 1
+        assert mock_fcn.await_args.args == (
+            {
+                "mode": "PermanentOverride",
+                "state": "Off",
+                "untilTime": None,
+            },
+        )
+        assert mock_fcn.await_args.kwargs == {}
 
 
 @pytest.mark.parametrize("install", TEST_INSTALLS_WITH_DHW)
 async def test_turn_on(
     hass: HomeAssistant,
-    config: dict[str, str],
     install: str,
+    dhw: EvoDHW,
 ) -> None:
     """Test water_heater services of a evohome-compatible DHW zone."""
 
-    async for _ in setup_evohome(hass, config, install=install):
-        dhw = get_dhw_entity(hass)
+    # turn_on(): PermanentOverride, On
+    with patch("evohomeasync2.hotwater.HotWater._set_mode") as mock_fcn:
+        await dhw.async_turn_on()
 
-        # turn_on(): PermanentOverride, On
-        with patch("evohomeasync2.hotwater.HotWater._set_mode") as mock_fcn:
-            await dhw.async_turn_on()
-
-            assert mock_fcn.await_count == 1
-            assert mock_fcn.await_args.args == (
-                {
-                    "mode": "PermanentOverride",
-                    "state": "On",
-                    "untilTime": None,
-                },
-            )
-            assert mock_fcn.await_args.kwargs == {}
+        assert mock_fcn.await_count == 1
+        assert mock_fcn.await_args.args == (
+            {
+                "mode": "PermanentOverride",
+                "state": "On",
+                "untilTime": None,
+            },
+        )
+        assert mock_fcn.await_args.kwargs == {}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR greatly simplifies the tests of the **WaterHeater** entity, by moving setup logic into **conftest.py**:
 - passes in `evohome` as a fixture rather than using `setup_evohome()`: thus, the integration is no longer setup in the test
 - uses a constant for the **WaterHeater** entity ID instead of extracting it as an attr of the entity  via `get_dhw_entity()` (this function is now removed) 

Once this PR is merged, I'll submit other PRs for replacing `get_ctl_entity()` and `get_zone_entity()` with fixtures

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
