### PR TITLE
Fix reload not triggered on DisabledError in HomeWizard

### DIFF
--- a/homeassistant/components/homewizard/coordinator.py
+++ b/homeassistant/components/homewizard/coordinator.py
@@ -77,7 +77,6 @@ class HWEnergyDeviceUpdateCoordinator(DataUpdateCoordinator[DeviceResponseEntry]
                     self.hass.config_entries.async_schedule_reload(
                         self.config_entry.entry_id
                     )
-                    )
 
             raise UpdateFailed(ex) from ex
 

--- a/homeassistant/components/homewizard/coordinator.py
+++ b/homeassistant/components/homewizard/coordinator.py
@@ -74,8 +74,10 @@ class HWEnergyDeviceUpdateCoordinator(DataUpdateCoordinator[DeviceResponseEntry]
 
                 # Do not reload when performing first refresh
                 if self.data is not None:
-                    await self.hass.config_entries.async_reload(
-                        self.config_entry.entry_id
+                    self.hass.async_create_task(
+                        self.hass.config_entries.async_reload(
+                            self.config_entry.entry_id
+                        )
                     )
 
             raise UpdateFailed(ex) from ex

--- a/homeassistant/components/homewizard/coordinator.py
+++ b/homeassistant/components/homewizard/coordinator.py
@@ -74,10 +74,9 @@ class HWEnergyDeviceUpdateCoordinator(DataUpdateCoordinator[DeviceResponseEntry]
 
                 # Do not reload when performing first refresh
                 if self.data is not None:
-                    self.hass.async_create_task(
-                        self.hass.config_entries.async_reload(
-                            self.config_entry.entry_id
-                        )
+                    self.hass.config_entries.async_schedule_reload(
+                        self.config_entry.entry_id
+                    )
                     )
 
             raise UpdateFailed(ex) from ex

--- a/homeassistant/components/homewizard/coordinator.py
+++ b/homeassistant/components/homewizard/coordinator.py
@@ -74,6 +74,7 @@ class HWEnergyDeviceUpdateCoordinator(DataUpdateCoordinator[DeviceResponseEntry]
 
                 # Do not reload when performing first refresh
                 if self.data is not None:
+                    # Reload config entry to let init flow handle retrying and trigger repair flow
                     self.hass.config_entries.async_schedule_reload(
                         self.config_entry.entry_id
                     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The call to `async_reload` did not return (deadlock or something?) when DisabledError was handled. Starting a task restores the expected behaviour.

I am not sure if this it the right solution, but it seems to work and is used at other places. I don't know when this bug got in existence.

**Current situation:**
1. Have a HomeWizard device configured and working
2. Disable the API via the app
3. Then:
   - All entities will go to 'unavailable'
   - No repair item is created
   - No log items
   - Pressing 'reload' in device settings will trigger an enormous error (see below)
   
<details><summary>Error</summary>
<p>

```
2024-10-18 10:00:14.718 ERROR (MainThread) [homeassistant.config_entries] Error unloading entry Energy Socket for button
Traceback (most recent call last):
  File "/Users/ducosebel/Development/HASS/core/homeassistant/config_entries.py", line 841, in async_unload
    result = await component.async_unload_entry(hass, self)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ducosebel/Development/HASS/core/homeassistant/components/button/__init__.py", line 73, in async_unload_entry
    return await hass.data[DATA_COMPONENT].async_unload_entry(entry)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ducosebel/Development/HASS/core/homeassistant/helpers/entity_component.py", line 204, in async_unload_entry
    raise ValueError("Config entry was never loaded!")
ValueError: Config entry was never loaded!
2024-10-18 10:00:14.722 ERROR (MainThread) [homeassistant.config_entries] Error unloading entry Energy Socket for number
Traceback (most recent call last):
  File "/Users/ducosebel/Development/HASS/core/homeassistant/config_entries.py", line 841, in async_unload
    result = await component.async_unload_entry(hass, self)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ducosebel/Development/HASS/core/homeassistant/components/number/__init__.py", line 134, in async_unload_entry
    return await hass.data[DATA_COMPONENT].async_unload_entry(entry)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ducosebel/Development/HASS/core/homeassistant/helpers/entity_component.py", line 204, in async_unload_entry
    raise ValueError("Config entry was never loaded!")
ValueError: Config entry was never loaded!
2024-10-18 10:00:14.723 ERROR (MainThread) [homeassistant.config_entries] Error unloading entry Energy Socket for sensor
Traceback (most recent call last):
  File "/Users/ducosebel/Development/HASS/core/homeassistant/config_entries.py", line 841, in async_unload
    result = await component.async_unload_entry(hass, self)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ducosebel/Development/HASS/core/homeassistant/components/sensor/__init__.py", line 138, in async_unload_entry
    return await hass.data[DATA_COMPONENT].async_unload_entry(entry)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ducosebel/Development/HASS/core/homeassistant/helpers/entity_component.py", line 204, in async_unload_entry
    raise ValueError("Config entry was never loaded!")
ValueError: Config entry was never loaded!
2024-10-18 10:00:14.725 ERROR (MainThread) [homeassistant.config_entries] Error unloading entry Energy Socket for switch
Traceback (most recent call last):
  File "/Users/ducosebel/Development/HASS/core/homeassistant/config_entries.py", line 841, in async_unload
    result = await component.async_unload_entry(hass, self)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ducosebel/Development/HASS/core/homeassistant/components/switch/__init__.py", line 99, in async_unload_entry
    return await hass.data[DATA_COMPONENT].async_unload_entry(entry)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ducosebel/Development/HASS/core/homeassistant/helpers/entity_component.py", line 204, in async_unload_entry
    raise ValueError("Config entry was never loaded!")
ValueError: Config entry was never loaded!
```

</p>
</details> 
 
**Expected behaviour (how it was and how it is after this PR)**
1. Have a HomeWizard device configured and working
2. Disable the API via the app
3. Then:
   - A repair item is created
   - HA tries to reload now and then
   - When you enable the API again, HA restores the situation

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/pull/128628
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
