### PR TITLE
Add select entity to Cambridge Audio

### DIFF
--- a/homeassistant/components/cambridge_audio/__init__.py
+++ b/homeassistant/components/cambridge_audio/__init__.py
@@ -15,7 +15,7 @@ from homeassistant.exceptions import ConfigEntryNotReady
 
 from .const import CONNECT_TIMEOUT, STREAM_MAGIC_EXCEPTIONS
 
-PLATFORMS: list[Platform] = [Platform.MEDIA_PLAYER]
+PLATFORMS: list[Platform] = [Platform.MEDIA_PLAYER, Platform.SELECT]
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/cambridge_audio/icons.json
+++ b/homeassistant/components/cambridge_audio/icons.json
@@ -1,0 +1,14 @@
+{
+  "entity": {
+    "select": {
+      "display_brightness": {
+        "default": "mdi:brightness-7",
+        "state": {
+          "bright": "mdi:brightness-7",
+          "dim": "mdi:brightness-6",
+          "off": "mdi:brightness-3"
+        }
+      }
+    }
+  }
+}

--- a/homeassistant/components/cambridge_audio/select.py
+++ b/homeassistant/components/cambridge_audio/select.py
@@ -1,0 +1,80 @@
+"""Support for Cambridge Audio select entities."""
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+
+from aiostreammagic import StreamMagicClient
+from aiostreammagic.models import Output
+
+from homeassistant.components.select import SelectEntity, SelectEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .entity import CambridgeAudioEntity
+
+
+@dataclass(frozen=True, kw_only=True)
+class CambridgeAudioSelectEntityDescription(SelectEntityDescription):
+    """Describes Cambridge Audio select entity."""
+
+    value_fn: Callable[[StreamMagicClient], str | None]
+    set_value_fn: Callable[[StreamMagicClient, str], Awaitable[None]]
+
+
+AUDIO_OUTPUT_ENTITY = CambridgeAudioSelectEntityDescription(
+    key="audio_output",
+    translation_key="audio_output",
+    entity_category=EntityCategory.CONFIG,
+    value_fn=lambda client: (client.state.audio_output),
+    set_value_fn=lambda client, value: print(value),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Cambridge Audio select entities based on a config entry."""
+
+    client: StreamMagicClient = entry.runtime_data
+    entities = []
+    client.audio_output.outputs = [
+        Output(id="bt", name="Bluetooth"),
+        Output(id="channel_a", name="Speaker A"),
+        Output(id="channel_b", name="Speaker B"),
+    ]
+    if client.audio_output.outputs:
+        options = [output.name for output in client.audio_output.outputs]
+        entities.append(CambridgeAudioSelect(client, AUDIO_OUTPUT_ENTITY, options))
+
+    async_add_entities(entities)
+
+
+class CambridgeAudioSelect(CambridgeAudioEntity, SelectEntity):
+    """Defines a Cambridge Audio select entity."""
+
+    entity_description: CambridgeAudioSelectEntityDescription
+
+    def __init__(
+        self,
+        client: StreamMagicClient,
+        description: CambridgeAudioSelectEntityDescription,
+        options: list[str] | None = None,
+    ) -> None:
+        """Initialize AirGradient select."""
+        super().__init__(client)
+        self.entity_description = description
+        self._attr_unique_id = f"{client.info.unit_id}-{description.key}"
+        self._attr_options = description.options or options
+
+    @property
+    def current_option(self) -> str | None:
+        """Return the state of the select."""
+        return self.entity_description.value_fn(self.client)
+
+    async def async_select_option(self, option: str) -> None:
+        """Change the selected option."""
+        await self.entity_description.set_value_fn(self.client, option)

--- a/homeassistant/components/cambridge_audio/strings.json
+++ b/homeassistant/components/cambridge_audio/strings.json
@@ -22,5 +22,16 @@
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
     }
+  },
+  "entity": {
+    "select": {
+      "audio_output": {
+        "name": "Audio output",
+        "state": {
+          "cloud": "Cloud",
+          "local": "Local"
+        }
+      }
+    }
   }
 }

--- a/homeassistant/components/cambridge_audio/strings.json
+++ b/homeassistant/components/cambridge_audio/strings.json
@@ -25,11 +25,12 @@
   },
   "entity": {
     "select": {
-      "audio_output": {
-        "name": "Audio output",
+      "display_brightness": {
+        "name": "Display brightness",
         "state": {
-          "cloud": "Cloud",
-          "local": "Local"
+          "bright": "Bright",
+          "dim": "Dim",
+          "off": "Off"
         }
       }
     }

--- a/tests/components/cambridge_audio/conftest.py
+++ b/tests/components/cambridge_audio/conftest.py
@@ -3,7 +3,7 @@
 from collections.abc import Generator
 from unittest.mock import Mock, patch
 
-from aiostreammagic.models import Info, NowPlaying, PlayState, Source, State
+from aiostreammagic.models import Display, Info, NowPlaying, PlayState, Source, State
 import pytest
 
 from homeassistant.components.cambridge_audio.const import DOMAIN
@@ -50,6 +50,7 @@ def mock_stream_magic_client() -> Generator[AsyncMock]:
         client.now_playing = NowPlaying.from_json(
             load_fixture("get_now_playing.json", DOMAIN)
         )
+        client.display = Display.from_json(load_fixture("get_display.json", DOMAIN))
         client.is_connected = Mock(return_value=True)
         client.position_last_updated = client.play_state.position
         client.unregister_state_update_callbacks = AsyncMock(return_value=True)

--- a/tests/components/cambridge_audio/fixtures/get_display.json
+++ b/tests/components/cambridge_audio/fixtures/get_display.json
@@ -1,0 +1,3 @@
+{
+  "brightness": "bright"
+}

--- a/tests/components/cambridge_audio/snapshots/test_select.ambr
+++ b/tests/components/cambridge_audio/snapshots/test_select.ambr
@@ -1,0 +1,58 @@
+# serializer version: 1
+# name: test_all_entities[select.cambridge_audio_cxnv2_display_brightness-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'bright',
+        'dim',
+        'off',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'select.cambridge_audio_cxnv2_display_brightness',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Display brightness',
+    'platform': 'cambridge_audio',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'display_brightness',
+    'unique_id': '0020c2d8-display_brightness',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[select.cambridge_audio_cxnv2_display_brightness-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Cambridge Audio CXNv2 Display brightness',
+      'options': list([
+        'bright',
+        'dim',
+        'off',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.cambridge_audio_cxnv2_display_brightness',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'bright',
+  })
+# ---

--- a/tests/components/cambridge_audio/test_select.py
+++ b/tests/components/cambridge_audio/test_select.py
@@ -1,4 +1,4 @@
-"""Tests for the AirGradient select platform."""
+"""Tests for the Cambridge Audio select platform."""
 
 from unittest.mock import AsyncMock, patch
 

--- a/tests/components/cambridge_audio/test_select.py
+++ b/tests/components/cambridge_audio/test_select.py
@@ -1,0 +1,53 @@
+"""Tests for the AirGradient select platform."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from syrupy import SnapshotAssertion
+
+from homeassistant.components.select import (
+    DOMAIN as SELECT_DOMAIN,
+    SERVICE_SELECT_OPTION,
+)
+from homeassistant.const import ATTR_ENTITY_ID, ATTR_OPTION, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from . import setup_integration
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_all_entities(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    mock_stream_magic_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test all entities."""
+    with patch("homeassistant.components.cambridge_audio.PLATFORMS", [Platform.SELECT]):
+        await setup_integration(hass, mock_config_entry)
+
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+async def test_setting_value(
+    hass: HomeAssistant,
+    mock_stream_magic_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test setting value."""
+    await setup_integration(hass, mock_config_entry)
+
+    await hass.services.async_call(
+        SELECT_DOMAIN,
+        SERVICE_SELECT_OPTION,
+        {
+            ATTR_ENTITY_ID: "select.cambridge_audio_cxnv2_display_brightness",
+            ATTR_OPTION: "dim",
+        },
+        blocking=True,
+    )
+    mock_stream_magic_client.set_display_brightness.assert_called_once_with("dim")


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds the select entity to Cambridge Audio to allow for configuration of device settings. The integration currently only implements a single select entity, with more to be implemented.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/35254

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
