### PR TITLE
Add ability to pass the config entry explicitly in data update coordinators

### DIFF
--- a/homeassistant/components/accuweather/__init__.py
+++ b/homeassistant/components/accuweather/__init__.py
@@ -2,13 +2,11 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 import logging
 
 from accuweather import AccuWeather
 
 from homeassistant.components.sensor import DOMAIN as SENSOR_PLATFORM
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_API_KEY, CONF_NAME, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -16,24 +14,15 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import DOMAIN, UPDATE_INTERVAL_DAILY_FORECAST, UPDATE_INTERVAL_OBSERVATION
 from .coordinator import (
+    AccuWeatherConfigEntry,
     AccuWeatherDailyForecastDataUpdateCoordinator,
+    AccuWeatherData,
     AccuWeatherObservationDataUpdateCoordinator,
 )
 
 _LOGGER = logging.getLogger(__name__)
 
 PLATFORMS = [Platform.SENSOR, Platform.WEATHER]
-
-
-@dataclass
-class AccuWeatherData:
-    """Data for AccuWeather integration."""
-
-    coordinator_observation: AccuWeatherObservationDataUpdateCoordinator
-    coordinator_daily_forecast: AccuWeatherDailyForecastDataUpdateCoordinator
-
-
-type AccuWeatherConfigEntry = ConfigEntry[AccuWeatherData]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: AccuWeatherConfigEntry) -> bool:

--- a/homeassistant/components/accuweather/__init__.py
+++ b/homeassistant/components/accuweather/__init__.py
@@ -50,6 +50,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: AccuWeatherConfigEntry) 
 
     coordinator_observation = AccuWeatherObservationDataUpdateCoordinator(
         hass,
+        entry,
         accuweather,
         name,
         "observation",
@@ -58,6 +59,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: AccuWeatherConfigEntry) 
 
     coordinator_daily_forecast = AccuWeatherDailyForecastDataUpdateCoordinator(
         hass,
+        entry,
         accuweather,
         name,
         "daily forecast",

--- a/homeassistant/components/accuweather/coordinator.py
+++ b/homeassistant/components/accuweather/coordinator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from asyncio import timeout
+from dataclasses import dataclass
 from datetime import timedelta
 import logging
 from typing import TYPE_CHECKING, Any
@@ -10,6 +11,7 @@ from typing import TYPE_CHECKING, Any
 from accuweather import AccuWeather, ApiError, InvalidApiKeyError, RequestsExceededError
 from aiohttp.client_exceptions import ClientConnectorError
 
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.update_coordinator import (
@@ -20,12 +22,20 @@ from homeassistant.helpers.update_coordinator import (
 
 from .const import DOMAIN, MANUFACTURER
 
-if TYPE_CHECKING:
-    from . import AccuWeatherConfigEntry
-
 EXCEPTIONS = (ApiError, ClientConnectorError, InvalidApiKeyError, RequestsExceededError)
 
 _LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class AccuWeatherData:
+    """Data for AccuWeather integration."""
+
+    coordinator_observation: AccuWeatherObservationDataUpdateCoordinator
+    coordinator_daily_forecast: AccuWeatherDailyForecastDataUpdateCoordinator
+
+
+type AccuWeatherConfigEntry = ConfigEntry[AccuWeatherData]
 
 
 class AccuWeatherObservationDataUpdateCoordinator(

--- a/homeassistant/components/accuweather/coordinator.py
+++ b/homeassistant/components/accuweather/coordinator.py
@@ -1,5 +1,7 @@
 """The AccuWeather coordinator."""
 
+from __future__ import annotations
+
 from asyncio import timeout
 from datetime import timedelta
 import logging
@@ -18,6 +20,9 @@ from homeassistant.helpers.update_coordinator import (
 
 from .const import DOMAIN, MANUFACTURER
 
+if TYPE_CHECKING:
+    from . import AccuWeatherConfigEntry
+
 EXCEPTIONS = (ApiError, ClientConnectorError, InvalidApiKeyError, RequestsExceededError)
 
 _LOGGER = logging.getLogger(__name__)
@@ -31,6 +36,7 @@ class AccuWeatherObservationDataUpdateCoordinator(
     def __init__(
         self,
         hass: HomeAssistant,
+        config_entry: AccuWeatherConfigEntry,
         accuweather: AccuWeather,
         name: str,
         coordinator_type: str,
@@ -48,6 +54,7 @@ class AccuWeatherObservationDataUpdateCoordinator(
         super().__init__(
             hass,
             _LOGGER,
+            config_entry=config_entry,
             name=f"{name} ({coordinator_type})",
             update_interval=update_interval,
         )
@@ -73,6 +80,7 @@ class AccuWeatherDailyForecastDataUpdateCoordinator(
     def __init__(
         self,
         hass: HomeAssistant,
+        config_entry: AccuWeatherConfigEntry,
         accuweather: AccuWeather,
         name: str,
         coordinator_type: str,
@@ -90,6 +98,7 @@ class AccuWeatherDailyForecastDataUpdateCoordinator(
         super().__init__(
             hass,
             _LOGGER,
+            config_entry=config_entry,
             name=f"{name} ({coordinator_type})",
             update_interval=update_interval,
         )

--- a/homeassistant/components/accuweather/diagnostics.py
+++ b/homeassistant/components/accuweather/diagnostics.py
@@ -8,7 +8,7 @@ from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.const import CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE
 from homeassistant.core import HomeAssistant
 
-from . import AccuWeatherConfigEntry, AccuWeatherData
+from .coordinator import AccuWeatherConfigEntry, AccuWeatherData
 
 TO_REDACT = {CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE}
 

--- a/homeassistant/components/accuweather/sensor.py
+++ b/homeassistant/components/accuweather/sensor.py
@@ -28,7 +28,6 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from . import AccuWeatherConfigEntry
 from .const import (
     API_METRIC,
     ATTR_CATEGORY,
@@ -41,6 +40,7 @@ from .const import (
     MAX_FORECAST_DAYS,
 )
 from .coordinator import (
+    AccuWeatherConfigEntry,
     AccuWeatherDailyForecastDataUpdateCoordinator,
     AccuWeatherObservationDataUpdateCoordinator,
 )

--- a/homeassistant/components/accuweather/system_health.py
+++ b/homeassistant/components/accuweather/system_health.py
@@ -9,8 +9,8 @@ from accuweather.const import ENDPOINT
 from homeassistant.components import system_health
 from homeassistant.core import HomeAssistant, callback
 
-from . import AccuWeatherConfigEntry
 from .const import DOMAIN
+from .coordinator import AccuWeatherConfigEntry
 
 
 @callback

--- a/homeassistant/components/accuweather/weather.py
+++ b/homeassistant/components/accuweather/weather.py
@@ -33,7 +33,6 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util.dt import utc_from_timestamp
 
-from . import AccuWeatherConfigEntry, AccuWeatherData
 from .const import (
     API_METRIC,
     ATTR_DIRECTION,
@@ -43,7 +42,9 @@ from .const import (
     CONDITION_MAP,
 )
 from .coordinator import (
+    AccuWeatherConfigEntry,
     AccuWeatherDailyForecastDataUpdateCoordinator,
+    AccuWeatherData,
     AccuWeatherObservationDataUpdateCoordinator,
 )
 

--- a/homeassistant/components/rainforest_raven/coordinator.py
+++ b/homeassistant/components/rainforest_raven/coordinator.py
@@ -75,6 +75,7 @@ class RAVEnDataCoordinator(DataUpdateCoordinator):
         super().__init__(
             hass,
             _LOGGER,
+            config_entry=entry,
             name=DOMAIN,
             update_interval=timedelta(seconds=30),
         )

--- a/homeassistant/helpers/update_coordinator.py
+++ b/homeassistant/helpers/update_coordinator.py
@@ -284,6 +284,10 @@ class DataUpdateCoordinator(BaseDataUpdateCoordinatorProtocol, Generic[_DataT]):
         fails. Additionally logging is handled by config entry setup
         to ensure that multiple retries do not cause log spam.
         """
+        if self.config_entry is None:
+            raise ValueError(
+                "This method is only supported for coordinators with a config entry"
+            )
         if await self.__wrap_async_setup():
             await self._async_refresh(
                 log_failures=False, raise_on_auth_failed=True, raise_on_entry_error=True

--- a/homeassistant/helpers/update_coordinator.py
+++ b/homeassistant/helpers/update_coordinator.py
@@ -29,6 +29,7 @@ from homeassistant.util.dt import utcnow
 
 from . import entity, event
 from .debounce import Debouncer
+from .typing import UNDEFINED, UndefinedType
 
 REQUEST_REFRESH_DEFAULT_COOLDOWN = 10
 REQUEST_REFRESH_DEFAULT_IMMEDIATE = True
@@ -68,6 +69,7 @@ class DataUpdateCoordinator(BaseDataUpdateCoordinatorProtocol, Generic[_DataT]):
         hass: HomeAssistant,
         logger: logging.Logger,
         *,
+        config_entry: config_entries.ConfigEntry | None | UndefinedType = UNDEFINED,
         name: str,
         update_interval: timedelta | None = None,
         update_method: Callable[[], Awaitable[_DataT]] | None = None,
@@ -84,7 +86,12 @@ class DataUpdateCoordinator(BaseDataUpdateCoordinatorProtocol, Generic[_DataT]):
         self._update_interval_seconds: float | None = None
         self.update_interval = update_interval
         self._shutdown_requested = False
-        self.config_entry = config_entries.current_entry.get()
+        if config_entry is UNDEFINED:
+            self.config_entry = config_entries.current_entry.get()
+            # This should be deprecated once all core integrations are updated
+            # to pass in the config entry explicitly.
+        else:
+            self.config_entry = config_entry
         self.always_update = always_update
 
         # It's None before the first successful update.

--- a/tests/components/gogogate2/test_init.py
+++ b/tests/components/gogogate2/test_init.py
@@ -3,11 +3,10 @@
 from unittest.mock import MagicMock, patch
 
 from ismartgate import GogoGate2Api
-import pytest
 
-from homeassistant.components.gogogate2 import DEVICE_TYPE_GOGOGATE2, async_setup_entry
+from homeassistant.components.gogogate2 import DEVICE_TYPE_GOGOGATE2
 from homeassistant.components.gogogate2.const import DEVICE_TYPE_ISMARTGATE, DOMAIN
-from homeassistant.config_entries import SOURCE_USER
+from homeassistant.config_entries import SOURCE_USER, ConfigEntryState
 from homeassistant.const import (
     CONF_DEVICE,
     CONF_IP_ADDRESS,
@@ -15,7 +14,6 @@ from homeassistant.const import (
     CONF_USERNAME,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady
 
 from tests.common import MockConfigEntry
 
@@ -97,6 +95,8 @@ async def test_api_failure_on_startup(hass: HomeAssistant) -> None:
             "homeassistant.components.gogogate2.common.ISmartGateApi.async_info",
             side_effect=TimeoutError,
         ),
-        pytest.raises(ConfigEntryNotReady),
     ):
-        await async_setup_entry(hass, config_entry)
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY

--- a/tests/helpers/test_update_coordinator.py
+++ b/tests/helpers/test_update_coordinator.py
@@ -57,7 +57,9 @@ KNOWN_ERRORS: list[tuple[Exception, type[Exception], str]] = [
 
 
 def get_crd(
-    hass: HomeAssistant, update_interval: timedelta | None
+    hass: HomeAssistant,
+    update_interval: timedelta | None,
+    config_entry: config_entries.ConfigEntry | None = None,
 ) -> update_coordinator.DataUpdateCoordinator[int]:
     """Make coordinator mocks."""
     calls = 0
@@ -70,6 +72,7 @@ def get_crd(
     return update_coordinator.DataUpdateCoordinator[int](
         hass,
         _LOGGER,
+        config_entry=config_entry,
         name="test",
         update_method=refresh,
         update_interval=update_interval,
@@ -121,8 +124,7 @@ async def test_async_refresh(
 
 
 async def test_shutdown(
-    hass: HomeAssistant,
-    crd: update_coordinator.DataUpdateCoordinator[int],
+    hass: HomeAssistant, crd: update_coordinator.DataUpdateCoordinator[int]
 ) -> None:
     """Test async_shutdown for update coordinator."""
     assert crd.data is None
@@ -158,8 +160,7 @@ async def test_shutdown(
 
 
 async def test_shutdown_on_entry_unload(
-    hass: HomeAssistant,
-    crd: update_coordinator.DataUpdateCoordinator[int],
+    hass: HomeAssistant, crd: update_coordinator.DataUpdateCoordinator[int]
 ) -> None:
     """Test shutdown is requested on entry unload."""
     entry = MockConfigEntry()
@@ -191,8 +192,7 @@ async def test_shutdown_on_entry_unload(
 
 
 async def test_shutdown_on_hass_stop(
-    hass: HomeAssistant,
-    crd: update_coordinator.DataUpdateCoordinator[int],
+    hass: HomeAssistant, crd: update_coordinator.DataUpdateCoordinator[int]
 ) -> None:
     """Test shutdown can be shutdown on STOP event."""
     calls = 0
@@ -539,8 +539,8 @@ async def test_stop_refresh_on_ha_stop(
     ["update_method", "setup_method"],
 )
 async def test_async_config_entry_first_refresh_failure(
+    hass: HomeAssistant,
     err_msg: tuple[Exception, type[Exception], str],
-    crd: update_coordinator.DataUpdateCoordinator[int],
     method: str,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -550,6 +550,8 @@ async def test_async_config_entry_first_refresh_failure(
     will be caught by config_entries.async_setup which will log it with
     a decreasing level of logging once the first message is logged.
     """
+    entry = MockConfigEntry()
+    crd = get_crd(hass, DEFAULT_UPDATE_INTERVAL, entry)
     setattr(crd, method, AsyncMock(side_effect=err_msg[0]))
 
     with pytest.raises(ConfigEntryNotReady):
@@ -572,8 +574,8 @@ async def test_async_config_entry_first_refresh_failure(
     ["update_method", "setup_method"],
 )
 async def test_async_config_entry_first_refresh_failure_passed_through(
+    hass: HomeAssistant,
     err_msg: tuple[Exception, type[Exception], str],
-    crd: update_coordinator.DataUpdateCoordinator[int],
     method: str,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -583,6 +585,8 @@ async def test_async_config_entry_first_refresh_failure_passed_through(
     will be caught by config_entries.async_setup which will log it with
     a decreasing level of logging once the first message is logged.
     """
+    entry = MockConfigEntry()
+    crd = get_crd(hass, DEFAULT_UPDATE_INTERVAL, entry)
     setattr(crd, method, AsyncMock(side_effect=err_msg[0]))
 
     with pytest.raises(err_msg[1]):
@@ -593,11 +597,10 @@ async def test_async_config_entry_first_refresh_failure_passed_through(
     assert err_msg[2] not in caplog.text
 
 
-async def test_async_config_entry_first_refresh_success(
-    crd: update_coordinator.DataUpdateCoordinator[int], caplog: pytest.LogCaptureFixture
-) -> None:
+async def test_async_config_entry_first_refresh_success(hass: HomeAssistant) -> None:
     """Test first refresh successfully."""
-
+    entry = MockConfigEntry()
+    crd = get_crd(hass, DEFAULT_UPDATE_INTERVAL, entry)
     crd.setup_method = AsyncMock()
     await crd.async_config_entry_first_refresh()
 
@@ -605,13 +608,26 @@ async def test_async_config_entry_first_refresh_success(
     crd.setup_method.assert_called_once()
 
 
+async def test_async_config_entry_first_refresh_no_entry(hass: HomeAssistant) -> None:
+    """Test first refresh successfully."""
+    crd = get_crd(hass, DEFAULT_UPDATE_INTERVAL, None)
+    crd.setup_method = AsyncMock()
+    with pytest.raises(
+        ValueError,
+        match="This method is only supported for coordinators with a config entry",
+    ):
+        await crd.async_config_entry_first_refresh()
+
+    assert crd.last_update_success is True
+    crd.setup_method.assert_not_called()
+
+
 async def test_not_schedule_refresh_if_system_option_disable_polling(
     hass: HomeAssistant,
 ) -> None:
     """Test we do not schedule a refresh if disable polling in config entry."""
     entry = MockConfigEntry(pref_disable_polling=True)
-    config_entries.current_entry.set(entry)
-    crd = get_crd(hass, DEFAULT_UPDATE_INTERVAL)
+    crd = get_crd(hass, DEFAULT_UPDATE_INTERVAL, entry)
     crd.async_add_listener(lambda: None)
     assert crd._unsub_refresh is None
 
@@ -651,7 +667,7 @@ async def test_async_set_update_error(
 
 
 async def test_only_callback_on_change_when_always_update_is_false(
-    crd: update_coordinator.DataUpdateCoordinator[int], caplog: pytest.LogCaptureFixture
+    crd: update_coordinator.DataUpdateCoordinator[int],
 ) -> None:
     """Test we do not callback listeners unless something has actually changed when always_update is false."""
     update_callback = Mock()
@@ -721,7 +737,7 @@ async def test_only_callback_on_change_when_always_update_is_false(
 
 
 async def test_always_callback_when_always_update_is_true(
-    crd: update_coordinator.DataUpdateCoordinator[int], caplog: pytest.LogCaptureFixture
+    crd: update_coordinator.DataUpdateCoordinator[int],
 ) -> None:
     """Test we callback listeners even though the data is the same when always_update is True."""
     update_callback = Mock()
@@ -801,7 +817,7 @@ async def test_config_entry(hass: HomeAssistant) -> None:
     """Test behavior of coordinator.entry."""
     entry = MockConfigEntry()
 
-    # Default should be None
+    # Default without context should be None
     crd = update_coordinator.DataUpdateCoordinator[int](hass, _LOGGER, name="test")
     assert crd.config_entry is None
 
@@ -820,11 +836,11 @@ async def test_config_entry(hass: HomeAssistant) -> None:
     # set ContextVar
     config_entries.current_entry.set(entry)
 
-    # Default should match the ContextVar
+    # Default with ContextVar should match the ContextVar
     crd = update_coordinator.DataUpdateCoordinator[int](hass, _LOGGER, name="test")
     assert crd.config_entry is entry
 
-    # Explicit entry not recommended, but should work
+    # Explicit entry different from ContextVar not recommended, but should work
     another_entry = MockConfigEntry()
     crd = update_coordinator.DataUpdateCoordinator[int](
         hass, _LOGGER, name="test", config_entry=another_entry

--- a/tests/helpers/test_update_coordinator.py
+++ b/tests/helpers/test_update_coordinator.py
@@ -795,3 +795,38 @@ async def test_timestamp_date_update_coordinator(hass: HomeAssistant) -> None:
     unsub()
     await crd.async_refresh()
     assert len(last_update_success_times) == 1
+
+
+async def test_config_entry(hass: HomeAssistant) -> None:
+    """Test behavior of coordinator.entry."""
+    entry = MockConfigEntry()
+
+    # Default should be None
+    crd = update_coordinator.DataUpdateCoordinator[int](hass, _LOGGER, name="test")
+    assert crd.config_entry is None
+
+    # Explicit None is OK
+    crd = update_coordinator.DataUpdateCoordinator[int](
+        hass, _LOGGER, name="test", config_entry=None
+    )
+    assert crd.config_entry is None
+
+    # Explicit entry is OK
+    crd = update_coordinator.DataUpdateCoordinator[int](
+        hass, _LOGGER, name="test", config_entry=entry
+    )
+    assert crd.config_entry is entry
+
+    # set ContextVar
+    config_entries.current_entry.set(entry)
+
+    # Default should match the ContextVar
+    crd = update_coordinator.DataUpdateCoordinator[int](hass, _LOGGER, name="test")
+    assert crd.config_entry is entry
+
+    # Explicit entry not recommended, but should work
+    another_entry = MockConfigEntry()
+    crd = update_coordinator.DataUpdateCoordinator[int](
+        hass, _LOGGER, name="test", config_entry=another_entry
+    )
+    assert crd.config_entry is another_entry


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
We should avoid relying on ContextVar, and should be passing the entry explicitely

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Base on Discord discussion with @emontnemery

We should avoid relying on ContextVar, and should be passing the entry explicitely.

We need to fix all core integrations before we can enable the deprecation

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
