### PR TITLE
Add light support to WMS WebControl pro

### DIFF
--- a/homeassistant/components/wmspro/__init__.py
+++ b/homeassistant/components/wmspro/__init__.py
@@ -15,7 +15,7 @@ from homeassistant.helpers.typing import UNDEFINED
 
 from .const import DOMAIN, MANUFACTURER
 
-PLATFORMS: list[Platform] = [Platform.COVER, Platform.SCENE]
+PLATFORMS: list[Platform] = [Platform.COVER, Platform.LIGHT, Platform.SCENE]
 
 type WebControlProConfigEntry = ConfigEntry[WebControlPro]
 

--- a/homeassistant/components/wmspro/const.py
+++ b/homeassistant/components/wmspro/const.py
@@ -5,3 +5,5 @@ SUGGESTED_HOST = "webcontrol"
 
 ATTRIBUTION = "Data provided by WMS WebControl pro API"
 MANUFACTURER = "WAREMA Renkhoff SE"
+
+BRIGHTNESS_SCALE = (1, 100)

--- a/homeassistant/components/wmspro/light.py
+++ b/homeassistant/components/wmspro/light.py
@@ -1,0 +1,89 @@
+"""Support for lights connected with WMS WebControl pro."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import Any
+
+from wmspro.const import WMS_WebControl_pro_API_actionDescription
+
+from homeassistant.components.light import ATTR_BRIGHTNESS, ColorMode, LightEntity
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.util.color import brightness_to_value, value_to_brightness
+
+from . import WebControlProConfigEntry
+from .const import BRIGHTNESS_SCALE
+from .entity import WebControlProGenericEntity
+
+SCAN_INTERVAL = timedelta(seconds=5)
+PARALLEL_UPDATES = 1
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: WebControlProConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the WMS based lights from a config entry."""
+    hub = config_entry.runtime_data
+
+    entities: list[WebControlProGenericEntity] = []
+    for dest in hub.dests.values():
+        if dest.action(WMS_WebControl_pro_API_actionDescription.LightDimming):
+            entities.append(WebControlProDimmer(config_entry.entry_id, dest))
+        elif dest.action(WMS_WebControl_pro_API_actionDescription.LightSwitch):
+            entities.append(WebControlProLight(config_entry.entry_id, dest))
+
+    async_add_entities(entities)
+
+
+class WebControlProLight(WebControlProGenericEntity, LightEntity):
+    """Representation of a WMS based light."""
+
+    _attr_color_mode = ColorMode.ONOFF
+    _attr_supported_color_modes = {ColorMode.ONOFF}
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if light is on."""
+        action = self._dest.action(WMS_WebControl_pro_API_actionDescription.LightSwitch)
+        return action["onOffState"]
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the light on."""
+        action = self._dest.action(WMS_WebControl_pro_API_actionDescription.LightSwitch)
+        await action(onOffState=True)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the light off."""
+        action = self._dest.action(WMS_WebControl_pro_API_actionDescription.LightSwitch)
+        await action(onOffState=False)
+
+
+class WebControlProDimmer(WebControlProLight):
+    """Representation of a WMS-based dimmable light."""
+
+    _attr_color_mode = ColorMode.BRIGHTNESS
+    _attr_supported_color_modes = {ColorMode.BRIGHTNESS}
+
+    @property
+    def brightness(self) -> int:
+        """Return the brightness of this light between 1..255."""
+        action = self._dest.action(
+            WMS_WebControl_pro_API_actionDescription.LightDimming
+        )
+        return value_to_brightness(BRIGHTNESS_SCALE, action["percentage"])
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the dimmer on."""
+        if ATTR_BRIGHTNESS not in kwargs:
+            await super().async_turn_on(**kwargs)
+            return
+
+        action = self._dest.action(
+            WMS_WebControl_pro_API_actionDescription.LightDimming
+        )
+        await action(
+            percentage=brightness_to_value(BRIGHTNESS_SCALE, kwargs[ATTR_BRIGHTNESS])
+        )

--- a/tests/components/wmspro/conftest.py
+++ b/tests/components/wmspro/conftest.py
@@ -83,6 +83,18 @@ def mock_hub_status_prod_awning() -> Generator[AsyncMock]:
 
 
 @pytest.fixture
+def mock_hub_status_prod_dimmer() -> Generator[AsyncMock]:
+    """Override WebControlPro._getStatus."""
+    with patch(
+        "wmspro.webcontrol.WebControlPro._getStatus",
+        return_value=load_json_object_fixture(
+            "example_status_prod_dimmer.json", DOMAIN
+        ),
+    ) as mock_dest_refresh:
+        yield mock_dest_refresh
+
+
+@pytest.fixture
 def mock_dest_refresh() -> Generator[AsyncMock]:
     """Override Destination.refresh."""
     with patch(

--- a/tests/components/wmspro/fixtures/example_status_prod_dimmer.json
+++ b/tests/components/wmspro/fixtures/example_status_prod_dimmer.json
@@ -1,0 +1,28 @@
+{
+  "command": "getStatus",
+  "protocolVersion": "1.0.0",
+  "details": [
+    {
+      "destinationId": 97358,
+      "data": {
+        "drivingCause": 0,
+        "heartbeatError": false,
+        "blocking": false,
+        "productData": [
+          {
+            "actionId": 0,
+            "value": {
+              "percentage": 0
+            }
+          },
+          {
+            "actionId": 20,
+            "value": {
+              "onOffState": false
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tests/components/wmspro/snapshots/test_light.ambr
+++ b/tests/components/wmspro/snapshots/test_light.ambr
@@ -1,0 +1,53 @@
+# serializer version: 1
+# name: test_light_device
+  DeviceRegistryEntrySnapshot({
+    'area_id': 'terrasse',
+    'config_entries': <ANY>,
+    'configuration_url': 'http://webcontrol/control',
+    'connections': set({
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'wmspro',
+        '97358',
+      ),
+    }),
+    'is_new': False,
+    'labels': set({
+    }),
+    'manufacturer': 'WAREMA Renkhoff SE',
+    'model': 'Dimmer',
+    'model_id': None,
+    'name': 'Licht',
+    'name_by_user': None,
+    'primary_config_entry': <ANY>,
+    'serial_number': '97358',
+    'suggested_area': 'Terrasse',
+    'sw_version': None,
+    'via_device_id': <ANY>,
+  })
+# ---
+# name: test_light_update
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by WMS WebControl pro API',
+      'brightness': None,
+      'color_mode': None,
+      'friendly_name': 'Licht',
+      'supported_color_modes': list([
+        <ColorMode.BRIGHTNESS: 'brightness'>,
+      ]),
+      'supported_features': <LightEntityFeature: 0>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'light.licht',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---

--- a/tests/components/wmspro/test_light.py
+++ b/tests/components/wmspro/test_light.py
@@ -1,0 +1,205 @@
+"""Test the wmspro cover support."""
+
+from unittest.mock import AsyncMock, patch
+
+from syrupy import SnapshotAssertion
+
+from homeassistant.components.light import ATTR_BRIGHTNESS
+from homeassistant.components.wmspro.const import DOMAIN
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    Platform,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+from homeassistant.setup import async_setup_component
+
+from . import setup_config_entry
+
+from tests.common import MockConfigEntry
+
+
+async def test_light_device(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_hub_ping: AsyncMock,
+    mock_hub_configuration_prod: AsyncMock,
+    mock_hub_status_prod_dimmer: AsyncMock,
+    device_registry: dr.DeviceRegistry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test that a light device is created correctly."""
+    assert await setup_config_entry(hass, mock_config_entry)
+    assert len(mock_hub_ping.mock_calls) == 1
+    assert len(mock_hub_configuration_prod.mock_calls) == 1
+    assert len(mock_hub_status_prod_dimmer.mock_calls) == 2
+
+    device_entry = device_registry.async_get_device(identifiers={(DOMAIN, "97358")})
+    assert device_entry is not None
+    assert device_entry == snapshot
+
+
+async def test_light_update(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_hub_ping: AsyncMock,
+    mock_hub_configuration_prod: AsyncMock,
+    mock_hub_status_prod_dimmer: AsyncMock,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test that a light entity is created and updated correctly."""
+    assert await setup_config_entry(hass, mock_config_entry)
+    assert len(mock_hub_ping.mock_calls) == 1
+    assert len(mock_hub_configuration_prod.mock_calls) == 1
+    assert len(mock_hub_status_prod_dimmer.mock_calls) == 2
+
+    entity = hass.states.get("light.licht")
+    assert entity is not None
+    assert entity == snapshot
+
+    await async_setup_component(hass, "homeassistant", {})
+    await hass.services.async_call(
+        "homeassistant",
+        "update_entity",
+        {ATTR_ENTITY_ID: entity.entity_id},
+        blocking=True,
+    )
+
+    assert len(mock_hub_status_prod_dimmer.mock_calls) == 3
+
+
+async def test_light_turn_on_and_off(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_hub_ping: AsyncMock,
+    mock_hub_configuration_prod: AsyncMock,
+    mock_hub_status_prod_dimmer: AsyncMock,
+    mock_action_call: AsyncMock,
+) -> None:
+    """Test that a light entity is turned on and off correctly."""
+    assert await setup_config_entry(hass, mock_config_entry)
+    assert len(mock_hub_ping.mock_calls) == 1
+    assert len(mock_hub_configuration_prod.mock_calls) == 1
+    assert len(mock_hub_status_prod_dimmer.mock_calls) >= 1
+
+    entity = hass.states.get("light.licht")
+    assert entity is not None
+    assert entity.state == "off"
+    assert entity.attributes["brightness"] is None
+
+    with patch(
+        "wmspro.destination.Destination.refresh",
+        return_value=True,
+    ):
+        before = len(mock_hub_status_prod_dimmer.mock_calls)
+
+        await hass.services.async_call(
+            Platform.LIGHT,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: entity.entity_id},
+            blocking=True,
+        )
+
+        entity = hass.states.get("light.licht")
+        assert entity is not None
+        assert entity.state == "on"
+        assert entity.attributes["brightness"] >= 1
+        assert len(mock_hub_status_prod_dimmer.mock_calls) == before
+
+    with patch(
+        "wmspro.destination.Destination.refresh",
+        return_value=True,
+    ):
+        before = len(mock_hub_status_prod_dimmer.mock_calls)
+
+        await hass.services.async_call(
+            Platform.LIGHT,
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: entity.entity_id},
+            blocking=True,
+        )
+
+        entity = hass.states.get("light.licht")
+        assert entity is not None
+        assert entity.state == "off"
+        assert entity.attributes["brightness"] is None
+        assert len(mock_hub_status_prod_dimmer.mock_calls) == before
+
+
+async def test_light_dimm_on_and_off(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_hub_ping: AsyncMock,
+    mock_hub_configuration_prod: AsyncMock,
+    mock_hub_status_prod_dimmer: AsyncMock,
+    mock_action_call: AsyncMock,
+) -> None:
+    """Test that a light entity is dimmed on and off correctly."""
+    assert await setup_config_entry(hass, mock_config_entry)
+    assert len(mock_hub_ping.mock_calls) == 1
+    assert len(mock_hub_configuration_prod.mock_calls) == 1
+    assert len(mock_hub_status_prod_dimmer.mock_calls) >= 1
+
+    entity = hass.states.get("light.licht")
+    assert entity is not None
+    assert entity.state == "off"
+    assert entity.attributes["brightness"] is None
+
+    with patch(
+        "wmspro.destination.Destination.refresh",
+        return_value=True,
+    ):
+        before = len(mock_hub_status_prod_dimmer.mock_calls)
+
+        await hass.services.async_call(
+            Platform.LIGHT,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: entity.entity_id},
+            blocking=True,
+        )
+
+        entity = hass.states.get("light.licht")
+        assert entity is not None
+        assert entity.state == "on"
+        assert entity.attributes["brightness"] >= 1
+        assert len(mock_hub_status_prod_dimmer.mock_calls) == before
+
+    with patch(
+        "wmspro.destination.Destination.refresh",
+        return_value=True,
+    ):
+        before = len(mock_hub_status_prod_dimmer.mock_calls)
+
+        await hass.services.async_call(
+            Platform.LIGHT,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: entity.entity_id, ATTR_BRIGHTNESS: 128},
+            blocking=True,
+        )
+
+        entity = hass.states.get("light.licht")
+        assert entity is not None
+        assert entity.state == "on"
+        assert entity.attributes["brightness"] == 128
+        assert len(mock_hub_status_prod_dimmer.mock_calls) == before
+
+    with patch(
+        "wmspro.destination.Destination.refresh",
+        return_value=True,
+    ):
+        before = len(mock_hub_status_prod_dimmer.mock_calls)
+
+        await hass.services.async_call(
+            Platform.LIGHT,
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: entity.entity_id},
+            blocking=True,
+        )
+
+        entity = hass.states.get("light.licht")
+        assert entity is not None
+        assert entity.state == "off"
+        assert entity.attributes["brightness"] is None
+        assert len(mock_hub_status_prod_dimmer.mock_calls) == before

--- a/tests/components/wmspro/test_light.py
+++ b/tests/components/wmspro/test_light.py
@@ -1,4 +1,4 @@
-"""Test the wmspro cover support."""
+"""Test the wmspro light support."""
 
 from unittest.mock import AsyncMock, patch
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for switchable and (brightness) dimmable lights to WMS WebControl pro.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/35208

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
