### PR TITLE
Migrate config entry in anova to remove devices from entry data

### DIFF
--- a/homeassistant/components/anova/config_flow.py
+++ b/homeassistant/components/anova/config_flow.py
@@ -6,7 +6,7 @@ from anova_wifi import AnovaApi, InvalidLogin
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
-from homeassistant.const import CONF_DEVICES, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import DOMAIN
@@ -16,6 +16,7 @@ class AnovaConfligFlow(ConfigFlow, domain=DOMAIN):
     """Sets up a config flow for Anova."""
 
     VERSION = 1
+    MINOR_VERSION = 2
 
     async def async_step_user(
         self, user_input: dict[str, str] | None = None
@@ -42,8 +43,6 @@ class AnovaConfligFlow(ConfigFlow, domain=DOMAIN):
                     data={
                         CONF_USERNAME: user_input[CONF_USERNAME],
                         CONF_PASSWORD: user_input[CONF_PASSWORD],
-                        # this can be removed in a migration to 1.2 in 2024.11
-                        CONF_DEVICES: [],
                     },
                 )
 

--- a/tests/components/anova/__init__.py
+++ b/tests/components/anova/__init__.py
@@ -36,6 +36,7 @@ def create_entry(hass: HomeAssistant, device_id: str = DEVICE_UNIQUE_ID) -> Conf
         },
         unique_id="sample@gmail.com",
         version=1,
+        minor_version=2,
     )
     entry.add_to_hass(hass)
     return entry

--- a/tests/components/anova/test_config_flow.py
+++ b/tests/components/anova/test_config_flow.py
@@ -6,7 +6,7 @@ from anova_wifi import AnovaApi, InvalidLogin
 
 from homeassistant import config_entries
 from homeassistant.components.anova.const import DOMAIN
-from homeassistant.const import CONF_DEVICES, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
@@ -27,7 +27,6 @@ async def test_flow_user(hass: HomeAssistant, anova_api: AnovaApi) -> None:
     assert result["data"] == {
         CONF_USERNAME: "sample@gmail.com",
         CONF_PASSWORD: "sample",
-        CONF_DEVICES: [],
     }
 
 

--- a/tests/components/anova/test_init.py
+++ b/tests/components/anova/test_init.py
@@ -1,12 +1,17 @@
 """Test init for Anova."""
 
+from unittest.mock import patch
+
 from anova_wifi import AnovaApi
 
 from homeassistant.components.anova.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import CONF_DEVICES, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 
 from . import async_init_integration, create_entry
+
+from tests.common import MockConfigEntry
 
 
 async def test_async_setup_entry(hass: HomeAssistant, anova_api: AnovaApi) -> None:
@@ -55,3 +60,34 @@ async def test_websocket_failure(
     """Test that we successfully handle a websocket failure on setup."""
     entry = await async_init_integration(hass)
     assert entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_migration_removing_devices_in_config_entry(
+    hass: HomeAssistant, anova_api: AnovaApi
+) -> None:
+    """Test a successful setup entry."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Anova",
+        data={
+            CONF_USERNAME: "sample@gmail.com",
+            CONF_PASSWORD: "sample",
+            CONF_DEVICES: [],
+        },
+        unique_id="sample@gmail.com",
+        version=1,
+        minor_version=1,
+    )
+    entry.add_to_hass(hass)
+
+    with patch("homeassistant.components.anova.AnovaApi.authenticate"):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.anova_precision_cooker_mode")
+    assert state is not None
+    assert state.state == "idle"
+
+    assert entry.version == 1
+    assert entry.minor_version == 2
+    assert CONF_DEVICES not in entry.data


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove devices from config entry data in `anova`.
It's not used anyhow for any deprecation period so it's not needed to make this breaking (if it was that has already been).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 