### PR TITLE
Add updates argument to update_reload_and_abort helper

### DIFF
--- a/homeassistant/components/airvisual_pro/config_flow.py
+++ b/homeassistant/components/airvisual_pro/config_flow.py
@@ -110,7 +110,7 @@ class AirVisualProFlowHandler(ConfigFlow, domain=DOMAIN):
             )
 
         return self.async_update_reload_and_abort(
-            self._get_reauth_entry(), updates=user_input
+            self._get_reauth_entry(), data_updates=user_input
         )
 
     async def async_step_user(

--- a/homeassistant/components/airvisual_pro/config_flow.py
+++ b/homeassistant/components/airvisual_pro/config_flow.py
@@ -14,7 +14,7 @@ from pyairvisual.node import (
 )
 import voluptuous as vol
 
-from homeassistant.config_entries import ConfigEntry, ConfigFlow, ConfigFlowResult
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_IP_ADDRESS, CONF_PASSWORD
 
 from .const import DOMAIN, LOGGER
@@ -76,7 +76,7 @@ class AirVisualProFlowHandler(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
-    _reauth_entry: ConfigEntry
+    _reauth_entry_data: Mapping[str, Any]
 
     async def async_step_import(self, import_data: dict[str, Any]) -> ConfigFlowResult:
         """Import a config entry from `airvisual` integration (see #83882)."""
@@ -86,7 +86,7 @@ class AirVisualProFlowHandler(ConfigFlow, domain=DOMAIN):
         self, entry_data: Mapping[str, Any]
     ) -> ConfigFlowResult:
         """Handle configuration by re-auth."""
-        self._reauth_entry = self._get_reauth_entry()
+        self._reauth_entry_data = entry_data
         return await self.async_step_reauth_confirm()
 
     async def async_step_reauth_confirm(
@@ -99,7 +99,7 @@ class AirVisualProFlowHandler(ConfigFlow, domain=DOMAIN):
             )
 
         validation_result = await async_validate_credentials(
-            self._reauth_entry.data[CONF_IP_ADDRESS], user_input[CONF_PASSWORD]
+            self._reauth_entry_data[CONF_IP_ADDRESS], user_input[CONF_PASSWORD]
         )
 
         if validation_result.errors:
@@ -110,7 +110,7 @@ class AirVisualProFlowHandler(ConfigFlow, domain=DOMAIN):
             )
 
         return self.async_update_reload_and_abort(
-            self._reauth_entry, data=self._reauth_entry.data | user_input
+            self._get_reauth_entry(), updates=user_input
         )
 
     async def async_step_user(

--- a/homeassistant/components/aosmith/config_flow.py
+++ b/homeassistant/components/aosmith/config_flow.py
@@ -92,7 +92,7 @@ class AOSmithConfigFlow(ConfigFlow, domain=DOMAIN):
             if error is None:
                 return self.async_update_reload_and_abort(
                     self._get_reauth_entry(),
-                    updates=user_input,
+                    data_updates=user_input,
                 )
             errors["base"] = error
 

--- a/homeassistant/components/aosmith/config_flow.py
+++ b/homeassistant/components/aosmith/config_flow.py
@@ -88,12 +88,11 @@ class AOSmithConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input:
             password = user_input[CONF_PASSWORD]
 
-            entry = self._get_reauth_entry()
             error = await self._async_validate_credentials(self._reauth_email, password)
             if error is None:
                 return self.async_update_reload_and_abort(
-                    entry,
-                    data=entry.data | user_input,
+                    self._get_reauth_entry(),
+                    updates=user_input,
                 )
             errors["base"] = error
 

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -2761,11 +2761,16 @@ class ConfigFlow(ConfigEntryBaseFlow):
         unique_id: str | None | UndefinedType = UNDEFINED,
         title: str | UndefinedType = UNDEFINED,
         data: Mapping[str, Any] | UndefinedType = UNDEFINED,
+        updates: dict[str, Any] | UndefinedType = UNDEFINED,
         options: Mapping[str, Any] | UndefinedType = UNDEFINED,
         reason: str | UndefinedType = UNDEFINED,
         reload_even_if_entry_is_unchanged: bool = True,
     ) -> ConfigFlowResult:
         """Update config entry, reload config entry and finish config flow."""
+        if updates is not UNDEFINED:
+            if data is not UNDEFINED:
+                raise ValueError("Cannot set both data and updates")
+            data = {**entry.data, **updates}
         result = self.hass.config_entries.async_update_entry(
             entry=entry,
             unique_id=unique_id,

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -2766,7 +2766,20 @@ class ConfigFlow(ConfigEntryBaseFlow):
         reason: str | UndefinedType = UNDEFINED,
         reload_even_if_entry_is_unchanged: bool = True,
     ) -> ConfigFlowResult:
-        """Update config entry, reload config entry and finish config flow."""
+        """Update config entry, reload config entry and finish config flow.
+
+        :param data: used to replace the entry data with new data
+        :param data_updates: used to merge of updated data with pre-existing entry data
+        :param options: used to replace the entry options with new options
+        :param title: used to replace the title of the entry
+        :param unique_id: used to replace the unique_id of the entry
+
+        :param reason: used to set the reason for the abort, defaults to
+        `reauth_successful` or `reconfigure_successful` based on flow source
+
+        :param reload_even_if_entry_is_unchanged: set this to `False` if the entry
+        should not be reloaded if it is unchanged
+        """
         if data_updates is not UNDEFINED:
             if data is not UNDEFINED:
                 raise ValueError("Cannot set both data and data_updates")

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -2761,7 +2761,7 @@ class ConfigFlow(ConfigEntryBaseFlow):
         unique_id: str | None | UndefinedType = UNDEFINED,
         title: str | UndefinedType = UNDEFINED,
         data: Mapping[str, Any] | UndefinedType = UNDEFINED,
-        data_updates: dict[str, Any] | UndefinedType = UNDEFINED,
+        data_updates: Mapping[str, Any] | UndefinedType = UNDEFINED,
         options: Mapping[str, Any] | UndefinedType = UNDEFINED,
         reason: str | UndefinedType = UNDEFINED,
         reload_even_if_entry_is_unchanged: bool = True,

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -2783,7 +2783,7 @@ class ConfigFlow(ConfigEntryBaseFlow):
         if data_updates is not UNDEFINED:
             if data is not UNDEFINED:
                 raise ValueError("Cannot set both data and data_updates")
-            data = {**entry.data, **data_updates}
+            data = entry.data | data_updates
         result = self.hass.config_entries.async_update_entry(
             entry=entry,
             unique_id=unique_id,

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -2761,16 +2761,16 @@ class ConfigFlow(ConfigEntryBaseFlow):
         unique_id: str | None | UndefinedType = UNDEFINED,
         title: str | UndefinedType = UNDEFINED,
         data: Mapping[str, Any] | UndefinedType = UNDEFINED,
-        updates: dict[str, Any] | UndefinedType = UNDEFINED,
+        data_updates: dict[str, Any] | UndefinedType = UNDEFINED,
         options: Mapping[str, Any] | UndefinedType = UNDEFINED,
         reason: str | UndefinedType = UNDEFINED,
         reload_even_if_entry_is_unchanged: bool = True,
     ) -> ConfigFlowResult:
         """Update config entry, reload config entry and finish config flow."""
-        if updates is not UNDEFINED:
+        if data_updates is not UNDEFINED:
             if data is not UNDEFINED:
-                raise ValueError("Cannot set both data and updates")
-            data = {**entry.data, **updates}
+                raise ValueError("Cannot set both data and data_updates")
+            data = {**entry.data, **data_updates}
         result = self.hass.config_entries.async_update_entry(
             entry=entry,
             unique_id=unique_id,

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -2768,13 +2768,14 @@ class ConfigFlow(ConfigEntryBaseFlow):
     ) -> ConfigFlowResult:
         """Update config entry, reload config entry and finish config flow.
 
-        :param data: used to replace the entry data with new data
-        :param data_updates: add items from data_updates to entry data
-        :param options: used to replace the entry options with new options
-        :param title: used to replace the title of the entry
-        :param unique_id: used to replace the unique_id of the entry
+        :param data: replace the entry data with new data
+        :param data_updates: add items from data_updates to entry data - existing keys
+        are overridden
+        :param options: replace the entry options with new options
+        :param title: replace the title of the entry
+        :param unique_id: replace the unique_id of the entry
 
-        :param reason: used to set the reason for the abort, defaults to
+        :param reason: set the reason for the abort, defaults to
         `reauth_successful` or `reconfigure_successful` based on flow source
 
         :param reload_even_if_entry_is_unchanged: set this to `False` if the entry

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -2769,7 +2769,7 @@ class ConfigFlow(ConfigEntryBaseFlow):
         """Update config entry, reload config entry and finish config flow.
 
         :param data: used to replace the entry data with new data
-        :param data_updates: used to merge of updated data with pre-existing entry data
+        :param data_updates: add items from data_updates to entry data
         :param options: used to replace the entry options with new options
         :param title: used to replace the title of the entry
         :param unique_id: used to replace the unique_id of the entry

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -5122,6 +5122,7 @@ def test_raise_trying_to_add_same_config_entry_twice(
         "expected_data",
         "expected_options",
         "calls_entry_load_unload",
+        "raises",
     ),
     [
         (
@@ -5136,6 +5137,7 @@ def test_raise_trying_to_add_same_config_entry_twice(
             {"vendor": "data2"},
             {"vendor": "options2"},
             (2, 1),
+            None,
         ),
         (
             {
@@ -5149,6 +5151,7 @@ def test_raise_trying_to_add_same_config_entry_twice(
             {"vendor": "data"},
             {"vendor": "options"},
             (2, 1),
+            None,
         ),
         (
             {
@@ -5163,6 +5166,7 @@ def test_raise_trying_to_add_same_config_entry_twice(
             {"vendor": "data2"},
             {"vendor": "options2"},
             (2, 1),
+            None,
         ),
         (
             {
@@ -5177,6 +5181,7 @@ def test_raise_trying_to_add_same_config_entry_twice(
             {"vendor": "data"},
             {"vendor": "options"},
             (1, 0),
+            None,
         ),
         (
             {},
@@ -5185,6 +5190,7 @@ def test_raise_trying_to_add_same_config_entry_twice(
             {"vendor": "data"},
             {"vendor": "options"},
             (2, 1),
+            None,
         ),
         (
             {"data": {"buyer": "me"}, "options": {}},
@@ -5193,6 +5199,31 @@ def test_raise_trying_to_add_same_config_entry_twice(
             {"buyer": "me"},
             {},
             (2, 1),
+            None,
+        ),
+        (
+            {"updates": {"buyer": "me"}},
+            "Test",
+            "1234",
+            {"vendor": "data", "buyer": "me"},
+            {"vendor": "options"},
+            (2, 1),
+            None,
+        ),
+        (
+            {
+                "unique_id": "5678",
+                "title": "Updated title",
+                "data": {"vendor": "data2"},
+                "options": {"vendor": "options2"},
+                "updates": {"buyer": "me"},
+            },
+            "Test",
+            "1234",
+            {"vendor": "data"},
+            {"vendor": "options"},
+            (1, 0),
+            ValueError,
         ),
     ],
     ids=[
@@ -5202,6 +5233,8 @@ def test_raise_trying_to_add_same_config_entry_twice(
         "unchanged_entry_no_reload",
         "no_kwargs",
         "replace_data",
+        "update_data",
+        "update_and_data_raises",
     ],
 )
 @pytest.mark.parametrize(
@@ -5221,6 +5254,7 @@ async def test_update_entry_and_reload(
     expected_options: dict[str, Any],
     kwargs: dict[str, Any],
     calls_entry_load_unload: tuple[int, int],
+    raises: type[Exception] | None,
 ) -> None:
     """Test updating an entry and reloading."""
     entry = MockConfigEntry(
@@ -5255,11 +5289,15 @@ async def test_update_entry_and_reload(
             """Mock Reconfigure."""
             return self.async_update_reload_and_abort(entry, **kwargs)
 
+    err: Exception
     with mock_config_flow("comp", MockFlowHandler):
-        if source == config_entries.SOURCE_REAUTH:
-            result = await entry.start_reauth_flow(hass)
-        elif source == config_entries.SOURCE_RECONFIGURE:
-            result = await entry.start_reconfigure_flow(hass)
+        try:
+            if source == config_entries.SOURCE_REAUTH:
+                result = await entry.start_reauth_flow(hass)
+            elif source == config_entries.SOURCE_RECONFIGURE:
+                result = await entry.start_reconfigure_flow(hass)
+        except Exception as ex:  # noqa: BLE001
+            err = ex
 
     await hass.async_block_till_done()
 
@@ -5268,8 +5306,11 @@ async def test_update_entry_and_reload(
     assert entry.data == expected_data
     assert entry.options == expected_options
     assert entry.state == config_entries.ConfigEntryState.LOADED
-    assert result["type"] == FlowResultType.ABORT
-    assert result["reason"] == reason
+    if raises:
+        assert isinstance(err, raises)
+    else:
+        assert result["type"] == FlowResultType.ABORT
+        assert result["reason"] == reason
     # Assert entry was reloaded
     assert len(comp.async_setup_entry.mock_calls) == calls_entry_load_unload[0]
     assert len(comp.async_unload_entry.mock_calls) == calls_entry_load_unload[1]

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -5202,7 +5202,7 @@ def test_raise_trying_to_add_same_config_entry_twice(
             None,
         ),
         (
-            {"updates": {"buyer": "me"}},
+            {"data_updates": {"buyer": "me"}},
             "Test",
             "1234",
             {"vendor": "data", "buyer": "me"},
@@ -5216,7 +5216,7 @@ def test_raise_trying_to_add_same_config_entry_twice(
                 "title": "Updated title",
                 "data": {"vendor": "data2"},
                 "options": {"vendor": "options2"},
-                "updates": {"buyer": "me"},
+                "data_updates": {"buyer": "me"},
             },
             "Test",
             "1234",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Quite often, the reauth/reconfigure entry is only loaded to merge the old data with the new data.

```python
    self._reauth_entry = self._get_reauth_entry()
    ...
    return self.async_update_reload_and_abort(
        self._reauth_entry,
        data=self._reauth_entry.data | user_input,
    )
```

This PR simplifies this, so that providing updates instead of data will merge the new input with the old:
```python
    return self.async_update_reload_and_abort(
        self._get_reauth_entry(),
        data_updates=user_input,
    )
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
