### PR TITLE
Add strict typing for govee_ble

### DIFF
--- a/.strict-typing
+++ b/.strict-typing
@@ -214,6 +214,7 @@ homeassistant.components.google_assistant_sdk.*
 homeassistant.components.google_cloud.*
 homeassistant.components.google_photos.*
 homeassistant.components.google_sheets.*
+homeassistant.components.govee_ble.*
 homeassistant.components.gpsd.*
 homeassistant.components.greeneye_monitor.*
 homeassistant.components.group.*

--- a/homeassistant/components/govee_ble/binary_sensor.py
+++ b/homeassistant/components/govee_ble/binary_sensor.py
@@ -44,7 +44,7 @@ BINARY_SENSOR_DESCRIPTIONS = {
 
 def sensor_update_to_bluetooth_data_update(
     sensor_update: SensorUpdate,
-) -> PassiveBluetoothDataUpdate:
+) -> PassiveBluetoothDataUpdate[bool | None]:
     """Convert a sensor update to a bluetooth data update."""
     return PassiveBluetoothDataUpdate(
         devices={
@@ -95,13 +95,13 @@ class GoveeBluetoothBinarySensorEntity(
 ):
     """Representation of a govee-ble binary sensor."""
 
-    processor: GoveeBLEPassiveBluetoothDataProcessor
+    processor: GoveeBLEPassiveBluetoothDataProcessor[bool | None]
 
     @property
     def available(self) -> bool:
         """Return False if sensor is in error."""
         coordinator = self.processor.coordinator
-        return self.processor.entity_data.get(self.entity_key) != ERROR and (
+        return self.processor.entity_data.get(self.entity_key) != ERROR and (  # type: ignore[comparison-overlap]
             ((model_info := coordinator.model_info) and model_info.sleepy)
             or super().available
         )

--- a/homeassistant/components/govee_ble/coordinator.py
+++ b/homeassistant/components/govee_ble/coordinator.py
@@ -1,5 +1,7 @@
 """The govee Bluetooth integration."""
 
+from __future__ import annotations
+
 from collections.abc import Callable
 from logging import Logger
 

--- a/homeassistant/components/govee_ble/sensor.py
+++ b/homeassistant/components/govee_ble/sensor.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from datetime import date, datetime
+from decimal import Decimal
+
 from govee_ble import DeviceClass, SensorUpdate, Units
 from govee_ble.parser import ERROR
 
@@ -28,6 +31,8 @@ from homeassistant.helpers.sensor import sensor_device_info_to_hass_device_info
 
 from .coordinator import GoveeBLEConfigEntry, GoveeBLEPassiveBluetoothDataProcessor
 from .device import device_key_to_bluetooth_entity_key
+
+type _SensorValueType = str | int | float | date | datetime | Decimal | None
 
 SENSOR_DESCRIPTIONS = {
     (DeviceClass.TEMPERATURE, Units.TEMP_CELSIUS): SensorEntityDescription(
@@ -72,7 +77,7 @@ SENSOR_DESCRIPTIONS = {
 
 def sensor_update_to_bluetooth_data_update(
     sensor_update: SensorUpdate,
-) -> PassiveBluetoothDataUpdate:
+) -> PassiveBluetoothDataUpdate[_SensorValueType]:
     """Convert a sensor update to a bluetooth data update."""
     return PassiveBluetoothDataUpdate(
         devices={
@@ -117,13 +122,13 @@ async def async_setup_entry(
 
 class GoveeBluetoothSensorEntity(
     PassiveBluetoothProcessorEntity[
-        PassiveBluetoothDataProcessor[float | int | str | None, SensorUpdate]
+        PassiveBluetoothDataProcessor[_SensorValueType, SensorUpdate]
     ],
     SensorEntity,
 ):
     """Representation of a govee ble sensor."""
 
-    processor: GoveeBLEPassiveBluetoothDataProcessor
+    processor: GoveeBLEPassiveBluetoothDataProcessor[_SensorValueType]
 
     @property
     def available(self) -> bool:
@@ -135,6 +140,6 @@ class GoveeBluetoothSensorEntity(
         )
 
     @property
-    def native_value(self) -> float | int | str | None:
+    def native_value(self) -> _SensorValueType:  # pylint: disable=hass-return-type
         """Return the native value."""
         return self.processor.entity_data.get(self.entity_key)

--- a/mypy.ini
+++ b/mypy.ini
@@ -1895,6 +1895,16 @@ disallow_untyped_defs = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.govee_ble.*]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-homeassistant.components.gpsd.*]
 check_untyped_defs = true
 disallow_incomplete_defs = true


### PR DESCRIPTION
## Proposed change
Add some missing generic types and enable strict typing.
The dependency is typed as well.

https://github.com/Bluetooth-Devices/govee-ble/blob/v0.40.0/src/govee_ble/py.typed

Both dependency is typed as well.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
