### PR TITLE
Improve check for user-visible flows when checking translations in tests

### DIFF
--- a/homeassistant/components/nest/strings.json
+++ b/homeassistant/components/nest/strings.json
@@ -45,6 +45,7 @@
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
       "missing_configuration": "[%key:common::config_flow::abort::oauth2_missing_configuration%]",
+      "missing_credentials": "[%key:common::config_flow::abort::oauth2_missing_credentials%]",
       "authorize_url_timeout": "[%key:common::config_flow::abort::oauth2_authorize_url_timeout%]",
       "unknown_authorize_url_generation": "[%key:common::config_flow::abort::unknown_authorize_url_generation%]",
       "no_url_available": "[%key:common::config_flow::abort::oauth2_no_url_available%]",

--- a/tests/components/conftest.py
+++ b/tests/components/conftest.py
@@ -533,13 +533,17 @@ def check_config_translations(ignore_translations: str | list[str]) -> Generator
         else:
             return result
 
-        # Exclude discovery flows - but only for first step
-        if flow.source == SOURCE_SYSTEM or flow.source in DISCOVERY_SOURCES:
-            if not hasattr(flow, "__user_visible"):
-                setattr(flow, "__user_visible", True)
-                return result
+        # Check if this flow has been seen before
+        # Gets set to False on first run, and to True on subsequent runs
+        setattr(flow, "__flow_seen_before", hasattr(flow, "__flow_seen_before"))
 
         if result["type"] is FlowResultType.ABORT:
+            # We don't need translations for a discovery flow which immediately
+            # aborts, since such flows won't be seen by users
+            if not flow.__flow_seen_before and (
+                flow.source == SOURCE_SYSTEM or flow.source in DISCOVERY_SOURCES
+            ):
+                return result
             await _ensure_translation_exists(
                 flow.hass,
                 _ignore_translations,

--- a/tests/components/conftest.py
+++ b/tests/components/conftest.py
@@ -533,11 +533,13 @@ def check_config_translations(ignore_translations: str | list[str]) -> Generator
         else:
             return result
 
-        if (
-            result["type"] is FlowResultType.ABORT
-            and flow.source != SOURCE_SYSTEM
-            and flow.source not in DISCOVERY_SOURCES
-        ):
+        # Exclude discovery flows - but only for first step
+        if flow.source == SOURCE_SYSTEM or flow.source in DISCOVERY_SOURCES:
+            if not hasattr(flow, "__user_visible"):
+                setattr(flow, "__user_visible", True)
+                return result
+
+        if result["type"] is FlowResultType.ABORT:
             await _ensure_translation_exists(
                 flow.hass,
                 _ignore_translations,

--- a/tests/components/homeassistant_hardware/test_config_flow_failures.py
+++ b/tests/components/homeassistant_hardware/test_config_flow_failures.py
@@ -31,6 +31,10 @@ async def fixture_mock_supervisor_client(supervisor_client: AsyncMock):
 
 
 @pytest.mark.parametrize(
+    "ignore_translations",
+    ["component.test_firmware_domain.config.abort.unsupported_firmware"],
+)
+@pytest.mark.parametrize(
     "next_step",
     [
         STEP_PICK_FIRMWARE_ZIGBEE,
@@ -60,6 +64,10 @@ async def test_config_flow_cannot_probe_firmware(
         assert result["reason"] == "unsupported_firmware"
 
 
+@pytest.mark.parametrize(
+    "ignore_translations",
+    ["component.test_firmware_domain.config.abort.not_hassio"],
+)
 async def test_config_flow_zigbee_not_hassio_wrong_firmware(
     hass: HomeAssistant,
 ) -> None:
@@ -85,6 +93,10 @@ async def test_config_flow_zigbee_not_hassio_wrong_firmware(
         assert result["reason"] == "not_hassio"
 
 
+@pytest.mark.parametrize(
+    "ignore_translations",
+    ["component.test_firmware_domain.config.abort.addon_already_running"],
+)
 async def test_config_flow_zigbee_flasher_addon_already_running(
     hass: HomeAssistant,
 ) -> None:
@@ -119,6 +131,10 @@ async def test_config_flow_zigbee_flasher_addon_already_running(
         assert result["reason"] == "addon_already_running"
 
 
+@pytest.mark.parametrize(
+    "ignore_translations",
+    ["component.test_firmware_domain.config.abort.addon_info_failed"],
+)
 async def test_config_flow_zigbee_flasher_addon_info_fails(hass: HomeAssistant) -> None:
     """Test failure case when flasher addon cannot be installed."""
     result = await hass.config_entries.flow.async_init(
@@ -152,6 +168,10 @@ async def test_config_flow_zigbee_flasher_addon_info_fails(hass: HomeAssistant) 
         assert result["reason"] == "addon_info_failed"
 
 
+@pytest.mark.parametrize(
+    "ignore_translations",
+    ["component.test_firmware_domain.config.abort.addon_install_failed"],
+)
 async def test_config_flow_zigbee_flasher_addon_install_fails(
     hass: HomeAssistant,
 ) -> None:
@@ -182,6 +202,10 @@ async def test_config_flow_zigbee_flasher_addon_install_fails(
         assert result["reason"] == "addon_install_failed"
 
 
+@pytest.mark.parametrize(
+    "ignore_translations",
+    ["component.test_firmware_domain.config.abort.addon_set_config_failed"],
+)
 async def test_config_flow_zigbee_flasher_addon_set_config_fails(
     hass: HomeAssistant,
 ) -> None:
@@ -216,6 +240,10 @@ async def test_config_flow_zigbee_flasher_addon_set_config_fails(
         assert result["reason"] == "addon_set_config_failed"
 
 
+@pytest.mark.parametrize(
+    "ignore_translations",
+    ["component.test_firmware_domain.config.abort.addon_start_failed"],
+)
 async def test_config_flow_zigbee_flasher_run_fails(hass: HomeAssistant) -> None:
     """Test failure case when flasher addon fails to run."""
     result = await hass.config_entries.flow.async_init(
@@ -277,6 +305,10 @@ async def test_config_flow_zigbee_flasher_uninstall_fails(hass: HomeAssistant) -
         assert result["step_id"] == "confirm_zigbee"
 
 
+@pytest.mark.parametrize(
+    "ignore_translations",
+    ["component.test_firmware_domain.config.abort.not_hassio_thread"],
+)
 async def test_config_flow_thread_not_hassio(hass: HomeAssistant) -> None:
     """Test when the stick is used with a non-hassio setup and Thread is selected."""
     result = await hass.config_entries.flow.async_init(
@@ -300,6 +332,10 @@ async def test_config_flow_thread_not_hassio(hass: HomeAssistant) -> None:
         assert result["reason"] == "not_hassio_thread"
 
 
+@pytest.mark.parametrize(
+    "ignore_translations",
+    ["component.test_firmware_domain.config.abort.addon_info_failed"],
+)
 async def test_config_flow_thread_addon_info_fails(hass: HomeAssistant) -> None:
     """Test failure case when flasher addon cannot be installed."""
     result = await hass.config_entries.flow.async_init(
@@ -324,6 +360,10 @@ async def test_config_flow_thread_addon_info_fails(hass: HomeAssistant) -> None:
         assert result["reason"] == "addon_info_failed"
 
 
+@pytest.mark.parametrize(
+    "ignore_translations",
+    ["component.test_firmware_domain.config.abort.otbr_addon_already_running"],
+)
 async def test_config_flow_thread_addon_already_running(hass: HomeAssistant) -> None:
     """Test failure case when the Thread addon is already running."""
     result = await hass.config_entries.flow.async_init(
@@ -359,6 +399,10 @@ async def test_config_flow_thread_addon_already_running(hass: HomeAssistant) -> 
         assert result["reason"] == "otbr_addon_already_running"
 
 
+@pytest.mark.parametrize(
+    "ignore_translations",
+    ["component.test_firmware_domain.config.abort.addon_install_failed"],
+)
 async def test_config_flow_thread_addon_install_fails(hass: HomeAssistant) -> None:
     """Test failure case when flasher addon cannot be installed."""
     result = await hass.config_entries.flow.async_init(
@@ -386,6 +430,10 @@ async def test_config_flow_thread_addon_install_fails(hass: HomeAssistant) -> No
         assert result["reason"] == "addon_install_failed"
 
 
+@pytest.mark.parametrize(
+    "ignore_translations",
+    ["component.test_firmware_domain.config.abort.addon_set_config_failed"],
+)
 async def test_config_flow_thread_addon_set_config_fails(hass: HomeAssistant) -> None:
     """Test failure case when flasher addon cannot be configured."""
     result = await hass.config_entries.flow.async_init(
@@ -413,6 +461,10 @@ async def test_config_flow_thread_addon_set_config_fails(hass: HomeAssistant) ->
         assert result["reason"] == "addon_set_config_failed"
 
 
+@pytest.mark.parametrize(
+    "ignore_translations",
+    ["component.test_firmware_domain.config.abort.addon_start_failed"],
+)
 async def test_config_flow_thread_flasher_run_fails(hass: HomeAssistant) -> None:
     """Test failure case when flasher addon fails to run."""
     result = await hass.config_entries.flow.async_init(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I originally excluded all discovery flows to avoid false positives from the translation checks added in #128140

As highlighted by @emontnemery, this could lead to false negatives when discovery flows are made visible to the users.

This PR attempts to reduce the number of false negatives - whilst still keeping the false positives out.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
