### PR TITLE
Add device_class for LCN sensors

### DIFF
--- a/homeassistant/components/lcn/sensor.py
+++ b/homeassistant/components/lcn/sensor.py
@@ -36,7 +36,7 @@ from .const import (
 from .entity import LcnEntity
 from .helpers import InputType
 
-SENSOR_DEVICE_CLASS = {
+DEVICE_CLASS_MAPPING = {
     pypck.lcn_defs.VarUnit.CELSIUS: SensorDeviceClass.TEMPERATURE,
     pypck.lcn_defs.VarUnit.KELVIN: SensorDeviceClass.TEMPERATURE,
     pypck.lcn_defs.VarUnit.FAHRENHEIT: SensorDeviceClass.TEMPERATURE,
@@ -104,7 +104,7 @@ class LcnVariableSensor(LcnEntity, SensorEntity):
         )
 
         self._attr_native_unit_of_measurement = cast(str, self.unit.value)
-        self._attr_device_class = SENSOR_DEVICE_CLASS.get(self.unit, None)
+        self._attr_device_class = DEVICE_CLASS_MAPPING.get(self.unit, None)
 
     async def async_added_to_hass(self) -> None:
         """Run when entity about to be added to hass."""

--- a/homeassistant/components/lcn/sensor.py
+++ b/homeassistant/components/lcn/sensor.py
@@ -7,7 +7,11 @@ from typing import cast
 
 import pypck
 
-from homeassistant.components.sensor import DOMAIN as DOMAIN_SENSOR, SensorEntity
+from homeassistant.components.sensor import (
+    DOMAIN as DOMAIN_SENSOR,
+    SensorDeviceClass,
+    SensorEntity,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_DOMAIN,
@@ -31,6 +35,17 @@ from .const import (
 )
 from .entity import LcnEntity
 from .helpers import InputType
+
+SENSOR_DEVICE_CLASS = {
+    pypck.lcn_defs.VarUnit.CELSIUS: SensorDeviceClass.TEMPERATURE,
+    pypck.lcn_defs.VarUnit.KELVIN: SensorDeviceClass.TEMPERATURE,
+    pypck.lcn_defs.VarUnit.FAHRENHEIT: SensorDeviceClass.TEMPERATURE,
+    pypck.lcn_defs.VarUnit.LUX_T: SensorDeviceClass.ILLUMINANCE,
+    pypck.lcn_defs.VarUnit.LUX_I: SensorDeviceClass.ILLUMINANCE,
+    pypck.lcn_defs.VarUnit.METERPERSECOND: SensorDeviceClass.SPEED,
+    pypck.lcn_defs.VarUnit.VOLT: SensorDeviceClass.VOLTAGE,
+    pypck.lcn_defs.VarUnit.AMPERE: SensorDeviceClass.CURRENT,
+}
 
 
 def add_lcn_entities(
@@ -87,7 +102,9 @@ class LcnVariableSensor(LcnEntity, SensorEntity):
         self.unit = pypck.lcn_defs.VarUnit.parse(
             config[CONF_DOMAIN_DATA][CONF_UNIT_OF_MEASUREMENT]
         )
+
         self._attr_native_unit_of_measurement = cast(str, self.unit.value)
+        self._attr_device_class = SENSOR_DEVICE_CLASS.get(self.unit, None)
 
     async def async_added_to_hass(self) -> None:
         """Run when entity about to be added to hass."""

--- a/tests/components/lcn/snapshots/test_sensor.ambr
+++ b/tests/components/lcn/snapshots/test_sensor.ambr
@@ -113,7 +113,7 @@
     'name': None,
     'options': dict({
     }),
-    'original_device_class': None,
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
     'original_icon': None,
     'original_name': 'Sensor_Setpoint1',
     'platform': 'lcn',
@@ -121,14 +121,15 @@
     'supported_features': 0,
     'translation_key': None,
     'unique_id': 'lcn/config_entry_pchk.json-m000007-r1varsetpoint',
-    'unit_of_measurement': '°C',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })
 # ---
 # name: test_setup_lcn_sensor[sensor.sensor_setpoint1-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
       'friendly_name': 'Sensor_Setpoint1',
-      'unit_of_measurement': '°C',
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
     }),
     'context': <ANY>,
     'entity_id': 'sensor.sensor_setpoint1',
@@ -160,7 +161,7 @@
     'name': None,
     'options': dict({
     }),
-    'original_device_class': None,
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
     'original_icon': None,
     'original_name': 'Sensor_Var1',
     'platform': 'lcn',
@@ -168,14 +169,15 @@
     'supported_features': 0,
     'translation_key': None,
     'unique_id': 'lcn/config_entry_pchk.json-m000007-var1',
-    'unit_of_measurement': '°C',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })
 # ---
 # name: test_setup_lcn_sensor[sensor.sensor_var1-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
       'friendly_name': 'Sensor_Var1',
-      'unit_of_measurement': '°C',
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
     }),
     'context': <ANY>,
     'entity_id': 'sensor.sensor_var1',


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

Add `device_class` attribute based on configured `unit_of_measurement` for LCN sensors.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
