### PR TITLE
Make IPP protocol version configurable

### DIFF
--- a/homeassistant/components/ipp/__init__.py
+++ b/homeassistant/components/ipp/__init__.py
@@ -12,7 +12,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 
-from .const import CONF_BASE_PATH
+from .const import CONF_BASE_PATH, CONF_PROTO_LEGACY
 from .coordinator import IPPDataUpdateCoordinator
 
 PLATFORMS = [Platform.SENSOR]
@@ -31,6 +31,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: IPPConfigEntry) -> bool:
         host=entry.data[CONF_HOST],
         port=entry.data[CONF_PORT],
         base_path=entry.data[CONF_BASE_PATH],
+        proto_legacy=entry.data[CONF_PROTO_LEGACY],
         tls=entry.data[CONF_SSL],
         verify_ssl=entry.data[CONF_VERIFY_SSL],
         device_id=device_id,

--- a/homeassistant/components/ipp/config_flow.py
+++ b/homeassistant/components/ipp/config_flow.py
@@ -29,7 +29,14 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import CONF_BASE_PATH, CONF_SERIAL, DOMAIN
+from .const import (
+    CONF_BASE_PATH,
+    CONF_PROTO_LEGACY,
+    CONF_SERIAL,
+    DOMAIN,
+    IPP_PROTO_VERSION_DEFAULT,
+    IPP_PROTO_VERSION_LEGACY,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -47,6 +54,9 @@ async def validate_input(hass: HomeAssistant, data: dict) -> dict[str, Any]:
         tls=data[CONF_SSL],
         verify_ssl=data[CONF_VERIFY_SSL],
         session=session,
+        ipp_version=IPP_PROTO_VERSION_LEGACY
+        if data[CONF_PROTO_LEGACY]
+        else IPP_PROTO_VERSION_DEFAULT,
     )
 
     printer = await ipp.printer()
@@ -56,8 +66,6 @@ async def validate_input(hass: HomeAssistant, data: dict) -> dict[str, Any]:
 
 class IPPFlowHandler(ConfigFlow, domain=DOMAIN):
     """Handle an IPP config flow."""
-
-    VERSION = 1
 
     def __init__(self) -> None:
         """Set up the instance."""
@@ -127,6 +135,7 @@ class IPPFlowHandler(ConfigFlow, domain=DOMAIN):
                 CONF_BASE_PATH: f"/{base_path}",
                 CONF_NAME: name,
                 CONF_UUID: unique_id,
+                CONF_PROTO_LEGACY: False,
             }
         )
 
@@ -215,6 +224,7 @@ class IPPFlowHandler(ConfigFlow, domain=DOMAIN):
                     vol.Required(CONF_BASE_PATH, default="/ipp/print"): str,
                     vol.Required(CONF_SSL, default=False): bool,
                     vol.Required(CONF_VERIFY_SSL, default=False): bool,
+                    vol.Required(CONF_PROTO_LEGACY, default=False): bool,
                 }
             ),
             errors=errors or {},

--- a/homeassistant/components/ipp/const.py
+++ b/homeassistant/components/ipp/const.py
@@ -16,5 +16,9 @@ ATTR_URI_SUPPORTED = "uri_supported"
 
 # Config Keys
 CONF_BASE_PATH = "base_path"
+CONF_PROTO_LEGACY = "proto_legacy"
 CONF_SERIAL = "serial"
 CONF_TLS = "tls"
+
+IPP_PROTO_VERSION_LEGACY = (1, 1)
+IPP_PROTO_VERSION_DEFAULT = (2, 0)

--- a/homeassistant/components/ipp/coordinator.py
+++ b/homeassistant/components/ipp/coordinator.py
@@ -11,7 +11,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import DOMAIN
+from .const import DOMAIN, IPP_PROTO_VERSION_DEFAULT, IPP_PROTO_VERSION_LEGACY
 
 SCAN_INTERVAL = timedelta(seconds=60)
 
@@ -30,6 +30,7 @@ class IPPDataUpdateCoordinator(DataUpdateCoordinator[IPPPrinter]):
         base_path: str,
         tls: bool,
         verify_ssl: bool,
+        proto_legacy: bool,
         device_id: str,
     ) -> None:
         """Initialize global IPP data updater."""
@@ -41,6 +42,9 @@ class IPPDataUpdateCoordinator(DataUpdateCoordinator[IPPPrinter]):
             tls=tls,
             verify_ssl=verify_ssl,
             session=async_get_clientsession(hass, verify_ssl),
+            ipp_version=IPP_PROTO_VERSION_LEGACY
+            if proto_legacy
+            else IPP_PROTO_VERSION_DEFAULT,
         )
 
         super().__init__(

--- a/homeassistant/components/ipp/strings.json
+++ b/homeassistant/components/ipp/strings.json
@@ -10,7 +10,8 @@
           "port": "[%key:common::config_flow::data::port%]",
           "base_path": "Relative path to the printer",
           "ssl": "[%key:common::config_flow::data::ssl%]",
-          "verify_ssl": "[%key:common::config_flow::data::verify_ssl%]"
+          "verify_ssl": "[%key:common::config_flow::data::verify_ssl%]",
+          "proto_legacy": "Use IPP v1.1 for compatibility with older printers"
         }
       },
       "zeroconf_confirm": {

--- a/tests/components/ipp/__init__.py
+++ b/tests/components/ipp/__init__.py
@@ -3,7 +3,7 @@
 from ipaddress import ip_address
 
 from homeassistant.components import zeroconf
-from homeassistant.components.ipp.const import CONF_BASE_PATH
+from homeassistant.components.ipp.const import CONF_BASE_PATH, CONF_PROTO_LEGACY
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_SSL, CONF_VERIFY_SSL
 
 ATTR_HOSTNAME = "hostname"
@@ -28,6 +28,16 @@ MOCK_USER_INPUT = {
     CONF_SSL: False,
     CONF_VERIFY_SSL: False,
     CONF_BASE_PATH: BASE_PATH,
+    CONF_PROTO_LEGACY: False,
+}
+
+MOCK_USER_INPUT_PROTO_LEGACY = {
+    CONF_HOST: "192.168.1.32",
+    CONF_PORT: PORT,
+    CONF_SSL: False,
+    CONF_VERIFY_SSL: False,
+    CONF_BASE_PATH: "/ipp",
+    CONF_PROTO_LEGACY: True,
 }
 
 MOCK_ZEROCONF_IPP_SERVICE_INFO = zeroconf.ZeroconfServiceInfo(

--- a/tests/components/ipp/conftest.py
+++ b/tests/components/ipp/conftest.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from pyipp import Printer
 import pytest
 
-from homeassistant.components.ipp.const import CONF_BASE_PATH, DOMAIN
+from homeassistant.components.ipp.const import CONF_BASE_PATH, CONF_PROTO_LEGACY, DOMAIN
 from homeassistant.const import (
     CONF_HOST,
     CONF_PORT,
@@ -33,6 +33,7 @@ def mock_config_entry() -> MockConfigEntry:
             CONF_VERIFY_SSL: True,
             CONF_BASE_PATH: "/ipp/print",
             CONF_UUID: "cfe92100-67c4-11d4-a45f-f8d027761251",
+            CONF_PROTO_LEGACY: False,
         },
         unique_id="cfe92100-67c4-11d4-a45f-f8d027761251",
     )

--- a/tests/components/ipp/fixtures/printer_proto_legacy.json
+++ b/tests/components/ipp/fixtures/printer_proto_legacy.json
@@ -1,0 +1,18 @@
+{
+  "printer-state": "idle",
+  "printer-name": "Test Legacy Printer",
+  "printer-location": null,
+  "printer-make-and-model": "Test C822 Series",
+  "printer-uri-supported": [
+    "http://192.168.1.32/ipp",
+    "http://192.168.1.32:631/ipp",
+    "http://192.168.1.32/ipp/lp",
+    "http://192.168.1.32:631/ipp/lp",
+    "ipp://192.168.1.32/ipp",
+    "ipp://192.168.1.32:631/ipp",
+    "ipp://192.168.1.32/ipp/lp",
+    "ipp://192.168.1.32:631/ipp/lp"
+  ],
+  "printer-info": "PCL,XPS,IBMPPR,EPSONFX",
+  "printer-more-info": null
+}

--- a/tests/components/ipp/snapshots/test_diagnostics.ambr
+++ b/tests/components/ipp/snapshots/test_diagnostics.ambr
@@ -91,6 +91,7 @@
         'base_path': '/ipp/print',
         'host': '192.168.1.31',
         'port': 631,
+        'proto_legacy': False,
         'ssl': False,
         'uuid': 'cfe92100-67c4-11d4-a45f-f8d027761251',
         'verify_ssl': True,

--- a/tests/components/ipp/test_config_flow.py
+++ b/tests/components/ipp/test_config_flow.py
@@ -15,7 +15,7 @@ from pyipp import (
 )
 import pytest
 
-from homeassistant.components.ipp.const import CONF_BASE_PATH, DOMAIN
+from homeassistant.components.ipp.const import CONF_BASE_PATH, CONF_PROTO_LEGACY, DOMAIN
 from homeassistant.config_entries import SOURCE_USER, SOURCE_ZEROCONF
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_SSL, CONF_UUID
 from homeassistant.core import HomeAssistant
@@ -23,6 +23,7 @@ from homeassistant.data_entry_flow import FlowResultType
 
 from . import (
     MOCK_USER_INPUT,
+    MOCK_USER_INPUT_PROTO_LEGACY,
     MOCK_ZEROCONF_IPP_SERVICE_INFO,
     MOCK_ZEROCONF_IPPS_SERVICE_INFO,
 )
@@ -130,6 +131,32 @@ async def test_user_connection_upgrade_required(
     assert result["step_id"] == "user"
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": "connection_upgrade"}
+
+
+async def test_user_legacy_printer(hass: HomeAssistant) -> None:
+    """Test that a legacy printer can be added."""
+    fixture = await hass.async_add_executor_job(
+        load_fixture, "ipp/printer_proto_legacy.json"
+    )
+    mock_legacy_printer = Printer.from_dict(json.loads(fixture))
+    user_input = MOCK_USER_INPUT_PROTO_LEGACY.copy()
+    with patch(
+        "homeassistant.components.ipp.config_flow.IPP", autospec=True
+    ) as ipp_mock:
+        client = ipp_mock.return_value
+        client.printer.return_value = mock_legacy_printer
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_USER},
+            data=user_input,
+        )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "192.168.1.32"
+
+    assert result["data"]
+    assert result["data"][CONF_HOST] == "192.168.1.32"
+    assert result["data"][CONF_PROTO_LEGACY] is True
 
 
 async def test_zeroconf_connection_upgrade_required(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
ipp: Make IPP protocol version configurable
Adds a checkbox to optionally configure a printer with legacy IPP v1.1 instead of the default v2.0.

Fixes: #93211

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Continuation of https://github.com/home-assistant/core/pull/115661
- This PR fixes or closes issue: fixes #93211
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
