### PR TITLE
Do not link nextbus coordinator to config entry

### DIFF
--- a/homeassistant/components/nextbus/__init__.py
+++ b/homeassistant/components/nextbus/__init__.py
@@ -3,6 +3,7 @@
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_STOP, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
 
 from .const import CONF_AGENCY, CONF_ROUTE, DOMAIN
 from .coordinator import NextBusDataUpdateCoordinator
@@ -29,7 +30,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     await coordinator.async_refresh()
     if not coordinator.last_update_success:
-        return False
+        raise ConfigEntryNotReady from coordinator.last_exception
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/homeassistant/components/nextbus/__init__.py
+++ b/homeassistant/components/nextbus/__init__.py
@@ -27,7 +27,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     coordinator.add_stop_route(entry_stop, entry.data[CONF_ROUTE])
 
-    await coordinator.async_config_entry_first_refresh()
+    await coordinator.async_refresh()
+    if not coordinator.last_update_success:
+        return False
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/homeassistant/components/nextbus/coordinator.py
+++ b/homeassistant/components/nextbus/coordinator.py
@@ -49,13 +49,6 @@ class NextBusDataUpdateCoordinator(DataUpdateCoordinator):
         """Check if this coordinator is tracking any routes."""
         return len(self._route_stops) > 0
 
-    async def async_shutdown(self) -> None:
-        """If there are no more routes, cancel any scheduled call, and ignore new runs."""
-        if self.has_routes():
-            return
-
-        await super().async_shutdown()
-
     async def _async_update_data(self) -> dict[str, Any]:
         """Fetch data from NextBus."""
 

--- a/homeassistant/components/nextbus/coordinator.py
+++ b/homeassistant/components/nextbus/coordinator.py
@@ -24,6 +24,7 @@ class NextBusDataUpdateCoordinator(DataUpdateCoordinator):
         super().__init__(
             hass,
             _LOGGER,
+            config_entry=None,  # It is shared between multiple entries
             name=DOMAIN,
             update_interval=timedelta(seconds=30),
         )

--- a/tests/components/nextbus/__init__.py
+++ b/tests/components/nextbus/__init__.py
@@ -1,1 +1,34 @@
 """The tests for the nexbus component."""
+
+from homeassistant.components.nextbus.const import CONF_AGENCY, CONF_ROUTE, DOMAIN
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import CONF_STOP
+from homeassistant.core import HomeAssistant
+
+from .const import VALID_AGENCY_TITLE, VALID_ROUTE_TITLE, VALID_STOP_TITLE
+
+from tests.common import MockConfigEntry
+
+
+async def assert_setup_sensor(
+    hass: HomeAssistant,
+    config: dict[str, dict[str, str]],
+    expected_state=ConfigEntryState.LOADED,
+    route_title: str = VALID_ROUTE_TITLE,
+) -> MockConfigEntry:
+    """Set up the sensor and assert it's been created."""
+    unique_id = f"{config[DOMAIN][CONF_AGENCY]}_{config[DOMAIN][CONF_ROUTE]}_{config[DOMAIN][CONF_STOP]}"
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=config[DOMAIN],
+        title=f"{VALID_AGENCY_TITLE} {route_title} {VALID_STOP_TITLE}",
+        unique_id=unique_id,
+    )
+    config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.state is expected_state
+
+    return config_entry

--- a/tests/components/nextbus/conftest.py
+++ b/tests/components/nextbus/conftest.py
@@ -1,9 +1,12 @@
 """Test helpers for NextBus tests."""
 
+from collections.abc import Generator
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
+
+from .const import BASIC_RESULTS
 
 
 @pytest.fixture(
@@ -128,3 +131,21 @@ def mock_nextbus_lists(
     instance.route_details.side_effect = route_details_side_effect
 
     return instance
+
+
+@pytest.fixture
+def mock_nextbus() -> Generator[MagicMock]:
+    """Create a mock py_nextbus module."""
+    with patch("homeassistant.components.nextbus.coordinator.NextBusClient") as client:
+        yield client
+
+
+@pytest.fixture
+def mock_nextbus_predictions(
+    mock_nextbus: MagicMock,
+) -> Generator[MagicMock]:
+    """Create a mock of NextBusClient predictions."""
+    instance = mock_nextbus.return_value
+    instance.predictions_for_stop.return_value = BASIC_RESULTS
+
+    return instance.predictions_for_stop

--- a/tests/components/nextbus/const.py
+++ b/tests/components/nextbus/const.py
@@ -1,0 +1,101 @@
+"""Constants for NextBus tests."""
+
+from homeassistant.components.nextbus.const import CONF_AGENCY, CONF_ROUTE, DOMAIN
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.const import CONF_STOP
+
+VALID_AGENCY = "sfmta-cis"
+VALID_ROUTE = "F"
+VALID_STOP = "5184"
+VALID_COORDINATOR_KEY = f"{VALID_AGENCY}-{VALID_STOP}"
+VALID_AGENCY_TITLE = "San Francisco Muni"
+VALID_ROUTE_TITLE = "F-Market & Wharves"
+VALID_STOP_TITLE = "Market St & 7th St"
+SENSOR_ID = "sensor.san_francisco_muni_f_market_wharves_market_st_7th_st"
+
+ROUTE_2 = "G"
+ROUTE_TITLE_2 = "G-Market & Wharves"
+SENSOR_ID_2 = "sensor.san_francisco_muni_g_market_wharves_market_st_7th_st"
+
+PLATFORM_CONFIG = {
+    SENSOR_DOMAIN: {
+        "platform": DOMAIN,
+        CONF_AGENCY: VALID_AGENCY,
+        CONF_ROUTE: VALID_ROUTE,
+        CONF_STOP: VALID_STOP,
+    },
+}
+
+
+CONFIG_BASIC = {
+    DOMAIN: {
+        CONF_AGENCY: VALID_AGENCY,
+        CONF_ROUTE: VALID_ROUTE,
+        CONF_STOP: VALID_STOP,
+    }
+}
+
+CONFIG_BASIC_2 = {
+    DOMAIN: {
+        CONF_AGENCY: VALID_AGENCY,
+        CONF_ROUTE: ROUTE_2,
+        CONF_STOP: VALID_STOP,
+    }
+}
+
+BASIC_RESULTS = [
+    {
+        "route": {
+            "title": VALID_ROUTE_TITLE,
+            "id": VALID_ROUTE,
+        },
+        "stop": {
+            "name": VALID_STOP_TITLE,
+            "id": VALID_STOP,
+        },
+        "values": [
+            {"minutes": 1, "timestamp": 1553807371000},
+            {"minutes": 2, "timestamp": 1553807372000},
+            {"minutes": 3, "timestamp": 1553807373000},
+            {"minutes": 10, "timestamp": 1553807380000},
+        ],
+    },
+    {
+        "route": {
+            "title": ROUTE_TITLE_2,
+            "id": ROUTE_2,
+        },
+        "stop": {
+            "name": VALID_STOP_TITLE,
+            "id": VALID_STOP,
+        },
+        "values": [
+            {"minutes": 90, "timestamp": 1553807379000},
+        ],
+    },
+]
+
+NO_UPCOMING = [
+    {
+        "route": {
+            "title": VALID_ROUTE_TITLE,
+            "id": VALID_ROUTE,
+        },
+        "stop": {
+            "name": VALID_STOP_TITLE,
+            "id": VALID_STOP,
+        },
+        "values": [],
+    },
+    {
+        "route": {
+            "title": ROUTE_TITLE_2,
+            "id": ROUTE_2,
+        },
+        "stop": {
+            "name": VALID_STOP_TITLE,
+            "id": VALID_STOP,
+        },
+        "values": [],
+    },
+]

--- a/tests/components/nextbus/test_init.py
+++ b/tests/components/nextbus/test_init.py
@@ -1,0 +1,27 @@
+"""The tests for the nexbus sensor component."""
+
+from unittest.mock import MagicMock
+from urllib.error import HTTPError
+
+from homeassistant.components.nextbus.coordinator import NextBusHTTPError
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+
+from . import assert_setup_sensor
+from .const import CONFIG_BASIC
+
+
+async def test_setup_retry(
+    hass: HomeAssistant,
+    mock_nextbus: MagicMock,
+    mock_nextbus_lists: MagicMock,
+    mock_nextbus_predictions: MagicMock,
+) -> None:
+    """Verify that a list of messages are rendered correctly."""
+
+    mock_nextbus_predictions.side_effect = NextBusHTTPError(
+        "failed", HTTPError("url", 500, "error", MagicMock(), None)
+    )
+    await assert_setup_sensor(
+        hass, CONFIG_BASIC, expected_state=ConfigEntryState.SETUP_RETRY
+    )

--- a/tests/components/nextbus/test_sensor.py
+++ b/tests/components/nextbus/test_sensor.py
@@ -1,161 +1,36 @@
 """The tests for the nexbus sensor component."""
 
-from collections.abc import Generator
 from copy import deepcopy
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 from urllib.error import HTTPError
 
 from freezegun.api import FrozenDateTimeFactory
 from py_nextbus.client import NextBusFormatError, NextBusHTTPError
 import pytest
 
-from homeassistant.components import sensor
-from homeassistant.components.nextbus.const import CONF_AGENCY, CONF_ROUTE, DOMAIN
+from homeassistant.components.nextbus.const import DOMAIN
 from homeassistant.components.nextbus.coordinator import NextBusDataUpdateCoordinator
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import CONF_NAME, CONF_STOP
+from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import UpdateFailed
 
-from tests.common import MockConfigEntry, async_fire_time_changed
+from . import assert_setup_sensor
+from .const import (
+    BASIC_RESULTS,
+    CONFIG_BASIC,
+    CONFIG_BASIC_2,
+    NO_UPCOMING,
+    ROUTE_TITLE_2,
+    SENSOR_ID,
+    SENSOR_ID_2,
+    VALID_AGENCY,
+    VALID_COORDINATOR_KEY,
+    VALID_ROUTE_TITLE,
+    VALID_STOP_TITLE,
+)
 
-VALID_AGENCY = "sfmta-cis"
-VALID_ROUTE = "F"
-VALID_STOP = "5184"
-VALID_COORDINATOR_KEY = f"{VALID_AGENCY}-{VALID_STOP}"
-VALID_AGENCY_TITLE = "San Francisco Muni"
-VALID_ROUTE_TITLE = "F-Market & Wharves"
-VALID_STOP_TITLE = "Market St & 7th St"
-SENSOR_ID = "sensor.san_francisco_muni_f_market_wharves_market_st_7th_st"
-
-ROUTE_2 = "G"
-ROUTE_TITLE_2 = "G-Market & Wharves"
-SENSOR_ID_2 = "sensor.san_francisco_muni_g_market_wharves_market_st_7th_st"
-
-PLATFORM_CONFIG = {
-    sensor.DOMAIN: {
-        "platform": DOMAIN,
-        CONF_AGENCY: VALID_AGENCY,
-        CONF_ROUTE: VALID_ROUTE,
-        CONF_STOP: VALID_STOP,
-    },
-}
-
-
-CONFIG_BASIC = {
-    DOMAIN: {
-        CONF_AGENCY: VALID_AGENCY,
-        CONF_ROUTE: VALID_ROUTE,
-        CONF_STOP: VALID_STOP,
-    }
-}
-
-CONFIG_BASIC_2 = {
-    DOMAIN: {
-        CONF_AGENCY: VALID_AGENCY,
-        CONF_ROUTE: ROUTE_2,
-        CONF_STOP: VALID_STOP,
-    }
-}
-
-BASIC_RESULTS = [
-    {
-        "route": {
-            "title": VALID_ROUTE_TITLE,
-            "id": VALID_ROUTE,
-        },
-        "stop": {
-            "name": VALID_STOP_TITLE,
-            "id": VALID_STOP,
-        },
-        "values": [
-            {"minutes": 1, "timestamp": 1553807371000},
-            {"minutes": 2, "timestamp": 1553807372000},
-            {"minutes": 3, "timestamp": 1553807373000},
-            {"minutes": 10, "timestamp": 1553807380000},
-        ],
-    },
-    {
-        "route": {
-            "title": ROUTE_TITLE_2,
-            "id": ROUTE_2,
-        },
-        "stop": {
-            "name": VALID_STOP_TITLE,
-            "id": VALID_STOP,
-        },
-        "values": [
-            {"minutes": 90, "timestamp": 1553807379000},
-        ],
-    },
-]
-
-NO_UPCOMING = [
-    {
-        "route": {
-            "title": VALID_ROUTE_TITLE,
-            "id": VALID_ROUTE,
-        },
-        "stop": {
-            "name": VALID_STOP_TITLE,
-            "id": VALID_STOP,
-        },
-        "values": [],
-    },
-    {
-        "route": {
-            "title": ROUTE_TITLE_2,
-            "id": ROUTE_2,
-        },
-        "stop": {
-            "name": VALID_STOP_TITLE,
-            "id": VALID_STOP,
-        },
-        "values": [],
-    },
-]
-
-
-@pytest.fixture
-def mock_nextbus() -> Generator[MagicMock]:
-    """Create a mock py_nextbus module."""
-    with patch("homeassistant.components.nextbus.coordinator.NextBusClient") as client:
-        yield client
-
-
-@pytest.fixture
-def mock_nextbus_predictions(
-    mock_nextbus: MagicMock,
-) -> Generator[MagicMock]:
-    """Create a mock of NextBusClient predictions."""
-    instance = mock_nextbus.return_value
-    instance.predictions_for_stop.return_value = BASIC_RESULTS
-
-    return instance.predictions_for_stop
-
-
-async def assert_setup_sensor(
-    hass: HomeAssistant,
-    config: dict[str, dict[str, str]],
-    expected_state=ConfigEntryState.LOADED,
-    route_title: str = VALID_ROUTE_TITLE,
-) -> MockConfigEntry:
-    """Set up the sensor and assert it's been created."""
-    unique_id = f"{config[DOMAIN][CONF_AGENCY]}_{config[DOMAIN][CONF_ROUTE]}_{config[DOMAIN][CONF_STOP]}"
-    config_entry = MockConfigEntry(
-        domain=DOMAIN,
-        data=config[DOMAIN],
-        title=f"{VALID_AGENCY_TITLE} {route_title} {VALID_STOP_TITLE}",
-        unique_id=unique_id,
-    )
-    config_entry.add_to_hass(hass)
-
-    await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    assert config_entry.state is expected_state
-
-    return config_entry
+from tests.common import async_fire_time_changed
 
 
 async def test_predictions(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Spotted in #128148

The coordinator is shared among all `nextbus` config entries

This fixes a bug where unloading one nextbus config entry would break the shared coordinator

Other potentially unwanted side effects:
- The `pref_disable_polling` option of the first loaded config entry would take precedence.
- Background tasks would get created against the first loaded config entry
- Reauth would trigger against the first loaded config entry

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
