### PR TITLE
Mark integrations as single_config_entry in manifest [r-z]

### DIFF
--- a/homeassistant/components/rtsp_to_webrtc/config_flow.py
+++ b/homeassistant/components/rtsp_to_webrtc/config_flow.py
@@ -36,6 +36,9 @@ class RTSPToWebRTCConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Configure the RTSPtoWebRTC server url."""
+        if self._async_current_entries():
+            return self.async_abort(reason="single_instance_allowed")
+
         if user_input is None:
             return self.async_show_form(step_id="user", data_schema=DATA_SCHEMA)
 
@@ -78,6 +81,9 @@ class RTSPToWebRTCConfigFlow(ConfigFlow, domain=DOMAIN):
         self, discovery_info: HassioServiceInfo
     ) -> ConfigFlowResult:
         """Prepare configuration for the RTSPtoWebRTC server add-on discovery."""
+        if self._async_current_entries():
+            return self.async_abort(reason="single_instance_allowed")
+
         self._hassio_discovery = discovery_info.config
         return await self.async_step_hassio_confirm()
 

--- a/homeassistant/components/rtsp_to_webrtc/config_flow.py
+++ b/homeassistant/components/rtsp_to_webrtc/config_flow.py
@@ -36,9 +36,6 @@ class RTSPToWebRTCConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Configure the RTSPtoWebRTC server url."""
-        if self._async_current_entries():
-            return self.async_abort(reason="single_instance_allowed")
-
         if user_input is None:
             return self.async_show_form(step_id="user", data_schema=DATA_SCHEMA)
 
@@ -81,9 +78,6 @@ class RTSPToWebRTCConfigFlow(ConfigFlow, domain=DOMAIN):
         self, discovery_info: HassioServiceInfo
     ) -> ConfigFlowResult:
         """Prepare configuration for the RTSPtoWebRTC server add-on discovery."""
-        if self._async_current_entries():
-            return self.async_abort(reason="single_instance_allowed")
-
         self._hassio_discovery = discovery_info.config
         return await self.async_step_hassio_confirm()
 

--- a/homeassistant/components/rtsp_to_webrtc/manifest.json
+++ b/homeassistant/components/rtsp_to_webrtc/manifest.json
@@ -7,6 +7,5 @@
   "documentation": "https://www.home-assistant.io/integrations/rtsp_to_webrtc",
   "iot_class": "local_push",
   "loggers": ["rtsp_to_webrtc"],
-  "requirements": ["rtsp-to-webrtc==0.5.1"],
-  "single_config_entry": true
+  "requirements": ["rtsp-to-webrtc==0.5.1"]
 }

--- a/homeassistant/components/rtsp_to_webrtc/manifest.json
+++ b/homeassistant/components/rtsp_to_webrtc/manifest.json
@@ -7,5 +7,6 @@
   "documentation": "https://www.home-assistant.io/integrations/rtsp_to_webrtc",
   "iot_class": "local_push",
   "loggers": ["rtsp_to_webrtc"],
-  "requirements": ["rtsp-to-webrtc==0.5.1"]
+  "requirements": ["rtsp-to-webrtc==0.5.1"],
+  "single_config_entry": true
 }

--- a/homeassistant/components/rtsp_to_webrtc/strings.json
+++ b/homeassistant/components/rtsp_to_webrtc/strings.json
@@ -19,6 +19,7 @@
       "server_unreachable": "Unable to communicate with RTSPtoWebRTC server. Check logs for more information."
     },
     "abort": {
+      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
       "server_failure": "[%key:component::rtsp_to_webrtc::config::error::server_failure%]",
       "server_unreachable": "[%key:component::rtsp_to_webrtc::config::error::server_unreachable%]"
     }

--- a/homeassistant/components/rtsp_to_webrtc/strings.json
+++ b/homeassistant/components/rtsp_to_webrtc/strings.json
@@ -19,7 +19,6 @@
       "server_unreachable": "Unable to communicate with RTSPtoWebRTC server. Check logs for more information."
     },
     "abort": {
-      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
       "server_failure": "[%key:component::rtsp_to_webrtc::config::error::server_failure%]",
       "server_unreachable": "[%key:component::rtsp_to_webrtc::config::error::server_unreachable%]"
     }

--- a/homeassistant/components/sentry/config_flow.py
+++ b/homeassistant/components/sentry/config_flow.py
@@ -55,9 +55,6 @@ class SentryConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle a user config flow."""
-        if self._async_current_entries():
-            return self.async_abort(reason="single_instance_allowed")
-
         errors = {}
         if user_input is not None:
             try:

--- a/homeassistant/components/sentry/manifest.json
+++ b/homeassistant/components/sentry/manifest.json
@@ -6,5 +6,6 @@
   "documentation": "https://www.home-assistant.io/integrations/sentry",
   "integration_type": "service",
   "iot_class": "cloud_polling",
-  "requirements": ["sentry-sdk==1.40.3"]
+  "requirements": ["sentry-sdk==1.40.3"],
+  "single_config_entry": true
 }

--- a/homeassistant/components/sentry/strings.json
+++ b/homeassistant/components/sentry/strings.json
@@ -10,9 +10,6 @@
     "error": {
       "unknown": "[%key:common::config_flow::error::unknown%]",
       "bad_dsn": "Invalid DSN"
-    },
-    "abort": {
-      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
     }
   },
   "options": {

--- a/homeassistant/components/slimproto/config_flow.py
+++ b/homeassistant/components/slimproto/config_flow.py
@@ -18,8 +18,5 @@ class SlimProtoConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle the initial step."""
-        if self._async_current_entries():
-            return self.async_abort(reason="single_instance_allowed")
-
         # we have nothing to configure so simply create the entry
         return self.async_create_entry(title=DEFAULT_NAME, data={})

--- a/homeassistant/components/slimproto/manifest.json
+++ b/homeassistant/components/slimproto/manifest.json
@@ -6,5 +6,6 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/slimproto",
   "iot_class": "local_push",
-  "requirements": ["aioslimproto==3.0.0"]
+  "requirements": ["aioslimproto==3.0.0"],
+  "single_config_entry": true
 }

--- a/homeassistant/components/slimproto/strings.json
+++ b/homeassistant/components/slimproto/strings.json
@@ -1,10 +1,1 @@
-{
-  "config": {
-    "step": {
-      "user": {}
-    },
-    "abort": {
-      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
-    }
-  }
-}
+{}

--- a/homeassistant/components/sms/config_flow.py
+++ b/homeassistant/components/sms/config_flow.py
@@ -61,8 +61,6 @@ class SMSFlowHandler(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle the initial step."""
-        if self._async_current_entries():
-            return self.async_abort(reason="single_instance_allowed")
         errors = {}
         if user_input is not None:
             try:

--- a/homeassistant/components/sms/manifest.json
+++ b/homeassistant/components/sms/manifest.json
@@ -6,5 +6,6 @@
   "documentation": "https://www.home-assistant.io/integrations/sms",
   "iot_class": "local_polling",
   "loggers": ["gammu"],
-  "requirements": ["python-gammu==3.2.4"]
+  "requirements": ["python-gammu==3.2.4"],
+  "single_config_entry": true
 }

--- a/homeassistant/components/sms/strings.json
+++ b/homeassistant/components/sms/strings.json
@@ -14,8 +14,7 @@
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
-      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
     }
   },
   "entity": {

--- a/homeassistant/components/speedtestdotnet/config_flow.py
+++ b/homeassistant/components/speedtestdotnet/config_flow.py
@@ -36,9 +36,6 @@ class SpeedTestFlowHandler(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle a flow initialized by the user."""
-        if self._async_current_entries():
-            return self.async_abort(reason="single_instance_allowed")
-
         if user_input is None:
             return self.async_show_form(step_id="user")
 

--- a/homeassistant/components/speedtestdotnet/manifest.json
+++ b/homeassistant/components/speedtestdotnet/manifest.json
@@ -5,5 +5,6 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/speedtestdotnet",
   "iot_class": "cloud_polling",
-  "requirements": ["speedtest-cli==2.1.3"]
+  "requirements": ["speedtest-cli==2.1.3"],
+  "single_config_entry": true
 }

--- a/homeassistant/components/speedtestdotnet/strings.json
+++ b/homeassistant/components/speedtestdotnet/strings.json
@@ -4,9 +4,6 @@
       "user": {
         "description": "[%key:common::config_flow::description::confirm_setup%]"
       }
-    },
-    "abort": {
-      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
     }
   },
   "options": {

--- a/homeassistant/components/tasmota/config_flow.py
+++ b/homeassistant/components/tasmota/config_flow.py
@@ -26,9 +26,6 @@ class FlowHandler(ConfigFlow, domain=DOMAIN):
         self, discovery_info: MqttServiceInfo
     ) -> ConfigFlowResult:
         """Handle a flow initialized by MQTT discovery."""
-        if self._async_in_progress() or self._async_current_entries():
-            return self.async_abort(reason="single_instance_allowed")
-
         await self.async_set_unique_id(DOMAIN)
 
         # Validate the message, abort if it fails
@@ -49,9 +46,6 @@ class FlowHandler(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle a flow initialized by the user."""
-        if self._async_current_entries():
-            return self.async_abort(reason="single_instance_allowed")
-
         if self.show_advanced_options:
             return await self.async_step_config()
         return await self.async_step_confirm()

--- a/homeassistant/components/tasmota/manifest.json
+++ b/homeassistant/components/tasmota/manifest.json
@@ -8,5 +8,6 @@
   "iot_class": "local_push",
   "loggers": ["hatasmota"],
   "mqtt": ["tasmota/discovery/#"],
-  "requirements": ["HATasmota==0.9.2"]
+  "requirements": ["HATasmota==0.9.2"],
+  "single_config_entry": true
 }

--- a/homeassistant/components/tasmota/strings.json
+++ b/homeassistant/components/tasmota/strings.json
@@ -10,9 +10,6 @@
         }
       }
     },
-    "abort": {
-      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
-    },
     "error": {
       "invalid_discovery_topic": "Invalid discovery topic prefix."
     }

--- a/homeassistant/components/todoist/config_flow.py
+++ b/homeassistant/components/todoist/config_flow.py
@@ -33,9 +33,6 @@ class TodoistConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle the initial step."""
-        if self._async_current_entries():
-            return self.async_abort(reason="single_instance_allowed")
-
         errors: dict[str, str] = {}
         if user_input is not None:
             api = TodoistAPIAsync(user_input[CONF_TOKEN])

--- a/homeassistant/components/todoist/manifest.json
+++ b/homeassistant/components/todoist/manifest.json
@@ -6,5 +6,6 @@
   "documentation": "https://www.home-assistant.io/integrations/todoist",
   "iot_class": "cloud_polling",
   "loggers": ["todoist"],
-  "requirements": ["todoist-api-python==2.1.2"]
+  "requirements": ["todoist-api-python==2.1.2"],
+  "single_config_entry": true
 }

--- a/homeassistant/components/todoist/strings.json
+++ b/homeassistant/components/todoist/strings.json
@@ -13,9 +13,6 @@
       "invalid_api_key": "[%key:common::config_flow::error::invalid_api_key%]",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
-    "abort": {
-      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
-    },
     "create_entry": {
       "default": "[%key:common::config_flow::create_entry::authenticated%]"
     }

--- a/homeassistant/components/vesync/config_flow.py
+++ b/homeassistant/components/vesync/config_flow.py
@@ -38,9 +38,6 @@ class VeSyncFlowHandler(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle a flow start."""
-        if self._async_current_entries():
-            return self.async_abort(reason="single_instance_allowed")
-
         if not user_input:
             return self._show_form()
 

--- a/homeassistant/components/vesync/manifest.json
+++ b/homeassistant/components/vesync/manifest.json
@@ -6,5 +6,6 @@
   "documentation": "https://www.home-assistant.io/integrations/vesync",
   "iot_class": "cloud_polling",
   "loggers": ["pyvesync"],
-  "requirements": ["pyvesync==2.1.12"]
+  "requirements": ["pyvesync==2.1.12"],
+  "single_config_entry": true
 }

--- a/homeassistant/components/vesync/strings.json
+++ b/homeassistant/components/vesync/strings.json
@@ -11,9 +11,6 @@
     },
     "error": {
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]"
-    },
-    "abort": {
-      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
     }
   },
   "entity": {

--- a/homeassistant/components/vicare/config_flow.py
+++ b/homeassistant/components/vicare/config_flow.py
@@ -56,9 +56,6 @@ class ViCareConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Invoke when a user initiates a flow via the user interface."""
-        if self._async_current_entries():
-            return self.async_abort(reason="single_instance_allowed")
-
         errors: dict[str, str] = {}
 
         if user_input is not None:
@@ -126,8 +123,5 @@ class ViCareConfigFlow(ConfigFlow, domain=DOMAIN):
 
         await self.async_set_unique_id(formatted_mac)
         self._abort_if_unique_id_configured()
-
-        if self._async_current_entries():
-            return self.async_abort(reason="single_instance_allowed")
 
         return await self.async_step_user()

--- a/homeassistant/components/vicare/manifest.json
+++ b/homeassistant/components/vicare/manifest.json
@@ -11,5 +11,6 @@
   "documentation": "https://www.home-assistant.io/integrations/vicare",
   "iot_class": "cloud_polling",
   "loggers": ["PyViCare"],
-  "requirements": ["PyViCare==2.34.0"]
+  "requirements": ["PyViCare==2.34.0"],
+  "single_config_entry": true
 }

--- a/homeassistant/components/vicare/strings.json
+++ b/homeassistant/components/vicare/strings.json
@@ -23,7 +23,6 @@
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]"
     },
     "abort": {
-      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     }

--- a/homeassistant/components/voip/config_flow.py
+++ b/homeassistant/components/voip/config_flow.py
@@ -28,9 +28,6 @@ class VoIPConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle the initial step."""
-        if self._async_current_entries():
-            return self.async_abort(reason="single_instance_allowed")
-
         if user_input is None:
             return self.async_show_form(
                 step_id="user",

--- a/homeassistant/components/voip/manifest.json
+++ b/homeassistant/components/voip/manifest.json
@@ -7,5 +7,6 @@
   "documentation": "https://www.home-assistant.io/integrations/voip",
   "iot_class": "local_push",
   "quality_scale": "internal",
-  "requirements": ["voip-utils==0.1.0"]
+  "requirements": ["voip-utils==0.1.0"],
+  "single_config_entry": true
 }

--- a/homeassistant/components/voip/strings.json
+++ b/homeassistant/components/voip/strings.json
@@ -4,9 +4,6 @@
       "user": {
         "description": "Receive Voice over IP calls to interact with Assist."
       }
-    },
-    "abort": {
-      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
     }
   },
   "entity": {

--- a/homeassistant/components/weatherflow/config_flow.py
+++ b/homeassistant/components/weatherflow/config_flow.py
@@ -51,12 +51,6 @@ class WeatherFlowConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle a flow initialized by the user."""
-
-        # Only allow a single instance of integration since the listener
-        # will pick up all devices on the network and we don't want to
-        # create multiple entries.
-        if self._async_current_entries():
-            return self.async_abort(reason="single_instance_allowed")
         found = False
         errors = {}
         try:

--- a/homeassistant/components/weatherflow/manifest.json
+++ b/homeassistant/components/weatherflow/manifest.json
@@ -7,5 +7,6 @@
   "integration_type": "hub",
   "iot_class": "local_push",
   "loggers": ["pyweatherflowudp"],
-  "requirements": ["pyweatherflowudp==1.4.5"]
+  "requirements": ["pyweatherflowudp==1.4.5"],
+  "single_config_entry": true
 }

--- a/homeassistant/components/weatherflow/strings.json
+++ b/homeassistant/components/weatherflow/strings.json
@@ -16,7 +16,6 @@
       "cannot_connect": "UDP discovery error."
     },
     "abort": {
-      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
       "no_devices_found": "[%key:common::config_flow::abort::no_devices_found%]"
     }
   },

--- a/homeassistant/components/xbox/config_flow.py
+++ b/homeassistant/components/xbox/config_flow.py
@@ -32,8 +32,4 @@ class OAuth2FlowHandler(
     ) -> ConfigFlowResult:
         """Handle a flow start."""
         await self.async_set_unique_id(DOMAIN)
-
-        if self._async_current_entries():
-            return self.async_abort(reason="single_instance_allowed")
-
         return await super().async_step_user(user_input)

--- a/homeassistant/components/xbox/manifest.json
+++ b/homeassistant/components/xbox/manifest.json
@@ -6,5 +6,6 @@
   "dependencies": ["auth", "application_credentials"],
   "documentation": "https://www.home-assistant.io/integrations/xbox",
   "iot_class": "cloud_polling",
-  "requirements": ["xbox-webapi==2.0.11"]
+  "requirements": ["xbox-webapi==2.0.11"],
+  "single_config_entry": true
 }

--- a/homeassistant/components/xbox/strings.json
+++ b/homeassistant/components/xbox/strings.json
@@ -6,7 +6,6 @@
       }
     },
     "abort": {
-      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
       "missing_configuration": "[%key:common::config_flow::abort::oauth2_missing_configuration%]",
       "authorize_url_timeout": "[%key:common::config_flow::abort::oauth2_authorize_url_timeout%]",
       "oauth_error": "[%key:common::config_flow::abort::oauth2_error%]",

--- a/homeassistant/components/zodiac/config_flow.py
+++ b/homeassistant/components/zodiac/config_flow.py
@@ -18,9 +18,6 @@ class ZodiacConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle a flow initialized by the user."""
-        if self._async_current_entries():
-            return self.async_abort(reason="single_instance_allowed")
-
         if user_input is not None:
             return self.async_create_entry(title=DEFAULT_NAME, data={})
 

--- a/homeassistant/components/zodiac/manifest.json
+++ b/homeassistant/components/zodiac/manifest.json
@@ -5,5 +5,6 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/zodiac",
   "iot_class": "calculated",
-  "quality_scale": "silver"
+  "quality_scale": "silver",
+  "single_config_entry": true
 }

--- a/homeassistant/components/zodiac/strings.json
+++ b/homeassistant/components/zodiac/strings.json
@@ -5,9 +5,6 @@
       "user": {
         "description": "[%key:common::config_flow::description::confirm_setup%]"
       }
-    },
-    "abort": {
-      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
     }
   },
   "entity": {

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -5225,7 +5225,8 @@
       "name": "RTSPtoWebRTC",
       "integration_type": "hub",
       "config_flow": true,
-      "iot_class": "local_push"
+      "iot_class": "local_push",
+      "single_config_entry": true
     },
     "ruckus_unleashed": {
       "name": "Ruckus",
@@ -5421,7 +5422,8 @@
       "name": "Sentry",
       "integration_type": "service",
       "config_flow": true,
-      "iot_class": "cloud_polling"
+      "iot_class": "cloud_polling",
+      "single_config_entry": true
     },
     "senz": {
       "name": "nVent RAYCHEM SENZ",
@@ -5604,7 +5606,8 @@
       "name": "SlimProto (Squeezebox players)",
       "integration_type": "hub",
       "config_flow": true,
-      "iot_class": "local_push"
+      "iot_class": "local_push",
+      "single_config_entry": true
     },
     "sma": {
       "name": "SMA Solar",
@@ -5673,7 +5676,8 @@
       "name": "SMS notifications via GSM-modem",
       "integration_type": "hub",
       "config_flow": true,
-      "iot_class": "local_polling"
+      "iot_class": "local_polling",
+      "single_config_entry": true
     },
     "smtp": {
       "name": "SMTP",
@@ -5819,7 +5823,8 @@
       "name": "Speedtest.net",
       "integration_type": "hub",
       "config_flow": true,
-      "iot_class": "cloud_polling"
+      "iot_class": "cloud_polling",
+      "single_config_entry": true
     },
     "splunk": {
       "name": "Splunk",
@@ -6105,7 +6110,8 @@
       "name": "Tasmota",
       "integration_type": "hub",
       "config_flow": true,
-      "iot_class": "local_push"
+      "iot_class": "local_push",
+      "single_config_entry": true
     },
     "tautulli": {
       "name": "Tautulli",
@@ -6328,7 +6334,8 @@
       "name": "Todoist",
       "integration_type": "hub",
       "config_flow": true,
-      "iot_class": "cloud_polling"
+      "iot_class": "cloud_polling",
+      "single_config_entry": true
     },
     "tolo": {
       "name": "TOLO Sauna",
@@ -6713,7 +6720,8 @@
       "name": "VeSync",
       "integration_type": "hub",
       "config_flow": true,
-      "iot_class": "cloud_polling"
+      "iot_class": "cloud_polling",
+      "single_config_entry": true
     },
     "viaggiatreno": {
       "name": "Trenitalia ViaggiaTreno",
@@ -6725,7 +6733,8 @@
       "name": "Viessmann ViCare",
       "integration_type": "hub",
       "config_flow": true,
-      "iot_class": "cloud_polling"
+      "iot_class": "cloud_polling",
+      "single_config_entry": true
     },
     "vilfo": {
       "name": "Vilfo Router",
@@ -6778,7 +6787,8 @@
       "name": "Voice over IP",
       "integration_type": "hub",
       "config_flow": true,
-      "iot_class": "local_push"
+      "iot_class": "local_push",
+      "single_config_entry": true
     },
     "volkszaehler": {
       "name": "Volkszaehler",
@@ -7218,7 +7228,8 @@
     "zodiac": {
       "integration_type": "hub",
       "config_flow": true,
-      "iot_class": "calculated"
+      "iot_class": "calculated",
+      "single_config_entry": true
     },
     "zondergas": {
       "name": "ZonderGas",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -5225,8 +5225,7 @@
       "name": "RTSPtoWebRTC",
       "integration_type": "hub",
       "config_flow": true,
-      "iot_class": "local_push",
-      "single_config_entry": true
+      "iot_class": "local_push"
     },
     "ruckus_unleashed": {
       "name": "Ruckus",

--- a/tests/components/vesync/test_config_flow.py
+++ b/tests/components/vesync/test_config_flow.py
@@ -3,6 +3,7 @@
 from unittest.mock import patch
 
 from homeassistant.components.vesync import DOMAIN, config_flow
+from homeassistant.config_entries import SOURCE_USER
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -12,13 +13,12 @@ from tests.common import MockConfigEntry
 
 async def test_abort_already_setup(hass: HomeAssistant) -> None:
     """Test if we abort because component is already setup."""
-    flow = config_flow.VeSyncFlowHandler()
-    flow.hass = hass
     MockConfigEntry(domain=DOMAIN, title="user", data={"user": "pass"}).add_to_hass(
         hass
     )
-    result = await flow.async_step_user()
-
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "single_instance_allowed"
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Found during while working on #128060. We can mark an integration as [`single_config_entry`](https://developers.home-assistant.io/docs/creating_integration_manifest/#single-config-entry-only) in the manifest, instead of checking for existing config entries and abort the config flow.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
