### PR TITLE
Fix transition config storage in LCN light and scene platform

### DIFF
--- a/homeassistant/components/lcn/__init__.py
+++ b/homeassistant/components/lcn/__init__.py
@@ -159,7 +159,7 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
         if config_entry.minor_version < 2:
             new_data[CONF_ACKNOWLEDGE] = False
 
-        # update to 2.0  (fix transitions for lights and switches)
+        # update to 2.1  (fix transitions for lights and switches)
         new_entities_data = [*new_data[CONF_ENTITIES]]
         for entity in new_entities_data:
             if entity[CONF_DOMAIN] in [Platform.LIGHT, Platform.SCENE]:
@@ -169,7 +169,7 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
         new_data[CONF_ENTITIES] = new_entities_data
 
     hass.config_entries.async_update_entry(
-        config_entry, data=new_data, minor_version=0, version=2
+        config_entry, data=new_data, minor_version=1, version=2
     )
 
     _LOGGER.debug(

--- a/homeassistant/components/lcn/__init__.py
+++ b/homeassistant/components/lcn/__init__.py
@@ -163,6 +163,8 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
         new_entities_data = [*new_data[CONF_ENTITIES]]
         for entity in new_entities_data:
             if entity[CONF_DOMAIN] in [Platform.LIGHT, Platform.SCENE]:
+                if entity[CONF_DOMAIN_DATA][CONF_TRANSITION] is None:
+                    entity[CONF_DOMAIN_DATA][CONF_TRANSITION] = 0
                 entity[CONF_DOMAIN_DATA][CONF_TRANSITION] /= 1000.0
         new_data[CONF_ENTITIES] = new_entities_data
 

--- a/homeassistant/components/lcn/__init__.py
+++ b/homeassistant/components/lcn/__init__.py
@@ -11,10 +11,13 @@ from pypck.connection import PchkConnectionManager
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import (
     CONF_DEVICE_ID,
+    CONF_DOMAIN,
+    CONF_ENTITIES,
     CONF_IP_ADDRESS,
     CONF_PASSWORD,
     CONF_PORT,
     CONF_USERNAME,
+    Platform,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
@@ -24,7 +27,9 @@ from .const import (
     ADD_ENTITIES_CALLBACKS,
     CONF_ACKNOWLEDGE,
     CONF_DIM_MODE,
+    CONF_DOMAIN_DATA,
     CONF_SK_NUM_TRIES,
+    CONF_TRANSITION,
     CONNECTION,
     DOMAIN,
     PLATFORMS,
@@ -147,15 +152,23 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
         config_entry.minor_version,
     )
 
-    if config_entry.version == 1:
-        new_data = {**config_entry.data}
+    new_data = {**config_entry.data}
 
+    if config_entry.version == 1:
+        # update to 1.2  (add acknowledge flag)
         if config_entry.minor_version < 2:
             new_data[CONF_ACKNOWLEDGE] = False
 
-        hass.config_entries.async_update_entry(
-            config_entry, data=new_data, minor_version=2, version=1
-        )
+        # update to 2.0  (fix transitions for lights and switches)
+        new_entities_data = [*new_data[CONF_ENTITIES]]
+        for entity in new_entities_data:
+            if entity[CONF_DOMAIN] in [Platform.LIGHT, Platform.SCENE]:
+                entity[CONF_DOMAIN_DATA][CONF_TRANSITION] /= 1000.0
+        new_data[CONF_ENTITIES] = new_entities_data
+
+    hass.config_entries.async_update_entry(
+        config_entry, data=new_data, minor_version=0, version=2
+    )
 
     _LOGGER.debug(
         "Migration to configuration version %s.%s successful",

--- a/homeassistant/components/lcn/config_flow.py
+++ b/homeassistant/components/lcn/config_flow.py
@@ -111,7 +111,7 @@ class LcnFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a LCN config flow."""
 
     VERSION = 2
-    MINOR_VERSION = 0
+    MINOR_VERSION = 1
 
     _context_entry: ConfigEntry
 

--- a/homeassistant/components/lcn/config_flow.py
+++ b/homeassistant/components/lcn/config_flow.py
@@ -110,8 +110,8 @@ async def validate_connection(data: ConfigType) -> str | None:
 class LcnFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a LCN config flow."""
 
-    VERSION = 1
-    MINOR_VERSION = 2
+    VERSION = 2
+    MINOR_VERSION = 0
 
     _context_entry: ConfigEntry
 

--- a/homeassistant/components/lcn/light.py
+++ b/homeassistant/components/lcn/light.py
@@ -90,7 +90,7 @@ class LcnOutputLight(LcnEntity, LightEntity):
         self.output = pypck.lcn_defs.OutputPort[config[CONF_DOMAIN_DATA][CONF_OUTPUT]]
 
         self._transition = pypck.lcn_defs.time_to_ramp_value(
-            config[CONF_DOMAIN_DATA][CONF_TRANSITION]
+            config[CONF_DOMAIN_DATA][CONF_TRANSITION] * 1000.0
         )
         self.dimmable = config[CONF_DOMAIN_DATA][CONF_DIMMABLE]
 

--- a/homeassistant/components/lcn/scene.py
+++ b/homeassistant/components/lcn/scene.py
@@ -87,7 +87,7 @@ class LcnScene(LcnEntity, Scene):
             self.transition = None
         else:
             self.transition = pypck.lcn_defs.time_to_ramp_value(
-                config[CONF_DOMAIN_DATA][CONF_TRANSITION]
+                config[CONF_DOMAIN_DATA][CONF_TRANSITION] * 1000.0
             )
 
     async def async_activate(self, **kwargs: Any) -> None:

--- a/homeassistant/components/lcn/schemas.py
+++ b/homeassistant/components/lcn/schemas.py
@@ -95,7 +95,7 @@ DOMAIN_DATA_LIGHT: VolDictType = {
     vol.Required(CONF_OUTPUT): vol.All(vol.Upper, vol.In(OUTPUT_PORTS + RELAY_PORTS)),
     vol.Optional(CONF_DIMMABLE, default=False): vol.Coerce(bool),
     vol.Optional(CONF_TRANSITION, default=0): vol.All(
-        vol.Coerce(float), vol.Range(min=0.0, max=486.0), lambda value: value * 1000
+        vol.Coerce(float), vol.Range(min=0.0, max=486.0)
     ),
 }
 
@@ -107,11 +107,7 @@ DOMAIN_DATA_SCENE: VolDictType = {
         cv.ensure_list, [vol.All(vol.Upper, vol.In(OUTPUT_PORTS + RELAY_PORTS))]
     ),
     vol.Optional(CONF_TRANSITION, default=None): vol.Any(
-        vol.All(
-            vol.Coerce(int),
-            vol.Range(min=0.0, max=486.0),
-            lambda value: value * 1000,
-        ),
+        vol.All(vol.Coerce(int), vol.Range(min=0.0, max=486.0)),
         None,
     ),
 }

--- a/homeassistant/components/lcn/schemas.py
+++ b/homeassistant/components/lcn/schemas.py
@@ -106,9 +106,8 @@ DOMAIN_DATA_SCENE: VolDictType = {
     vol.Optional(CONF_OUTPUTS, default=[]): vol.All(
         cv.ensure_list, [vol.All(vol.Upper, vol.In(OUTPUT_PORTS + RELAY_PORTS))]
     ),
-    vol.Optional(CONF_TRANSITION, default=None): vol.Any(
-        vol.All(vol.Coerce(int), vol.Range(min=0.0, max=486.0)),
-        None,
+    vol.Optional(CONF_TRANSITION, default=0): vol.Any(
+        vol.All(vol.Coerce(int), vol.Range(min=0.0, max=486.0))
     ),
 }
 

--- a/tests/components/lcn/fixtures/config_entry_pchk_v1_1.json
+++ b/tests/components/lcn/fixtures/config_entry_pchk_v1_1.json
@@ -156,7 +156,7 @@
         "register": 0,
         "scene": 1,
         "outputs": ["OUTPUT1", "OUTPUT2", "RELAY1"],
-        "transition": 10
+        "transition": 10000
       }
     },
     {

--- a/tests/components/lcn/fixtures/config_entry_pchk_v1_2.json
+++ b/tests/components/lcn/fixtures/config_entry_pchk_v1_2.json
@@ -32,7 +32,7 @@
       "domain_data": {
         "output": "OUTPUT1",
         "dimmable": true,
-        "transition": 5.0
+        "transition": 5000.0
       }
     },
     {
@@ -43,7 +43,7 @@
       "domain_data": {
         "output": "OUTPUT2",
         "dimmable": false,
-        "transition": 0.0
+        "transition": 0
       }
     },
     {
@@ -145,7 +145,7 @@
         "register": 0,
         "scene": 0,
         "outputs": ["OUTPUT1", "OUTPUT2", "RELAY1"],
-        "transition": 0.0
+        "transition": null
       }
     },
     {
@@ -157,7 +157,7 @@
         "register": 0,
         "scene": 1,
         "outputs": ["OUTPUT1", "OUTPUT2", "RELAY1"],
-        "transition": 10.0
+        "transition": 10000
       }
     },
     {

--- a/tests/components/lcn/test_init.py
+++ b/tests/components/lcn/test_init.py
@@ -140,7 +140,7 @@ async def test_migrate_1_1(hass: HomeAssistant, entry) -> None:
     entry_migrated = hass.config_entries.async_get_entry(entry_v1_1.entry_id)
     assert entry_migrated.state is ConfigEntryState.LOADED
     assert entry_migrated.version == 2
-    assert entry_migrated.minor_version == 0
+    assert entry_migrated.minor_version == 1
     assert entry_migrated.data == entry.data
 
 
@@ -156,5 +156,5 @@ async def test_migrate_1_2(hass: HomeAssistant, entry) -> None:
     entry_migrated = hass.config_entries.async_get_entry(entry_v1_2.entry_id)
     assert entry_migrated.state is ConfigEntryState.LOADED
     assert entry_migrated.version == 2
-    assert entry_migrated.minor_version == 0
+    assert entry_migrated.minor_version == 1
     assert entry_migrated.data == entry.data

--- a/tests/components/lcn/test_init.py
+++ b/tests/components/lcn/test_init.py
@@ -139,6 +139,22 @@ async def test_migrate_1_1(hass: HomeAssistant, entry) -> None:
 
     entry_migrated = hass.config_entries.async_get_entry(entry_v1_1.entry_id)
     assert entry_migrated.state is ConfigEntryState.LOADED
-    assert entry_migrated.version == 1
-    assert entry_migrated.minor_version == 2
+    assert entry_migrated.version == 2
+    assert entry_migrated.minor_version == 0
+    assert entry_migrated.data == entry.data
+
+
+@patch("homeassistant.components.lcn.PchkConnectionManager", MockPchkConnectionManager)
+async def test_migrate_1_2(hass: HomeAssistant, entry) -> None:
+    """Test migration config entry."""
+    entry_v1_2 = create_config_entry("pchk_v1_2", version=(1, 2))
+    entry_v1_2.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(entry_v1_2.entry_id)
+    await hass.async_block_till_done()
+
+    entry_migrated = hass.config_entries.async_get_entry(entry_v1_2.entry_id)
+    assert entry_migrated.state is ConfigEntryState.LOADED
+    assert entry_migrated.version == 2
+    assert entry_migrated.minor_version == 0
     assert entry_migrated.data == entry.data

--- a/tests/components/lcn/test_scene.py
+++ b/tests/components/lcn/test_scene.py
@@ -51,7 +51,7 @@ async def test_scene_activate(
     assert state is not None
 
     activate_scene.assert_awaited_with(
-        0, 0, [OutputPort.OUTPUT1, OutputPort.OUTPUT2], [RelayPort.RELAY1], None
+        0, 0, [OutputPort.OUTPUT1, OutputPort.OUTPUT2], [RelayPort.RELAY1], 0.0
     )
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
Due to historical reasons the light/scene transition duration is stored in the config entry in milliseconds.
With future changes this will lead to unnecessary conversions from milliseconds to seconds back and forth.

To overcome this, it is desirable to store the transition duration in seconds. This PR implements the migration.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
