### PR TITLE
Use device name for matter entities

### DIFF
--- a/homeassistant/components/matter/climate.py
+++ b/homeassistant/components/matter/climate.py
@@ -188,7 +188,7 @@ class MatterClimate(MatterEntity, ClimateEntity):
     _attr_hvac_mode: HVACMode = HVACMode.OFF
     _feature_map: int | None = None
     _enable_turn_on_off_backwards_compatibility = False
-    _postfix_translation_key = "thermostat"
+    _platform_translation_key = "thermostat"
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""

--- a/homeassistant/components/matter/climate.py
+++ b/homeassistant/components/matter/climate.py
@@ -428,6 +428,7 @@ DISCOVERY_SCHEMAS = [
         platform=Platform.CLIMATE,
         entity_description=ClimateEntityDescription(
             key="MatterThermostat",
+            name=None,
         ),
         entity_class=MatterClimate,
         required_attributes=(clusters.Thermostat.Attributes.LocalTemperature,),

--- a/homeassistant/components/matter/climate.py
+++ b/homeassistant/components/matter/climate.py
@@ -188,6 +188,7 @@ class MatterClimate(MatterEntity, ClimateEntity):
     _attr_hvac_mode: HVACMode = HVACMode.OFF
     _feature_map: int | None = None
     _enable_turn_on_off_backwards_compatibility = False
+    _postfix_translation_key = "thermostat"
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""

--- a/homeassistant/components/matter/climate.py
+++ b/homeassistant/components/matter/climate.py
@@ -427,7 +427,6 @@ DISCOVERY_SCHEMAS = [
         platform=Platform.CLIMATE,
         entity_description=ClimateEntityDescription(
             key="MatterThermostat",
-            translation_key="thermostat",
         ),
         entity_class=MatterClimate,
         required_attributes=(clusters.Thermostat.Attributes.LocalTemperature,),

--- a/homeassistant/components/matter/cover.py
+++ b/homeassistant/components/matter/cover.py
@@ -201,7 +201,8 @@ DISCOVERY_SCHEMAS = [
     MatterDiscoverySchema(
         platform=Platform.COVER,
         entity_description=CoverEntityDescription(
-            key="MatterCover", translation_key="cover"
+            key="MatterCover",
+            name=None,
         ),
         entity_class=MatterCover,
         required_attributes=(
@@ -216,7 +217,7 @@ DISCOVERY_SCHEMAS = [
     MatterDiscoverySchema(
         platform=Platform.COVER,
         entity_description=CoverEntityDescription(
-            key="MatterCoverPositionAwareLift", translation_key="cover"
+            key="MatterCoverPositionAwareLift", name=None
         ),
         entity_class=MatterCover,
         required_attributes=(
@@ -231,7 +232,7 @@ DISCOVERY_SCHEMAS = [
     MatterDiscoverySchema(
         platform=Platform.COVER,
         entity_description=CoverEntityDescription(
-            key="MatterCoverPositionAwareTilt", translation_key="cover"
+            key="MatterCoverPositionAwareTilt", name=None
         ),
         entity_class=MatterCover,
         required_attributes=(
@@ -246,7 +247,7 @@ DISCOVERY_SCHEMAS = [
     MatterDiscoverySchema(
         platform=Platform.COVER,
         entity_description=CoverEntityDescription(
-            key="MatterCoverPositionAwareLiftAndTilt", translation_key="cover"
+            key="MatterCoverPositionAwareLiftAndTilt", name=None
         ),
         entity_class=MatterCover,
         required_attributes=(

--- a/homeassistant/components/matter/entity.py
+++ b/homeassistant/components/matter/entity.py
@@ -45,7 +45,7 @@ class MatterEntity(Entity):
     _attr_has_entity_name = True
     _attr_should_poll = False
     _name_postfix: str | None = None
-    _postfix_translation_key: str | None = None
+    _platform_translation_key: str | None = None
 
     def __init__(
         self,
@@ -84,8 +84,8 @@ class MatterEntity(Entity):
             and ep.has_attribute(None, entity_info.primary_attribute)
         ):
             self._name_postfix = str(self._endpoint.endpoint_id)
-            if self._postfix_translation_key and not self.translation_key:
-                self._attr_translation_key = self._postfix_translation_key
+            if self._platform_translation_key and not self.translation_key:
+                self._attr_translation_key = self._platform_translation_key
 
         # prefer the label attribute for the entity name
         # Matter has a way for users and/or vendors to specify a name for an endpoint

--- a/homeassistant/components/matter/entity.py
+++ b/homeassistant/components/matter/entity.py
@@ -148,11 +148,8 @@ class MatterEntity(Entity):
             # an explicit entity name was defined, we use that
             return self._attr_name
         name = super().name
-        if self._name_postfix:
-            if name:
-                name = f"{name} ({self._name_postfix})"
-            else:
-                name = self._name_postfix
+        if name and self._name_postfix:
+            name = f"{name} ({self._name_postfix})"
         return name
 
     @callback

--- a/homeassistant/components/matter/entity.py
+++ b/homeassistant/components/matter/entity.py
@@ -45,6 +45,7 @@ class MatterEntity(Entity):
     _attr_has_entity_name = True
     _attr_should_poll = False
     _name_postfix: str | None = None
+    _postfix_translation_key: str | None = None
 
     def __init__(
         self,
@@ -83,6 +84,8 @@ class MatterEntity(Entity):
             and ep.has_attribute(None, entity_info.primary_attribute)
         ):
             self._name_postfix = str(self._endpoint.endpoint_id)
+            if self._postfix_translation_key:
+                self._name_translation_key = self._postfix_translation_key
 
         # prefer the label attribute for the entity name
         # Matter has a way for users and/or vendors to specify a name for an endpoint
@@ -145,8 +148,11 @@ class MatterEntity(Entity):
             # an explicit entity name was defined, we use that
             return self._attr_name
         name = super().name
-        if name and self._name_postfix:
-            name = f"{name} ({self._name_postfix})"
+        if self._name_postfix:
+            if name:
+                name = f"{name} ({self._name_postfix})"
+            else:
+                name = self._name_postfix
         return name
 
     @callback

--- a/homeassistant/components/matter/entity.py
+++ b/homeassistant/components/matter/entity.py
@@ -84,8 +84,8 @@ class MatterEntity(Entity):
             and ep.has_attribute(None, entity_info.primary_attribute)
         ):
             self._name_postfix = str(self._endpoint.endpoint_id)
-            if self._postfix_translation_key:
-                self._name_translation_key = self._postfix_translation_key
+            if self._postfix_translation_key and not self.translation_key:
+                self._attr_translation_key = self._postfix_translation_key
 
         # prefer the label attribute for the entity name
         # Matter has a way for users and/or vendors to specify a name for an endpoint

--- a/homeassistant/components/matter/fan.py
+++ b/homeassistant/components/matter/fan.py
@@ -328,9 +328,7 @@ class MatterFan(MatterEntity, FanEntity):
 DISCOVERY_SCHEMAS = [
     MatterDiscoverySchema(
         platform=Platform.FAN,
-        entity_description=FanEntityDescription(
-            key="MatterFan", name=None, translation_key="fan"
-        ),
+        entity_description=FanEntityDescription(key="MatterFan"),
         entity_class=MatterFan,
         # FanEntityFeature
         required_attributes=(

--- a/homeassistant/components/matter/fan.py
+++ b/homeassistant/components/matter/fan.py
@@ -60,7 +60,7 @@ class MatterFan(MatterEntity, FanEntity):
     _last_known_percentage: int = 0
     _enable_turn_on_off_backwards_compatibility = False
     _feature_map: int | None = None
-    _postfix_translation_key: str | None = None
+    _platform_translation_key = "fan"
 
     async def async_turn_on(
         self,

--- a/homeassistant/components/matter/fan.py
+++ b/homeassistant/components/matter/fan.py
@@ -329,7 +329,10 @@ class MatterFan(MatterEntity, FanEntity):
 DISCOVERY_SCHEMAS = [
     MatterDiscoverySchema(
         platform=Platform.FAN,
-        entity_description=FanEntityDescription(key="MatterFan"),
+        entity_description=FanEntityDescription(
+            key="MatterFan",
+            name=None,
+        ),
         entity_class=MatterFan,
         # FanEntityFeature
         required_attributes=(

--- a/homeassistant/components/matter/fan.py
+++ b/homeassistant/components/matter/fan.py
@@ -60,6 +60,7 @@ class MatterFan(MatterEntity, FanEntity):
     _last_known_percentage: int = 0
     _enable_turn_on_off_backwards_compatibility = False
     _feature_map: int | None = None
+    _postfix_translation_key: str | None = None
 
     async def async_turn_on(
         self,

--- a/homeassistant/components/matter/light.py
+++ b/homeassistant/components/matter/light.py
@@ -510,7 +510,7 @@ DISCOVERY_SCHEMAS = [
     MatterDiscoverySchema(
         platform=Platform.LIGHT,
         entity_description=LightEntityDescription(
-            key="MatterColorTemperatureLightFallback", translation_key="light"
+            key="MatterColorTemperatureLightFallback"
         ),
         entity_class=MatterLight,
         required_attributes=(

--- a/homeassistant/components/matter/light.py
+++ b/homeassistant/components/matter/light.py
@@ -89,7 +89,7 @@ class MatterLight(MatterEntity, LightEntity):
     _supports_color = False
     _supports_color_temperature = False
     _transitions_disabled = False
-    _postfix_translation_key = "light"
+    _platform_translation_key = "light"
 
     async def _set_xy_color(
         self, xy_color: tuple[float, float], transition: float = 0.0

--- a/homeassistant/components/matter/light.py
+++ b/homeassistant/components/matter/light.py
@@ -89,6 +89,7 @@ class MatterLight(MatterEntity, LightEntity):
     _supports_color = False
     _supports_color_temperature = False
     _transitions_disabled = False
+    _postfix_translation_key = "light"
 
     async def _set_xy_color(
         self, xy_color: tuple[float, float], transition: float = 0.0
@@ -442,9 +443,7 @@ class MatterLight(MatterEntity, LightEntity):
 DISCOVERY_SCHEMAS = [
     MatterDiscoverySchema(
         platform=Platform.LIGHT,
-        entity_description=LightEntityDescription(
-            key="MatterLight", translation_key="light"
-        ),
+        entity_description=LightEntityDescription(key="MatterLight"),
         entity_class=MatterLight,
         required_attributes=(clusters.OnOff.Attributes.OnOff,),
         optional_attributes=(
@@ -469,9 +468,7 @@ DISCOVERY_SCHEMAS = [
     # Additional schema to match (HS Color) lights with incorrect/missing device type
     MatterDiscoverySchema(
         platform=Platform.LIGHT,
-        entity_description=LightEntityDescription(
-            key="MatterHSColorLightFallback", translation_key="light"
-        ),
+        entity_description=LightEntityDescription(key="MatterHSColorLightFallback"),
         entity_class=MatterLight,
         required_attributes=(
             clusters.OnOff.Attributes.OnOff,
@@ -489,9 +486,7 @@ DISCOVERY_SCHEMAS = [
     # Additional schema to match (XY Color) lights with incorrect/missing device type
     MatterDiscoverySchema(
         platform=Platform.LIGHT,
-        entity_description=LightEntityDescription(
-            key="MatterXYColorLightFallback", translation_key="light"
-        ),
+        entity_description=LightEntityDescription(key="MatterXYColorLightFallback"),
         entity_class=MatterLight,
         required_attributes=(
             clusters.OnOff.Attributes.OnOff,

--- a/homeassistant/components/matter/light.py
+++ b/homeassistant/components/matter/light.py
@@ -443,7 +443,10 @@ class MatterLight(MatterEntity, LightEntity):
 DISCOVERY_SCHEMAS = [
     MatterDiscoverySchema(
         platform=Platform.LIGHT,
-        entity_description=LightEntityDescription(key="MatterLight"),
+        entity_description=LightEntityDescription(
+            key="MatterLight",
+            name=None,
+        ),
         entity_class=MatterLight,
         required_attributes=(clusters.OnOff.Attributes.OnOff,),
         optional_attributes=(
@@ -468,7 +471,10 @@ DISCOVERY_SCHEMAS = [
     # Additional schema to match (HS Color) lights with incorrect/missing device type
     MatterDiscoverySchema(
         platform=Platform.LIGHT,
-        entity_description=LightEntityDescription(key="MatterHSColorLightFallback"),
+        entity_description=LightEntityDescription(
+            key="MatterHSColorLightFallback",
+            name=None,
+        ),
         entity_class=MatterLight,
         required_attributes=(
             clusters.OnOff.Attributes.OnOff,
@@ -486,7 +492,10 @@ DISCOVERY_SCHEMAS = [
     # Additional schema to match (XY Color) lights with incorrect/missing device type
     MatterDiscoverySchema(
         platform=Platform.LIGHT,
-        entity_description=LightEntityDescription(key="MatterXYColorLightFallback"),
+        entity_description=LightEntityDescription(
+            key="MatterXYColorLightFallback",
+            name=None,
+        ),
         entity_class=MatterLight,
         required_attributes=(
             clusters.OnOff.Attributes.OnOff,
@@ -505,7 +514,8 @@ DISCOVERY_SCHEMAS = [
     MatterDiscoverySchema(
         platform=Platform.LIGHT,
         entity_description=LightEntityDescription(
-            key="MatterColorTemperatureLightFallback"
+            key="MatterColorTemperatureLightFallback",
+            name=None,
         ),
         entity_class=MatterLight,
         required_attributes=(

--- a/homeassistant/components/matter/lock.py
+++ b/homeassistant/components/matter/lock.py
@@ -40,6 +40,7 @@ class MatterLock(MatterEntity, LockEntity):
 
     _feature_map: int | None = None
     _optimistic_timer: asyncio.TimerHandle | None = None
+    _postfix_translation_key: str | None = "lock"
 
     @property
     def code_format(self) -> str | None:

--- a/homeassistant/components/matter/lock.py
+++ b/homeassistant/components/matter/lock.py
@@ -200,7 +200,10 @@ class MatterLock(MatterEntity, LockEntity):
 DISCOVERY_SCHEMAS = [
     MatterDiscoverySchema(
         platform=Platform.LOCK,
-        entity_description=LockEntityDescription(key="MatterLock"),
+        entity_description=LockEntityDescription(
+            key="MatterLock",
+            name=None,
+        ),
         entity_class=MatterLock,
         required_attributes=(clusters.DoorLock.Attributes.LockState,),
         optional_attributes=(clusters.DoorLock.Attributes.DoorState,),

--- a/homeassistant/components/matter/lock.py
+++ b/homeassistant/components/matter/lock.py
@@ -40,7 +40,7 @@ class MatterLock(MatterEntity, LockEntity):
 
     _feature_map: int | None = None
     _optimistic_timer: asyncio.TimerHandle | None = None
-    _postfix_translation_key: str | None = "lock"
+    _platform_translation_key = "lock"
 
     @property
     def code_format(self) -> str | None:

--- a/homeassistant/components/matter/lock.py
+++ b/homeassistant/components/matter/lock.py
@@ -199,9 +199,7 @@ class MatterLock(MatterEntity, LockEntity):
 DISCOVERY_SCHEMAS = [
     MatterDiscoverySchema(
         platform=Platform.LOCK,
-        entity_description=LockEntityDescription(
-            key="MatterLock", translation_key="lock"
-        ),
+        entity_description=LockEntityDescription(key="MatterLock"),
         entity_class=MatterLock,
         required_attributes=(clusters.DoorLock.Attributes.LockState,),
         optional_attributes=(clusters.DoorLock.Attributes.DoorState,),

--- a/homeassistant/components/matter/strings.json
+++ b/homeassistant/components/matter/strings.json
@@ -95,6 +95,16 @@
         "name": "Reset filter condition"
       }
     },
+    "climate": {
+      "thermostat": {
+        "name": "Thermostat"
+      }
+    },
+    "cover": {
+      "cover": {
+        "name": "[%key:component::cover::title%]"
+      }
+    },
     "event": {
       "button": {
         "name": "Button",
@@ -121,6 +131,7 @@
     },
     "fan": {
       "fan": {
+        "name": "[%key:component::fan::title%]",
         "state_attributes": {
           "preset_mode": {
             "state": {
@@ -150,6 +161,16 @@
       },
       "altitude": {
         "name": "Altitude above Sea Level"
+      }
+    },
+    "light": {
+      "light": {
+        "name": "[%key:component::light::title%]"
+      }
+    },
+    "lock": {
+      "lock": {
+        "name": "[%key:component::lock::title%]"
       }
     },
     "select": {
@@ -224,8 +245,16 @@
       }
     },
     "switch": {
+      "switch": {
+        "name": "[%key:component::switch::title%]"
+      },
       "power": {
         "name": "Power"
+      }
+    },
+    "valve": {
+      "valve": {
+        "name": "[%key:component::valve::title%]"
       }
     }
   },

--- a/homeassistant/components/matter/strings.json
+++ b/homeassistant/components/matter/strings.json
@@ -95,16 +95,6 @@
         "name": "Reset filter condition"
       }
     },
-    "climate": {
-      "thermostat": {
-        "name": "Thermostat"
-      }
-    },
-    "cover": {
-      "cover": {
-        "name": "[%key:component::cover::title%]"
-      }
-    },
     "event": {
       "button": {
         "name": "Button",
@@ -131,7 +121,6 @@
     },
     "fan": {
       "fan": {
-        "name": "[%key:component::fan::title%]",
         "state_attributes": {
           "preset_mode": {
             "state": {
@@ -161,16 +150,6 @@
       },
       "altitude": {
         "name": "Altitude above Sea Level"
-      }
-    },
-    "light": {
-      "light": {
-        "name": "[%key:component::light::title%]"
-      }
-    },
-    "lock": {
-      "lock": {
-        "name": "[%key:component::lock::title%]"
       }
     },
     "select": {
@@ -245,16 +224,8 @@
       }
     },
     "switch": {
-      "switch": {
-        "name": "[%key:component::switch::title%]"
-      },
       "power": {
         "name": "Power"
-      }
-    },
-    "valve": {
-      "valve": {
-        "name": "[%key:component::valve::title%]"
       }
     }
   },

--- a/homeassistant/components/matter/switch.py
+++ b/homeassistant/components/matter/switch.py
@@ -35,6 +35,8 @@ async def async_setup_entry(
 class MatterSwitch(MatterEntity, SwitchEntity):
     """Representation of a Matter switch."""
 
+    _postfix_translation_key: str | None = "switch"
+
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn switch on."""
         await self.matter_client.send_device_command(

--- a/homeassistant/components/matter/switch.py
+++ b/homeassistant/components/matter/switch.py
@@ -78,7 +78,7 @@ DISCOVERY_SCHEMAS = [
         platform=Platform.SWITCH,
         entity_description=SwitchEntityDescription(
             key="MatterPowerToggle",
-            device_class=SwitchDeviceClass.OUTLET,
+            device_class=SwitchDeviceClass.SWITCH,
             translation_key="power",
         ),
         entity_class=MatterSwitch,
@@ -107,7 +107,7 @@ DISCOVERY_SCHEMAS = [
         platform=Platform.SWITCH,
         entity_description=SwitchEntityDescription(
             key="MatterSwitch",
-            device_class=SwitchDeviceClass.SWITCH,
+            device_class=SwitchDeviceClass.OUTLET,
             name=None,
         ),
         entity_class=MatterSwitch,

--- a/homeassistant/components/matter/switch.py
+++ b/homeassistant/components/matter/switch.py
@@ -78,7 +78,7 @@ DISCOVERY_SCHEMAS = [
         platform=Platform.SWITCH,
         entity_description=SwitchEntityDescription(
             key="MatterPowerToggle",
-            device_class=SwitchDeviceClass.SWITCH,
+            device_class=SwitchDeviceClass.OUTLET,
             translation_key="power",
         ),
         entity_class=MatterSwitch,

--- a/homeassistant/components/matter/switch.py
+++ b/homeassistant/components/matter/switch.py
@@ -35,7 +35,7 @@ async def async_setup_entry(
 class MatterSwitch(MatterEntity, SwitchEntity):
     """Representation of a Matter switch."""
 
-    _postfix_translation_key: str | None = "switch"
+    _platform_translation_key = "switch"
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn switch on."""

--- a/homeassistant/components/matter/switch.py
+++ b/homeassistant/components/matter/switch.py
@@ -66,7 +66,6 @@ DISCOVERY_SCHEMAS = [
         entity_description=SwitchEntityDescription(
             key="MatterPlug",
             device_class=SwitchDeviceClass.OUTLET,
-            translation_key="switch",
         ),
         entity_class=MatterSwitch,
         required_attributes=(clusters.OnOff.Attributes.OnOff,),
@@ -105,8 +104,7 @@ DISCOVERY_SCHEMAS = [
         platform=Platform.SWITCH,
         entity_description=SwitchEntityDescription(
             key="MatterSwitch",
-            device_class=SwitchDeviceClass.OUTLET,
-            translation_key="switch",
+            device_class=SwitchDeviceClass.SWITCH,
         ),
         entity_class=MatterSwitch,
         required_attributes=(clusters.OnOff.Attributes.OnOff,),

--- a/homeassistant/components/matter/switch.py
+++ b/homeassistant/components/matter/switch.py
@@ -68,6 +68,7 @@ DISCOVERY_SCHEMAS = [
         entity_description=SwitchEntityDescription(
             key="MatterPlug",
             device_class=SwitchDeviceClass.OUTLET,
+            name=None,
         ),
         entity_class=MatterSwitch,
         required_attributes=(clusters.OnOff.Attributes.OnOff,),
@@ -107,6 +108,7 @@ DISCOVERY_SCHEMAS = [
         entity_description=SwitchEntityDescription(
             key="MatterSwitch",
             device_class=SwitchDeviceClass.SWITCH,
+            name=None,
         ),
         entity_class=MatterSwitch,
         required_attributes=(clusters.OnOff.Attributes.OnOff,),

--- a/homeassistant/components/matter/valve.py
+++ b/homeassistant/components/matter/valve.py
@@ -40,7 +40,7 @@ class MatterValve(MatterEntity, ValveEntity):
 
     _feature_map: int | None = None
     entity_description: ValveEntityDescription
-    _postfix_translation_key: str | None = "valve"
+    _platform_translation_key = "valve"
 
     async def send_device_command(
         self,

--- a/homeassistant/components/matter/valve.py
+++ b/homeassistant/components/matter/valve.py
@@ -140,6 +140,7 @@ DISCOVERY_SCHEMAS = [
         entity_description=ValveEntityDescription(
             key="MatterValve",
             device_class=ValveDeviceClass.WATER,
+            name=None,
         ),
         entity_class=MatterValve,
         required_attributes=(

--- a/homeassistant/components/matter/valve.py
+++ b/homeassistant/components/matter/valve.py
@@ -139,7 +139,6 @@ DISCOVERY_SCHEMAS = [
         entity_description=ValveEntityDescription(
             key="MatterValve",
             device_class=ValveDeviceClass.WATER,
-            translation_key="valve",
         ),
         entity_class=MatterValve,
         required_attributes=(

--- a/homeassistant/components/matter/valve.py
+++ b/homeassistant/components/matter/valve.py
@@ -40,6 +40,7 @@ class MatterValve(MatterEntity, ValveEntity):
 
     _feature_map: int | None = None
     entity_description: ValveEntityDescription
+    _postfix_translation_key: str | None = "valve"
 
     async def send_device_command(
         self,

--- a/tests/components/matter/snapshots/test_climate.ambr
+++ b/tests/components/matter/snapshots/test_climate.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_climates[air_purifier][climate.air_purifier_thermostat-entry]
+# name: test_climates[air_purifier][climate.air_purifier-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -18,7 +18,7 @@
     'disabled_by': None,
     'domain': 'climate',
     'entity_category': None,
-    'entity_id': 'climate.air_purifier_thermostat',
+    'entity_id': 'climate.air_purifier',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -30,20 +30,20 @@
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Thermostat',
+    'original_name': None,
     'platform': 'matter',
     'previous_unique_id': None,
     'supported_features': <ClimateEntityFeature: 385>,
-    'translation_key': 'thermostat',
+    'translation_key': None,
     'unique_id': '00000000000004D2-000000000000008F-MatterNodeDevice-5-MatterThermostat-513-0',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_climates[air_purifier][climate.air_purifier_thermostat-state]
+# name: test_climates[air_purifier][climate.air_purifier-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 20.0,
-      'friendly_name': 'Air Purifier Thermostat',
+      'friendly_name': 'Air Purifier',
       'hvac_modes': list([
         <HVACMode.OFF: 'off'>,
         <HVACMode.HEAT: 'heat'>,
@@ -54,14 +54,14 @@
       'temperature': 20.0,
     }),
     'context': <ANY>,
-    'entity_id': 'climate.air_purifier_thermostat',
+    'entity_id': 'climate.air_purifier',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'off',
   })
 # ---
-# name: test_climates[eve_thermo][climate.eve_thermo_thermostat-entry]
+# name: test_climates[eve_thermo][climate.eve_thermo-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -80,7 +80,7 @@
     'disabled_by': None,
     'domain': 'climate',
     'entity_category': None,
-    'entity_id': 'climate.eve_thermo_thermostat',
+    'entity_id': 'climate.eve_thermo',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -92,20 +92,20 @@
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Thermostat',
+    'original_name': None,
     'platform': 'matter',
     'previous_unique_id': None,
     'supported_features': <ClimateEntityFeature: 385>,
-    'translation_key': 'thermostat',
+    'translation_key': None,
     'unique_id': '00000000000004D2-0000000000000021-MatterNodeDevice-1-MatterThermostat-513-0',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_climates[eve_thermo][climate.eve_thermo_thermostat-state]
+# name: test_climates[eve_thermo][climate.eve_thermo-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 21.0,
-      'friendly_name': 'Eve Thermo Thermostat',
+      'friendly_name': 'Eve Thermo',
       'hvac_modes': list([
         <HVACMode.OFF: 'off'>,
         <HVACMode.HEAT: 'heat'>,
@@ -116,14 +116,14 @@
       'temperature': 17.0,
     }),
     'context': <ANY>,
-    'entity_id': 'climate.eve_thermo_thermostat',
+    'entity_id': 'climate.eve_thermo',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'heat',
   })
 # ---
-# name: test_climates[room_airconditioner][climate.room_airconditioner_thermostat-entry]
+# name: test_climates[room_airconditioner][climate.room_airconditioner-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -146,7 +146,7 @@
     'disabled_by': None,
     'domain': 'climate',
     'entity_category': None,
-    'entity_id': 'climate.room_airconditioner_thermostat',
+    'entity_id': 'climate.room_airconditioner',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -158,20 +158,20 @@
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Thermostat',
+    'original_name': None,
     'platform': 'matter',
     'previous_unique_id': None,
     'supported_features': <ClimateEntityFeature: 385>,
-    'translation_key': 'thermostat',
+    'translation_key': None,
     'unique_id': '00000000000004D2-0000000000000024-MatterNodeDevice-1-MatterThermostat-513-0',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_climates[room_airconditioner][climate.room_airconditioner_thermostat-state]
+# name: test_climates[room_airconditioner][climate.room_airconditioner-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 20.0,
-      'friendly_name': 'Room AirConditioner Thermostat',
+      'friendly_name': 'Room AirConditioner',
       'hvac_modes': list([
         <HVACMode.OFF: 'off'>,
         <HVACMode.HEAT: 'heat'>,
@@ -186,14 +186,14 @@
       'temperature': 20.0,
     }),
     'context': <ANY>,
-    'entity_id': 'climate.room_airconditioner_thermostat',
+    'entity_id': 'climate.room_airconditioner',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'off',
   })
 # ---
-# name: test_climates[thermostat][climate.longan_link_hvac_thermostat-entry]
+# name: test_climates[thermostat][climate.longan_link_hvac-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -214,7 +214,7 @@
     'disabled_by': None,
     'domain': 'climate',
     'entity_category': None,
-    'entity_id': 'climate.longan_link_hvac_thermostat',
+    'entity_id': 'climate.longan_link_hvac',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -226,20 +226,20 @@
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Thermostat',
+    'original_name': None,
     'platform': 'matter',
     'previous_unique_id': None,
     'supported_features': <ClimateEntityFeature: 387>,
-    'translation_key': 'thermostat',
+    'translation_key': None,
     'unique_id': '00000000000004D2-0000000000000004-MatterNodeDevice-1-MatterThermostat-513-0',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_climates[thermostat][climate.longan_link_hvac_thermostat-state]
+# name: test_climates[thermostat][climate.longan_link_hvac-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 28.3,
-      'friendly_name': 'Longan link HVAC Thermostat',
+      'friendly_name': 'Longan link HVAC',
       'hvac_modes': list([
         <HVACMode.OFF: 'off'>,
         <HVACMode.HEAT: 'heat'>,
@@ -254,7 +254,7 @@
       'temperature': None,
     }),
     'context': <ANY>,
-    'entity_id': 'climate.longan_link_hvac_thermostat',
+    'entity_id': 'climate.longan_link_hvac',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/matter/snapshots/test_cover.ambr
+++ b/tests/components/matter/snapshots/test_cover.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_covers[window_covering_full][cover.mock_full_window_covering_cover-entry]
+# name: test_covers[window_covering_full][cover.mock_full_window_covering-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -11,7 +11,7 @@
     'disabled_by': None,
     'domain': 'cover',
     'entity_category': None,
-    'entity_id': 'cover.mock_full_window_covering_cover',
+    'entity_id': 'cover.mock_full_window_covering',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -23,33 +23,33 @@
     }),
     'original_device_class': <CoverDeviceClass.AWNING: 'awning'>,
     'original_icon': None,
-    'original_name': 'Cover',
+    'original_name': None,
     'platform': 'matter',
     'previous_unique_id': None,
     'supported_features': <CoverEntityFeature: 143>,
-    'translation_key': 'cover',
+    'translation_key': None,
     'unique_id': '00000000000004D2-0000000000000032-MatterNodeDevice-1-MatterCoverPositionAwareLiftAndTilt-258-10',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_covers[window_covering_full][cover.mock_full_window_covering_cover-state]
+# name: test_covers[window_covering_full][cover.mock_full_window_covering-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_position': 100,
       'current_tilt_position': 100,
       'device_class': 'awning',
-      'friendly_name': 'Mock Full Window Covering Cover',
+      'friendly_name': 'Mock Full Window Covering',
       'supported_features': <CoverEntityFeature: 143>,
     }),
     'context': <ANY>,
-    'entity_id': 'cover.mock_full_window_covering_cover',
+    'entity_id': 'cover.mock_full_window_covering',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'open',
   })
 # ---
-# name: test_covers[window_covering_lift][cover.mock_lift_window_covering_cover-entry]
+# name: test_covers[window_covering_lift][cover.mock_lift_window_covering-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -61,7 +61,7 @@
     'disabled_by': None,
     'domain': 'cover',
     'entity_category': None,
-    'entity_id': 'cover.mock_lift_window_covering_cover',
+    'entity_id': 'cover.mock_lift_window_covering',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -73,31 +73,31 @@
     }),
     'original_device_class': <CoverDeviceClass.AWNING: 'awning'>,
     'original_icon': None,
-    'original_name': 'Cover',
+    'original_name': None,
     'platform': 'matter',
     'previous_unique_id': None,
     'supported_features': <CoverEntityFeature: 15>,
-    'translation_key': 'cover',
+    'translation_key': None,
     'unique_id': '00000000000004D2-0000000000000032-MatterNodeDevice-1-MatterCover-258-10',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_covers[window_covering_lift][cover.mock_lift_window_covering_cover-state]
+# name: test_covers[window_covering_lift][cover.mock_lift_window_covering-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'awning',
-      'friendly_name': 'Mock Lift Window Covering Cover',
+      'friendly_name': 'Mock Lift Window Covering',
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,
-    'entity_id': 'cover.mock_lift_window_covering_cover',
+    'entity_id': 'cover.mock_lift_window_covering',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unknown',
   })
 # ---
-# name: test_covers[window_covering_pa_lift][cover.longan_link_wncv_da01_cover-entry]
+# name: test_covers[window_covering_pa_lift][cover.longan_link_wncv_da01-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -109,7 +109,7 @@
     'disabled_by': None,
     'domain': 'cover',
     'entity_category': None,
-    'entity_id': 'cover.longan_link_wncv_da01_cover',
+    'entity_id': 'cover.longan_link_wncv_da01',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -121,32 +121,32 @@
     }),
     'original_device_class': <CoverDeviceClass.AWNING: 'awning'>,
     'original_icon': None,
-    'original_name': 'Cover',
+    'original_name': None,
     'platform': 'matter',
     'previous_unique_id': None,
     'supported_features': <CoverEntityFeature: 15>,
-    'translation_key': 'cover',
+    'translation_key': None,
     'unique_id': '00000000000004D2-0000000000000001-MatterNodeDevice-1-MatterCoverPositionAwareLift-258-10',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_covers[window_covering_pa_lift][cover.longan_link_wncv_da01_cover-state]
+# name: test_covers[window_covering_pa_lift][cover.longan_link_wncv_da01-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_position': 51,
       'device_class': 'awning',
-      'friendly_name': 'Longan link WNCV DA01 Cover',
+      'friendly_name': 'Longan link WNCV DA01',
       'supported_features': <CoverEntityFeature: 15>,
     }),
     'context': <ANY>,
-    'entity_id': 'cover.longan_link_wncv_da01_cover',
+    'entity_id': 'cover.longan_link_wncv_da01',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'open',
   })
 # ---
-# name: test_covers[window_covering_pa_tilt][cover.mock_pa_tilt_window_covering_cover-entry]
+# name: test_covers[window_covering_pa_tilt][cover.mock_pa_tilt_window_covering-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -158,7 +158,7 @@
     'disabled_by': None,
     'domain': 'cover',
     'entity_category': None,
-    'entity_id': 'cover.mock_pa_tilt_window_covering_cover',
+    'entity_id': 'cover.mock_pa_tilt_window_covering',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -170,32 +170,32 @@
     }),
     'original_device_class': <CoverDeviceClass.AWNING: 'awning'>,
     'original_icon': None,
-    'original_name': 'Cover',
+    'original_name': None,
     'platform': 'matter',
     'previous_unique_id': None,
     'supported_features': <CoverEntityFeature: 139>,
-    'translation_key': 'cover',
+    'translation_key': None,
     'unique_id': '00000000000004D2-0000000000000032-MatterNodeDevice-1-MatterCoverPositionAwareTilt-258-10',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_covers[window_covering_pa_tilt][cover.mock_pa_tilt_window_covering_cover-state]
+# name: test_covers[window_covering_pa_tilt][cover.mock_pa_tilt_window_covering-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_tilt_position': 100,
       'device_class': 'awning',
-      'friendly_name': 'Mock PA Tilt Window Covering Cover',
+      'friendly_name': 'Mock PA Tilt Window Covering',
       'supported_features': <CoverEntityFeature: 139>,
     }),
     'context': <ANY>,
-    'entity_id': 'cover.mock_pa_tilt_window_covering_cover',
+    'entity_id': 'cover.mock_pa_tilt_window_covering',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unknown',
   })
 # ---
-# name: test_covers[window_covering_tilt][cover.mock_tilt_window_covering_cover-entry]
+# name: test_covers[window_covering_tilt][cover.mock_tilt_window_covering-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -207,7 +207,7 @@
     'disabled_by': None,
     'domain': 'cover',
     'entity_category': None,
-    'entity_id': 'cover.mock_tilt_window_covering_cover',
+    'entity_id': 'cover.mock_tilt_window_covering',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -219,24 +219,24 @@
     }),
     'original_device_class': <CoverDeviceClass.AWNING: 'awning'>,
     'original_icon': None,
-    'original_name': 'Cover',
+    'original_name': None,
     'platform': 'matter',
     'previous_unique_id': None,
     'supported_features': <CoverEntityFeature: 139>,
-    'translation_key': 'cover',
+    'translation_key': None,
     'unique_id': '00000000000004D2-0000000000000032-MatterNodeDevice-1-MatterCover-258-10',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_covers[window_covering_tilt][cover.mock_tilt_window_covering_cover-state]
+# name: test_covers[window_covering_tilt][cover.mock_tilt_window_covering-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'awning',
-      'friendly_name': 'Mock Tilt Window Covering Cover',
+      'friendly_name': 'Mock Tilt Window Covering',
       'supported_features': <CoverEntityFeature: 139>,
     }),
     'context': <ANY>,
-    'entity_id': 'cover.mock_tilt_window_covering_cover',
+    'entity_id': 'cover.mock_tilt_window_covering',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/matter/snapshots/test_fan.ambr
+++ b/tests/components/matter/snapshots/test_fan.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_fans[air_purifier][fan.air_purifier_fan-entry]
+# name: test_fans[air_purifier][fan.air_purifier-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -20,7 +20,7 @@
     'disabled_by': None,
     'domain': 'fan',
     'entity_category': None,
-    'entity_id': 'fan.air_purifier_fan',
+    'entity_id': 'fan.air_purifier',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -32,20 +32,20 @@
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Fan',
+    'original_name': None,
     'platform': 'matter',
     'previous_unique_id': None,
     'supported_features': <FanEntityFeature: 63>,
-    'translation_key': 'fan',
+    'translation_key': None,
     'unique_id': '00000000000004D2-000000000000008F-MatterNodeDevice-1-MatterFan-514-0',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_fans[air_purifier][fan.air_purifier_fan-state]
+# name: test_fans[air_purifier][fan.air_purifier-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'direction': 'forward',
-      'friendly_name': 'Air Purifier Fan',
+      'friendly_name': 'Air Purifier',
       'oscillating': False,
       'percentage': None,
       'percentage_step': 10.0,
@@ -61,14 +61,14 @@
       'supported_features': <FanEntityFeature: 63>,
     }),
     'context': <ANY>,
-    'entity_id': 'fan.air_purifier_fan',
+    'entity_id': 'fan.air_purifier',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'on',
   })
 # ---
-# name: test_fans[fan][fan.mocked_fan_switch_fan-entry]
+# name: test_fans[fan][fan.mocked_fan_switch-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -89,7 +89,7 @@
     'disabled_by': None,
     'domain': 'fan',
     'entity_category': None,
-    'entity_id': 'fan.mocked_fan_switch_fan',
+    'entity_id': 'fan.mocked_fan_switch',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -101,19 +101,19 @@
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Fan',
+    'original_name': None,
     'platform': 'matter',
     'previous_unique_id': None,
     'supported_features': <FanEntityFeature: 57>,
-    'translation_key': 'fan',
+    'translation_key': None,
     'unique_id': '00000000000004D2-000000000000001D-MatterNodeDevice-1-MatterFan-514-0',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_fans[fan][fan.mocked_fan_switch_fan-state]
+# name: test_fans[fan][fan.mocked_fan_switch-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Mocked Fan Switch Fan',
+      'friendly_name': 'Mocked Fan Switch',
       'percentage': 0,
       'percentage_step': 33.333333333333336,
       'preset_mode': None,
@@ -128,14 +128,14 @@
       'supported_features': <FanEntityFeature: 57>,
     }),
     'context': <ANY>,
-    'entity_id': 'fan.mocked_fan_switch_fan',
+    'entity_id': 'fan.mocked_fan_switch',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'off',
   })
 # ---
-# name: test_fans[room_airconditioner][fan.room_airconditioner_fan-entry]
+# name: test_fans[room_airconditioner][fan.room_airconditioner-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -155,7 +155,7 @@
     'disabled_by': None,
     'domain': 'fan',
     'entity_category': None,
-    'entity_id': 'fan.room_airconditioner_fan',
+    'entity_id': 'fan.room_airconditioner',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -167,19 +167,19 @@
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Fan',
+    'original_name': None,
     'platform': 'matter',
     'previous_unique_id': None,
     'supported_features': <FanEntityFeature: 57>,
-    'translation_key': 'fan',
+    'translation_key': None,
     'unique_id': '00000000000004D2-0000000000000024-MatterNodeDevice-1-MatterFan-514-0',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_fans[room_airconditioner][fan.room_airconditioner_fan-state]
+# name: test_fans[room_airconditioner][fan.room_airconditioner-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Room AirConditioner Fan',
+      'friendly_name': 'Room AirConditioner',
       'percentage': 0,
       'percentage_step': 33.333333333333336,
       'preset_mode': None,
@@ -193,14 +193,14 @@
       'supported_features': <FanEntityFeature: 57>,
     }),
     'context': <ANY>,
-    'entity_id': 'fan.room_airconditioner_fan',
+    'entity_id': 'fan.room_airconditioner',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'off',
   })
 # ---
-# name: test_fans[thermostat][fan.longan_link_hvac_fan-entry]
+# name: test_fans[thermostat][fan.longan_link_hvac-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -219,7 +219,7 @@
     'disabled_by': None,
     'domain': 'fan',
     'entity_category': None,
-    'entity_id': 'fan.longan_link_hvac_fan',
+    'entity_id': 'fan.longan_link_hvac',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -231,19 +231,19 @@
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Fan',
+    'original_name': None,
     'platform': 'matter',
     'previous_unique_id': None,
     'supported_features': <FanEntityFeature: 56>,
-    'translation_key': 'fan',
+    'translation_key': None,
     'unique_id': '00000000000004D2-0000000000000004-MatterNodeDevice-1-MatterFan-514-0',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_fans[thermostat][fan.longan_link_hvac_fan-state]
+# name: test_fans[thermostat][fan.longan_link_hvac-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Longan link HVAC Fan',
+      'friendly_name': 'Longan link HVAC',
       'preset_mode': None,
       'preset_modes': list([
         'low',
@@ -254,7 +254,7 @@
       'supported_features': <FanEntityFeature: 56>,
     }),
     'context': <ANY>,
-    'entity_id': 'fan.longan_link_hvac_fan',
+    'entity_id': 'fan.longan_link_hvac',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/matter/snapshots/test_light.ambr
+++ b/tests/components/matter/snapshots/test_light.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_lights[color_temperature_light][light.mock_color_temperature_light_light-entry]
+# name: test_lights[color_temperature_light][light.mock_color_temperature_light-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -19,7 +19,7 @@
     'disabled_by': None,
     'domain': 'light',
     'entity_category': None,
-    'entity_id': 'light.mock_color_temperature_light_light',
+    'entity_id': 'light.mock_color_temperature_light',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -31,23 +31,23 @@
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Light',
+    'original_name': None,
     'platform': 'matter',
     'previous_unique_id': None,
     'supported_features': <LightEntityFeature: 32>,
-    'translation_key': 'light',
+    'translation_key': None,
     'unique_id': '00000000000004D2-0000000000000001-MatterNodeDevice-1-MatterLight-6-0',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_lights[color_temperature_light][light.mock_color_temperature_light_light-state]
+# name: test_lights[color_temperature_light][light.mock_color_temperature_light-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'brightness': 128,
       'color_mode': <ColorMode.COLOR_TEMP: 'color_temp'>,
       'color_temp': 284,
       'color_temp_kelvin': 3521,
-      'friendly_name': 'Mock Color Temperature Light Light',
+      'friendly_name': 'Mock Color Temperature Light',
       'hs_color': tuple(
         27.152,
         44.32,
@@ -71,14 +71,14 @@
       ),
     }),
     'context': <ANY>,
-    'entity_id': 'light.mock_color_temperature_light_light',
+    'entity_id': 'light.mock_color_temperature_light',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'on',
   })
 # ---
-# name: test_lights[dimmable_light][light.mock_dimmable_light_light-entry]
+# name: test_lights[dimmable_light][light.mock_dimmable_light-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -94,7 +94,7 @@
     'disabled_by': None,
     'domain': 'light',
     'entity_category': None,
-    'entity_id': 'light.mock_dimmable_light_light',
+    'entity_id': 'light.mock_dimmable_light',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -106,35 +106,35 @@
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Light',
+    'original_name': None,
     'platform': 'matter',
     'previous_unique_id': None,
     'supported_features': <LightEntityFeature: 32>,
-    'translation_key': 'light',
+    'translation_key': None,
     'unique_id': '00000000000004D2-0000000000000001-MatterNodeDevice-1-MatterLight-6-0',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_lights[dimmable_light][light.mock_dimmable_light_light-state]
+# name: test_lights[dimmable_light][light.mock_dimmable_light-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'brightness': 51,
       'color_mode': <ColorMode.BRIGHTNESS: 'brightness'>,
-      'friendly_name': 'Mock Dimmable Light Light',
+      'friendly_name': 'Mock Dimmable Light',
       'supported_color_modes': list([
         <ColorMode.BRIGHTNESS: 'brightness'>,
       ]),
       'supported_features': <LightEntityFeature: 32>,
     }),
     'context': <ANY>,
-    'entity_id': 'light.mock_dimmable_light_light',
+    'entity_id': 'light.mock_dimmable_light',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'on',
   })
 # ---
-# name: test_lights[dimmable_plugin_unit][light.dimmable_plugin_unit_light-entry]
+# name: test_lights[dimmable_plugin_unit][light.dimmable_plugin_unit-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -150,7 +150,7 @@
     'disabled_by': None,
     'domain': 'light',
     'entity_category': None,
-    'entity_id': 'light.dimmable_plugin_unit_light',
+    'entity_id': 'light.dimmable_plugin_unit',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -162,35 +162,35 @@
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Light',
+    'original_name': None,
     'platform': 'matter',
     'previous_unique_id': None,
     'supported_features': <LightEntityFeature: 32>,
-    'translation_key': 'light',
+    'translation_key': None,
     'unique_id': '00000000000004D2-0000000000000024-MatterNodeDevice-1-MatterLight-6-0',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_lights[dimmable_plugin_unit][light.dimmable_plugin_unit_light-state]
+# name: test_lights[dimmable_plugin_unit][light.dimmable_plugin_unit-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'brightness': 255,
       'color_mode': <ColorMode.BRIGHTNESS: 'brightness'>,
-      'friendly_name': 'Dimmable Plugin Unit Light',
+      'friendly_name': 'Dimmable Plugin Unit',
       'supported_color_modes': list([
         <ColorMode.BRIGHTNESS: 'brightness'>,
       ]),
       'supported_features': <LightEntityFeature: 32>,
     }),
     'context': <ANY>,
-    'entity_id': 'light.dimmable_plugin_unit_light',
+    'entity_id': 'light.dimmable_plugin_unit',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'on',
   })
 # ---
-# name: test_lights[extended_color_light][light.mock_extended_color_light_light-entry]
+# name: test_lights[extended_color_light][light.mock_extended_color_light-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -212,7 +212,7 @@
     'disabled_by': None,
     'domain': 'light',
     'entity_category': None,
-    'entity_id': 'light.mock_extended_color_light_light',
+    'entity_id': 'light.mock_extended_color_light',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -224,23 +224,23 @@
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Light',
+    'original_name': None,
     'platform': 'matter',
     'previous_unique_id': None,
     'supported_features': <LightEntityFeature: 32>,
-    'translation_key': 'light',
+    'translation_key': None,
     'unique_id': '00000000000004D2-0000000000000001-MatterNodeDevice-1-MatterLight-6-0',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_lights[extended_color_light][light.mock_extended_color_light_light-state]
+# name: test_lights[extended_color_light][light.mock_extended_color_light-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'brightness': 128,
       'color_mode': <ColorMode.HS: 'hs'>,
       'color_temp': None,
       'color_temp_kelvin': None,
-      'friendly_name': 'Mock Extended Color Light Light',
+      'friendly_name': 'Mock Extended Color Light',
       'hs_color': tuple(
         51.024,
         20.079,
@@ -266,7 +266,7 @@
       ),
     }),
     'context': <ANY>,
-    'entity_id': 'light.mock_extended_color_light_light',
+    'entity_id': 'light.mock_extended_color_light',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -402,7 +402,7 @@
     'state': 'off',
   })
 # ---
-# name: test_lights[onoff_light][light.mock_onoff_light_light-entry]
+# name: test_lights[onoff_light][light.mock_onoff_light-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -418,7 +418,7 @@
     'disabled_by': None,
     'domain': 'light',
     'entity_category': None,
-    'entity_id': 'light.mock_onoff_light_light',
+    'entity_id': 'light.mock_onoff_light',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -430,34 +430,34 @@
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Light',
+    'original_name': None,
     'platform': 'matter',
     'previous_unique_id': None,
     'supported_features': 0,
-    'translation_key': 'light',
+    'translation_key': None,
     'unique_id': '00000000000004D2-0000000000000001-MatterNodeDevice-1-MatterLight-6-0',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_lights[onoff_light][light.mock_onoff_light_light-state]
+# name: test_lights[onoff_light][light.mock_onoff_light-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'color_mode': <ColorMode.ONOFF: 'onoff'>,
-      'friendly_name': 'Mock OnOff Light Light',
+      'friendly_name': 'Mock OnOff Light',
       'supported_color_modes': list([
         <ColorMode.ONOFF: 'onoff'>,
       ]),
       'supported_features': <LightEntityFeature: 0>,
     }),
     'context': <ANY>,
-    'entity_id': 'light.mock_onoff_light_light',
+    'entity_id': 'light.mock_onoff_light',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'on',
   })
 # ---
-# name: test_lights[onoff_light_alt_name][light.mock_onoff_light_light-entry]
+# name: test_lights[onoff_light_alt_name][light.mock_onoff_light-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -479,7 +479,7 @@
     'disabled_by': None,
     'domain': 'light',
     'entity_category': None,
-    'entity_id': 'light.mock_onoff_light_light',
+    'entity_id': 'light.mock_onoff_light',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -491,23 +491,23 @@
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Light',
+    'original_name': None,
     'platform': 'matter',
     'previous_unique_id': None,
     'supported_features': <LightEntityFeature: 32>,
-    'translation_key': 'light',
+    'translation_key': None,
     'unique_id': '00000000000004D2-0000000000000001-MatterNodeDevice-1-MatterLight-6-0',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_lights[onoff_light_alt_name][light.mock_onoff_light_light-state]
+# name: test_lights[onoff_light_alt_name][light.mock_onoff_light-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'brightness': None,
       'color_mode': <ColorMode.COLOR_TEMP: 'color_temp'>,
       'color_temp': None,
       'color_temp_kelvin': None,
-      'friendly_name': 'Mock OnOff Light Light',
+      'friendly_name': 'Mock OnOff Light',
       'hs_color': None,
       'max_color_temp_kelvin': 6535,
       'max_mireds': 500,
@@ -523,14 +523,14 @@
       'xy_color': None,
     }),
     'context': <ANY>,
-    'entity_id': 'light.mock_onoff_light_light',
+    'entity_id': 'light.mock_onoff_light',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'on',
   })
 # ---
-# name: test_lights[onoff_light_no_name][light.mock_light_light-entry]
+# name: test_lights[onoff_light_no_name][light.mock_light-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -552,7 +552,7 @@
     'disabled_by': None,
     'domain': 'light',
     'entity_category': None,
-    'entity_id': 'light.mock_light_light',
+    'entity_id': 'light.mock_light',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -564,23 +564,23 @@
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Light',
+    'original_name': None,
     'platform': 'matter',
     'previous_unique_id': None,
     'supported_features': <LightEntityFeature: 32>,
-    'translation_key': 'light',
+    'translation_key': None,
     'unique_id': '00000000000004D2-0000000000000001-MatterNodeDevice-1-MatterLight-6-0',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_lights[onoff_light_no_name][light.mock_light_light-state]
+# name: test_lights[onoff_light_no_name][light.mock_light-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'brightness': None,
       'color_mode': <ColorMode.COLOR_TEMP: 'color_temp'>,
       'color_temp': None,
       'color_temp_kelvin': None,
-      'friendly_name': 'Mock Light Light',
+      'friendly_name': 'Mock Light',
       'hs_color': None,
       'max_color_temp_kelvin': 6535,
       'max_mireds': 500,
@@ -596,14 +596,14 @@
       'xy_color': None,
     }),
     'context': <ANY>,
-    'entity_id': 'light.mock_light_light',
+    'entity_id': 'light.mock_light',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'on',
   })
 # ---
-# name: test_lights[onoff_light_with_levelcontrol_present][light.d215s_light-entry]
+# name: test_lights[onoff_light_with_levelcontrol_present][light.d215s-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -619,7 +619,7 @@
     'disabled_by': None,
     'domain': 'light',
     'entity_category': None,
-    'entity_id': 'light.d215s_light',
+    'entity_id': 'light.d215s',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -631,27 +631,27 @@
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Light',
+    'original_name': None,
     'platform': 'matter',
     'previous_unique_id': None,
     'supported_features': 0,
-    'translation_key': 'light',
+    'translation_key': None,
     'unique_id': '00000000000004D2-0000000000000008-MatterNodeDevice-1-MatterLight-6-0',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_lights[onoff_light_with_levelcontrol_present][light.d215s_light-state]
+# name: test_lights[onoff_light_with_levelcontrol_present][light.d215s-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'color_mode': None,
-      'friendly_name': 'D215S Light',
+      'friendly_name': 'D215S',
       'supported_color_modes': list([
         <ColorMode.ONOFF: 'onoff'>,
       ]),
       'supported_features': <LightEntityFeature: 0>,
     }),
     'context': <ANY>,
-    'entity_id': 'light.d215s_light',
+    'entity_id': 'light.d215s',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/matter/snapshots/test_lock.ambr
+++ b/tests/components/matter/snapshots/test_lock.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_locks[door_lock][lock.mock_door_lock_lock-entry]
+# name: test_locks[door_lock][lock.mock_door_lock-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -11,7 +11,7 @@
     'disabled_by': None,
     'domain': 'lock',
     'entity_category': None,
-    'entity_id': 'lock.mock_door_lock_lock',
+    'entity_id': 'lock.mock_door_lock',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -23,30 +23,30 @@
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Lock',
+    'original_name': None,
     'platform': 'matter',
     'previous_unique_id': None,
     'supported_features': 0,
-    'translation_key': 'lock',
+    'translation_key': None,
     'unique_id': '00000000000004D2-0000000000000001-MatterNodeDevice-1-MatterLock-257-0',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_locks[door_lock][lock.mock_door_lock_lock-state]
+# name: test_locks[door_lock][lock.mock_door_lock-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Mock Door Lock Lock',
+      'friendly_name': 'Mock Door Lock',
       'supported_features': <LockEntityFeature: 0>,
     }),
     'context': <ANY>,
-    'entity_id': 'lock.mock_door_lock_lock',
+    'entity_id': 'lock.mock_door_lock',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unlocked',
   })
 # ---
-# name: test_locks[door_lock_with_unbolt][lock.mock_door_lock_lock-entry]
+# name: test_locks[door_lock_with_unbolt][lock.mock_door_lock-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -58,7 +58,7 @@
     'disabled_by': None,
     'domain': 'lock',
     'entity_category': None,
-    'entity_id': 'lock.mock_door_lock_lock',
+    'entity_id': 'lock.mock_door_lock',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -70,23 +70,23 @@
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Lock',
+    'original_name': None,
     'platform': 'matter',
     'previous_unique_id': None,
     'supported_features': <LockEntityFeature: 1>,
-    'translation_key': 'lock',
+    'translation_key': None,
     'unique_id': '00000000000004D2-0000000000000001-MatterNodeDevice-1-MatterLock-257-0',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_locks[door_lock_with_unbolt][lock.mock_door_lock_lock-state]
+# name: test_locks[door_lock_with_unbolt][lock.mock_door_lock-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Mock Door Lock Lock',
+      'friendly_name': 'Mock Door Lock',
       'supported_features': <LockEntityFeature: 1>,
     }),
     'context': <ANY>,
-    'entity_id': 'lock.mock_door_lock_lock',
+    'entity_id': 'lock.mock_door_lock',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/matter/snapshots/test_switch.ambr
+++ b/tests/components/matter/snapshots/test_switch.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_switches[door_lock][switch.mock_door_lock_switch-entry]
+# name: test_switches[door_lock][switch.mock_door_lock-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -11,7 +11,7 @@
     'disabled_by': None,
     'domain': 'switch',
     'entity_category': None,
-    'entity_id': 'switch.mock_door_lock_switch',
+    'entity_id': 'switch.mock_door_lock',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -23,30 +23,30 @@
     }),
     'original_device_class': <SwitchDeviceClass.OUTLET: 'outlet'>,
     'original_icon': None,
-    'original_name': 'Switch',
+    'original_name': None,
     'platform': 'matter',
     'previous_unique_id': None,
     'supported_features': 0,
-    'translation_key': 'switch',
+    'translation_key': None,
     'unique_id': '00000000000004D2-0000000000000001-MatterNodeDevice-1-MatterSwitch-6-0',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_switches[door_lock][switch.mock_door_lock_switch-state]
+# name: test_switches[door_lock][switch.mock_door_lock-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'outlet',
-      'friendly_name': 'Mock Door Lock Switch',
+      'friendly_name': 'Mock Door Lock',
     }),
     'context': <ANY>,
-    'entity_id': 'switch.mock_door_lock_switch',
+    'entity_id': 'switch.mock_door_lock',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'off',
   })
 # ---
-# name: test_switches[door_lock_with_unbolt][switch.mock_door_lock_switch-entry]
+# name: test_switches[door_lock_with_unbolt][switch.mock_door_lock-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -58,7 +58,7 @@
     'disabled_by': None,
     'domain': 'switch',
     'entity_category': None,
-    'entity_id': 'switch.mock_door_lock_switch',
+    'entity_id': 'switch.mock_door_lock',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -70,30 +70,30 @@
     }),
     'original_device_class': <SwitchDeviceClass.OUTLET: 'outlet'>,
     'original_icon': None,
-    'original_name': 'Switch',
+    'original_name': None,
     'platform': 'matter',
     'previous_unique_id': None,
     'supported_features': 0,
-    'translation_key': 'switch',
+    'translation_key': None,
     'unique_id': '00000000000004D2-0000000000000001-MatterNodeDevice-1-MatterSwitch-6-0',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_switches[door_lock_with_unbolt][switch.mock_door_lock_switch-state]
+# name: test_switches[door_lock_with_unbolt][switch.mock_door_lock-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'outlet',
-      'friendly_name': 'Mock Door Lock Switch',
+      'friendly_name': 'Mock Door Lock',
     }),
     'context': <ANY>,
-    'entity_id': 'switch.mock_door_lock_switch',
+    'entity_id': 'switch.mock_door_lock',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'off',
   })
 # ---
-# name: test_switches[eve_energy_plug][switch.eve_energy_plug_switch-entry]
+# name: test_switches[eve_energy_plug][switch.eve_energy_plug-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -105,7 +105,7 @@
     'disabled_by': None,
     'domain': 'switch',
     'entity_category': None,
-    'entity_id': 'switch.eve_energy_plug_switch',
+    'entity_id': 'switch.eve_energy_plug',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -117,30 +117,30 @@
     }),
     'original_device_class': <SwitchDeviceClass.OUTLET: 'outlet'>,
     'original_icon': None,
-    'original_name': 'Switch',
+    'original_name': None,
     'platform': 'matter',
     'previous_unique_id': None,
     'supported_features': 0,
-    'translation_key': 'switch',
+    'translation_key': None,
     'unique_id': '00000000000004D2-0000000000000053-MatterNodeDevice-1-MatterPlug-6-0',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_switches[eve_energy_plug][switch.eve_energy_plug_switch-state]
+# name: test_switches[eve_energy_plug][switch.eve_energy_plug-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'outlet',
-      'friendly_name': 'Eve Energy Plug Switch',
+      'friendly_name': 'Eve Energy Plug',
     }),
     'context': <ANY>,
-    'entity_id': 'switch.eve_energy_plug_switch',
+    'entity_id': 'switch.eve_energy_plug',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'off',
   })
 # ---
-# name: test_switches[eve_energy_plug_patched][switch.eve_energy_plug_patched_switch-entry]
+# name: test_switches[eve_energy_plug_patched][switch.eve_energy_plug_patched-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -152,7 +152,7 @@
     'disabled_by': None,
     'domain': 'switch',
     'entity_category': None,
-    'entity_id': 'switch.eve_energy_plug_patched_switch',
+    'entity_id': 'switch.eve_energy_plug_patched',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -164,30 +164,30 @@
     }),
     'original_device_class': <SwitchDeviceClass.OUTLET: 'outlet'>,
     'original_icon': None,
-    'original_name': 'Switch',
+    'original_name': None,
     'platform': 'matter',
     'previous_unique_id': None,
     'supported_features': 0,
-    'translation_key': 'switch',
+    'translation_key': None,
     'unique_id': '00000000000004D2-00000000000000B7-MatterNodeDevice-1-MatterPlug-6-0',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_switches[eve_energy_plug_patched][switch.eve_energy_plug_patched_switch-state]
+# name: test_switches[eve_energy_plug_patched][switch.eve_energy_plug_patched-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'outlet',
-      'friendly_name': 'Eve Energy Plug Patched Switch',
+      'friendly_name': 'Eve Energy Plug Patched',
     }),
     'context': <ANY>,
-    'entity_id': 'switch.eve_energy_plug_patched_switch',
+    'entity_id': 'switch.eve_energy_plug_patched',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'off',
   })
 # ---
-# name: test_switches[on_off_plugin_unit][switch.mock_onoffpluginunit_switch-entry]
+# name: test_switches[on_off_plugin_unit][switch.mock_onoffpluginunit-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -199,7 +199,7 @@
     'disabled_by': None,
     'domain': 'switch',
     'entity_category': None,
-    'entity_id': 'switch.mock_onoffpluginunit_switch',
+    'entity_id': 'switch.mock_onoffpluginunit',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -211,23 +211,23 @@
     }),
     'original_device_class': <SwitchDeviceClass.OUTLET: 'outlet'>,
     'original_icon': None,
-    'original_name': 'Switch',
+    'original_name': None,
     'platform': 'matter',
     'previous_unique_id': None,
     'supported_features': 0,
-    'translation_key': 'switch',
+    'translation_key': None,
     'unique_id': '00000000000004D2-0000000000000001-MatterNodeDevice-1-MatterPlug-6-0',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_switches[on_off_plugin_unit][switch.mock_onoffpluginunit_switch-state]
+# name: test_switches[on_off_plugin_unit][switch.mock_onoffpluginunit-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'outlet',
-      'friendly_name': 'Mock OnOffPluginUnit Switch',
+      'friendly_name': 'Mock OnOffPluginUnit',
     }),
     'context': <ANY>,
-    'entity_id': 'switch.mock_onoffpluginunit_switch',
+    'entity_id': 'switch.mock_onoffpluginunit',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -281,7 +281,7 @@
     'state': 'off',
   })
 # ---
-# name: test_switches[switch_unit][switch.mock_switchunit_switch-entry]
+# name: test_switches[switch_unit][switch.mock_switchunit-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -293,7 +293,7 @@
     'disabled_by': None,
     'domain': 'switch',
     'entity_category': None,
-    'entity_id': 'switch.mock_switchunit_switch',
+    'entity_id': 'switch.mock_switchunit',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -305,30 +305,30 @@
     }),
     'original_device_class': <SwitchDeviceClass.OUTLET: 'outlet'>,
     'original_icon': None,
-    'original_name': 'Switch',
+    'original_name': None,
     'platform': 'matter',
     'previous_unique_id': None,
     'supported_features': 0,
-    'translation_key': 'switch',
+    'translation_key': None,
     'unique_id': '00000000000004D2-0000000000000001-MatterNodeDevice-1-MatterSwitch-6-0',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_switches[switch_unit][switch.mock_switchunit_switch-state]
+# name: test_switches[switch_unit][switch.mock_switchunit-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'outlet',
-      'friendly_name': 'Mock SwitchUnit Switch',
+      'friendly_name': 'Mock SwitchUnit',
     }),
     'context': <ANY>,
-    'entity_id': 'switch.mock_switchunit_switch',
+    'entity_id': 'switch.mock_switchunit',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'off',
   })
 # ---
-# name: test_switches[thermostat][switch.longan_link_hvac_switch-entry]
+# name: test_switches[thermostat][switch.longan_link_hvac-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -340,7 +340,7 @@
     'disabled_by': None,
     'domain': 'switch',
     'entity_category': None,
-    'entity_id': 'switch.longan_link_hvac_switch',
+    'entity_id': 'switch.longan_link_hvac',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -352,23 +352,23 @@
     }),
     'original_device_class': <SwitchDeviceClass.OUTLET: 'outlet'>,
     'original_icon': None,
-    'original_name': 'Switch',
+    'original_name': None,
     'platform': 'matter',
     'previous_unique_id': None,
     'supported_features': 0,
-    'translation_key': 'switch',
+    'translation_key': None,
     'unique_id': '00000000000004D2-0000000000000004-MatterNodeDevice-1-MatterSwitch-6-0',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_switches[thermostat][switch.longan_link_hvac_switch-state]
+# name: test_switches[thermostat][switch.longan_link_hvac-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'outlet',
-      'friendly_name': 'Longan link HVAC Switch',
+      'friendly_name': 'Longan link HVAC',
     }),
     'context': <ANY>,
-    'entity_id': 'switch.longan_link_hvac_switch',
+    'entity_id': 'switch.longan_link_hvac',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/matter/snapshots/test_valve.ambr
+++ b/tests/components/matter/snapshots/test_valve.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_valves[valve][valve.valve_valve-entry]
+# name: test_valves[valve][valve.valve-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -11,7 +11,7 @@
     'disabled_by': None,
     'domain': 'valve',
     'entity_category': None,
-    'entity_id': 'valve.valve_valve',
+    'entity_id': 'valve.valve',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -23,24 +23,24 @@
     }),
     'original_device_class': <ValveDeviceClass.WATER: 'water'>,
     'original_icon': None,
-    'original_name': 'Valve',
+    'original_name': None,
     'platform': 'matter',
     'previous_unique_id': None,
     'supported_features': <ValveEntityFeature: 3>,
-    'translation_key': 'valve',
+    'translation_key': None,
     'unique_id': '00000000000004D2-000000000000004B-MatterNodeDevice-1-MatterValve-129-4',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_valves[valve][valve.valve_valve-state]
+# name: test_valves[valve][valve.valve-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'water',
-      'friendly_name': 'Valve Valve',
+      'friendly_name': 'Valve',
       'supported_features': <ValveEntityFeature: 3>,
     }),
     'context': <ANY>,
-    'entity_id': 'valve.valve_valve',
+    'entity_id': 'valve.valve',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/matter/test_adapter.py
+++ b/tests/components/matter/test_adapter.py
@@ -135,13 +135,13 @@ async def test_node_added_subscription(
     node_added_callback = matter_client.subscribe_events.call_args.kwargs["callback"]
     node = create_node_from_fixture("onoff_light")
 
-    entity_state = hass.states.get("light.mock_onoff_light_light")
+    entity_state = hass.states.get("light.mock_onoff_light")
     assert not entity_state
 
     node_added_callback(EventType.NODE_ADDED, node)
     await hass.async_block_till_done()
 
-    entity_state = hass.states.get("light.mock_onoff_light_light")
+    entity_state = hass.states.get("light.mock_onoff_light")
     assert entity_state
 
 
@@ -200,6 +200,6 @@ async def test_bad_node_not_crash_integration(
     await hass.async_block_till_done()
 
     assert matter_client.get_nodes.call_count == 1
-    assert hass.states.get("light.mock_onoff_light_light") is not None
+    assert hass.states.get("light.mock_onoff_light") is not None
     assert len(hass.states.async_all("light")) == 1
     assert "Error setting up node" in caplog.text

--- a/tests/components/matter/test_climate.py
+++ b/tests/components/matter/test_climate.py
@@ -38,7 +38,7 @@ async def test_thermostat_base(
 ) -> None:
     """Test thermostat base attributes and state updates."""
     # test entity attributes
-    state = hass.states.get("climate.longan_link_hvac_thermostat")
+    state = hass.states.get("climate.longan_link_hvac")
     assert state
     assert state.attributes["min_temp"] == 7
     assert state.attributes["max_temp"] == 35
@@ -60,7 +60,7 @@ async def test_thermostat_base(
     set_node_attribute(matter_node, 1, 513, 5, 1600)
     set_node_attribute(matter_node, 1, 513, 6, 3000)
     await trigger_subscription_callback(hass, matter_client)
-    state = hass.states.get("climate.longan_link_hvac_thermostat")
+    state = hass.states.get("climate.longan_link_hvac")
     assert state
     assert state.attributes["min_temp"] == 16
     assert state.attributes["max_temp"] == 30
@@ -74,56 +74,56 @@ async def test_thermostat_base(
     # test system mode update from device
     set_node_attribute(matter_node, 1, 513, 28, 0)
     await trigger_subscription_callback(hass, matter_client)
-    state = hass.states.get("climate.longan_link_hvac_thermostat")
+    state = hass.states.get("climate.longan_link_hvac")
     assert state
     assert state.state == HVACMode.OFF
 
     # test running state update from device
     set_node_attribute(matter_node, 1, 513, 41, 1)
     await trigger_subscription_callback(hass, matter_client)
-    state = hass.states.get("climate.longan_link_hvac_thermostat")
+    state = hass.states.get("climate.longan_link_hvac")
     assert state
     assert state.attributes["hvac_action"] == HVACAction.HEATING
 
     set_node_attribute(matter_node, 1, 513, 41, 8)
     await trigger_subscription_callback(hass, matter_client)
-    state = hass.states.get("climate.longan_link_hvac_thermostat")
+    state = hass.states.get("climate.longan_link_hvac")
     assert state
     assert state.attributes["hvac_action"] == HVACAction.HEATING
 
     set_node_attribute(matter_node, 1, 513, 41, 2)
     await trigger_subscription_callback(hass, matter_client)
-    state = hass.states.get("climate.longan_link_hvac_thermostat")
+    state = hass.states.get("climate.longan_link_hvac")
     assert state
     assert state.attributes["hvac_action"] == HVACAction.COOLING
 
     set_node_attribute(matter_node, 1, 513, 41, 16)
     await trigger_subscription_callback(hass, matter_client)
-    state = hass.states.get("climate.longan_link_hvac_thermostat")
+    state = hass.states.get("climate.longan_link_hvac")
     assert state
     assert state.attributes["hvac_action"] == HVACAction.COOLING
 
     set_node_attribute(matter_node, 1, 513, 41, 4)
     await trigger_subscription_callback(hass, matter_client)
-    state = hass.states.get("climate.longan_link_hvac_thermostat")
+    state = hass.states.get("climate.longan_link_hvac")
     assert state
     assert state.attributes["hvac_action"] == HVACAction.FAN
 
     set_node_attribute(matter_node, 1, 513, 41, 32)
     await trigger_subscription_callback(hass, matter_client)
-    state = hass.states.get("climate.longan_link_hvac_thermostat")
+    state = hass.states.get("climate.longan_link_hvac")
     assert state
     assert state.attributes["hvac_action"] == HVACAction.FAN
 
     set_node_attribute(matter_node, 1, 513, 41, 64)
     await trigger_subscription_callback(hass, matter_client)
-    state = hass.states.get("climate.longan_link_hvac_thermostat")
+    state = hass.states.get("climate.longan_link_hvac")
     assert state
     assert state.attributes["hvac_action"] == HVACAction.FAN
 
     set_node_attribute(matter_node, 1, 513, 41, 66)
     await trigger_subscription_callback(hass, matter_client)
-    state = hass.states.get("climate.longan_link_hvac_thermostat")
+    state = hass.states.get("climate.longan_link_hvac")
     assert state
     assert state.attributes["hvac_action"] == HVACAction.OFF
 
@@ -131,7 +131,7 @@ async def test_thermostat_base(
     set_node_attribute(matter_node, 1, 513, 28, 4)
     await trigger_subscription_callback(hass, matter_client)
 
-    state = hass.states.get("climate.longan_link_hvac_thermostat")
+    state = hass.states.get("climate.longan_link_hvac")
     assert state
     assert state.state == HVACMode.HEAT
 
@@ -139,7 +139,7 @@ async def test_thermostat_base(
     set_node_attribute(matter_node, 1, 513, 18, 2000)
     await trigger_subscription_callback(hass, matter_client)
 
-    state = hass.states.get("climate.longan_link_hvac_thermostat")
+    state = hass.states.get("climate.longan_link_hvac")
     assert state
     assert state.attributes["temperature"] == 20
 
@@ -152,14 +152,14 @@ async def test_thermostat_service_calls(
 ) -> None:
     """Test climate platform service calls."""
     # test single-setpoint temperature adjustment when cool mode is active
-    state = hass.states.get("climate.longan_link_hvac_thermostat")
+    state = hass.states.get("climate.longan_link_hvac")
     assert state
     assert state.state == HVACMode.COOL
     await hass.services.async_call(
         "climate",
         "set_temperature",
         {
-            "entity_id": "climate.longan_link_hvac_thermostat",
+            "entity_id": "climate.longan_link_hvac",
             "temperature": 25,
         },
         blocking=True,
@@ -180,7 +180,7 @@ async def test_thermostat_service_calls(
         "climate",
         "set_temperature",
         {
-            "entity_id": "climate.longan_link_hvac_thermostat",
+            "entity_id": "climate.longan_link_hvac",
             "temperature": 25,
         },
         blocking=True,
@@ -192,7 +192,7 @@ async def test_thermostat_service_calls(
     # test single-setpoint temperature adjustment when heat mode is active
     set_node_attribute(matter_node, 1, 513, 28, 4)
     await trigger_subscription_callback(hass, matter_client)
-    state = hass.states.get("climate.longan_link_hvac_thermostat")
+    state = hass.states.get("climate.longan_link_hvac")
     assert state
     assert state.state == HVACMode.HEAT
 
@@ -200,7 +200,7 @@ async def test_thermostat_service_calls(
         "climate",
         "set_temperature",
         {
-            "entity_id": "climate.longan_link_hvac_thermostat",
+            "entity_id": "climate.longan_link_hvac",
             "temperature": 20,
         },
         blocking=True,
@@ -217,7 +217,7 @@ async def test_thermostat_service_calls(
     # test dual setpoint temperature adjustments when heat_cool mode is active
     set_node_attribute(matter_node, 1, 513, 28, 1)
     await trigger_subscription_callback(hass, matter_client)
-    state = hass.states.get("climate.longan_link_hvac_thermostat")
+    state = hass.states.get("climate.longan_link_hvac")
     assert state
     assert state.state == HVACMode.HEAT_COOL
 
@@ -225,7 +225,7 @@ async def test_thermostat_service_calls(
         "climate",
         "set_temperature",
         {
-            "entity_id": "climate.longan_link_hvac_thermostat",
+            "entity_id": "climate.longan_link_hvac",
             "target_temp_low": 10,
             "target_temp_high": 30,
         },
@@ -250,7 +250,7 @@ async def test_thermostat_service_calls(
         "climate",
         "set_hvac_mode",
         {
-            "entity_id": "climate.longan_link_hvac_thermostat",
+            "entity_id": "climate.longan_link_hvac",
             "hvac_mode": HVACMode.HEAT,
         },
         blocking=True,
@@ -274,7 +274,7 @@ async def test_thermostat_service_calls(
         "climate",
         "set_temperature",
         {
-            "entity_id": "climate.longan_link_hvac_thermostat",
+            "entity_id": "climate.longan_link_hvac",
             "temperature": 22,
             "hvac_mode": HVACMode.COOL,
         },
@@ -304,7 +304,7 @@ async def test_room_airconditioner(
     matter_node: MatterNode,
 ) -> None:
     """Test if a climate entity is created for a Room Airconditioner device."""
-    state = hass.states.get("climate.room_airconditioner_thermostat")
+    state = hass.states.get("climate.room_airconditioner")
     assert state
     assert state.attributes["current_temperature"] == 20
     # room airconditioner has mains power on OnOff cluster with value set to False
@@ -318,7 +318,7 @@ async def test_room_airconditioner(
     # set mains power to ON (OnOff cluster)
     set_node_attribute(matter_node, 1, 6, 0, True)
     await trigger_subscription_callback(hass, matter_client)
-    state = hass.states.get("climate.room_airconditioner_thermostat")
+    state = hass.states.get("climate.room_airconditioner")
 
     # test supported HVAC modes include fan and dry modes
     assert state.attributes["hvac_modes"] == [
@@ -332,19 +332,19 @@ async def test_room_airconditioner(
     # test fan-only hvac mode
     set_node_attribute(matter_node, 1, 513, 28, 7)
     await trigger_subscription_callback(hass, matter_client)
-    state = hass.states.get("climate.room_airconditioner_thermostat")
+    state = hass.states.get("climate.room_airconditioner")
     assert state
     assert state.state == HVACMode.FAN_ONLY
 
     # test dry hvac mode
     set_node_attribute(matter_node, 1, 513, 28, 8)
     await trigger_subscription_callback(hass, matter_client)
-    state = hass.states.get("climate.room_airconditioner_thermostat")
+    state = hass.states.get("climate.room_airconditioner")
     assert state
     assert state.state == HVACMode.DRY
 
     # test featuremap update
     set_node_attribute(matter_node, 1, 513, 65532, 1)
     await trigger_subscription_callback(hass, matter_client)
-    state = hass.states.get("climate.room_airconditioner_thermostat")
+    state = hass.states.get("climate.room_airconditioner")
     assert state.attributes["supported_features"] & ClimateEntityFeature.TURN_ON

--- a/tests/components/matter/test_cover.py
+++ b/tests/components/matter/test_cover.py
@@ -33,11 +33,11 @@ async def test_covers(
 @pytest.mark.parametrize(
     ("node_fixture", "entity_id"),
     [
-        ("window_covering_lift", "cover.mock_lift_window_covering_cover"),
-        ("window_covering_pa_lift", "cover.longan_link_wncv_da01_cover"),
-        ("window_covering_tilt", "cover.mock_tilt_window_covering_cover"),
-        ("window_covering_pa_tilt", "cover.mock_pa_tilt_window_covering_cover"),
-        ("window_covering_full", "cover.mock_full_window_covering_cover"),
+        ("window_covering_lift", "cover.mock_lift_window_covering"),
+        ("window_covering_pa_lift", "cover.longan_link_wncv_da01"),
+        ("window_covering_tilt", "cover.mock_tilt_window_covering"),
+        ("window_covering_pa_tilt", "cover.mock_pa_tilt_window_covering"),
+        ("window_covering_full", "cover.mock_full_window_covering"),
     ],
 )
 async def test_cover(
@@ -103,9 +103,9 @@ async def test_cover(
 @pytest.mark.parametrize(
     ("node_fixture", "entity_id"),
     [
-        ("window_covering_lift", "cover.mock_lift_window_covering_cover"),
-        ("window_covering_pa_lift", "cover.longan_link_wncv_da01_cover"),
-        ("window_covering_full", "cover.mock_full_window_covering_cover"),
+        ("window_covering_lift", "cover.mock_lift_window_covering"),
+        ("window_covering_pa_lift", "cover.longan_link_wncv_da01"),
+        ("window_covering_full", "cover.mock_full_window_covering"),
     ],
 )
 async def test_cover_lift(
@@ -151,7 +151,7 @@ async def test_cover_lift(
 @pytest.mark.parametrize(
     ("node_fixture", "entity_id"),
     [
-        ("window_covering_lift", "cover.mock_lift_window_covering_cover"),
+        ("window_covering_lift", "cover.mock_lift_window_covering"),
     ],
 )
 async def test_cover_lift_only(
@@ -188,7 +188,7 @@ async def test_cover_lift_only(
 @pytest.mark.parametrize(
     ("node_fixture", "entity_id"),
     [
-        ("window_covering_pa_lift", "cover.longan_link_wncv_da01_cover"),
+        ("window_covering_pa_lift", "cover.longan_link_wncv_da01"),
     ],
 )
 async def test_cover_position_aware_lift(
@@ -232,9 +232,9 @@ async def test_cover_position_aware_lift(
 @pytest.mark.parametrize(
     ("node_fixture", "entity_id"),
     [
-        ("window_covering_tilt", "cover.mock_tilt_window_covering_cover"),
-        ("window_covering_pa_tilt", "cover.mock_pa_tilt_window_covering_cover"),
-        ("window_covering_full", "cover.mock_full_window_covering_cover"),
+        ("window_covering_tilt", "cover.mock_tilt_window_covering"),
+        ("window_covering_pa_tilt", "cover.mock_pa_tilt_window_covering"),
+        ("window_covering_full", "cover.mock_full_window_covering"),
     ],
 )
 async def test_cover_tilt(
@@ -282,7 +282,7 @@ async def test_cover_tilt(
 @pytest.mark.parametrize(
     ("node_fixture", "entity_id"),
     [
-        ("window_covering_tilt", "cover.mock_tilt_window_covering_cover"),
+        ("window_covering_tilt", "cover.mock_tilt_window_covering"),
     ],
 )
 async def test_cover_tilt_only(
@@ -317,7 +317,7 @@ async def test_cover_tilt_only(
 @pytest.mark.parametrize(
     ("node_fixture", "entity_id"),
     [
-        ("window_covering_pa_tilt", "cover.mock_pa_tilt_window_covering_cover"),
+        ("window_covering_pa_tilt", "cover.mock_pa_tilt_window_covering"),
     ],
 )
 async def test_cover_position_aware_tilt(
@@ -357,7 +357,7 @@ async def test_cover_full_features(
     matter_node: MatterNode,
 ) -> None:
     """Test window covering devices with all the features."""
-    entity_id = "cover.mock_full_window_covering_cover"
+    entity_id = "cover.mock_full_window_covering"
 
     state = hass.states.get(entity_id)
     assert state

--- a/tests/components/matter/test_fan.py
+++ b/tests/components/matter/test_fan.py
@@ -51,7 +51,7 @@ async def test_fan_base(
     matter_node: MatterNode,
 ) -> None:
     """Test Fan platform."""
-    entity_id = "fan.air_purifier_fan"
+    entity_id = "fan.air_purifier"
     state = hass.states.get(entity_id)
     assert state
     assert state.attributes["preset_modes"] == [
@@ -119,7 +119,7 @@ async def test_fan_turn_on_with_percentage(
     matter_node: MatterNode,
 ) -> None:
     """Test turning on the fan with a specific percentage."""
-    entity_id = "fan.air_purifier_fan"
+    entity_id = "fan.air_purifier"
     await hass.services.async_call(
         FAN_DOMAIN,
         SERVICE_TURN_ON,
@@ -157,7 +157,7 @@ async def test_fan_turn_on_with_preset_mode(
     matter_node: MatterNode,
 ) -> None:
     """Test turning on the fan with a specific preset mode."""
-    entity_id = "fan.mocked_fan_switch_fan"
+    entity_id = "fan.mocked_fan_switch"
     await hass.services.async_call(
         FAN_DOMAIN,
         SERVICE_TURN_ON,
@@ -233,7 +233,7 @@ async def test_fan_turn_off(
     matter_node: MatterNode,
 ) -> None:
     """Test turning off the fan."""
-    entity_id = "fan.air_purifier_fan"
+    entity_id = "fan.air_purifier"
     await hass.services.async_call(
         FAN_DOMAIN,
         SERVICE_TURN_OFF,
@@ -276,7 +276,7 @@ async def test_fan_oscillate(
     matter_node: MatterNode,
 ) -> None:
     """Test oscillating the fan."""
-    entity_id = "fan.air_purifier_fan"
+    entity_id = "fan.air_purifier"
     for oscillating, value in ((True, 1), (False, 0)):
         await hass.services.async_call(
             FAN_DOMAIN,
@@ -300,7 +300,7 @@ async def test_fan_set_direction(
     matter_node: MatterNode,
 ) -> None:
     """Test oscillating the fan."""
-    entity_id = "fan.air_purifier_fan"
+    entity_id = "fan.air_purifier"
     for direction, value in ((DIRECTION_FORWARD, 0), (DIRECTION_REVERSE, 1)):
         await hass.services.async_call(
             FAN_DOMAIN,
@@ -323,7 +323,7 @@ async def test_fan_set_direction(
     [
         (
             "fan",
-            "fan.mocked_fan_switch_fan",
+            "fan.mocked_fan_switch",
             {
                 "1/514/65532": 0,
             },
@@ -331,7 +331,7 @@ async def test_fan_set_direction(
         ),
         (
             "fan",
-            "fan.mocked_fan_switch_fan",
+            "fan.mocked_fan_switch",
             {
                 "1/514/65532": 1,
             },
@@ -343,7 +343,7 @@ async def test_fan_set_direction(
         ),
         (
             "fan",
-            "fan.mocked_fan_switch_fan",
+            "fan.mocked_fan_switch",
             {
                 "1/514/65532": 4,
             },
@@ -355,7 +355,7 @@ async def test_fan_set_direction(
         ),
         (
             "fan",
-            "fan.mocked_fan_switch_fan",
+            "fan.mocked_fan_switch",
             {
                 "1/514/65532": 36,
             },
@@ -387,7 +387,7 @@ async def test_fan_supported_features(
     [
         (
             "fan",
-            "fan.mocked_fan_switch_fan",
+            "fan.mocked_fan_switch",
             {"1/514/1": 0, "1/514/65532": 0},
             [
                 "low",
@@ -397,7 +397,7 @@ async def test_fan_supported_features(
         ),
         (
             "fan",
-            "fan.mocked_fan_switch_fan",
+            "fan.mocked_fan_switch",
             {"1/514/1": 1, "1/514/65532": 0},
             [
                 "low",
@@ -406,25 +406,25 @@ async def test_fan_supported_features(
         ),
         (
             "fan",
-            "fan.mocked_fan_switch_fan",
+            "fan.mocked_fan_switch",
             {"1/514/1": 2, "1/514/65532": 0},
             ["low", "medium", "high", "auto"],
         ),
         (
             "fan",
-            "fan.mocked_fan_switch_fan",
+            "fan.mocked_fan_switch",
             {"1/514/1": 4, "1/514/65532": 0},
             ["high", "auto"],
         ),
         (
             "fan",
-            "fan.mocked_fan_switch_fan",
+            "fan.mocked_fan_switch",
             {"1/514/1": 5, "1/514/65532": 0},
             ["high"],
         ),
         (
             "fan",
-            "fan.mocked_fan_switch_fan",
+            "fan.mocked_fan_switch",
             {"1/514/1": 5, "1/514/65532": 8, "1/514/9": 3},
             ["high", "natural_wind", "sleep_wind"],
         ),

--- a/tests/components/matter/test_init.py
+++ b/tests/components/matter/test_init.py
@@ -67,7 +67,7 @@ async def test_entry_setup_unload(
     assert matter_client.connect.call_count == 1
     assert matter_client.set_default_fabric_label.call_count == 1
     assert entry.state is ConfigEntryState.LOADED
-    entity_state = hass.states.get("light.mock_onoff_light_light")
+    entity_state = hass.states.get("light.mock_onoff_light")
     assert entity_state
     assert entity_state.state != STATE_UNAVAILABLE
 
@@ -75,7 +75,7 @@ async def test_entry_setup_unload(
 
     assert matter_client.disconnect.call_count == 1
     assert entry.state is ConfigEntryState.NOT_LOADED
-    entity_state = hass.states.get("light.mock_onoff_light_light")
+    entity_state = hass.states.get("light.mock_onoff_light")
     assert entity_state
     assert entity_state.state == STATE_UNAVAILABLE
 
@@ -676,7 +676,7 @@ async def test_remove_config_entry_device(
     device_entry = dr.async_entries_for_config_entry(
         device_registry, config_entry.entry_id
     )[0]
-    entity_id = "light.m5stamp_lighting_app_light"
+    entity_id = "light.m5stamp_lighting_app"
 
     assert device_entry
     assert entity_registry.async_get(entity_id)

--- a/tests/components/matter/test_light.py
+++ b/tests/components/matter/test_light.py
@@ -34,17 +34,17 @@ async def test_lights(
     [
         (
             "extended_color_light",
-            "light.mock_extended_color_light_light",
+            "light.mock_extended_color_light",
             ["color_temp", "hs", "xy"],
         ),
         (
             "color_temperature_light",
-            "light.mock_color_temperature_light_light",
+            "light.mock_color_temperature_light",
             ["color_temp"],
         ),
-        ("dimmable_light", "light.mock_dimmable_light_light", ["brightness"]),
-        ("onoff_light", "light.mock_onoff_light_light", ["onoff"]),
-        ("onoff_light_with_levelcontrol_present", "light.d215s_light", ["onoff"]),
+        ("dimmable_light", "light.mock_dimmable_light", ["brightness"]),
+        ("onoff_light", "light.mock_onoff_light", ["onoff"]),
+        ("onoff_light_with_levelcontrol_present", "light.d215s", ["onoff"]),
     ],
 )
 async def test_light_turn_on_off(
@@ -117,10 +117,10 @@ async def test_light_turn_on_off(
 @pytest.mark.parametrize(
     ("node_fixture", "entity_id"),
     [
-        ("extended_color_light", "light.mock_extended_color_light_light"),
-        ("color_temperature_light", "light.mock_color_temperature_light_light"),
-        ("dimmable_light", "light.mock_dimmable_light_light"),
-        ("dimmable_plugin_unit", "light.dimmable_plugin_unit_light"),
+        ("extended_color_light", "light.mock_extended_color_light"),
+        ("color_temperature_light", "light.mock_color_temperature_light"),
+        ("dimmable_light", "light.mock_dimmable_light"),
+        ("dimmable_plugin_unit", "light.dimmable_plugin_unit"),
     ],
 )
 async def test_dimmable_light(
@@ -185,8 +185,8 @@ async def test_dimmable_light(
 @pytest.mark.parametrize(
     ("node_fixture", "entity_id"),
     [
-        ("extended_color_light", "light.mock_extended_color_light_light"),
-        ("color_temperature_light", "light.mock_color_temperature_light_light"),
+        ("extended_color_light", "light.mock_extended_color_light"),
+        ("color_temperature_light", "light.mock_color_temperature_light"),
     ],
 )
 async def test_color_temperature_light(
@@ -274,7 +274,7 @@ async def test_color_temperature_light(
 @pytest.mark.parametrize(
     ("node_fixture", "entity_id"),
     [
-        ("extended_color_light", "light.mock_extended_color_light_light"),
+        ("extended_color_light", "light.mock_extended_color_light"),
     ],
 )
 async def test_extended_color_light(

--- a/tests/components/matter/test_lock.py
+++ b/tests/components/matter/test_lock.py
@@ -41,7 +41,7 @@ async def test_lock(
         "lock",
         "unlock",
         {
-            "entity_id": "lock.mock_door_lock_lock",
+            "entity_id": "lock.mock_door_lock",
         },
         blocking=True,
     )
@@ -59,7 +59,7 @@ async def test_lock(
         "lock",
         "lock",
         {
-            "entity_id": "lock.mock_door_lock_lock",
+            "entity_id": "lock.mock_door_lock",
         },
         blocking=True,
     )
@@ -74,42 +74,42 @@ async def test_lock(
     matter_client.send_device_command.reset_mock()
 
     await hass.async_block_till_done()
-    state = hass.states.get("lock.mock_door_lock_lock")
+    state = hass.states.get("lock.mock_door_lock")
     assert state
     assert state.state == LockState.LOCKING
 
     set_node_attribute(matter_node, 1, 257, 0, 0)
     await trigger_subscription_callback(hass, matter_client)
 
-    state = hass.states.get("lock.mock_door_lock_lock")
+    state = hass.states.get("lock.mock_door_lock")
     assert state
     assert state.state == LockState.UNLOCKED
 
     set_node_attribute(matter_node, 1, 257, 0, 2)
     await trigger_subscription_callback(hass, matter_client)
 
-    state = hass.states.get("lock.mock_door_lock_lock")
+    state = hass.states.get("lock.mock_door_lock")
     assert state
     assert state.state == LockState.UNLOCKED
 
     set_node_attribute(matter_node, 1, 257, 0, 1)
     await trigger_subscription_callback(hass, matter_client)
 
-    state = hass.states.get("lock.mock_door_lock_lock")
+    state = hass.states.get("lock.mock_door_lock")
     assert state
     assert state.state == LockState.LOCKED
 
     set_node_attribute(matter_node, 1, 257, 0, None)
     await trigger_subscription_callback(hass, matter_client)
 
-    state = hass.states.get("lock.mock_door_lock_lock")
+    state = hass.states.get("lock.mock_door_lock")
     assert state
     assert state.state == STATE_UNKNOWN
 
     # test featuremap update
     set_node_attribute(matter_node, 1, 257, 65532, 4096)
     await trigger_subscription_callback(hass, matter_client)
-    state = hass.states.get("lock.mock_door_lock_lock")
+    state = hass.states.get("lock.mock_door_lock")
     assert state.attributes["supported_features"] & LockEntityFeature.OPEN
 
 
@@ -135,7 +135,7 @@ async def test_lock_requires_pin(
         await hass.services.async_call(
             "lock",
             "lock",
-            {"entity_id": "lock.mock_door_lock_lock", ATTR_CODE: "1234"},
+            {"entity_id": "lock.mock_door_lock", ATTR_CODE: "1234"},
             blocking=True,
         )
 
@@ -144,7 +144,7 @@ async def test_lock_requires_pin(
     await hass.services.async_call(
         "lock",
         "lock",
-        {"entity_id": "lock.mock_door_lock_lock", ATTR_CODE: code},
+        {"entity_id": "lock.mock_door_lock", ATTR_CODE: code},
         blocking=True,
     )
     assert matter_client.send_device_command.call_count == 1
@@ -158,13 +158,13 @@ async def test_lock_requires_pin(
     # Lock door using default code
     default_code = "7654321"
     entity_registry.async_update_entity_options(
-        "lock.mock_door_lock_lock", "lock", {"default_code": default_code}
+        "lock.mock_door_lock", "lock", {"default_code": default_code}
     )
     await trigger_subscription_callback(hass, matter_client)
     await hass.services.async_call(
         "lock",
         "lock",
-        {"entity_id": "lock.mock_door_lock_lock"},
+        {"entity_id": "lock.mock_door_lock"},
         blocking=True,
     )
     assert matter_client.send_device_command.call_count == 2
@@ -183,7 +183,7 @@ async def test_lock_with_unbolt(
     matter_node: MatterNode,
 ) -> None:
     """Test door lock."""
-    state = hass.states.get("lock.mock_door_lock_lock")
+    state = hass.states.get("lock.mock_door_lock")
     assert state
     assert state.state == LockState.LOCKED
     assert state.attributes["supported_features"] & LockEntityFeature.OPEN
@@ -192,7 +192,7 @@ async def test_lock_with_unbolt(
         "lock",
         "unlock",
         {
-            "entity_id": "lock.mock_door_lock_lock",
+            "entity_id": "lock.mock_door_lock",
         },
         blocking=True,
     )
@@ -210,7 +210,7 @@ async def test_lock_with_unbolt(
         "lock",
         "open",
         {
-            "entity_id": "lock.mock_door_lock_lock",
+            "entity_id": "lock.mock_door_lock",
         },
         blocking=True,
     )
@@ -223,20 +223,20 @@ async def test_lock_with_unbolt(
     )
 
     await hass.async_block_till_done()
-    state = hass.states.get("lock.mock_door_lock_lock")
+    state = hass.states.get("lock.mock_door_lock")
     assert state
     assert state.state == LockState.OPENING
 
     set_node_attribute(matter_node, 1, 257, 0, 0)
     await trigger_subscription_callback(hass, matter_client)
 
-    state = hass.states.get("lock.mock_door_lock_lock")
+    state = hass.states.get("lock.mock_door_lock")
     assert state
     assert state.state == LockState.UNLOCKED
 
     set_node_attribute(matter_node, 1, 257, 0, 3)
     await trigger_subscription_callback(hass, matter_client)
 
-    state = hass.states.get("lock.mock_door_lock_lock")
+    state = hass.states.get("lock.mock_door_lock")
     assert state
     assert state.state == LockState.OPEN

--- a/tests/components/matter/test_switch.py
+++ b/tests/components/matter/test_switch.py
@@ -35,7 +35,7 @@ async def test_turn_on(
     matter_node: MatterNode,
 ) -> None:
     """Test turning on a switch."""
-    state = hass.states.get("switch.mock_onoffpluginunit_switch")
+    state = hass.states.get("switch.mock_onoffpluginunit")
     assert state
     assert state.state == "off"
 
@@ -43,7 +43,7 @@ async def test_turn_on(
         "switch",
         "turn_on",
         {
-            "entity_id": "switch.mock_onoffpluginunit_switch",
+            "entity_id": "switch.mock_onoffpluginunit",
         },
         blocking=True,
     )
@@ -58,7 +58,7 @@ async def test_turn_on(
     set_node_attribute(matter_node, 1, 6, 0, True)
     await trigger_subscription_callback(hass, matter_client)
 
-    state = hass.states.get("switch.mock_onoffpluginunit_switch")
+    state = hass.states.get("switch.mock_onoffpluginunit")
     assert state
     assert state.state == "on"
 
@@ -70,7 +70,7 @@ async def test_turn_off(
     matter_node: MatterNode,
 ) -> None:
     """Test turning off a switch."""
-    state = hass.states.get("switch.mock_onoffpluginunit_switch")
+    state = hass.states.get("switch.mock_onoffpluginunit")
     assert state
     assert state.state == "off"
 
@@ -78,7 +78,7 @@ async def test_turn_off(
         "switch",
         "turn_off",
         {
-            "entity_id": "switch.mock_onoffpluginunit_switch",
+            "entity_id": "switch.mock_onoffpluginunit",
         },
         blocking=True,
     )
@@ -97,10 +97,10 @@ async def test_switch_unit(hass: HomeAssistant, matter_node: MatterNode) -> None
     # A switch entity should be discovered as fallback for ANY Matter device (endpoint)
     # that has the OnOff cluster and does not fall into an explicit discovery schema
     # by another platform (e.g. light, lock etc.).
-    state = hass.states.get("switch.mock_switchunit_switch")
+    state = hass.states.get("switch.mock_switchunit")
     assert state
     assert state.state == "off"
-    assert state.attributes["friendly_name"] == "Mock SwitchUnit Switch"
+    assert state.attributes["friendly_name"] == "Mock SwitchUnit"
 
 
 @pytest.mark.parametrize("node_fixture", ["room_airconditioner"])

--- a/tests/components/matter/test_valve.py
+++ b/tests/components/matter/test_valve.py
@@ -35,11 +35,11 @@ async def test_valve(
     matter_node: MatterNode,
 ) -> None:
     """Test valve entity is created for a Matter ValveConfigurationAndControl Cluster."""
-    entity_id = "valve.valve_valve"
+    entity_id = "valve.valve"
     state = hass.states.get(entity_id)
     assert state
     assert state.state == "closed"
-    assert state.attributes["friendly_name"] == "Valve Valve"
+    assert state.attributes["friendly_name"] == "Valve"
 
     # test close_valve action
     await hass.services.async_call(


### PR DESCRIPTION
## Proposed change

Use device name for matter entities. The translation key will only be used if a suffix is added to the entity name.
It will avoid have entity id and entity name suffixed with the domain. (eg. `light.bedside_lamp_light` will become `light.bedside_lamp`)

As you can see in the following example, the logic will only be changed when the device have primary attribute on multiple endpoints. A translation key is added to have `Switch (1)` instead of weird name like `(1)`.

Examples:

### 1. A regular lamp (one light entity)

Device name : **Bedside lamp**

**Before**

| Entity ID | Entity name | Full name (device + entity name) |
| --- | --- | --- |
| light.bedside_lamp_light | Light | Bedside lamp light |

**After**

| Entity ID | Entity name | Full name (device + entity name) |
| --- | --- | --- |
| light.bedside_lamp | `None` | Bedside lamp |

### 2. A power strip (two switch entity for each outlet)

Device name : **Power strip**

**Before**

| Entity ID | Entity name | Full name (device + entity name) |
| --- | --- | --- |
| light.power_strip_switch_1 | Switch (1) | Power strip Switch (1) |
| light.power_strip_switch_2 | Switch (2) | Power strip Switch (2) |

**After**

| Entity ID | Entity name | Full name (device + entity name) |
| --- | --- | --- |
| light.power_strip_switch_1 | Switch (1) | Power strip Switch (1) |
| light.power_strip_switch_2 | Switch (2) | Power strip Switch (2) |

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
