### PR TITLE
Use raw value for remaining time at Home Connect

### DIFF
--- a/homeassistant/components/home_connect/api.py
+++ b/homeassistant/components/home_connect/api.py
@@ -29,7 +29,6 @@ from .const import (
     ATTR_DEVICE,
     ATTR_KEY,
     ATTR_SENSOR_TYPE,
-    ATTR_SIGN,
     ATTR_UNIT,
     ATTR_VALUE,
     BSH_ACTIVE_PROGRAM,
@@ -191,24 +190,21 @@ class DeviceWithPrograms(HomeConnectDevice):
         sensors = {
             BSH_REMAINING_PROGRAM_TIME: (
                 "Remaining Program Time",
+                UnitOfTime.SECONDS,
                 None,
-                None,
-                SensorDeviceClass.TIMESTAMP,
-                1,
+                SensorDeviceClass.DURATION,
             ),
             BSH_COMMON_OPTION_DURATION: (
                 "Duration",
                 UnitOfTime.SECONDS,
                 "mdi:update",
                 None,
-                1,
             ),
             BSH_COMMON_OPTION_PROGRAM_PROGRESS: (
                 "Program Progress",
                 PERCENTAGE,
                 "mdi:progress-clock",
                 None,
-                1,
             ),
         }
         return [
@@ -219,9 +215,8 @@ class DeviceWithPrograms(HomeConnectDevice):
                 ATTR_UNIT: unit,
                 ATTR_ICON: icon,
                 ATTR_DEVICE_CLASS: device_class,
-                ATTR_SIGN: sign,
             }
-            for k, (desc, unit, icon, device_class, sign) in sensors.items()
+            for k, (desc, unit, icon, device_class) in sensors.items()
         ]
 
 
@@ -239,7 +234,6 @@ class DeviceWithOpState(HomeConnectDevice):
                 ATTR_UNIT: None,
                 ATTR_ICON: "mdi:state-machine",
                 ATTR_DEVICE_CLASS: None,
-                ATTR_SIGN: 1,
             }
         ]
 

--- a/homeassistant/components/home_connect/const.py
+++ b/homeassistant/components/home_connect/const.py
@@ -102,7 +102,6 @@ ATTR_DEVICE = "device"
 ATTR_KEY = "key"
 ATTR_PROGRAM = "program"
 ATTR_SENSOR_TYPE = "sensor_type"
-ATTR_SIGN = "sign"
 ATTR_UNIT = "unit"
 ATTR_VALUE = "value"
 
@@ -112,7 +111,6 @@ OLD_NEW_UNIQUE_ID_SUFFIX_MAP = {
     "Light": COOKING_LIGHTING,
     "AmbientLight": BSH_AMBIENT_LIGHT_ENABLED,
     "Power": BSH_POWER_STATE,
-    "Remaining Program Time": BSH_REMAINING_PROGRAM_TIME,
     "Duration": BSH_COMMON_OPTION_DURATION,
     "Program Progress": BSH_COMMON_OPTION_PROGRAM_PROGRESS,
     "Remote Control": BSH_REMOTE_CONTROL_ACTIVATION_STATE,

--- a/homeassistant/components/home_connect/sensor.py
+++ b/homeassistant/components/home_connect/sensor.py
@@ -18,6 +18,7 @@ import homeassistant.util.dt as dt_util
 
 from .api import ConfigEntryAuth, HomeConnectDevice
 from .const import (
+    ATTR_BSH_KEY,
     ATTR_DEVICE,
     ATTR_VALUE,
     BSH_EVENT_PRESENT_STATE_OFF,
@@ -25,6 +26,7 @@ from .const import (
     BSH_OPERATION_STATE_FINISHED,
     BSH_OPERATION_STATE_PAUSE,
     BSH_OPERATION_STATE_RUN,
+    BSH_REMAINING_PROGRAM_TIME,
     COFFEE_EVENT_BEAN_CONTAINER_EMPTY,
     COFFEE_EVENT_DRIP_TRAY_FULL,
     COFFEE_EVENT_WATER_TANK_EMPTY,
@@ -98,6 +100,11 @@ async def async_setup_entry(
         for device_dict in hc_api.devices:
             entity_dicts = device_dict.get(CONF_ENTITIES, {}).get("sensor", [])
             entities += [HomeConnectSensor(**d) for d in entity_dicts]
+            for entity_dict in entity_dicts:
+                if entity_dict[ATTR_BSH_KEY] == BSH_REMAINING_PROGRAM_TIME:
+                    entities.append(
+                        HomeConnectFinishTimeSensor(device_dict[ATTR_DEVICE])
+                    )
             device: HomeConnectDevice = device_dict[ATTR_DEVICE]
             # Auto-discover entities
             entities.extend(
@@ -117,21 +124,18 @@ class HomeConnectSensor(HomeConnectEntity, SensorEntity):
     """Sensor class for Home Connect."""
 
     _key: str
-    _sign: int
 
     def __init__(
         self,
         device: HomeConnectDevice,
         bsh_key: str,
         desc: str,
-        unit: str,
-        icon: str,
-        device_class: SensorDeviceClass,
-        sign: int = 1,
+        unit: str | None,
+        icon: str | None,
+        device_class: SensorDeviceClass | None,
     ) -> None:
         """Initialize the entity."""
         super().__init__(device, bsh_key, desc)
-        self._sign = sign
         self._attr_native_unit_of_measurement = unit
         self._attr_icon = icon
         self._attr_device_class = device_class
@@ -143,44 +147,14 @@ class HomeConnectSensor(HomeConnectEntity, SensorEntity):
 
     async def async_update(self) -> None:
         """Update the sensor's status."""
-        status = self.device.appliance.status
-        if self.bsh_key not in status:
-            self._attr_native_value = None
-        elif self.device_class == SensorDeviceClass.TIMESTAMP:
-            if ATTR_VALUE not in status[self.bsh_key]:
-                self._attr_native_value = None
-            elif (
-                self._attr_native_value is not None
-                and self._sign == 1
-                and isinstance(self._attr_native_value, datetime)
-                and self._attr_native_value < dt_util.utcnow()
-            ):
-                # if the date is supposed to be in the future but we're
-                # already past it, set state to None.
-                self._attr_native_value = None
-            elif (
-                BSH_OPERATION_STATE in status
-                and ATTR_VALUE in status[BSH_OPERATION_STATE]
-                and status[BSH_OPERATION_STATE][ATTR_VALUE]
-                in [
-                    BSH_OPERATION_STATE_RUN,
-                    BSH_OPERATION_STATE_PAUSE,
-                    BSH_OPERATION_STATE_FINISHED,
-                ]
-            ):
-                seconds = self._sign * float(status[self.bsh_key][ATTR_VALUE])
-                self._attr_native_value = dt_util.utcnow() + timedelta(seconds=seconds)
-            else:
-                self._attr_native_value = None
-        else:
-            self._attr_native_value = status[self.bsh_key].get(ATTR_VALUE)
-            if self.bsh_key == BSH_OPERATION_STATE:
-                # Value comes back as an enum, we only really care about the
-                # last part, so split it off
-                # https://developer.home-connect.com/docs/status/operation_state
-                self._attr_native_value = cast(str, self._attr_native_value).split(".")[
-                    -1
-                ]
+        self._attr_native_value = self.device.appliance.status.get(
+            self.bsh_key, {}
+        ).get(ATTR_VALUE)
+        if self._attr_native_value and self.bsh_key == BSH_OPERATION_STATE:
+            # Value comes back as an enum, we only really care about the
+            # last part, so split it off
+            # https://developer.home-connect.com/docs/status/operation_state
+            self._attr_native_value = cast(str, self._attr_native_value).split(".")[-1]
         _LOGGER.debug("Updated, new state: %s", self._attr_native_value)
 
 
@@ -218,3 +192,54 @@ class HomeConnectAlarmSensor(HomeConnectEntity, SensorEntity):
             self._attr_unique_id,
             self._attr_native_value,
         )
+
+
+class HomeConnectFinishTimeSensor(HomeConnectSensor):
+    """Sensor for remaining program time."""
+
+    _sign: int
+
+    def __init__(self, device: HomeConnectDevice) -> None:
+        """Initialize the entity."""
+        super().__init__(
+            device,
+            BSH_REMAINING_PROGRAM_TIME,
+            "Finish Time",
+            None,
+            None,
+            SensorDeviceClass.TIMESTAMP,
+        )
+        self._sign = 1
+        # We leave the old unique_id although it doesn't fit with the real functionality
+        # to avoid breaking users setups during deprecation period
+        self._attr_unique_id = f"{device.appliance.haId}-Remaining Program Time"
+
+    async def async_update(self) -> None:
+        """Update the sensor's status."""
+        status = self.device.appliance.status
+        if self.bsh_key not in status or ATTR_VALUE not in status[self.bsh_key]:
+            self._attr_native_value = None
+        elif (
+            self._attr_native_value is not None
+            and self._sign == 1
+            and isinstance(self._attr_native_value, datetime)
+            and self._attr_native_value < dt_util.utcnow()
+        ):
+            # if the date is supposed to be in the future but we're
+            # already past it, set state to None.
+            self._attr_native_value = None
+        elif (
+            BSH_OPERATION_STATE in status
+            and ATTR_VALUE in status[BSH_OPERATION_STATE]
+            and status[BSH_OPERATION_STATE][ATTR_VALUE]
+            in [
+                BSH_OPERATION_STATE_RUN,
+                BSH_OPERATION_STATE_PAUSE,
+                BSH_OPERATION_STATE_FINISHED,
+            ]
+        ):
+            seconds = self._sign * float(status[self.bsh_key][ATTR_VALUE])
+            self._attr_native_value = dt_util.utcnow() + timedelta(seconds=seconds)
+        else:
+            self._attr_native_value = None
+        _LOGGER.debug("Updated, new state: %s", self._attr_native_value)

--- a/tests/components/home_connect/test_sensor.py
+++ b/tests/components/home_connect/test_sensor.py
@@ -109,7 +109,7 @@ ENTITY_ID_STATES = {
         "Run",
         "Ready",
     ),
-    "sensor.dishwasher_remaining_program_time": (
+    "sensor.dishwasher_finish_time": (
         "unavailable",
         "2021-01-09T12:00:00+00:00",
         "2021-01-09T12:00:00+00:00",
@@ -187,7 +187,7 @@ ENTITY_ID_EDGE_CASE_STATES = [
 
 @pytest.mark.parametrize("appliance", [TEST_HC_APP], indirect=True)
 @pytest.mark.usefixtures("bypass_throttle")
-async def test_remaining_prog_time_edge_cases(
+async def test_finish_time_edge_cases(
     appliance: Mock,
     freezer: FrozenDateTimeFactory,
     hass: HomeAssistant,
@@ -198,7 +198,7 @@ async def test_remaining_prog_time_edge_cases(
 ) -> None:
     """Run program sequence to test edge cases for the remaining_prog_time entity."""
     get_appliances.return_value = [appliance]
-    entity_id = "sensor.dishwasher_remaining_program_time"
+    entity_id = "sensor.dishwasher_finish_time"
     time_to_freeze = "2021-01-09 12:00:00+00:00"
     freezer.move_to(time_to_freeze)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
 As discussed at https://github.com/home-assistant/core/pull/127870#discussion_r1790741729, API data should be displayed as raw as possible and `sensor.remaining_program_time` was performing a transformation to a timestamp (and the given name doesn't match the actual functionality).

These changes expose the raw value of the remaining program time and separates into a sensor class the old functionality that will be deprecated.

Also the name has been changed to match functionality.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [X] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

If anyone wants to have this entity after its deprecation period, this is the template that you can use to achieve same functionality:
```jinja
{% if (states("sensor.dishwasher_remaining_program_time") | is_number)
   and is_state("sensor.dishwasher_operation_state", "Run")
   or is_state("sensor.dishwasher_operation_state", "Pause")
   or is_state("sensor.dishwasher_operation_state", "Finished") %}
{{ now() + timedelta(seconds=states("sensor.dishwasher_remaining_program_time")|int) }}
{%- endif %}
```
Device class should be Timestamp and the template entity can be added to the device
## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
