### PR TITLE
Cleanup unnecessary reconfigure_confirm from config flows

### DIFF
--- a/homeassistant/components/brother/config_flow.py
+++ b/homeassistant/components/brother/config_flow.py
@@ -143,12 +143,6 @@ class BrotherConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle a reconfiguration flow initialized by the user."""
-        return await self.async_step_reconfigure_confirm()
-
-    async def async_step_reconfigure_confirm(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
-        """Handle a reconfiguration flow initialized by the user."""
         entry = self._get_reconfigure_entry()
         errors = {}
 
@@ -170,7 +164,7 @@ class BrotherConfigFlow(ConfigFlow, domain=DOMAIN):
                 )
 
         return self.async_show_form(
-            step_id="reconfigure_confirm",
+            step_id="reconfigure",
             data_schema=self.add_suggested_values_to_schema(
                 data_schema=RECONFIGURE_SCHEMA,
                 suggested_values=entry.data | (user_input or {}),

--- a/homeassistant/components/brother/strings.json
+++ b/homeassistant/components/brother/strings.json
@@ -18,7 +18,7 @@
           "type": "[%key:component::brother::config::step::user::data::type%]"
         }
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "description": "Update configuration for {printer_name}.",
         "data": {
           "host": "[%key:common::config_flow::data::host%]"

--- a/homeassistant/components/bryant_evolution/config_flow.py
+++ b/homeassistant/components/bryant_evolution/config_flow.py
@@ -63,12 +63,6 @@ class BryantConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle integration reconfiguration."""
-        return await self.async_step_reconfigure_confirm()
-
-    async def async_step_reconfigure_confirm(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
-        """Handle integration reconfiguration."""
         errors: dict[str, str] = {}
         if user_input is not None:
             system_zone = await _enumerate_sz(user_input[CONF_FILENAME])
@@ -82,7 +76,7 @@ class BryantConfigFlow(ConfigFlow, domain=DOMAIN):
                 )
             errors["base"] = "cannot_connect"
         return self.async_show_form(
-            step_id="reconfigure_confirm",
+            step_id="reconfigure",
             data_schema=STEP_USER_DATA_SCHEMA,
             errors=errors,
         )

--- a/homeassistant/components/bryant_evolution/strings.json
+++ b/homeassistant/components/bryant_evolution/strings.json
@@ -1,7 +1,7 @@
 {
   "config": {
     "step": {
-      "reconfigure_confirm": {
+      "reconfigure": {
         "data": {
           "filename": "[%key:component::bryant_evolution::config::step::user::data::filename%]"
         }

--- a/homeassistant/components/enphase_envoy/config_flow.py
+++ b/homeassistant/components/enphase_envoy/config_flow.py
@@ -236,12 +236,6 @@ class EnphaseConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Add reconfigure step to allow to manually reconfigure a config entry."""
-        return await self.async_step_reconfigure_confirm()
-
-    async def async_step_reconfigure_confirm(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
-        """Add reconfigure step to allow to manually reconfigure a config entry."""
         reconfigure_entry = self._get_reconfigure_entry()
         errors: dict[str, str] = {}
         description_placeholders: dict[str, str] = {}
@@ -285,7 +279,7 @@ class EnphaseConfigFlow(ConfigFlow, domain=DOMAIN):
 
         suggested_values: Mapping[str, Any] = user_input or reconfigure_entry.data
         return self.async_show_form(
-            step_id="reconfigure_confirm",
+            step_id="reconfigure",
             data_schema=self.add_suggested_values_to_schema(
                 self._async_generate_schema(), suggested_values
             ),

--- a/homeassistant/components/enphase_envoy/strings.json
+++ b/homeassistant/components/enphase_envoy/strings.json
@@ -13,7 +13,7 @@
           "host": "The hostname or IP address of your Enphase Envoy gateway."
         }
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "description": "[%key:component::enphase_envoy::config::step::user::description%]",
         "data": {
           "host": "[%key:common::config_flow::data::host%]",

--- a/homeassistant/components/feedreader/config_flow.py
+++ b/homeassistant/components/feedreader/config_flow.py
@@ -123,18 +123,12 @@ class FeedReaderConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle a reconfiguration flow initialized by the user."""
-        return await self.async_step_reconfigure_confirm()
-
-    async def async_step_reconfigure_confirm(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
-        """Handle a reconfiguration flow initialized by the user."""
         reconfigure_entry = self._get_reconfigure_entry()
         if not user_input:
             return self.show_user_form(
                 user_input={**reconfigure_entry.data},
                 description_placeholders={"name": reconfigure_entry.title},
-                step_id="reconfigure_confirm",
+                step_id="reconfigure",
             )
 
         feed = await async_fetch_feed(self.hass, user_input[CONF_URL])
@@ -145,7 +139,7 @@ class FeedReaderConfigFlow(ConfigFlow, domain=DOMAIN):
                 return self.show_user_form(
                     user_input=user_input,
                     description_placeholders={"name": reconfigure_entry.title},
-                    step_id="reconfigure_confirm",
+                    step_id="reconfigure",
                     errors={"base": "url_error"},
                 )
 

--- a/homeassistant/components/feedreader/strings.json
+++ b/homeassistant/components/feedreader/strings.json
@@ -6,7 +6,7 @@
           "url": "[%key:common::config_flow::data::url%]"
         }
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "description": "Update your configuration information for {name}.",
         "data": {
           "url": "[%key:common::config_flow::data::url%]"

--- a/homeassistant/components/google_travel_time/config_flow.py
+++ b/homeassistant/components/google_travel_time/config_flow.py
@@ -238,12 +238,6 @@ class GoogleTravelTimeConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle reconfiguration."""
-        return await self.async_step_reconfigure_confirm()
-
-    async def async_step_reconfigure_confirm(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
-        """Handle reconfiguration."""
         errors: dict[str, str] | None = None
         if user_input is not None:
             errors = await validate_input(self.hass, user_input)
@@ -253,7 +247,7 @@ class GoogleTravelTimeConfigFlow(ConfigFlow, domain=DOMAIN):
                 )
 
         return self.async_show_form(
-            step_id="reconfigure_confirm",
+            step_id="reconfigure",
             data_schema=self.add_suggested_values_to_schema(
                 RECONFIGURE_SCHEMA, self._get_reconfigure_entry().data
             ),

--- a/homeassistant/components/google_travel_time/strings.json
+++ b/homeassistant/components/google_travel_time/strings.json
@@ -11,7 +11,7 @@
           "destination": "Destination"
         }
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "description": "[%key:component::google_travel_time::config::step::user::description%]",
         "data": {
           "api_key": "[%key:common::config_flow::data::api_key%]",

--- a/homeassistant/components/holiday/config_flow.py
+++ b/homeassistant/components/holiday/config_flow.py
@@ -114,12 +114,6 @@ class HolidayConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle the re-configuration of a province."""
-        return await self.async_step_reconfigure_confirm()
-
-    async def async_step_reconfigure_confirm(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
-        """Handle the re-configuration of a province."""
         reconfigure_entry = self._get_reconfigure_entry()
         if user_input is not None:
             combined_input: dict[str, Any] = {**reconfigure_entry.data, **user_input}
@@ -160,6 +154,4 @@ class HolidayConfigFlow(ConfigFlow, domain=DOMAIN):
             }
         )
 
-        return self.async_show_form(
-            step_id="reconfigure_confirm", data_schema=province_schema
-        )
+        return self.async_show_form(step_id="reconfigure", data_schema=province_schema)

--- a/homeassistant/components/holiday/strings.json
+++ b/homeassistant/components/holiday/strings.json
@@ -16,7 +16,7 @@
           "province": "Province"
         }
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "data": {
           "province": "[%key:component::holiday::config::step::province::data::province%]"
         }

--- a/homeassistant/components/homeworks/config_flow.py
+++ b/homeassistant/components/homeworks/config_flow.py
@@ -583,12 +583,6 @@ class HomeworksConfigFlowHandler(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle a reconfigure flow."""
-        return await self.async_step_reconfigure_confirm()
-
-    async def async_step_reconfigure_confirm(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
-        """Handle a reconfigure flow."""
         errors = {}
         reconfigure_entry = self._get_reconfigure_entry()
         suggested_values = {
@@ -628,7 +622,7 @@ class HomeworksConfigFlowHandler(ConfigFlow, domain=DOMAIN):
                 )
 
         return self.async_show_form(
-            step_id="reconfigure_confirm",
+            step_id="reconfigure",
             data_schema=self.add_suggested_values_to_schema(
                 DATA_SCHEMA_EDIT_CONTROLLER, suggested_values
             ),

--- a/homeassistant/components/homeworks/strings.json
+++ b/homeassistant/components/homeworks/strings.json
@@ -22,7 +22,7 @@
           "name": "[%key:component::homeworks::config::step::user::data_description::name%]"
         }
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "data": {
           "host": "[%key:common::config_flow::data::host%]",
           "port": "[%key:common::config_flow::data::port%]",
@@ -45,8 +45,8 @@
         },
         "data_description": {
           "name": "A unique name identifying the Lutron Homeworks controller",
-          "password": "[%key:component::homeworks::config::step::reconfigure_confirm::data_description::password%]",
-          "username": "[%key:component::homeworks::config::step::reconfigure_confirm::data_description::username%]"
+          "password": "[%key:component::homeworks::config::step::reconfigure::data_description::password%]",
+          "username": "[%key:component::homeworks::config::step::reconfigure::data_description::username%]"
         },
         "description": "Add a Lutron Homeworks controller"
       }

--- a/homeassistant/components/lamarzocco/config_flow.py
+++ b/homeassistant/components/lamarzocco/config_flow.py
@@ -284,16 +284,10 @@ class LmConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Perform reconfiguration of the config entry."""
-        return await self.async_step_reconfigure_confirm()
-
-    async def async_step_reconfigure_confirm(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
-        """Confirm reconfiguration of the device."""
         if not user_input:
             reconfigure_entry = self._get_reconfigure_entry()
             return self.async_show_form(
-                step_id="reconfigure_confirm",
+                step_id="reconfigure",
                 data_schema=vol.Schema(
                     {
                         vol.Required(

--- a/homeassistant/components/lamarzocco/strings.json
+++ b/homeassistant/components/lamarzocco/strings.json
@@ -47,7 +47,7 @@
           "password": "[%key:component::lamarzocco::config::step::user::data_description::password%]"
         }
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "data": {
           "username": "[%key:common::config_flow::data::username%]",
           "password": "[%key:common::config_flow::data::password%]"

--- a/homeassistant/components/lcn/config_flow.py
+++ b/homeassistant/components/lcn/config_flow.py
@@ -196,12 +196,6 @@ class LcnFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> config_entries.ConfigFlowResult:
         """Reconfigure LCN configuration."""
-        return await self.async_step_reconfigure_confirm()
-
-    async def async_step_reconfigure_confirm(
-        self, user_input: dict[str, Any] | None = None
-    ) -> config_entries.ConfigFlowResult:
-        """Reconfigure LCN configuration."""
         reconfigure_entry = self._get_reconfigure_entry()
         errors = None
         if user_input is not None:
@@ -219,7 +213,7 @@ class LcnFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             await self.hass.config_entries.async_setup(reconfigure_entry.entry_id)
 
         return self.async_show_form(
-            step_id="reconfigure_confirm",
+            step_id="reconfigure",
             data_schema=self.add_suggested_values_to_schema(
                 CONFIG_SCHEMA, reconfigure_entry.data
             ),

--- a/homeassistant/components/lcn/strings.json
+++ b/homeassistant/components/lcn/strings.json
@@ -34,7 +34,7 @@
           "acknowledge": "Retry sendig commands if no response is received (increases bus traffic)."
         }
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "title": "Reconfigure LCN host",
         "description": "Reconfigure connection to LCN host.",
         "data": {

--- a/homeassistant/components/madvr/config_flow.py
+++ b/homeassistant/components/madvr/config_flow.py
@@ -45,14 +45,8 @@ class MadVRConfigFlow(ConfigFlow, domain=DOMAIN):
     async def async_step_reconfigure(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Handle reconfiguration of the device."""
-        return await self.async_step_reconfigure_confirm()
-
-    async def async_step_reconfigure_confirm(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
         """Handle a reconfiguration flow initialized by the user."""
-        return await self._handle_config_step(user_input, step_id="reconfigure_confirm")
+        return await self._handle_config_step(user_input, step_id="reconfigure")
 
     async def _handle_config_step(
         self, user_input: dict[str, Any] | None = None, step_id: str = "user"

--- a/homeassistant/components/madvr/strings.json
+++ b/homeassistant/components/madvr/strings.json
@@ -13,7 +13,7 @@
           "port": "The port your madVR Envy is listening on. In 99% of cases, leave this as the default."
         }
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "title": "Reconfigure madVR Envy",
         "description": "Your device needs to be on in order to reconfigure the integation.",
         "data": {

--- a/homeassistant/components/mealie/config_flow.py
+++ b/homeassistant/components/mealie/config_flow.py
@@ -116,12 +116,6 @@ class MealieConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle reconfiguration of the integration."""
-        return await self.async_step_reconfigure_confirm()
-
-    async def async_step_reconfigure_confirm(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
-        """Handle reconfiguration confirmation."""
         errors: dict[str, str] = {}
         if user_input:
             self.host = user_input[CONF_HOST]
@@ -141,7 +135,7 @@ class MealieConfigFlow(ConfigFlow, domain=DOMAIN):
                     },
                 )
         return self.async_show_form(
-            step_id="reconfigure_confirm",
+            step_id="reconfigure",
             data_schema=USER_SCHEMA,
             errors=errors,
         )

--- a/homeassistant/components/mealie/strings.json
+++ b/homeassistant/components/mealie/strings.json
@@ -17,7 +17,7 @@
           "api_token": "[%key:common::config_flow::data::api_token%]"
         }
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "description": "Please reconfigure with Mealie.",
         "data": {
           "host": "[%key:common::config_flow::data::url%]",

--- a/homeassistant/components/melcloud/config_flow.py
+++ b/homeassistant/components/melcloud/config_flow.py
@@ -144,12 +144,6 @@ class FlowHandler(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle a reconfiguration flow initialized by the user."""
-        return await self.async_step_reconfigure_confirm()
-
-    async def async_step_reconfigure_confirm(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
-        """Handle a reconfiguration flow initialized by the user."""
         errors: dict[str, str] = {}
         acquired_token = None
         reconfigure_entry = self._get_reconfigure_entry()
@@ -190,7 +184,7 @@ class FlowHandler(ConfigFlow, domain=DOMAIN):
                 )
 
         return self.async_show_form(
-            step_id="reconfigure_confirm",
+            step_id="reconfigure",
             data_schema=vol.Schema(
                 {
                     vol.Required(CONF_PASSWORD): str,

--- a/homeassistant/components/melcloud/strings.json
+++ b/homeassistant/components/melcloud/strings.json
@@ -17,7 +17,7 @@
           "password": "[%key:common::config_flow::data::password%]"
         }
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "title": "Reconfigure your MelCloud",
         "description": "Reconfigure the entry to obtain a new token, for your account: `{username}`.",
         "data": {

--- a/homeassistant/components/nam/config_flow.py
+++ b/homeassistant/components/nam/config_flow.py
@@ -222,16 +222,9 @@ class NAMFlowHandler(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle a reconfiguration flow initialized by the user."""
-        self.host = self._get_reconfigure_entry().data[CONF_HOST]
-
-        return await self.async_step_reconfigure_confirm()
-
-    async def async_step_reconfigure_confirm(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
-        """Handle a reconfiguration flow initialized by the user."""
         errors = {}
         reconfigure_entry = self._get_reconfigure_entry()
+        self.host = reconfigure_entry.data[CONF_HOST]
 
         if user_input is not None:
             try:
@@ -247,7 +240,7 @@ class NAMFlowHandler(ConfigFlow, domain=DOMAIN):
                 )
 
         return self.async_show_form(
-            step_id="reconfigure_confirm",
+            step_id="reconfigure",
             data_schema=vol.Schema(
                 {
                     vol.Required(CONF_HOST, default=self.host): str,

--- a/homeassistant/components/nam/strings.json
+++ b/homeassistant/components/nam/strings.json
@@ -28,7 +28,7 @@
       "confirm_discovery": {
         "description": "Do you want to set up Nettigo Air Monitor at {host}?"
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "description": "Update configuration for {device_name}.",
         "data": {
           "host": "[%key:common::config_flow::data::host%]"

--- a/homeassistant/components/pyload/config_flow.py
+++ b/homeassistant/components/pyload/config_flow.py
@@ -194,12 +194,6 @@ class PyLoadConfigFlow(ConfigFlow, domain=DOMAIN):
     async def async_step_reconfigure(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Perform a reconfiguration."""
-        return await self.async_step_reconfigure_confirm()
-
-    async def async_step_reconfigure_confirm(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
         """Handle the reconfiguration flow."""
         errors = {}
         reconfig_entry = self._get_reconfigure_entry()
@@ -222,7 +216,7 @@ class PyLoadConfigFlow(ConfigFlow, domain=DOMAIN):
                 )
 
         return self.async_show_form(
-            step_id="reconfigure_confirm",
+            step_id="reconfigure",
             data_schema=self.add_suggested_values_to_schema(
                 STEP_USER_DATA_SCHEMA,
                 user_input or reconfig_entry.data,

--- a/homeassistant/components/pyload/strings.json
+++ b/homeassistant/components/pyload/strings.json
@@ -15,7 +15,7 @@
           "port": "pyLoad uses port 8000 by default."
         }
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "data": {
           "host": "[%key:common::config_flow::data::host%]",
           "username": "[%key:common::config_flow::data::username%]",

--- a/homeassistant/components/shelly/config_flow.py
+++ b/homeassistant/components/shelly/config_flow.py
@@ -401,18 +401,10 @@ class ShellyConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle a reconfiguration flow initialized by the user."""
-        entry_data = self._get_reconfigure_entry().data
-        self.host = entry_data[CONF_HOST]
-        self.port = entry_data.get(CONF_PORT, DEFAULT_HTTP_PORT)
-
-        return await self.async_step_reconfigure_confirm()
-
-    async def async_step_reconfigure_confirm(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
-        """Handle a reconfiguration flow initialized by the user."""
         errors = {}
         reconfigure_entry = self._get_reconfigure_entry()
+        self.host = reconfigure_entry.data[CONF_HOST]
+        self.port = reconfigure_entry.data.get(CONF_PORT, DEFAULT_HTTP_PORT)
 
         if user_input is not None:
             host = user_input[CONF_HOST]
@@ -433,7 +425,7 @@ class ShellyConfigFlow(ConfigFlow, domain=DOMAIN):
                 )
 
         return self.async_show_form(
-            step_id="reconfigure_confirm",
+            step_id="reconfigure",
             data_schema=vol.Schema(
                 {
                     vol.Required(CONF_HOST, default=self.host): str,

--- a/homeassistant/components/shelly/strings.json
+++ b/homeassistant/components/shelly/strings.json
@@ -28,7 +28,7 @@
       "confirm_discovery": {
         "description": "Do you want to set up the {model} at {host}?\n\nBattery-powered devices that are password protected must be woken up before continuing with setting up.\nBattery-powered devices that are not password protected will be added when the device wakes up, you can now manually wake the device up using a button on it or wait for the next data update from the device."
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "description": "Update configuration for {device_name}.\n\nBefore setup, battery-powered devices must be woken up, you can now wake the device up using a button on it.",
         "data": {
           "host": "[%key:common::config_flow::data::host%]",

--- a/homeassistant/components/smhi/config_flow.py
+++ b/homeassistant/components/smhi/config_flow.py
@@ -84,12 +84,6 @@ class SmhiFlowHandler(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle a reconfiguration flow initialized by the user."""
-        return await self.async_step_reconfigure_confirm()
-
-    async def async_step_reconfigure_confirm(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
-        """Handle a reconfiguration flow initialized by the user."""
         errors: dict[str, str] = {}
         reconfigure_entry = self._get_reconfigure_entry()
 
@@ -132,5 +126,5 @@ class SmhiFlowHandler(ConfigFlow, domain=DOMAIN):
             reconfigure_entry.data,
         )
         return self.async_show_form(
-            step_id="reconfigure_confirm", data_schema=schema, errors=errors
+            step_id="reconfigure", data_schema=schema, errors=errors
         )

--- a/homeassistant/components/smhi/strings.json
+++ b/homeassistant/components/smhi/strings.json
@@ -12,7 +12,7 @@
           "longitude": "[%key:common::config_flow::data::longitude%]"
         }
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "title": "Reconfigure your location in Sweden",
         "data": {
           "latitude": "[%key:common::config_flow::data::latitude%]",

--- a/homeassistant/components/solarlog/config_flow.py
+++ b/homeassistant/components/solarlog/config_flow.py
@@ -139,12 +139,6 @@ class SolarLogConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle a reconfiguration flow initialized by the user."""
-        return await self.async_step_reconfigure_confirm()
-
-    async def async_step_reconfigure_confirm(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
-        """Handle a reconfiguration flow initialized by the user."""
         reconfigure_entry = self._get_reconfigure_entry()
         if user_input is not None:
             if not user_input[CONF_HAS_PWD] or user_input.get(CONF_PASSWORD, "") == "":
@@ -164,7 +158,7 @@ class SolarLogConfigFlow(ConfigFlow, domain=DOMAIN):
                 )
 
         return self.async_show_form(
-            step_id="reconfigure_confirm",
+            step_id="reconfigure",
             data_schema=vol.Schema(
                 {
                     vol.Optional(

--- a/homeassistant/components/solarlog/strings.json
+++ b/homeassistant/components/solarlog/strings.json
@@ -29,7 +29,7 @@
           "password": "[%key:common::config_flow::data::password%]"
         }
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "title": "Configure SolarLog",
         "data": {
           "has_password": "[%key:component::solarlog::config::step::user::data::has_password%]",

--- a/homeassistant/components/tado/config_flow.py
+++ b/homeassistant/components/tado/config_flow.py
@@ -119,12 +119,6 @@ class TadoConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle a reconfiguration flow initialized by the user."""
-        return await self.async_step_reconfigure_confirm()
-
-    async def async_step_reconfigure_confirm(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
-        """Handle a reconfiguration flow initialized by the user."""
         errors: dict[str, str] = {}
         reconfigure_entry = self._get_reconfigure_entry()
 
@@ -148,7 +142,7 @@ class TadoConfigFlow(ConfigFlow, domain=DOMAIN):
                 )
 
         return self.async_show_form(
-            step_id="reconfigure_confirm",
+            step_id="reconfigure",
             data_schema=vol.Schema(
                 {
                     vol.Required(CONF_PASSWORD): str,

--- a/homeassistant/components/tado/strings.json
+++ b/homeassistant/components/tado/strings.json
@@ -12,7 +12,7 @@
         },
         "title": "Connect to your Tado account"
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "title": "Reconfigure your Tado",
         "description": "Reconfigure the entry, for your account: `{username}`.",
         "data": {

--- a/homeassistant/components/vallox/config_flow.py
+++ b/homeassistant/components/vallox/config_flow.py
@@ -86,16 +86,10 @@ class ValloxConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle reconfiguration of the Vallox device host address."""
-        return await self.async_step_reconfigure_confirm()
-
-    async def async_step_reconfigure_confirm(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
-        """Handle reconfiguration of the Vallox device host address."""
         reconfigure_entry = self._get_reconfigure_entry()
         if not user_input:
             return self.async_show_form(
-                step_id="reconfigure_confirm",
+                step_id="reconfigure",
                 data_schema=self.add_suggested_values_to_schema(
                     CONFIG_SCHEMA, {CONF_HOST: reconfigure_entry.data.get(CONF_HOST)}
                 ),
@@ -123,7 +117,7 @@ class ValloxConfigFlow(ConfigFlow, domain=DOMAIN):
             )
 
         return self.async_show_form(
-            step_id="reconfigure_confirm",
+            step_id="reconfigure",
             data_schema=self.add_suggested_values_to_schema(
                 CONFIG_SCHEMA, {CONF_HOST: updated_host}
             ),

--- a/homeassistant/components/vallox/strings.json
+++ b/homeassistant/components/vallox/strings.json
@@ -9,7 +9,7 @@
           "host": "Hostname or IP address of your Vallox device."
         }
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "data": {
           "host": "[%key:common::config_flow::data::host%]"
         },

--- a/tests/components/brother/test_config_flow.py
+++ b/tests/components/brother/test_config_flow.py
@@ -261,7 +261,7 @@ async def test_reconfigure_successful(
     result = await mock_config_entry.start_reconfigure_flow(hass)
 
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "reconfigure_confirm"
+    assert result["step_id"] == "reconfigure"
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -297,7 +297,7 @@ async def test_reconfigure_not_successful(
     result = await mock_config_entry.start_reconfigure_flow(hass)
 
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "reconfigure_confirm"
+    assert result["step_id"] == "reconfigure"
 
     mock_brother_client.async_update.side_effect = exc
 
@@ -307,7 +307,7 @@ async def test_reconfigure_not_successful(
     )
 
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "reconfigure_confirm"
+    assert result["step_id"] == "reconfigure"
     assert result["errors"] == {"base": base_error}
 
     mock_brother_client.async_update.side_effect = None
@@ -336,7 +336,7 @@ async def test_reconfigure_invalid_hostname(
     result = await mock_config_entry.start_reconfigure_flow(hass)
 
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "reconfigure_confirm"
+    assert result["step_id"] == "reconfigure"
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -344,7 +344,7 @@ async def test_reconfigure_invalid_hostname(
     )
 
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "reconfigure_confirm"
+    assert result["step_id"] == "reconfigure"
     assert result["errors"] == {CONF_HOST: "wrong_host"}
 
 
@@ -359,7 +359,7 @@ async def test_reconfigure_not_the_same_device(
     result = await mock_config_entry.start_reconfigure_flow(hass)
 
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "reconfigure_confirm"
+    assert result["step_id"] == "reconfigure"
 
     mock_brother_client.serial = "9876543210"
 
@@ -369,5 +369,5 @@ async def test_reconfigure_not_the_same_device(
     )
 
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "reconfigure_confirm"
+    assert result["step_id"] == "reconfigure"
     assert result["errors"] == {"base": "another_device"}

--- a/tests/components/enphase_envoy/test_config_flow.py
+++ b/tests/components/enphase_envoy/test_config_flow.py
@@ -703,7 +703,7 @@ async def test_reconfigure(
     await setup_integration(hass, config_entry)
     result = await config_entry.start_reconfigure_flow(hass)
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "reconfigure_confirm"
+    assert result["step_id"] == "reconfigure"
     assert result["errors"] == {}
 
     # original entry
@@ -739,7 +739,7 @@ async def test_reconfigure_nochange(
     await setup_integration(hass, config_entry)
     result = await config_entry.start_reconfigure_flow(hass)
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "reconfigure_confirm"
+    assert result["step_id"] == "reconfigure"
     assert result["errors"] == {}
 
     # original entry
@@ -775,7 +775,7 @@ async def test_reconfigure_otherenvoy(
     await setup_integration(hass, config_entry)
     result = await config_entry.start_reconfigure_flow(hass)
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "reconfigure_confirm"
+    assert result["step_id"] == "reconfigure"
     assert result["errors"] == {}
 
     # let mock return different serial from first time, sim it's other one on changed ip
@@ -889,7 +889,7 @@ async def test_reconfigure_change_ip_to_existing(
 
     result = await config_entry.start_reconfigure_flow(hass)
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "reconfigure_confirm"
+    assert result["step_id"] == "reconfigure"
     assert result["errors"] == {}
 
     # original entry

--- a/tests/components/feedreader/test_config_flow.py
+++ b/tests/components/feedreader/test_config_flow.py
@@ -164,7 +164,7 @@ async def test_reconfigure(hass: HomeAssistant, feedparser) -> None:
     # init user flow
     result = await entry.start_reconfigure_flow(hass)
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "reconfigure_confirm"
+    assert result["step_id"] == "reconfigure"
 
     # success
     with patch(
@@ -196,7 +196,7 @@ async def test_reconfigure_errors(
     # init user flow
     result = await entry.start_reconfigure_flow(hass)
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "reconfigure_confirm"
+    assert result["step_id"] == "reconfigure"
 
     # raise URLError
     feedparser.side_effect = urllib.error.URLError("Test")
@@ -208,7 +208,7 @@ async def test_reconfigure_errors(
         },
     )
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "reconfigure_confirm"
+    assert result["step_id"] == "reconfigure"
     assert result["errors"] == {"base": "url_error"}
 
     # success

--- a/tests/components/google_travel_time/test_config_flow.py
+++ b/tests/components/google_travel_time/test_config_flow.py
@@ -200,7 +200,7 @@ async def test_reconfigure(hass: HomeAssistant, mock_config: MockConfigEntry) ->
     """Test reconfigure flow."""
     reconfigure_result = await mock_config.start_reconfigure_flow(hass)
     assert reconfigure_result["type"] is FlowResultType.FORM
-    assert reconfigure_result["step_id"] == "reconfigure_confirm"
+    assert reconfigure_result["step_id"] == "reconfigure"
 
     await assert_common_reconfigure_steps(hass, reconfigure_result)
 

--- a/tests/components/homeworks/test_config_flow.py
+++ b/tests/components/homeworks/test_config_flow.py
@@ -243,7 +243,7 @@ async def test_reconfigure_flow(
 
     result = await mock_config_entry.start_reconfigure_flow(hass)
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "reconfigure_confirm"
+    assert result["step_id"] == "reconfigure"
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -308,7 +308,7 @@ async def test_reconfigure_flow_flow_duplicate(
 
     result = await entry1.start_reconfigure_flow(hass)
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "reconfigure_confirm"
+    assert result["step_id"] == "reconfigure"
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -318,7 +318,7 @@ async def test_reconfigure_flow_flow_duplicate(
         },
     )
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "reconfigure_confirm"
+    assert result["step_id"] == "reconfigure"
     assert result["errors"] == {"base": "duplicated_host_port"}
 
 
@@ -330,7 +330,7 @@ async def test_reconfigure_flow_flow_no_change(
 
     result = await mock_config_entry.start_reconfigure_flow(hass)
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "reconfigure_confirm"
+    assert result["step_id"] == "reconfigure"
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -375,7 +375,7 @@ async def test_reconfigure_flow_credentials_password_only(
 
     result = await mock_config_entry.start_reconfigure_flow(hass)
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "reconfigure_confirm"
+    assert result["step_id"] == "reconfigure"
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -386,7 +386,7 @@ async def test_reconfigure_flow_credentials_password_only(
         },
     )
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "reconfigure_confirm"
+    assert result["step_id"] == "reconfigure"
     assert result["errors"] == {"base": "need_username_with_password"}
 
 

--- a/tests/components/lamarzocco/test_config_flow.py
+++ b/tests/components/lamarzocco/test_config_flow.py
@@ -271,7 +271,7 @@ async def test_reconfigure_flow(
     result = await mock_config_entry.start_reconfigure_flow(hass)
 
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "reconfigure_confirm"
+    assert result["step_id"] == "reconfigure"
 
     result2 = await __do_successful_user_step(hass, result, mock_cloud_client)
     service_info = get_bluetooth_service_info(

--- a/tests/components/lcn/test_config_flow.py
+++ b/tests/components/lcn/test_config_flow.py
@@ -206,7 +206,7 @@ async def test_step_reconfigure(hass: HomeAssistant, entry: MockConfigEntry) -> 
 
     result = await entry.start_reconfigure_flow(hass)
     assert result["type"] == data_entry_flow.FlowResultType.FORM
-    assert result["step_id"] == "reconfigure_confirm"
+    assert result["step_id"] == "reconfigure"
 
     with (
         patch("homeassistant.components.lcn.PchkConnectionManager.async_connect"),
@@ -244,7 +244,7 @@ async def test_step_reconfigure_error(
 
     result = await entry.start_reconfigure_flow(hass)
     assert result["type"] == data_entry_flow.FlowResultType.FORM
-    assert result["step_id"] == "reconfigure_confirm"
+    assert result["step_id"] == "reconfigure"
 
     with patch(
         "homeassistant.components.lcn.PchkConnectionManager.async_connect",

--- a/tests/components/madvr/test_config_flow.py
+++ b/tests/components/madvr/test_config_flow.py
@@ -138,7 +138,7 @@ async def test_reconfigure_flow(
     result = await mock_config_entry.start_reconfigure_flow(hass)
 
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "reconfigure_confirm"
+    assert result["step_id"] == "reconfigure"
     assert result["errors"] == {}
 
     # define new host
@@ -204,7 +204,7 @@ async def test_reconfigure_flow_errors(
     result = await mock_config_entry.start_reconfigure_flow(hass)
 
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "reconfigure_confirm"
+    assert result["step_id"] == "reconfigure"
 
     # Test CannotConnect error
     mock_madvr_client.open_connection.side_effect = TimeoutError

--- a/tests/components/mealie/test_config_flow.py
+++ b/tests/components/mealie/test_config_flow.py
@@ -244,7 +244,7 @@ async def test_reconfigure_flow(
 
     result = await mock_config_entry.start_reconfigure_flow(hass)
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "reconfigure_confirm"
+    assert result["step_id"] == "reconfigure"
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -273,7 +273,7 @@ async def test_reconfigure_flow_wrong_account(
 
     result = await mock_config_entry.start_reconfigure_flow(hass)
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "reconfigure_confirm"
+    assert result["step_id"] == "reconfigure"
 
     mock_mealie_client.get_user_info.return_value.user_id = "wrong_user_id"
 
@@ -308,7 +308,7 @@ async def test_reconfigure_flow_exceptions(
 
     result = await mock_config_entry.start_reconfigure_flow(hass)
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "reconfigure_confirm"
+    assert result["step_id"] == "reconfigure"
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -316,7 +316,7 @@ async def test_reconfigure_flow_exceptions(
     )
 
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "reconfigure_confirm"
+    assert result["step_id"] == "reconfigure"
     assert result["errors"] == {"base": error}
 
     mock_mealie_client.get_user_info.side_effect = None

--- a/tests/components/nam/test_config_flow.py
+++ b/tests/components/nam/test_config_flow.py
@@ -445,7 +445,7 @@ async def test_reconfigure_successful(hass: HomeAssistant) -> None:
     result = await entry.start_reconfigure_flow(hass)
 
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "reconfigure_confirm"
+    assert result["step_id"] == "reconfigure"
 
     with (
         patch(
@@ -488,7 +488,7 @@ async def test_reconfigure_not_successful(hass: HomeAssistant) -> None:
     result = await entry.start_reconfigure_flow(hass)
 
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "reconfigure_confirm"
+    assert result["step_id"] == "reconfigure"
 
     with patch(
         "homeassistant.components.nam.NettigoAirMonitor.async_check_credentials",
@@ -500,7 +500,7 @@ async def test_reconfigure_not_successful(hass: HomeAssistant) -> None:
         )
 
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "reconfigure_confirm"
+    assert result["step_id"] == "reconfigure"
     assert result["errors"] == {"base": "cannot_connect"}
 
     with (
@@ -544,7 +544,7 @@ async def test_reconfigure_not_the_same_device(hass: HomeAssistant) -> None:
     result = await entry.start_reconfigure_flow(hass)
 
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "reconfigure_confirm"
+    assert result["step_id"] == "reconfigure"
 
     with (
         patch(

--- a/tests/components/pyload/test_config_flow.py
+++ b/tests/components/pyload/test_config_flow.py
@@ -250,7 +250,7 @@ async def test_reconfiguration(
     result = await config_entry.start_reconfigure_flow(hass)
 
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "reconfigure_confirm"
+    assert result["step_id"] == "reconfigure"
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -285,7 +285,7 @@ async def test_reconfigure_errors(
     result = await config_entry.start_reconfigure_flow(hass)
 
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "reconfigure_confirm"
+    assert result["step_id"] == "reconfigure"
 
     mock_pyloadapi.login.side_effect = side_effect
     result = await hass.config_entries.flow.async_configure(

--- a/tests/components/shelly/test_config_flow.py
+++ b/tests/components/shelly/test_config_flow.py
@@ -1364,7 +1364,7 @@ async def test_reconfigure_successful(
     result = await entry.start_reconfigure_flow(hass)
 
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "reconfigure_confirm"
+    assert result["step_id"] == "reconfigure"
 
     with patch(
         "homeassistant.components.shelly.config_flow.get_info",
@@ -1396,7 +1396,7 @@ async def test_reconfigure_unsuccessful(
     result = await entry.start_reconfigure_flow(hass)
 
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "reconfigure_confirm"
+    assert result["step_id"] == "reconfigure"
 
     with patch(
         "homeassistant.components.shelly.config_flow.get_info",
@@ -1433,7 +1433,7 @@ async def test_reconfigure_with_exception(
     result = await entry.start_reconfigure_flow(hass)
 
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "reconfigure_confirm"
+    assert result["step_id"] == "reconfigure"
 
     with patch("homeassistant.components.shelly.config_flow.get_info", side_effect=exc):
         result = await hass.config_entries.flow.async_configure(

--- a/tests/components/solarlog/test_config_flow.py
+++ b/tests/components/solarlog/test_config_flow.py
@@ -207,7 +207,7 @@ async def test_reconfigure_flow(
 
     result = await entry.start_reconfigure_flow(hass)
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "reconfigure_confirm"
+    assert result["step_id"] == "reconfigure"
 
     # test with all data provided
     result = await hass.config_entries.flow.async_configure(

--- a/tests/components/vallox/conftest.py
+++ b/tests/components/vallox/conftest.py
@@ -81,7 +81,7 @@ async def init_reconfigure_flow(
     result = await mock_entry.start_reconfigure_flow(hass)
 
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "reconfigure_confirm"
+    assert result["step_id"] == "reconfigure"
 
     # original entry
     assert mock_entry.data["host"] == "192.168.100.50"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As follow-up to #127329, this cleans up most of the `reconfigure_confirm` flows that are not needed.

This may cause invalidation of the translations, but I think the cleanup still makes sense.

Three integrations will be adjusted separately:
- [x] fritz #128089
- [x] fritzbox #128087
- [ ] teedee #128025

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
