### PR TITLE
Use async_update_reload_and_abort in awair

### DIFF
--- a/homeassistant/components/awair/config_flow.py
+++ b/homeassistant/components/awair/config_flow.py
@@ -209,10 +209,9 @@ class AwairFlowHandler(ConfigFlow, domain=DOMAIN):
             _, error = await self._check_cloud_connection(access_token)
 
             if error is None:
-                entry = await self.async_set_unique_id(self.unique_id)
-                assert entry
-                self.hass.config_entries.async_update_entry(entry, data=user_input)
-                return self.async_abort(reason="reauth_successful")
+                return self.async_update_reload_and_abort(
+                    self._get_reauth_entry(), data_updates=user_input
+                )
 
             if error != "invalid_access_token":
                 return self.async_abort(reason=error)

--- a/tests/components/awair/test_config_flow.py
+++ b/tests/components/awair/test_config_flow.py
@@ -158,7 +158,7 @@ async def test_reauth(hass: HomeAssistant, user, cloud_devices) -> None:
         ),
         patch(
             "homeassistant.components.awair.async_setup_entry", return_value=True
-        ) as mock_setup,
+        ) as mock_setup_entry,
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -168,7 +168,7 @@ async def test_reauth(hass: HomeAssistant, user, cloud_devices) -> None:
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reauth_successful"
-    mock_setup.assert_called_once()
+    mock_setup_entry.assert_called_once()
     assert dict(mock_config.data) == {CONF_ACCESS_TOKEN: "good"}
 
 
@@ -400,10 +400,6 @@ async def test_zeroconf_discovery_update_configuration(
             return_value=True,
         ) as mock_setup_entry,
         patch("python_awair.AwairClient.query", side_effect=[local_devices]),
-        patch(
-            "homeassistant.components.awair.async_setup_entry",
-            return_value=True,
-        ),
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,

--- a/tests/components/awair/test_config_flow.py
+++ b/tests/components/awair/test_config_flow.py
@@ -144,27 +144,32 @@ async def test_reauth(hass: HomeAssistant, user, cloud_devices) -> None:
     with patch("python_awair.AwairClient.query", side_effect=AuthError()):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            user_input=CLOUD_CONFIG,
+            user_input={CONF_ACCESS_TOKEN: "bad"},
         )
 
-        assert result["type"] is FlowResultType.FORM
-        assert result["step_id"] == "reauth_confirm"
-        assert result["errors"] == {CONF_ACCESS_TOKEN: "invalid_access_token"}
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+    assert result["errors"] == {CONF_ACCESS_TOKEN: "invalid_access_token"}
 
     with (
         patch(
             "python_awair.AwairClient.query",
             side_effect=[user, cloud_devices],
         ),
-        patch("homeassistant.components.awair.async_setup_entry", return_value=True),
+        patch(
+            "homeassistant.components.awair.async_setup_entry", return_value=True
+        ) as mock_setup,
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            user_input=CLOUD_CONFIG,
+            user_input={CONF_ACCESS_TOKEN: "good"},
         )
+        await hass.async_block_till_done()
 
-        assert result["type"] is FlowResultType.ABORT
-        assert result["reason"] == "reauth_successful"
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+    mock_setup.assert_called_once()
+    assert dict(mock_config.data) == {CONF_ACCESS_TOKEN: "good"}
 
 
 async def test_reauth_error(hass: HomeAssistant) -> None:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
