### PR TITLE
Improve logic for detecting unused ignore translations

### DIFF
--- a/tests/components/conftest.py
+++ b/tests/components/conftest.py
@@ -475,12 +475,12 @@ async def _ensure_translation_exists(
 ) -> None:
     """Raise if translation doesn't exist."""
     full_key = f"component.{component}.{category}.{key}"
-    if full_key in ignore_translations:
-        ignore_translations[full_key] = "used"
-        return
-
     translations = await async_get_translations(hass, "en", category, [component])
     if full_key in translations:
+        return
+
+    if full_key in ignore_translations:
+        ignore_translations[full_key] = "used"
         return
 
     key_parts = key.split(".")

--- a/tests/components/gardena_bluetooth/snapshots/test_config_flow.ambr
+++ b/tests/components/gardena_bluetooth/snapshots/test_config_flow.ambr
@@ -84,7 +84,7 @@
     'type': <FlowResultType.ABORT: 'abort'>,
   })
 # ---
-# name: test_failed_connect[component.gardena_bluetooth.config.abort.cannot_connect]
+# name: test_failed_connect
   FlowResultSnapshot({
     'data_schema': list([
       dict({
@@ -109,7 +109,7 @@
     'type': <FlowResultType.FORM: 'form'>,
   })
 # ---
-# name: test_failed_connect[component.gardena_bluetooth.config.abort.cannot_connect].1
+# name: test_failed_connect.1
   FlowResultSnapshot({
     'data_schema': None,
     'description_placeholders': dict({
@@ -124,7 +124,7 @@
     'type': <FlowResultType.FORM: 'form'>,
   })
 # ---
-# name: test_failed_connect[component.gardena_bluetooth.config.abort.cannot_connect].2
+# name: test_failed_connect.2
   FlowResultSnapshot({
     'description_placeholders': dict({
       'error': 'something went wrong',

--- a/tests/components/gardena_bluetooth/test_config_flow.py
+++ b/tests/components/gardena_bluetooth/test_config_flow.py
@@ -50,10 +50,6 @@ async def test_user_selection(
     assert result == snapshot
 
 
-@pytest.mark.parametrize(  # Remove when translations fixed
-    "ignore_translations",
-    ["component.gardena_bluetooth.config.abort.cannot_connect"],
-)
 async def test_failed_connect(
     hass: HomeAssistant,
     mock_client: Mock,

--- a/tests/components/google/test_config_flow.py
+++ b/tests/components/google/test_config_flow.py
@@ -437,10 +437,6 @@ async def test_multiple_config_entries(
     assert len(entries) == 2
 
 
-@pytest.mark.parametrize(  # Remove when translations fixed
-    "ignore_translations",
-    ["component.google.config.abort.missing_credentials"],
-)
 async def test_missing_configuration(
     hass: HomeAssistant,
 ) -> None:

--- a/tests/components/iotty/test_config_flow.py
+++ b/tests/components/iotty/test_config_flow.py
@@ -45,10 +45,6 @@ def current_request_with_host(current_request: MagicMock) -> None:
     )
 
 
-@pytest.mark.parametrize(  # Remove when translations fixed
-    "ignore_translations",
-    ["component.iotty.config.abort.missing_credentials"],
-)
 async def test_config_flow_no_credentials(hass: HomeAssistant) -> None:
     """Test config flow base case with no credentials registered."""
     result = await hass.config_entries.flow.async_init(

--- a/tests/components/lifx/test_config_flow.py
+++ b/tests/components/lifx/test_config_flow.py
@@ -101,10 +101,6 @@ async def test_discovery(hass: HomeAssistant) -> None:
     assert result2["reason"] == "no_devices_found"
 
 
-@pytest.mark.parametrize(  # Remove when translations fixed
-    "ignore_translations",
-    ["component.lifx.config.abort.cannot_connect"],
-)
 async def test_discovery_but_cannot_connect(hass: HomeAssistant) -> None:
     """Test we can discover the device but we cannot connect."""
     with _patch_discovery(), _patch_config_flow_try_connect(no_device=True):

--- a/tests/components/melcloud/test_config_flow.py
+++ b/tests/components/melcloud/test_config_flow.py
@@ -73,10 +73,6 @@ async def test_form(hass: HomeAssistant, mock_login, mock_get_devices) -> None:
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-@pytest.mark.parametrize(  # Remove when translations fixed
-    "ignore_translations",
-    ["component.melcloud.config.abort.cannot_connect"],
-)
 @pytest.mark.parametrize(
     ("error", "reason"),
     [(ClientError(), "cannot_connect"), (TimeoutError(), "cannot_connect")],

--- a/tests/components/teslemetry/test_config_flow.py
+++ b/tests/components/teslemetry/test_config_flow.py
@@ -89,10 +89,6 @@ async def test_form_errors(
     assert result3["type"] is FlowResultType.CREATE_ENTRY
 
 
-@pytest.mark.parametrize(  # Remove when translations fixed
-    "ignore_translations",
-    ["component.teslemetry.config.abort.reauth_successful"],
-)
 async def test_reauth(hass: HomeAssistant, mock_metadata: AsyncMock) -> None:
     """Test reauth flow."""
 
@@ -124,10 +120,6 @@ async def test_reauth(hass: HomeAssistant, mock_metadata: AsyncMock) -> None:
     assert mock_entry.data == CONFIG
 
 
-@pytest.mark.parametrize(  # Remove when translations fixed
-    "ignore_translations",
-    ["component.teslemetry.config.abort.reauth_successful"],
-)
 @pytest.mark.parametrize(
     ("side_effect", "error"),
     [

--- a/tests/components/yolink/test_config_flow.py
+++ b/tests/components/yolink/test_config_flow.py
@@ -22,10 +22,6 @@ CLIENT_SECRET = "6789"
 DOMAIN = "yolink"
 
 
-@pytest.mark.parametrize(  # Remove when translations fixed
-    "ignore_translations",
-    ["component.yolink.config.abort.missing_credentials"],
-)
 async def test_abort_if_no_configuration(hass: HomeAssistant) -> None:
     """Check flow abort when no configuration."""
     result = await hass.config_entries.flow.async_init(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
#128422 added detection of obsolete ignores when the string wasn't used in the test (for example if the config flow was adjusted to use a different translation key)
 
However, it didn't detect the obsolete ignore if the string was still used in the test, but the translation has since been added.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
