### PR TITLE
Allow fetching HA url to display it in the network settings

### DIFF
--- a/homeassistant/components/network/const.py
+++ b/homeassistant/components/network/const.py
@@ -30,3 +30,5 @@ NETWORK_CONFIG_SCHEMA = vol.Schema(
         ): vol.Schema(vol.All(cv.ensure_list, [cv.string])),
     }
 )
+
+URL_TYPES: Final = ["internal", "external", "cloud"]

--- a/homeassistant/components/network/const.py
+++ b/homeassistant/components/network/const.py
@@ -30,5 +30,3 @@ NETWORK_CONFIG_SCHEMA = vol.Schema(
         ): vol.Schema(vol.All(cv.ensure_list, [cv.string])),
     }
 )
-
-URL_TYPES: Final = ["internal", "external", "cloud"]

--- a/homeassistant/components/network/websocket.py
+++ b/homeassistant/components/network/websocket.py
@@ -67,14 +67,14 @@ async def websocket_network_adapters_configure(
     )
 
 
+@callback
 @websocket_api.require_admin
 @websocket_api.websocket_command(
     {
         vol.Required("type"): "network/url",
     }
 )
-@websocket_api.async_response
-async def websocket_network_url(
+def websocket_network_url(
     hass: HomeAssistant,
     connection: ActiveConnection,
     msg: dict[str, Any],

--- a/homeassistant/components/network/websocket.py
+++ b/homeassistant/components/network/websocket.py
@@ -80,12 +80,15 @@ async def websocket_network_url(
     msg: dict[str, Any],
 ) -> None:
     """Get the internal URL."""
+    if msg["url_type"] not in ["internal", "external", "cloud"]:
+        connection.send_error(msg["id"], "invalid_url_type", "Invalid URL type")
+        return
     connection.send_result(
         msg["id"],
         get_url(
             hass,
             allow_internal=msg["url_type"] == "internal",
-            allow_external=msg["url_type"] == "external",
-            allow_cloud=msg["url_type"] == "cloud",
+            allow_external=msg["url_type"] in ["external", "cloud"],
+            require_cloud=msg["url_type"] == "cloud",
         ),
     )

--- a/homeassistant/components/network/websocket.py
+++ b/homeassistant/components/network/websocket.py
@@ -11,7 +11,12 @@ from homeassistant.components.websocket_api import ActiveConnection
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.network import get_url
 
-from .const import ATTR_ADAPTERS, ATTR_CONFIGURED_ADAPTERS, NETWORK_CONFIG_SCHEMA
+from .const import (
+    ATTR_ADAPTERS,
+    ATTR_CONFIGURED_ADAPTERS,
+    NETWORK_CONFIG_SCHEMA,
+    URL_TYPES,
+)
 from .network import async_get_network
 
 
@@ -70,7 +75,7 @@ async def websocket_network_adapters_configure(
 @websocket_api.websocket_command(
     {
         vol.Required("type"): "network/url",
-        vol.Required("url_type"): str,
+        vol.Required("url_type"): vol.In(URL_TYPES),
     }
 )
 @websocket_api.async_response
@@ -80,9 +85,6 @@ async def websocket_network_url(
     msg: dict[str, Any],
 ) -> None:
     """Get the internal URL."""
-    if msg["url_type"] not in ["internal", "external", "cloud"]:
-        connection.send_error(msg["id"], "invalid_url_type", "Invalid URL type")
-        return
     connection.send_result(
         msg["id"],
         get_url(

--- a/tests/components/network/test_init.py
+++ b/tests/components/network/test_init.py
@@ -925,4 +925,4 @@ async def test_websocket_network_url(
     await client.send_json({"id": 4, "type": "network/url", "url_type": "invalid"})
     msg = await client.receive_json()
     assert not msg["success"]
-    assert msg["error"]["code"] == "invalid_url_type"
+    assert msg["error"]["code"] == "invalid_format"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allow fetching of the internal or external URL through WS. The purpose of this is to display the automatically resolved url in the Network->URL settings component for easier debugging.

Frontend PR https://github.com/home-assistant/frontend/pull/22379


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
