### PR TITLE
LinkPlay multiroom support

### DIFF
--- a/homeassistant/components/linkplay/__init__.py
+++ b/homeassistant/components/linkplay/__init__.py
@@ -13,7 +13,7 @@ from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 
-from .const import CONTROLLER, DOMAIN, PLATFORMS
+from .const import CONTROLLER, CONTROLLER_KEY, DOMAIN, PLATFORMS
 from .utils import async_get_client_session
 
 
@@ -42,12 +42,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: LinkPlayConfigEntry) -> 
         ) from exception
 
     # setup the controller and discover multirooms
-    controller = None
+    controller: LinkPlayController | None = None
+    hass.data.setdefault(DOMAIN, {})
     if CONTROLLER not in hass.data[DOMAIN]:
         controller = LinkPlayController(session)
-        hass.data[DOMAIN][CONTROLLER] = controller
+        hass.data[DOMAIN][CONTROLLER_KEY] = controller
     else:
-        controller = hass.data[DOMAIN][CONTROLLER]
+        controller = hass.data[DOMAIN][CONTROLLER_KEY]
 
     await controller.add_bridge(bridge)
     await controller.discover_multirooms()

--- a/homeassistant/components/linkplay/__init__.py
+++ b/homeassistant/components/linkplay/__init__.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 
 from aiohttp import ClientSession
 from linkplay.bridge import LinkPlayBridge
+from linkplay.controller import LinkPlayController
 from linkplay.discovery import linkplay_factory_httpapi_bridge
 from linkplay.exceptions import LinkPlayRequestException
 
@@ -12,7 +13,7 @@ from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 
-from .const import PLATFORMS
+from .const import CONTROLLER, DOMAIN, PLATFORMS
 from .utils import async_get_client_session
 
 
@@ -32,6 +33,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: LinkPlayConfigEntry) -> 
     session: ClientSession = await async_get_client_session(hass)
     bridge: LinkPlayBridge | None = None
 
+    # try create a bridge
     try:
         bridge = await linkplay_factory_httpapi_bridge(entry.data[CONF_HOST], session)
     except LinkPlayRequestException as exception:
@@ -39,6 +41,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: LinkPlayConfigEntry) -> 
             f"Failed to connect to LinkPlay device at {entry.data[CONF_HOST]}"
         ) from exception
 
+    # setup the controller and discover multirooms
+    controller = None
+    if CONTROLLER not in hass.data[DOMAIN]:
+        controller = LinkPlayController(session)
+        hass.data[DOMAIN][CONTROLLER] = controller
+    else:
+        controller = hass.data[DOMAIN][CONTROLLER]
+
+    await controller.add_bridge(bridge)
+    await controller.discover_multirooms()
+
+    # forward to platforms
     entry.runtime_data = LinkPlayData(bridge=bridge)
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True

--- a/homeassistant/components/linkplay/const.py
+++ b/homeassistant/components/linkplay/const.py
@@ -1,8 +1,12 @@
 """LinkPlay constants."""
 
+from linkplay.controller import LinkPlayController
+
 from homeassistant.const import Platform
+from homeassistant.util.hass_dict import HassKey
 
 DOMAIN = "linkplay"
 CONTROLLER = "controller"
+CONTROLLER_KEY: HassKey[LinkPlayController] = HassKey(CONTROLLER)
 PLATFORMS = [Platform.MEDIA_PLAYER]
 DATA_SESSION = "session"

--- a/homeassistant/components/linkplay/const.py
+++ b/homeassistant/components/linkplay/const.py
@@ -3,5 +3,6 @@
 from homeassistant.const import Platform
 
 DOMAIN = "linkplay"
+CONTROLLER = "controller"
 PLATFORMS = [Platform.MEDIA_PLAYER]
 DATA_SESSION = "session"

--- a/homeassistant/components/linkplay/media_player.py
+++ b/homeassistant/components/linkplay/media_player.py
@@ -36,7 +36,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util.dt import utcnow
 
 from . import LinkPlayConfigEntry, LinkPlayData
-from .const import CONTROLLER, DOMAIN
+from .const import CONTROLLER_KEY, DOMAIN
 from .utils import MANUFACTURER_GENERIC, get_info_from_project
 
 _LOGGER = logging.getLogger(__name__)
@@ -297,7 +297,7 @@ class LinkPlayMediaPlayerEntity(MediaPlayerEntity):
     async def async_join_players(self, group_members: list[str]) -> None:
         """Join `group_members` as a player group with the current player."""
 
-        controller: LinkPlayController = self.hass.data[DOMAIN][CONTROLLER]
+        controller: LinkPlayController = self.hass.data[DOMAIN][CONTROLLER_KEY]
         multiroom = self._bridge.multiroom
         if multiroom is None:
             multiroom = LinkPlayMultiroom(self._bridge)
@@ -352,7 +352,7 @@ class LinkPlayMediaPlayerEntity(MediaPlayerEntity):
     @exception_wrap
     async def async_unjoin_player(self) -> None:
         """Remove this player from any group."""
-        controller: LinkPlayController = self.hass.data[DOMAIN][CONTROLLER]
+        controller: LinkPlayController = self.hass.data[DOMAIN][CONTROLLER_KEY]
 
         multiroom = self._bridge.multiroom
         if multiroom is not None:

--- a/homeassistant/components/linkplay/media_player.py
+++ b/homeassistant/components/linkplay/media_player.py
@@ -8,6 +8,7 @@ from typing import Any, Concatenate
 
 from linkplay.bridge import LinkPlayBridge
 from linkplay.consts import EqualizerMode, LoopMode, PlayingMode, PlayingStatus
+from linkplay.controller import LinkPlayController, LinkPlayMultiroom
 from linkplay.exceptions import LinkPlayException, LinkPlayRequestException
 import voluptuous as vol
 
@@ -22,18 +23,20 @@ from homeassistant.components.media_player import (
     RepeatMode,
     async_process_play_media_url,
 )
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import (
     config_validation as cv,
     device_registry as dr,
     entity_platform,
+    entity_registry as er,
 )
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util.dt import utcnow
 
-from . import LinkPlayConfigEntry
-from .const import DOMAIN
+from . import LinkPlayConfigEntry, LinkPlayData
+from .const import CONTROLLER, DOMAIN
 from .utils import MANUFACTURER_GENERIC, get_info_from_project
 
 _LOGGER = logging.getLogger(__name__)
@@ -289,6 +292,73 @@ class LinkPlayMediaPlayerEntity(MediaPlayerEntity):
     async def async_play_preset(self, preset_number: int) -> None:
         """Play preset number."""
         await self._bridge.player.play_preset(preset_number)
+
+    @exception_wrap
+    async def async_join_players(self, group_members: list[str]) -> None:
+        """Join `group_members` as a player group with the current player."""
+
+        controller: LinkPlayController = self.hass.data[DOMAIN][CONTROLLER]
+        multiroom = self._bridge.multiroom
+        if multiroom is None:
+            multiroom = LinkPlayMultiroom(self._bridge)
+
+        for group_member in group_members:
+            bridge = self._get_linkplay_bridge(group_member)
+            if bridge:
+                await multiroom.add_follower(bridge)
+
+        await controller.discover_multirooms()
+
+    def _get_linkplay_bridge(self, entity_id: str) -> LinkPlayBridge:
+        """Get linkplay bridge from entity_id."""
+
+        entity_registry = er.async_get(self.hass)
+
+        # Check for valid linkplay media_player entity
+        entity_entry = entity_registry.async_get(entity_id)
+
+        if (
+            entity_entry is None
+            or entity_entry.domain != Platform.MEDIA_PLAYER
+            or entity_entry.platform != DOMAIN
+            or entity_entry.config_entry_id is None
+        ):
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="invalid_grouping_entity",
+                translation_placeholders={"entity_id": entity_id},
+            )
+
+        config_entry = self.hass.config_entries.async_get_entry(
+            entity_entry.config_entry_id
+        )
+        assert config_entry
+
+        # Return bridge
+        data: LinkPlayData = config_entry.runtime_data
+        return data.bridge
+
+    @property
+    def group_members(self) -> list[str]:
+        """List of players which are grouped together."""
+        multiroom = self._bridge.multiroom
+        if multiroom is not None:
+            return [multiroom.leader.device.uuid] + [
+                follower.device.uuid for follower in multiroom.followers
+            ]
+
+        return []
+
+    @exception_wrap
+    async def async_unjoin_player(self) -> None:
+        """Remove this player from any group."""
+        controller: LinkPlayController = self.hass.data[DOMAIN][CONTROLLER]
+
+        multiroom = self._bridge.multiroom
+        if multiroom is not None:
+            await multiroom.remove_follower(self._bridge)
+
+        await controller.discover_multirooms()
 
     def _update_properties(self) -> None:
         """Update the properties of the media player."""

--- a/homeassistant/components/linkplay/strings.json
+++ b/homeassistant/components/linkplay/strings.json
@@ -37,7 +37,7 @@
   },
   "exceptions": {
     "invalid_grouping_entity": {
-      "message": "Entity with id {entity_id} can't be added to the LinkPlay group. Is the entity a LinkPlay media_player?"
+      "message": "Entity with id {entity_id} can't be added to the LinkPlay multiroom. Is the entity a LinkPlay mediaplayer?"
     }
   }
 }

--- a/homeassistant/components/linkplay/strings.json
+++ b/homeassistant/components/linkplay/strings.json
@@ -34,5 +34,10 @@
         }
       }
     }
+  },
+  "exceptions": {
+    "invalid_grouping_entity": {
+      "message": "Entity with id {entity_id} can't be added to the LinkPlay group. Is the entity a LinkPlay media_player?"
+    }
   }
 }


### PR DESCRIPTION
## Proposed change
Mulitroom grouping/ungrouping support for LinkPlay. 


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #123553 fixes #125082 fixes #125770 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
