### PR TITLE
Fix visualization by inverting open/closed state of patio awnings

### DIFF
--- a/homeassistant/components/wmspro/cover.py
+++ b/homeassistant/components/wmspro/cover.py
@@ -46,12 +46,12 @@ class WebControlProAwning(WebControlProGenericEntity, CoverEntity):
     def current_cover_position(self) -> int | None:
         """Return current position of cover."""
         action = self._dest.action(WMS_WebControl_pro_API_actionDescription.AwningDrive)
-        return action["percentage"]
+        return 100 - action["percentage"]
 
     async def async_set_cover_position(self, **kwargs: Any) -> None:
         """Move the cover to a specific position."""
         action = self._dest.action(WMS_WebControl_pro_API_actionDescription.AwningDrive)
-        await action(percentage=kwargs[ATTR_POSITION])
+        await action(percentage=100 - kwargs[ATTR_POSITION])
 
     @property
     def is_closed(self) -> bool | None:
@@ -61,12 +61,12 @@ class WebControlProAwning(WebControlProGenericEntity, CoverEntity):
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""
         action = self._dest.action(WMS_WebControl_pro_API_actionDescription.AwningDrive)
-        await action(percentage=100)
+        await action(percentage=0)
 
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close the cover."""
         action = self._dest.action(WMS_WebControl_pro_API_actionDescription.AwningDrive)
-        await action(percentage=0)
+        await action(percentage=100)
 
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Stop the device if in motion."""

--- a/tests/components/wmspro/snapshots/test_cover.ambr
+++ b/tests/components/wmspro/snapshots/test_cover.ambr
@@ -35,7 +35,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by WMS WebControl pro API',
-      'current_position': 100,
+      'current_position': 0,
       'device_class': 'awning',
       'friendly_name': 'Markise',
       'supported_features': <CoverEntityFeature: 15>,
@@ -45,6 +45,6 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'open',
+    'state': 'closed',
   })
 # ---

--- a/tests/components/wmspro/test_cover.py
+++ b/tests/components/wmspro/test_cover.py
@@ -71,7 +71,7 @@ async def test_cover_update(
     assert len(mock_hub_status_prod_awning.mock_calls) == 3
 
 
-async def test_cover_close_and_open(
+async def test_cover_open_and_close(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_hub_ping: AsyncMock,
@@ -87,27 +87,8 @@ async def test_cover_close_and_open(
 
     entity = hass.states.get("cover.markise")
     assert entity is not None
-    assert entity.state == "open"
-    assert entity.attributes["current_position"] == 100
-
-    with patch(
-        "wmspro.destination.Destination.refresh",
-        return_value=True,
-    ):
-        before = len(mock_hub_status_prod_awning.mock_calls)
-
-        await hass.services.async_call(
-            Platform.COVER,
-            SERVICE_CLOSE_COVER,
-            {ATTR_ENTITY_ID: entity.entity_id},
-            blocking=True,
-        )
-
-        entity = hass.states.get("cover.markise")
-        assert entity is not None
-        assert entity.state == "closed"
-        assert entity.attributes["current_position"] == 0
-        assert len(mock_hub_status_prod_awning.mock_calls) == before
+    assert entity.state == "closed"
+    assert entity.attributes["current_position"] == 0
 
     with patch(
         "wmspro.destination.Destination.refresh",
@@ -128,8 +109,27 @@ async def test_cover_close_and_open(
         assert entity.attributes["current_position"] == 100
         assert len(mock_hub_status_prod_awning.mock_calls) == before
 
+    with patch(
+        "wmspro.destination.Destination.refresh",
+        return_value=True,
+    ):
+        before = len(mock_hub_status_prod_awning.mock_calls)
 
-async def test_cover_move(
+        await hass.services.async_call(
+            Platform.COVER,
+            SERVICE_CLOSE_COVER,
+            {ATTR_ENTITY_ID: entity.entity_id},
+            blocking=True,
+        )
+
+        entity = hass.states.get("cover.markise")
+        assert entity is not None
+        assert entity.state == "closed"
+        assert entity.attributes["current_position"] == 0
+        assert len(mock_hub_status_prod_awning.mock_calls) == before
+
+
+async def test_cover_open_to_pos(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_hub_ping: AsyncMock,
@@ -137,7 +137,7 @@ async def test_cover_move(
     mock_hub_status_prod_awning: AsyncMock,
     mock_action_call: AsyncMock,
 ) -> None:
-    """Test that a cover entity is moved and closed correctly."""
+    """Test that a cover entity is opened to correct position."""
     assert await setup_config_entry(hass, mock_config_entry)
     assert len(mock_hub_ping.mock_calls) == 1
     assert len(mock_hub_configuration_prod.mock_calls) == 1
@@ -145,8 +145,8 @@ async def test_cover_move(
 
     entity = hass.states.get("cover.markise")
     assert entity is not None
-    assert entity.state == "open"
-    assert entity.attributes["current_position"] == 100
+    assert entity.state == "closed"
+    assert entity.attributes["current_position"] == 0
 
     with patch(
         "wmspro.destination.Destination.refresh",
@@ -168,7 +168,7 @@ async def test_cover_move(
         assert len(mock_hub_status_prod_awning.mock_calls) == before
 
 
-async def test_cover_move_and_stop(
+async def test_cover_open_and_stop(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_hub_ping: AsyncMock,
@@ -176,7 +176,7 @@ async def test_cover_move_and_stop(
     mock_hub_status_prod_awning: AsyncMock,
     mock_action_call: AsyncMock,
 ) -> None:
-    """Test that a cover entity is moved and closed correctly."""
+    """Test that a cover entity is opened and stopped correctly."""
     assert await setup_config_entry(hass, mock_config_entry)
     assert len(mock_hub_ping.mock_calls) == 1
     assert len(mock_hub_configuration_prod.mock_calls) == 1
@@ -184,8 +184,8 @@ async def test_cover_move_and_stop(
 
     entity = hass.states.get("cover.markise")
     assert entity is not None
-    assert entity.state == "open"
-    assert entity.attributes["current_position"] == 100
+    assert entity.state == "closed"
+    assert entity.attributes["current_position"] == 0
 
     with patch(
         "wmspro.destination.Destination.refresh",


### PR DESCRIPTION
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The open/closed state of awnings will be inverted, so that the UI visualization and positioning matches reality. This means open (100%) now refers to the awning being completely retracted and closed (0%) now means the awning is fully expanded. This is not in line with industry terminology, but HA does not yet natively support awnings of type patio.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Until the referenced architectural discussion is solved and support for new types of covers has been implemented natively, invert the reported state of patio awnings to match the expections of the UI visualizations based on the cover platform and solve representation of virtical awnings until those can be handled more differentiated.

Details including screenshots without this change: https://github.com/home-assistant/architecture/discussions/979#discussioncomment-10884489

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/home-assistant.io/issues/35116
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
