### PR TITLE
Add model_id to rainforest_raven device info

### DIFF
--- a/homeassistant/components/rainforest_raven/coordinator.py
+++ b/homeassistant/components/rainforest_raven/coordinator.py
@@ -82,20 +82,6 @@ class RAVEnDataCoordinator(DataUpdateCoordinator):
         )
 
     @property
-    def device_fw_version(self) -> str | None:
-        """Return the firmware version of the device."""
-        if self._device_info:
-            return self._device_info.fw_version
-        return None
-
-    @property
-    def device_hw_version(self) -> str | None:
-        """Return the hardware version of the device."""
-        if self._device_info:
-            return self._device_info.hw_version
-        return None
-
-    @property
     def device_mac_address(self) -> str | None:
         """Return the MAC address of the device."""
         if self._device_info and self._device_info.device_mac_id:
@@ -103,35 +89,18 @@ class RAVEnDataCoordinator(DataUpdateCoordinator):
         return None
 
     @property
-    def device_manufacturer(self) -> str | None:
-        """Return the manufacturer of the device."""
-        if self._device_info:
-            return self._device_info.manufacturer
-        return None
-
-    @property
-    def device_model(self) -> str | None:
-        """Return the model of the device."""
-        if self._device_info:
-            return self._device_info.model_id
-        return None
-
-    @property
-    def device_name(self) -> str:
-        """Return the product name of the device."""
-        return "RAVEn Device"
-
-    @property
     def device_info(self) -> DeviceInfo | None:
         """Return device info."""
-        if self._device_info and self.device_mac_address:
+        if (device_info := self._device_info) and (
+            mac_address := self.device_mac_address
+        ):
             return DeviceInfo(
-                identifiers={(DOMAIN, self.device_mac_address)},
-                manufacturer=self.device_manufacturer,
-                model=self.device_model,
-                name=self.device_name,
-                sw_version=self.device_fw_version,
-                hw_version=self.device_hw_version,
+                identifiers={(DOMAIN, mac_address)},
+                manufacturer=device_info.manufacturer,
+                model=device_info.model_id,
+                name="RAVEn Device",
+                sw_version=device_info.fw_version,
+                hw_version=device_info.hw_version,
             )
         return None
 

--- a/homeassistant/components/rainforest_raven/coordinator.py
+++ b/homeassistant/components/rainforest_raven/coordinator.py
@@ -98,6 +98,7 @@ class RAVEnDataCoordinator(DataUpdateCoordinator):
                 identifiers={(DOMAIN, mac_address)},
                 manufacturer=device_info.manufacturer,
                 model=device_info.model_id,
+                model_id=device_info.model_id,
                 name="RAVEn Device",
                 sw_version=device_info.fw_version,
                 hw_version=device_info.hw_version,

--- a/tests/components/rainforest_raven/snapshots/test_init.ambr
+++ b/tests/components/rainforest_raven/snapshots/test_init.ambr
@@ -1,0 +1,39 @@
+# serializer version: 1
+# name: test_device_registry[None-0]
+  list([
+  ])
+# ---
+# name: test_device_registry[device_info0-1]
+  list([
+    DeviceRegistryEntrySnapshot({
+      'area_id': None,
+      'config_entries': <ANY>,
+      'configuration_url': None,
+      'connections': set({
+      }),
+      'disabled_by': None,
+      'entry_type': None,
+      'hw_version': '2.7.3',
+      'id': <ANY>,
+      'identifiers': set({
+        tuple(
+          'rainforest_raven',
+          'abcdef0123456789',
+        ),
+      }),
+      'is_new': False,
+      'labels': set({
+      }),
+      'manufacturer': 'Rainforest Automation, Inc.',
+      'model': 'Z105-2-EMU2-LEDD_JM',
+      'model_id': None,
+      'name': 'RAVEn Device',
+      'name_by_user': None,
+      'primary_config_entry': <ANY>,
+      'serial_number': None,
+      'suggested_area': None,
+      'sw_version': '2.0.0 (7400)',
+      'via_device_id': None,
+    }),
+  ])
+# ---

--- a/tests/components/rainforest_raven/snapshots/test_init.ambr
+++ b/tests/components/rainforest_raven/snapshots/test_init.ambr
@@ -26,7 +26,7 @@
       }),
       'manufacturer': 'Rainforest Automation, Inc.',
       'model': 'Z105-2-EMU2-LEDD_JM',
-      'model_id': None,
+      'model_id': 'Z105-2-EMU2-LEDD_JM',
       'name': 'RAVEn Device',
       'name_by_user': None,
       'primary_config_entry': <ANY>,

--- a/tests/components/rainforest_raven/test_coordinator.py
+++ b/tests/components/rainforest_raven/test_coordinator.py
@@ -15,32 +15,6 @@ from homeassistant.exceptions import ConfigEntryNotReady
 from . import create_mock_entry
 
 
-@pytest.mark.usefixtures("mock_device")
-async def test_coordinator_device_info(hass: HomeAssistant) -> None:
-    """Test reporting device information from the coordinator."""
-    entry = create_mock_entry()
-    entry._async_set_state(hass, ConfigEntryState.SETUP_IN_PROGRESS, None)
-    coordinator = RAVEnDataCoordinator(hass, entry)
-
-    assert coordinator.device_fw_version is None
-    assert coordinator.device_hw_version is None
-    assert coordinator.device_info is None
-    assert coordinator.device_mac_address is None
-    assert coordinator.device_manufacturer is None
-    assert coordinator.device_model is None
-    assert coordinator.device_name == "RAVEn Device"
-
-    await coordinator.async_config_entry_first_refresh()
-
-    assert coordinator.device_fw_version == "2.0.0 (7400)"
-    assert coordinator.device_hw_version == "2.7.3"
-    assert coordinator.device_info
-    assert coordinator.device_mac_address
-    assert coordinator.device_manufacturer == "Rainforest Automation, Inc."
-    assert coordinator.device_model == "Z105-2-EMU2-LEDD_JM"
-    assert coordinator.device_name == "RAVEn Device"
-
-
 async def test_coordinator_cache_device(
     hass: HomeAssistant, mock_device: AsyncMock
 ) -> None:

--- a/tests/components/rainforest_raven/test_init.py
+++ b/tests/components/rainforest_raven/test_init.py
@@ -1,8 +1,18 @@
 """Tests for the Rainforest RAVEn component initialisation."""
 
+from unittest.mock import AsyncMock
+
+from aioraven.data import DeviceInfo as RAVenDeviceInfo
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
 from homeassistant.components.rainforest_raven.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+
+from . import create_mock_entry
+from .const import DEVICE_INFO
 
 from tests.common import MockConfigEntry
 
@@ -18,4 +28,30 @@ async def test_load_unload_entry(
     await hass.async_block_till_done()
 
     assert mock_entry.state is ConfigEntryState.NOT_LOADED
-    assert not hass.data.get(DOMAIN)
+
+
+@pytest.mark.parametrize(
+    ("device_info", "device_count"),
+    [(DEVICE_INFO, 1), (None, 0)],
+)
+async def test_device_registry(
+    hass: HomeAssistant,
+    mock_device: AsyncMock,
+    device_registry: dr.DeviceRegistry,
+    snapshot: SnapshotAssertion,
+    device_info: RAVenDeviceInfo | None,
+    device_count: int,
+) -> None:
+    """Test device registry, including if get_device_info returns None."""
+    mock_device.get_device_info.return_value = device_info
+    entry = create_mock_entry()
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+
+    assert entry.state is ConfigEntryState.LOADED
+
+    assert len(hass.states.async_all()) == 5
+
+    entries = dr.async_entries_for_config_entry(device_registry, entry.entry_id)
+    assert len(entries) == device_count
+    assert entries == snapshot


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- add `model_id` to `rainforest_raven` device info
- remove single-use coordinator variables - they were only used to populate the device info
- move the device info tests to `test_init.py`, and check the device registry state rather than coordinator properties

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
