### PR TITLE
Add reboot button for tplink

### DIFF
--- a/homeassistant/components/tplink/button.py
+++ b/homeassistant/components/tplink/button.py
@@ -9,6 +9,7 @@ from kasa import Feature
 
 from homeassistant.components.button import (
     DOMAIN as BUTTON_DOMAIN,
+    ButtonDeviceClass,
     ButtonEntity,
     ButtonEntityDescription,
 )
@@ -47,6 +48,7 @@ BUTTON_DESCRIPTIONS: Final = [
     ),
     TPLinkButtonEntityDescription(
         key="reboot",
+        device_class=ButtonDeviceClass.RESTART,
     ),
 ]
 

--- a/homeassistant/components/tplink/button.py
+++ b/homeassistant/components/tplink/button.py
@@ -45,6 +45,9 @@ BUTTON_DESCRIPTIONS: Final = [
             breaks_in_ha_version="2025.4.0",
         ),
     ),
+    TPLinkButtonEntityDescription(
+        key="reboot",
+    ),
 ]
 
 BUTTON_DESCRIPTIONS_MAP = {desc.key: desc for desc in BUTTON_DESCRIPTIONS}

--- a/homeassistant/components/tplink/strings.json
+++ b/homeassistant/components/tplink/strings.json
@@ -98,9 +98,6 @@
       }
     },
     "button": {
-      "reboot": {
-        "name": "Reboot"
-      },
       "test_alarm": {
         "name": "Test alarm"
       },

--- a/homeassistant/components/tplink/strings.json
+++ b/homeassistant/components/tplink/strings.json
@@ -98,6 +98,9 @@
       }
     },
     "button": {
+      "reboot": {
+        "name": "Reboot"
+      },
       "test_alarm": {
         "name": "Test alarm"
       },

--- a/tests/components/tplink/fixtures/features.json
+++ b/tests/components/tplink/fixtures/features.json
@@ -205,6 +205,11 @@
     "type": "BinarySensor",
     "category": "Info"
   },
+  "reboot": {
+    "value": "<Action>",
+    "type": "Action",
+    "category": "Debug"
+  },
   "test_alarm": {
     "value": "<Action>",
     "type": "Action",

--- a/tests/components/tplink/snapshots/test_button.ambr
+++ b/tests/components/tplink/snapshots/test_button.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_states[button.my_device_reboot-entry]
+# name: test_states[button.my_device_restart-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -11,7 +11,7 @@
     'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
     'domain': 'button',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'button.my_device_reboot',
+    'entity_id': 'button.my_device_restart',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -23,7 +23,7 @@
     }),
     'original_device_class': <ButtonDeviceClass.RESTART: 'restart'>,
     'original_icon': None,
-    'original_name': 'Reboot',
+    'original_name': 'Restart',
     'platform': 'tplink',
     'previous_unique_id': None,
     'supported_features': 0,

--- a/tests/components/tplink/snapshots/test_button.ambr
+++ b/tests/components/tplink/snapshots/test_button.ambr
@@ -1,4 +1,37 @@
 # serializer version: 1
+# name: test_states[button.my_device_reboot-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
+    'domain': 'button',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'button.my_device_reboot',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <ButtonDeviceClass.RESTART: 'restart'>,
+    'original_icon': None,
+    'original_name': 'Reboot',
+    'platform': 'tplink',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'reboot',
+    'unique_id': '123456789ABCDEFGH_reboot',
+    'unit_of_measurement': None,
+  })
+# ---
 # name: test_states[button.my_device_stop_alarm-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add reboot button for tplink devices, allowing one to restart the devices.
This can be found in diagnostics section and is disabled per default.

![image](https://github.com/user-attachments/assets/2ee352f3-48c9-44ed-b381-021f162b8ddd)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
