### PR TITLE
Fix devolo_home_network devices not reporting a MAC address

### DIFF
--- a/homeassistant/components/devolo_home_network/entity.py
+++ b/homeassistant/components/devolo_home_network/entity.py
@@ -9,6 +9,7 @@ from devolo_plc_api.device_api import (
 )
 from devolo_plc_api.plcnet_api import DataRate, LogicalNetwork
 
+from homeassistant.const import ATTR_CONNECTIONS
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.update_coordinator import (
@@ -45,7 +46,6 @@ class DevoloEntity(Entity):
 
         self._attr_device_info = DeviceInfo(
             configuration_url=f"http://{self.device.ip}",
-            connections={(CONNECTION_NETWORK_MAC, self.device.mac)},
             identifiers={(DOMAIN, str(self.device.serial_number))},
             manufacturer="devolo",
             model=self.device.product,
@@ -53,6 +53,10 @@ class DevoloEntity(Entity):
             serial_number=self.device.serial_number,
             sw_version=self.device.firmware_version,
         )
+        if self.device.mac:
+            self._attr_device_info[ATTR_CONNECTIONS] = {
+                (CONNECTION_NETWORK_MAC, self.device.mac)
+            }
         self._attr_translation_key = self.entity_description.key
         self._attr_unique_id = (
             f"{self.device.serial_number}_{self.entity_description.key}"

--- a/tests/components/devolo_home_network/mock.py
+++ b/tests/components/devolo_home_network/mock.py
@@ -50,7 +50,7 @@ class MockDevice(Device):
         self, session_instance: httpx.AsyncClient | None = None
     ) -> None:
         """Give a mocked device the needed properties."""
-        self.mac = DISCOVERY_INFO.properties["PlcMacAddress"]
+        self.mac = DISCOVERY_INFO.properties["PlcMacAddress"] if self.plcnet else None
         self.mt_number = DISCOVERY_INFO.properties["MT"]
         self.product = DISCOVERY_INFO.properties["Product"]
         self.serial_number = DISCOVERY_INFO.properties["SN"]

--- a/tests/components/devolo_home_network/snapshots/test_init.ambr
+++ b/tests/components/devolo_home_network/snapshots/test_init.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_setup_entry
+# name: test_setup_entry[mock_device]
   DeviceRegistryEntrySnapshot({
     'area_id': None,
     'config_entries': <ANY>,
@@ -9,6 +9,38 @@
         'mac',
         'aa:bb:cc:dd:ee:ff',
       ),
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'devolo_home_network',
+        '1234567890',
+      ),
+    }),
+    'is_new': False,
+    'labels': set({
+    }),
+    'manufacturer': 'devolo',
+    'model': 'dLAN pro 1200+ WiFi ac',
+    'model_id': '2730',
+    'name': 'Mock Title',
+    'name_by_user': None,
+    'primary_config_entry': <ANY>,
+    'serial_number': '1234567890',
+    'suggested_area': None,
+    'sw_version': '5.6.1',
+    'via_device_id': None,
+  })
+# ---
+# name: test_setup_entry[mock_repeater_device]
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'configuration_url': 'http://192.0.2.1',
+    'connections': set({
     }),
     'disabled_by': None,
     'entry_type': None,

--- a/tests/components/devolo_home_network/test_init.py
+++ b/tests/components/devolo_home_network/test_init.py
@@ -27,13 +27,16 @@ from .mock import MockDevice
 from tests.common import MockConfigEntry
 
 
+@pytest.mark.parametrize("device", ["mock_device", "mock_repeater_device"])
 async def test_setup_entry(
     hass: HomeAssistant,
-    mock_device: MockDevice,
+    device: str,
     device_registry: dr.DeviceRegistry,
     snapshot: SnapshotAssertion,
+    request: pytest.FixtureRequest,
 ) -> None:
     """Test setup entry."""
+    mock_device: MockDevice = request.getfixturevalue(device)
     entry = configure_integration(hass)
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I falsely assumed that I always get a MAC address from devolo Home Network devices and added it to the device info. However, repeaters don't give me a MAC address, thus the connection attribute is None and if multiple repeaters are added, they get merged into a single device. This gets fixed here. Thanks @bong1991 for the debug session.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/128983
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
