### PR TITLE
Add port to config flow of P1 Monitor integration

### DIFF
--- a/homeassistant/components/p1_monitor/__init__.py
+++ b/homeassistant/components/p1_monitor/__init__.py
@@ -40,7 +40,7 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
         if ":" in host:
             host, port = host.split(":")
         else:
-            port = config_entry.data.get(CONF_PORT, 80)
+            port = 80
 
         new_data = {
             **config_entry.data,

--- a/homeassistant/components/p1_monitor/__init__.py
+++ b/homeassistant/components/p1_monitor/__init__.py
@@ -3,11 +3,11 @@
 from __future__ import annotations
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import Platform
+from homeassistant.const import CONF_HOST, CONF_PORT, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 
-from .const import DOMAIN
+from .const import DOMAIN, LOGGER
 from .coordinator import P1MonitorDataUpdateCoordinator
 
 PLATFORMS = [Platform.SENSOR]
@@ -27,6 +27,29 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data[DOMAIN][entry.entry_id] = coordinator
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    return True
+
+
+async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+    """Migrate old entry."""
+    LOGGER.debug("Migrating from version %s", config_entry.version)
+
+    if config_entry.version == 1:
+        # Migrate to split host and port
+        host = config_entry.data[CONF_HOST]
+        if ":" in host:
+            host, port = host.split(":")
+        else:
+            port = config_entry.data.get(CONF_PORT, 80)
+
+        new_data = {
+            **config_entry.data,
+            CONF_HOST: host,
+            CONF_PORT: int(port),
+        }
+
+        hass.config_entries.async_update_entry(config_entry, data=new_data, version=2)
+        LOGGER.debug("Migration to version %s successful", config_entry.version)
     return True
 
 

--- a/homeassistant/components/p1_monitor/config_flow.py
+++ b/homeassistant/components/p1_monitor/config_flow.py
@@ -8,7 +8,7 @@ from p1monitor import P1Monitor, P1MonitorError
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
-from homeassistant.const import CONF_HOST
+from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.selector import TextSelector
 
@@ -18,7 +18,7 @@ from .const import DOMAIN
 class P1MonitorFlowHandler(ConfigFlow, domain=DOMAIN):
     """Config flow for P1 Monitor."""
 
-    VERSION = 1
+    VERSION = 2
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -31,7 +31,9 @@ class P1MonitorFlowHandler(ConfigFlow, domain=DOMAIN):
             session = async_get_clientsession(self.hass)
             try:
                 async with P1Monitor(
-                    host=user_input[CONF_HOST], session=session
+                    host=user_input[CONF_HOST],
+                    port=user_input[CONF_PORT],
+                    session=session,
                 ) as client:
                     await client.smartmeter()
             except P1MonitorError:
@@ -41,6 +43,7 @@ class P1MonitorFlowHandler(ConfigFlow, domain=DOMAIN):
                     title="P1 Monitor",
                     data={
                         CONF_HOST: user_input[CONF_HOST],
+                        CONF_PORT: user_input[CONF_PORT],
                     },
                 )
 
@@ -49,6 +52,7 @@ class P1MonitorFlowHandler(ConfigFlow, domain=DOMAIN):
             data_schema=vol.Schema(
                 {
                     vol.Required(CONF_HOST): TextSelector(),
+                    vol.Required(CONF_PORT, default=80): int,
                 }
             ),
             errors=errors,

--- a/homeassistant/components/p1_monitor/coordinator.py
+++ b/homeassistant/components/p1_monitor/coordinator.py
@@ -15,7 +15,7 @@ from p1monitor import (
 )
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_HOST
+from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
@@ -59,7 +59,9 @@ class P1MonitorDataUpdateCoordinator(DataUpdateCoordinator[P1MonitorData]):
         )
 
         self.p1monitor = P1Monitor(
-            self.config_entry.data[CONF_HOST], session=async_get_clientsession(hass)
+            host=self.config_entry.data[CONF_HOST],
+            port=self.config_entry.data[CONF_PORT],
+            session=async_get_clientsession(hass),
         )
 
     async def _async_update_data(self) -> P1MonitorData:

--- a/homeassistant/components/p1_monitor/diagnostics.py
+++ b/homeassistant/components/p1_monitor/diagnostics.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_HOST
+from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import HomeAssistant
 
 from .const import (
@@ -22,9 +22,7 @@ from .coordinator import P1MonitorDataUpdateCoordinator
 if TYPE_CHECKING:
     from _typeshed import DataclassInstance
 
-TO_REDACT = {
-    CONF_HOST,
-}
+TO_REDACT = {CONF_HOST, CONF_PORT}
 
 
 async def async_get_config_entry_diagnostics(

--- a/homeassistant/components/p1_monitor/strings.json
+++ b/homeassistant/components/p1_monitor/strings.json
@@ -4,10 +4,12 @@
       "user": {
         "description": "Set up P1 Monitor to integrate with Home Assistant.",
         "data": {
-          "host": "[%key:common::config_flow::data::host%]"
+          "host": "[%key:common::config_flow::data::host%]",
+          "port": "[%key:common::config_flow::data::port%]"
         },
         "data_description": {
-          "host": "The IP address or hostname of your P1 Monitor installation."
+          "host": "The IP address or hostname of your P1 Monitor installation.",
+          "port": "The port of your P1 Monitor installation."
         }
       }
     },

--- a/tests/components/p1_monitor/conftest.py
+++ b/tests/components/p1_monitor/conftest.py
@@ -7,7 +7,7 @@ from p1monitor import Phases, Settings, SmartMeter, WaterMeter
 import pytest
 
 from homeassistant.components.p1_monitor.const import DOMAIN
-from homeassistant.const import CONF_HOST
+from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry, load_fixture
@@ -19,8 +19,9 @@ def mock_config_entry() -> MockConfigEntry:
     return MockConfigEntry(
         title="monitor",
         domain=DOMAIN,
-        data={CONF_HOST: "example"},
+        data={CONF_HOST: "example", CONF_PORT: 80},
         unique_id="unique_thingy",
+        version=2,
     )
 
 

--- a/tests/components/p1_monitor/snapshots/test_init.ambr
+++ b/tests/components/p1_monitor/snapshots/test_init.ambr
@@ -1,0 +1,45 @@
+# serializer version: 1
+# name: test_migration
+  ConfigEntrySnapshot({
+    'data': dict({
+      'host': 'example',
+      'port': 80,
+    }),
+    'disabled_by': None,
+    'discovery_keys': dict({
+    }),
+    'domain': 'p1_monitor',
+    'entry_id': <ANY>,
+    'minor_version': 1,
+    'options': dict({
+    }),
+    'pref_disable_new_entities': False,
+    'pref_disable_polling': False,
+    'source': 'user',
+    'title': 'Mock Title',
+    'unique_id': 'unique_thingy',
+    'version': 2,
+  })
+# ---
+# name: test_port_migration
+  ConfigEntrySnapshot({
+    'data': dict({
+      'host': 'example',
+      'port': 80,
+    }),
+    'disabled_by': None,
+    'discovery_keys': dict({
+    }),
+    'domain': 'p1_monitor',
+    'entry_id': <ANY>,
+    'minor_version': 1,
+    'options': dict({
+    }),
+    'pref_disable_new_entities': False,
+    'pref_disable_polling': False,
+    'source': 'user',
+    'title': 'Mock Title',
+    'unique_id': 'unique_thingy',
+    'version': 2,
+  })
+# ---

--- a/tests/components/p1_monitor/test_config_flow.py
+++ b/tests/components/p1_monitor/test_config_flow.py
@@ -6,7 +6,7 @@ from p1monitor import P1MonitorError
 
 from homeassistant.components.p1_monitor.const import DOMAIN
 from homeassistant.config_entries import SOURCE_USER
-from homeassistant.const import CONF_HOST
+from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
@@ -30,12 +30,12 @@ async def test_full_user_flow(hass: HomeAssistant) -> None:
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            user_input={CONF_HOST: "example.com"},
+            user_input={CONF_HOST: "example.com", CONF_PORT: 80},
         )
 
     assert result2.get("type") is FlowResultType.CREATE_ENTRY
     assert result2.get("title") == "P1 Monitor"
-    assert result2.get("data") == {CONF_HOST: "example.com"}
+    assert result2.get("data") == {CONF_HOST: "example.com", CONF_PORT: 80}
 
     assert len(mock_setup_entry.mock_calls) == 1
     assert len(mock_p1monitor.mock_calls) == 1
@@ -50,7 +50,7 @@ async def test_api_error(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": SOURCE_USER},
-            data={CONF_HOST: "example.com"},
+            data={CONF_HOST: "example.com", CONF_PORT: 80},
         )
 
     assert result.get("type") is FlowResultType.FORM

--- a/tests/components/p1_monitor/test_diagnostics.py
+++ b/tests/components/p1_monitor/test_diagnostics.py
@@ -21,6 +21,7 @@ async def test_diagnostics(
             "title": "monitor",
             "data": {
                 "host": REDACTED,
+                "port": REDACTED,
             },
         },
         "data": {

--- a/tests/components/p1_monitor/test_init.py
+++ b/tests/components/p1_monitor/test_init.py
@@ -3,9 +3,11 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from p1monitor import P1MonitorConnectionError
+from syrupy import SnapshotAssertion
 
 from homeassistant.components.p1_monitor.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
@@ -44,3 +46,35 @@ async def test_config_entry_not_ready(
 
     assert mock_request.call_count == 1
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_migration(hass: HomeAssistant, snapshot: SnapshotAssertion) -> None:
+    """Test config entry version 1 -> 2 migration."""
+    mock_config_entry = MockConfigEntry(
+        unique_id="unique_thingy",
+        domain=DOMAIN,
+        data={CONF_HOST: "example"},
+        version=1,
+    )
+    mock_config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert hass.config_entries.async_get_entry(mock_config_entry.entry_id) == snapshot
+
+
+async def test_port_migration(hass: HomeAssistant, snapshot: SnapshotAssertion) -> None:
+    """Test migration of host:port to separate host and port."""
+    mock_config_entry = MockConfigEntry(
+        unique_id="unique_thingy",
+        domain=DOMAIN,
+        data={CONF_HOST: "example:80"},
+        version=1,
+    )
+    mock_config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert hass.config_entries.async_get_entry(mock_config_entry.entry_id) == snapshot


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds the ability to specify a separate port during the config flow. This is because some people do not run the P1 Monitor software on a Raspberry Pi, but in a Docker container with a custom port.

The migration takes into account 2 situations:
- Users that do not use a separate port and are migrated to port `80` in the config entry.
- Users who previously specified a port number as a host, for example `192.168.x.x:84`. The migration will then split the port from host and use it seperate in the config entry.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #127394
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
