### PR TITLE
Fix null hass error in supervisor update entities

### DIFF
--- a/homeassistant/components/hassio/coordinator.py
+++ b/homeassistant/components/hassio/coordinator.py
@@ -7,7 +7,7 @@ from collections import defaultdict
 import logging
 from typing import TYPE_CHECKING, Any
 
-from aiohasupervisor import SupervisorClient, SupervisorError
+from aiohasupervisor import SupervisorError
 from aiohasupervisor.models import StoreInfo
 
 from homeassistant.config_entries import ConfigEntry
@@ -318,12 +318,7 @@ class HassioDataUpdateCoordinator(DataUpdateCoordinator):
         self._container_updates: defaultdict[str, dict[str, set[str]]] = defaultdict(
             lambda: defaultdict(set)
         )
-        self._supervisor_client = get_supervisor_client(hass)
-
-    @property
-    def supervisor_client(self) -> SupervisorClient:
-        """Get supervisor client."""
-        return self._supervisor_client
+        self.supervisor_client = get_supervisor_client(hass)
 
     async def _async_update_data(self) -> dict[str, Any]:
         """Update data via library."""
@@ -508,7 +503,7 @@ class HassioDataUpdateCoordinator(DataUpdateCoordinator):
     async def _update_addon_stats(self, slug: str) -> tuple[str, dict[str, Any] | None]:
         """Update single addon stats."""
         try:
-            stats = await self._supervisor_client.addons.addon_stats(slug)
+            stats = await self.supervisor_client.addons.addon_stats(slug)
         except SupervisorError as err:
             _LOGGER.warning("Could not fetch stats for %s: %s", slug, err)
             return (slug, None)
@@ -517,7 +512,7 @@ class HassioDataUpdateCoordinator(DataUpdateCoordinator):
     async def _update_addon_changelog(self, slug: str) -> tuple[str, str | None]:
         """Return the changelog for an add-on."""
         try:
-            changelog = await self._supervisor_client.store.addon_changelog(slug)
+            changelog = await self.supervisor_client.store.addon_changelog(slug)
         except SupervisorError as err:
             _LOGGER.warning("Could not fetch changelog for %s: %s", slug, err)
             return (slug, None)
@@ -526,7 +521,7 @@ class HassioDataUpdateCoordinator(DataUpdateCoordinator):
     async def _update_addon_info(self, slug: str) -> tuple[str, dict[str, Any] | None]:
         """Return the info for an add-on."""
         try:
-            info = await self._supervisor_client.addons.addon_info(slug)
+            info = await self.supervisor_client.addons.addon_info(slug)
         except SupervisorError as err:
             _LOGGER.warning("Could not fetch info for %s: %s", slug, err)
             return (slug, None)

--- a/homeassistant/components/hassio/coordinator.py
+++ b/homeassistant/components/hassio/coordinator.py
@@ -7,7 +7,7 @@ from collections import defaultdict
 import logging
 from typing import TYPE_CHECKING, Any
 
-from aiohasupervisor import SupervisorError
+from aiohasupervisor import SupervisorClient, SupervisorError
 from aiohasupervisor.models import StoreInfo
 
 from homeassistant.config_entries import ConfigEntry
@@ -319,6 +319,11 @@ class HassioDataUpdateCoordinator(DataUpdateCoordinator):
             lambda: defaultdict(set)
         )
         self._supervisor_client = get_supervisor_client(hass)
+
+    @property
+    def supervisor_client(self) -> SupervisorClient:
+        """Get supervisor client."""
+        return self._supervisor_client
 
     async def _async_update_data(self) -> dict[str, Any]:
         """Update data via library."""

--- a/homeassistant/components/hassio/update.py
+++ b/homeassistant/components/hassio/update.py
@@ -108,7 +108,7 @@ class SupervisorAddonUpdateEntity(HassioAddonEntity, UpdateEntity):
     ) -> None:
         """Initialize object."""
         super().__init__(coordinator, entity_description, addon)
-        self._supervisor_client = get_supervisor_client(self.hass)
+        self._supervisor_client = get_supervisor_client(coordinator.hass)
 
     @property
     def _addon_data(self) -> dict:

--- a/homeassistant/components/hassio/update.py
+++ b/homeassistant/components/hassio/update.py
@@ -17,7 +17,6 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_ICON, ATTR_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import (
@@ -31,7 +30,6 @@ from .const import (
     DATA_KEY_OS,
     DATA_KEY_SUPERVISOR,
 )
-from .coordinator import HassioDataUpdateCoordinator
 from .entity import (
     HassioAddonEntity,
     HassioCoreEntity,
@@ -43,7 +41,6 @@ from .handler import (
     async_update_core,
     async_update_os,
     async_update_supervisor,
-    get_supervisor_client,
 )
 
 ENTITY_DESCRIPTION = UpdateEntityDescription(
@@ -99,16 +96,6 @@ class SupervisorAddonUpdateEntity(HassioAddonEntity, UpdateEntity):
         | UpdateEntityFeature.BACKUP
         | UpdateEntityFeature.RELEASE_NOTES
     )
-
-    def __init__(
-        self,
-        coordinator: HassioDataUpdateCoordinator,
-        entity_description: EntityDescription,
-        addon: dict[str, Any],
-    ) -> None:
-        """Initialize object."""
-        super().__init__(coordinator, entity_description, addon)
-        self._supervisor_client = get_supervisor_client(coordinator.hass)
 
     @property
     def _addon_data(self) -> dict:
@@ -179,7 +166,7 @@ class SupervisorAddonUpdateEntity(HassioAddonEntity, UpdateEntity):
     ) -> None:
         """Install an update."""
         try:
-            await self._supervisor_client.store.update_addon(
+            await self.coordinator.supervisor_client.store.update_addon(
                 self._addon_slug, StoreAddonUpdate(backup=backup)
             )
         except SupervisorError as err:

--- a/tests/components/conftest.py
+++ b/tests/components/conftest.py
@@ -478,10 +478,6 @@ def supervisor_client() -> Generator[AsyncMock]:
             return_value=supervisor_client,
         ),
         patch(
-            "homeassistant.components.hassio.update.get_supervisor_client",
-            return_value=supervisor_client,
-        ),
-        patch(
             "homeassistant.components.hassio.get_supervisor_client",
             return_value=supervisor_client,
         ),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
```
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 365, in _async_setup_platform
    await asyncio.shield(awaitable)
  File "/usr/src/homeassistant/homeassistant/components/hassio/update.py", line 74, in async_setup_entry
    entities.extend(
  File "/usr/src/homeassistant/homeassistant/components/hassio/update.py", line 75, in <genexpr>
    SupervisorAddonUpdateEntity(
  File "/usr/src/homeassistant/homeassistant/components/hassio/update.py", line 111, in __init__
    self._supervisor_client = get_supervisor_client(self.hass)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/helpers/singleton.py", line 41, in wrapped
    if data_key not in hass.data:
                       ^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'data'
```

`hass` is not passed directly to update entities and the `hass` field is not set. Use the field in the coordinator instead.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
