### PR TITLE
Use unique_id_mismatch in aseko_pool_live reauth

### DIFF
--- a/homeassistant/components/aseko_pool_live/config_flow.py
+++ b/homeassistant/components/aseko_pool_live/config_flow.py
@@ -70,7 +70,6 @@ class AsekoConfigFlow(ConfigFlow, domain=DOMAIN):
     async def async_store_credentials(self, info: dict[str, Any]) -> ConfigFlowResult:
         """Store validated credentials."""
 
-        await self.async_set_unique_id(info[CONF_UNIQUE_ID])
         if self.source == SOURCE_REAUTH:
             return self.async_update_reload_and_abort(
                 self._get_reauth_entry(),
@@ -82,6 +81,7 @@ class AsekoConfigFlow(ConfigFlow, domain=DOMAIN):
                 },
             )
 
+        await self.async_set_unique_id(info[CONF_UNIQUE_ID])
         self._abort_if_unique_id_configured()
 
         return self.async_create_entry(

--- a/homeassistant/components/aseko_pool_live/config_flow.py
+++ b/homeassistant/components/aseko_pool_live/config_flow.py
@@ -70,17 +70,18 @@ class AsekoConfigFlow(ConfigFlow, domain=DOMAIN):
     async def async_store_credentials(self, info: dict[str, Any]) -> ConfigFlowResult:
         """Store validated credentials."""
 
+        await self.async_set_unique_id(info[CONF_UNIQUE_ID])
         if self.source == SOURCE_REAUTH:
             return self.async_update_reload_and_abort(
                 self._get_reauth_entry(),
                 title=info[CONF_EMAIL],
+                unique_id=info[CONF_UNIQUE_ID],
                 data={
                     CONF_EMAIL: info[CONF_EMAIL],
                     CONF_PASSWORD: info[CONF_PASSWORD],
                 },
             )
 
-        await self.async_set_unique_id(info[CONF_UNIQUE_ID])
         self._abort_if_unique_id_configured()
 
         return self.async_create_entry(

--- a/homeassistant/components/aseko_pool_live/config_flow.py
+++ b/homeassistant/components/aseko_pool_live/config_flow.py
@@ -29,7 +29,7 @@ class AsekoConfigFlow(ConfigFlow, domain=DOMAIN):
         }
     )
 
-    async def get_account_info(self, email: str, password: str) -> dict:
+    async def get_account_info(self, email: str, password: str) -> dict[str, Any]:
         """Get account info from the mobile API and the web API."""
         aseko = Aseko(email, password)
         user = await aseko.login()

--- a/homeassistant/components/aseko_pool_live/config_flow.py
+++ b/homeassistant/components/aseko_pool_live/config_flow.py
@@ -70,18 +70,18 @@ class AsekoConfigFlow(ConfigFlow, domain=DOMAIN):
     async def async_store_credentials(self, info: dict[str, Any]) -> ConfigFlowResult:
         """Store validated credentials."""
 
+        await self.async_set_unique_id(info[CONF_UNIQUE_ID])
         if self.source == SOURCE_REAUTH:
+            self._abort_if_unique_id_mismatch()
             return self.async_update_reload_and_abort(
                 self._get_reauth_entry(),
                 title=info[CONF_EMAIL],
-                unique_id=info[CONF_UNIQUE_ID],
                 data={
                     CONF_EMAIL: info[CONF_EMAIL],
                     CONF_PASSWORD: info[CONF_PASSWORD],
                 },
             )
 
-        await self.async_set_unique_id(info[CONF_UNIQUE_ID])
         self._abort_if_unique_id_configured()
 
         return self.async_create_entry(

--- a/homeassistant/components/aseko_pool_live/strings.json
+++ b/homeassistant/components/aseko_pool_live/strings.json
@@ -21,7 +21,8 @@
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
-      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
+      "unique_id_mismatch": "The user identifier does not match the previous identifier"
     }
   },
   "entity": {

--- a/tests/components/aseko_pool_live/test_config_flow.py
+++ b/tests/components/aseko_pool_live/test_config_flow.py
@@ -129,7 +129,8 @@ async def test_async_step_reauth_success(hass: HomeAssistant, user: User) -> Non
     mock_entry = MockConfigEntry(
         domain=DOMAIN,
         unique_id="UID",
-        data={CONF_EMAIL: "aseko@example.com"},
+        data={CONF_EMAIL: "aseko@example.com", CONF_PASSWORD: "passw0rd"},
+        version=2,
     )
     mock_entry.add_to_hass(hass)
 
@@ -151,13 +152,18 @@ async def test_async_step_reauth_success(hass: HomeAssistant, user: User) -> Non
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            {CONF_EMAIL: "aseko@example.com", CONF_PASSWORD: "passw0rd"},
+            {CONF_EMAIL: "aseko@example.com", CONF_PASSWORD: "new_password"},
         )
         await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reauth_successful"
     assert len(mock_setup_entry.mock_calls) == 1
+    assert mock_entry.unique_id == "a_user_id"
+    assert dict(mock_entry.data) == {
+        CONF_EMAIL: "aseko@example.com",
+        CONF_PASSWORD: "new_password",
+    }
 
 
 @pytest.mark.parametrize(

--- a/tests/components/aseko_pool_live/test_config_flow.py
+++ b/tests/components/aseko_pool_live/test_config_flow.py
@@ -128,7 +128,7 @@ async def test_async_step_reauth_success(hass: HomeAssistant, user: User) -> Non
 
     mock_entry = MockConfigEntry(
         domain=DOMAIN,
-        unique_id="UID",
+        unique_id="a_user_id",
         data={CONF_EMAIL: "aseko@example.com", CONF_PASSWORD: "passw0rd"},
         version=2,
     )
@@ -163,6 +163,49 @@ async def test_async_step_reauth_success(hass: HomeAssistant, user: User) -> Non
     assert dict(mock_entry.data) == {
         CONF_EMAIL: "aseko@example.com",
         CONF_PASSWORD: "new_password",
+    }
+
+
+async def test_async_step_reauth_mismatch(hass: HomeAssistant, user: User) -> None:
+    """Test mismatch reauthentication."""
+
+    mock_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="UID",
+        data={CONF_EMAIL: "aseko@example.com", CONF_PASSWORD: "passw0rd"},
+        version=2,
+    )
+    mock_entry.add_to_hass(hass)
+
+    result = await mock_entry.start_reauth_flow(hass)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+    assert result["errors"] == {}
+
+    with (
+        patch(
+            "homeassistant.components.aseko_pool_live.config_flow.Aseko.login",
+            return_value=user,
+        ),
+        patch(
+            "homeassistant.components.aseko_pool_live.async_setup_entry",
+            return_value=True,
+        ) as mock_setup_entry,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_EMAIL: "aseko@example.com", CONF_PASSWORD: "new_password"},
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "unique_id_mismatch"
+    assert len(mock_setup_entry.mock_calls) == 0
+    assert mock_entry.unique_id == "UID"
+    assert dict(mock_entry.data) == {
+        CONF_EMAIL: "aseko@example.com",
+        CONF_PASSWORD: "passw0rd",
     }
 
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The tests imply that the unique_id of the config entry may change during the reauth process.
This ensures that it is rejected...

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
