### PR TITLE
Deprecate extra state attributes in Habitica task sensors

### DIFF
--- a/homeassistant/components/habitica/sensor.py
+++ b/homeassistant/components/habitica/sensor.py
@@ -306,4 +306,30 @@ class HabitipyTaskSensor(HabiticaBase, SensorEntity):
                     DOMAIN,
                     f"deprecated_task_entity_{self.entity_description.key}",
                 )
+
+            if (
+                self.enabled
+                and self.entity_description.key
+                in (HabitipySensorEntity.HABITS, HabitipySensorEntity.REWARDS)
+                and entity_used_in(self.hass, entity_id)
+            ):
+                async_create_issue(
+                    self.hass,
+                    DOMAIN,
+                    f"deprecated_state_attributes_{self.entity_description.key}",
+                    breaks_in_ha_version="2025.5.0",
+                    is_fixable=False,
+                    severity=IssueSeverity.WARNING,
+                    translation_key="deprecated_state_attributes",
+                    translation_placeholders={
+                        "task_name": str(self.name),
+                        "entity": entity_id,
+                    },
+                )
+            else:
+                async_delete_issue(
+                    self.hass,
+                    DOMAIN,
+                    f"deprecated_state_attributes_{self.entity_description.key}",
+                )
         await super().async_added_to_hass()

--- a/homeassistant/components/habitica/strings.json
+++ b/homeassistant/components/habitica/strings.json
@@ -172,6 +172,10 @@
     "deprecated_task_entity": {
       "title": "The Habitica {task_name} sensor is deprecated",
       "description": "The Habitica entity `{entity}` is deprecated and will be removed in a future release.\nPlease update your automations and scripts to replace the sensor entity with the newly added todo entity.\nWhen you are done migrating you can disable `{entity}`."
+    },
+    "deprecated_state_attributes": {
+      "title": "The Habitica {task_name} sensor's attributes are deprecated",
+      "description": "The **attributes** of the Habitica entity `{entity}` are deprecated and will be removed in a future release.\nPlease update your automations and scripts."
     }
   },
   "services": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The task sensors in the Habitica integration have extra state attributes containing the complete raw json data of the corresponding task types. The to-do and dailies sensors have already been deprecated as they were migrated to the todo platform. The remaining sensors habits and rewards were not migrated as it is not possible to represent them appropriately. 
These sensors will remain and display the amount of habits and rewards the users have in their Habitica accounts, only the state attributes will be removed. 

when it is detected that these sensors are used in an automation or script a repair issue is raised informing about the deprecation. As the amount of habits and rewards is a number that doesn't tend to change often once set up, it is very unlikely that the state is used for automations. It can be assumed quite safely that the sensors are used in automations for their attributes. 
Another use for the attributes could be in templates, but i think that cannot be detected in HA.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/35231

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
