### PR TITLE
DNM: Ensure config_flow translations are available

### DIFF
--- a/tests/components/conftest.py
+++ b/tests/components/conftest.py
@@ -452,7 +452,7 @@ def check_config_translations(hass: HomeAssistant) -> Generator[None]:
         self: FlowManager, flow: FlowHandler, *args
     ) -> ConfigFlowResult:
         result = await _original_call(flow, *args)
-        if result["type"] is FlowResultType.ABORT:
+        if result["type"] is FlowResultType.ABORT and (reason := result.get("reason")):
             translations = await async_get_translations(
                 self.hass, "en", "config", [flow.handler]
             )

--- a/tests/components/conftest.py
+++ b/tests/components/conftest.py
@@ -459,7 +459,7 @@ _IGNORE_TRANSLATION_VIOLATIONS = {
     "component.airvisual.config.step.user.data.type",
     "component.ambient_network.config.step.user.data.location",
     "component.axis.options.step.configure_stream.data.video_source",
-    "config.step.pick_implementation.data.implementation",
+    "component.tesla_fleet.config.step.pick_implementation.data.implementation",
 }
 
 

--- a/tests/components/conftest.py
+++ b/tests/components/conftest.py
@@ -460,7 +460,7 @@ def check_config_translations(hass: HomeAssistant) -> Generator[None]:
             )
             if f"component.{flow.handler}.config.abort.{reason}" not in translations:
                 raise ValueError(
-                    f"Abort reason `{reason}` not found in `strings.json`: {translations}"
+                    f"Abort reason `{reason}` not found in `strings.json`"
                 )
         return result
 

--- a/tests/components/conftest.py
+++ b/tests/components/conftest.py
@@ -453,8 +453,6 @@ def check_config_translations(hass: HomeAssistant) -> Generator[None]:
     ) -> ConfigFlowResult:
         result = await _original_call(flow, *args)
         if result["type"] is FlowResultType.ABORT:
-            if not (reason := result.get("reason")):
-                raise ValueError("Abort string not found")
             translations = await async_get_translations(
                 self.hass, "en", "config", [flow.handler]
             )

--- a/tests/components/conftest.py
+++ b/tests/components/conftest.py
@@ -454,9 +454,12 @@ def supervisor_client() -> Generator[AsyncMock]:
 
 
 _IGNORE_TRANSLATION_VIOLATIONS = {
-    "component.airvisual.config.step.user.data.type",  # Uses description
-    "component.ambient_network.config.step.user.data.location",  # Uses description
-    "component.axis.options.step.configure_stream.data.video_source",  # Uses description
+    # These data input have a step description and it would be redundant to add
+    # a separate description for the data input
+    "component.airvisual.config.step.user.data.type",
+    "component.ambient_network.config.step.user.data.location",
+    "component.axis.options.step.configure_stream.data.video_source",
+    "config.step.pick_implementation.data.implementation",
 }
 
 

--- a/tests/components/conftest.py
+++ b/tests/components/conftest.py
@@ -448,13 +448,25 @@ def supervisor_client() -> Generator[AsyncMock]:
         yield supervisor_client
 
 
+_IGNORE_TRANSLATION_VIOLATIONS = {
+    "component.airvisual.config.step.user.data.type",  # Uses description
+}
+
+
 async def _ensure_translation_exists(
     hass: HomeAssistant, category: str, component: str, key: str
 ) -> None:
     """Raise if translation doesn't exist."""
+    full_key = f"component.{component}.{category}.{key}"
+    if full_key in _IGNORE_TRANSLATION_VIOLATIONS:
+        return
+
     translations = await async_get_translations(hass, "en", category, [component])
-    if f"component.{component}.{category}.{key}" not in translations:
-        raise ValueError(f"Translation not found for {component}: `{category}.{key}`")
+    if full_key not in translations:
+        raise ValueError(
+            f"Translation not found for {component}: `{category}.{key}` "
+            f"(see homeassistant/components/{component}/config_flow.py)"
+        )
 
 
 @pytest.fixture(autouse=True)

--- a/tests/components/conftest.py
+++ b/tests/components/conftest.py
@@ -459,9 +459,7 @@ def check_config_translations(hass: HomeAssistant) -> Generator[None]:
                 self.hass, "en", "config", [flow.handler]
             )
             if f"component.{flow.handler}.config.abort.{reason}" not in translations:
-                raise ValueError(
-                    f"Abort reason `{reason}` not found in `strings.json`"
-                )
+                raise ValueError(f"Abort reason `{reason}` not found in `strings.json`")
         return result
 
     with patch(

--- a/tests/components/conftest.py
+++ b/tests/components/conftest.py
@@ -476,20 +476,29 @@ def check_config_translations() -> Generator[None]:
             return result
 
         if result["type"] is FlowResultType.FORM:
+            if data_schema := result.get("data_schema"):
+                for key in data_schema.schema:
+                    await _ensure_translation_exists(
+                        flow.hass,
+                        category,
+                        component,
+                        f"step.{result['step_id']}.data.{key}",
+                    )
             if errors := result.get("errors"):
                 for error in errors.values():
                     await _ensure_translation_exists(
-                        self.hass,
+                        flow.hass,
                         category,
                         component,
                         f"error.{error}",
                     )
+
         if (
             result["type"] is FlowResultType.ABORT
             and flow.source not in DISCOVERY_SOURCES
         ):
             await _ensure_translation_exists(
-                self.hass,
+                flow.hass,
                 category,
                 component,
                 f"abort.{result["reason"]}",

--- a/tests/components/conftest.py
+++ b/tests/components/conftest.py
@@ -455,7 +455,7 @@ def check_config_translations() -> Generator[None]:
         if (
             result["type"] is FlowResultType.ABORT
             and isinstance(self, ConfigEntriesFlowManager)
-            and flow.source not in {"bluetooth", "hardware", "usb", "zeroconf"}
+            and flow.source not in {"bluetooth", "dhcp", "hardware", "usb", "zeroconf"}
         ):
             reason = result.get("reason")
             translations = await async_get_translations(

--- a/tests/components/conftest.py
+++ b/tests/components/conftest.py
@@ -444,14 +444,14 @@ def supervisor_client() -> Generator[AsyncMock]:
 
 
 @pytest.fixture(autouse=True)
-def check_config_translations(hass: HomeAssistant) -> Generator[None]:
+def check_config_translations() -> Generator[None]:
     """Ensure config_flow translations are available."""
-    _original_call = hass.config_entries.flow._async_handle_step
+    _original = FlowManager._async_handle_step
 
     async def _async_handle_step(
         self: FlowManager, flow: FlowHandler, *args
     ) -> ConfigFlowResult:
-        result = await _original_call(flow, *args)
+        result = await _original(self, flow, *args)
         if result["type"] is FlowResultType.ABORT and (reason := result.get("reason")):
             translations = await async_get_translations(
                 self.hass, "en", "config", [flow.handler]

--- a/tests/components/conftest.py
+++ b/tests/components/conftest.py
@@ -11,7 +11,11 @@ from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 from aiohasupervisor.models import StoreInfo
 import pytest
 
-from homeassistant.config_entries import ConfigEntriesFlowManager, FlowResult
+from homeassistant.config_entries import (
+    DISCOVERY_SOURCES,
+    ConfigEntriesFlowManager,
+    FlowResult,
+)
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowHandler, FlowManager, FlowResultType
@@ -455,7 +459,7 @@ def check_config_translations() -> Generator[None]:
         if (
             result["type"] is FlowResultType.ABORT
             and isinstance(self, ConfigEntriesFlowManager)
-            and flow.source not in {"bluetooth", "dhcp", "hardware", "usb", "zeroconf"}
+            and flow.source not in DISCOVERY_SOURCES
         ):
             reason = result.get("reason")
             translations = await async_get_translations(

--- a/tests/components/conftest.py
+++ b/tests/components/conftest.py
@@ -450,6 +450,8 @@ def supervisor_client() -> Generator[AsyncMock]:
 
 _IGNORE_TRANSLATION_VIOLATIONS = {
     "component.airvisual.config.step.user.data.type",  # Uses description
+    "component.ambient_network.config.step.user.data.location",  # Uses description
+    "component.axis.options.step.configure_stream.data.video_source",  # Uses description
 }
 
 
@@ -464,8 +466,9 @@ async def _ensure_translation_exists(
     translations = await async_get_translations(hass, "en", category, [component])
     if full_key not in translations:
         raise ValueError(
-            f"Translation not found for {component}: `{category}.{key}` "
-            f"(see homeassistant/components/{component}/config_flow.py)"
+            f"Translation not found for {component}: `{category}.{key}`. "
+            f"Please add to homeassistant/components/{component}/strings.json "
+            "or add to _IGNORE_TRANSLATION_VIOLATIONS."
         )
 
 

--- a/tests/components/conftest.py
+++ b/tests/components/conftest.py
@@ -19,7 +19,12 @@ from homeassistant.config_entries import (
 )
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
-from homeassistant.data_entry_flow import FlowHandler, FlowManager, FlowResultType
+from homeassistant.data_entry_flow import (
+    FlowHandler,
+    FlowManager,
+    FlowResultType,
+    section,
+)
 from homeassistant.helpers.translation import async_get_translations
 
 if TYPE_CHECKING:
@@ -492,13 +497,22 @@ def check_config_translations() -> Generator[None]:
 
         if result["type"] is FlowResultType.FORM:
             if data_schema := result.get("data_schema"):
-                for key in data_schema.schema:
-                    await _ensure_translation_exists(
-                        flow.hass,
-                        category,
-                        component,
-                        f"step.{result['step_id']}.data.{key}",
-                    )
+                for key, value in data_schema.schema.items():
+                    if isinstance(value, section):
+                        for sub_key in value.schema.schema:
+                            await _ensure_translation_exists(
+                                flow.hass,
+                                category,
+                                component,
+                                f"step.{result['step_id']}.sections.{key}.data.{sub_key}",
+                            )
+                    else:
+                        await _ensure_translation_exists(
+                            flow.hass,
+                            category,
+                            component,
+                            f"step.{result['step_id']}.data.{key}",
+                        )
             if errors := result.get("errors"):
                 for error in errors.values():
                     await _ensure_translation_exists(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
DO NOT MERGE

This is an attempt to check automatically that translations for config flow are available.
Violations are tracked in https://github.com/home-assistant/core/issues/127811

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
