### PR TITLE
Add config subentry support to entity platform

### DIFF
--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -80,6 +80,22 @@ class AddEntitiesCallback(Protocol):
         """Define add_entities type."""
 
 
+class AddConfigEntryEntitiesCallback(Protocol):
+    """Protocol type for EntityPlatform.add_entities callback."""
+
+    def __call__(
+        self,
+        new_entities: Iterable[Entity],
+        update_before_add: bool = False,
+        *,
+        subentry_id: str | None = None,
+    ) -> None:
+        """Define add_entities type.
+
+        :param subentry_id: subentry which the entities should be added to
+        """
+
+
 class EntityPlatformModule(Protocol):
     """Protocol type for entity platform modules."""
 
@@ -105,7 +121,7 @@ class EntityPlatformModule(Protocol):
         self,
         hass: HomeAssistant,
         entry: config_entries.ConfigEntry,
-        async_add_entities: AddEntitiesCallback,
+        async_add_entities: AddConfigEntryEntitiesCallback,
     ) -> None:
         """Set up an integration platform from a config entry."""
 
@@ -516,13 +532,21 @@ class EntityPlatform:
 
     @callback
     def _async_schedule_add_entities_for_entry(
-        self, new_entities: Iterable[Entity], update_before_add: bool = False
+        self,
+        new_entities: Iterable[Entity],
+        update_before_add: bool = False,
+        *,
+        subentry_id: str | None = None,
     ) -> None:
         """Schedule adding entities for a single platform async and track the task."""
         assert self.config_entry
         task = self.config_entry.async_create_task(
             self.hass,
-            self.async_add_entities(new_entities, update_before_add=update_before_add),
+            self.async_add_entities(
+                new_entities,
+                update_before_add=update_before_add,
+                subentry_id=subentry_id,
+            ),
             f"EntityPlatform async_add_entities_for_entry {self.domain}.{self.platform_name}",
             eager_start=True,
         )
@@ -624,12 +648,26 @@ class EntityPlatform:
             )
 
     async def async_add_entities(
-        self, new_entities: Iterable[Entity], update_before_add: bool = False
+        self,
+        new_entities: Iterable[Entity],
+        update_before_add: bool = False,
+        *,
+        subentry_id: str | None = None,
     ) -> None:
         """Add entities for a single platform async.
 
         This method must be run in the event loop.
+
+        :param subentry_id: subentry which the entities should be added to
         """
+        if subentry_id and (
+            not self.config_entry or subentry_id not in self.config_entry.subentries
+        ):
+            raise HomeAssistantError(
+                f"Can't add entities to unknown subentry {subentry_id} of config "
+                f"entry {self.config_entry.entry_id if self.config_entry else None}"
+            )
+
         # handle empty list from component/platform
         if not new_entities:  # type: ignore[truthy-iterable]
             return
@@ -640,7 +678,9 @@ class EntityPlatform:
         entities: list[Entity] = []
         for entity in new_entities:
             coros.append(
-                self._async_add_entity(entity, update_before_add, entity_registry)
+                self._async_add_entity(
+                    entity, update_before_add, entity_registry, subentry_id
+                )
             )
             entities.append(entity)
 
@@ -719,6 +759,7 @@ class EntityPlatform:
         entity: Entity,
         update_before_add: bool,
         entity_registry: EntityRegistry,
+        subentry_id: str | None,
     ) -> None:
         """Add an entity to the platform."""
         if entity is None:
@@ -778,6 +819,7 @@ class EntityPlatform:
                 try:
                     device = dev_reg.async_get(self.hass).async_get_or_create(
                         config_entry_id=self.config_entry.entry_id,
+                        config_subentry_id=subentry_id,
                         **device_info,
                     )
                 except dev_reg.DeviceInfoError as exc:
@@ -824,6 +866,7 @@ class EntityPlatform:
                 entity.unique_id,
                 capabilities=entity.capability_attributes,
                 config_entry=self.config_entry,
+                config_subentry_id=subentry_id,
                 device_id=device.id if device else None,
                 disabled_by=disabled_by,
                 entity_category=entity.entity_category,

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -88,11 +88,11 @@ class AddConfigEntryEntitiesCallback(Protocol):
         new_entities: Iterable[Entity],
         update_before_add: bool = False,
         *,
-        subentry_id: str | None = None,
+        config_subentry_id: str | None = None,
     ) -> None:
         """Define add_entities type.
 
-        :param subentry_id: subentry which the entities should be added to
+        :param config_subentry_id: subentry which the entities should be added to
         """
 
 
@@ -536,7 +536,7 @@ class EntityPlatform:
         new_entities: Iterable[Entity],
         update_before_add: bool = False,
         *,
-        subentry_id: str | None = None,
+        config_subentry_id: str | None = None,
     ) -> None:
         """Schedule adding entities for a single platform async and track the task."""
         assert self.config_entry
@@ -545,7 +545,7 @@ class EntityPlatform:
             self.async_add_entities(
                 new_entities,
                 update_before_add=update_before_add,
-                subentry_id=subentry_id,
+                config_subentry_id=config_subentry_id,
             ),
             f"EntityPlatform async_add_entities_for_entry {self.domain}.{self.platform_name}",
             eager_start=True,
@@ -652,7 +652,7 @@ class EntityPlatform:
         new_entities: Iterable[Entity],
         update_before_add: bool = False,
         *,
-        subentry_id: str | None = None,
+        config_subentry_id: str | None = None,
     ) -> None:
         """Add entities for a single platform async.
 
@@ -660,11 +660,12 @@ class EntityPlatform:
 
         :param subentry_id: subentry which the entities should be added to
         """
-        if subentry_id and (
-            not self.config_entry or subentry_id not in self.config_entry.subentries
+        if config_subentry_id and (
+            not self.config_entry
+            or config_subentry_id not in self.config_entry.subentries
         ):
             raise HomeAssistantError(
-                f"Can't add entities to unknown subentry {subentry_id} of config "
+                f"Can't add entities to unknown subentry {config_subentry_id} of config "
                 f"entry {self.config_entry.entry_id if self.config_entry else None}"
             )
 
@@ -679,7 +680,7 @@ class EntityPlatform:
         for entity in new_entities:
             coros.append(
                 self._async_add_entity(
-                    entity, update_before_add, entity_registry, subentry_id
+                    entity, update_before_add, entity_registry, config_subentry_id
                 )
             )
             entities.append(entity)
@@ -759,7 +760,7 @@ class EntityPlatform:
         entity: Entity,
         update_before_add: bool,
         entity_registry: EntityRegistry,
-        subentry_id: str | None,
+        config_subentry_id: str | None,
     ) -> None:
         """Add an entity to the platform."""
         if entity is None:
@@ -819,7 +820,7 @@ class EntityPlatform:
                 try:
                     device = dev_reg.async_get(self.hass).async_get_or_create(
                         config_entry_id=self.config_entry.entry_id,
-                        config_subentry_id=subentry_id,
+                        config_subentry_id=config_subentry_id,
                         **device_info,
                     )
                 except dev_reg.DeviceInfoError as exc:
@@ -866,7 +867,7 @@ class EntityPlatform:
                 entity.unique_id,
                 capabilities=entity.capability_attributes,
                 config_entry=self.config_entry,
-                config_subentry_id=subentry_id,
+                config_subentry_id=config_subentry_id,
                 device_id=device.id if device else None,
                 disabled_by=disabled_by,
                 entity_category=entity.entity_category,

--- a/tests/helpers/snapshots/test_entity_platform.ambr
+++ b/tests/helpers/snapshots/test_entity_platform.ambr
@@ -36,3 +36,40 @@
     'via_device_id': <ANY>,
   })
 # ---
+# name: test_device_info_called.1
+  DeviceRegistryEntrySnapshot({
+    'area_id': 'heliport',
+    'config_entries': <ANY>,
+    'config_entries_subentries': <ANY>,
+    'configuration_url': 'http://192.168.0.100/config',
+    'connections': set({
+      tuple(
+        'mac',
+        'efgh',
+      ),
+    }),
+    'disabled_by': None,
+    'entry_type': <DeviceEntryType.SERVICE: 'service'>,
+    'hw_version': 'test-hw',
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'hue',
+        'efgh',
+      ),
+    }),
+    'is_new': False,
+    'labels': set({
+    }),
+    'manufacturer': 'test-manuf',
+    'model': 'test-model',
+    'model_id': None,
+    'name': 'test-name',
+    'name_by_user': None,
+    'primary_config_entry': <ANY>,
+    'serial_number': None,
+    'suggested_area': 'Heliport',
+    'sw_version': 'test-sw',
+    'via_device_id': <ANY>,
+  })
+# ---

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -11,7 +11,7 @@ import pytest
 from syrupy.assertion import SnapshotAssertion
 import voluptuous as vol
 
-from homeassistant.config_entries import ConfigEntry
+from homeassistant.config_entries import ConfigEntry, ConfigSubentryData
 from homeassistant.const import EVENT_HOMEASSISTANT_STARTED, PERCENTAGE, EntityCategory
 from homeassistant.core import (
     CoreState,
@@ -36,7 +36,10 @@ from homeassistant.helpers.entity_component import (
     DEFAULT_SCAN_INTERVAL,
     EntityComponent,
 )
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.entity_platform import (
+    AddConfigEntryEntitiesCallback,
+    AddEntitiesCallback,
+)
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.util import dt as dt_util
 
@@ -223,7 +226,7 @@ async def test_set_scan_interval_via_platform(hass: HomeAssistant) -> None:
     def platform_setup(
         hass: HomeAssistant,
         config: ConfigType,
-        add_entities: entity_platform.AddEntitiesCallback,
+        add_entities: AddEntitiesCallback,
         discovery_info: DiscoveryInfoType | None = None,
     ) -> None:
         """Test the platform setup."""
@@ -862,13 +865,27 @@ async def test_setup_entry(
     async def async_setup_entry(
         hass: HomeAssistant,
         config_entry: ConfigEntry,
-        async_add_entities: AddEntitiesCallback,
+        async_add_entities: AddConfigEntryEntitiesCallback,
     ) -> None:
         """Mock setup entry method."""
-        async_add_entities([MockEntity(name="test1", unique_id="unique")])
+        async_add_entities([MockEntity(name="test1", unique_id="unique1")])
+        async_add_entities(
+            [MockEntity(name="test2", unique_id="unique2")],
+            subentry_id="mock-subentry-id-1",
+        )
 
     platform = MockPlatform(async_setup_entry=async_setup_entry)
-    config_entry = MockConfigEntry(entry_id="super-mock-id")
+    config_entry = MockConfigEntry(
+        entry_id="super-mock-id",
+        subentries_data=(
+            ConfigSubentryData(
+                data={},
+                subentry_id="mock-subentry-id-1",
+                title="Mock title",
+                unique_id="test",
+            ),
+        ),
+    )
     config_entry.add_to_hass(hass)
     entity_platform = MockEntityPlatform(
         hass, platform_name=config_entry.domain, platform=platform
@@ -878,11 +895,16 @@ async def test_setup_entry(
     await hass.async_block_till_done()
     full_name = f"{config_entry.domain}.{entity_platform.domain}"
     assert full_name in hass.config.components
-    assert len(hass.states.async_entity_ids()) == 1
-    assert len(entity_registry.entities) == 1
+    assert len(hass.states.async_entity_ids()) == 2
+    assert len(entity_registry.entities) == 2
 
     entity_registry_entry = entity_registry.entities["test_domain.test1"]
     assert entity_registry_entry.config_entry_id == "super-mock-id"
+    assert entity_registry_entry.config_subentry_id is None
+
+    entity_registry_entry = entity_registry.entities["test_domain.test2"]
+    assert entity_registry_entry.config_entry_id == "super-mock-id"
+    assert entity_registry_entry.config_subentry_id == "mock-subentry-id-1"
 
 
 async def test_setup_entry_platform_not_ready(
@@ -1138,7 +1160,17 @@ async def test_device_info_called(
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test device info is forwarded correctly."""
-    config_entry = MockConfigEntry(entry_id="super-mock-id")
+    config_entry = MockConfigEntry(
+        entry_id="super-mock-id",
+        subentries_data=(
+            ConfigSubentryData(
+                data={},
+                subentry_id="mock-subentry-id-1",
+                title="Mock title",
+                unique_id="test",
+            ),
+        ),
+    )
     config_entry.add_to_hass(hass)
     via = device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,
@@ -1151,7 +1183,7 @@ async def test_device_info_called(
     async def async_setup_entry(
         hass: HomeAssistant,
         config_entry: ConfigEntry,
-        async_add_entities: AddEntitiesCallback,
+        async_add_entities: AddConfigEntryEntitiesCallback,
     ) -> None:
         """Mock setup entry method."""
         async_add_entities(
@@ -1177,6 +1209,28 @@ async def test_device_info_called(
                 ),
             ]
         )
+        async_add_entities(
+            [
+                # Valid device info
+                MockEntity(
+                    unique_id="efgh",
+                    device_info={
+                        "identifiers": {("hue", "efgh")},
+                        "configuration_url": "http://192.168.0.100/config",
+                        "connections": {(dr.CONNECTION_NETWORK_MAC, "efgh")},
+                        "manufacturer": "test-manuf",
+                        "model": "test-model",
+                        "name": "test-name",
+                        "sw_version": "test-sw",
+                        "hw_version": "test-hw",
+                        "suggested_area": "Heliport",
+                        "entry_type": dr.DeviceEntryType.SERVICE,
+                        "via_device": ("hue", "via-id"),
+                    },
+                ),
+            ],
+            subentry_id="mock-subentry-id-1",
+        )
 
     platform = MockPlatform(async_setup_entry=async_setup_entry)
     entity_platform = MockEntityPlatform(
@@ -1186,11 +1240,18 @@ async def test_device_info_called(
     assert await entity_platform.async_setup_entry(config_entry)
     await hass.async_block_till_done()
 
-    assert len(hass.states.async_entity_ids()) == 2
+    assert len(hass.states.async_entity_ids()) == 3
 
     device = device_registry.async_get_device(identifiers={("hue", "1234")})
     assert device == snapshot
     assert device.config_entries == {config_entry.entry_id}
+    assert device.config_entries_subentries == {config_entry.entry_id: {None}}
+    assert device.primary_config_entry == config_entry.entry_id
+    assert device.via_device_id == via.id
+    device = device_registry.async_get_device(identifiers={("hue", "efgh")})
+    assert device == snapshot
+    assert device.config_entries == {config_entry.entry_id}
+    assert device.config_entries_subentries == {config_entry.entry_id: {"mock-subentry-id-1"}}
     assert device.primary_config_entry == config_entry.entry_id
     assert device.via_device_id == via.id
 
@@ -1214,7 +1275,7 @@ async def test_device_info_not_overrides(
     async def async_setup_entry(
         hass: HomeAssistant,
         config_entry: ConfigEntry,
-        async_add_entities: AddEntitiesCallback,
+        async_add_entities: AddConfigEntryEntitiesCallback,
     ) -> None:
         """Mock setup entry method."""
         async_add_entities(
@@ -1267,7 +1328,7 @@ async def test_device_info_homeassistant_url(
     async def async_setup_entry(
         hass: HomeAssistant,
         config_entry: ConfigEntry,
-        async_add_entities: AddEntitiesCallback,
+        async_add_entities: AddConfigEntryEntitiesCallback,
     ) -> None:
         """Mock setup entry method."""
         async_add_entities(
@@ -1319,7 +1380,7 @@ async def test_device_info_change_to_no_url(
     async def async_setup_entry(
         hass: HomeAssistant,
         config_entry: ConfigEntry,
-        async_add_entities: AddEntitiesCallback,
+        async_add_entities: AddConfigEntryEntitiesCallback,
     ) -> None:
         """Mock setup entry method."""
         async_add_entities(
@@ -1391,7 +1452,7 @@ async def test_entity_disabled_by_device(
     async def async_setup_entry(
         hass: HomeAssistant,
         config_entry: ConfigEntry,
-        async_add_entities: AddEntitiesCallback,
+        async_add_entities: AddConfigEntryEntitiesCallback,
     ) -> None:
         """Mock setup entry method."""
         async_add_entities([entity_disabled])
@@ -1877,7 +1938,7 @@ async def test_setup_entry_with_entities_that_block_forever(
     async def async_setup_entry(
         hass: HomeAssistant,
         config_entry: ConfigEntry,
-        async_add_entities: AddEntitiesCallback,
+        async_add_entities: AddConfigEntryEntitiesCallback,
     ) -> None:
         """Mock setup entry method."""
         async_add_entities(
@@ -1926,7 +1987,7 @@ async def test_cancellation_is_not_blocked(
     async def async_setup_entry(
         hass: HomeAssistant,
         config_entry: ConfigEntry,
-        async_add_entities: AddEntitiesCallback,
+        async_add_entities: AddConfigEntryEntitiesCallback,
     ) -> None:
         """Mock setup entry method."""
         async_add_entities(
@@ -2024,7 +2085,7 @@ async def test_entity_name_influences_entity_id(
     async def async_setup_entry(
         hass: HomeAssistant,
         config_entry: ConfigEntry,
-        async_add_entities: AddEntitiesCallback,
+        async_add_entities: AddConfigEntryEntitiesCallback,
     ) -> None:
         """Mock setup entry method."""
         async_add_entities(
@@ -2112,7 +2173,7 @@ async def test_translated_entity_name_influences_entity_id(
     async def async_setup_entry(
         hass: HomeAssistant,
         config_entry: ConfigEntry,
-        async_add_entities: AddEntitiesCallback,
+        async_add_entities: AddConfigEntryEntitiesCallback,
     ) -> None:
         """Mock setup entry method."""
         async_add_entities(
@@ -2200,7 +2261,7 @@ async def test_translated_device_class_name_influences_entity_id(
     async def async_setup_entry(
         hass: HomeAssistant,
         config_entry: ConfigEntry,
-        async_add_entities: AddEntitiesCallback,
+        async_add_entities: AddConfigEntryEntitiesCallback,
     ) -> None:
         """Mock setup entry method."""
         async_add_entities([TranslatedDeviceClassEntity(device_class, has_entity_name)])
@@ -2262,7 +2323,7 @@ async def test_device_name_defaulting_config_entry(
     async def async_setup_entry(
         hass: HomeAssistant,
         config_entry: ConfigEntry,
-        async_add_entities: AddEntitiesCallback,
+        async_add_entities: AddConfigEntryEntitiesCallback,
     ) -> None:
         """Mock setup entry method."""
         async_add_entities([DeviceNameEntity()])
@@ -2318,7 +2379,7 @@ async def test_device_type_error_checking(
     async def async_setup_entry(
         hass: HomeAssistant,
         config_entry: ConfigEntry,
-        async_add_entities: AddEntitiesCallback,
+        async_add_entities: AddConfigEntryEntitiesCallback,
     ) -> None:
         """Mock setup entry method."""
         async_add_entities([DeviceNameEntity()])

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -871,7 +871,7 @@ async def test_setup_entry(
         async_add_entities([MockEntity(name="test1", unique_id="unique1")])
         async_add_entities(
             [MockEntity(name="test2", unique_id="unique2")],
-            subentry_id="mock-subentry-id-1",
+            config_subentry_id="mock-subentry-id-1",
         )
 
     platform = MockPlatform(async_setup_entry=async_setup_entry)
@@ -1229,7 +1229,7 @@ async def test_device_info_called(
                     },
                 ),
             ],
-            subentry_id="mock-subentry-id-1",
+            config_subentry_id="mock-subentry-id-1",
         )
 
     platform = MockPlatform(async_setup_entry=async_setup_entry)
@@ -1251,7 +1251,9 @@ async def test_device_info_called(
     device = device_registry.async_get_device(identifiers={("hue", "efgh")})
     assert device == snapshot
     assert device.config_entries == {config_entry.entry_id}
-    assert device.config_entries_subentries == {config_entry.entry_id: {"mock-subentry-id-1"}}
+    assert device.config_entries_subentries == {
+        config_entry.entry_id: {"mock-subentry-id-1"}
+    }
     assert device.primary_config_entry == config_entry.entry_id
     assert device.via_device_id == via.id
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add config subentry support to entity platform

This is intended as a follow-up to https://github.com/home-assistant/core/pull/117355

Needs https://github.com/home-assistant/core/pull/128155 and https://github.com/home-assistant/core/pull/128157

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
