### PR TITLE
Mark integrations as single_config_entry in manifest [k-r]

### DIFF
--- a/homeassistant/components/kitchen_sink/config_flow.py
+++ b/homeassistant/components/kitchen_sink/config_flow.py
@@ -37,9 +37,6 @@ class KitchenSinkConfigFlow(ConfigFlow, domain=DOMAIN):
 
     async def async_step_import(self, import_data: dict[str, Any]) -> ConfigFlowResult:
         """Set the config entry up from yaml."""
-        if self._async_current_entries():
-            return self.async_abort(reason="single_instance_allowed")
-
         return self.async_create_entry(title="Kitchen Sink", data=import_data)
 
     async def async_step_reauth(

--- a/homeassistant/components/kitchen_sink/manifest.json
+++ b/homeassistant/components/kitchen_sink/manifest.json
@@ -5,5 +5,6 @@
   "codeowners": ["@home-assistant/core"],
   "documentation": "https://www.home-assistant.io/integrations/kitchen_sink",
   "iot_class": "calculated",
-  "quality_scale": "internal"
+  "quality_scale": "internal",
+  "single_config_entry": true
 }

--- a/homeassistant/components/launch_library/config_flow.py
+++ b/homeassistant/components/launch_library/config_flow.py
@@ -18,10 +18,6 @@ class LaunchLibraryFlowHandler(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle a flow initialized by the user."""
-        # Check if already configured
-        if self._async_current_entries():
-            return self.async_abort(reason="single_instance_allowed")
-
         if user_input is not None:
             return self.async_create_entry(title="Launch Library", data=user_input)
 

--- a/homeassistant/components/launch_library/manifest.json
+++ b/homeassistant/components/launch_library/manifest.json
@@ -6,5 +6,6 @@
   "documentation": "https://www.home-assistant.io/integrations/launch_library",
   "integration_type": "service",
   "iot_class": "cloud_polling",
-  "requirements": ["pylaunches==2.0.0"]
+  "requirements": ["pylaunches==2.0.0"],
+  "single_config_entry": true
 }

--- a/homeassistant/components/launch_library/strings.json
+++ b/homeassistant/components/launch_library/strings.json
@@ -4,9 +4,6 @@
       "user": {
         "description": "Do you want to configure the Launch Library?"
       }
-    },
-    "abort": {
-      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
     }
   },
   "entity": {

--- a/homeassistant/components/litejet/config_flow.py
+++ b/homeassistant/components/litejet/config_flow.py
@@ -57,9 +57,6 @@ class LiteJetConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Create a LiteJet config entry based upon user input."""
-        if self._async_current_entries():
-            return self.async_abort(reason="single_instance_allowed")
-
         errors = {}
         if user_input is not None:
             port = user_input[CONF_PORT]

--- a/homeassistant/components/litejet/manifest.json
+++ b/homeassistant/components/litejet/manifest.json
@@ -8,5 +8,6 @@
   "iot_class": "local_push",
   "loggers": ["pylitejet"],
   "quality_scale": "platinum",
-  "requirements": ["pylitejet==0.6.3"]
+  "requirements": ["pylitejet==0.6.3"],
+  "single_config_entry": true
 }

--- a/homeassistant/components/litejet/strings.json
+++ b/homeassistant/components/litejet/strings.json
@@ -9,9 +9,6 @@
         }
       }
     },
-    "abort": {
-      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
-    },
     "error": {
       "open_failed": "Cannot open the specified serial port."
     }

--- a/homeassistant/components/local_ip/config_flow.py
+++ b/homeassistant/components/local_ip/config_flow.py
@@ -16,9 +16,6 @@ class SimpleConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle the initial step."""
-        if self._async_current_entries():
-            return self.async_abort(reason="single_instance_allowed")
-
         if user_input is None:
             return self.async_show_form(step_id="user")
 

--- a/homeassistant/components/local_ip/manifest.json
+++ b/homeassistant/components/local_ip/manifest.json
@@ -5,5 +5,6 @@
   "config_flow": true,
   "dependencies": ["network"],
   "documentation": "https://www.home-assistant.io/integrations/local_ip",
-  "iot_class": "local_polling"
+  "iot_class": "local_polling",
+  "single_config_entry": true
 }

--- a/homeassistant/components/local_ip/strings.json
+++ b/homeassistant/components/local_ip/strings.json
@@ -6,9 +6,6 @@
         "title": "[%key:component::local_ip::title%]",
         "description": "[%key:common::config_flow::description::confirm_setup%]"
       }
-    },
-    "abort": {
-      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
     }
   }
 }

--- a/homeassistant/components/lutron/config_flow.py
+++ b/homeassistant/components/lutron/config_flow.py
@@ -26,11 +26,6 @@ class LutronConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """First step in the config flow."""
-
-        # Check if a configuration entry already exists
-        if self._async_current_entries():
-            return self.async_abort(reason="single_instance_allowed")
-
         errors = {}
 
         if user_input is not None:

--- a/homeassistant/components/lutron/manifest.json
+++ b/homeassistant/components/lutron/manifest.json
@@ -6,5 +6,6 @@
   "documentation": "https://www.home-assistant.io/integrations/lutron",
   "iot_class": "local_polling",
   "loggers": ["pylutron"],
-  "requirements": ["pylutron==0.2.15"]
+  "requirements": ["pylutron==0.2.15"],
+  "single_config_entry": true
 }

--- a/homeassistant/components/lutron/strings.json
+++ b/homeassistant/components/lutron/strings.json
@@ -17,9 +17,6 @@
         "description": "Please enter the main repeater login information",
         "title": "Main repeater setup"
       }
-    },
-    "abort": {
-      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
     }
   },
   "entity": {

--- a/homeassistant/components/nzbget/config_flow.py
+++ b/homeassistant/components/nzbget/config_flow.py
@@ -50,9 +50,6 @@ class NZBGetConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle a flow initiated by the user."""
-        if self._async_current_entries():
-            return self.async_abort(reason="single_instance_allowed")
-
         errors = {}
 
         if user_input is not None:

--- a/homeassistant/components/nzbget/manifest.json
+++ b/homeassistant/components/nzbget/manifest.json
@@ -6,5 +6,6 @@
   "documentation": "https://www.home-assistant.io/integrations/nzbget",
   "iot_class": "local_polling",
   "loggers": ["pynzbgetapi"],
-  "requirements": ["pynzbgetapi==0.2.0"]
+  "requirements": ["pynzbgetapi==0.2.0"],
+  "single_config_entry": true
 }

--- a/homeassistant/components/nzbget/strings.json
+++ b/homeassistant/components/nzbget/strings.json
@@ -19,7 +19,6 @@
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
     },
     "abort": {
-      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     }
   },

--- a/homeassistant/components/omnilogic/config_flow.py
+++ b/homeassistant/components/omnilogic/config_flow.py
@@ -42,12 +42,6 @@ class OmniLogicConfigFlow(ConfigFlow, domain=DOMAIN):
         """Handle the initial step."""
         errors: dict[str, str] = {}
 
-        config_entry = self._async_current_entries()
-        if config_entry:
-            return self.async_abort(reason="single_instance_allowed")
-
-        errors = {}
-
         if user_input is not None:
             username = user_input[CONF_USERNAME]
             password = user_input[CONF_PASSWORD]

--- a/homeassistant/components/omnilogic/manifest.json
+++ b/homeassistant/components/omnilogic/manifest.json
@@ -6,5 +6,6 @@
   "documentation": "https://www.home-assistant.io/integrations/omnilogic",
   "iot_class": "cloud_polling",
   "loggers": ["config", "omnilogic"],
-  "requirements": ["omnilogic==0.4.5"]
+  "requirements": ["omnilogic==0.4.5"],
+  "single_config_entry": true
 }

--- a/homeassistant/components/omnilogic/strings.json
+++ b/homeassistant/components/omnilogic/strings.json
@@ -14,8 +14,7 @@
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
-      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_account%]"
     }
   },
   "options": {

--- a/homeassistant/components/ondilo_ico/config_flow.py
+++ b/homeassistant/components/ondilo_ico/config_flow.py
@@ -21,9 +21,6 @@ class OndiloIcoOAuth2FlowHandler(AbstractOAuth2FlowHandler, domain=DOMAIN):
         """Handle a flow initialized by the user."""
         await self.async_set_unique_id(DOMAIN)
 
-        if self._async_current_entries():
-            return self.async_abort(reason="single_instance_allowed")
-
         self.async_register_implementation(
             self.hass,
             OndiloOauth2Implementation(self.hass),

--- a/homeassistant/components/ondilo_ico/manifest.json
+++ b/homeassistant/components/ondilo_ico/manifest.json
@@ -8,5 +8,6 @@
   "integration_type": "hub",
   "iot_class": "cloud_polling",
   "loggers": ["ondilo"],
-  "requirements": ["ondilo==0.5.0"]
+  "requirements": ["ondilo==0.5.0"],
+  "single_config_entry": true
 }

--- a/homeassistant/components/owntracks/config_flow.py
+++ b/homeassistant/components/owntracks/config_flow.py
@@ -23,9 +23,6 @@ class OwnTracksFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle a user initiated set up flow to create OwnTracks webhook."""
-        if self._async_current_entries():
-            return self.async_abort(reason="single_instance_allowed")
-
         if user_input is None:
             return self.async_show_form(step_id="user")
 

--- a/homeassistant/components/owntracks/manifest.json
+++ b/homeassistant/components/owntracks/manifest.json
@@ -8,5 +8,6 @@
   "documentation": "https://www.home-assistant.io/integrations/owntracks",
   "iot_class": "local_push",
   "loggers": ["nacl"],
-  "requirements": ["PyNaCl==1.5.0"]
+  "requirements": ["PyNaCl==1.5.0"],
+  "single_config_entry": true
 }

--- a/homeassistant/components/owntracks/strings.json
+++ b/homeassistant/components/owntracks/strings.json
@@ -7,8 +7,7 @@
       }
     },
     "abort": {
-      "cloud_not_connected": "[%key:common::config_flow::abort::cloud_not_connected%]",
-      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
+      "cloud_not_connected": "[%key:common::config_flow::abort::cloud_not_connected%]"
     },
     "create_entry": {
       "default": "On Android, open [the OwnTracks app]({android_url}), go to Preferences > Connection. Change the following settings:\n - Mode: HTTP\n - Host: {webhook_url}\n - Identification:\n   - Username: `'(Your name)'`\n   - Device ID: `'(Your device name)'`\n\nOn iOS, open [the OwnTracks app]({ios_url}), tap (i) icon in top left > Settings. Change the following settings:\n - Mode: HTTP\n - URL: {webhook_url}\n - Turn on authentication\n - UserID: `'(Your name)'`\n\n{secret}\n\nSee [the documentation]({docs_url}) for more information."

--- a/homeassistant/components/profiler/config_flow.py
+++ b/homeassistant/components/profiler/config_flow.py
@@ -16,9 +16,6 @@ class ProfilerConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle the initial step."""
-        if self._async_current_entries():
-            return self.async_abort(reason="single_instance_allowed")
-
         if user_input is not None:
             return self.async_create_entry(title=DEFAULT_NAME, data={})
 

--- a/homeassistant/components/profiler/manifest.json
+++ b/homeassistant/components/profiler/manifest.json
@@ -9,5 +9,6 @@
     "pyprof2calltree==1.4.5",
     "guppy3==3.1.4.post1",
     "objgraph==3.5.0"
-  ]
+  ],
+  "single_config_entry": true
 }

--- a/homeassistant/components/profiler/strings.json
+++ b/homeassistant/components/profiler/strings.json
@@ -4,9 +4,6 @@
       "user": {
         "description": "[%key:common::config_flow::description::confirm_setup%]"
       }
-    },
-    "abort": {
-      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
     }
   },
   "services": {

--- a/homeassistant/components/radio_browser/config_flow.py
+++ b/homeassistant/components/radio_browser/config_flow.py
@@ -18,9 +18,6 @@ class RadioBrowserConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle the initial step."""
-        if self._async_current_entries():
-            return self.async_abort(reason="single_instance_allowed")
-
         if user_input is not None:
             return self.async_create_entry(title="Radio Browser", data={})
 

--- a/homeassistant/components/radio_browser/manifest.json
+++ b/homeassistant/components/radio_browser/manifest.json
@@ -6,5 +6,6 @@
   "documentation": "https://www.home-assistant.io/integrations/radio_browser",
   "integration_type": "service",
   "iot_class": "cloud_polling",
-  "requirements": ["radios==0.3.1", "pycountry==23.12.11"]
+  "requirements": ["radios==0.3.1", "pycountry==23.12.11"],
+  "single_config_entry": true
 }

--- a/homeassistant/components/radio_browser/strings.json
+++ b/homeassistant/components/radio_browser/strings.json
@@ -4,9 +4,6 @@
       "user": {
         "description": "Do you want to add Radio Browser to Home Assistant?"
       }
-    },
-    "abort": {
-      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
     }
   }
 }

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -3098,7 +3098,8 @@
       "name": "Everything but the Kitchen Sink",
       "integration_type": "hub",
       "config_flow": false,
-      "iot_class": "calculated"
+      "iot_class": "calculated",
+      "single_config_entry": true
     },
     "kiwi": {
       "name": "KIWI",
@@ -3212,7 +3213,8 @@
       "name": "Launch Library",
       "integration_type": "service",
       "config_flow": true,
-      "iot_class": "cloud_polling"
+      "iot_class": "cloud_polling",
+      "single_config_entry": true
     },
     "laundrify": {
       "name": "laundrify",
@@ -3354,7 +3356,8 @@
       "name": "LiteJet",
       "integration_type": "hub",
       "config_flow": true,
-      "iot_class": "local_push"
+      "iot_class": "local_push",
+      "single_config_entry": true
     },
     "litterrobot": {
       "name": "Litter-Robot",
@@ -3388,7 +3391,8 @@
     "local_ip": {
       "integration_type": "hub",
       "config_flow": true,
-      "iot_class": "local_polling"
+      "iot_class": "local_polling",
+      "single_config_entry": true
     },
     "local_todo": {
       "integration_type": "hub",
@@ -4239,7 +4243,8 @@
       "name": "NZBGet",
       "integration_type": "hub",
       "config_flow": true,
-      "iot_class": "local_polling"
+      "iot_class": "local_polling",
+      "single_config_entry": true
     },
     "oasa_telematics": {
       "name": "OASA Telematics",
@@ -4287,7 +4292,8 @@
       "name": "Hayward Omnilogic",
       "integration_type": "hub",
       "config_flow": true,
-      "iot_class": "cloud_polling"
+      "iot_class": "cloud_polling",
+      "single_config_entry": true
     },
     "oncue": {
       "name": "Oncue by Kohler",
@@ -4299,7 +4305,8 @@
       "name": "Ondilo ICO",
       "integration_type": "hub",
       "config_flow": true,
-      "iot_class": "cloud_polling"
+      "iot_class": "cloud_polling",
+      "single_config_entry": true
     },
     "onewire": {
       "name": "1-Wire",
@@ -4507,7 +4514,8 @@
       "name": "OwnTracks",
       "integration_type": "hub",
       "config_flow": true,
-      "iot_class": "local_push"
+      "iot_class": "local_push",
+      "single_config_entry": true
     },
     "p1_monitor": {
       "name": "P1 Monitor",
@@ -4722,7 +4730,8 @@
     "profiler": {
       "name": "Profiler",
       "integration_type": "hub",
-      "config_flow": true
+      "config_flow": true,
+      "single_config_entry": true
     },
     "progettihwsw": {
       "name": "ProgettiHWSW Automation",
@@ -4937,7 +4946,8 @@
       "name": "Radio Browser",
       "integration_type": "service",
       "config_flow": true,
-      "iot_class": "cloud_polling"
+      "iot_class": "cloud_polling",
+      "single_config_entry": true
     },
     "radiotherm": {
       "name": "Radio Thermostat",

--- a/tests/components/owntracks/test_config_flow.py
+++ b/tests/components/owntracks/test_config_flow.py
@@ -94,13 +94,14 @@ async def test_import_setup(hass: HomeAssistant) -> None:
 
 async def test_abort_if_already_setup(hass: HomeAssistant) -> None:
     """Test that we can't add more than one instance."""
-    flow = await init_config_flow(hass)
-
     MockConfigEntry(domain=DOMAIN, data={}).add_to_hass(hass)
     assert hass.config_entries.async_entries(DOMAIN)
 
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
     # Should fail, already setup (flow)
-    result = await flow.async_step_user({})
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "single_instance_allowed"
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Found during while working on #128060. We can mark an integration as [`single_config_entry`](https://developers.home-assistant.io/docs/creating_integration_manifest/#single-config-entry-only) in the manifest, instead of checking for existing config entries and abort the config flow.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
