### PR TITLE
Use reconfigure helpers in fronius config flow

### DIFF
--- a/homeassistant/components/fronius/config_flow.py
+++ b/homeassistant/components/fronius/config_flow.py
@@ -155,7 +155,6 @@ class FroniusConfigFlow(ConfigFlow, domain=DOMAIN):
                 _LOGGER.exception("Unexpected exception")
                 errors["base"] = "unknown"
             else:
-                self._async_abort_entries_match(dict(info))
                 await self.async_set_unique_id(unique_id)
                 self._abort_if_unique_id_mismatch()
 

--- a/homeassistant/components/fronius/config_flow.py
+++ b/homeassistant/components/fronius/config_flow.py
@@ -10,7 +10,7 @@ from pyfronius import Fronius, FroniusError
 import voluptuous as vol
 
 from homeassistant.components.dhcp import DhcpServiceInfo
-from homeassistant.config_entries import ConfigEntry, ConfigFlow, ConfigFlowResult
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -72,7 +72,6 @@ class FroniusConfigFlow(ConfigFlow, domain=DOMAIN):
     def __init__(self) -> None:
         """Initialize flow."""
         self.info: FroniusConfigEntryData
-        self._entry: ConfigEntry | None = None
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -145,6 +144,7 @@ class FroniusConfigFlow(ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Add reconfigure step to allow to reconfigure a config entry."""
         errors = {}
+        reconfigure_entry = self._get_reconfigure_entry()
 
         if user_input is not None:
             try:
@@ -155,33 +155,17 @@ class FroniusConfigFlow(ConfigFlow, domain=DOMAIN):
                 _LOGGER.exception("Unexpected exception")
                 errors["base"] = "unknown"
             else:
-                # Config didn't change or is already configured in another entry
                 self._async_abort_entries_match(dict(info))
+                await self.async_set_unique_id(unique_id)
+                self._abort_if_unique_id_mismatch()
 
-                existing_entry = await self.async_set_unique_id(
-                    unique_id, raise_on_progress=False
-                )
-                assert self._entry is not None
-                if existing_entry and existing_entry.entry_id != self._entry.entry_id:
-                    # Uid of device is already configured in another entry (but with different host)
-                    self._abort_if_unique_id_configured()
+                return self.async_update_reload_and_abort(reconfigure_entry, data=info)
 
-                return self.async_update_reload_and_abort(
-                    self._entry,
-                    data=info,
-                    reason="reconfigure_successful",
-                )
-
-        if self._entry is None:
-            self._entry = self.hass.config_entries.async_get_entry(
-                self.context["entry_id"]
-            )
-            assert self._entry is not None
-        host = self._entry.data[CONF_HOST]
+        host = reconfigure_entry.data[CONF_HOST]
         return self.async_show_form(
             step_id="reconfigure",
             data_schema=vol.Schema({vol.Required(CONF_HOST, default=host): str}),
-            description_placeholders={"device": self._entry.title},
+            description_placeholders={"device": reconfigure_entry.title},
             errors=errors,
         )
 

--- a/homeassistant/components/fronius/strings.json
+++ b/homeassistant/components/fronius/strings.json
@@ -26,7 +26,8 @@
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
       "invalid_host": "[%key:common::config_flow::error::invalid_host%]",
-      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]",
+      "unique_id_mismatch": "The identifier does not match the previous identifier"
     }
   },
   "entity": {

--- a/tests/components/fronius/test_config_flow.py
+++ b/tests/components/fronius/test_config_flow.py
@@ -344,7 +344,7 @@ async def test_reconfigure(hass: HomeAssistant) -> None:
     """Test reconfiguring an entry."""
     entry = MockConfigEntry(
         domain=DOMAIN,
-        unique_id="123.4567890",
+        unique_id="1234567",
         data={
             CONF_HOST: "10.1.2.3",
             "is_logger": True,
@@ -490,7 +490,7 @@ async def test_reconfigure_already_configured(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "already_configured"
+    assert result["reason"] == "unique_id_mismatch"
     assert len(mock_setup_entry.mock_calls) == 0
 
 
@@ -531,4 +531,4 @@ async def test_reconfigure_already_existing(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     assert result2["type"] is FlowResultType.ABORT
-    assert result2["reason"] == "already_configured"
+    assert result2["reason"] == "unique_id_mismatch"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- do not cache the entry in class attributes
- use `_abort_if_unique_id_mismatch`
- remove default reason from `async_update_reload_and_abort`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
