### PR TITLE
Fix hassio data fetching over list[Repository]

### DIFF
--- a/homeassistant/components/hassio/coordinator.py
+++ b/homeassistant/components/hassio/coordinator.py
@@ -337,7 +337,7 @@ class HassioDataUpdateCoordinator(DataUpdateCoordinator):
 
         if store_data:
             repositories = {
-                repo[ATTR_SLUG]: repo[ATTR_NAME]
+                repo.slug: repo.name
                 for repo in StoreInfo.from_dict(store_data).repositories
             }
         else:

--- a/tests/components/conftest.py
+++ b/tests/components/conftest.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
-from aiohasupervisor.models import StoreInfo
+from aiohasupervisor.models import Repository, StoreAddon, StoreInfo
 import pytest
 
 from homeassistant.const import STATE_OFF, STATE_ON
@@ -407,10 +407,28 @@ def update_addon_fixture() -> Generator[AsyncMock]:
     yield from mock_update_addon()
 
 
+@pytest.fixture(name="store_addons")
+def store_addons_fixture() -> list[StoreAddon]:
+    """Mock store addons list."""
+    return []
+
+
+@pytest.fixture(name="store_repositories")
+def store_repositories_fixture() -> list[Repository]:
+    """Mock store repositories list."""
+    return []
+
+
 @pytest.fixture(name="store_info")
-def store_info_fixture(supervisor_client: AsyncMock) -> AsyncMock:
+def store_info_fixture(
+    supervisor_client: AsyncMock,
+    store_addons: list[StoreAddon],
+    store_repositories: list[Repository],
+) -> AsyncMock:
     """Mock store info."""
-    supervisor_client.store.info.return_value = StoreInfo(addons=[], repositories=[])
+    supervisor_client.store.info.return_value = StoreInfo(
+        addons=store_addons, repositories=store_repositories
+    )
     return supervisor_client.store.info
 
 

--- a/tests/components/hassio/common.py
+++ b/tests/components/hassio/common.py
@@ -9,7 +9,13 @@ from types import MethodType
 from typing import Any
 from unittest.mock import DEFAULT, AsyncMock, Mock, patch
 
-from aiohasupervisor.models import InstalledAddonComplete, StoreAddonComplete
+from aiohasupervisor.models import (
+    AddonStage,
+    InstalledAddonComplete,
+    Repository,
+    StoreAddon,
+    StoreAddonComplete,
+)
 
 from homeassistant.components.hassio.addon_manager import AddonManager
 from homeassistant.core import HomeAssistant
@@ -17,6 +23,39 @@ from homeassistant.core import HomeAssistant
 LOGGER = logging.getLogger(__name__)
 INSTALLED_ADDON_FIELDS = [field.name for field in fields(InstalledAddonComplete)]
 STORE_ADDON_FIELDS = [field.name for field in fields(StoreAddonComplete)]
+
+MOCK_STORE_ADDONS = [
+    StoreAddon(
+        name="test",
+        arch=[],
+        documentation=False,
+        advanced=False,
+        available=True,
+        build=False,
+        description="Test add-on service",
+        homeassistant=None,
+        icon=False,
+        logo=False,
+        repository="core",
+        slug="core_test",
+        stage=AddonStage.EXPERIMENTAL,
+        update_available=False,
+        url="https://example.com/addons/tree/master/test",
+        version_latest="1.0.0",
+        version="1.0.0",
+        installed=True,
+    )
+]
+
+MOCK_REPOSITORIES = [
+    Repository(
+        slug="core",
+        name="Official add-ons",
+        source="core",
+        url="https://home-assistant.io/addons",
+        maintainer="Home Assistant",
+    )
+]
 
 
 def mock_to_dict(obj: Mock, fields: list[str]) -> dict[str, Any]:

--- a/tests/components/hassio/test_binary_sensor.py
+++ b/tests/components/hassio/test_binary_sensor.py
@@ -10,6 +10,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
+from .common import MOCK_REPOSITORIES, MOCK_STORE_ADDONS
+
 from tests.common import MockConfigEntry
 from tests.test_util.aiohttp import AiohttpClientMocker
 
@@ -177,6 +179,9 @@ def mock_all(aioclient_mock: AiohttpClientMocker, addon_installed, store_info) -
     )
 
 
+@pytest.mark.parametrize(
+    ("store_addons", "store_repositories"), [(MOCK_STORE_ADDONS, MOCK_REPOSITORIES)]
+)
 @pytest.mark.parametrize(
     ("entity_id", "expected", "addon_state"),
     [

--- a/tests/components/hassio/test_sensor.py
+++ b/tests/components/hassio/test_sensor.py
@@ -21,6 +21,8 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
+from .common import MOCK_REPOSITORIES, MOCK_STORE_ADDONS
+
 from tests.common import MockConfigEntry, async_fire_time_changed
 from tests.test_util.aiohttp import AiohttpClientMocker
 
@@ -204,6 +206,9 @@ def _install_default_mocks(aioclient_mock: AiohttpClientMocker):
 
 
 @pytest.mark.parametrize(
+    ("store_addons", "store_repositories"), [(MOCK_STORE_ADDONS, MOCK_REPOSITORIES)]
+)
+@pytest.mark.parametrize(
     ("entity_id", "expected"),
     [
         ("sensor.home_assistant_operating_system_version", "1.0.0"),
@@ -261,6 +266,9 @@ async def test_sensor(
     assert state.state == expected
 
 
+@pytest.mark.parametrize(
+    ("store_addons", "store_repositories"), [(MOCK_STORE_ADDONS, MOCK_REPOSITORIES)]
+)
 @pytest.mark.parametrize(
     ("entity_id", "expected"),
     [


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes:

![afbeelding](https://github.com/user-attachments/assets/30ae6fad-060b-458e-a692-1893aa55bfbc)

```
2024-10-11 21:58:05.578 ERROR (MainThread) [homeassistant.components.hassio.coordinator] Unexpected error fetching hassio data
Traceback (most recent call last):
  File "/workspaces/core/homeassistant/helpers/update_coordinator.py", line 370, in _async_refresh
    self.data = await self._async_update_data()
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/core/homeassistant/components/hassio/coordinator.py", line 340, in _async_update_data
    repo[ATTR_SLUG]: repo[ATTR_NAME]
    ~~~~^^^^^^^^^^^
TypeError: 'Repository' object is not subscriptable
```

In

https://github.com/home-assistant/core/blob/9a59cba7f376aefa3c9cf767c0c3c73b6f8fee69/homeassistant/components/hassio/coordinator.py#L338-L342

The `repositories` attribute returns type `list[Repositiory]` but this is not subscriptable. It seems the `dict` now as a `dataclass`, and we can access the attributes `slug` and `name` directly.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
