### PR TITLE
Do not cache reauth/reconfigure entry in solarlog config flow

### DIFF
--- a/homeassistant/components/solarlog/config_flow.py
+++ b/homeassistant/components/solarlog/config_flow.py
@@ -17,7 +17,6 @@ from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PASSWORD
 from homeassistant.util import slugify
 
-from . import SolarlogConfigEntry
 from .const import CONF_HAS_PWD, DEFAULT_HOST, DEFAULT_NAME, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
@@ -26,7 +25,6 @@ _LOGGER = logging.getLogger(__name__)
 class SolarLogConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for solarlog."""
 
-    _entry: SolarlogConfigEntry
     VERSION = 1
     MINOR_VERSION = 3
 
@@ -141,32 +139,28 @@ class SolarLogConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle a reconfiguration flow initialized by the user."""
-        self._entry = self._get_reconfigure_entry()
-
         return await self.async_step_reconfigure_confirm()
 
     async def async_step_reconfigure_confirm(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle a reconfiguration flow initialized by the user."""
+        reconfigure_entry = self._get_reconfigure_entry()
         if user_input is not None:
             if not user_input[CONF_HAS_PWD] or user_input.get(CONF_PASSWORD, "") == "":
                 user_input[CONF_PASSWORD] = ""
                 user_input[CONF_HAS_PWD] = False
                 return self.async_update_reload_and_abort(
-                    self._entry,
-                    reason="reconfigure_successful",
-                    data={**self._entry.data, **user_input},
+                    reconfigure_entry, data_updates=user_input
                 )
 
             if await self._test_extended_data(
-                self._entry.data[CONF_HOST], user_input.get(CONF_PASSWORD, "")
+                reconfigure_entry.data[CONF_HOST], user_input.get(CONF_PASSWORD, "")
             ):
                 # if password has been provided, only save if extended data is available
                 return self.async_update_reload_and_abort(
-                    self._entry,
-                    reason="reconfigure_successful",
-                    data={**self._entry.data, **user_input},
+                    reconfigure_entry,
+                    data_updates=user_input,
                 )
 
         return self.async_show_form(
@@ -174,7 +168,7 @@ class SolarLogConfigFlow(ConfigFlow, domain=DOMAIN):
             data_schema=vol.Schema(
                 {
                     vol.Optional(
-                        CONF_HAS_PWD, default=self._entry.data[CONF_HAS_PWD]
+                        CONF_HAS_PWD, default=reconfigure_entry.data[CONF_HAS_PWD]
                     ): bool,
                     vol.Optional(CONF_PASSWORD): str,
                 }
@@ -185,24 +179,24 @@ class SolarLogConfigFlow(ConfigFlow, domain=DOMAIN):
         self, entry_data: Mapping[str, Any]
     ) -> ConfigFlowResult:
         """Handle flow upon an API authentication error."""
-        self._entry = self._get_reauth_entry()
         return await self.async_step_reauth_confirm()
 
     async def async_step_reauth_confirm(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle reauthorization flow."""
+        reauth_entry = self._get_reauth_entry()
         if user_input and await self._test_extended_data(
-            self._entry.data[CONF_HOST], user_input.get(CONF_PASSWORD, "")
+            reauth_entry.data[CONF_HOST], user_input.get(CONF_PASSWORD, "")
         ):
             return self.async_update_reload_and_abort(
-                self._entry, data={**self._entry.data, **user_input}
+                reauth_entry, data_updates=user_input
             )
 
         data_schema = vol.Schema(
             {
                 vol.Optional(
-                    CONF_HAS_PWD, default=self._entry.data[CONF_HAS_PWD]
+                    CONF_HAS_PWD, default=reauth_entry.data[CONF_HAS_PWD]
                 ): bool,
                 vol.Optional(CONF_PASSWORD): str,
             }


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
It is not needed

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
