### PR TITLE
Mark integrations as single_config_entry in manifest [system integrations]

### DIFF
--- a/homeassistant/components/hardkernel/config_flow.py
+++ b/homeassistant/components/hardkernel/config_flow.py
@@ -18,7 +18,4 @@ class HardkernelConfigFlow(ConfigFlow, domain=DOMAIN):
         self, data: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle the initial step."""
-        if self._async_current_entries():
-            return self.async_abort(reason="single_instance_allowed")
-
         return self.async_create_entry(title="Hardkernel", data={})

--- a/homeassistant/components/hardkernel/manifest.json
+++ b/homeassistant/components/hardkernel/manifest.json
@@ -6,5 +6,6 @@
   "config_flow": false,
   "dependencies": ["hardware"],
   "documentation": "https://www.home-assistant.io/integrations/hardkernel",
-  "integration_type": "hardware"
+  "integration_type": "hardware",
+  "single_config_entry": true
 }

--- a/homeassistant/components/homeassistant_green/config_flow.py
+++ b/homeassistant/components/homeassistant_green/config_flow.py
@@ -55,9 +55,6 @@ class HomeAssistantGreenConfigFlow(ConfigFlow, domain=DOMAIN):
         self, data: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle the initial step."""
-        if self._async_current_entries():
-            return self.async_abort(reason="single_instance_allowed")
-
         return self.async_create_entry(title="Home Assistant Green", data={})
 
 

--- a/homeassistant/components/homeassistant_green/manifest.json
+++ b/homeassistant/components/homeassistant_green/manifest.json
@@ -6,5 +6,6 @@
   "config_flow": false,
   "dependencies": ["hardware", "homeassistant_hardware"],
   "documentation": "https://www.home-assistant.io/integrations/homeassistant_green",
-  "integration_type": "hardware"
+  "integration_type": "hardware",
+  "single_config_entry": true
 }

--- a/homeassistant/components/homeassistant_green/strings.json
+++ b/homeassistant/components/homeassistant_green/strings.json
@@ -21,7 +21,6 @@
     "abort": {
       "not_hassio": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::abort::not_hassio%]",
       "read_hw_settings_error": "Failed to read hardware settings",
-      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
       "write_hw_settings_error": "Failed to write hardware settings"
     }
   }

--- a/homeassistant/components/homeassistant_yellow/config_flow.py
+++ b/homeassistant/components/homeassistant_yellow/config_flow.py
@@ -77,9 +77,6 @@ class HomeAssistantYellowConfigFlow(BaseFirmwareConfigFlow, domain=DOMAIN):
         self, data: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle the initial step."""
-        if self._async_current_entries():
-            return self.async_abort(reason="single_instance_allowed")
-
         # We do not actually use any portion of `BaseFirmwareConfigFlow` beyond this
         await self._probe_firmware_type()
 

--- a/homeassistant/components/homeassistant_yellow/manifest.json
+++ b/homeassistant/components/homeassistant_yellow/manifest.json
@@ -6,5 +6,6 @@
   "config_flow": false,
   "dependencies": ["hardware", "homeassistant_hardware"],
   "documentation": "https://www.home-assistant.io/integrations/homeassistant_yellow",
-  "integration_type": "hardware"
+  "integration_type": "hardware",
+  "single_config_entry": true
 }

--- a/homeassistant/components/rhasspy/config_flow.py
+++ b/homeassistant/components/rhasspy/config_flow.py
@@ -20,9 +20,6 @@ class RhasspyConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle the initial step."""
-        if self._async_current_entries():
-            return self.async_abort(reason="single_instance_allowed")
-
         if user_input is None:
             return self.async_show_form(step_id="user", data_schema=vol.Schema({}))
 

--- a/homeassistant/components/rhasspy/manifest.json
+++ b/homeassistant/components/rhasspy/manifest.json
@@ -5,5 +5,6 @@
   "config_flow": true,
   "dependencies": ["intent"],
   "documentation": "https://www.home-assistant.io/integrations/rhasspy",
-  "iot_class": "local_push"
+  "iot_class": "local_push",
+  "single_config_entry": true
 }

--- a/homeassistant/components/rhasspy/strings.json
+++ b/homeassistant/components/rhasspy/strings.json
@@ -4,9 +4,6 @@
       "user": {
         "description": "Do you want to enable Rhasspy support?"
       }
-    },
-    "abort": {
-      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
     }
   }
 }

--- a/homeassistant/components/rpi_power/config_flow.py
+++ b/homeassistant/components/rpi_power/config_flow.py
@@ -37,8 +37,6 @@ class RPiPowerFlow(DiscoveryFlowHandler[Awaitable[bool]], domain=DOMAIN):
         self, data: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle a flow initialized by onboarding."""
-        if self._async_current_entries():
-            return self.async_abort(reason="single_instance_allowed")
         has_devices = await self._discovery_function(self.hass)
 
         if not has_devices:

--- a/homeassistant/components/rpi_power/manifest.json
+++ b/homeassistant/components/rpi_power/manifest.json
@@ -6,5 +6,6 @@
   "documentation": "https://www.home-assistant.io/integrations/rpi_power",
   "iot_class": "local_polling",
   "loggers": ["rpi_bad_power"],
-  "requirements": ["rpi-bad-power==0.1.0"]
+  "requirements": ["rpi-bad-power==0.1.0"],
+  "single_config_entry": true
 }

--- a/homeassistant/components/rpi_power/strings.json
+++ b/homeassistant/components/rpi_power/strings.json
@@ -7,7 +7,6 @@
       }
     },
     "abort": {
-      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
       "no_devices_found": "Can't find the system class needed for this component, make sure that your kernel is recent and the hardware is supported"
     }
   }

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -5112,7 +5112,8 @@
       "name": "Rhasspy",
       "integration_type": "hub",
       "config_flow": true,
-      "iot_class": "local_push"
+      "iot_class": "local_push",
+      "single_config_entry": true
     },
     "ridwell": {
       "name": "Ridwell",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Found during while working on #128060. We can mark an integration as [`single_config_entry`](https://developers.home-assistant.io/docs/creating_integration_manifest/#single-config-entry-only) in the manifest, instead of checking for existing config entries and abort the config flow.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
