### PR TITLE
Use custom function instead mashumaro in WebRTC dataclasses

### DIFF
--- a/homeassistant/components/camera/webrtc.py
+++ b/homeassistant/components/camera/webrtc.py
@@ -7,9 +7,6 @@ from collections.abc import Awaitable, Callable, Coroutine
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Protocol
 
-from mashumaro import field_options
-from mashumaro.config import BaseConfig
-from mashumaro.mixins.dict import DataClassDictMixin
 import voluptuous as vol
 
 from homeassistant.components import websocket_api
@@ -32,19 +29,8 @@ DATA_ICE_SERVERS: HassKey[list[Callable[[], Coroutine[Any, Any, RTCIceServer]]]]
 )
 
 
-class _RTCBaseModel(DataClassDictMixin):
-    """Base class for RTC models."""
-
-    class Config(BaseConfig):
-        """Mashumaro config."""
-
-        # Serialize to spec conform names and omit default values
-        omit_default = True
-        serialize_by_alias = True
-
-
 @dataclass
-class RTCIceServer(_RTCBaseModel):
+class RTCIceServer:
     """RTC Ice Server.
 
     See https://www.w3.org/TR/webrtc/#rtciceserver-dictionary
@@ -54,30 +40,56 @@ class RTCIceServer(_RTCBaseModel):
     username: str | None = None
     credential: str | None = None
 
+    def to_frontend_dict(self) -> dict[str, Any]:
+        """Return a dict that can be used by the frontend."""
+
+        data = {
+            "urls": self.urls,
+        }
+        if self.username is not None:
+            data["username"] = self.username
+        if self.credential is not None:
+            data["credential"] = self.credential
+        return data
+
 
 @dataclass
-class RTCConfiguration(_RTCBaseModel):
+class RTCConfiguration:
     """RTC Configuration.
 
     See https://www.w3.org/TR/webrtc/#rtcconfiguration-dictionary
     """
 
-    ice_servers: list[RTCIceServer] = field(
-        metadata=field_options(alias="iceServers"), default_factory=list
-    )
+    ice_servers: list[RTCIceServer] = field(default_factory=list)
+
+    def to_frontend_dict(self) -> dict[str, Any]:
+        """Return a dict that can be used by the frontend."""
+        if not self.ice_servers:
+            return {}
+
+        return {
+            "iceServers": [server.to_frontend_dict() for server in self.ice_servers]
+        }
 
 
 @dataclass(kw_only=True)
-class WebRTCClientConfiguration(_RTCBaseModel):
+class WebRTCClientConfiguration:
     """WebRTC configuration for the client.
 
     Not part of the spec, but required to configure client.
     """
 
     configuration: RTCConfiguration = field(default_factory=RTCConfiguration)
-    data_channel: str | None = field(
-        metadata=field_options(alias="dataChannel"), default=None
-    )
+    data_channel: str | None = None
+
+    def to_frontend_dict(self) -> dict[str, Any]:
+        """Return a dict that can be used by the frontend."""
+        data: dict[str, Any] = {
+            "configuration": self.configuration.to_frontend_dict(),
+        }
+        if self.data_channel is not None:
+            data["dataChannel"] = self.data_channel
+        return data
 
 
 class CameraWebRTCProvider(Protocol):
@@ -153,7 +165,7 @@ async def ws_get_client_config(
         )
         return
 
-    config = (await camera.async_get_webrtc_client_configuration()).to_dict()
+    config = (await camera.async_get_webrtc_client_configuration()).to_frontend_dict()
     connection.send_result(
         msg["id"],
         config,

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -38,7 +38,6 @@ httpx==0.27.2
 ifaddr==0.2.0
 Jinja2==3.1.4
 lru-dict==1.3.0
-mashumaro==3.13.1
 mutagen==1.47.0
 orjson==3.10.7
 packaging>=23.1
@@ -122,6 +121,9 @@ backoff>=2.0
 # Required to avoid breaking (#101042).
 # v2 has breaking changes (#99218).
 pydantic==1.10.18
+
+# Required for Python 3.12.4 compatibility (#119223).
+mashumaro>=3.13.1
 
 # Breaks asyncio
 # https://github.com/pubnub/python/issues/130

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,6 @@ dependencies    = [
     "ifaddr==0.2.0",
     "Jinja2==3.1.4",
     "lru-dict==1.3.0",
-    "mashumaro==3.13.1",
     "PyJWT==2.9.0",
     # PyJWT has loose dependency. We want the latest one.
     "cryptography==43.0.1",

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,6 @@ home-assistant-bluetooth==1.13.0
 ifaddr==0.2.0
 Jinja2==3.1.4
 lru-dict==1.3.0
-mashumaro==3.13.1
 PyJWT==2.9.0
 cryptography==43.0.1
 Pillow==10.4.0

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -140,6 +140,9 @@ backoff>=2.0
 # v2 has breaking changes (#99218).
 pydantic==1.10.18
 
+# Required for Python 3.12.4 compatibility (#119223).
+mashumaro>=3.13.1
+
 # Breaks asyncio
 # https://github.com/pubnub/python/issues/130
 pubnub!=6.4.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove Mashumaro from core and use custom functions instead to get a dict for the frontend.
Mashumaro was added in #124410 and as there was no stable release since them, we don't need to deprecate or mark it as breaking change
CC @allenporter 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
