### PR TITLE
Add checks for config entry state in async_config_entry_first_refresh

### DIFF
--- a/homeassistant/helpers/update_coordinator.py
+++ b/homeassistant/helpers/update_coordinator.py
@@ -293,6 +293,17 @@ class DataUpdateCoordinator(BaseDataUpdateCoordinatorProtocol, Generic[_DataT]):
                 error_if_core=True,
                 error_if_integration=False,
             )
+        elif (
+            self.config_entry.state
+            is not config_entries.ConfigEntryState.SETUP_IN_PROGRESS
+        ):
+            report(
+                "uses `async_config_entry_first_refresh`, which is only supported "
+                f"when entry state is {config_entries.ConfigEntryState.SETUP_IN_PROGRESS}. "
+                "This will stop working in Home Assistant 2025.11",
+                error_if_core=True,
+                error_if_integration=True,
+            )
         if await self.__wrap_async_setup():
             await self._async_refresh(
                 log_failures=False, raise_on_auth_failed=True, raise_on_entry_error=True

--- a/homeassistant/helpers/update_coordinator.py
+++ b/homeassistant/helpers/update_coordinator.py
@@ -303,7 +303,7 @@ class DataUpdateCoordinator(BaseDataUpdateCoordinatorProtocol, Generic[_DataT]):
                 f"but it is in state {self.config_entry.state}, "
                 "This will stop working in Home Assistant 2025.11",
                 error_if_core=True,
-                error_if_integration=True,
+                error_if_integration=False,
             )
         if await self.__wrap_async_setup():
             await self._async_refresh(

--- a/homeassistant/helpers/update_coordinator.py
+++ b/homeassistant/helpers/update_coordinator.py
@@ -299,7 +299,8 @@ class DataUpdateCoordinator(BaseDataUpdateCoordinatorProtocol, Generic[_DataT]):
         ):
             report(
                 "uses `async_config_entry_first_refresh`, which is only supported "
-                f"when entry state is {config_entries.ConfigEntryState.SETUP_IN_PROGRESS}. "
+                f"when entry state is {config_entries.ConfigEntryState.SETUP_IN_PROGRESS}, "
+                f"but it is in state {self.config_entry.state}, "
                 "This will stop working in Home Assistant 2025.11",
                 error_if_core=True,
                 error_if_integration=True,

--- a/tests/components/rainforest_raven/test_coordinator.py
+++ b/tests/components/rainforest_raven/test_coordinator.py
@@ -8,6 +8,7 @@ from aioraven.device import RAVEnConnectionError
 import pytest
 
 from homeassistant.components.rainforest_raven.coordinator import RAVEnDataCoordinator
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 
@@ -18,6 +19,7 @@ from . import create_mock_entry
 async def test_coordinator_device_info(hass: HomeAssistant) -> None:
     """Test reporting device information from the coordinator."""
     entry = create_mock_entry()
+    entry._async_set_state(hass, ConfigEntryState.SETUP_IN_PROGRESS, None)
     coordinator = RAVEnDataCoordinator(hass, entry)
 
     assert coordinator.device_fw_version is None
@@ -44,6 +46,7 @@ async def test_coordinator_cache_device(
 ) -> None:
     """Test that the device isn't re-opened for subsequent refreshes."""
     entry = create_mock_entry()
+    entry._async_set_state(hass, ConfigEntryState.SETUP_IN_PROGRESS, None)
     coordinator = RAVEnDataCoordinator(hass, entry)
 
     await coordinator.async_config_entry_first_refresh()
@@ -60,6 +63,7 @@ async def test_coordinator_device_error_setup(
 ) -> None:
     """Test handling of a device error during initialization."""
     entry = create_mock_entry()
+    entry._async_set_state(hass, ConfigEntryState.SETUP_IN_PROGRESS, None)
     coordinator = RAVEnDataCoordinator(hass, entry)
 
     mock_device.get_network_info.side_effect = RAVEnConnectionError
@@ -72,6 +76,7 @@ async def test_coordinator_device_error_update(
 ) -> None:
     """Test handling of a device error during an update."""
     entry = create_mock_entry()
+    entry._async_set_state(hass, ConfigEntryState.SETUP_IN_PROGRESS, None)
     coordinator = RAVEnDataCoordinator(hass, entry)
 
     await coordinator.async_config_entry_first_refresh()
@@ -87,6 +92,7 @@ async def test_coordinator_device_timeout_update(
 ) -> None:
     """Test handling of a device timeout during an update."""
     entry = create_mock_entry()
+    entry._async_set_state(hass, ConfigEntryState.SETUP_IN_PROGRESS, None)
     coordinator = RAVEnDataCoordinator(hass, entry)
 
     await coordinator.async_config_entry_first_refresh()
@@ -102,6 +108,7 @@ async def test_coordinator_comm_error(
 ) -> None:
     """Test handling of an error parsing or reading raw device data."""
     entry = create_mock_entry()
+    entry._async_set_state(hass, ConfigEntryState.SETUP_IN_PROGRESS, None)
     coordinator = RAVEnDataCoordinator(hass, entry)
 
     mock_device.synchronize.side_effect = RAVEnConnectionError

--- a/tests/helpers/test_update_coordinator.py
+++ b/tests/helpers/test_update_coordinator.py
@@ -620,7 +620,7 @@ async def test_async_config_entry_first_refresh_success(hass: HomeAssistant) -> 
 async def test_async_config_entry_first_refresh_invalid_state(
     hass: HomeAssistant,
 ) -> None:
-    """Test first refresh successfully."""
+    """Test first refresh fails due to invalid state."""
     entry = MockConfigEntry()
     crd = get_crd(hass, DEFAULT_UPDATE_INTERVAL, entry)
     crd.setup_method = AsyncMock()
@@ -635,6 +635,26 @@ async def test_async_config_entry_first_refresh_invalid_state(
 
     assert crd.last_update_success is True
     crd.setup_method.assert_not_called()
+
+
+@pytest.mark.usefixtures("mock_integration_frame")
+async def test_async_config_entry_first_refresh_invalid_state_in_integration(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test first refresh successfully, despite wrong state."""
+    entry = MockConfigEntry()
+    crd = get_crd(hass, DEFAULT_UPDATE_INTERVAL, entry)
+    crd.setup_method = AsyncMock()
+
+    await crd.async_config_entry_first_refresh()
+    assert crd.last_update_success is True
+    crd.setup_method.assert_called()
+    assert (
+        "Detected that integration 'hue' uses `async_config_entry_first_refresh`, which "
+        "is only supported when entry state is ConfigEntryState.SETUP_IN_PROGRESS, "
+        "but it is in state ConfigEntryState.NOT_LOADED, This will stop working "
+        "in Home Assistant 2025.11"
+    ) in caplog.text
 
 
 async def test_async_config_entry_first_refresh_no_entry(hass: HomeAssistant) -> None:

--- a/tests/helpers/test_update_coordinator.py
+++ b/tests/helpers/test_update_coordinator.py
@@ -551,6 +551,9 @@ async def test_async_config_entry_first_refresh_failure(
     a decreasing level of logging once the first message is logged.
     """
     entry = MockConfigEntry()
+    entry._async_set_state(
+        hass, config_entries.ConfigEntryState.SETUP_IN_PROGRESS, None
+    )
     crd = get_crd(hass, DEFAULT_UPDATE_INTERVAL, entry)
     setattr(crd, method, AsyncMock(side_effect=err_msg[0]))
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
It should not be possible to call `async_config_entry_first_refresh` if a config entry is not in `SETUP_IN_PROGRESS`.

If it is called after the entry has been setup, then `ConfigEntryNotReady` will be raised but not handled, and failures will not be logged. It could also then be called more than once - leading to multiple calls to `async_setup`

Needs:
- [x] #128082
- [x] #128151
- [x] #128152
- [x] #128153

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
