### PR TITLE
Remove deprecated speed limit lock entity from tessie

### DIFF
--- a/homeassistant/components/tessie/lock.py
+++ b/homeassistant/components/tessie/lock.py
@@ -4,21 +4,11 @@ from __future__ import annotations
 
 from typing import Any
 
-from tessie_api import (
-    disable_speed_limit,
-    enable_speed_limit,
-    lock,
-    open_unlock_charge_port,
-    unlock,
-)
+from tessie_api import lock, open_unlock_charge_port, unlock
 
-from homeassistant.components.automation import automations_with_entity
-from homeassistant.components.lock import ATTR_CODE, LockEntity
-from homeassistant.components.script import scripts_with_entity
-from homeassistant.const import Platform
+from homeassistant.components.lock import LockEntity
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
-from homeassistant.helpers import entity_registry as er, issue_registry as ir
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import TessieConfigEntry
@@ -37,46 +27,11 @@ async def async_setup_entry(
     """Set up the Tessie sensor platform from a config entry."""
     data = entry.runtime_data
 
-    entities: list[TessieEntity] = [
+    async_add_entities(
         klass(vehicle)
         for klass in (TessieLockEntity, TessieCableLockEntity)
         for vehicle in data.vehicles
-    ]
-
-    ent_reg = er.async_get(hass)
-
-    for vehicle in data.vehicles:
-        entity_id = ent_reg.async_get_entity_id(
-            Platform.LOCK,
-            DOMAIN,
-            f"{vehicle.vin}-vehicle_state_speed_limit_mode_active",
-        )
-        if entity_id:
-            entity_entry = ent_reg.async_get(entity_id)
-            assert entity_entry
-            if entity_entry.disabled:
-                ent_reg.async_remove(entity_id)
-            else:
-                entities.append(TessieSpeedLimitEntity(vehicle))
-
-                entity_automations = automations_with_entity(hass, entity_id)
-                entity_scripts = scripts_with_entity(hass, entity_id)
-                for item in entity_automations + entity_scripts:
-                    ir.async_create_issue(
-                        hass,
-                        DOMAIN,
-                        f"deprecated_speed_limit_{entity_id}_{item}",
-                        breaks_in_ha_version="2024.11.0",
-                        is_fixable=True,
-                        is_persistent=False,
-                        severity=ir.IssueSeverity.WARNING,
-                        translation_key="deprecated_speed_limit_entity",
-                        translation_placeholders={
-                            "entity": entity_id,
-                            "info": item,
-                        },
-                    )
-    async_add_entities(entities)
+    )
 
 
 class TessieLockEntity(TessieEntity, LockEntity):
@@ -103,58 +58,6 @@ class TessieLockEntity(TessieEntity, LockEntity):
         """Set new value."""
         await self.run(unlock)
         self.set((self.key, False))
-
-
-class TessieSpeedLimitEntity(TessieEntity, LockEntity):
-    """Speed Limit with PIN entity for Tessie."""
-
-    _attr_code_format = r"^\d\d\d\d$"
-
-    def __init__(
-        self,
-        vehicle: TessieVehicleData,
-    ) -> None:
-        """Initialize the sensor."""
-        super().__init__(vehicle, "vehicle_state_speed_limit_mode_active")
-
-    @property
-    def is_locked(self) -> bool | None:
-        """Return the state of the Lock."""
-        return self._value
-
-    async def async_lock(self, **kwargs: Any) -> None:
-        """Enable speed limit with pin."""
-        ir.async_create_issue(
-            self.coordinator.hass,
-            DOMAIN,
-            "deprecated_speed_limit_locked",
-            breaks_in_ha_version="2024.11.0",
-            is_fixable=True,
-            is_persistent=False,
-            severity=ir.IssueSeverity.WARNING,
-            translation_key="deprecated_speed_limit_locked",
-        )
-        code: str | None = kwargs.get(ATTR_CODE)
-        if code:
-            await self.run(enable_speed_limit, pin=code)
-            self.set((self.key, True))
-
-    async def async_unlock(self, **kwargs: Any) -> None:
-        """Disable speed limit with pin."""
-        ir.async_create_issue(
-            self.coordinator.hass,
-            DOMAIN,
-            "deprecated_speed_limit_unlocked",
-            breaks_in_ha_version="2024.11.0",
-            is_fixable=True,
-            is_persistent=False,
-            severity=ir.IssueSeverity.WARNING,
-            translation_key="deprecated_speed_limit_unlocked",
-        )
-        code: str | None = kwargs.get(ATTR_CODE)
-        if code:
-            await self.run(disable_speed_limit, pin=code)
-            self.set((self.key, False))
 
 
 class TessieCableLockEntity(TessieEntity, LockEntity):

--- a/tests/components/tessie/test_lock.py
+++ b/tests/components/tessie/test_lock.py
@@ -6,7 +6,6 @@ import pytest
 from syrupy import SnapshotAssertion
 
 from homeassistant.components.lock import (
-    ATTR_CODE,
     DOMAIN as LOCK_DOMAIN,
     SERVICE_LOCK,
     SERVICE_UNLOCK,
@@ -15,26 +14,15 @@ from homeassistant.components.lock import (
 from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
-from homeassistant.helpers import entity_registry as er, issue_registry as ir
+from homeassistant.helpers import entity_registry as er
 
-from .common import DOMAIN, assert_entities, setup_platform
+from .common import assert_entities, setup_platform
 
 
 async def test_locks(
     hass: HomeAssistant, snapshot: SnapshotAssertion, entity_registry: er.EntityRegistry
 ) -> None:
     """Tests that the lock entity is correct."""
-
-    # Create the deprecated speed limit lock entity
-    entity_registry.async_get_or_create(
-        LOCK_DOMAIN,
-        DOMAIN,
-        "VINVINVIN-vehicle_state_speed_limit_mode_active",
-        original_name="Charge cable lock",
-        has_entity_name=True,
-        translation_key="vehicle_state_speed_limit_mode_active",
-        disabled_by=er.RegistryEntryDisabler.INTEGRATION,
-    )
 
     entry = await setup_platform(hass, [Platform.LOCK])
 
@@ -83,65 +71,3 @@ async def test_locks(
         )
         assert hass.states.get(entity_id).state == LockState.UNLOCKED
         mock_run.assert_called_once()
-
-
-async def test_speed_limit_lock(
-    hass: HomeAssistant,
-    entity_registry: er.EntityRegistry,
-    issue_registry: ir.IssueRegistry,
-) -> None:
-    """Tests that the deprecated speed limit lock entity is correct."""
-    # Create the deprecated speed limit lock entity
-    entity = entity_registry.async_get_or_create(
-        LOCK_DOMAIN,
-        DOMAIN,
-        "VINVINVIN-vehicle_state_speed_limit_mode_active",
-        original_name="Charge cable lock",
-        has_entity_name=True,
-        translation_key="vehicle_state_speed_limit_mode_active",
-    )
-
-    with patch(
-        "homeassistant.components.tessie.lock.automations_with_entity",
-        return_value=["item"],
-    ):
-        await setup_platform(hass, [Platform.LOCK])
-        assert issue_registry.async_get_issue(
-            DOMAIN, f"deprecated_speed_limit_{entity.entity_id}_item"
-        )
-
-    # Test lock set value functions
-    with patch(
-        "homeassistant.components.tessie.lock.enable_speed_limit"
-    ) as mock_enable_speed_limit:
-        await hass.services.async_call(
-            LOCK_DOMAIN,
-            SERVICE_LOCK,
-            {ATTR_ENTITY_ID: [entity.entity_id], ATTR_CODE: "1234"},
-            blocking=True,
-        )
-        assert hass.states.get(entity.entity_id).state == LockState.LOCKED
-        mock_enable_speed_limit.assert_called_once()
-        # Assert issue has been raised in the issue register
-        assert issue_registry.async_get_issue(DOMAIN, "deprecated_speed_limit_locked")
-
-    with patch(
-        "homeassistant.components.tessie.lock.disable_speed_limit"
-    ) as mock_disable_speed_limit:
-        await hass.services.async_call(
-            LOCK_DOMAIN,
-            SERVICE_UNLOCK,
-            {ATTR_ENTITY_ID: [entity.entity_id], ATTR_CODE: "1234"},
-            blocking=True,
-        )
-        assert hass.states.get(entity.entity_id).state == LockState.UNLOCKED
-        mock_disable_speed_limit.assert_called_once()
-        assert issue_registry.async_get_issue(DOMAIN, "deprecated_speed_limit_unlocked")
-
-    with pytest.raises(ServiceValidationError):
-        await hass.services.async_call(
-            LOCK_DOMAIN,
-            SERVICE_UNLOCK,
-            {ATTR_ENTITY_ID: [entity.entity_id], ATTR_CODE: "abc"},
-            blocking=True,
-        )


### PR DESCRIPTION
## Breaking change
The speed limit lock entity has been deprecated in 2024.5. The entity has been completely removed now. 

## Proposed change
Remove the deprecated speed limit lock entity from tessie

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
