### PR TITLE
WIP: Deprecate implicit config entry in data update coordinators

### DIFF
--- a/homeassistant/helpers/update_coordinator.py
+++ b/homeassistant/helpers/update_coordinator.py
@@ -97,7 +97,7 @@ class DataUpdateCoordinator(BaseDataUpdateCoordinatorProtocol, Generic[_DataT]):
                     "will stop working in Home Assistant 2025.11, "
                     "pass config entry explicitly instead",
                     error_if_core=True,
-                    error_if_integration=False,
+                    error_if_integration=True,
                 )
         else:
             self.config_entry = config_entry

--- a/homeassistant/helpers/update_coordinator.py
+++ b/homeassistant/helpers/update_coordinator.py
@@ -29,6 +29,7 @@ from homeassistant.util.dt import utcnow
 
 from . import entity, event
 from .debounce import Debouncer
+from .frame import report
 from .typing import UNDEFINED, UndefinedType
 
 REQUEST_REFRESH_DEFAULT_COOLDOWN = 10
@@ -88,8 +89,16 @@ class DataUpdateCoordinator(BaseDataUpdateCoordinatorProtocol, Generic[_DataT]):
         self._shutdown_requested = False
         if config_entry is UNDEFINED:
             self.config_entry = config_entries.current_entry.get()
-            # This should be deprecated once all core integrations are updated
-            # to pass in the config entry explicitly.
+            if self.config_entry:
+                report(
+                    f"initialises coordinator {name} without explicit config entry for "
+                    f"integration, {self.config_entry.domain} with title: {self.config_entry.title} "
+                    f"and entry_id: {self.config_entry.entry_id}, which is deprecated and "
+                    "will stop working in Home Assistant 2025.11, "
+                    "pass config entry explicitly instead",
+                    error_if_core=True,
+                    error_if_integration=False,
+                )
         else:
             self.config_entry = config_entry
         self.always_update = always_update

--- a/homeassistant/helpers/update_coordinator.py
+++ b/homeassistant/helpers/update_coordinator.py
@@ -89,16 +89,13 @@ class DataUpdateCoordinator(BaseDataUpdateCoordinatorProtocol, Generic[_DataT]):
         self._shutdown_requested = False
         if config_entry is UNDEFINED:
             self.config_entry = config_entries.current_entry.get()
-            if self.config_entry:
-                report(
-                    f"initialises coordinator {name} without explicit config entry for "
-                    f"integration, {self.config_entry.domain} with title: {self.config_entry.title} "
-                    f"and entry_id: {self.config_entry.entry_id}, which is deprecated and "
-                    "will stop working in Home Assistant 2025.11, "
-                    "pass config entry explicitly instead",
-                    error_if_core=True,
-                    error_if_integration=True,
-                )
+            report(
+                f"initialises coordinator {name} without explicit config entry, "
+                "which is deprecated and will stop working in "
+                "Home Assistant 2025.11, pass config entry explicitly instead",
+                error_if_core=True,
+                error_if_integration=True,
+            )
         else:
             self.config_entry = config_entry
         self.always_update = always_update

--- a/homeassistant/helpers/update_coordinator.py
+++ b/homeassistant/helpers/update_coordinator.py
@@ -70,7 +70,8 @@ class DataUpdateCoordinator(BaseDataUpdateCoordinatorProtocol, Generic[_DataT]):
         hass: HomeAssistant,
         logger: logging.Logger,
         *,
-        config_entry: config_entries.ConfigEntry | None | UndefinedType = UNDEFINED,
+        # TODO: set default to UNDEFINED once core integrations have been updated
+        config_entry: config_entries.ConfigEntry | None | UndefinedType,
         name: str,
         update_interval: timedelta | None = None,
         update_method: Callable[[], Awaitable[_DataT]] | None = None,

--- a/tests/helpers/test_update_coordinator.py
+++ b/tests/helpers/test_update_coordinator.py
@@ -818,37 +818,41 @@ async def test_config_entry(
 ) -> None:
     """Test behavior of coordinator.entry."""
     entry = MockConfigEntry()
+    caplog.clear()
+
+    deprecated_text = (
+        "Detected code that initialises coordinator test "
+        "without explicit config entry"
+    )
 
     # Default without context should be None
     crd = update_coordinator.DataUpdateCoordinator[int](hass, _LOGGER, name="test")
     assert crd.config_entry is None
+    assert deprecated_text in caplog.text
+    caplog.clear()
 
     # Explicit None is OK
     crd = update_coordinator.DataUpdateCoordinator[int](
         hass, _LOGGER, name="test", config_entry=None
     )
     assert crd.config_entry is None
+    assert deprecated_text not in caplog.text
 
     # Explicit entry is OK
     crd = update_coordinator.DataUpdateCoordinator[int](
         hass, _LOGGER, name="test", config_entry=entry
     )
     assert crd.config_entry is entry
+    assert deprecated_text not in caplog.text
 
     # set ContextVar
-    assert (
-        "Detected code that initialises coordinator test without "
-        "explicit config entry for integration"
-    ) not in caplog.text
     config_entries.current_entry.set(entry)
 
     # Default with ContextVar should match the ContextVar
     crd = update_coordinator.DataUpdateCoordinator[int](hass, _LOGGER, name="test")
     assert crd.config_entry is entry
-    assert (
-        "Detected code that initialises coordinator test without "
-        "explicit config entry for integration"
-    ) in caplog.text
+    assert deprecated_text in caplog.text
+    caplog.clear()
 
     # Explicit entry different from ContextVar not recommended, but should work
     another_entry = MockConfigEntry()
@@ -856,7 +860,4 @@ async def test_config_entry(
         hass, _LOGGER, name="test", config_entry=another_entry
     )
     assert crd.config_entry is another_entry
-    assert (
-        "Detected code that initialises coordinator test without "
-        "explicit config entry for integration"
-    ) not in caplog.text
+    assert deprecated_text not in caplog.text

--- a/tests/helpers/test_update_coordinator.py
+++ b/tests/helpers/test_update_coordinator.py
@@ -813,7 +813,9 @@ async def test_timestamp_date_update_coordinator(hass: HomeAssistant) -> None:
     assert len(last_update_success_times) == 1
 
 
-async def test_config_entry(hass: HomeAssistant) -> None:
+async def test_config_entry(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test behavior of coordinator.entry."""
     entry = MockConfigEntry()
 
@@ -834,11 +836,19 @@ async def test_config_entry(hass: HomeAssistant) -> None:
     assert crd.config_entry is entry
 
     # set ContextVar
+    assert (
+        "Detected code that initialises coordinator test without "
+        "explicit config entry for integration"
+    ) not in caplog.text
     config_entries.current_entry.set(entry)
 
     # Default with ContextVar should match the ContextVar
     crd = update_coordinator.DataUpdateCoordinator[int](hass, _LOGGER, name="test")
     assert crd.config_entry is entry
+    assert (
+        "Detected code that initialises coordinator test without "
+        "explicit config entry for integration"
+    ) in caplog.text
 
     # Explicit entry different from ContextVar not recommended, but should work
     another_entry = MockConfigEntry()
@@ -846,3 +856,7 @@ async def test_config_entry(hass: HomeAssistant) -> None:
         hass, _LOGGER, name="test", config_entry=another_entry
     )
     assert crd.config_entry is another_entry
+    assert (
+        "Detected code that initialises coordinator test without "
+        "explicit config entry for integration"
+    ) not in caplog.text


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Data update coordinators should be initialised with an explicit config_entry argument.
This should be the current entry, or `None` if there is no entry available.

Not passing the argument will stop working in Home Assistant 2025.11

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow-up to #127980

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
