### PR TITLE
Add throttling functionality to Alert component

### DIFF
--- a/homeassistant/components/alert/__init__.py
+++ b/homeassistant/components/alert/__init__.py
@@ -26,9 +26,11 @@ from .const import (
     CONF_DONE_MESSAGE,
     CONF_NOTIFIERS,
     CONF_SKIP_FIRST,
+    CONF_THROTTLE,
     CONF_TITLE,
     DEFAULT_CAN_ACK,
     DEFAULT_SKIP_FIRST,
+    DEFAULT_THROTTLE,
     DOMAIN,
     LOGGER,
 )
@@ -47,6 +49,7 @@ ALERT_SCHEMA = vol.Schema(
         ),
         vol.Optional(CONF_CAN_ACK, default=DEFAULT_CAN_ACK): cv.boolean,
         vol.Optional(CONF_SKIP_FIRST, default=DEFAULT_SKIP_FIRST): cv.boolean,
+        vol.Optional(CONF_THROTTLE, default=DEFAULT_THROTTLE): vol.Coerce(float),
         vol.Optional(CONF_ALERT_MESSAGE): cv.template,
         vol.Optional(CONF_DONE_MESSAGE): cv.template,
         vol.Optional(CONF_TITLE): cv.template,
@@ -77,6 +80,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         alert_state = cfg[CONF_STATE]
         repeat = cfg[CONF_REPEAT]
         skip_first = cfg[CONF_SKIP_FIRST]
+        throttle = cfg[CONF_THROTTLE]
         message_template = cfg.get(CONF_ALERT_MESSAGE)
         done_message_template = cfg.get(CONF_DONE_MESSAGE)
         notifiers = cfg[CONF_NOTIFIERS]
@@ -93,6 +97,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
                 alert_state,
                 repeat,
                 skip_first,
+                throttle,
                 message_template,
                 done_message_template,
                 notifiers,

--- a/homeassistant/components/alert/const.py
+++ b/homeassistant/components/alert/const.py
@@ -12,8 +12,10 @@ CONF_NOTIFIERS = "notifiers"
 CONF_SKIP_FIRST = "skip_first"
 CONF_ALERT_MESSAGE = "message"
 CONF_DONE_MESSAGE = "done_message"
+CONF_THROTTLE = "throttle"
 CONF_TITLE = "title"
 CONF_DATA = "data"
 
 DEFAULT_CAN_ACK = True
+DEFAULT_THROTTLE = 0
 DEFAULT_SKIP_FIRST = False


### PR DESCRIPTION
## Proposed change
This PR adds a throttling feature to the Alert component in Home Assistant. The new throttle configuration option allows users to set a minimum time interval (in minutes) between consecutive notifications, preventing multiple notifications in quick succession when alert conditions repeatedly change states (e.g., due to sensor malfunctions or intermittent issues).

The feature helps reduce notification fatigue in cases where alert conditions fluctuate rapidly, improving the user experience when using Home Assistant’s notification system.

Key changes:

- Added throttle option in alert schema to specify the minimum time between notifications.
- Modified the AlertEntity class to track the last notification time and delay notifications accordingly if the throttle limit is not yet met.
- Backward compatible: the throttling behavior is disabled by default, ensuring existing alerts function as they did before unless the throttle option is explicitly set.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/35279

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure