### PR TITLE
Allow empty clientSecrect for LocalOAuth2Implementation

### DIFF
--- a/homeassistant/components/google/config_flow.py
+++ b/homeassistant/components/google/config_flow.py
@@ -126,7 +126,7 @@ class OAuth2FlowHandler(
                 device_flow = await async_create_device_flow(
                     self.hass,
                     self.flow_impl.client_id,
-                    self.flow_impl.client_secret,
+                    self.flow_impl.client_secret or "",
                     calendar_access,
                 )
             except TimeoutError as err:

--- a/homeassistant/components/lyric/api.py
+++ b/homeassistant/components/lyric/api.py
@@ -57,7 +57,9 @@ class LyricLocalOAuth2Implementation(
             data["client_secret"] = self.client_secret or ""
 
         headers = {
-            "Authorization": BasicAuth(self.client_id, self.client_secret or "").encode(),
+            "Authorization": BasicAuth(
+                self.client_id, self.client_secret or ""
+            ).encode(),
             "Content-Type": "application/x-www-form-urlencoded",
         }
 

--- a/homeassistant/components/lyric/api.py
+++ b/homeassistant/components/lyric/api.py
@@ -54,10 +54,10 @@ class LyricLocalOAuth2Implementation(
         data["client_id"] = self.client_id
 
         if self.client_secret is not None:
-            data["client_secret"] = self.client_secret
+            data["client_secret"] = self.client_secret or ""
 
         headers = {
-            "Authorization": BasicAuth(self.client_id, self.client_secret).encode(),
+            "Authorization": BasicAuth(self.client_id, self.client_secret or "").encode(),
             "Content-Type": "application/x-www-form-urlencoded",
         }
 

--- a/homeassistant/components/nest/api.py
+++ b/homeassistant/components/nest/api.py
@@ -118,7 +118,7 @@ async def new_subscriber(
         aiohttp_client.async_get_clientsession(hass),
         config_entry_oauth2_flow.OAuth2Session(hass, entry, implementation),
         implementation.client_id,
-        implementation.client_secret,
+        implementation.client_secret or "",
     )
     return GoogleNestSubscriber(auth, entry.data[CONF_PROJECT_ID], subscriber_id)
 

--- a/homeassistant/helpers/config_entry_oauth2_flow.py
+++ b/homeassistant/helpers/config_entry_oauth2_flow.py
@@ -119,7 +119,7 @@ class LocalOAuth2Implementation(AbstractOAuth2Implementation):
         hass: HomeAssistant,
         domain: str,
         client_id: str,
-        client_secret: str,
+        client_secret: str | None,
         authorize_url: str,
         token_url: str,
     ) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The `LocalOAuth2Implementation` can handle empty `clientSecrets` but it was not allowed to set this to `None` due to type restrictions. This is needed for [OAuth2 with PKCE](https://blog.postman.com/what-is-pkce/) authentication.

https://github.com/home-assistant/core/blob/dddc1906c2e2ba966207da2e47d2329618d5da4c/homeassistant/helpers/config_entry_oauth2_flow.py#L208-L209

Needed for moving vicare integration to local oauth2: https://github.com/home-assistant/core/compare/dev...CFenner:home-assistant-core:oauth2

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
