### PR TITLE
Use STATE_ON/STATE_OFF constants in template test

### DIFF
--- a/tests/components/template/test_binary_sensor.py
+++ b/tests/components/template/test_binary_sensor.py
@@ -33,9 +33,6 @@ from tests.common import (
     mock_restore_cache_with_extra_data,
 )
 
-ON = "on"
-OFF = "off"
-
 
 @pytest.mark.parametrize("count", [1])
 @pytest.mark.parametrize(
@@ -78,7 +75,7 @@ async def test_setup_minimal(hass: HomeAssistant, entity_id, name, attributes) -
     state = hass.states.get(entity_id)
     assert state is not None
     assert state.name == name
-    assert state.state == ON
+    assert state.state == STATE_ON
     assert state.attributes == attributes
 
 
@@ -123,7 +120,7 @@ async def test_setup(hass: HomeAssistant, entity_id) -> None:
     state = hass.states.get(entity_id)
     assert state is not None
     assert state.name == "virtual thingy"
-    assert state.state == ON
+    assert state.state == STATE_ON
     assert state.attributes["device_class"] == "motion"
 
 
@@ -460,13 +457,13 @@ async def test_match_all(hass: HomeAssistant, setup_mock) -> None:
 async def test_event(hass: HomeAssistant) -> None:
     """Test the event."""
     state = hass.states.get("binary_sensor.test")
-    assert state.state == OFF
+    assert state.state == STATE_OFF
 
-    hass.states.async_set("sensor.test_state", ON)
+    hass.states.async_set("sensor.test_state", STATE_ON)
     await hass.async_block_till_done()
 
     state = hass.states.get("binary_sensor.test")
-    assert state.state == ON
+    assert state.state == STATE_ON
 
 
 @pytest.mark.parametrize(
@@ -571,42 +568,42 @@ async def test_event(hass: HomeAssistant) -> None:
 async def test_template_delay_on_off(hass: HomeAssistant) -> None:
     """Test binary sensor template delay on."""
     # Ensure the initial state is not on
-    assert hass.states.get("binary_sensor.test_on").state != ON
-    assert hass.states.get("binary_sensor.test_off").state != ON
+    assert hass.states.get("binary_sensor.test_on").state != STATE_ON
+    assert hass.states.get("binary_sensor.test_off").state != STATE_ON
 
     hass.states.async_set("input_number.delay", 5)
-    hass.states.async_set("sensor.test_state", ON)
+    hass.states.async_set("sensor.test_state", STATE_ON)
     await hass.async_block_till_done()
-    assert hass.states.get("binary_sensor.test_on").state == OFF
-    assert hass.states.get("binary_sensor.test_off").state == ON
+    assert hass.states.get("binary_sensor.test_on").state == STATE_OFF
+    assert hass.states.get("binary_sensor.test_off").state == STATE_ON
 
     future = dt_util.utcnow() + timedelta(seconds=5)
     async_fire_time_changed(hass, future)
     await hass.async_block_till_done()
-    assert hass.states.get("binary_sensor.test_on").state == ON
-    assert hass.states.get("binary_sensor.test_off").state == ON
+    assert hass.states.get("binary_sensor.test_on").state == STATE_ON
+    assert hass.states.get("binary_sensor.test_off").state == STATE_ON
 
     # check with time changes
-    hass.states.async_set("sensor.test_state", OFF)
+    hass.states.async_set("sensor.test_state", STATE_OFF)
     await hass.async_block_till_done()
-    assert hass.states.get("binary_sensor.test_on").state == OFF
-    assert hass.states.get("binary_sensor.test_off").state == ON
+    assert hass.states.get("binary_sensor.test_on").state == STATE_OFF
+    assert hass.states.get("binary_sensor.test_off").state == STATE_ON
 
-    hass.states.async_set("sensor.test_state", ON)
+    hass.states.async_set("sensor.test_state", STATE_ON)
     await hass.async_block_till_done()
-    assert hass.states.get("binary_sensor.test_on").state == OFF
-    assert hass.states.get("binary_sensor.test_off").state == ON
+    assert hass.states.get("binary_sensor.test_on").state == STATE_OFF
+    assert hass.states.get("binary_sensor.test_off").state == STATE_ON
 
-    hass.states.async_set("sensor.test_state", OFF)
+    hass.states.async_set("sensor.test_state", STATE_OFF)
     await hass.async_block_till_done()
-    assert hass.states.get("binary_sensor.test_on").state == OFF
-    assert hass.states.get("binary_sensor.test_off").state == ON
+    assert hass.states.get("binary_sensor.test_on").state == STATE_OFF
+    assert hass.states.get("binary_sensor.test_off").state == STATE_ON
 
     future = dt_util.utcnow() + timedelta(seconds=5)
     async_fire_time_changed(hass, future)
     await hass.async_block_till_done()
-    assert hass.states.get("binary_sensor.test_on").state == OFF
-    assert hass.states.get("binary_sensor.test_off").state == OFF
+    assert hass.states.get("binary_sensor.test_on").state == STATE_OFF
+    assert hass.states.get("binary_sensor.test_off").state == STATE_OFF
 
 
 @pytest.mark.parametrize("count", [1])
@@ -813,29 +810,29 @@ async def test_no_update_template_match_all(
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
     await hass.async_block_till_done()
 
-    assert hass.states.get("binary_sensor.all_state").state == ON
-    assert hass.states.get("binary_sensor.all_icon").state == ON
-    assert hass.states.get("binary_sensor.all_entity_picture").state == ON
-    assert hass.states.get("binary_sensor.all_attribute").state == ON
+    assert hass.states.get("binary_sensor.all_state").state == STATE_ON
+    assert hass.states.get("binary_sensor.all_icon").state == STATE_ON
+    assert hass.states.get("binary_sensor.all_entity_picture").state == STATE_ON
+    assert hass.states.get("binary_sensor.all_attribute").state == STATE_ON
 
     hass.states.async_set("binary_sensor.test_sensor", "false")
     await hass.async_block_till_done()
 
-    assert hass.states.get("binary_sensor.all_state").state == ON
+    assert hass.states.get("binary_sensor.all_state").state == STATE_ON
     # Will now process because we have one valid template
-    assert hass.states.get("binary_sensor.all_icon").state == OFF
-    assert hass.states.get("binary_sensor.all_entity_picture").state == OFF
-    assert hass.states.get("binary_sensor.all_attribute").state == OFF
+    assert hass.states.get("binary_sensor.all_icon").state == STATE_OFF
+    assert hass.states.get("binary_sensor.all_entity_picture").state == STATE_OFF
+    assert hass.states.get("binary_sensor.all_attribute").state == STATE_OFF
 
     await async_update_entity(hass, "binary_sensor.all_state")
     await async_update_entity(hass, "binary_sensor.all_icon")
     await async_update_entity(hass, "binary_sensor.all_entity_picture")
     await async_update_entity(hass, "binary_sensor.all_attribute")
 
-    assert hass.states.get("binary_sensor.all_state").state == ON
-    assert hass.states.get("binary_sensor.all_icon").state == OFF
-    assert hass.states.get("binary_sensor.all_entity_picture").state == OFF
-    assert hass.states.get("binary_sensor.all_attribute").state == OFF
+    assert hass.states.get("binary_sensor.all_state").state == STATE_ON
+    assert hass.states.get("binary_sensor.all_icon").state == STATE_OFF
+    assert hass.states.get("binary_sensor.all_entity_picture").state == STATE_OFF
+    assert hass.states.get("binary_sensor.all_attribute").state == STATE_OFF
 
 
 @pytest.mark.parametrize(("count", "domain"), [(1, "template")])
@@ -848,7 +845,7 @@ async def test_no_update_template_match_all(
                 "binary_sensor": {
                     "name": "top-level",
                     "unique_id": "sensor-id",
-                    "state": ON,
+                    "state": STATE_ON,
                 },
             },
             "binary_sensor": {
@@ -1008,30 +1005,30 @@ async def test_availability_icon_picture(hass: HomeAssistant, entity_id) -> None
 @pytest.mark.parametrize(
     ("extra_config", "source_state", "restored_state", "initial_state"),
     [
-        ({}, OFF, ON, OFF),
-        ({}, OFF, OFF, OFF),
-        ({}, OFF, STATE_UNAVAILABLE, OFF),
-        ({}, OFF, STATE_UNKNOWN, OFF),
-        ({"delay_off": 5}, OFF, ON, ON),
-        ({"delay_off": 5}, OFF, OFF, OFF),
-        ({"delay_off": 5}, OFF, STATE_UNAVAILABLE, STATE_UNKNOWN),
-        ({"delay_off": 5}, OFF, STATE_UNKNOWN, STATE_UNKNOWN),
-        ({"delay_on": 5}, OFF, ON, OFF),
-        ({"delay_on": 5}, OFF, OFF, OFF),
-        ({"delay_on": 5}, OFF, STATE_UNAVAILABLE, OFF),
-        ({"delay_on": 5}, OFF, STATE_UNKNOWN, OFF),
-        ({}, ON, ON, ON),
-        ({}, ON, OFF, ON),
-        ({}, ON, STATE_UNAVAILABLE, ON),
-        ({}, ON, STATE_UNKNOWN, ON),
-        ({"delay_off": 5}, ON, ON, ON),
-        ({"delay_off": 5}, ON, OFF, ON),
-        ({"delay_off": 5}, ON, STATE_UNAVAILABLE, ON),
-        ({"delay_off": 5}, ON, STATE_UNKNOWN, ON),
-        ({"delay_on": 5}, ON, ON, ON),
-        ({"delay_on": 5}, ON, OFF, OFF),
-        ({"delay_on": 5}, ON, STATE_UNAVAILABLE, STATE_UNKNOWN),
-        ({"delay_on": 5}, ON, STATE_UNKNOWN, STATE_UNKNOWN),
+        ({}, STATE_OFF, STATE_ON, STATE_OFF),
+        ({}, STATE_OFF, STATE_OFF, STATE_OFF),
+        ({}, STATE_OFF, STATE_UNAVAILABLE, STATE_OFF),
+        ({}, STATE_OFF, STATE_UNKNOWN, STATE_OFF),
+        ({"delay_off": 5}, STATE_OFF, STATE_ON, STATE_ON),
+        ({"delay_off": 5}, STATE_OFF, STATE_OFF, STATE_OFF),
+        ({"delay_off": 5}, STATE_OFF, STATE_UNAVAILABLE, STATE_UNKNOWN),
+        ({"delay_off": 5}, STATE_OFF, STATE_UNKNOWN, STATE_UNKNOWN),
+        ({"delay_on": 5}, STATE_OFF, STATE_ON, STATE_OFF),
+        ({"delay_on": 5}, STATE_OFF, STATE_OFF, STATE_OFF),
+        ({"delay_on": 5}, STATE_OFF, STATE_UNAVAILABLE, STATE_OFF),
+        ({"delay_on": 5}, STATE_OFF, STATE_UNKNOWN, STATE_OFF),
+        ({}, STATE_ON, STATE_ON, STATE_ON),
+        ({}, STATE_ON, STATE_OFF, STATE_ON),
+        ({}, STATE_ON, STATE_UNAVAILABLE, STATE_ON),
+        ({}, STATE_ON, STATE_UNKNOWN, STATE_ON),
+        ({"delay_off": 5}, STATE_ON, STATE_ON, STATE_ON),
+        ({"delay_off": 5}, STATE_ON, STATE_OFF, STATE_ON),
+        ({"delay_off": 5}, STATE_ON, STATE_UNAVAILABLE, STATE_ON),
+        ({"delay_off": 5}, STATE_ON, STATE_UNKNOWN, STATE_ON),
+        ({"delay_on": 5}, STATE_ON, STATE_ON, STATE_ON),
+        ({"delay_on": 5}, STATE_ON, STATE_OFF, STATE_OFF),
+        ({"delay_on": 5}, STATE_ON, STATE_UNAVAILABLE, STATE_UNKNOWN),
+        ({"delay_on": 5}, STATE_ON, STATE_UNKNOWN, STATE_UNKNOWN),
     ],
 )
 async def test_restore_state(
@@ -1145,7 +1142,7 @@ async def test_trigger_entity(
     await hass.async_block_till_done()
 
     state = hass.states.get("binary_sensor.hello_name")
-    assert state.state == ON
+    assert state.state == STATE_ON
     assert state.attributes.get("device_class") == "battery"
     assert state.attributes.get("icon") == "mdi:pirate"
     assert state.attributes.get("entity_picture") == "/local/dogs.png"
@@ -1163,7 +1160,7 @@ async def test_trigger_entity(
     )
 
     state = hass.states.get("binary_sensor.via_list")
-    assert state.state == ON
+    assert state.state == STATE_ON
     assert state.attributes.get("device_class") == "battery"
     assert state.attributes.get("icon") == "mdi:pirate"
     assert state.attributes.get("entity_picture") == "/local/dogs.png"
@@ -1175,7 +1172,7 @@ async def test_trigger_entity(
     hass.bus.async_fire("test_event", {"beer": 2, "uno_mas": "si"})
     await hass.async_block_till_done()
     state = hass.states.get("binary_sensor.via_list")
-    assert state.state == ON
+    assert state.state == STATE_ON
     assert state.attributes.get("another") == "si"
 
 
@@ -1217,7 +1214,7 @@ async def test_template_with_trigger_templated_delay_on(hass: HomeAssistant) -> 
     await hass.async_block_till_done()
 
     state = hass.states.get("binary_sensor.test")
-    assert state.state == ON
+    assert state.state == STATE_ON
 
     # Now wait for the auto-off
     future = dt_util.utcnow() + timedelta(seconds=2)
@@ -1225,7 +1222,7 @@ async def test_template_with_trigger_templated_delay_on(hass: HomeAssistant) -> 
     await hass.async_block_till_done()
 
     state = hass.states.get("binary_sensor.test")
-    assert state.state == OFF
+    assert state.state == STATE_OFF
 
 
 @pytest.mark.parametrize(("count", "domain"), [(1, "template")])
@@ -1253,8 +1250,8 @@ async def test_template_with_trigger_templated_delay_on(hass: HomeAssistant) -> 
 @pytest.mark.parametrize(
     ("restored_state", "initial_state", "initial_attributes"),
     [
-        (ON, ON, ["entity_picture", "icon", "plus_one"]),
-        (OFF, OFF, ["entity_picture", "icon", "plus_one"]),
+        (STATE_ON, STATE_ON, ["entity_picture", "icon", "plus_one"]),
+        (STATE_OFF, STATE_OFF, ["entity_picture", "icon", "plus_one"]),
         (STATE_UNAVAILABLE, STATE_UNKNOWN, []),
         (STATE_UNKNOWN, STATE_UNKNOWN, []),
     ],
@@ -1309,7 +1306,7 @@ async def test_trigger_entity_restore_state(
     await hass.async_block_till_done()
 
     state = hass.states.get("binary_sensor.test")
-    assert state.state == ON
+    assert state.state == STATE_ON
     assert state.attributes["icon"] == "mdi:pirate"
     assert state.attributes["entity_picture"] == "/local/dogs.png"
     assert state.attributes["plus_one"] == 3
@@ -1333,7 +1330,7 @@ async def test_trigger_entity_restore_state(
         },
     ],
 )
-@pytest.mark.parametrize("restored_state", [ON, OFF])
+@pytest.mark.parametrize("restored_state", [STATE_ON, STATE_OFF])
 async def test_trigger_entity_restore_state_auto_off(
     hass: HomeAssistant,
     count,
@@ -1377,7 +1374,7 @@ async def test_trigger_entity_restore_state_auto_off(
     await hass.async_block_till_done()
 
     state = hass.states.get("binary_sensor.test")
-    assert state.state == OFF
+    assert state.state == STATE_OFF
 
 
 @pytest.mark.parametrize(("count", "domain"), [(1, "template")])
@@ -1405,7 +1402,7 @@ async def test_trigger_entity_restore_state_auto_off_expired(
     freezer.move_to("2022-02-02 12:02:00+00:00")
     fake_state = State(
         "binary_sensor.test",
-        ON,
+        STATE_ON,
         {},
     )
     fake_extra_data = {
@@ -1427,7 +1424,7 @@ async def test_trigger_entity_restore_state_auto_off_expired(
         await hass.async_block_till_done()
 
     state = hass.states.get("binary_sensor.test")
-    assert state.state == OFF
+    assert state.state == STATE_OFF
 
 
 async def test_device_id(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I don't see any reason to have distinct constants

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
