### PR TITLE
Improve discovery of WMS WebControl pro by updating IP address

### DIFF
--- a/homeassistant/components/wmspro/config_flow.py
+++ b/homeassistant/components/wmspro/config_flow.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ipaddress
 import logging
 from typing import Any
 
@@ -38,7 +39,19 @@ class WebControlProConfigFlow(ConfigFlow, domain=DOMAIN):
         """Handle the DHCP discovery step."""
         unique_id = format_mac(discovery_info.macaddress)
         await self.async_set_unique_id(unique_id)
-        self._abort_if_unique_id_configured()
+
+        entry = self.hass.config_entries.async_entry_for_domain_unique_id(
+            DOMAIN, unique_id
+        )
+        if entry:
+            try:  # Check if current host is a valid IP address
+                ipaddress.ip_address(entry.data[CONF_HOST])
+            except ValueError:  # Do not touch name-based host
+                return self.async_abort(reason="already_configured")
+            else:  # Update existing host with new IP address
+                self._abort_if_unique_id_configured(
+                    updates={CONF_HOST: discovery_info.ip}
+                )
 
         for entry in self.hass.config_entries.async_entries(DOMAIN):
             if not entry.unique_id and entry.data[CONF_HOST] in (

--- a/tests/components/wmspro/test_config_flow.py
+++ b/tests/components/wmspro/test_config_flow.py
@@ -112,6 +112,96 @@ async def test_config_flow_from_dhcp_add_mac(
     assert hass.config_entries.async_entries(DOMAIN)[0].unique_id == "00:11:22:33:44:55"
 
 
+async def test_config_flow_from_dhcp_ip_update(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+) -> None:
+    """Test we can use DHCP discovery to update IP in a config entry."""
+    info = DhcpServiceInfo(
+        ip="1.2.3.4", hostname="webcontrol", macaddress="00:11:22:33:44:55"
+    )
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_DHCP}, data=info
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {}
+
+    with patch(
+        "wmspro.webcontrol.WebControlPro.ping",
+        return_value=True,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_HOST: "1.2.3.4",
+            },
+        )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "1.2.3.4"
+    assert result["data"] == {
+        CONF_HOST: "1.2.3.4",
+    }
+    assert len(mock_setup_entry.mock_calls) == 1
+    assert hass.config_entries.async_entries(DOMAIN)[0].unique_id == "00:11:22:33:44:55"
+
+    info = DhcpServiceInfo(
+        ip="5.6.7.8", hostname="webcontrol", macaddress="00:11:22:33:44:55"
+    )
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_DHCP}, data=info
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+    assert hass.config_entries.async_entries(DOMAIN)[0].unique_id == "00:11:22:33:44:55"
+    assert hass.config_entries.async_entries(DOMAIN)[0].data[CONF_HOST] == "5.6.7.8"
+
+
+async def test_config_flow_from_dhcp_no_update(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+) -> None:
+    """Test we do not use DHCP discovery to overwrite hostname with IP in config entry."""
+    info = DhcpServiceInfo(
+        ip="1.2.3.4", hostname="webcontrol", macaddress="00:11:22:33:44:55"
+    )
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_DHCP}, data=info
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {}
+
+    with patch(
+        "wmspro.webcontrol.WebControlPro.ping",
+        return_value=True,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_HOST: "webcontrol",
+            },
+        )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "webcontrol"
+    assert result["data"] == {
+        CONF_HOST: "webcontrol",
+    }
+    assert len(mock_setup_entry.mock_calls) == 1
+    assert hass.config_entries.async_entries(DOMAIN)[0].unique_id == "00:11:22:33:44:55"
+
+    info = DhcpServiceInfo(
+        ip="5.6.7.8", hostname="webcontrol", macaddress="00:11:22:33:44:55"
+    )
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_DHCP}, data=info
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+    assert hass.config_entries.async_entries(DOMAIN)[0].unique_id == "00:11:22:33:44:55"
+    assert hass.config_entries.async_entries(DOMAIN)[0].data[CONF_HOST] == "webcontrol"
+
+
 async def test_config_flow_ping_failed(
     hass: HomeAssistant, mock_setup_entry: AsyncMock
 ) -> None:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow the best practice as suggested by @Joostlek during initial integration PR to follow IP changes if a MAC address is available as unique_id for the config entry. But do not overwrite the host with the IP address for hostname-based entries. 

This should be merged together with this discovery fix: https://github.com/home-assistant/core/pull/127939

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
