### PR TITLE
Add option to extract licenses [ci]

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -615,6 +615,10 @@ jobs:
         && github.event.inputs.mypy-only != 'true'
         || github.event.inputs.audit-licenses-only == 'true')
       && needs.info.outputs.requirements == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ${{ fromJson(needs.info.outputs.python_versions) }}
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@v4.2.2
@@ -633,19 +637,19 @@ jobs:
           key: >-
             ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
             needs.info.outputs.python_cache_key }}
-      - name: Run pip-licenses
+      - name: Extract license data
         run: |
           . venv/bin/activate
-          pip-licenses --format=json --output-file=licenses.json
+          python -m script.licenses extract --output-file=licenses-${{ matrix.python-version }}.json
       - name: Upload licenses
         uses: actions/upload-artifact@v4.4.3
         with:
-          name: licenses
-          path: licenses.json
-      - name: Process licenses
+          name: licenses-${{ github.run_number }}-${{ matrix.python-version }}
+          path: licenses-${{ matrix.python-version }}.json
+      - name: Check licenses
         run: |
           . venv/bin/activate
-          python -m script.licenses licenses.json
+          python -m script.licenses check licenses-${{ matrix.python-version }}.json
 
   pylint:
     name: Check pylint

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -17,7 +17,6 @@ pydantic==1.10.18
 pylint==3.3.1
 pylint-per-file-ignores==1.3.2
 pipdeptree==2.23.4
-pip-licenses==5.0.0
 pytest-asyncio==0.24.0
 pytest-aiohttp==1.0.5
 pytest-cov==5.0.0

--- a/script/licenses.py
+++ b/script/licenses.py
@@ -257,10 +257,10 @@ def get_package_metadata(dist: metadata.Distribution) -> PackageMetadata:
     return {
         "name": dist.name,
         "version": dist.version,
-        "license_expression": dist.metadata.get("license-expression"),
-        "license_metadata": dist.metadata.get("license"),
+        "license_expression": dist.metadata.get("License-Expression"),
+        "license_metadata": dist.metadata.get("License"),
         "license_classifier": extract_license_classifier(
-            dist.metadata.get_all("classifier")
+            dist.metadata.get_all("Classifier")
         ),
     }
 

--- a/script/licenses.py
+++ b/script/licenses.py
@@ -242,15 +242,14 @@ def check_licenses(args: CheckArgs) -> int:
     return exit_code
 
 
-def extract_license_classifier(classifiers: list[str] | None) -> list[str]:
-    """Extract license from list of classifiers."""
-    return [
-        license_classifier
-        for classifier in classifiers or ()
-        if classifier.startswith("License")
-        and (license_classifier := classifier.rpartition(" :: ")[2])
-        and license_classifier != "OSI Approved"
-    ]
+def extract_licenses(args: ExtractArgs) -> int:
+    """Extract license data for installed packages."""
+    licenses = sorted(
+        [get_package_metadata(dist) for dist in list(metadata.distributions())],
+        key=lambda dist: dist["name"],
+    )
+    Path(args.output_file).write_text(json.dumps(licenses, indent=2))
+    return 0
 
 
 def get_package_metadata(dist: metadata.Distribution) -> PackageMetadata:
@@ -266,14 +265,15 @@ def get_package_metadata(dist: metadata.Distribution) -> PackageMetadata:
     }
 
 
-def extract_licenses(args: ExtractArgs) -> int:
-    """Extract license data for installed packages."""
-    licenses = sorted(
-        [get_package_metadata(dist) for dist in list(metadata.distributions())],
-        key=lambda dist: dist["name"],
-    )
-    Path(args.output_file).write_text(json.dumps(licenses, indent=2))
-    return 0
+def extract_license_classifier(classifiers: list[str] | None) -> list[str]:
+    """Extract license from list of classifiers."""
+    return [
+        license_classifier
+        for classifier in classifiers or ()
+        if classifier.startswith("License")
+        and (license_classifier := classifier.rpartition(" :: ")[2])
+        and license_classifier != "OSI Approved"
+    ]
 
 
 class ExtractArgs(Namespace):

--- a/script/licenses.py
+++ b/script/licenses.py
@@ -266,7 +266,11 @@ def get_package_metadata(dist: metadata.Distribution) -> PackageMetadata:
 
 
 def extract_license_classifier(classifiers: list[str] | None) -> list[str]:
-    """Extract license from list of classifiers."""
+    """Extract license from list of classifiers.
+
+    E.g. 'License :: OSI Approved :: MIT License' -> 'MIT License'.
+    Filter out bare 'License :: OSI Approved'.
+    """
     return [
         license_classifier
         for classifier in classifiers or ()

--- a/script/licenses.py
+++ b/script/licenses.py
@@ -36,7 +36,9 @@ class PackageDefinition:
     def from_dict(cls, data: PackageMetadata) -> PackageDefinition:
         """Create a package definition from PackageMetadata."""
         if not (license_str := "; ".join(data["license_classifier"])):
-            license_str = data["license_metadata"] or "UNKNOWN"
+            license_str = (
+                data["license_metadata"] or data["license_expression"] or "UNKNOWN"
+            )
         return cls(
             license=license_str,
             name=data["name"],
@@ -142,7 +144,6 @@ EXCEPTIONS = {
     "aioecowitt",  # https://github.com/home-assistant-libs/aioecowitt/pull/180
     "aioopenexchangerates",  # https://github.com/MartinHjelmare/aioopenexchangerates/pull/94
     "aiooui",  # https://github.com/Bluetooth-Devices/aiooui/pull/8
-    "aioruuvigateway",  # https://github.com/akx/aioruuvigateway/pull/6
     "apple_weatherkit",  # https://github.com/tjhorner/python-weatherkit/pull/3
     "asyncio",  # PSF License
     "chacha20poly1305",  # LGPL
@@ -173,14 +174,10 @@ EXCEPTIONS = {
     "pyvera",  # https://github.com/maximvelichko/pyvera/pull/164
     "pyxeoma",  # https://github.com/jeradM/pyxeoma/pull/11
     "repoze.lru",
-    "ruuvitag-ble",  # https://github.com/Bluetooth-Devices/ruuvitag-ble/pull/10
-    "sensirion-ble",  # https://github.com/akx/sensirion-ble/pull/9
     "sharp_aquos_rc",  # https://github.com/jmoore987/sharp_aquos_rc/pull/14
     "tapsaff",  # https://github.com/bazwilliams/python-taps-aff/pull/5
     "vincenty",  # Public domain
     "zeversolar",  # https://github.com/kvanzuijlen/zeversolar/pull/46
-    # Using License-Expression (with hatchling)
-    "ftfy",  # Apache-2.0
 }
 
 TODO = {

--- a/script/licenses.py
+++ b/script/licenses.py
@@ -2,14 +2,26 @@
 
 from __future__ import annotations
 
-from argparse import ArgumentParser
+from argparse import ArgumentParser, Namespace
 from collections.abc import Sequence
 from dataclasses import dataclass
+from importlib import metadata
 import json
 from pathlib import Path
 import sys
+from typing import TypedDict, cast
 
 from awesomeversion import AwesomeVersion
+
+
+class PackageMetadata(TypedDict):
+    """Package metadata."""
+
+    name: str
+    version: str
+    license_expression: str | None
+    license_metadata: str | None
+    license_classifier: list[str]
 
 
 @dataclass
@@ -21,12 +33,14 @@ class PackageDefinition:
     version: AwesomeVersion
 
     @classmethod
-    def from_dict(cls, data: dict[str, str]) -> PackageDefinition:
-        """Create a package definition from a dictionary."""
+    def from_dict(cls, data: PackageMetadata) -> PackageDefinition:
+        """Create a package definition from PackageMetadata."""
+        if not (license_str := "; ".join(data["license_classifier"])):
+            license_str = data["license_metadata"] or "UNKNOWN"
         return cls(
-            license=data["License"],
-            name=data["Name"],
-            version=AwesomeVersion(data["Version"]),
+            license=license_str,
+            name=data["name"],
+            version=AwesomeVersion(data["version"]),
         )
 
 
@@ -176,22 +190,9 @@ TODO = {
 }
 
 
-def main(argv: Sequence[str] | None = None) -> int:
-    """Run the main script."""
+def check_licenses(args: CheckArgs) -> int:
+    """Check licenses are OSI approved."""
     exit_code = 0
-
-    parser = ArgumentParser()
-    parser.add_argument(
-        "path",
-        nargs="?",
-        metavar="PATH",
-        default="licenses.json",
-        help="Path to json licenses file",
-    )
-
-    argv = argv or sys.argv[1:]
-    args = parser.parse_args(argv)
-
     raw_licenses = json.loads(Path(args.path).read_text())
     package_definitions = [PackageDefinition.from_dict(data) for data in raw_licenses]
     for package in package_definitions:
@@ -244,8 +245,88 @@ def main(argv: Sequence[str] | None = None) -> int:
     return exit_code
 
 
+def extract_license_classifier(classifiers: list[str] | None) -> list[str]:
+    """Extract license from list of classifiers."""
+    return [
+        license_classifier
+        for classifier in classifiers or ()
+        if classifier.startswith("License")
+        and (license_classifier := classifier.rpartition(" :: ")[2])
+        and license_classifier != "OSI Approved"
+    ]
+
+
+def get_package_metadata(dist: metadata.Distribution) -> PackageMetadata:
+    """Get package metadata for distribution."""
+    return {
+        "name": dist.name,
+        "version": dist.version,
+        "license_expression": dist.metadata.get("license-expression"),
+        "license_metadata": dist.metadata.get("license"),
+        "license_classifier": extract_license_classifier(
+            dist.metadata.get_all("classifier")
+        ),
+    }
+
+
+def extract_licenses(args: ExtractArgs) -> int:
+    """Extract license data for installed packages."""
+    licenses = sorted(
+        [get_package_metadata(dist) for dist in list(metadata.distributions())],
+        key=lambda dist: dist["name"],
+    )
+    Path(args.output_file).write_text(json.dumps(licenses, indent=2))
+    return 0
+
+
+class ExtractArgs(Namespace):
+    """Extract arguments."""
+
+    output_file: str
+
+
+class CheckArgs(Namespace):
+    """Check arguments."""
+
+    path: str
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the main script."""
+    parser = ArgumentParser()
+    subparsers = parser.add_subparsers(title="Subcommands", required=True)
+
+    parser_extract = subparsers.add_parser("extract")
+    parser_extract.set_defaults(action="extract")
+    parser_extract.add_argument(
+        "--output-file",
+        default="licenses.json",
+        help="Path to store the licenses file",
+    )
+
+    parser_check = subparsers.add_parser("check")
+    parser_check.set_defaults(action="check")
+    parser_check.add_argument(
+        "path",
+        nargs="?",
+        metavar="PATH",
+        default="licenses.json",
+        help="Path to json licenses file",
+    )
+
+    argv = argv or sys.argv[1:]
+    args = parser.parse_args(argv)
+
+    if args.action == "extract":
+        args = cast(ExtractArgs, args)
+        return extract_licenses(args)
+    if args.action == "check":
+        args = cast(CheckArgs, args)
+        if (exit_code := check_licenses(args)) == 0:
+            print("All licenses are approved!")
+        return exit_code
+    return 0
+
+
 if __name__ == "__main__":
-    exit_code = main()
-    if exit_code == 0:
-        print("All licenses are approved!")
-    sys.exit(exit_code)
+    sys.exit(main())


### PR DESCRIPTION
## Proposed change
Rewrite license script to remove dependency on `pip-licenses`.
- `pip-licenses` doesn't yet support `License-Expression`. I've opened a PR upstream but there hasn't been any activity on that repo recently.
- The license fallback implemented in `pip-licenses` always had some limitations. It would output `UNKNOWN` instead of `None`.
- Implementing it ourselves is strait forward.

This PR mostly emulates the license string values that `pip-licenses` would have outputted when validating the license list. It just adds an additional fallback to `License-Expression`. A future PR can adjust the validation check to process each type individually (e.g. `Classifier` vs `License` vs `License-Metadata`).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
