### PR TITLE
Remove config entry import from lg_netcast

### DIFF
--- a/homeassistant/components/lg_netcast/config_flow.py
+++ b/homeassistant/components/lg_netcast/config_flow.py
@@ -18,10 +18,9 @@ from homeassistant.const import (
     CONF_MODEL,
     CONF_NAME,
 )
-from homeassistant.core import CALLBACK_TYPE, DOMAIN as HOMEASSISTANT_DOMAIN, callback
+from homeassistant.core import CALLBACK_TYPE, callback
 from homeassistant.data_entry_flow import AbortFlow
 from homeassistant.helpers.event import async_track_time_interval
-from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 from homeassistant.util.network import is_host_valid
 
 from .const import DEFAULT_NAME, DOMAIN
@@ -67,56 +66,6 @@ class LGNetCast(config_entries.ConfigFlow, domain=DOMAIN):
             data_schema=vol.Schema({vol.Required(CONF_HOST): str}),
             errors=errors,
         )
-
-    async def async_step_import(self, import_data: dict[str, Any]) -> ConfigFlowResult:
-        """Import configuration from yaml."""
-        self.device_config = {
-            CONF_HOST: import_data[CONF_HOST],
-            CONF_NAME: import_data[CONF_NAME],
-        }
-
-        def _create_issue():
-            async_create_issue(
-                self.hass,
-                HOMEASSISTANT_DOMAIN,
-                f"deprecated_yaml_{DOMAIN}",
-                breaks_in_ha_version="2024.11.0",
-                is_fixable=False,
-                issue_domain=DOMAIN,
-                severity=IssueSeverity.WARNING,
-                translation_key="deprecated_yaml",
-                translation_placeholders={
-                    "domain": DOMAIN,
-                    "integration_title": "LG Netcast",
-                },
-            )
-
-        try:
-            result: ConfigFlowResult = await self.async_step_authorize(import_data)
-        except AbortFlow as err:
-            if err.reason != "already_configured":
-                async_create_issue(
-                    self.hass,
-                    DOMAIN,
-                    "deprecated_yaml_import_issue_{err.reason}",
-                    breaks_in_ha_version="2024.11.0",
-                    is_fixable=False,
-                    issue_domain=DOMAIN,
-                    severity=IssueSeverity.WARNING,
-                    translation_key=f"deprecated_yaml_import_issue_{err.reason}",
-                    translation_placeholders={
-                        "domain": DOMAIN,
-                        "integration_title": "LG Netcast",
-                        "error_type": err.reason,
-                    },
-                )
-            else:
-                _create_issue()
-            raise
-
-        _create_issue()
-
-        return result
 
     async def async_discover_client(self):
         """Handle Discovery step."""

--- a/homeassistant/components/lg_netcast/media_player.py
+++ b/homeassistant/components/lg_netcast/media_player.py
@@ -7,26 +7,20 @@ from typing import TYPE_CHECKING, Any
 
 from pylgnetcast import LG_COMMAND, LgNetCastClient, LgNetCastError
 from requests import RequestException
-import voluptuous as vol
 
 from homeassistant.components.media_player import (
-    PLATFORM_SCHEMA as MEDIA_PLAYER_PLATFORM_SCHEMA,
     MediaPlayerDeviceClass,
     MediaPlayerEntity,
     MediaPlayerEntityFeature,
     MediaPlayerState,
     MediaType,
 )
-from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ACCESS_TOKEN, CONF_HOST, CONF_MODEL, CONF_NAME
 from homeassistant.core import HomeAssistant
-from homeassistant.data_entry_flow import FlowResultType
-from homeassistant.exceptions import PlatformNotReady
-import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.trigger import PluggableAction
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from .const import ATTR_MANUFACTURER, DOMAIN
 from .triggers.turn_on import async_get_turn_on_trigger
@@ -49,15 +43,6 @@ SUPPORT_LGTV = (
     | MediaPlayerEntityFeature.STOP
 )
 
-PLATFORM_SCHEMA = MEDIA_PLAYER_PLATFORM_SCHEMA.extend(
-    {
-        vol.Optional(CONF_ON_ACTION): cv.SCRIPT_SCHEMA,
-        vol.Required(CONF_HOST): cv.string,
-        vol.Optional(CONF_ACCESS_TOKEN): vol.All(cv.string, vol.Length(max=6)),
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    }
-)
-
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -77,27 +62,6 @@ async def async_setup_entry(
     hass.data[DOMAIN][config_entry.entry_id] = client
 
     async_add_entities([LgTVDevice(client, name, model, unique_id=unique_id)])
-
-
-async def async_setup_platform(
-    hass: HomeAssistant,
-    config: ConfigType,
-    async_add_entities: AddEntitiesCallback,
-    discovery_info: DiscoveryInfoType | None = None,
-) -> None:
-    """Set up the LG TV platform."""
-
-    host = config.get(CONF_HOST)
-
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_IMPORT}, data=config
-    )
-
-    if (
-        result.get("type") == FlowResultType.ABORT
-        and result.get("reason") == "cannot_connect"
-    ):
-        raise PlatformNotReady(f"Connection error while connecting to {host}")
 
 
 class LgTVDevice(MediaPlayerEntity):

--- a/tests/components/lg_netcast/test_config_flow.py
+++ b/tests/components/lg_netcast/test_config_flow.py
@@ -5,7 +5,7 @@ from unittest.mock import DEFAULT, patch
 
 from homeassistant import data_entry_flow
 from homeassistant.components.lg_netcast.const import DOMAIN
-from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
+from homeassistant.config_entries import SOURCE_USER
 from homeassistant.const import (
     CONF_ACCESS_TOKEN,
     CONF_HOST,
@@ -23,8 +23,6 @@ from . import (
     UNIQUE_ID,
     _patch_lg_netcast,
 )
-
-from tests.common import MockConfigEntry
 
 
 async def test_show_form(hass: HomeAssistant) -> None:
@@ -144,77 +142,6 @@ async def test_invalid_session_id(hass: HomeAssistant) -> None:
         assert result2["step_id"] == "authorize"
         assert result2["errors"] is not None
         assert result2["errors"]["base"] == "cannot_connect"
-
-
-async def test_import(hass: HomeAssistant) -> None:
-    """Test that the import works."""
-    with _patch_lg_netcast():
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": SOURCE_IMPORT},
-            data={
-                CONF_HOST: IP_ADDRESS,
-                CONF_ACCESS_TOKEN: FAKE_PIN,
-                CONF_NAME: MODEL_NAME,
-            },
-        )
-
-        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
-        assert result["result"].unique_id == UNIQUE_ID
-        assert result["data"] == {
-            CONF_HOST: IP_ADDRESS,
-            CONF_ACCESS_TOKEN: FAKE_PIN,
-            CONF_NAME: MODEL_NAME,
-            CONF_MODEL: MODEL_NAME,
-            CONF_ID: UNIQUE_ID,
-        }
-
-
-async def test_import_not_online(hass: HomeAssistant) -> None:
-    """Test that the import works."""
-    with _patch_lg_netcast(fail_connection=True):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": SOURCE_IMPORT},
-            data={
-                CONF_HOST: IP_ADDRESS,
-                CONF_ACCESS_TOKEN: FAKE_PIN,
-                CONF_NAME: MODEL_NAME,
-            },
-        )
-
-        assert result["type"] == data_entry_flow.FlowResultType.ABORT
-        assert result["reason"] == "cannot_connect"
-
-
-async def test_import_duplicate_error(hass: HomeAssistant) -> None:
-    """Test that errors are shown when duplicates are added during import."""
-    config_entry = MockConfigEntry(
-        domain=DOMAIN,
-        unique_id=UNIQUE_ID,
-        data={
-            CONF_HOST: IP_ADDRESS,
-            CONF_ACCESS_TOKEN: FAKE_PIN,
-            CONF_NAME: MODEL_NAME,
-            CONF_ID: UNIQUE_ID,
-        },
-    )
-    config_entry.add_to_hass(hass)
-
-    with _patch_lg_netcast():
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": SOURCE_IMPORT},
-            data={
-                CONF_HOST: IP_ADDRESS,
-                CONF_ACCESS_TOKEN: FAKE_PIN,
-                CONF_NAME: MODEL_NAME,
-                CONF_ID: UNIQUE_ID,
-            },
-        )
-
-        assert result["type"] == data_entry_flow.FlowResultType.ABORT
-        assert result["reason"] == "already_configured"
 
 
 async def test_display_access_token_aborted(hass: HomeAssistant) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
This removes the previously deprecated yaml setup. Your configuration has been imported and can now be removed.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
See breaking

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 