### PR TITLE
Improve internal naming

### DIFF
--- a/homeassistant/components/husqvarna_automower/binary_sensor.py
+++ b/homeassistant/components/husqvarna_automower/binary_sensor.py
@@ -28,7 +28,7 @@ class AutomowerBinarySensorEntityDescription(BinarySensorEntityDescription):
     value_fn: Callable[[MowerAttributes], bool]
 
 
-BINARY_SENSOR_TYPES: tuple[AutomowerBinarySensorEntityDescription, ...] = (
+MOWER_BINARY_SENSOR_TYPES: tuple[AutomowerBinarySensorEntityDescription, ...] = (
     AutomowerBinarySensorEntityDescription(
         key="battery_charging",
         value_fn=lambda data: data.mower.activity == MowerActivities.CHARGING,
@@ -57,7 +57,7 @@ async def async_setup_entry(
     async_add_entities(
         AutomowerBinarySensorEntity(mower_id, coordinator, description)
         for mower_id in coordinator.data
-        for description in BINARY_SENSOR_TYPES
+        for description in MOWER_BINARY_SENSOR_TYPES
     )
 
 

--- a/homeassistant/components/husqvarna_automower/button.py
+++ b/homeassistant/components/husqvarna_automower/button.py
@@ -46,7 +46,7 @@ class AutomowerButtonEntityDescription(ButtonEntityDescription):
     press_fn: Callable[[AutomowerSession, str], Awaitable[Any]]
 
 
-BUTTON_TYPES: tuple[AutomowerButtonEntityDescription, ...] = (
+MOWER_BUTTON_TYPES: tuple[AutomowerButtonEntityDescription, ...] = (
     AutomowerButtonEntityDescription(
         key="confirm_error",
         translation_key="confirm_error",
@@ -73,7 +73,7 @@ async def async_setup_entry(
     async_add_entities(
         AutomowerButtonEntity(mower_id, coordinator, description)
         for mower_id in coordinator.data
-        for description in BUTTON_TYPES
+        for description in MOWER_BUTTON_TYPES
         if description.exists_fn(coordinator.data[mower_id])
     )
 

--- a/homeassistant/components/husqvarna_automower/number.py
+++ b/homeassistant/components/husqvarna_automower/number.py
@@ -65,7 +65,7 @@ class AutomowerNumberEntityDescription(NumberEntityDescription):
     set_value_fn: Callable[[AutomowerSession, str, float], Awaitable[Any]]
 
 
-NUMBER_TYPES: tuple[AutomowerNumberEntityDescription, ...] = (
+MOWER_NUMBER_TYPES: tuple[AutomowerNumberEntityDescription, ...] = (
     AutomowerNumberEntityDescription(
         key="cutting_height",
         translation_key="cutting_height",
@@ -81,7 +81,7 @@ NUMBER_TYPES: tuple[AutomowerNumberEntityDescription, ...] = (
 
 
 @dataclass(frozen=True, kw_only=True)
-class AutomowerWorkAreaNumberEntityDescription(NumberEntityDescription):
+class WorkAreaNumberEntityDescription(NumberEntityDescription):
     """Describes Automower work area number entity."""
 
     value_fn: Callable[[WorkArea], int]
@@ -91,8 +91,8 @@ class AutomowerWorkAreaNumberEntityDescription(NumberEntityDescription):
     ]
 
 
-WORK_AREA_NUMBER_TYPES: tuple[AutomowerWorkAreaNumberEntityDescription, ...] = (
-    AutomowerWorkAreaNumberEntityDescription(
+WORK_AREA_NUMBER_TYPES: tuple[WorkAreaNumberEntityDescription, ...] = (
+    WorkAreaNumberEntityDescription(
         key="cutting_height_work_area",
         translation_key_fn=_work_area_translation_key,
         entity_category=EntityCategory.CONFIG,
@@ -117,7 +117,7 @@ async def async_setup_entry(
             _work_areas = coordinator.data[mower_id].work_areas
             if _work_areas is not None:
                 entities.extend(
-                    AutomowerWorkAreaNumberEntity(
+                    WorkAreaNumberEntity(
                         mower_id, coordinator, description, work_area_id
                     )
                     for description in WORK_AREA_NUMBER_TYPES
@@ -126,7 +126,7 @@ async def async_setup_entry(
             async_remove_work_area_entities(hass, coordinator, entry, mower_id)
         entities.extend(
             AutomowerNumberEntity(mower_id, coordinator, description)
-            for description in NUMBER_TYPES
+            for description in MOWER_NUMBER_TYPES
             if description.exists_fn(coordinator.data[mower_id])
         )
     async_add_entities(entities)
@@ -161,16 +161,16 @@ class AutomowerNumberEntity(AutomowerControlEntity, NumberEntity):
         )
 
 
-class AutomowerWorkAreaNumberEntity(WorkAreaControlEntity, NumberEntity):
-    """Defining the AutomowerWorkAreaNumberEntity with AutomowerWorkAreaNumberEntityDescription."""
+class WorkAreaNumberEntity(WorkAreaControlEntity, NumberEntity):
+    """Defining the WorkAreaNumberEntity with WorkAreaNumberEntityDescription."""
 
-    entity_description: AutomowerWorkAreaNumberEntityDescription
+    entity_description: WorkAreaNumberEntityDescription
 
     def __init__(
         self,
         mower_id: str,
         coordinator: AutomowerDataUpdateCoordinator,
-        description: AutomowerWorkAreaNumberEntityDescription,
+        description: WorkAreaNumberEntityDescription,
         work_area_id: int,
     ) -> None:
         """Set up AutomowerNumberEntity."""

--- a/homeassistant/components/husqvarna_automower/select.py
+++ b/homeassistant/components/husqvarna_automower/select.py
@@ -33,13 +33,13 @@ async def async_setup_entry(
     """Set up select platform."""
     coordinator = entry.runtime_data
     async_add_entities(
-        AutomowerSelectEntity(mower_id, coordinator)
+        AutomowerHeadlightModeSelectEntity(mower_id, coordinator)
         for mower_id in coordinator.data
         if coordinator.data[mower_id].capabilities.headlights
     )
 
 
-class AutomowerSelectEntity(AutomowerControlEntity, SelectEntity):
+class AutomowerHeadlightModeSelectEntity(AutomowerControlEntity, SelectEntity):
     """Defining the headlight mode entity."""
 
     _attr_options = HEADLIGHT_MODES

--- a/homeassistant/components/husqvarna_automower/select.py
+++ b/homeassistant/components/husqvarna_automower/select.py
@@ -33,13 +33,13 @@ async def async_setup_entry(
     """Set up select platform."""
     coordinator = entry.runtime_data
     async_add_entities(
-        AutomowerHeadlightModeSelectEntity(mower_id, coordinator)
+        AutomowerSelectEntity(mower_id, coordinator)
         for mower_id in coordinator.data
         if coordinator.data[mower_id].capabilities.headlights
     )
 
 
-class AutomowerHeadlightModeSelectEntity(AutomowerControlEntity, SelectEntity):
+class AutomowerSelectEntity(AutomowerControlEntity, SelectEntity):
     """Defining the headlight mode entity."""
 
     _attr_options = HEADLIGHT_MODES

--- a/homeassistant/components/husqvarna_automower/switch.py
+++ b/homeassistant/components/husqvarna_automower/switch.py
@@ -40,9 +40,7 @@ async def async_setup_entry(
             _stay_out_zones = coordinator.data[mower_id].stay_out_zones
             if _stay_out_zones is not None:
                 entities.extend(
-                    AutomowerStayOutZoneSwitchEntity(
-                        coordinator, mower_id, stay_out_zone_uid
-                    )
+                    StayOutZoneSwitchEntity(coordinator, mower_id, stay_out_zone_uid)
                     for stay_out_zone_uid in _stay_out_zones.zones
                 )
             async_remove_entities(hass, coordinator, entry, mower_id)
@@ -86,7 +84,7 @@ class AutomowerScheduleSwitchEntity(AutomowerControlEntity, SwitchEntity):
         await self.coordinator.api.commands.resume_schedule(self.mower_id)
 
 
-class AutomowerStayOutZoneSwitchEntity(AutomowerControlEntity, SwitchEntity):
+class StayOutZoneSwitchEntity(AutomowerControlEntity, SwitchEntity):
     """Defining the Automower stay out zone switch."""
 
     _attr_translation_key = "stay_out_zones"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The names in the entities are sometimes a little bit confusing. With this PR they should be aligned.
- The descriptions tuple gets the prefix `MOWER`, if entities are only generated for each mower
- The EntityDescriptions class gets the prefix `Automower`, if entities are only generated for each mower
- The descriptions tuple gets the prefix `WORK_AREA`, if entities are generated for each work area
- The EntityDescriptions class gets the prefix `WorkArea`, if entities are generated for each work area

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
