### PR TITLE
Add new function to allow binary sensor templates to return state unknown

### DIFF
--- a/homeassistant/components/template/binary_sensor.py
+++ b/homeassistant/components/template/binary_sensor.py
@@ -303,7 +303,7 @@ class BinarySensorTemplate(TemplateEntity, BinarySensorEntity, RestoreEntity):
 
         state = (
             None
-            if isinstance(result, TemplateError)
+            if result is template.NONE_SENTINEL or isinstance(result, TemplateError)
             else template.result_as_boolean(result)
         )
 

--- a/homeassistant/components/template/binary_sensor.py
+++ b/homeassistant/components/template/binary_sensor.py
@@ -301,11 +301,13 @@ class BinarySensorTemplate(TemplateEntity, BinarySensorEntity, RestoreEntity):
             self._delay_cancel()
             self._delay_cancel = None
 
-        state = (
-            None
-            if result is template.NONE_SENTINEL or isinstance(result, TemplateError)
-            else template.result_as_boolean(result)
-        )
+        state: bool | None = None
+        if (
+            not isinstance(result, TemplateError)
+            # Temporary workaround for None in binary_sensor templates
+            and result != str(template.NONE_SENTINEL_STRING)
+        ):
+            state = template.result_as_boolean(result)
 
         if state == self._attr_is_on:
             return

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -126,6 +126,8 @@ _COLLECTABLE_STATE_ATTRIBUTES = {
 
 ALL_STATES_RATE_LIMIT = 60  # seconds
 DOMAIN_STATES_RATE_LIMIT = 1  # seconds
+# Temporary workaround for None in binary_sensor templates
+NONE_SENTINEL = object()
 
 _render_info: ContextVar[RenderInfo | None] = ContextVar("_render_info", default=None)
 
@@ -1274,6 +1276,12 @@ def forgiving_boolean[_T](
         if default is _SENTINEL:
             raise_no_default("bool", value)
         return default
+
+
+# Temporary workaround for None in binary_sensor templates
+def none_sentinel():
+    """Return a sentinel value for None."""
+    return NONE_SENTINEL
 
 
 def result_as_boolean(template_result: Any | None) -> bool:
@@ -2952,6 +2960,10 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         self.tests["match"] = regex_match
         self.tests["search"] = regex_search
         self.tests["contains"] = contains
+
+        # Temporary workaround for None in binary_sensor templates
+        self.globals["none_sentinel"] = none_sentinel
+        self.filters["none_sentinel"] = self.globals["none_sentinel"]
 
         if hass is None:
             return

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -128,6 +128,7 @@ ALL_STATES_RATE_LIMIT = 60  # seconds
 DOMAIN_STATES_RATE_LIMIT = 1  # seconds
 # Temporary workaround for None in binary_sensor templates
 NONE_SENTINEL = object()
+NONE_SENTINEL_STRING = str(NONE_SENTINEL)
 
 _render_info: ContextVar[RenderInfo | None] = ContextVar("_render_info", default=None)
 
@@ -1279,7 +1280,7 @@ def forgiving_boolean[_T](
 
 
 # Temporary workaround for None in binary_sensor templates
-def none_sentinel():
+def none_sentinel() -> object:
     """Return a sentinel value for None."""
     return NONE_SENTINEL
 

--- a/tests/components/template/test_binary_sensor.py
+++ b/tests/components/template/test_binary_sensor.py
@@ -1464,3 +1464,58 @@ async def test_device_id(
     template_entity = entity_registry.async_get("binary_sensor.my_template")
     assert template_entity is not None
     assert template_entity.device_id == device_entry.id
+
+
+@pytest.mark.parametrize(
+    ("state_template", "expected_result"),
+    [
+        ("{{ None }}", STATE_OFF),
+        ("{{ True }}", STATE_ON),
+        ("{{ False }}", STATE_OFF),
+        ("{{ 1 }}", STATE_ON),
+        (
+            "{% if states('binary_sensor.three') in ('unknown','unavailable') %}"
+            "{{ None }}"
+            "{% else %}"
+            "{{ states('binary_sensor.three') == 'off' }}"
+            "{% endif %}",
+            STATE_OFF,  # Sadly None currently maps to OFF
+        ),
+        (
+            "{% if states('binary_sensor.three') in ('unknown','unavailable') %}"
+            "{{ none_sentinel() }}"
+            "{% else %}"
+            "{{ states('binary_sensor.three') == 'off' }}"
+            "{% endif %}",
+            STATE_OFF,
+        ),
+    ],
+)
+async def test_state(
+    hass: HomeAssistant,
+    state_template: str,
+    expected_result: str,
+) -> None:
+    """Test the config flow."""
+    hass.states.async_set("binary_sensor.one", "on")
+    hass.states.async_set("binary_sensor.two", "off")
+    hass.states.async_set("binary_sensor.three", "unknown")
+
+    template_config_entry = MockConfigEntry(
+        data={},
+        domain=template.DOMAIN,
+        options={
+            "name": "My template",
+            "state": state_template,
+            "template_type": binary_sensor.DOMAIN,
+        },
+        title="My template",
+    )
+    template_config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(template_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.my_template")
+    assert state is not None
+    assert state.state == expected_result


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
None - but we could introduce a migration/deprecation later

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently, and contrary to most binary sensors, binary sensor templates are unable to return state `unknown`.

In order to avoid a breaking change (contrary to #128861), yet give the ability to use it straight away (contrary to #126909), this adds a new template function which returns a new sentinel value that can be checked

As follow-up to #60193, and as alternative to #126909/#128861

Proposal for architecture discussion https://github.com/home-assistant/architecture/discussions/1148

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/35332

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
