### PR TITLE
Prevent duplicate WMS WebControl pro config entry creation

### DIFF
--- a/homeassistant/components/wmspro/config_flow.py
+++ b/homeassistant/components/wmspro/config_flow.py
@@ -87,7 +87,11 @@ class WebControlProConfigFlow(ConfigFlow, domain=DOMAIN):
                     await hub.refresh()
                     rooms = set(hub.rooms.keys())
                     for entry in self.hass.config_entries.async_entries(DOMAIN):
-                        if set(entry.runtime_data.rooms.keys()) == rooms:
+                        if (
+                            entry.runtime_data
+                            and entry.runtime_data.rooms
+                            and set(entry.runtime_data.rooms.keys()) == rooms
+                        ):
                             return self.async_abort(reason="already_configured")
                     return self.async_create_entry(title=host, data=user_input)
 

--- a/homeassistant/components/wmspro/config_flow.py
+++ b/homeassistant/components/wmspro/config_flow.py
@@ -86,7 +86,7 @@ class WebControlProConfigFlow(ConfigFlow, domain=DOMAIN):
                 else:
                     await hub.refresh()
                     rooms = set(hub.rooms.keys())
-                    for entry in self.hass.config_entries.async_entries(DOMAIN):
+                    for entry in self.hass.config_entries.async_loaded_entries(DOMAIN):
                         if (
                             entry.runtime_data
                             and entry.runtime_data.rooms

--- a/homeassistant/components/wmspro/config_flow.py
+++ b/homeassistant/components/wmspro/config_flow.py
@@ -84,6 +84,11 @@ class WebControlProConfigFlow(ConfigFlow, domain=DOMAIN):
                 if not pong:
                     errors["base"] = "cannot_connect"
                 else:
+                    await hub.refresh()
+                    rooms = set(hub.rooms.keys())
+                    for entry in self.hass.config_entries.async_entries(DOMAIN):
+                        if set(entry.runtime_data.rooms.keys()) == rooms:
+                            return self.async_abort(reason="already_configured")
                     return self.async_create_entry(title=host, data=user_input)
 
         if self.source == dhcp.DOMAIN:

--- a/tests/components/wmspro/test_config_flow.py
+++ b/tests/components/wmspro/test_config_flow.py
@@ -333,6 +333,7 @@ async def test_config_flow_unknown_error(
 async def test_config_flow_duplicate_entries(
     hass: HomeAssistant,
     mock_hub_ping: AsyncMock,
+    mock_dest_refresh: AsyncMock,
     mock_hub_configuration_test: AsyncMock,
 ) -> None:
     """Test we prevent creation of duplicate config entries."""
@@ -353,6 +354,8 @@ async def test_config_flow_duplicate_entries(
         CONF_HOST: "1.2.3.4",
     }
 
+    await hass.async_block_till_done()
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
@@ -372,6 +375,7 @@ async def test_config_flow_duplicate_entries(
 async def test_config_flow_multiple_entries(
     hass: HomeAssistant,
     mock_hub_ping: AsyncMock,
+    mock_dest_refresh: AsyncMock,
     mock_hub_configuration_test: AsyncMock,
     mock_hub_configuration_prod: AsyncMock,
 ) -> None:
@@ -392,6 +396,8 @@ async def test_config_flow_multiple_entries(
     assert result["data"] == {
         CONF_HOST: "1.2.3.4",
     }
+
+    await hass.async_block_till_done()
 
     mock_hub_configuration_prod.return_value = mock_hub_configuration_test.return_value
 

--- a/tests/components/wmspro/test_config_flow.py
+++ b/tests/components/wmspro/test_config_flow.py
@@ -335,7 +335,7 @@ async def test_config_flow_duplicate_entries(
     mock_hub_ping: AsyncMock,
     mock_hub_configuration_test: AsyncMock,
 ) -> None:
-    """Test we handle an unknown error."""
+    """Test we prevent creation of duplicate config entries."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
@@ -375,7 +375,7 @@ async def test_config_flow_multiple_entries(
     mock_hub_configuration_test: AsyncMock,
     mock_hub_configuration_prod: AsyncMock,
 ) -> None:
-    """Test we handle an unknown error."""
+    """Test we allow creation of different config entries."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )

--- a/tests/components/wmspro/test_config_flow.py
+++ b/tests/components/wmspro/test_config_flow.py
@@ -6,10 +6,14 @@ import aiohttp
 
 from homeassistant.components.dhcp import DhcpServiceInfo
 from homeassistant.components.wmspro.const import DOMAIN
-from homeassistant.config_entries import SOURCE_DHCP, SOURCE_USER
+from homeassistant.config_entries import SOURCE_DHCP, SOURCE_USER, ConfigEntryState
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+
+from . import setup_config_entry
+
+from tests.common import MockConfigEntry
 
 
 async def test_config_flow(
@@ -332,29 +336,14 @@ async def test_config_flow_unknown_error(
 
 async def test_config_flow_duplicate_entries(
     hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
     mock_hub_ping: AsyncMock,
     mock_dest_refresh: AsyncMock,
     mock_hub_configuration_test: AsyncMock,
 ) -> None:
     """Test we prevent creation of duplicate config entries."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_USER}
-    )
-
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        {
-            CONF_HOST: "1.2.3.4",
-        },
-    )
-
-    assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == "1.2.3.4"
-    assert result["data"] == {
-        CONF_HOST: "1.2.3.4",
-    }
-
-    await hass.async_block_till_done()
+    await setup_config_entry(hass, mock_config_entry)
+    assert mock_config_entry.state is ConfigEntryState.LOADED
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
@@ -374,30 +363,15 @@ async def test_config_flow_duplicate_entries(
 
 async def test_config_flow_multiple_entries(
     hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
     mock_hub_ping: AsyncMock,
     mock_dest_refresh: AsyncMock,
     mock_hub_configuration_test: AsyncMock,
     mock_hub_configuration_prod: AsyncMock,
 ) -> None:
     """Test we allow creation of different config entries."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_USER}
-    )
-
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        {
-            CONF_HOST: "1.2.3.4",
-        },
-    )
-
-    assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == "1.2.3.4"
-    assert result["data"] == {
-        CONF_HOST: "1.2.3.4",
-    }
-
-    await hass.async_block_till_done()
+    await setup_config_entry(hass, mock_config_entry)
+    assert mock_config_entry.state is ConfigEntryState.LOADED
 
     mock_hub_configuration_prod.return_value = mock_hub_configuration_test.return_value
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Compare set of rooms available to identify duplicates. More or less suggested by @joostlek.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
