### PR TITLE
Fix race condition in statistics that created spikes

### DIFF
--- a/homeassistant/components/statistics/config_flow.py
+++ b/homeassistant/components/statistics/config_flow.py
@@ -169,8 +169,8 @@ class StatisticsConfigFlowHandler(SchemaConfigFlowHandler, domain=DOMAIN):
         vol.Required("user_input"): dict,
     }
 )
-@callback
-def ws_start_preview(
+@websocket_api.async_response
+async def ws_start_preview(
     hass: HomeAssistant,
     connection: websocket_api.ActiveConnection,
     msg: dict[str, Any],
@@ -234,6 +234,6 @@ def ws_start_preview(
     preview_entity.hass = hass
 
     connection.send_result(msg["id"])
-    connection.subscriptions[msg["id"]] = preview_entity.async_start_preview(
+    connection.subscriptions[msg["id"]] = await preview_entity.async_start_preview(
         async_preview_updated
     )

--- a/tests/components/statistics/test_sensor.py
+++ b/tests/components/statistics/test_sensor.py
@@ -1737,13 +1737,15 @@ async def test_update_before_load(recorder_mock: Recorder, hass: HomeAssistant) 
                         "platform": "statistics",
                         "name": "test",
                         "entity_id": "sensor.test_monitored",
-                        "state_characteristic": "average_step",
+                        "state_characteristic": "average_timeless",
                         "max_age": {"seconds": 10},
                     },
                 ]
             },
         )
         # this value is going to be ignored, since loading from the database hasn't finished yet
+        # if this value would be added before loading the historic data
+        # it would mess up the order of the internal queue which is supposed to be sorted by time
         hass.states.async_set(
             "sensor.test_monitored",
             "10",
@@ -1753,5 +1755,6 @@ async def test_update_before_load(recorder_mock: Recorder, hass: HomeAssistant) 
 
     avg: float = float(hass.states.get("sensor.test").state)
     # this is the average of VALUES_NUMERIC_LINEAR without the ignored value
-    assert avg >= 4.49
-    assert avg <= 4.51
+    # so we compute the average of 1 .. 9 and not 1 .. 10
+    assert avg > 4.99
+    assert avg < 5.01

--- a/tests/components/statistics/test_sensor.py
+++ b/tests/components/statistics/test_sensor.py
@@ -1713,10 +1713,6 @@ async def test_update_before_load(recorder_mock: Recorder, hass: HomeAssistant) 
     await hass.async_block_till_done()
     await async_wait_recording_done(hass)
 
-    # enable and pre-fill the recorder
-    await hass.async_block_till_done()
-    await async_wait_recording_done(hass)
-
     with (
         freeze_time(current_time) as freezer,
     ):

--- a/tests/components/statistics/test_sensor.py
+++ b/tests/components/statistics/test_sensor.py
@@ -1754,10 +1754,10 @@ async def test_update_before_load(recorder_mock: Recorder, hass: HomeAssistant) 
         )
         await hass.async_block_till_done()
 
-    avg: float = float(hass.states.get("sensor.test").state)
     # depending on timing we will either end up with a buffer of [1 .. 9] or [1 .. 10]
     # what may not happen is that the 10 will be added somewhere in between
     # so we compute average_step for either 1 .. 9 or 1 .. 10
     # this leads to 1+2+3+4+5+6+7+8/8 = 4.5
     #            or 1+2+3+4+5+6+7+8+9/9 = 5
-    assert (4.49 < avg < 4.51) or (4.99 < avg < 5.01)
+    avg: float = float(hass.states.get("sensor.test").state)
+    assert avg == pytest.approx(4.5) or avg == pytest.approx(5.0)

--- a/tests/components/statistics/test_sensor.py
+++ b/tests/components/statistics/test_sensor.py
@@ -1744,7 +1744,7 @@ async def test_update_before_load(recorder_mock: Recorder, hass: HomeAssistant) 
             },
         )
         # this value is probably going to be ignored, since loading from the database has
-        # most likely hasn't finished yet
+        # most likely not finished yet
         # if this value would be added before loading the historic data
         # it would mess up the order of the internal queue which is supposed to be sorted by time
         hass.states.async_set(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The statistics sensor is using an internal list to keep the history of previous states.
This list is accessed by various functions in an asynchronous manner (new sensor values arrive, sensor values become outdated and historical data loaded from the database is added to the list).
Currently, there is no synchronization of events that will prevent a corruption of the list (it is supposed to be sorted by time). Race conditions have been seen to cause spikes (incorrect values) in the statistics. This was caused by new values being appended to the list before the historic values were loaded from the database (they were also appended, and hence destroyed the order).
The proposed change will make sure that the order of the list will always be kept intact.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #119738 #98262 #67627
- This PR is related to issue:
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
