### PR TITLE
Issue 6_group3_Refactoring support_mfa as a class level variable in homeassistant/auth/providers/__init__.py

### DIFF
--- a/.scannerwork/report-task.txt
+++ b/.scannerwork/report-task.txt
@@ -1,0 +1,6 @@
+projectKey=Ha-core
+serverUrl=http://localhost:9000
+serverVersion=10.6.0.92116
+dashboardUrl=http://localhost:9000/dashboard?id=Ha-core
+ceTaskId=d25d6e3a-8e20-4b1f-80dc-5de8bdc39d4b
+ceTaskUrl=http://localhost:9000/api/ce/task?id=d25d6e3a-8e20-4b1f-80dc-5de8bdc39d4b

--- a/homeassistant/components/alexa/capabilities.py
+++ b/homeassistant/components/alexa/capabilities.py
@@ -122,10 +122,10 @@ class AlexaCapability:
     supported_locales: set[str] = {"en-US"}
 
     def __init__(
-        self,
-        entity: State,
-        instance: str | None = None,
-        non_controllable_properties: bool | None = None,
+            self,
+            entity: State,
+            instance: str | None = None,
+            non_controllable_properties: bool | None = None,
     ) -> None:
         """Initialize an Alexa capability."""
         self.entity = entity
@@ -869,7 +869,7 @@ class AlexaInputController(AlexaCapability):
     def inputs(self) -> list[dict[str, str]] | None:
         """Return the list of valid supported inputs."""
         source_list: list[Any] = (
-            self.entity.attributes.get(media_player.ATTR_INPUT_SOURCE_LIST) or []
+                self.entity.attributes.get(media_player.ATTR_INPUT_SOURCE_LIST) or []
         )
         return AlexaInputController.get_valid_inputs(source_list)
 
@@ -1127,8 +1127,8 @@ class AlexaThermostatController(AlexaCapability):
             if supported & climate.ClimateEntityFeature.TARGET_TEMPERATURE:
                 properties.append({"name": "targetSetpoint"})
         elif (
-            self.entity.domain == water_heater.DOMAIN
-            and supported & water_heater.WaterHeaterEntityFeature.TARGET_TEMPERATURE
+                self.entity.domain == water_heater.DOMAIN
+                and supported & water_heater.WaterHeaterEntityFeature.TARGET_TEMPERATURE
         ):
             properties.append({"name": "targetSetpoint"})
         return properties
@@ -1389,7 +1389,7 @@ class AlexaModeController(AlexaCapability):
     }
 
     def __init__(
-        self, entity: State, instance: str, non_controllable: bool = False
+            self, entity: State, instance: str, non_controllable: bool = False
     ) -> None:
         """Initialize the entity."""
         AlexaCapability.__init__(self, entity, instance, non_controllable)
@@ -1412,76 +1412,101 @@ class AlexaModeController(AlexaCapability):
         """Return True if properties can be retrieved."""
         return True
 
-    def get_property(self, name: str) -> Any:
-        """Read and return a property."""
-        if name != "mode":
-            raise UnsupportedProperty(name)
-
+    def get_fan_direction(self) -> Any:
         # Fan Direction
         if self.instance == f"{fan.DOMAIN}.{fan.ATTR_DIRECTION}":
             mode = self.entity.attributes.get(fan.ATTR_DIRECTION, None)
             if mode in (fan.DIRECTION_FORWARD, fan.DIRECTION_REVERSE, STATE_UNKNOWN):
                 return f"{fan.ATTR_DIRECTION}.{mode}"
+        return None
 
+    def get_fan_preset_mode(self) -> Any:
         # Fan preset_mode
         if self.instance == f"{fan.DOMAIN}.{fan.ATTR_PRESET_MODE}":
             mode = self.entity.attributes.get(fan.ATTR_PRESET_MODE, None)
             if mode in self.entity.attributes.get(fan.ATTR_PRESET_MODES, None):
                 return f"{fan.ATTR_PRESET_MODE}.{mode}"
+        return None
 
+    def get_humidifier_mode(self) -> Any:
         # Humidifier mode
         if self.instance == f"{humidifier.DOMAIN}.{humidifier.ATTR_MODE}":
             mode = self.entity.attributes.get(humidifier.ATTR_MODE)
             modes: list[str] = (
-                self.entity.attributes.get(humidifier.ATTR_AVAILABLE_MODES) or []
+                    self.entity.attributes.get(humidifier.ATTR_AVAILABLE_MODES) or []
             )
             if mode in modes:
                 return f"{humidifier.ATTR_MODE}.{mode}"
+        return None
 
+    def get_remote_activity(self) -> Any:
         # Remote Activity
         if self.instance == f"{remote.DOMAIN}.{remote.ATTR_ACTIVITY}":
             activity = self.entity.attributes.get(remote.ATTR_CURRENT_ACTIVITY, None)
             if activity in self.entity.attributes.get(remote.ATTR_ACTIVITY_LIST, []):
                 return f"{remote.ATTR_ACTIVITY}.{activity}"
+        return None
 
+    def get_water_heater_operation_mode(self) -> Any:
         # Water heater operation mode
         if self.instance == f"{water_heater.DOMAIN}.{water_heater.ATTR_OPERATION_MODE}":
-            operation_mode = self.entity.attributes.get(
-                water_heater.ATTR_OPERATION_MODE
-            )
+            operation_mode = self.entity.attributes.get(water_heater.ATTR_OPERATION_MODE)
             operation_modes: list[str] = (
-                self.entity.attributes.get(water_heater.ATTR_OPERATION_LIST) or []
+                    self.entity.attributes.get(water_heater.ATTR_OPERATION_LIST) or []
             )
             if operation_mode in operation_modes:
                 return f"{water_heater.ATTR_OPERATION_MODE}.{operation_mode}"
+        return None
 
+    def get_cover_position(self) -> Any:
         # Cover Position
         if self.instance == f"{cover.DOMAIN}.{cover.ATTR_POSITION}":
             # Return state instead of position when using ModeController.
             mode = self.entity.state
             if mode in (
-                cover.STATE_OPEN,
-                cover.STATE_OPENING,
-                cover.STATE_CLOSED,
-                cover.STATE_CLOSING,
-                STATE_UNKNOWN,
+                    cover.STATE_OPEN,
+                    cover.STATE_OPENING,
+                    cover.STATE_CLOSED,
+                    cover.STATE_CLOSING,
+                    STATE_UNKNOWN,
             ):
                 return f"{cover.ATTR_POSITION}.{mode}"
+        return None
 
+    def get_valve_position_state(self) -> Any:
         # Valve position state
         if self.instance == f"{valve.DOMAIN}.state":
             # Return state instead of position when using ModeController.
             state = self.entity.state
             if state in (
-                valve.STATE_OPEN,
-                valve.STATE_OPENING,
-                valve.STATE_CLOSED,
-                valve.STATE_CLOSING,
-                STATE_UNKNOWN,
+                    valve.STATE_OPEN,
+                    valve.STATE_OPENING,
+                    valve.STATE_CLOSED,
+                    valve.STATE_CLOSING,
+                    STATE_UNKNOWN,
             ):
                 return f"state.{state}"
-
         return None
+
+    def get_property(self, name: str) -> Any:
+        """Read and return a property."""
+        if name != "mode":
+            raise UnsupportedProperty(name)
+
+        if fan_direction := self.get_fan_direction():
+            return fan_direction
+        elif fan_preset_mode := self.get_fan_preset_mode():
+            return fan_preset_mode
+        elif humidifier_mode := self.get_humidifier_mode():
+            return humidifier_mode
+        elif remote_activity := self.get_remote_activity():
+            return remote_activity
+        elif water_heater_operation_mode := self.get_water_heater_operation_mode():
+            return water_heater_operation_mode
+        elif cover_position := self.get_cover_position():
+            return cover_position
+        else:
+            return self.get_valve_position_state()
 
     def configuration(self) -> dict[str, Any] | None:
         """Return configuration with modeResources."""
@@ -1542,7 +1567,7 @@ class AlexaModeController(AlexaCapability):
         if self.instance == f"{water_heater.DOMAIN}.{water_heater.ATTR_OPERATION_MODE}":
             self._resource = AlexaModeResource([AlexaGlobalCatalog.SETTING_MODE], False)
             operation_modes = (
-                self.entity.attributes.get(water_heater.ATTR_OPERATION_LIST) or []
+                    self.entity.attributes.get(water_heater.ATTR_OPERATION_LIST) or []
             )
             for operation_mode in operation_modes:
                 self._resource.add_mode(
@@ -1727,7 +1752,7 @@ class AlexaRangeController(AlexaCapability):
     }
 
     def __init__(
-        self, entity: State, instance: str | None, non_controllable: bool = False
+            self, entity: State, instance: str | None, non_controllable: bool = False
     ) -> None:
         """Initialize the entity."""
         AlexaCapability.__init__(self, entity, instance, non_controllable)
@@ -2070,7 +2095,7 @@ class AlexaToggleController(AlexaCapability):
     }
 
     def __init__(
-        self, entity: State, instance: str, non_controllable: bool = False
+            self, entity: State, instance: str, non_controllable: bool = False
     ) -> None:
         """Initialize the entity."""
         AlexaCapability.__init__(self, entity, instance, non_controllable)
@@ -2333,7 +2358,7 @@ class AlexaEventDetectionSensor(AlexaCapability):
                 "humanPresence": {
                     "featureAvailability": "ENABLED",
                     "supportsNotDetected": self.entity.domain
-                    not in [input_button.DOMAIN, button.DOMAIN],
+                                           not in [input_button.DOMAIN, button.DOMAIN],
                 }
             },
         }

--- a/homeassistant/components/alexa/handlers.py
+++ b/homeassistant/components/alexa/handlers.py
@@ -81,7 +81,7 @@ from .errors import (
     AlexaVideoActionNotPermittedForContentError,
 )
 from .state_report import AlexaDirective, AlexaResponse, async_enable_proactive_mode
-
+_ALEXA_SECURITY_PANEL_CONTROLLER_NAMESPACE = "Alexa.securityPanelController"
 _LOGGER = logging.getLogger(__name__)
 DIRECTIVE_NOT_SUPPORTED = "Entity does not support directive"
 
@@ -1070,7 +1070,7 @@ async def async_api_reportstate(
     return directive.response(name="StateReport")
 
 
-@HANDLERS.register(("Alexa.SecurityPanelController", "Arm"))
+@HANDLERS.register((_ALEXA_SECURITY_PANEL_CONTROLLER_NAMESPACE, "Arm"))
 async def async_api_arm(
     hass: ha.HomeAssistant,
     config: AbstractConfig,
@@ -1104,13 +1104,13 @@ async def async_api_arm(
     payload: dict[str, Any] = {"exitDelayInSeconds": 0}
 
     response = directive.response(
-        name="Arm.Response", namespace="Alexa.SecurityPanelController", payload=payload
+        name="Arm.Response", namespace=_ALEXA_SECURITY_PANEL_CONTROLLER_NAMESPACE, payload=payload
     )
 
     response.add_context_property(
         {
             "name": "armState",
-            "namespace": "Alexa.SecurityPanelController",
+            "namespace": _ALEXA_SECURITY_PANEL_CONTROLLER_NAMESPACE,
             "value": arm_state,
         }
     )
@@ -1118,7 +1118,7 @@ async def async_api_arm(
     return response
 
 
-@HANDLERS.register(("Alexa.SecurityPanelController", "Disarm"))
+@HANDLERS.register((_ALEXA_SECURITY_PANEL_CONTROLLER_NAMESPACE, "Disarm"))
 async def async_api_disarm(
     hass: ha.HomeAssistant,
     config: AbstractConfig,
@@ -1149,7 +1149,7 @@ async def async_api_disarm(
     response.add_context_property(
         {
             "name": "armState",
-            "namespace": "Alexa.SecurityPanelController",
+            "namespace": _ALEXA_SECURITY_PANEL_CONTROLLER_NAMESPACE,
             "value": "DISARMED",
         }
     )

--- a/homeassistant/components/assist_pipeline/pipeline.py
+++ b/homeassistant/components/assist_pipeline/pipeline.py
@@ -1534,10 +1534,8 @@ class PipelineStorageCollection(
         if not (data := await super()._async_load_data()):
             pipeline = await _async_create_default_pipeline(self.hass, self)
             self._preferred_item = pipeline.id
-            return data
-
-        self._preferred_item = data["preferred_item"]
-
+        else:
+            self._preferred_item = data["preferred_item"]
         return data
 
     async def _process_create_data(self, data: dict) -> dict:

--- a/homeassistant/components/buienradar/sensor.py
+++ b/homeassistant/components/buienradar/sensor.py
@@ -59,6 +59,7 @@ from .const import (
 )
 from .util import BrData
 
+_MDI_GAUGE_ICON = "mdi:gauge"
 _LOGGER = logging.getLogger(__name__)
 
 MEASURED_LABEL = "Measured"
@@ -81,19 +82,19 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
     SensorEntityDescription(
         key="barometerfc",
         translation_key="barometerfc",
-        icon="mdi:gauge",
+        icon=_MDI_GAUGE_ICON,
     ),
     # new in json api (>1.0.0):
     SensorEntityDescription(
         key="barometerfcname",
         translation_key="barometerfcname",
-        icon="mdi:gauge",
+        icon=_MDI_GAUGE_ICON,
     ),
     # new in json api (>1.0.0):
     SensorEntityDescription(
         key="barometerfcnamenl",
         translation_key="barometerfcnamenl",
-        icon="mdi:gauge",
+        icon=_MDI_GAUGE_ICON,
     ),
     SensorEntityDescription(
         key="condition",
@@ -175,7 +176,7 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
         key="pressure",
         device_class=SensorDeviceClass.PRESSURE,
         native_unit_of_measurement=UnitOfPressure.HPA,
-        icon="mdi:gauge",
+        icon=_MDI_GAUGE_ICON,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     SensorEntityDescription(

--- a/homeassistant/components/buienradar/sensor.py
+++ b/homeassistant/components/buienradar/sensor.py
@@ -60,6 +60,7 @@ from .const import (
 from .util import BrData
 
 _MDI_GAUGE_ICON = "mdi:gauge"
+_MDI_WEATHER_POURING_ICON = "mdi:weather-pouring"
 _LOGGER = logging.getLogger(__name__)
 
 MEASURED_LABEL = "Measured"
@@ -386,31 +387,31 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
         key="rainchance_1d",
         translation_key="rainchance_1d",
         native_unit_of_measurement=PERCENTAGE,
-        icon="mdi:weather-pouring",
+        icon=_MDI_WEATHER_POURING_ICON,
     ),
     SensorEntityDescription(
         key="rainchance_2d",
         translation_key="rainchance_2d",
         native_unit_of_measurement=PERCENTAGE,
-        icon="mdi:weather-pouring",
+        icon=_MDI_WEATHER_POURING_ICON,
     ),
     SensorEntityDescription(
         key="rainchance_3d",
         translation_key="rainchance_3d",
         native_unit_of_measurement=PERCENTAGE,
-        icon="mdi:weather-pouring",
+        icon=_MDI_WEATHER_POURING_ICON,
     ),
     SensorEntityDescription(
         key="rainchance_4d",
         translation_key="rainchance_4d",
         native_unit_of_measurement=PERCENTAGE,
-        icon="mdi:weather-pouring",
+        icon=_MDI_WEATHER_POURING_ICON,
     ),
     SensorEntityDescription(
         key="rainchance_5d",
         translation_key="rainchance_5d",
         native_unit_of_measurement=PERCENTAGE,
-        icon="mdi:weather-pouring",
+        icon=_MDI_WEATHER_POURING_ICON,
     ),
     SensorEntityDescription(
         key="sunchance_1d",


### PR DESCRIPTION
The issue at line 156 is that this code always returns True. This means whenever you call support_mfa for any instance of AuthProvider, it will return True. This is what SonarQube highlighted as a problem because it adds no dynamic value.then it can be simplified or refactored. so I Add a new class-level variable called support_mfa and deleted the Delete the method with the same name.
/Hoda

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
