### PR TITLE
Create a script service schema based on fields

### DIFF
--- a/homeassistant/components/script/__init__.py
+++ b/homeassistant/components/script/__init__.py
@@ -18,11 +18,13 @@ from homeassistant.const import (
     ATTR_MODE,
     ATTR_NAME,
     CONF_ALIAS,
+    CONF_DEFAULT,
     CONF_DESCRIPTION,
     CONF_ICON,
     CONF_MODE,
     CONF_NAME,
     CONF_PATH,
+    CONF_SELECTOR,
     CONF_SEQUENCE,
     CONF_VARIABLES,
     SERVICE_RELOAD,
@@ -58,6 +60,7 @@ from homeassistant.helpers.script import (
     ScriptRunResult,
     script_stack_cv,
 )
+from homeassistant.helpers.selector import selector
 from homeassistant.helpers.service import async_set_service_schema
 from homeassistant.helpers.trace import trace_get, trace_path
 from homeassistant.helpers.typing import ConfigType
@@ -71,6 +74,7 @@ from .const import (
     ATTR_LAST_TRIGGERED,
     ATTR_VARIABLES,
     CONF_FIELDS,
+    CONF_REQUIRED,
     CONF_TRACE,
     DOMAIN,
     ENTITY_ID_FORMAT,
@@ -730,11 +734,26 @@ class ScriptEntity(BaseScriptEntity, RestoreEntity):
 
         unique_id = self.unique_id
         hass = self.hass
+
+        service_schema = {}
+        for field_name, field_info in self.fields.items():
+            key_cls = vol.Required if field_info[CONF_REQUIRED] else vol.Optional
+            key_kwargs = {}
+            if CONF_DEFAULT in field_info:
+                key_kwargs["default"] = field_info[CONF_DEFAULT]
+
+            if CONF_SELECTOR in field_info:
+                validator: Any = selector(field_info[CONF_SELECTOR])
+            else:
+                validator = cv.match_all
+
+            service_schema[key_cls(field_name, **key_kwargs)] = validator
+
         hass.services.async_register(
             DOMAIN,
             unique_id,
             self._service_handler,
-            schema=SCRIPT_SERVICE_SCHEMA,
+            schema=vol.Schema(service_schema, extra=vol.ALLOW_EXTRA),
             supports_response=SupportsResponse.OPTIONAL,
         )
 

--- a/homeassistant/components/script/__init__.py
+++ b/homeassistant/components/script/__init__.py
@@ -744,6 +744,20 @@ class ScriptEntity(BaseScriptEntity, RestoreEntity):
 
             if CONF_SELECTOR in field_info:
                 validator: Any = selector(field_info[CONF_SELECTOR])
+
+                # Default values need to match the validator.
+                # When they don't match, we will not enforce validation
+                if CONF_DEFAULT in field_info:
+                    try:
+                        validator(field_info[CONF_DEFAULT])
+                    except vol.Invalid:
+                        logging.getLogger(f"{__name__}.{self._attr_unique_id}").warning(
+                            "Field %s has invalid default value %s",
+                            field_name,
+                            field_info[CONF_DEFAULT],
+                        )
+                        validator = cv.match_all
+
             else:
                 validator = cv.match_all
 

--- a/tests/components/script/test_init.py
+++ b/tests/components/script/test_init.py
@@ -6,6 +6,7 @@ from typing import Any
 from unittest.mock import ANY, Mock, patch
 
 import pytest
+import voluptuous as vol
 
 from homeassistant.components import script
 from homeassistant.components.script import DOMAIN, EVENT_SCRIPT_STARTED, ScriptEntity
@@ -48,6 +49,7 @@ import homeassistant.util.dt as dt_util
 from tests.common import (
     MockConfigEntry,
     MockUser,
+    async_capture_events,
     async_fire_time_changed,
     async_mock_service,
     mock_restore_cache,
@@ -555,6 +557,87 @@ async def test_reload_unchanged_script(
         await hass.services.async_call(DOMAIN, object_id)
         await hass.async_block_till_done()
         assert len(calls) == 2
+
+
+async def test_service_schema(hass: HomeAssistant) -> None:
+    """Test that service schema are defined correctly."""
+    events = async_capture_events(hass, "test_event")
+
+    assert await async_setup_component(
+        hass,
+        "script",
+        {
+            "script": {
+                "test": {
+                    "fields": {
+                        "param_with_default": {
+                            "default": "default_value",
+                        },
+                        "required_param": {
+                            "required": True,
+                        },
+                        "selector_param": {
+                            "selector": {
+                                "select": {
+                                    "options": [
+                                        "one",
+                                        "two",
+                                    ]
+                                }
+                            }
+                        },
+                    },
+                    "sequence": [
+                        {
+                            "event": "test_event",
+                            "event_data": {
+                                "param_with_default": "{{ param_with_default }}",
+                                "required_param": "{{ required_param }}",
+                                "selector_param": "{{ selector_param | default('not_set') }}",
+                            },
+                        }
+                    ],
+                }
+            }
+        },
+    )
+
+    await hass.services.async_call(
+        DOMAIN,
+        "test",
+        {"required_param": "required_value"},
+        blocking=True,
+    )
+    assert len(events) == 1
+    assert events[0].data["param_with_default"] == "default_value"
+    assert events[0].data["required_param"] == "required_value"
+    assert events[0].data["selector_param"] == "not_set"
+
+    with pytest.raises(vol.Invalid):
+        await hass.services.async_call(
+            DOMAIN,
+            "test",
+            {
+                "required_param": "required_value",
+                "selector_param": "invalid_value",
+            },
+            blocking=True,
+        )
+
+    await hass.services.async_call(
+        DOMAIN,
+        "test",
+        {
+            "param_with_default": "service_set_value",
+            "required_param": "required_value",
+            "selector_param": "one",
+        },
+        blocking=True,
+    )
+    assert len(events) == 2
+    assert events[1].data["param_with_default"] == "service_set_value"
+    assert events[1].data["required_param"] == "required_value"
+    assert events[1].data["selector_param"] == "one"
 
 
 async def test_service_descriptions(hass: HomeAssistant) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
It is possible for users to define fields on scripts. These fields are currently registered as the service description, but they are not actually used for validation.

This means that the user is guided to set the correct data when configuring an action call to this script. But when a user writes YAML, or adds a new field with a default in the future, this is not applied. It also means that the user is not getting correct feedback.

~~**Note to discuss:** voluptuous requires default values to pass validation by the validator. This means that this could be a breaking change for any script where the user has mistakenly picked the wrong default value (can we guarantee all UI created scripts are correct?).~~

When a default value is passed in that doesn't match the validator, I will now issue a warning and don't validate the key (The default will still work)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
