### PR TITLE
Add check for valid abort reason translation in option flows

### DIFF
--- a/tests/components/conftest.py
+++ b/tests/components/conftest.py
@@ -16,6 +16,7 @@ from homeassistant.config_entries import (
     SOURCE_SYSTEM,
     ConfigEntriesFlowManager,
     FlowResult,
+    OptionsFlowManager,
 )
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
@@ -530,6 +531,9 @@ def check_config_translations(ignore_translations: str | list[str]) -> Generator
         if isinstance(self, ConfigEntriesFlowManager):
             category = "config"
             component = flow.handler
+        elif isinstance(self, OptionsFlowManager):
+            category = "options"
+            component = flow.hass.config_entries.async_get_entry(flow.handler).domain
         else:
             return result
 

--- a/tests/components/homeassistant_hardware/test_config_flow_failures.py
+++ b/tests/components/homeassistant_hardware/test_config_flow_failures.py
@@ -526,6 +526,10 @@ async def test_config_flow_thread_flasher_uninstall_fails(hass: HomeAssistant) -
         assert result["step_id"] == "confirm_otbr"
 
 
+@pytest.mark.parametrize(
+    "ignore_translations",
+    ["component.test_firmware_domain.options.abort.zha_still_using_stick"],
+)
 async def test_options_flow_zigbee_to_thread_zha_configured(
     hass: HomeAssistant,
 ) -> None:
@@ -563,6 +567,10 @@ async def test_options_flow_zigbee_to_thread_zha_configured(
     assert result["reason"] == "zha_still_using_stick"
 
 
+@pytest.mark.parametrize(
+    "ignore_translations",
+    ["component.test_firmware_domain.options.abort.otbr_still_using_stick"],
+)
 async def test_options_flow_thread_to_zigbee_otbr_configured(
     hass: HomeAssistant,
 ) -> None:

--- a/tests/components/homeassistant_hardware/test_silabs_multiprotocol_addon.py
+++ b/tests/components/homeassistant_hardware/test_silabs_multiprotocol_addon.py
@@ -453,6 +453,10 @@ async def test_option_flow_install_multi_pan_addon_zha_other_radio(
     }
 
 
+@pytest.mark.parametrize(
+    "ignore_translations",
+    ["component.test.options.abort.not_hassio"],
+)
 async def test_option_flow_non_hassio(
     hass: HomeAssistant,
 ) -> None:
@@ -765,6 +769,10 @@ async def test_option_flow_addon_installed_same_device_do_not_uninstall_multi_pa
     assert result["type"] is FlowResultType.CREATE_ENTRY
 
 
+@pytest.mark.parametrize(
+    "ignore_translations",
+    ["component.test.options.abort.addon_already_running"],
+)
 async def test_option_flow_flasher_already_running_failure(
     hass: HomeAssistant,
     addon_info,
@@ -876,6 +884,10 @@ async def test_option_flow_addon_installed_same_device_flasher_already_installed
     assert result["type"] is FlowResultType.CREATE_ENTRY
 
 
+@pytest.mark.parametrize(
+    "ignore_translations",
+    ["component.test.options.abort.addon_install_failed"],
+)
 async def test_option_flow_flasher_install_failure(
     hass: HomeAssistant,
     addon_info,
@@ -942,6 +954,10 @@ async def test_option_flow_flasher_install_failure(
     assert result["reason"] == "addon_install_failed"
 
 
+@pytest.mark.parametrize(
+    "ignore_translations",
+    ["component.test.options.abort.addon_start_failed"],
+)
 async def test_option_flow_flasher_addon_flash_failure(
     hass: HomeAssistant,
     addon_info,
@@ -1004,6 +1020,10 @@ async def test_option_flow_flasher_addon_flash_failure(
     assert result["description_placeholders"]["addon_name"] == "Silicon Labs Flasher"
 
 
+@pytest.mark.parametrize(
+    "ignore_translations",
+    ["component.test.options.abort.zha_migration_failed"],
+)
 @patch(
     "homeassistant.components.zha.radio_manager.ZhaMultiPANMigrationHelper.async_initiate_migration",
     side_effect=Exception("Boom!"),
@@ -1065,6 +1085,10 @@ async def test_option_flow_uninstall_migration_initiate_failure(
     mock_initiate_migration.assert_called_once()
 
 
+@pytest.mark.parametrize(
+    "ignore_translations",
+    ["component.test.options.abort.zha_migration_failed"],
+)
 @patch(
     "homeassistant.components.zha.radio_manager.ZhaMultiPANMigrationHelper.async_finish_migration",
     side_effect=Exception("Boom!"),
@@ -1166,6 +1190,10 @@ async def test_option_flow_do_not_install_multi_pan_addon(
     assert result["type"] is FlowResultType.CREATE_ENTRY
 
 
+@pytest.mark.parametrize(
+    "ignore_translations",
+    ["component.test.options.abort.addon_install_failed"],
+)
 async def test_option_flow_install_multi_pan_addon_install_fails(
     hass: HomeAssistant,
     addon_store_info,
@@ -1209,6 +1237,10 @@ async def test_option_flow_install_multi_pan_addon_install_fails(
     assert result["reason"] == "addon_install_failed"
 
 
+@pytest.mark.parametrize(
+    "ignore_translations",
+    ["component.test.options.abort.addon_start_failed"],
+)
 async def test_option_flow_install_multi_pan_addon_start_fails(
     hass: HomeAssistant,
     addon_store_info,
@@ -1271,6 +1303,10 @@ async def test_option_flow_install_multi_pan_addon_start_fails(
     assert result["reason"] == "addon_start_failed"
 
 
+@pytest.mark.parametrize(
+    "ignore_translations",
+    ["component.test.options.abort.addon_set_config_failed"],
+)
 async def test_option_flow_install_multi_pan_addon_set_options_fails(
     hass: HomeAssistant,
     addon_store_info,
@@ -1314,6 +1350,10 @@ async def test_option_flow_install_multi_pan_addon_set_options_fails(
     assert result["reason"] == "addon_set_config_failed"
 
 
+@pytest.mark.parametrize(
+    "ignore_translations",
+    ["component.test.options.abort.addon_info_failed"],
+)
 async def test_option_flow_addon_info_fails(
     hass: HomeAssistant,
     addon_store_info,
@@ -1337,6 +1377,10 @@ async def test_option_flow_addon_info_fails(
     assert result["reason"] == "addon_info_failed"
 
 
+@pytest.mark.parametrize(
+    "ignore_translations",
+    ["component.test.options.abort.zha_migration_failed"],
+)
 @patch(
     "homeassistant.components.zha.radio_manager.ZhaMultiPANMigrationHelper.async_initiate_migration",
     side_effect=Exception("Boom!"),
@@ -1392,6 +1436,10 @@ async def test_option_flow_install_multi_pan_addon_zha_migration_fails_step_1(
     set_addon_options.assert_not_called()
 
 
+@pytest.mark.parametrize(
+    "ignore_translations",
+    ["component.test.options.abort.zha_migration_failed"],
+)
 @patch(
     "homeassistant.components.zha.radio_manager.ZhaMultiPANMigrationHelper.async_finish_migration",
     side_effect=Exception("Boom!"),

--- a/tests/components/hyperion/test_config_flow.py
+++ b/tests/components/hyperion/test_config_flow.py
@@ -826,7 +826,7 @@ async def test_options_effect_show_list(hass: HomeAssistant) -> None:
 
 @pytest.mark.parametrize(  # Remove when translations fixed
     "ignore_translations",
-    ["component.hyperion.config.abort.cannot_connect"],
+    ["component.hyperion.options.abort.cannot_connect"],
 )
 async def test_options_effect_hide_list_cannot_connect(hass: HomeAssistant) -> None:
     """Check an options flow effect hide list with a failed connection."""

--- a/tests/components/hyperion/test_config_flow.py
+++ b/tests/components/hyperion/test_config_flow.py
@@ -9,6 +9,7 @@ from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
 from hyperion import const
+import pytest
 
 from homeassistant.components import ssdp
 from homeassistant.components.hyperion.const import (
@@ -823,6 +824,10 @@ async def test_options_effect_show_list(hass: HomeAssistant) -> None:
         assert result["data"][CONF_EFFECT_HIDE_LIST] == ["effect2"]
 
 
+@pytest.mark.parametrize(  # Remove when translations fixed
+    "ignore_translations",
+    ["component.hyperion.config.abort.cannot_connect"],
+)
 async def test_options_effect_hide_list_cannot_connect(hass: HomeAssistant) -> None:
     """Check an options flow effect hide list with a failed connection."""
 

--- a/tests/components/onewire/test_config_flow.py
+++ b/tests/components/onewire/test_config_flow.py
@@ -253,6 +253,10 @@ async def test_user_options_set_multiple(
     )
 
 
+@pytest.mark.parametrize(  # Remove when translations fixed
+    "ignore_translations",
+    ["component.onewire.options.abort.No configurable devices found."],
+)
 async def test_user_options_no_devices(
     hass: HomeAssistant, config_entry: ConfigEntry
 ) -> None:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As follow-up to https://github.com/home-assistant/core/pull/128140, add checks for abort reasons in `OptionsFlowManager`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
