### PR TITLE
Bump reolink_aio to 0.10.0

### DIFF
--- a/homeassistant/components/reolink/manifest.json
+++ b/homeassistant/components/reolink/manifest.json
@@ -18,5 +18,5 @@
   "documentation": "https://www.home-assistant.io/integrations/reolink",
   "iot_class": "local_push",
   "loggers": ["reolink_aio"],
-  "requirements": ["reolink-aio==0.9.11"]
+  "requirements": ["reolink-aio==0.10.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2540,7 +2540,7 @@ renault-api==0.2.7
 renson-endura-delta==1.7.1
 
 # homeassistant.components.reolink
-reolink-aio==0.9.11
+reolink-aio==0.10.0
 
 # homeassistant.components.idteck_prox
 rfk101py==0.0.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2025,7 +2025,7 @@ renault-api==0.2.7
 renson-endura-delta==1.7.1
 
 # homeassistant.components.reolink
-reolink-aio==0.9.11
+reolink-aio==0.10.0
 
 # homeassistant.components.rflink
 rflink==0.0.66


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is a very significant version bump:

It implements a completly new API/protocol on a diffrent port which is always open and cannot be disabled since the Reolink mobile app and desktop client relay on this API/protocol.
This allows the Reolink Home Assistant integration to open the required HTTPs port such that it can acces the publicly available HTTP(s) API which this integration relay on.
For the user this means he no longer needs to go into the Reolink mobile app/desktop client to settings->network->advanced->server settings and then enable the HTTP(s) port prior to setting up the Home Assistant integration.
On most reolink devices the HTTPs port is already open by factory default, but on some it is not.
Moreover there have been firmware updates that closed the HTTPs port after which the user needed to open it again before the integration could continue functioning. That is now also resolved by automatically re-opening the port during runtime.
A user can even close the HTTP port and open the HTTPs port during runtime and the reolink homeassistant integration will automatically swich to using the HTTPs port instead of the HTTP port.

In short: it will greathly enhance the initial setup experiance of first time users of the Reolink integration.

Bump reolink_aio to 0.10.0:
**Breaking changes:**
- Dropped Pyhton 3.10 support, now at least Python 3.11 is required

**Additions:**
- Implement Baichuan protocol on port 9000
   - Implement baichuan in normal API
   - Implement automatic opening of the HTTPs port
   - Also open RTMP port if login still fails
   - Update acknowledgments
   - Check for minimum firmware when login fails
   - Wait for HTTP port to open and also open RTSP and ONVIF ports
   - Implement TCP data transport instead of TCP stream
   - Optimize login_try_ports
   - Add login_open_ports method
   - Properly handle messages received in 2 packets or multiple messages in 1 packet
   - Implement baichuan push message parsing

**Bug fixes:**
- Watch for spaces when matching firmware
- Better match firmware model with brackets ( )
- Fix camera_online property for very old NVRs

**Optimizations:**
- Only send DingDongOpt cmd when chime is online

**Documentation:**
-  Fix error in example docs
-  Create Rich notifications using Home Assistant.pdf
- update logo

**Full Changelog**: https://github.com/starkillerOG/reolink_aio/compare/0.9.11...0.10.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/35265

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
