### PR TITLE
Add default reconfigure reason in update_reload_and_abort

### DIFF
--- a/homeassistant/components/bryant_evolution/config_flow.py
+++ b/homeassistant/components/bryant_evolution/config_flow.py
@@ -79,7 +79,6 @@ class BryantConfigFlow(ConfigFlow, domain=DOMAIN):
                         CONF_FILENAME: user_input[CONF_FILENAME],
                         CONF_SYSTEM_ZONE: system_zone,
                     },
-                    reason="reconfigure_successful",
                 )
             errors["base"] = "cannot_connect"
         return self.async_show_form(

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -2745,12 +2745,11 @@ class ConfigFlow(ConfigEntryBaseFlow):
         if reload_even_if_entry_is_unchanged or result:
             self.hass.config_entries.async_schedule_reload(entry.entry_id)
         if reason is UNDEFINED:
-            if (source := self.source) == SOURCE_REAUTH:
-                reason = "reauth_successful"
-            elif source == SOURCE_RECONFIGURE:
-                reason = "reconfigure_successful"
-            else:
-                raise ValueError(f"Default reason not available for {source} flows")
+            reason = (
+                "reconfigure_successful"
+                if self.source == SOURCE_RECONFIGURE
+                else "reauth_successful"
+            )
         return self.async_abort(reason=reason)
 
     def is_matching(self, other_flow: Self) -> bool:

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -2745,11 +2745,9 @@ class ConfigFlow(ConfigEntryBaseFlow):
         if reload_even_if_entry_is_unchanged or result:
             self.hass.config_entries.async_schedule_reload(entry.entry_id)
         if reason is UNDEFINED:
-            reason = (
-                "reconfigure_successful"
-                if self.source == SOURCE_RECONFIGURE
-                else "reauth_successful"
-            )
+            reason = "reauth_successful"
+            if self.source == SOURCE_RECONFIGURE:
+                reason = "reconfigure_successful"
         return self.async_abort(reason=reason)
 
     def is_matching(self, other_flow: Self) -> bool:

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -2731,7 +2731,7 @@ class ConfigFlow(ConfigEntryBaseFlow):
         title: str | UndefinedType = UNDEFINED,
         data: Mapping[str, Any] | UndefinedType = UNDEFINED,
         options: Mapping[str, Any] | UndefinedType = UNDEFINED,
-        reason: str = "reauth_successful",
+        reason: str | UndefinedType = UNDEFINED,
         reload_even_if_entry_is_unchanged: bool = True,
     ) -> ConfigFlowResult:
         """Update config entry, reload config entry and finish config flow."""
@@ -2744,6 +2744,13 @@ class ConfigFlow(ConfigEntryBaseFlow):
         )
         if reload_even_if_entry_is_unchanged or result:
             self.hass.config_entries.async_schedule_reload(entry.entry_id)
+        if reason is UNDEFINED:
+            if (source := self.source) == SOURCE_REAUTH:
+                reason = "reauth_successful"
+            elif source == SOURCE_RECONFIGURE:
+                reason = "reconfigure_successful"
+            else:
+                raise ValueError(f"Default reason not available for {source} flows")
         return self.async_abort(reason=reason)
 
     def is_matching(self, other_flow: Self) -> bool:

--- a/tests/components/config/test_config_entries.py
+++ b/tests/components/config/test_config_entries.py
@@ -2421,7 +2421,7 @@ async def test_supports_reconfigure(
     data.pop("flow_id")
     assert data == {
         "handler": "test",
-        "reason": "reauth_successful",
+        "reason": "reconfigure_successful",
         "type": "abort",
         "description_placeholders": None,
     }


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently, the default reconfigure reason in `async_update_reload_and_abort` helper is `reauth_successful`, which forces us to add an explicit reason when calling it from a reconfigure flow.

This PR changes the default to `reconfigure_successful` in a reconfigure flow.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
