### PR TITLE
Add check for valid error code in translation checks in flows

### DIFF
--- a/tests/components/config/test_config_entries.py
+++ b/tests/components/config/test_config_entries.py
@@ -393,6 +393,10 @@ async def test_available_flows(
 ############################
 
 
+@pytest.mark.parametrize(
+    "ignore_translations",
+    ["component.test.config.error.Should be unique."],
+)
 async def test_initialize_flow(hass: HomeAssistant, client: TestClient) -> None:
     """Test we can initialize a flow."""
     mock_platform(hass, "test.config_flow", None)
@@ -772,6 +776,10 @@ async def test_get_progress_index_unauth(
     assert response["error"]["code"] == "unauthorized"
 
 
+@pytest.mark.parametrize(
+    "ignore_translations",
+    ["component.test.config.error.Should be unique."],
+)
 async def test_get_progress_flow(hass: HomeAssistant, client: TestClient) -> None:
     """Test we can query the API for same result as we get from init a flow."""
     mock_platform(hass, "test.config_flow", None)
@@ -804,6 +812,10 @@ async def test_get_progress_flow(hass: HomeAssistant, client: TestClient) -> Non
     assert data == data2
 
 
+@pytest.mark.parametrize(
+    "ignore_translations",
+    ["component.test.config.error.Should be unique."],
+)
 async def test_get_progress_flow_unauth(
     hass: HomeAssistant, client: TestClient, hass_admin_user: MockUser
 ) -> None:

--- a/tests/components/conftest.py
+++ b/tests/components/conftest.py
@@ -498,7 +498,7 @@ async def _ensure_translation_exists(
     ):
         return
 
-    raise ValueError(
+    pytest.fail(
         f"Translation not found for {component}: `{category}.{key}`. "
         f"Please add to homeassistant/components/{component}/strings.json"
     )

--- a/tests/components/conftest.py
+++ b/tests/components/conftest.py
@@ -498,7 +498,7 @@ async def _ensure_translation_exists(
     ):
         return
 
-    pytest.fail(
+    raise ValueError(
         f"Translation not found for {component}: `{category}.{key}`. "
         f"Please add to homeassistant/components/{component}/strings.json"
     )

--- a/tests/components/conftest.py
+++ b/tests/components/conftest.py
@@ -540,6 +540,18 @@ def check_config_translations(ignore_translations: str | list[str]) -> Generator
         # Gets set to False on first run, and to True on subsequent runs
         setattr(flow, "__flow_seen_before", hasattr(flow, "__flow_seen_before"))
 
+        if result["type"] is FlowResultType.FORM:
+            if errors := result.get("errors"):
+                for error in errors.values():
+                    await _ensure_translation_exists(
+                        flow.hass,
+                        _ignore_translations,
+                        category,
+                        component,
+                        f"error.{error}",
+                    )
+            return result
+
         if result["type"] is FlowResultType.ABORT:
             # We don't need translations for a discovery flow which immediately
             # aborts, since such flows won't be seen by users

--- a/tests/components/emoncms/test_config_flow.py
+++ b/tests/components/emoncms/test_config_flow.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import AsyncMock
 
+import pytest
+
 from homeassistant.components.emoncms.const import CONF_ONLY_INCLUDE_FEEDID, DOMAIN
 from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
 from homeassistant.const import CONF_API_KEY, CONF_URL
@@ -127,6 +129,10 @@ async def test_options_flow(
     assert config_entry.options == CONFIG_ENTRY
 
 
+@pytest.mark.parametrize(  # Remove when translations fixed
+    "ignore_translations",
+    ["component.emoncms.options.error.failure"],
+)
 async def test_options_flow_failure(
     hass: HomeAssistant,
     mock_setup_entry: AsyncMock,

--- a/tests/components/flume/test_config_flow.py
+++ b/tests/components/flume/test_config_flow.py
@@ -61,6 +61,10 @@ async def test_form(hass: HomeAssistant) -> None:
     assert len(mock_setup_entry.mock_calls) == 1
 
 
+@pytest.mark.parametrize(  # Remove when translations fixed
+    "ignore_translations",
+    ["component.flume.config.error.invalid_auth"],
+)
 @pytest.mark.usefixtures("access_token")
 async def test_form_invalid_auth(hass: HomeAssistant, requests_mock: Mocker) -> None:
     """Test we handle invalid auth."""
@@ -89,6 +93,10 @@ async def test_form_invalid_auth(hass: HomeAssistant, requests_mock: Mocker) -> 
     assert result2["errors"] == {"password": "invalid_auth"}
 
 
+@pytest.mark.parametrize(  # Remove when translations fixed
+    "ignore_translations",
+    ["component.flume.config.error.cannot_connect"],
+)
 @pytest.mark.usefixtures("access_token", "device_list_timeout")
 async def test_form_cannot_connect(hass: HomeAssistant) -> None:
     """Test we handle cannot connect error."""
@@ -112,7 +120,13 @@ async def test_form_cannot_connect(hass: HomeAssistant) -> None:
 
 @pytest.mark.parametrize(  # Remove when translations fixed
     "ignore_translations",
-    ["component.flume.config.abort.reauth_successful"],
+    [
+        [
+            "component.flume.config.abort.reauth_successful",
+            "component.flume.config.error.cannot_connect",
+            "component.flume.config.error.invalid_auth",
+        ]
+    ],
 )
 @pytest.mark.usefixtures("access_token")
 async def test_reauth(hass: HomeAssistant, requests_mock: Mocker) -> None:
@@ -194,6 +208,10 @@ async def test_reauth(hass: HomeAssistant, requests_mock: Mocker) -> None:
     assert result4["reason"] == "reauth_successful"
 
 
+@pytest.mark.parametrize(  # Remove when translations fixed
+    "ignore_translations",
+    ["component.flume.config.error.cannot_connect"],
+)
 @pytest.mark.usefixtures("access_token")
 async def test_form_no_devices(hass: HomeAssistant, requests_mock: Mocker) -> None:
     """Test a device list response that contains no values will raise an error."""

--- a/tests/components/generic/test_config_flow.py
+++ b/tests/components/generic/test_config_flow.py
@@ -637,6 +637,10 @@ async def test_form_stream_other_error(hass: HomeAssistant, user_flow) -> None:
     await hass.async_block_till_done()
 
 
+@pytest.mark.parametrize(  # Remove when translations fixed
+    "ignore_translations",
+    ["component.generic.config.error.Some message"],
+)
 @respx.mock
 @pytest.mark.usefixtures("fakeimg_png")
 async def test_form_stream_worker_error(

--- a/tests/components/guardian/test_config_flow.py
+++ b/tests/components/guardian/test_config_flow.py
@@ -33,6 +33,10 @@ async def test_duplicate_error(hass: HomeAssistant, config: dict[str, Any]) -> N
     assert result["reason"] == "already_configured"
 
 
+@pytest.mark.parametrize(  # Remove when translations fixed
+    "ignore_translations",
+    ["component.guardian.config.error.cannot_connect"],
+)
 async def test_connect_error(hass: HomeAssistant, config: dict[str, Any]) -> None:
     """Test that the config entry errors out if the device cannot connect."""
     with patch(

--- a/tests/components/hvv_departures/test_config_flow.py
+++ b/tests/components/hvv_departures/test_config_flow.py
@@ -4,6 +4,7 @@ import json
 from unittest.mock import patch
 
 from pygti.exceptions import CannotConnect, InvalidAuth
+import pytest
 
 from homeassistant.components.hvv_departures.const import (
     CONF_FILTER,
@@ -312,6 +313,10 @@ async def test_options_flow(hass: HomeAssistant) -> None:
         }
 
 
+@pytest.mark.parametrize(  # Remove when translations fixed
+    "ignore_translations",
+    ["component.hvv_departures.options.error.invalid_auth"],
+)
 async def test_options_flow_invalid_auth(hass: HomeAssistant) -> None:
     """Test that options flow works."""
 
@@ -355,6 +360,10 @@ async def test_options_flow_invalid_auth(hass: HomeAssistant) -> None:
         assert result["errors"] == {"base": "invalid_auth"}
 
 
+@pytest.mark.parametrize(  # Remove when translations fixed
+    "ignore_translations",
+    ["component.hvv_departures.options.error.cannot_connect"],
+)
 async def test_options_flow_cannot_connect(hass: HomeAssistant) -> None:
     """Test that options flow works."""
 

--- a/tests/components/hydrawise/test_config_flow.py
+++ b/tests/components/hydrawise/test_config_flow.py
@@ -93,6 +93,10 @@ async def test_form_connect_timeout(
     assert result2["type"] is FlowResultType.CREATE_ENTRY
 
 
+@pytest.mark.parametrize(  # Remove when translations fixed
+    "ignore_translations",
+    ["component.hydrawise.config.error.invalid_auth"],
+)
 async def test_form_not_authorized_error(
     hass: HomeAssistant, mock_pydrawise: AsyncMock, user: User
 ) -> None:

--- a/tests/components/lamarzocco/test_config_flow.py
+++ b/tests/components/lamarzocco/test_config_flow.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 
 from lmcloud.exceptions import AuthFail, RequestNotSuccessful
 from lmcloud.models import LaMarzoccoDeviceInfo
+import pytest
 
 from homeassistant.components.lamarzocco.config_flow import CONF_MACHINE
 from homeassistant.components.lamarzocco.const import CONF_USE_BLUETOOTH, DOMAIN
@@ -365,6 +366,10 @@ async def test_bluetooth_discovery(
     }
 
 
+@pytest.mark.parametrize(  # Remove when translations fixed
+    "ignore_translations",
+    ["component.lamarzocco.config.error.machine_not_found"],
+)
 async def test_bluetooth_discovery_errors(
     hass: HomeAssistant,
     mock_lamarzocco: MagicMock,

--- a/tests/components/landisgyr_heat_meter/test_config_flow.py
+++ b/tests/components/landisgyr_heat_meter/test_config_flow.py
@@ -101,6 +101,10 @@ async def test_list_entry(mock_port, mock_heat_meter, hass: HomeAssistant) -> No
     }
 
 
+@pytest.mark.parametrize(  # Remove when translations fixed
+    "ignore_translations",
+    ["component.landisgyr_heat_meter.config.error.cannot_connect"],
+)
 @patch(API_HEAT_METER_SERVICE)
 async def test_manual_entry_fail(mock_heat_meter, hass: HomeAssistant) -> None:
     """Test manual entry fails."""
@@ -131,6 +135,10 @@ async def test_manual_entry_fail(mock_heat_meter, hass: HomeAssistant) -> None:
     assert result["errors"] == {"base": "cannot_connect"}
 
 
+@pytest.mark.parametrize(  # Remove when translations fixed
+    "ignore_translations",
+    ["component.landisgyr_heat_meter.config.error.cannot_connect"],
+)
 @patch(API_HEAT_METER_SERVICE)
 @patch("serial.tools.list_ports.comports", return_value=[mock_serial_port()])
 async def test_list_entry_fail(mock_port, mock_heat_meter, hass: HomeAssistant) -> None:

--- a/tests/components/nina/test_config_flow.py
+++ b/tests/components/nina/test_config_flow.py
@@ -8,6 +8,7 @@ from typing import Any
 from unittest.mock import patch
 
 from pynina import ApiError
+import pytest
 
 from homeassistant.components.nina.const import (
     CONF_AREA_FILTER,
@@ -278,6 +279,10 @@ async def test_options_flow_connection_error(hass: HomeAssistant) -> None:
         assert result["errors"] == {"base": "cannot_connect"}
 
 
+@pytest.mark.parametrize(  # Remove when translations fixed
+    "ignore_translations",
+    ["component.nina.options.error.unknown"],
+)
 async def test_options_flow_unexpected_exception(hass: HomeAssistant) -> None:
     """Test config flow options but with an unexpected exception."""
     config_entry = MockConfigEntry(

--- a/tests/components/ovo_energy/test_config_flow.py
+++ b/tests/components/ovo_energy/test_config_flow.py
@@ -121,6 +121,10 @@ async def test_full_flow_implementation(hass: HomeAssistant) -> None:
     assert result2["data"][CONF_ACCOUNT] == FIXTURE_USER_INPUT[CONF_ACCOUNT]
 
 
+@pytest.mark.parametrize(  # Remove when translations fixed
+    "ignore_translations",
+    ["component.ovo_energy.config.error.authorization_error"],
+)
 async def test_reauth_authorization_error(hass: HomeAssistant) -> None:
     """Test we show user form on authorization error."""
     mock_config = MockConfigEntry(
@@ -147,6 +151,10 @@ async def test_reauth_authorization_error(hass: HomeAssistant) -> None:
         assert result2["errors"] == {"base": "authorization_error"}
 
 
+@pytest.mark.parametrize(  # Remove when translations fixed
+    "ignore_translations",
+    ["component.ovo_energy.config.error.connection_error"],
+)
 async def test_reauth_connection_error(hass: HomeAssistant) -> None:
     """Test we show user form on connection error."""
     mock_config = MockConfigEntry(
@@ -175,7 +183,12 @@ async def test_reauth_connection_error(hass: HomeAssistant) -> None:
 
 @pytest.mark.parametrize(  # Remove when translations fixed
     "ignore_translations",
-    ["component.ovo_energy.config.abort.reauth_successful"],
+    [
+        [
+            "component.ovo_energy.config.abort.reauth_successful",
+            "component.ovo_energy.config.error.authorization_error",
+        ]
+    ],
 )
 async def test_reauth_flow(hass: HomeAssistant) -> None:
     """Test reauth works."""

--- a/tests/components/tradfri/test_config_flow.py
+++ b/tests/components/tradfri/test_config_flow.py
@@ -86,6 +86,10 @@ async def test_user_connection_timeout(
     assert result["errors"] == {"base": "timeout"}
 
 
+@pytest.mark.parametrize(  # Remove when translations fixed
+    "ignore_translations",
+    ["component.tradfri.config.error.invalid_security_code"],
+)
 async def test_user_connection_bad_key(
     hass: HomeAssistant, mock_auth, mock_entry_setup
 ) -> None:

--- a/tests/components/utility_meter/test_config_flow.py
+++ b/tests/components/utility_meter/test_config_flow.py
@@ -72,6 +72,10 @@ async def test_config_flow(hass: HomeAssistant, platform) -> None:
     assert config_entry.title == "Electricity meter"
 
 
+@pytest.mark.parametrize(  # Remove when translations fixed
+    "ignore_translations",
+    ["component.utility_meter.config.error.tariffs_not_unique"],
+)
 async def test_tariffs(hass: HomeAssistant) -> None:
     """Test tariffs."""
     input_sensor_entity_id = "sensor.input"

--- a/tests/components/vilfo/test_config_flow.py
+++ b/tests/components/vilfo/test_config_flow.py
@@ -150,6 +150,10 @@ async def test_form_exceptions(
     assert result["type"] is FlowResultType.CREATE_ENTRY
 
 
+@pytest.mark.parametrize(  # Remove when translations fixed
+    "ignore_translations",
+    ["component.vilfo.config.error.wrong_host"],
+)
 async def test_form_wrong_host(
     hass: HomeAssistant,
     mock_is_valid_host: AsyncMock,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As follow-up to #128140, add checks for error codes in flows

Needs:
- [x] #128444 (to avoid conflicts)
- [x] https://github.com/home-assistant/core/pull/128447
- [x] https://github.com/home-assistant/core/pull/128448
- [x] https://github.com/home-assistant/core/pull/128450

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
