### PR TITLE
Fix issues washtower can't get mqtt event.

### DIFF
--- a/homeassistant/components/lg_thinq/entity.py
+++ b/homeassistant/components/lg_thinq/entity.py
@@ -102,14 +102,14 @@ class ThinQEntity(CoordinatorEntity[DeviceDataUpdateCoordinator]):
         """Call the given api and handle exception."""
         try:
             await target
-        except ThinQAPIException as exc:
+        except (ThinQAPIException, ValueError) as exc:
             if on_fail_method:
                 on_fail_method()
 
             raise ServiceValidationError(
-                exc.message,
+                exc.message if isinstance(exc, ThinQAPIException) else str(exc),
                 translation_domain=DOMAIN,
-                translation_key=exc.code,
+                translation_key=(
+                    exc.code if isinstance(exc, ThinQAPIException) else None
+                ),
             ) from exc
-        finally:
-            await self.coordinator.async_request_refresh()

--- a/homeassistant/components/lg_thinq/entity.py
+++ b/homeassistant/components/lg_thinq/entity.py
@@ -102,14 +102,13 @@ class ThinQEntity(CoordinatorEntity[DeviceDataUpdateCoordinator]):
         """Call the given api and handle exception."""
         try:
             await target
-        except (ThinQAPIException, ValueError) as exc:
+        except ThinQAPIException as exc:
             if on_fail_method:
                 on_fail_method()
-
             raise ServiceValidationError(
-                exc.message if isinstance(exc, ThinQAPIException) else str(exc),
-                translation_domain=DOMAIN,
-                translation_key=(
-                    exc.code if isinstance(exc, ThinQAPIException) else None
-                ),
+                exc.message, translation_domain=DOMAIN, translation_key=exc.code
             ) from exc
+        except ValueError as exc:
+            if on_fail_method:
+                on_fail_method()
+            raise ServiceValidationError(exc) from exc

--- a/homeassistant/components/lg_thinq/mqtt.py
+++ b/homeassistant/components/lg_thinq/mqtt.py
@@ -170,7 +170,7 @@ class ThinQMQTT:
         _LOGGER.debug("async_handle_device_event: message=%s", message)
         unique_id = (
             f"{message["deviceId"]}_{list(message["report"].keys())[0]}"
-            if (message["deviceType"]) == DeviceType.WASHTOWER
+            if message["deviceType"] == DeviceType.WASHTOWER
             else message["deviceId"]
         )
         coordinator = self.coordinators.get(unique_id)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix issues washtower can't get mqtt event.
mqtt works on unique_id.
In general, unique_id is same as device_id. But in washtower, unique_id is not device_id but device_id+sub_id

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
