### PR TITLE
Refresh Tibber get price service price info

### DIFF
--- a/homeassistant/components/tibber/services.py
+++ b/homeassistant/components/tibber/services.py
@@ -47,6 +47,9 @@ async def __get_prices(call: ServiceCall, *, hass: HomeAssistant) -> ServiceResp
     for tibber_home in tibber_connection.get_homes(only_active=True):
         home_nickname = tibber_home.name
 
+        # sometimes there are no priceInfo, get fresh data with priceInfo
+        await tibber_home.update_info_and_price_info()
+
         price_info = tibber_home.info["viewer"]["home"]["currentSubscription"][
             "priceInfo"
         ]

--- a/tests/components/tibber/test_services.py
+++ b/tests/components/tibber/test_services.py
@@ -1,7 +1,7 @@
 """Test service for Tibber integration."""
 
 import datetime as dt
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, AsyncMock
 
 from freezegun.api import FrozenDateTimeFactory
 import pytest
@@ -20,6 +20,7 @@ def generate_mock_home_data():
     mock_homes = [
         MagicMock(
             name="first_home",
+            update_info_and_price_info=AsyncMock(),
             info={
                 "viewer": {
                     "home": {
@@ -61,6 +62,7 @@ def generate_mock_home_data():
         ),
         MagicMock(
             name="second_home",
+            update_info_and_price_info=AsyncMock(),
             info={
                 "viewer": {
                     "home": {
@@ -128,6 +130,7 @@ async def test_get_prices(
     """Test get_prices with mock data."""
     freezer.move_to(START_TIME)
     mock_tibber_setup.get_homes.return_value = generate_mock_home_data()
+    mock_tibber_setup.update_info_and_price_info.return_value = data
 
     result = await hass.services.async_call(
         DOMAIN, PRICE_SERVICE_NAME, data, blocking=True, return_response=True


### PR DESCRIPTION
some refreshing of the tibber module only get the actual price and not the price info for today and tomorrow solves issue https://github.com/home-assistant/core/issues/125674

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
there is an error in the tibber component, so the service call not always works.
it is now fixed by getting new data on each service call
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: https://github.com/home-assistant/core/issues/125674
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
