### PR TITLE
Fix calculation of attributes in group sensor

### DIFF
--- a/homeassistant/components/group/sensor.py
+++ b/homeassistant/components/group/sensor.py
@@ -172,6 +172,17 @@ def async_create_preview_sensor(
     )
 
 
+def _has_numeric_state(hass: HomeAssistant, entity_id: str) -> bool:
+    """Test if state is numeric."""
+    if not (state := hass.states.get(entity_id)):
+        return False
+    try:
+        float(state.state)
+    except ValueError:
+        return False
+    return True
+
+
 def calc_min(
     sensor_values: list[tuple[str, float, State]],
 ) -> tuple[dict[str, str | None], float | None]:
@@ -698,16 +709,8 @@ class SensorGroup(GroupEntity, SensorEntity):
     ) -> list[str]:
         """Return list of valid entities."""
 
-        def _has_numeric_state(entity_id: str) -> bool:
-            """Test if state is numeric."""
-            if not (state := self.hass.states.get(entity_id)):
-                return False
-            try:
-                float(state.state)
-            except ValueError:
-                return False
-            return True
-
         return [
-            entity_id for entity_id in self._entity_ids if _has_numeric_state(entity_id)
+            entity_id
+            for entity_id in self._entity_ids
+            if _has_numeric_state(self.hass, entity_id)
         ]

--- a/tests/components/group/test_sensor.py
+++ b/tests/components/group/test_sensor.py
@@ -948,7 +948,7 @@ async def test_sensor_different_attributes_ignore_non_numeric(
     await hass.async_block_till_done()
 
     state = hass.states.get("sensor.test_sum")
-    assert state.state == str(float(VALUES[0]))
+    assert state.state == str(float(sum([VALUES[0], VALUES[1]])))
     assert state.attributes.get("state_class") == SensorStateClass.MEASUREMENT
     assert state.attributes.get("device_class") is None
     assert state.attributes.get("unit_of_measurement") == PERCENTAGE
@@ -965,15 +965,10 @@ async def test_sensor_different_attributes_ignore_non_numeric(
     await hass.async_block_till_done()
 
     state = hass.states.get("sensor.test_sum")
-    assert state.state == str(float(VALUES[0]))
+    assert state.state == str(float(sum(VALUES)))
     assert state.attributes.get("state_class") == SensorStateClass.MEASUREMENT
     assert state.attributes.get("device_class") is None
     assert state.attributes.get("unit_of_measurement") is None
-
-    assert (
-        "Unable to use state. Only entities with correct unit of measurement is"
-        " supported"
-    ) in caplog.text
 
     hass.states.async_set(
         entity_ids[2],
@@ -987,7 +982,7 @@ async def test_sensor_different_attributes_ignore_non_numeric(
     await hass.async_block_till_done()
 
     state = hass.states.get("sensor.test_sum")
-    assert state.state == str(float(VALUES[0]))
+    assert state.state == str(float(sum(VALUES)))
     assert state.attributes.get("state_class") == SensorStateClass.MEASUREMENT
     assert (
         state.attributes.get("device_class") is None
@@ -1006,7 +1001,7 @@ async def test_sensor_different_attributes_ignore_non_numeric(
     await hass.async_block_till_done()
 
     state = hass.states.get("sensor.test_sum")
-    assert state.state == str(float(VALUES[0]))
+    assert state.state == str(float(sum(VALUES)))
     assert state.attributes.get("state_class") == SensorStateClass.MEASUREMENT
     assert (
         state.attributes.get("device_class") == SensorDeviceClass.HUMIDITY


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix the `group` sensor to recalculate the attributes on each input sensor state change (align with all other helpers).

If all input sensors should be available then only calculate when all input sensors have a valid state (numeric)
If all input sensors don't need to be available then calculate for each state change (when it has a valid state)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 