### PR TITLE
Remove string literals from modbus component tests

### DIFF
--- a/tests/components/modbus/test_binary_sensor.py
+++ b/tests/components/modbus/test_binary_sensor.py
@@ -3,6 +3,7 @@
 import pytest
 
 from homeassistant.components.binary_sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.components.homeassistant import SERVICE_UPDATE_ENTITY
 from homeassistant.components.modbus.const import (
     CALL_TYPE_COIL,
     CALL_TYPE_DISCRETE,
@@ -15,10 +16,12 @@ from homeassistant.components.modbus.const import (
     MODBUS_DOMAIN,
 )
 from homeassistant.const import (
+    ATTR_ENTITY_ID,
     CONF_ADDRESS,
     CONF_BINARY_SENSORS,
     CONF_DEVICE_CLASS,
     CONF_NAME,
+    CONF_PLATFORM,
     CONF_SCAN_INTERVAL,
     CONF_SLAVE,
     CONF_UNIQUE_ID,
@@ -26,7 +29,7 @@ from homeassistant.const import (
     STATE_ON,
     STATE_UNAVAILABLE,
 )
-from homeassistant.core import HomeAssistant, State
+from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant, State
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
@@ -212,14 +215,20 @@ async def test_service_binary_sensor_update(
     """Run test for service homeassistant.update_entity."""
 
     await hass.services.async_call(
-        "homeassistant", "update_entity", {"entity_id": ENTITY_ID}, blocking=True
+        HOMEASSISTANT_DOMAIN,
+        SERVICE_UPDATE_ENTITY,
+        {ATTR_ENTITY_ID: ENTITY_ID},
+        blocking=True,
     )
     await hass.async_block_till_done()
     assert hass.states.get(ENTITY_ID).state == STATE_OFF
 
     mock_modbus_ha.read_coils.return_value = ReadResult([0x01])
     await hass.services.async_call(
-        "homeassistant", "update_entity", {"entity_id": ENTITY_ID}, blocking=True
+        HOMEASSISTANT_DOMAIN,
+        SERVICE_UPDATE_ENTITY,
+        {ATTR_ENTITY_ID: ENTITY_ID},
+        blocking=True,
     )
     await hass.async_block_till_done()
     assert hass.states.get(ENTITY_ID).state == STATE_ON
@@ -428,7 +437,7 @@ async def test_no_discovery_info_binary_sensor(
     assert await async_setup_component(
         hass,
         SENSOR_DOMAIN,
-        {SENSOR_DOMAIN: {"platform": MODBUS_DOMAIN}},
+        {SENSOR_DOMAIN: {CONF_PLATFORM: MODBUS_DOMAIN}},
     )
     await hass.async_block_till_done()
     assert SENSOR_DOMAIN in hass.config.components

--- a/tests/components/modbus/test_climate.py
+++ b/tests/components/modbus/test_climate.py
@@ -20,6 +20,10 @@ from homeassistant.components.climate import (
     FAN_OFF,
     FAN_ON,
     FAN_TOP,
+    SERVICE_SET_FAN_MODE,
+    SERVICE_SET_HVAC_MODE,
+    SERVICE_SET_SWING_MODE,
+    SERVICE_SET_TEMPERATURE,
     SWING_BOTH,
     SWING_HORIZONTAL,
     SWING_OFF,
@@ -27,6 +31,7 @@ from homeassistant.components.climate import (
     SWING_VERTICAL,
     HVACMode,
 )
+from homeassistant.components.homeassistant import SERVICE_UPDATE_ENTITY
 from homeassistant.components.modbus.const import (
     CONF_CLIMATES,
     CONF_DATA_TYPE,
@@ -66,15 +71,17 @@ from homeassistant.components.modbus.const import (
     DataType,
 )
 from homeassistant.const import (
+    ATTR_ENTITY_ID,
     ATTR_TEMPERATURE,
     CONF_ADDRESS,
     CONF_NAME,
+    CONF_PLATFORM,
     CONF_SCAN_INTERVAL,
     CONF_SLAVE,
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
 )
-from homeassistant.core import HomeAssistant, State
+from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant, State
 from homeassistant.setup import async_setup_component
 
 from .conftest import TEST_ENTITY_NAME, ReadResult
@@ -152,13 +159,13 @@ ENTITY_ID = f"{CLIMATE_DOMAIN}.{TEST_ENTITY_NAME}".replace(" ", "_")
                     CONF_HVAC_MODE_REGISTER: {
                         CONF_ADDRESS: 11,
                         CONF_HVAC_MODE_VALUES: {
-                            "state_off": 0,
-                            "state_heat": 1,
-                            "state_cool": 2,
-                            "state_heat_cool": 3,
-                            "state_dry": 4,
-                            "state_fan_only": 5,
-                            "state_auto": 6,
+                            CONF_HVAC_MODE_OFF: 0,
+                            CONF_HVAC_MODE_HEAT: 1,
+                            CONF_HVAC_MODE_COOL: 2,
+                            CONF_HVAC_MODE_HEAT_COOL: 3,
+                            CONF_HVAC_MODE_DRY: 4,
+                            CONF_HVAC_MODE_FAN_ONLY: 5,
+                            CONF_HVAC_MODE_AUTO: 6,
                         },
                     },
                 }
@@ -176,13 +183,13 @@ ENTITY_ID = f"{CLIMATE_DOMAIN}.{TEST_ENTITY_NAME}".replace(" ", "_")
                         CONF_ADDRESS: 11,
                         CONF_WRITE_REGISTERS: True,
                         CONF_HVAC_MODE_VALUES: {
-                            "state_off": 0,
-                            "state_heat": 1,
-                            "state_cool": 2,
-                            "state_heat_cool": 3,
-                            "state_dry": 4,
-                            "state_fan_only": 5,
-                            "state_auto": 6,
+                            CONF_HVAC_MODE_OFF: 0,
+                            CONF_HVAC_MODE_HEAT: 1,
+                            CONF_HVAC_MODE_COOL: 2,
+                            CONF_HVAC_MODE_HEAT_COOL: 3,
+                            CONF_HVAC_MODE_DRY: 4,
+                            CONF_HVAC_MODE_FAN_ONLY: 5,
+                            CONF_HVAC_MODE_AUTO: 6,
                         },
                     },
                 }
@@ -501,7 +508,10 @@ async def test_service_climate_update(
     """Run test for service homeassistant.update_entity."""
     mock_modbus_ha.read_holding_registers.return_value = ReadResult(register_words)
     await hass.services.async_call(
-        "homeassistant", "update_entity", {"entity_id": ENTITY_ID}, blocking=True
+        HOMEASSISTANT_DOMAIN,
+        SERVICE_UPDATE_ENTITY,
+        {ATTR_ENTITY_ID: ENTITY_ID},
+        blocking=True,
     )
     await hass.async_block_till_done()
     assert hass.states.get(ENTITY_ID).state == result
@@ -616,7 +626,10 @@ async def test_service_climate_fan_update(
     """Run test for service homeassistant.update_entity."""
     mock_modbus_ha.read_holding_registers.return_value = ReadResult(register_words)
     await hass.services.async_call(
-        "homeassistant", "update_entity", {"entity_id": ENTITY_ID}, blocking=True
+        HOMEASSISTANT_DOMAIN,
+        SERVICE_UPDATE_ENTITY,
+        {ATTR_ENTITY_ID: ENTITY_ID},
+        blocking=True,
     )
     await hass.async_block_till_done()
     assert hass.states.get(ENTITY_ID).attributes[ATTR_FAN_MODE] == result
@@ -756,7 +769,10 @@ async def test_service_climate_swing_update(
     """Run test for service homeassistant.update_entity."""
     mock_modbus_ha.read_holding_registers.return_value = ReadResult(register_words)
     await hass.services.async_call(
-        "homeassistant", "update_entity", {"entity_id": ENTITY_ID}, blocking=True
+        HOMEASSISTANT_DOMAIN,
+        SERVICE_UPDATE_ENTITY,
+        {ATTR_ENTITY_ID: ENTITY_ID},
+        blocking=True,
     )
     await hass.async_block_till_done()
     assert hass.states.get(ENTITY_ID).attributes[ATTR_SWING_MODE] == result
@@ -850,9 +866,9 @@ async def test_service_climate_set_temperature(
     mock_modbus_ha.read_holding_registers.return_value = ReadResult(result)
     await hass.services.async_call(
         CLIMATE_DOMAIN,
-        "set_temperature",
+        SERVICE_SET_TEMPERATURE,
         {
-            "entity_id": ENTITY_ID,
+            ATTR_ENTITY_ID: ENTITY_ID,
             ATTR_TEMPERATURE: temperature,
         },
         blocking=True,
@@ -961,9 +977,9 @@ async def test_service_set_hvac_mode(
 
     await hass.services.async_call(
         CLIMATE_DOMAIN,
-        "set_hvac_mode",
+        SERVICE_SET_HVAC_MODE,
         {
-            "entity_id": ENTITY_ID,
+            ATTR_ENTITY_ID: ENTITY_ID,
             ATTR_HVAC_MODE: hvac_mode,
         },
         blocking=True,
@@ -1024,9 +1040,9 @@ async def test_service_set_fan_mode(
     mock_modbus_ha.read_holding_registers.return_value = ReadResult(result)
     await hass.services.async_call(
         CLIMATE_DOMAIN,
-        "set_fan_mode",
+        SERVICE_SET_FAN_MODE,
         {
-            "entity_id": ENTITY_ID,
+            ATTR_ENTITY_ID: ENTITY_ID,
             ATTR_FAN_MODE: fan_mode,
         },
         blocking=True,
@@ -1087,9 +1103,9 @@ async def test_service_set_swing_mode(
     mock_modbus_ha.read_holding_registers.return_value = ReadResult(result)
     await hass.services.async_call(
         CLIMATE_DOMAIN,
-        "set_swing_mode",
+        SERVICE_SET_SWING_MODE,
         {
-            "entity_id": ENTITY_ID,
+            ATTR_ENTITY_ID: ENTITY_ID,
             ATTR_SWING_MODE: swing_mode,
         },
         blocking=True,
@@ -1174,7 +1190,7 @@ async def test_no_discovery_info_climate(
     assert await async_setup_component(
         hass,
         CLIMATE_DOMAIN,
-        {CLIMATE_DOMAIN: {"platform": MODBUS_DOMAIN}},
+        {CLIMATE_DOMAIN: {CONF_PLATFORM: MODBUS_DOMAIN}},
     )
     await hass.async_block_till_done()
     assert CLIMATE_DOMAIN in hass.config.components

--- a/tests/components/modbus/test_fan.py
+++ b/tests/components/modbus/test_fan.py
@@ -4,6 +4,7 @@ from pymodbus.exceptions import ModbusException
 import pytest
 
 from homeassistant.components.fan import DOMAIN as FAN_DOMAIN
+from homeassistant.components.homeassistant import SERVICE_UPDATE_ENTITY
 from homeassistant.components.modbus.const import (
     CALL_TYPE_COIL,
     CALL_TYPE_DISCRETE,
@@ -19,17 +20,21 @@ from homeassistant.components.modbus.const import (
     MODBUS_DOMAIN,
 )
 from homeassistant.const import (
+    ATTR_ENTITY_ID,
     CONF_ADDRESS,
     CONF_COMMAND_OFF,
     CONF_COMMAND_ON,
     CONF_NAME,
+    CONF_PLATFORM,
     CONF_SCAN_INTERVAL,
     CONF_SLAVE,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
     STATE_OFF,
     STATE_ON,
     STATE_UNAVAILABLE,
 )
-from homeassistant.core import HomeAssistant, State
+from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant, State
 from homeassistant.setup import async_setup_component
 
 from .conftest import TEST_ENTITY_NAME, ReadResult
@@ -269,12 +274,12 @@ async def test_fan_service_turn(
 
     assert hass.states.get(ENTITY_ID).state == STATE_OFF
     await hass.services.async_call(
-        "fan", "turn_on", service_data={"entity_id": ENTITY_ID}
+        FAN_DOMAIN, SERVICE_TURN_ON, service_data={ATTR_ENTITY_ID: ENTITY_ID}
     )
     await hass.async_block_till_done()
     assert hass.states.get(ENTITY_ID).state == STATE_ON
     await hass.services.async_call(
-        "fan", "turn_off", service_data={"entity_id": ENTITY_ID}
+        FAN_DOMAIN, SERVICE_TURN_OFF, service_data={ATTR_ENTITY_ID: ENTITY_ID}
     )
     await hass.async_block_till_done()
     assert hass.states.get(ENTITY_ID).state == STATE_OFF
@@ -282,26 +287,26 @@ async def test_fan_service_turn(
     mock_modbus.read_holding_registers.return_value = ReadResult([0x01])
     assert hass.states.get(ENTITY_ID2).state == STATE_OFF
     await hass.services.async_call(
-        "fan", "turn_on", service_data={"entity_id": ENTITY_ID2}
+        FAN_DOMAIN, SERVICE_TURN_ON, service_data={ATTR_ENTITY_ID: ENTITY_ID2}
     )
     await hass.async_block_till_done()
     assert hass.states.get(ENTITY_ID2).state == STATE_ON
     mock_modbus.read_holding_registers.return_value = ReadResult([0x00])
     await hass.services.async_call(
-        "fan", "turn_off", service_data={"entity_id": ENTITY_ID2}
+        FAN_DOMAIN, SERVICE_TURN_OFF, service_data={ATTR_ENTITY_ID: ENTITY_ID2}
     )
     await hass.async_block_till_done()
     assert hass.states.get(ENTITY_ID2).state == STATE_OFF
 
     mock_modbus.write_register.side_effect = ModbusException("fail write_")
     await hass.services.async_call(
-        "fan", "turn_on", service_data={"entity_id": ENTITY_ID2}
+        FAN_DOMAIN, SERVICE_TURN_ON, service_data={ATTR_ENTITY_ID: ENTITY_ID2}
     )
     await hass.async_block_till_done()
     assert hass.states.get(ENTITY_ID2).state == STATE_UNAVAILABLE
     mock_modbus.write_coil.side_effect = ModbusException("fail write_")
     await hass.services.async_call(
-        "fan", "turn_off", service_data={"entity_id": ENTITY_ID}
+        FAN_DOMAIN, SERVICE_TURN_OFF, service_data={ATTR_ENTITY_ID: ENTITY_ID}
     )
     await hass.async_block_till_done()
     assert hass.states.get(ENTITY_ID).state == STATE_UNAVAILABLE
@@ -325,12 +330,18 @@ async def test_fan_service_turn(
 async def test_service_fan_update(hass: HomeAssistant, mock_modbus_ha) -> None:
     """Run test for service homeassistant.update_entity."""
     await hass.services.async_call(
-        "homeassistant", "update_entity", {"entity_id": ENTITY_ID}, blocking=True
+        HOMEASSISTANT_DOMAIN,
+        SERVICE_UPDATE_ENTITY,
+        {ATTR_ENTITY_ID: ENTITY_ID},
+        blocking=True,
     )
     assert hass.states.get(ENTITY_ID).state == STATE_OFF
     mock_modbus_ha.read_coils.return_value = ReadResult([0x01])
     await hass.services.async_call(
-        "homeassistant", "update_entity", {"entity_id": ENTITY_ID}, blocking=True
+        HOMEASSISTANT_DOMAIN,
+        SERVICE_UPDATE_ENTITY,
+        {ATTR_ENTITY_ID: ENTITY_ID},
+        blocking=True,
     )
     assert hass.states.get(ENTITY_ID).state == STATE_ON
 
@@ -343,7 +354,7 @@ async def test_no_discovery_info_fan(
     assert await async_setup_component(
         hass,
         FAN_DOMAIN,
-        {FAN_DOMAIN: {"platform": MODBUS_DOMAIN}},
+        {FAN_DOMAIN: {CONF_PLATFORM: MODBUS_DOMAIN}},
     )
     await hass.async_block_till_done()
     assert FAN_DOMAIN in hass.config.components

--- a/tests/components/modbus/test_light.py
+++ b/tests/components/modbus/test_light.py
@@ -3,6 +3,7 @@
 from pymodbus.exceptions import ModbusException
 import pytest
 
+from homeassistant.components.homeassistant import SERVICE_UPDATE_ENTITY
 from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
 from homeassistant.components.modbus.const import (
     CALL_TYPE_COIL,
@@ -18,18 +19,22 @@ from homeassistant.components.modbus.const import (
     MODBUS_DOMAIN,
 )
 from homeassistant.const import (
+    ATTR_ENTITY_ID,
     CONF_ADDRESS,
     CONF_COMMAND_OFF,
     CONF_COMMAND_ON,
     CONF_LIGHTS,
     CONF_NAME,
+    CONF_PLATFORM,
     CONF_SCAN_INTERVAL,
     CONF_SLAVE,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
     STATE_OFF,
     STATE_ON,
     STATE_UNAVAILABLE,
 )
-from homeassistant.core import HomeAssistant, State
+from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant, State
 from homeassistant.setup import async_setup_component
 
 from .conftest import TEST_ENTITY_NAME, ReadResult
@@ -269,12 +274,12 @@ async def test_light_service_turn(
 
     assert hass.states.get(ENTITY_ID).state == STATE_OFF
     await hass.services.async_call(
-        "light", "turn_on", service_data={"entity_id": ENTITY_ID}
+        LIGHT_DOMAIN, SERVICE_TURN_ON, service_data={ATTR_ENTITY_ID: ENTITY_ID}
     )
     await hass.async_block_till_done()
     assert hass.states.get(ENTITY_ID).state == STATE_ON
     await hass.services.async_call(
-        "light", "turn_off", service_data={"entity_id": ENTITY_ID}
+        LIGHT_DOMAIN, SERVICE_TURN_OFF, service_data={ATTR_ENTITY_ID: ENTITY_ID}
     )
     await hass.async_block_till_done()
     assert hass.states.get(ENTITY_ID).state == STATE_OFF
@@ -282,20 +287,20 @@ async def test_light_service_turn(
     mock_modbus.read_holding_registers.return_value = ReadResult([0x01])
     assert hass.states.get(ENTITY_ID2).state == STATE_OFF
     await hass.services.async_call(
-        "light", "turn_on", service_data={"entity_id": ENTITY_ID2}
+        LIGHT_DOMAIN, SERVICE_TURN_ON, service_data={ATTR_ENTITY_ID: ENTITY_ID2}
     )
     await hass.async_block_till_done()
     assert hass.states.get(ENTITY_ID2).state == STATE_ON
     mock_modbus.read_holding_registers.return_value = ReadResult([0x00])
     await hass.services.async_call(
-        "light", "turn_off", service_data={"entity_id": ENTITY_ID2}
+        LIGHT_DOMAIN, SERVICE_TURN_OFF, service_data={ATTR_ENTITY_ID: ENTITY_ID2}
     )
     await hass.async_block_till_done()
     assert hass.states.get(ENTITY_ID2).state == STATE_OFF
 
     mock_modbus.write_register.side_effect = ModbusException("fail write_")
     await hass.services.async_call(
-        "light", "turn_on", service_data={"entity_id": ENTITY_ID2}
+        LIGHT_DOMAIN, SERVICE_TURN_ON, service_data={ATTR_ENTITY_ID: ENTITY_ID2}
     )
     await hass.async_block_till_done()
     assert hass.states.get(ENTITY_ID2).state == STATE_UNAVAILABLE
@@ -319,12 +324,18 @@ async def test_light_service_turn(
 async def test_service_light_update(hass: HomeAssistant, mock_modbus_ha) -> None:
     """Run test for service homeassistant.update_entity."""
     await hass.services.async_call(
-        "homeassistant", "update_entity", {"entity_id": ENTITY_ID}, blocking=True
+        HOMEASSISTANT_DOMAIN,
+        SERVICE_UPDATE_ENTITY,
+        {ATTR_ENTITY_ID: ENTITY_ID},
+        blocking=True,
     )
     assert hass.states.get(ENTITY_ID).state == STATE_OFF
     mock_modbus_ha.read_coils.return_value = ReadResult([0x01])
     await hass.services.async_call(
-        "homeassistant", "update_entity", {"entity_id": ENTITY_ID}, blocking=True
+        HOMEASSISTANT_DOMAIN,
+        SERVICE_UPDATE_ENTITY,
+        {ATTR_ENTITY_ID: ENTITY_ID},
+        blocking=True,
     )
     assert hass.states.get(ENTITY_ID).state == STATE_ON
 
@@ -337,7 +348,7 @@ async def test_no_discovery_info_light(
     assert await async_setup_component(
         hass,
         LIGHT_DOMAIN,
-        {LIGHT_DOMAIN: {"platform": MODBUS_DOMAIN}},
+        {LIGHT_DOMAIN: {CONF_PLATFORM: MODBUS_DOMAIN}},
     )
     await hass.async_block_till_done()
     assert LIGHT_DOMAIN in hass.config.components

--- a/tests/components/modbus/test_sensor.py
+++ b/tests/components/modbus/test_sensor.py
@@ -4,6 +4,7 @@ import struct
 
 import pytest
 
+from homeassistant.components.homeassistant import SERVICE_UPDATE_ENTITY
 from homeassistant.components.modbus.const import (
     CALL_TYPE_REGISTER_HOLDING,
     CALL_TYPE_REGISTER_INPUT,
@@ -32,11 +33,13 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.const import (
+    ATTR_ENTITY_ID,
     CONF_ADDRESS,
     CONF_COUNT,
     CONF_DEVICE_CLASS,
     CONF_NAME,
     CONF_OFFSET,
+    CONF_PLATFORM,
     CONF_SCAN_INTERVAL,
     CONF_SENSORS,
     CONF_SLAVE,
@@ -45,7 +48,7 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
 )
-from homeassistant.core import HomeAssistant, State
+from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant, State
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
@@ -1395,12 +1398,18 @@ async def test_service_sensor_update(hass: HomeAssistant, mock_modbus_ha) -> Non
     """Run test for service homeassistant.update_entity."""
     mock_modbus_ha.read_input_registers.return_value = ReadResult([27])
     await hass.services.async_call(
-        "homeassistant", "update_entity", {"entity_id": ENTITY_ID}, blocking=True
+        HOMEASSISTANT_DOMAIN,
+        SERVICE_UPDATE_ENTITY,
+        {ATTR_ENTITY_ID: ENTITY_ID},
+        blocking=True,
     )
     assert hass.states.get(ENTITY_ID).state == "27"
     mock_modbus_ha.read_input_registers.return_value = ReadResult([32])
     await hass.services.async_call(
-        "homeassistant", "update_entity", {"entity_id": ENTITY_ID}, blocking=True
+        HOMEASSISTANT_DOMAIN,
+        SERVICE_UPDATE_ENTITY,
+        {ATTR_ENTITY_ID: ENTITY_ID},
+        blocking=True,
     )
     assert hass.states.get(ENTITY_ID).state == "32"
 
@@ -1413,7 +1422,7 @@ async def test_no_discovery_info_sensor(
     assert await async_setup_component(
         hass,
         SENSOR_DOMAIN,
-        {SENSOR_DOMAIN: {"platform": MODBUS_DOMAIN}},
+        {SENSOR_DOMAIN: {CONF_PLATFORM: MODBUS_DOMAIN}},
     )
     await hass.async_block_till_done()
     assert SENSOR_DOMAIN in hass.config.components

--- a/tests/components/modbus/test_switch.py
+++ b/tests/components/modbus/test_switch.py
@@ -6,6 +6,7 @@ from unittest import mock
 from pymodbus.exceptions import ModbusException
 import pytest
 
+from homeassistant.components.homeassistant import SERVICE_UPDATE_ENTITY
 from homeassistant.components.modbus.const import (
     CALL_TYPE_COIL,
     CALL_TYPE_DISCRETE,
@@ -21,20 +22,24 @@ from homeassistant.components.modbus.const import (
 )
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.const import (
+    ATTR_ENTITY_ID,
     CONF_ADDRESS,
     CONF_COMMAND_OFF,
     CONF_COMMAND_ON,
     CONF_DELAY,
     CONF_DEVICE_CLASS,
     CONF_NAME,
+    CONF_PLATFORM,
     CONF_SCAN_INTERVAL,
     CONF_SLAVE,
     CONF_SWITCHES,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
     STATE_OFF,
     STATE_ON,
     STATE_UNAVAILABLE,
 )
-from homeassistant.core import HomeAssistant, State
+from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant, State
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
@@ -75,7 +80,7 @@ ENTITY_ID3 = f"{ENTITY_ID}_3"
                     CONF_SLAVE: 1,
                     CONF_COMMAND_OFF: 0x00,
                     CONF_COMMAND_ON: 0x01,
-                    CONF_DEVICE_CLASS: "switch",
+                    CONF_DEVICE_CLASS: SWITCH_DOMAIN,
                     CONF_VERIFY: {
                         CONF_INPUT_TYPE: CALL_TYPE_REGISTER_HOLDING,
                         CONF_ADDRESS: 1235,
@@ -93,7 +98,7 @@ ENTITY_ID3 = f"{ENTITY_ID}_3"
                     CONF_DEVICE_ADDRESS: 1,
                     CONF_COMMAND_OFF: 0x00,
                     CONF_COMMAND_ON: 0x01,
-                    CONF_DEVICE_CLASS: "switch",
+                    CONF_DEVICE_CLASS: SWITCH_DOMAIN,
                     CONF_VERIFY: {
                         CONF_INPUT_TYPE: CALL_TYPE_REGISTER_HOLDING,
                         CONF_ADDRESS: 1235,
@@ -111,7 +116,7 @@ ENTITY_ID3 = f"{ENTITY_ID}_3"
                     CONF_SLAVE: 1,
                     CONF_COMMAND_OFF: 0x00,
                     CONF_COMMAND_ON: 0x01,
-                    CONF_DEVICE_CLASS: "switch",
+                    CONF_DEVICE_CLASS: SWITCH_DOMAIN,
                     CONF_VERIFY: {
                         CONF_INPUT_TYPE: CALL_TYPE_REGISTER_INPUT,
                         CONF_ADDRESS: 1235,
@@ -130,7 +135,7 @@ ENTITY_ID3 = f"{ENTITY_ID}_3"
                     CONF_SLAVE: 1,
                     CONF_COMMAND_OFF: 0x00,
                     CONF_COMMAND_ON: 0x01,
-                    CONF_DEVICE_CLASS: "switch",
+                    CONF_DEVICE_CLASS: SWITCH_DOMAIN,
                     CONF_VERIFY: {
                         CONF_INPUT_TYPE: CALL_TYPE_DISCRETE,
                         CONF_ADDRESS: 1235,
@@ -148,7 +153,7 @@ ENTITY_ID3 = f"{ENTITY_ID}_3"
                     CONF_SLAVE: 1,
                     CONF_COMMAND_OFF: 0x00,
                     CONF_COMMAND_ON: 0x01,
-                    CONF_DEVICE_CLASS: "switch",
+                    CONF_DEVICE_CLASS: SWITCH_DOMAIN,
                     CONF_SCAN_INTERVAL: 0,
                     CONF_VERIFY: None,
                 }
@@ -162,7 +167,7 @@ ENTITY_ID3 = f"{ENTITY_ID}_3"
                     CONF_DEVICE_ADDRESS: 10,
                     CONF_COMMAND_OFF: 0x00,
                     CONF_COMMAND_ON: 0x01,
-                    CONF_DEVICE_CLASS: "switch",
+                    CONF_DEVICE_CLASS: SWITCH_DOMAIN,
                     CONF_VERIFY: {
                         CONF_INPUT_TYPE: CALL_TYPE_REGISTER_HOLDING,
                         CONF_ADDRESS: 1235,
@@ -180,7 +185,7 @@ ENTITY_ID3 = f"{ENTITY_ID}_3"
                     CONF_DEVICE_ADDRESS: 10,
                     CONF_COMMAND_OFF: 0x00,
                     CONF_COMMAND_ON: 0x01,
-                    CONF_DEVICE_CLASS: "switch",
+                    CONF_DEVICE_CLASS: SWITCH_DOMAIN,
                     CONF_VERIFY: {
                         CONF_INPUT_TYPE: CALL_TYPE_REGISTER_HOLDING,
                         CONF_ADDRESS: 1235,
@@ -339,12 +344,12 @@ async def test_switch_service_turn(
 
     assert hass.states.get(ENTITY_ID).state == STATE_OFF
     await hass.services.async_call(
-        "switch", "turn_on", service_data={"entity_id": ENTITY_ID}
+        SWITCH_DOMAIN, SERVICE_TURN_ON, service_data={ATTR_ENTITY_ID: ENTITY_ID}
     )
     await hass.async_block_till_done()
     assert hass.states.get(ENTITY_ID).state == STATE_ON
     await hass.services.async_call(
-        "switch", "turn_off", service_data={"entity_id": ENTITY_ID}
+        SWITCH_DOMAIN, SERVICE_TURN_OFF, service_data={ATTR_ENTITY_ID: ENTITY_ID}
     )
     await hass.async_block_till_done()
     assert hass.states.get(ENTITY_ID).state == STATE_OFF
@@ -352,45 +357,45 @@ async def test_switch_service_turn(
     mock_modbus.read_holding_registers.return_value = ReadResult([0x01])
     assert hass.states.get(ENTITY_ID2).state == STATE_OFF
     await hass.services.async_call(
-        "switch", "turn_on", service_data={"entity_id": ENTITY_ID2}
+        SWITCH_DOMAIN, SERVICE_TURN_ON, service_data={ATTR_ENTITY_ID: ENTITY_ID2}
     )
     await hass.async_block_till_done()
     assert hass.states.get(ENTITY_ID2).state == STATE_ON
     mock_modbus.read_holding_registers.return_value = ReadResult([0x00])
     await hass.services.async_call(
-        "switch", "turn_off", service_data={"entity_id": ENTITY_ID2}
+        SWITCH_DOMAIN, SERVICE_TURN_OFF, service_data={ATTR_ENTITY_ID: ENTITY_ID2}
     )
     await hass.async_block_till_done()
     assert hass.states.get(ENTITY_ID2).state == STATE_OFF
     mock_modbus.read_holding_registers.return_value = ReadResult([0x03])
     assert hass.states.get(ENTITY_ID3).state == STATE_OFF
     await hass.services.async_call(
-        "switch", "turn_on", service_data={"entity_id": ENTITY_ID3}
+        SWITCH_DOMAIN, SERVICE_TURN_ON, service_data={ATTR_ENTITY_ID: ENTITY_ID3}
     )
     await hass.async_block_till_done()
     assert hass.states.get(ENTITY_ID3).state == STATE_ON
     mock_modbus.read_holding_registers.return_value = ReadResult([0x00])
     await hass.services.async_call(
-        "switch", "turn_off", service_data={"entity_id": ENTITY_ID3}
+        SWITCH_DOMAIN, SERVICE_TURN_OFF, service_data={ATTR_ENTITY_ID: ENTITY_ID3}
     )
     await hass.async_block_till_done()
     assert hass.states.get(ENTITY_ID3).state == STATE_OFF
 
     mock_modbus.write_register.side_effect = ModbusException("fail write_")
     await hass.services.async_call(
-        "switch", "turn_on", service_data={"entity_id": ENTITY_ID2}
+        SWITCH_DOMAIN, SERVICE_TURN_ON, service_data={ATTR_ENTITY_ID: ENTITY_ID2}
     )
     await hass.async_block_till_done()
     assert hass.states.get(ENTITY_ID2).state == STATE_UNAVAILABLE
     mock_modbus.write_coil.side_effect = ModbusException("fail write_")
     await hass.services.async_call(
-        "switch", "turn_off", service_data={"entity_id": ENTITY_ID}
+        SWITCH_DOMAIN, SERVICE_TURN_OFF, service_data={ATTR_ENTITY_ID: ENTITY_ID}
     )
     await hass.async_block_till_done()
     assert hass.states.get(ENTITY_ID).state == STATE_UNAVAILABLE
     mock_modbus.write_register.side_effect = ModbusException("fail write_")
     await hass.services.async_call(
-        "switch", "turn_on", service_data={"entity_id": ENTITY_ID3}
+        SWITCH_DOMAIN, SERVICE_TURN_ON, service_data={ATTR_ENTITY_ID: ENTITY_ID3}
     )
     await hass.async_block_till_done()
     assert hass.states.get(ENTITY_ID3).state == STATE_UNAVAILABLE
@@ -434,12 +439,18 @@ async def test_switch_service_turn(
 async def test_service_switch_update(hass: HomeAssistant, mock_modbus_ha) -> None:
     """Run test for service homeassistant.update_entity."""
     await hass.services.async_call(
-        "homeassistant", "update_entity", {"entity_id": ENTITY_ID}, blocking=True
+        HOMEASSISTANT_DOMAIN,
+        SERVICE_UPDATE_ENTITY,
+        {ATTR_ENTITY_ID: ENTITY_ID},
+        blocking=True,
     )
     assert hass.states.get(ENTITY_ID).state == STATE_OFF
     mock_modbus_ha.read_coils.return_value = ReadResult([0x01])
     await hass.services.async_call(
-        "homeassistant", "update_entity", {"entity_id": ENTITY_ID}, blocking=True
+        HOMEASSISTANT_DOMAIN,
+        SERVICE_UPDATE_ENTITY,
+        {ATTR_ENTITY_ID: ENTITY_ID},
+        blocking=True,
     )
     assert hass.states.get(ENTITY_ID).state == STATE_ON
 
@@ -467,7 +478,7 @@ async def test_delay_switch(hass: HomeAssistant, mock_modbus) -> None:
     mock_modbus.read_holding_registers.return_value = ReadResult([0x01])
     now = dt_util.utcnow()
     await hass.services.async_call(
-        "switch", "turn_on", service_data={"entity_id": ENTITY_ID}
+        SWITCH_DOMAIN, SERVICE_TURN_ON, service_data={ATTR_ENTITY_ID: ENTITY_ID}
     )
     await hass.async_block_till_done()
     assert hass.states.get(ENTITY_ID).state == STATE_OFF
@@ -486,7 +497,7 @@ async def test_no_discovery_info_switch(
     assert await async_setup_component(
         hass,
         SWITCH_DOMAIN,
-        {SWITCH_DOMAIN: {"platform": MODBUS_DOMAIN}},
+        {SWITCH_DOMAIN: {CONF_PLATFORM: MODBUS_DOMAIN}},
     )
     await hass.async_block_till_done()
     assert SWITCH_DOMAIN in hass.config.components


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
For code quality purposes, string literals have been removed and replaced by Home Assistant Constants.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
