### PR TITLE
End deprecation for config entry import for folder watcher

### DIFF
--- a/homeassistant/components/folder_watcher/__init__.py
+++ b/homeassistant/components/folder_watcher/__init__.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import Any, cast
+from typing import cast
 
-import voluptuous as vol
 from watchdog.events import (
     FileClosedEvent,
     FileCreatedEvent,
@@ -19,67 +18,15 @@ from watchdog.events import (
 )
 from watchdog.observers import Observer
 
-from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import Event, HomeAssistant
-import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.dispatcher import dispatcher_send
 from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
-from homeassistant.helpers.typing import ConfigType
 
-from .const import CONF_FOLDER, CONF_PATTERNS, DEFAULT_PATTERN, DOMAIN, PLATFORMS
+from .const import CONF_FOLDER, CONF_PATTERNS, DOMAIN, PLATFORMS
 
 _LOGGER = logging.getLogger(__name__)
-
-
-CONFIG_SCHEMA = vol.Schema(
-    {
-        DOMAIN: vol.All(
-            cv.ensure_list,
-            [
-                vol.Schema(
-                    {
-                        vol.Required(CONF_FOLDER): cv.isdir,
-                        vol.Optional(CONF_PATTERNS, default=[DEFAULT_PATTERN]): vol.All(
-                            cv.ensure_list, [cv.string]
-                        ),
-                    }
-                )
-            ],
-        )
-    },
-    extra=vol.ALLOW_EXTRA,
-)
-
-
-async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
-    """Set up the folder watcher."""
-    if DOMAIN in config:
-        conf: list[dict[str, Any]] = config[DOMAIN]
-        for watcher in conf:
-            path: str = watcher[CONF_FOLDER]
-            if not hass.config.is_allowed_path(path):
-                async_create_issue(
-                    hass,
-                    DOMAIN,
-                    f"import_failed_not_allowed_path_{path}",
-                    is_fixable=False,
-                    is_persistent=False,
-                    severity=IssueSeverity.ERROR,
-                    translation_key="import_failed_not_allowed_path",
-                    translation_placeholders={
-                        "path": path,
-                        "config_variable": "allowlist_external_dirs",
-                    },
-                )
-                continue
-            hass.async_create_task(
-                hass.config_entries.flow.async_init(
-                    DOMAIN, context={"source": SOURCE_IMPORT}, data=watcher
-                )
-            )
-
-    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/folder_watcher/config_flow.py
+++ b/homeassistant/components/folder_watcher/config_flow.py
@@ -8,10 +8,8 @@ from typing import Any
 
 import voluptuous as vol
 
-from homeassistant.components.homeassistant import DOMAIN as HOMEASSISTANT_DOMAIN
 from homeassistant.config_entries import ConfigFlowResult
 from homeassistant.core import callback
-from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 from homeassistant.helpers.schema_config_entry_flow import (
     SchemaCommonFlowHandler,
     SchemaConfigFlowHandler,
@@ -46,28 +44,6 @@ async def validate_setup(
     return user_input
 
 
-async def validate_import_setup(
-    handler: SchemaCommonFlowHandler, user_input: dict[str, Any]
-) -> dict[str, Any]:
-    """Create issue on successful import."""
-    async_create_issue(
-        handler.parent_handler.hass,
-        HOMEASSISTANT_DOMAIN,
-        f"deprecated_yaml_{DOMAIN}",
-        breaks_in_ha_version="2024.11.0",
-        is_fixable=False,
-        is_persistent=False,
-        issue_domain=DOMAIN,
-        severity=IssueSeverity.WARNING,
-        translation_key="deprecated_yaml",
-        translation_placeholders={
-            "domain": DOMAIN,
-            "integration_title": "Folder Watcher",
-        },
-    )
-    return user_input
-
-
 OPTIONS_SCHEMA = vol.Schema(
     {
         vol.Optional(CONF_PATTERNS, default=[DEFAULT_PATTERN]): SelectSelector(
@@ -88,9 +64,6 @@ DATA_SCHEMA = vol.Schema(
 
 CONFIG_FLOW = {
     "user": SchemaFlowFormStep(schema=DATA_SCHEMA, validate_user_input=validate_setup),
-    "import": SchemaFlowFormStep(
-        schema=DATA_SCHEMA, validate_user_input=validate_import_setup
-    ),
 }
 OPTIONS_FLOW = {
     "init": SchemaFlowFormStep(schema=OPTIONS_SCHEMA),

--- a/tests/components/folder_watcher/test_config_flow.py
+++ b/tests/components/folder_watcher/test_config_flow.py
@@ -148,39 +148,3 @@ async def test_form_already_configured(hass: HomeAssistant, tmp_path: Path) -> N
 
     assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "already_configured"
-
-
-async def test_import(hass: HomeAssistant, tmp_path: Path) -> None:
-    """Test import flow."""
-    path = tmp_path.as_posix()
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": config_entries.SOURCE_IMPORT},
-        data={CONF_FOLDER: path, CONF_PATTERNS: ["*"]},
-    )
-    await hass.async_block_till_done()
-
-    assert result["type"] == FlowResultType.CREATE_ENTRY
-    assert result["title"] == f"Folder Watcher {path}"
-    assert result["options"] == {CONF_FOLDER: path, CONF_PATTERNS: ["*"]}
-
-
-async def test_import_already_configured(hass: HomeAssistant, tmp_path: Path) -> None:
-    """Test we abort import when entry is already configured."""
-    path = tmp_path.as_posix()
-
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        title=f"Folder Watcher {path}",
-        data={CONF_FOLDER: path},
-    )
-    entry.add_to_hass(hass)
-
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": config_entries.SOURCE_IMPORT},
-        data={CONF_FOLDER: path},
-    )
-
-    assert result["type"] == FlowResultType.ABORT
-    assert result["reason"] == "already_configured"

--- a/tests/components/folder_watcher/test_init.py
+++ b/tests/components/folder_watcher/test_init.py
@@ -1,33 +1,68 @@
 """The tests for the folder_watcher component."""
 
-import os
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
+from freezegun.api import FrozenDateTimeFactory
+
 from homeassistant.components import folder_watcher
+from homeassistant.components.folder_watcher.const import DOMAIN
+from homeassistant.config_entries import SOURCE_USER, ConfigEntryState
 from homeassistant.core import HomeAssistant
-from homeassistant.setup import async_setup_component
+from homeassistant.helpers import issue_registry as ir
+
+from tests.common import MockConfigEntry
 
 
-async def test_invalid_path_setup(hass: HomeAssistant) -> None:
+async def test_invalid_path_setup(
+    hass: HomeAssistant,
+    tmp_path: Path,
+    freezer: FrozenDateTimeFactory,
+    issue_registry: ir.IssueRegistry,
+) -> None:
     """Test that an invalid path is not set up."""
-    assert not await async_setup_component(
-        hass,
-        folder_watcher.DOMAIN,
-        {folder_watcher.DOMAIN: {folder_watcher.CONF_FOLDER: "invalid_path"}},
+    freezer.move_to("2022-04-19 10:31:02+00:00")
+    path = tmp_path.as_posix()
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        source=SOURCE_USER,
+        title=f"Folder Watcher {path!s}",
+        data={},
+        options={"folder": str(path), "patterns": ["*"]},
+        entry_id="1",
     )
 
+    config_entry.add_to_hass(hass)
 
-async def test_valid_path_setup(hass: HomeAssistant) -> None:
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert config_entry.state is ConfigEntryState.SETUP_ERROR
+    assert len(issue_registry.issues) == 1
+
+
+async def test_valid_path_setup(
+    hass: HomeAssistant, tmp_path: Path, freezer: FrozenDateTimeFactory
+) -> None:
     """Test that a valid path is setup."""
-    cwd = os.path.join(os.path.dirname(__file__))
-    hass.config.allowlist_external_dirs = {cwd}
-    with patch.object(folder_watcher, "Watcher"):
-        assert await async_setup_component(
-            hass,
-            folder_watcher.DOMAIN,
-            {folder_watcher.DOMAIN: {folder_watcher.CONF_FOLDER: cwd}},
-        )
+    freezer.move_to("2022-04-19 10:31:02+00:00")
+    path = tmp_path.as_posix()
+    hass.config.allowlist_external_dirs = {path}
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        source=SOURCE_USER,
+        title=f"Folder Watcher {path!s}",
+        data={},
+        options={"folder": str(path), "patterns": ["*"]},
+        entry_id="1",
+    )
+
+    config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.LOADED
 
 
 def test_event() -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Config entry import from yaml deprecation period has ended and import is now removed.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
See breaking

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 