### PR TITLE
Resume adding Z-Wave device if the page is refreshed

### DIFF
--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -790,12 +790,13 @@ async def websocket_add_node(
 
     try:
         if controller.inclusion_state == InclusionState.INCLUDING:
-            result = True  # Inclusion is already in progress
+            connection.send_result(
+                msg[ID],
+                True,  # Inclusion is already in progress
+            )
             # Check for nodes that have been added but not fully included
             for node in controller.nodes.values():
-                if node.node_id == 3 or (
-                    node.status != NodeStatus.DEAD and not node.ready
-                ):
+                if node.status != NodeStatus.DEAD and not node.ready:
                     forward_node_added(
                         node,
                         not node.is_secure,
@@ -808,6 +809,10 @@ async def websocket_add_node(
                 provisioning=provisioning,
                 dsk=dsk,
             )
+            connection.send_result(
+                msg[ID],
+                result,
+            )
     except ValueError as err:
         connection.send_error(
             msg[ID],
@@ -815,11 +820,6 @@ async def websocket_add_node(
             err.args[0],
         )
         return
-
-    connection.send_result(
-        msg[ID],
-        result,
-    )
 
 
 @websocket_api.require_admin

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -13,8 +13,10 @@ from zwave_js_server.client import Client
 from zwave_js_server.const import (
     CommandClass,
     ExclusionStrategy,
+    InclusionState,
     InclusionStrategy,
     LogLevel,
+    NodeStatus,
     Protocols,
     ProvisioningEntryStatus,
     QRCodeVersion,
@@ -694,6 +696,30 @@ async def websocket_add_node(
         )
 
     @callback
+    def forward_node_added(
+        node: Node, low_security: bool, low_security_reason: str | None
+    ) -> None:
+        interview_unsubs = [
+            node.on("interview started", forward_event),
+            node.on("interview completed", forward_event),
+            node.on("interview stage completed", forward_stage),
+            node.on("interview failed", forward_event),
+        ]
+        unsubs.extend(interview_unsubs)
+        node_details = {
+            "node_id": node.node_id,
+            "status": node.status,
+            "ready": node.ready,
+            "low_security": low_security,
+            "low_security_reason": low_security_reason,
+        }
+        connection.send_message(
+            websocket_api.event_message(
+                msg[ID], {"event": "node added", "node": node_details}
+            )
+        )
+
+    @callback
     def forward_requested_grant(event: dict) -> None:
         connection.send_message(
             websocket_api.event_message(
@@ -727,25 +753,10 @@ async def websocket_add_node(
 
     @callback
     def node_added(event: dict) -> None:
-        node = event["node"]
-        interview_unsubs = [
-            node.on("interview started", forward_event),
-            node.on("interview completed", forward_event),
-            node.on("interview stage completed", forward_stage),
-            node.on("interview failed", forward_event),
-        ]
-        unsubs.extend(interview_unsubs)
-        node_details = {
-            "node_id": node.node_id,
-            "status": node.status,
-            "ready": node.ready,
-            "low_security": event["result"].get("lowSecurity", False),
-            "low_security_reason": event["result"].get("lowSecurityReason"),
-        }
-        connection.send_message(
-            websocket_api.event_message(
-                msg[ID], {"event": "node added", "node": node_details}
-            )
+        forward_node_added(
+            event["node"],
+            event["result"].get("lowSecurity", False),
+            event["result"].get("lowSecurityReason"),
         )
 
     @callback
@@ -778,12 +789,25 @@ async def websocket_add_node(
     msg[DATA_UNSUBSCRIBE] = unsubs
 
     try:
-        result = await controller.async_begin_inclusion(
-            INCLUSION_STRATEGY_NOT_SMART_START[inclusion_strategy.value],
-            force_security=force_security,
-            provisioning=provisioning,
-            dsk=dsk,
-        )
+        if controller.inclusion_state == InclusionState.INCLUDING:
+            result = True  # Inclusion is already in progress
+            # Check for nodes that have been added but not fully included
+            for node in controller.nodes.values():
+                if node.node_id == 3 or (
+                    node.status != NodeStatus.DEAD and not node.ready
+                ):
+                    forward_node_added(
+                        node,
+                        not node.is_secure,
+                        None,
+                    )
+        else:
+            result = await controller.async_begin_inclusion(
+                INCLUSION_STRATEGY_NOT_SMART_START[inclusion_strategy.value],
+                force_security=force_security,
+                provisioning=provisioning,
+                dsk=dsk,
+            )
     except ValueError as err:
         connection.send_error(
             msg[ID],

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -949,7 +949,7 @@ async def test_add_node(
     node_data["values"] = {}
     node_data["endpoints"] = {}
     node = Node(client, node_data)
-    client.driver.controller.nodes[1] = node
+    client.driver.controller.nodes[node.node_id] = node
 
     await ws_client.send_json(
         {

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -5,7 +5,7 @@ from http import HTTPStatus
 from io import BytesIO
 import json
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import PropertyMock, patch
 
 import pytest
 from zwave_js_server.const import (
@@ -489,6 +489,7 @@ async def test_node_alerts(
 
 async def test_add_node(
     hass: HomeAssistant,
+    nortek_thermostat,
     nortek_thermostat_added_event,
     integration,
     client,
@@ -936,12 +937,46 @@ async def test_add_node(
         assert msg["error"]["code"] == "zwave_error"
         assert msg["error"]["message"] == "zwave_error: Z-Wave error 1 - error message"
 
+    # Test inclusion already in progress
+    client.async_send_command.reset_mock()
+    type(client.driver.controller).inclusion_state = PropertyMock(
+        return_value=InclusionState.INCLUDING
+    )
+
+    # Create a node that's not ready
+    node_data = deepcopy(nortek_thermostat.data)  # Copy to allow modification in tests.
+    node_data["ready"] = False
+    node_data["values"] = {}
+    node_data["endpoints"] = {}
+    node = Node(client, node_data)
+    client.driver.controller.nodes[1] = node
+
+    await ws_client.send_json(
+        {
+            ID: 11,
+            TYPE: "zwave_js/add_node",
+            ENTRY_ID: entry.entry_id,
+            INCLUSION_STRATEGY: InclusionStrategy.DEFAULT.value,
+        }
+    )
+
+    msg = await ws_client.receive_json()
+    assert msg["success"]
+
+    # Verify no command was sent since inclusion is already in progress
+    assert len(client.async_send_command.call_args_list) == 0
+
+    # Verify we got a node added event
+    msg = await ws_client.receive_json()
+    assert msg["event"]["event"] == "node added"
+    assert msg["event"]["node"]["node_id"] == node.node_id
+
     # Test sending command with not loaded entry fails
     await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
 
     await ws_client.send_json(
-        {ID: 11, TYPE: "zwave_js/add_node", ENTRY_ID: entry.entry_id}
+        {ID: 12, TYPE: "zwave_js/add_node", ENTRY_ID: entry.entry_id}
     )
     msg = await ws_client.receive_json()
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
If device inclusion is already in progress when the "zwave_js/add_node" is received, we subscribe to the controller events but if the "node added" has passed, we will not be subscribed to the node events. So the client will not know when the device inclusion ended.
This PR checks if inclusion is in progress and if there is already a node that hasn't finished the process. It then subscribes to the node events and sends "node added" event to the frontend so proper progress can be displayed.
The use case for this is refreshing the Configure page or reopening it after a crash, for example.

A frontend PR will follow to better utilize these changes but is not required for this to work. FE PR https://github.com/home-assistant/frontend/pull/22519

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
