### PR TITLE
Bump python bsblan version 0.6.4

### DIFF
--- a/homeassistant/components/bsblan/coordinator.py
+++ b/homeassistant/components/bsblan/coordinator.py
@@ -54,6 +54,9 @@ class BSBLanUpdateCoordinator(DataUpdateCoordinator[BSBLanCoordinatorData]):
     async def _async_update_data(self) -> BSBLanCoordinatorData:
         """Get state and sensor data from BSB-Lan device."""
         try:
+            # initialize the client, this is cached and will only be called once
+            await self.client.initialize()
+
             state = await self.client.state()
             sensor = await self.client.sensor()
         except BSBLANConnectionError as err:

--- a/homeassistant/components/bsblan/manifest.json
+++ b/homeassistant/components/bsblan/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "loggers": ["bsblan"],
-  "requirements": ["python-bsblan==0.6.2"]
+  "requirements": ["python-bsblan==0.6.3"]
 }

--- a/homeassistant/components/bsblan/manifest.json
+++ b/homeassistant/components/bsblan/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "loggers": ["bsblan"],
-  "requirements": ["python-bsblan==0.6.3"]
+  "requirements": ["python-bsblan==0.6.4"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2299,7 +2299,7 @@ python-awair==0.2.4
 python-blockchain-api==0.0.2
 
 # homeassistant.components.bsblan
-python-bsblan==0.6.3
+python-bsblan==0.6.4
 
 # homeassistant.components.clementine
 python-clementine-remote==1.0.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2299,7 +2299,7 @@ python-awair==0.2.4
 python-blockchain-api==0.0.2
 
 # homeassistant.components.bsblan
-python-bsblan==0.6.2
+python-bsblan==0.6.3
 
 # homeassistant.components.clementine
 python-clementine-remote==1.0.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1844,7 +1844,7 @@ python-MotionMount==2.2.0
 python-awair==0.2.4
 
 # homeassistant.components.bsblan
-python-bsblan==0.6.3
+python-bsblan==0.6.4
 
 # homeassistant.components.ecobee
 python-ecobee-api==0.2.20

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1844,7 +1844,7 @@ python-MotionMount==2.2.0
 python-awair==0.2.4
 
 # homeassistant.components.bsblan
-python-bsblan==0.6.2
+python-bsblan==0.6.3
 
 # homeassistant.components.ecobee
 python-ecobee-api==0.2.20

--- a/tests/components/bsblan/fixtures/state.json
+++ b/tests/components/bsblan/fixtures/state.json
@@ -97,5 +97,14 @@
     "dataType": 1,
     "readonly": 1,
     "unit": ""
+  },
+  "room1_temp_setpoint_boost": {
+    "name": "Room 1 Temp Setpoint Boost",
+    "error": 0,
+    "value": "22.5",
+    "desc": "Boost",
+    "dataType": 1,
+    "readonly": 1,
+    "unit": "°C"
   }
 }

--- a/tests/components/bsblan/snapshots/test_diagnostics.ambr
+++ b/tests/components/bsblan/snapshots/test_diagnostics.ambr
@@ -47,6 +47,13 @@
           'unit': '',
           'value': '2',
         }),
+        'room1_temp_setpoint_boost': dict({
+          'data_type': 1,
+          'desc': 'Boost',
+          'name': 'Room 1 Temp Setpoint Boost',
+          'unit': '°C',
+          'value': '22.5',
+        }),
         'room1_thermostat_mode': dict({
           'data_type': 1,
           'desc': 'Kein Bedarf',


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

Bump library version to version 0.6.4
This update include some groundwork to add DHW platform to BSBLan.
The library was refactored and require initialisation. This is added to the coordinator.
```
async def initialize(self) -> None:
        """Initialize the BSBLAN client."""
        if not self._initialized:
            await self._fetch_firmware_version()
            await self._initialize_temperature_range()
            await self._initialize_api_data()
            self._initialized = True
```
This initialize is cached.
https://github.com/liudger/python-bsblan/compare/v0.6.2...v0.6.4
https://github.com/liudger/python-bsblan/releases/tag/v0.6.4


## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
