### PR TITLE
Fix bosch shc multi controller support

### DIFF
--- a/homeassistant/components/bosch_shc/config_flow.py
+++ b/homeassistant/components/bosch_shc/config_flow.py
@@ -39,10 +39,14 @@ HOST_SCHEMA = vol.Schema(
 )
 
 
-def write_tls_asset(hass: HomeAssistant, folder: str, filename: str, asset: bytes) -> None:
+def write_tls_asset(
+    hass: HomeAssistant, folder: str, filename: str, asset: bytes
+) -> None:
     """Write the tls assets to disk."""
     makedirs(hass.config.path(DOMAIN, folder), exist_ok=True)
-    with open(hass.config.path(DOMAIN, folder, filename), "w", encoding="utf8") as file_handle:
+    with open(
+        hass.config.path(DOMAIN, folder, filename), "w", encoding="utf8"
+    ) as file_handle:
         file_handle.write(asset.decode("utf-8"))
 
 

--- a/homeassistant/components/bosch_shc/config_flow.py
+++ b/homeassistant/components/bosch_shc/config_flow.py
@@ -39,10 +39,10 @@ HOST_SCHEMA = vol.Schema(
 )
 
 
-def write_tls_asset(hass: HomeAssistant, filename: str, asset: bytes) -> None:
+def write_tls_asset(hass: HomeAssistant, folder: str, filename: str, asset: bytes) -> None:
     """Write the tls assets to disk."""
-    makedirs(hass.config.path(DOMAIN), exist_ok=True)
-    with open(hass.config.path(DOMAIN, filename), "w", encoding="utf8") as file_handle:
+    makedirs(hass.config.path(DOMAIN, folder), exist_ok=True)
+    with open(hass.config.path(DOMAIN, folder, filename), "w", encoding="utf8") as file_handle:
         file_handle.write(asset.decode("utf-8"))
 
 
@@ -56,19 +56,17 @@ def create_credentials_and_validate(
     """Create and store credentials and validate session."""
     helper = SHCRegisterClient(host, user_input[CONF_PASSWORD])
     result = helper.register(host, "HomeAssistant")
-    # Save key/certificate pair for each registered host separately
-    # otherwise only the last registered host is accessible.
-    conf_shc_cert = f"{unique_id}/{CONF_SHC_CERT}"
-    conf_shc_key = f"{unique_id}/{CONF_SHC_KEY}"
 
     if result is not None:
-        write_tls_asset(hass, conf_shc_cert, result["cert"])
-        write_tls_asset(hass, conf_shc_key, result["key"])
+        # Save key/certificate pair for each registered host separately
+        # otherwise only the last registered host is accessible.
+        write_tls_asset(hass, unique_id, CONF_SHC_CERT, result["cert"])
+        write_tls_asset(hass, unique_id, CONF_SHC_KEY, result["key"])
 
         session = SHCSession(
             host,
-            hass.config.path(DOMAIN, conf_shc_cert),
-            hass.config.path(DOMAIN, conf_shc_key),
+            hass.config.path(DOMAIN, unique_id, CONF_SHC_CERT),
+            hass.config.path(DOMAIN, unique_id, CONF_SHC_KEY),
             True,
             zeroconf_instance,
         )

--- a/homeassistant/components/bosch_shc/config_flow.py
+++ b/homeassistant/components/bosch_shc/config_flow.py
@@ -152,7 +152,7 @@ class BoschSHCConfigFlow(ConfigFlow, domain=DOMAIN):
             zeroconf_instance = await zeroconf.async_get_instance(self.hass)
             # unique_id uniquely identifies the registered controller and is used
             # to save the key/certificate pair for each controller separately
-            unique_id = self.info["unique_id"] or ""
+            unique_id: str = self.info["unique_id"]
             try:
                 result = await self.hass.async_add_executor_job(
                     create_credentials_and_validate,

--- a/homeassistant/components/bosch_shc/config_flow.py
+++ b/homeassistant/components/bosch_shc/config_flow.py
@@ -152,7 +152,7 @@ class BoschSHCConfigFlow(ConfigFlow, domain=DOMAIN):
             zeroconf_instance = await zeroconf.async_get_instance(self.hass)
             # unique_id uniquely identifies the registered controller and is used
             # to save the key/certificate pair for each controller separately
-            unique_id = self.info.get("unique_id") or ""
+            unique_id = self.info["unique_id"] or ""
             try:
                 result = await self.hass.async_add_executor_job(
                     create_credentials_and_validate,

--- a/homeassistant/components/bosch_shc/config_flow.py
+++ b/homeassistant/components/bosch_shc/config_flow.py
@@ -152,7 +152,8 @@ class BoschSHCConfigFlow(ConfigFlow, domain=DOMAIN):
             zeroconf_instance = await zeroconf.async_get_instance(self.hass)
             # unique_id uniquely identifies the registered controller and is used
             # to save the key/certificate pair for each controller separately
-            unique_id: str = self.info["unique_id"]
+            unique_id = self.info["unique_id"]
+            assert unique_id
             try:
                 result = await self.hass.async_add_executor_job(
                     create_credentials_and_validate,

--- a/tests/components/bosch_shc/test_config_flow.py
+++ b/tests/components/bosch_shc/test_config_flow.py
@@ -733,11 +733,11 @@ async def test_tls_assets_writer(hass: HomeAssistant) -> None:
         mocked_file().write.assert_called_with("content_key")
 
 
-# @pytest.mark.usefixtures("mock_zeroconf")
+@pytest.mark.usefixtures("mock_zeroconf")
 async def test_register_multiple_controllers(hass: HomeAssistant) -> None:
     """Test register multiple controllers.
 
-    Each registered controller must get its own key/certifiacate pair,
+    Each registered controller must get its own key/certificate pair,
     which must not get overwritten when a new controller is added.
     """
 

--- a/tests/components/bosch_shc/test_config_flow.py
+++ b/tests/components/bosch_shc/test_config_flow.py
@@ -708,6 +708,7 @@ async def test_reauth(hass: HomeAssistant) -> None:
 
 async def test_tls_assets_writer(hass: HomeAssistant) -> None:
     """Test we write tls assets to correct location."""
+    unique_id = "test-mac"
     assets = {
         "token": "abc:123",
         "cert": b"content_cert",
@@ -719,15 +720,15 @@ async def test_tls_assets_writer(hass: HomeAssistant) -> None:
             "homeassistant.components.bosch_shc.config_flow.open", mock_open()
         ) as mocked_file,
     ):
-        write_tls_asset(hass, CONF_SHC_CERT, assets["cert"])
+        write_tls_asset(hass, unique_id, CONF_SHC_CERT, assets["cert"])
         mocked_file.assert_called_with(
-            hass.config.path(DOMAIN, CONF_SHC_CERT), "w", encoding="utf8"
+            hass.config.path(DOMAIN, unique_id, CONF_SHC_CERT), "w", encoding="utf8"
         )
         mocked_file().write.assert_called_with("content_cert")
 
-        write_tls_asset(hass, CONF_SHC_KEY, assets["key"])
+        write_tls_asset(hass, unique_id, CONF_SHC_KEY, assets["key"])
         mocked_file.assert_called_with(
-            hass.config.path(DOMAIN, CONF_SHC_KEY), "w", encoding="utf8"
+            hass.config.path(DOMAIN, unique_id, CONF_SHC_KEY), "w", encoding="utf8"
         )
         mocked_file().write.assert_called_with("content_key")
 

--- a/tests/components/bosch_shc/test_config_flow.py
+++ b/tests/components/bosch_shc/test_config_flow.py
@@ -99,8 +99,8 @@ async def test_form_user(hass: HomeAssistant) -> None:
     assert result3["title"] == "shc012345"
     assert result3["data"] == {
         "host": "1.1.1.1",
-        "ssl_certificate": hass.config.path(DOMAIN, CONF_SHC_CERT),
-        "ssl_key": hass.config.path(DOMAIN, CONF_SHC_KEY),
+        "ssl_certificate": hass.config.path(DOMAIN, "test-mac", CONF_SHC_CERT),
+        "ssl_key": hass.config.path(DOMAIN, "test-mac", CONF_SHC_KEY),
         "token": "abc:123",
         "hostname": "123",
     }
@@ -549,8 +549,8 @@ async def test_zeroconf(hass: HomeAssistant) -> None:
     assert result3["title"] == "shc012345"
     assert result3["data"] == {
         "host": "1.1.1.1",
-        "ssl_certificate": hass.config.path(DOMAIN, CONF_SHC_CERT),
-        "ssl_key": hass.config.path(DOMAIN, CONF_SHC_KEY),
+        "ssl_certificate": hass.config.path(DOMAIN, "test-mac", CONF_SHC_CERT),
+        "ssl_key": hass.config.path(DOMAIN, "test-mac", CONF_SHC_KEY),
         "token": "abc:123",
         "hostname": "123",
     }
@@ -730,3 +730,152 @@ async def test_tls_assets_writer(hass: HomeAssistant) -> None:
             hass.config.path(DOMAIN, CONF_SHC_KEY), "w", encoding="utf8"
         )
         mocked_file().write.assert_called_with("content_key")
+
+
+# @pytest.mark.usefixtures("mock_zeroconf")
+async def test_register_multiple_controllers(hass: HomeAssistant) -> None:
+    """Test register multiple controllers.
+
+    Each registered controller must get its own key/certifiacate pair,
+    which must not get overwritten when a new controller is added.
+    """
+
+    controller_1 = {
+        "hostname": "shc111111",
+        "mac": "test-mac1",
+        "host": "1.1.1.1",
+        "register": {
+            "token": "abc:shc111111",
+            "cert": b"content_cert1",
+            "key": b"content_key1",
+        },
+    }
+    controller_2 = {
+        "hostname": "shc222222",
+        "mac": "test-mac2",
+        "host": "2.2.2.2",
+        "register": {
+            "token": "abc:shc222222",
+            "cert": b"content_cert2",
+            "key": b"content_key2",
+        },
+    }
+
+    # Set up controller 1
+    ctrl_1_result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with (
+        patch(
+            "boschshcpy.session.SHCSession.mdns_info",
+            return_value=SHCInformation,
+        ),
+        patch(
+            "boschshcpy.information.SHCInformation.name",
+            new_callable=PropertyMock,
+            return_value=controller_1["hostname"],
+        ),
+        patch(
+            "boschshcpy.information.SHCInformation.unique_id",
+            new_callable=PropertyMock,
+            return_value=controller_1["mac"],
+        ),
+    ):
+        ctrl_1_result2 = await hass.config_entries.flow.async_configure(
+            ctrl_1_result["flow_id"],
+            {"host": controller_1["host"]},
+        )
+
+    with (
+        patch(
+            "boschshcpy.register_client.SHCRegisterClient.register",
+            return_value=controller_1["register"],
+        ),
+        patch("os.mkdir"),
+        patch("homeassistant.components.bosch_shc.config_flow.open"),
+        patch("boschshcpy.session.SHCSession.authenticate"),
+        patch(
+            "homeassistant.components.bosch_shc.async_setup_entry",
+            return_value=True,
+        ),
+    ):
+        ctrl_1_result3 = await hass.config_entries.flow.async_configure(
+            ctrl_1_result2["flow_id"],
+            {"password": "test"},
+        )
+        await hass.async_block_till_done()
+
+    assert ctrl_1_result3["type"] is FlowResultType.CREATE_ENTRY
+    assert ctrl_1_result3["title"] == "shc111111"
+    assert ctrl_1_result3["context"]["unique_id"] == controller_1["mac"]
+    assert ctrl_1_result3["data"] == {
+        "host": "1.1.1.1",
+        "ssl_certificate": hass.config.path(DOMAIN, controller_1["mac"], CONF_SHC_CERT),
+        "ssl_key": hass.config.path(DOMAIN, controller_1["mac"], CONF_SHC_KEY),
+        "token": "abc:shc111111",
+        "hostname": "shc111111",
+    }
+
+    # Set up controller 2
+    ctrl_2_result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with (
+        patch(
+            "boschshcpy.session.SHCSession.mdns_info",
+            return_value=SHCInformation,
+        ),
+        patch(
+            "boschshcpy.information.SHCInformation.name",
+            new_callable=PropertyMock,
+            return_value=controller_2["hostname"],
+        ),
+        patch(
+            "boschshcpy.information.SHCInformation.unique_id",
+            new_callable=PropertyMock,
+            return_value=controller_2["mac"],
+        ),
+    ):
+        ctrl_2_result2 = await hass.config_entries.flow.async_configure(
+            ctrl_2_result["flow_id"],
+            {"host": controller_2["host"]},
+        )
+
+    with (
+        patch(
+            "boschshcpy.register_client.SHCRegisterClient.register",
+            return_value=controller_2["register"],
+        ),
+        patch("os.mkdir"),
+        patch("homeassistant.components.bosch_shc.config_flow.open"),
+        patch("boschshcpy.session.SHCSession.authenticate"),
+        patch(
+            "homeassistant.components.bosch_shc.async_setup_entry",
+            return_value=True,
+        ),
+    ):
+        ctrl_2_result3 = await hass.config_entries.flow.async_configure(
+            ctrl_2_result2["flow_id"],
+            {"password": "test"},
+        )
+        await hass.async_block_till_done()
+
+    assert ctrl_2_result3["type"] is FlowResultType.CREATE_ENTRY
+    assert ctrl_2_result3["title"] == "shc222222"
+    assert ctrl_2_result3["context"]["unique_id"] == controller_2["mac"]
+    assert ctrl_2_result3["data"] == {
+        "host": "2.2.2.2",
+        "ssl_certificate": hass.config.path(DOMAIN, controller_2["mac"], CONF_SHC_CERT),
+        "ssl_key": hass.config.path(DOMAIN, controller_2["mac"], CONF_SHC_KEY),
+        "token": "abc:shc222222",
+        "hostname": "shc222222",
+    }
+
+    # Check that each controller has its own key/certificate pair
+    assert (
+        ctrl_1_result3["data"]["ssl_certificate"]
+        != ctrl_2_result3["data"]["ssl_certificate"]
+    )
+    assert ctrl_1_result3["data"]["ssl_key"] != ctrl_2_result3["data"]["ssl_key"]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When registering a bosch smart home controller within homeassistant a certificate and key file are written to the config folder, which are used for authentication whenever an entity provided by that controller is accessed.
While it is possible to register multiple controllers, the certificate and key are written to a fixed location so that upon registering a second controller, the certificate and key of the first controller are overwritten. This means that authentication only works for the latest registered controller.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
I tested this locally with two controllers. Additionally, I verified that an already registered controller (registered without this fix) still works with this fix.

- This PR fixes or closes issue: fixes #106386 (already closed due to inactivity but not because the issue is solved)
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
