### PR TITLE
Fix zwave_js config validation for values

### DIFF
--- a/homeassistant/components/zwave_js/config_validation.py
+++ b/homeassistant/components/zwave_js/config_validation.py
@@ -34,6 +34,8 @@ def boolean(value: Any) -> bool:
 
 VALUE_SCHEMA = vol.Any(
     boolean,
+    float,
+    int,
     vol.Coerce(int),
     vol.Coerce(float),
     BITMASK_SCHEMA,

--- a/tests/components/zwave_js/test_config_validation.py
+++ b/tests/components/zwave_js/test_config_validation.py
@@ -1,27 +1,31 @@
 """Test the Z-Wave JS config validation helpers."""
 
+from typing import Any
+
 import pytest
 import voluptuous as vol
 
-from homeassistant.components.zwave_js.config_validation import boolean
+from homeassistant.components.zwave_js.config_validation import VALUE_SCHEMA, boolean
 
 
-def test_boolean_validation() -> None:
-    """Test boolean config validator."""
-    # test bool
-    assert boolean(True)
-    assert not boolean(False)
-    # test strings
-    assert boolean("TRUE")
-    assert not boolean("FALSE")
-    assert boolean("ON")
-    assert not boolean("NO")
-    # ensure 1's and 0's don't get converted to bool
+@pytest.mark.parametrize(
+    ("test_cases", "expected_value"),
+    [
+        ([True, "true", "yes", "on", "ON", "enable"], True),
+        ([False, "false", "no", "off", "NO", "disable"], False),
+        ([1.1, "1.1"], 1.1),
+        ([1.0, "1.0"], 1.0),
+        ([1, "1"], 1),
+    ],
+)
+def test_validation(test_cases: list[Any], expected_value: Any) -> None:
+    """Test config validation."""
+    for case in test_cases:
+        assert VALUE_SCHEMA(case) == expected_value
+
+
+@pytest.mark.parametrize("value", ["invalid", "1", "0", 1, 0])
+def test_invalid_boolean_validation(value: str | int) -> None:
+    """Test invalid cases for boolean config validator."""
     with pytest.raises(vol.Invalid):
-        boolean("1")
-    with pytest.raises(vol.Invalid):
-        boolean("0")
-    with pytest.raises(vol.Invalid):
-        boolean(1)
-    with pytest.raises(vol.Invalid):
-        boolean(0)
+        boolean(value)


### PR DESCRIPTION
## Proposed change
Our validation logic is not handling native types, specifically `float` properly. This fixes it and also adds a more comprehensive test case so we can be more prepared for these types of scenarios.

Thanks to @kpine for finding the issue


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/127400

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
