### PR TITLE
Fix cancellation leaking upward from the timeout util

### DIFF
--- a/tests/util/test_timeout.py
+++ b/tests/util/test_timeout.py
@@ -154,9 +154,10 @@ async def test_simple_global_timeout_does_not_leak_upward(
     current_task = asyncio.current_task()
     assert current_task is not None
 
-    async with timeout.async_timeout(0.1), timeout.async_freeze():
-        assert current_task.cancelling() == 0
-        await asyncio.sleep(0.3)
+    with pytest.raises(asyncio.TimeoutError):
+        async with timeout.async_timeout(0.1):
+            assert current_task.cancelling() == 0
+            await asyncio.sleep(0.3)
 
     # After the context manager exits, the task should no longer be cancelling
     assert current_task.cancelling() == 0
@@ -174,7 +175,8 @@ async def test_simple_global_timeout_does_swallow_cancellation(
         new_task = asyncio.current_task()
         assert new_task is not None
         with pytest.raises(asyncio.TimeoutError):
-            async with timeout.async_timeout(0.1), timeout.async_freeze():
+            assert current_task.cancelling() == 0
+            async with timeout.async_timeout(0.1):
                 await asyncio.sleep(0.3)
 
     # After the context manager exits, the task should no longer be cancelling
@@ -223,9 +225,10 @@ async def test_simple_zone_timeout_does_not_leak_upward(
     current_task = asyncio.current_task()
     assert current_task is not None
 
-    async with timeout.async_timeout(0.1, "test"):
-        assert current_task.cancelling() == 0
-        await asyncio.sleep(0.3)
+    with pytest.raises(asyncio.TimeoutError):
+        async with timeout.async_timeout(0.1, "test"):
+            assert current_task.cancelling() == 0
+            await asyncio.sleep(0.3)
 
     # After the context manager exits, the task should no longer be cancelling
     assert current_task.cancelling() == 0

--- a/tests/util/test_timeout.py
+++ b/tests/util/test_timeout.py
@@ -153,12 +153,14 @@ async def test_simple_global_timeout_does_not_leak_upward(
     timeout = TimeoutManager()
     current_task = asyncio.current_task()
     assert current_task is not None
+    cancelling_inside_timeout = None
 
-    with pytest.raises(asyncio.TimeoutError):
+    with pytest.raises(asyncio.TimeoutError):  # noqa: PT012
         async with timeout.async_timeout(0.1):
-            assert current_task.cancelling() == 0
+            cancelling_inside_timeout = current_task.cancelling()
             await asyncio.sleep(0.3)
 
+    assert cancelling_inside_timeout == 0
     # After the context manager exits, the task should no longer be cancelling
     assert current_task.cancelling() == 0
 
@@ -170,15 +172,18 @@ async def test_simple_global_timeout_does_swallow_cancellation(
     timeout = TimeoutManager()
     current_task = asyncio.current_task()
     assert current_task is not None
+    cancelling_inside_timeout = None
 
     async def task_with_timeout() -> None:
+        nonlocal cancelling_inside_timeout
         new_task = asyncio.current_task()
         assert new_task is not None
-        with pytest.raises(asyncio.TimeoutError):
-            assert current_task.cancelling() == 0
+        with pytest.raises(asyncio.TimeoutError):  # noqa: PT012
+            cancelling_inside_timeout = new_task.cancelling()
             async with timeout.async_timeout(0.1):
                 await asyncio.sleep(0.3)
 
+    assert cancelling_inside_timeout == 0
     # After the context manager exits, the task should no longer be cancelling
     assert current_task.cancelling() == 0
 
@@ -224,12 +229,14 @@ async def test_simple_zone_timeout_does_not_leak_upward(
     timeout = TimeoutManager()
     current_task = asyncio.current_task()
     assert current_task is not None
+    cancelling_inside_timeout = None
 
-    with pytest.raises(asyncio.TimeoutError):
+    with pytest.raises(asyncio.TimeoutError):  # noqa: PT012
         async with timeout.async_timeout(0.1, "test"):
-            assert current_task.cancelling() == 0
+            cancelling_inside_timeout = current_task.cancelling()
             await asyncio.sleep(0.3)
 
+    assert cancelling_inside_timeout == 0
     # After the context manager exits, the task should no longer be cancelling
     assert current_task.cancelling() == 0
 
@@ -241,14 +248,18 @@ async def test_simple_zone_timeout_does_swallow_cancellation(
     timeout = TimeoutManager()
     current_task = asyncio.current_task()
     assert current_task is not None
+    cancelling_inside_timeout = None
 
     async def task_with_timeout() -> None:
+        nonlocal cancelling_inside_timeout
         new_task = asyncio.current_task()
         assert new_task is not None
-        with pytest.raises(asyncio.TimeoutError):
+        with pytest.raises(asyncio.TimeoutError):  # noqa: PT012
             async with timeout.async_timeout(0.1, "test"):
+                cancelling_inside_timeout = current_task.cancelling()
                 await asyncio.sleep(0.3)
 
+    assert cancelling_inside_timeout == 0
     # After the context manager exits, the task should no longer be cancelling
     assert current_task.cancelling() == 0
 

--- a/tests/util/test_timeout.py
+++ b/tests/util/test_timeout.py
@@ -146,6 +146,55 @@ async def test_simple_global_timeout_freeze_with_executor_job(
         await hass.async_add_executor_job(time.sleep, 0.3)
 
 
+async def test_simple_global_timeout_does_not_leak_upward(
+    hass: HomeAssistant,
+) -> None:
+    """Test a global timeout does not leak upward."""
+    timeout = TimeoutManager()
+    current_task = asyncio.current_task()
+    assert current_task is not None
+
+    async with timeout.async_timeout(0.1), timeout.async_freeze():
+        assert current_task.cancelling() == 0
+        await asyncio.sleep(0.3)
+
+    # After the context manager exits, the task should no longer be cancelling
+    assert current_task.cancelling() == 0
+
+
+async def test_simple_global_timeout_does_swallow_cancellation(
+    hass: HomeAssistant,
+) -> None:
+    """Test a global timeout does not swallow cancellation."""
+    timeout = TimeoutManager()
+    current_task = asyncio.current_task()
+    assert current_task is not None
+
+    async def task_with_timeout() -> None:
+        new_task = asyncio.current_task()
+        assert new_task is not None
+        with pytest.raises(asyncio.TimeoutError):
+            async with timeout.async_timeout(0.1), timeout.async_freeze():
+                await asyncio.sleep(0.3)
+
+    # After the context manager exits, the task should no longer be cancelling
+    assert current_task.cancelling() == 0
+
+    task = asyncio.create_task(task_with_timeout())
+    await asyncio.sleep(0)
+    task.cancel()
+    assert task.cancelling() == 1
+
+    # Cancellation should not leak into the current task
+    assert current_task.cancelling() == 0
+    # Cancellation should not be swallowed if the task is cancelled
+    # and it also times out
+    await asyncio.sleep(0)
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert task.cancelling() == 1
+
+
 async def test_simple_global_timeout_freeze_reset() -> None:
     """Test a simple global timeout freeze reset."""
     timeout = TimeoutManager()
@@ -327,7 +376,7 @@ async def test_simple_zone_timeout_freeze_without_timeout_exeption() -> None:
             await asyncio.sleep(0.4)
 
 
-async def test_simple_zone_timeout_zone_with_timeout_exeption() -> None:
+async def test_simple_zone_timeout_zone_with_timeout_exception() -> None:
     """Test a simple zone timeout freeze on a zone that does not have a timeout set."""
     timeout = TimeoutManager()
 

--- a/tests/util/test_timeout.py
+++ b/tests/util/test_timeout.py
@@ -183,7 +183,6 @@ async def test_simple_global_timeout_does_swallow_cancellation(
             async with timeout.async_timeout(0.1):
                 await asyncio.sleep(0.3)
 
-    assert cancelling_inside_timeout == 0
     # After the context manager exits, the task should no longer be cancelling
     assert current_task.cancelling() == 0
 
@@ -192,6 +191,7 @@ async def test_simple_global_timeout_does_swallow_cancellation(
     task.cancel()
     assert task.cancelling() == 1
 
+    assert cancelling_inside_timeout == 0
     # Cancellation should not leak into the current task
     assert current_task.cancelling() == 0
     # Cancellation should not be swallowed if the task is cancelled
@@ -259,7 +259,6 @@ async def test_simple_zone_timeout_does_swallow_cancellation(
                 cancelling_inside_timeout = current_task.cancelling()
                 await asyncio.sleep(0.3)
 
-    assert cancelling_inside_timeout == 0
     # After the context manager exits, the task should no longer be cancelling
     assert current_task.cancelling() == 0
 
@@ -269,6 +268,7 @@ async def test_simple_zone_timeout_does_swallow_cancellation(
     assert task.cancelling() == 1
 
     # Cancellation should not leak into the current task
+    assert cancelling_inside_timeout == 0
     assert current_task.cancelling() == 0
     # Cancellation should not be swallowed if the task is cancelled
     # and it also times out


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix cancellation leak in timeout util as `uncancel` was never called when the internal cancellation was propagated as an `asyncio.TimeoutError` which caused cancellation to leak upward.

Same fix as https://github.com/aio-libs/async-timeout/pull/363 and https://github.com/aio-libs/aiohttp/pull/9326

related issues (most of them have other root causes, and this is a secondary effect):
https://github.com/home-assistant/core/issues/128266
https://github.com/home-assistant/core/issues/109343
https://github.com/home-assistant/core/issues/124832
https://github.com/home-assistant/core/issues/117827
https://github.com/home-assistant/core/issues/124044
https://github.com/home-assistant/core/issues/126115
https://github.com/home-assistant/core/issues/122878
https://github.com/home-assistant/core/issues/117256
https://github.com/home-assistant/core/issues/110232
https://github.com/home-assistant/core/issues/124034
https://github.com/home-assistant/core/issues/115881
https://github.com/home-assistant/core/issues/115468
https://github.com/home-assistant/core/issues/120220
https://github.com/home-assistant/core/issues/120220
https://github.com/home-assistant/core/issues/108941
https://github.com/home-assistant/core/issues/109968
https://github.com/home-assistant/core/issues/107954
https://github.com/home-assistant/core/issues/103039
https://github.com/home-assistant/core/issues/107474
https://github.com/home-assistant/core/issues/114118
https://github.com/home-assistant/core/issues/112568
https://github.com/home-assistant/core/issues/110321
https://github.com/home-assistant/core/issues/99795
https://github.com/home-assistant/core/issues/109299
https://github.com/home-assistant/core/issues/107588
https://github.com/home-assistant/core/issues/99421
https://github.com/home-assistant/core/issues/90558
https://github.com/home-assistant/core/issues/100539
https://github.com/home-assistant/core/issues/99862
https://github.com/home-assistant/core/issues/99816
https://github.com/home-assistant/core/issues/102000

Likely related to https://forum.hacf.fr/t/probleme-de-demarrage-integrations-ne-se-charge-pas/42289/12 as well

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
