### PR TITLE
Fail on unused ignore_translations fixture

### DIFF
--- a/tests/components/application_credentials/test_init.py
+++ b/tests/components/application_credentials/test_init.py
@@ -49,18 +49,6 @@ TEST_DOMAIN = "fake_integration"
 
 
 @pytest.fixture
-def ignore_translations() -> list[str]:
-    """Ignore specific translations.
-
-    We can ignore translations for the fake_integration we are testing with.
-    """
-    return [
-        f"component.{TEST_DOMAIN}.config.abort.missing_configuration",
-        f"component.{TEST_DOMAIN}.config.abort.missing_credentials",
-    ]
-
-
-@pytest.fixture
 async def authorization_server() -> AuthorizationServer:
     """Fixture AuthorizationServer for mock application_credentials integration."""
     return AuthorizationServer(AUTHORIZE_URL, TOKEN_URL)
@@ -435,6 +423,10 @@ async def test_import_named_credential(
     ]
 
 
+@pytest.mark.parametrize(
+    "ignore_translations",
+    ["component.fake_integration.config.abort.missing_credentials"],
+)
 async def test_config_flow_no_credentials(hass: HomeAssistant) -> None:
     """Test config flow base case with no credentials registered."""
     result = await hass.config_entries.flow.async_init(
@@ -444,6 +436,10 @@ async def test_config_flow_no_credentials(hass: HomeAssistant) -> None:
     assert result.get("reason") == "missing_credentials"
 
 
+@pytest.mark.parametrize(
+    "ignore_translations",
+    ["component.fake_integration.config.abort.missing_credentials"],
+)
 async def test_config_flow_other_domain(
     hass: HomeAssistant,
     ws_client: ClientFixture,
@@ -571,6 +567,10 @@ async def test_config_flow_multiple_entries(
     )
 
 
+@pytest.mark.parametrize(
+    "ignore_translations",
+    ["component.fake_integration.config.abort.missing_credentials"],
+)
 async def test_config_flow_create_delete_credential(
     hass: HomeAssistant,
     ws_client: ClientFixture,
@@ -616,6 +616,10 @@ async def test_config_flow_with_config_credential(
     assert result["data"].get("auth_implementation") == TEST_DOMAIN
 
 
+@pytest.mark.parametrize(
+    "ignore_translations",
+    ["component.fake_integration.config.abort.missing_configuration"],
+)
 @pytest.mark.parametrize("mock_application_credentials_integration", [None])
 async def test_import_without_setup(hass: HomeAssistant, config_credential) -> None:
     """Test import of credentials without setting up the integration."""
@@ -631,6 +635,10 @@ async def test_import_without_setup(hass: HomeAssistant, config_credential) -> N
     assert result.get("reason") == "missing_configuration"
 
 
+@pytest.mark.parametrize(
+    "ignore_translations",
+    ["component.fake_integration.config.abort.missing_configuration"],
+)
 @pytest.mark.parametrize("mock_application_credentials_integration", [None])
 async def test_websocket_without_platform(
     hass: HomeAssistant, ws_client: ClientFixture

--- a/tests/components/conftest.py
+++ b/tests/components/conftest.py
@@ -498,7 +498,7 @@ async def _ensure_translation_exists(
     ):
         return
 
-    raise ValueError(
+    pytest.fail(
         f"Translation not found for {component}: `{category}.{key}`. "
         f"Please add to homeassistant/components/{component}/strings.json"
     )
@@ -556,7 +556,7 @@ def check_config_translations(ignore_translations: str | list[str]) -> Generator
 
     unused_ignore = [k for k, v in _ignore_translations.items() if v == "unused"]
     if unused_ignore:
-        raise ValueError(
+        pytest.fail(
             f"Unused ignore translations: {', '.join(unused_ignore)}. "
             "Please remove them from the ignore_translations fixture."
         )

--- a/tests/components/matter/test_config_flow.py
+++ b/tests/components/matter/test_config_flow.py
@@ -827,10 +827,6 @@ async def test_addon_running(
     assert setup_entry.call_count == 1
 
 
-@pytest.mark.parametrize(  # Remove when translations fixed
-    "ignore_translations",
-    ["component.matter.config.abort.cannot_connect"],
-)
 @pytest.mark.parametrize(
     (
         "discovery_info",

--- a/tests/components/melcloud/test_config_flow.py
+++ b/tests/components/melcloud/test_config_flow.py
@@ -98,15 +98,6 @@ async def test_form_errors(
     assert result["reason"] == reason
 
 
-@pytest.mark.parametrize(  # Remove when translations fixed
-    "ignore_translations",
-    [
-        [
-            "component.melcloud.config.abort.cannot_connect",
-            "component.melcloud.config.abort.invalid_auth",
-        ],
-    ],
-)
 @pytest.mark.parametrize(
     ("error", "message"),
     [

--- a/tests/components/tplink/test_config_flow.py
+++ b/tests/components/tplink/test_config_flow.py
@@ -1348,10 +1348,6 @@ async def test_reauth_errors(
     assert result3["reason"] == "reauth_successful"
 
 
-@pytest.mark.parametrize(  # Remove when translations fixed
-    "ignore_translations",
-    ["component.tplink.config.abort.cannot_connect"],
-)
 @pytest.mark.parametrize(
     ("error_type", "expected_flow"),
     [


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In #128140, we added some checks to ensure translations exists, with a fixture to allow temporary violations.

This PR adds a check to ensure that when these temporary violations are no longer needed, the test fails until the ignore is removed.

Needs:
- [x] #128364
- [x] #128423
- [x] #128425
- [x] #128431

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
