### PR TITLE
Switch to using a fixture for evohome Climate tests (of zones)

### DIFF
--- a/tests/components/evohome/conftest.py
+++ b/tests/components/evohome/conftest.py
@@ -187,7 +187,6 @@ async def zone_id(
 
     async for mock_client in setup_evohome(hass, config, install=install):
         evo: EvohomeClient = mock_client.return_value
-
         zone: Zone = list(evo._get_single_tcs().zones.values())[0]
 
         yield f"{Platform.CLIMATE}.{slugify(zone.name)}"

--- a/tests/components/evohome/conftest.py
+++ b/tests/components/evohome/conftest.py
@@ -11,12 +11,14 @@ from unittest.mock import MagicMock, patch
 from aiohttp import ClientSession
 from evohomeasync2 import EvohomeClient
 from evohomeasync2.broker import Broker
+from evohomeasync2.zone import Zone
 import pytest
 
 from homeassistant.components.evohome import CONF_PASSWORD, CONF_USERNAME, DOMAIN
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
-from homeassistant.util import dt as dt_util
+from homeassistant.util import dt as dt_util, slugify
 from homeassistant.util.json import JsonArrayType, JsonObjectType
 
 from .const import ACCESS_TOKEN, REFRESH_TOKEN, USERNAME
@@ -173,3 +175,21 @@ async def evohome(
 
     async for mock_client in setup_evohome(hass, config, install=install):
         yield mock_client
+
+
+@pytest.fixture
+async def zone_id(
+    hass: HomeAssistant,
+    config: dict[str, str],
+    install: MagicMock,
+) -> AsyncGenerator[str]:
+    """Return the entity_id of the evohome integration' first Climate zone."""
+
+    zone: Zone
+
+    async for mock_client in setup_evohome(hass, config, install=install):
+        evo: EvohomeClient = mock_client.return_value
+
+        zone = list(evo._get_single_tcs().zones.values())[0]
+
+        yield f"{Platform.CLIMATE}.{slugify(zone.name)}"

--- a/tests/components/evohome/conftest.py
+++ b/tests/components/evohome/conftest.py
@@ -185,11 +185,9 @@ async def zone_id(
 ) -> AsyncGenerator[str]:
     """Return the entity_id of the evohome integration' first Climate zone."""
 
-    zone: Zone
-
     async for mock_client in setup_evohome(hass, config, install=install):
         evo: EvohomeClient = mock_client.return_value
 
-        zone = list(evo._get_single_tcs().zones.values())[0]
+        zone: Zone = list(evo._get_single_tcs().zones.values())[0]
 
         yield f"{Platform.CLIMATE}.{slugify(zone.name)}"

--- a/tests/components/evohome/snapshots/test_climate.ambr
+++ b/tests/components/evohome/snapshots/test_climate.ambr
@@ -2,189 +2,180 @@
 # name: test_zone_set_hvac_mode[default]
   list([
     tuple(
-      dict({
-        'HeatSetpointValue': 5.0,
-        'setpointMode': <ZoneMode.PERMANENT_OVERRIDE: 'PermanentOverride'>,
-      }),
+      5.0,
     ),
+    dict({
+      'until': None,
+    }),
   ])
 # ---
 # name: test_zone_set_hvac_mode[h032585]
   list([
     tuple(
-      dict({
-        'HeatSetpointValue': 4.5,
-        'setpointMode': <ZoneMode.PERMANENT_OVERRIDE: 'PermanentOverride'>,
-      }),
+      4.5,
     ),
+    dict({
+      'until': None,
+    }),
   ])
 # ---
 # name: test_zone_set_hvac_mode[h099625]
   list([
     tuple(
-      dict({
-        'HeatSetpointValue': 5.0,
-        'setpointMode': <ZoneMode.PERMANENT_OVERRIDE: 'PermanentOverride'>,
-      }),
+      5.0,
     ),
+    dict({
+      'until': None,
+    }),
   ])
 # ---
 # name: test_zone_set_hvac_mode[minimal]
   list([
     tuple(
-      dict({
-        'HeatSetpointValue': 5.0,
-        'setpointMode': <ZoneMode.PERMANENT_OVERRIDE: 'PermanentOverride'>,
-      }),
+      5.0,
     ),
+    dict({
+      'until': None,
+    }),
   ])
 # ---
 # name: test_zone_set_hvac_mode[sys_004]
   list([
     tuple(
-      dict({
-        'HeatSetpointValue': 5.0,
-        'setpointMode': <ZoneMode.PERMANENT_OVERRIDE: 'PermanentOverride'>,
-      }),
+      5.0,
     ),
+    dict({
+      'until': None,
+    }),
   ])
 # ---
 # name: test_zone_set_preset_mode[default]
   list([
     tuple(
-      dict({
-        'HeatSetpointValue': 17.0,
-        'setpointMode': <ZoneMode.PERMANENT_OVERRIDE: 'PermanentOverride'>,
-      }),
+      17.0,
     ),
+    dict({
+      'until': None,
+    }),
     tuple(
-      dict({
-        'HeatSetpointValue': 17.0,
-        'setpointMode': <ZoneMode.TEMPORARY_OVERRIDE: 'TemporaryOverride'>,
-        'timeUntil': '2024-07-10T21:10:00Z',
-      }),
+      17.0,
     ),
+    dict({
+      'until': datetime.datetime(2024, 7, 10, 21, 10, tzinfo=datetime.timezone.utc),
+    }),
   ])
 # ---
 # name: test_zone_set_preset_mode[h032585]
   list([
     tuple(
-      dict({
-        'HeatSetpointValue': 21.5,
-        'setpointMode': <ZoneMode.PERMANENT_OVERRIDE: 'PermanentOverride'>,
-      }),
+      21.5,
     ),
+    dict({
+      'until': None,
+    }),
     tuple(
-      dict({
-        'HeatSetpointValue': 21.5,
-        'setpointMode': <ZoneMode.TEMPORARY_OVERRIDE: 'TemporaryOverride'>,
-        'timeUntil': '2024-07-10T21:10:00Z',
-      }),
+      21.5,
     ),
+    dict({
+      'until': datetime.datetime(2024, 7, 10, 21, 10, tzinfo=datetime.timezone.utc),
+    }),
   ])
 # ---
 # name: test_zone_set_preset_mode[h099625]
   list([
     tuple(
-      dict({
-        'HeatSetpointValue': 21.5,
-        'setpointMode': <ZoneMode.PERMANENT_OVERRIDE: 'PermanentOverride'>,
-      }),
+      21.5,
     ),
+    dict({
+      'until': None,
+    }),
     tuple(
-      dict({
-        'HeatSetpointValue': 21.5,
-        'setpointMode': <ZoneMode.TEMPORARY_OVERRIDE: 'TemporaryOverride'>,
-        'timeUntil': '2024-07-10T19:10:00Z',
-      }),
+      21.5,
     ),
+    dict({
+      'until': datetime.datetime(2024, 7, 10, 19, 10, tzinfo=datetime.timezone.utc),
+    }),
   ])
 # ---
 # name: test_zone_set_preset_mode[minimal]
   list([
     tuple(
-      dict({
-        'HeatSetpointValue': 17.0,
-        'setpointMode': <ZoneMode.PERMANENT_OVERRIDE: 'PermanentOverride'>,
-      }),
+      17.0,
     ),
+    dict({
+      'until': None,
+    }),
     tuple(
-      dict({
-        'HeatSetpointValue': 17.0,
-        'setpointMode': <ZoneMode.TEMPORARY_OVERRIDE: 'TemporaryOverride'>,
-        'timeUntil': '2024-07-10T21:10:00Z',
-      }),
+      17.0,
     ),
+    dict({
+      'until': datetime.datetime(2024, 7, 10, 21, 10, tzinfo=datetime.timezone.utc),
+    }),
   ])
 # ---
 # name: test_zone_set_preset_mode[sys_004]
   list([
     tuple(
-      dict({
-        'HeatSetpointValue': 15.0,
-        'setpointMode': <ZoneMode.PERMANENT_OVERRIDE: 'PermanentOverride'>,
-      }),
+      15.0,
     ),
+    dict({
+      'until': None,
+    }),
     tuple(
-      dict({
-        'HeatSetpointValue': 15.0,
-        'setpointMode': <ZoneMode.TEMPORARY_OVERRIDE: 'TemporaryOverride'>,
-        'timeUntil': '2024-07-10T20:10:00Z',
-      }),
+      15.0,
     ),
+    dict({
+      'until': datetime.datetime(2024, 7, 10, 20, 10, tzinfo=datetime.timezone.utc),
+    }),
   ])
 # ---
 # name: test_zone_set_temperature[default]
   list([
     tuple(
-      dict({
-        'HeatSetpointValue': 19.1,
-        'setpointMode': <ZoneMode.TEMPORARY_OVERRIDE: 'TemporaryOverride'>,
-        'timeUntil': '2024-07-10T21:10:00Z',
-      }),
+      19.1,
     ),
+    dict({
+      'until': datetime.datetime(2024, 7, 10, 21, 10, tzinfo=datetime.timezone.utc),
+    }),
   ])
 # ---
 # name: test_zone_set_temperature[h032585]
   list([
     tuple(
-      dict({
-        'HeatSetpointValue': 19.1,
-        'setpointMode': <ZoneMode.TEMPORARY_OVERRIDE: 'TemporaryOverride'>,
-        'timeUntil': '2024-07-10T21:10:00Z',
-      }),
+      19.1,
     ),
+    dict({
+      'until': datetime.datetime(2024, 7, 10, 21, 10, tzinfo=datetime.timezone.utc),
+    }),
   ])
 # ---
 # name: test_zone_set_temperature[h099625]
   list([
     tuple(
-      dict({
-        'HeatSetpointValue': 19.1,
-        'setpointMode': <ZoneMode.TEMPORARY_OVERRIDE: 'TemporaryOverride'>,
-        'timeUntil': '2024-07-10T19:10:00Z',
-      }),
+      19.1,
     ),
+    dict({
+      'until': datetime.datetime(2024, 7, 10, 19, 10, tzinfo=datetime.timezone.utc),
+    }),
   ])
 # ---
 # name: test_zone_set_temperature[minimal]
   list([
     tuple(
-      dict({
-        'HeatSetpointValue': 19.1,
-        'setpointMode': <ZoneMode.TEMPORARY_OVERRIDE: 'TemporaryOverride'>,
-        'timeUntil': '2024-07-10T21:10:00Z',
-      }),
+      19.1,
     ),
+    dict({
+      'until': datetime.datetime(2024, 7, 10, 21, 10, tzinfo=datetime.timezone.utc),
+    }),
   ])
 # ---
 # name: test_zone_set_temperature[sys_004]
   list([
     tuple(
-      dict({
-        'HeatSetpointValue': 19.1,
-        'setpointMode': <ZoneMode.PERMANENT_OVERRIDE: 'PermanentOverride'>,
-      }),
+      19.1,
     ),
+    dict({
+      'until': None,
+    }),
   ])
 # ---

--- a/tests/components/evohome/snapshots/test_climate.ambr
+++ b/tests/components/evohome/snapshots/test_climate.ambr
@@ -4,9 +4,6 @@
     tuple(
       5.0,
     ),
-    dict({
-      'until': None,
-    }),
   ])
 # ---
 # name: test_zone_set_hvac_mode[h032585]
@@ -14,9 +11,6 @@
     tuple(
       4.5,
     ),
-    dict({
-      'until': None,
-    }),
   ])
 # ---
 # name: test_zone_set_hvac_mode[h099625]
@@ -24,9 +18,6 @@
     tuple(
       5.0,
     ),
-    dict({
-      'until': None,
-    }),
   ])
 # ---
 # name: test_zone_set_hvac_mode[minimal]
@@ -34,9 +25,6 @@
     tuple(
       5.0,
     ),
-    dict({
-      'until': None,
-    }),
   ])
 # ---
 # name: test_zone_set_hvac_mode[sys_004]
@@ -44,9 +32,6 @@
     tuple(
       5.0,
     ),
-    dict({
-      'until': None,
-    }),
   ])
 # ---
 # name: test_zone_set_preset_mode[default]
@@ -54,9 +39,6 @@
     tuple(
       17.0,
     ),
-    dict({
-      'until': None,
-    }),
     tuple(
       17.0,
     ),
@@ -70,9 +52,6 @@
     tuple(
       21.5,
     ),
-    dict({
-      'until': None,
-    }),
     tuple(
       21.5,
     ),
@@ -86,9 +65,6 @@
     tuple(
       21.5,
     ),
-    dict({
-      'until': None,
-    }),
     tuple(
       21.5,
     ),
@@ -102,9 +78,6 @@
     tuple(
       17.0,
     ),
-    dict({
-      'until': None,
-    }),
     tuple(
       17.0,
     ),
@@ -118,9 +91,6 @@
     tuple(
       15.0,
     ),
-    dict({
-      'until': None,
-    }),
     tuple(
       15.0,
     ),
@@ -131,9 +101,6 @@
 # ---
 # name: test_zone_set_temperature[default]
   list([
-    tuple(
-      19.1,
-    ),
     dict({
       'until': datetime.datetime(2024, 7, 10, 21, 10, tzinfo=datetime.timezone.utc),
     }),
@@ -141,9 +108,6 @@
 # ---
 # name: test_zone_set_temperature[h032585]
   list([
-    tuple(
-      19.1,
-    ),
     dict({
       'until': datetime.datetime(2024, 7, 10, 21, 10, tzinfo=datetime.timezone.utc),
     }),
@@ -151,9 +115,6 @@
 # ---
 # name: test_zone_set_temperature[h099625]
   list([
-    tuple(
-      19.1,
-    ),
     dict({
       'until': datetime.datetime(2024, 7, 10, 19, 10, tzinfo=datetime.timezone.utc),
     }),
@@ -161,9 +122,6 @@
 # ---
 # name: test_zone_set_temperature[minimal]
   list([
-    tuple(
-      19.1,
-    ),
     dict({
       'until': datetime.datetime(2024, 7, 10, 21, 10, tzinfo=datetime.timezone.utc),
     }),
@@ -171,11 +129,43 @@
 # ---
 # name: test_zone_set_temperature[sys_004]
   list([
-    tuple(
-      19.1,
-    ),
     dict({
       'until': None,
     }),
+  ])
+# ---
+# name: test_zone_turn_off[default]
+  list([
+    tuple(
+      5.0,
+    ),
+  ])
+# ---
+# name: test_zone_turn_off[h032585]
+  list([
+    tuple(
+      4.5,
+    ),
+  ])
+# ---
+# name: test_zone_turn_off[h099625]
+  list([
+    tuple(
+      5.0,
+    ),
+  ])
+# ---
+# name: test_zone_turn_off[minimal]
+  list([
+    tuple(
+      5.0,
+    ),
+  ])
+# ---
+# name: test_zone_turn_off[sys_004]
+  list([
+    tuple(
+      5.0,
+    ),
   ])
 # ---

--- a/tests/components/evohome/test_climate.py
+++ b/tests/components/evohome/test_climate.py
@@ -11,78 +11,62 @@ from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy import SnapshotAssertion
 
-from homeassistant.components.climate import HVACMode
-from homeassistant.components.evohome import DOMAIN
-from homeassistant.components.evohome.climate import EvoZone
-from homeassistant.components.evohome.coordinator import EvoBroker
-from homeassistant.const import Platform
+from homeassistant.components.climate import (
+    ATTR_HVAC_MODE,
+    ATTR_PRESET_MODE,
+    SERVICE_SET_HVAC_MODE,
+    SERVICE_SET_PRESET_MODE,
+    SERVICE_SET_TEMPERATURE,
+    HVACMode,
+)
+from homeassistant.const import ATTR_ENTITY_ID, ATTR_TEMPERATURE, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers.entity_component import EntityComponent
-from homeassistant.util import dt as dt_util
 
-from .conftest import setup_evohome
 from .const import TEST_INSTALLS
-
-
-def get_zone_entity(hass: HomeAssistant) -> EvoZone:
-    """Return the entity of the first zone of the evohome system."""
-
-    broker: EvoBroker = hass.data[DOMAIN]["broker"]
-
-    unique_id = broker.tcs._zones[0]._id
-    if unique_id == broker.tcs._id:
-        unique_id += "z"  # special case of merged controller/zone
-
-    entity_registry = er.async_get(hass)
-    entity_id = entity_registry.async_get_entity_id(Platform.CLIMATE, DOMAIN, unique_id)
-
-    component: EntityComponent = hass.data.get(Platform.CLIMATE)  # type: ignore[assignment]
-    return next(e for e in component.entities if e.entity_id == entity_id)  # type: ignore[return-value]
 
 
 @pytest.mark.parametrize("install", TEST_INSTALLS)
 async def test_zone_set_hvac_mode(
     hass: HomeAssistant,
-    config: dict[str, str],
-    install: str,
+    zone_id: str,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test climate methods of a evohome-compatible zone."""
 
     results = []
 
-    async for _ in setup_evohome(hass, config, install=install):
-        zone = get_zone_entity(hass)
+    # SERVICE_SET_HVAC_MODE(HVACMode.HEAT)
+    with patch("evohomeasync2.zone.Zone.reset_mode") as mock_fcn:
+        await hass.services.async_call(
+            Platform.CLIMATE,
+            SERVICE_SET_HVAC_MODE,
+            {
+                ATTR_ENTITY_ID: zone_id,
+                ATTR_HVAC_MODE: HVACMode.HEAT,
+            },
+            blocking=True,
+        )
 
-        assert zone.hvac_modes == [HVACMode.OFF, HVACMode.HEAT]
+        assert mock_fcn.await_count == 1
+        assert mock_fcn.await_args.args == ()
+        assert mock_fcn.await_args.kwargs == {}
 
-        # set_hvac_mode(HVACMode.HEAT): FollowSchedule
-        with patch("evohomeasync2.zone.Zone._set_mode") as mock_fcn:
-            await zone.async_set_hvac_mode(HVACMode.HEAT)
+    # SERVICE_SET_HVAC_MODE(HVACMode.OFF)
+    with patch("evohomeasync2.zone.Zone.set_temperature") as mock_fcn:
+        await hass.services.async_call(
+            Platform.CLIMATE,
+            SERVICE_SET_HVAC_MODE,
+            {
+                ATTR_ENTITY_ID: zone_id,
+                ATTR_HVAC_MODE: HVACMode.OFF,
+            },
+            blocking=True,
+        )
 
-            assert mock_fcn.await_count == 1
-            assert install != "default" or mock_fcn.await_args.args == (
-                {
-                    "setpointMode": "FollowSchedule",
-                },
-            )
-            assert mock_fcn.await_args.kwargs == {}
+        assert mock_fcn.await_count == 1
 
-        # set_hvac_mode(HVACMode.OFF): PermanentOverride, minHeatSetpoint
-        with patch("evohomeasync2.zone.Zone._set_mode") as mock_fcn:
-            await zone.async_set_hvac_mode(HVACMode.OFF)
-
-            assert mock_fcn.await_count == 1
-            assert install != "default" or mock_fcn.await_args.args == (
-                {
-                    "setpointMode": "PermanentOverride",
-                    "HeatSetpointValue": 5.0,  # varies by install
-                },
-            )
-            assert mock_fcn.await_args.kwargs == {}
-
-            results.append(mock_fcn.await_args.args)
+        results.append(mock_fcn.await_args.args)
+        results.append(mock_fcn.await_args.kwargs)
 
     assert results == snapshot
 
@@ -90,8 +74,7 @@ async def test_zone_set_hvac_mode(
 @pytest.mark.parametrize("install", TEST_INSTALLS)
 async def test_zone_set_preset_mode(
     hass: HomeAssistant,
-    config: dict[str, str],
-    install: str,
+    zone_id: str,
     freezer: FrozenDateTimeFactory,
     snapshot: SnapshotAssertion,
 ) -> None:
@@ -100,53 +83,55 @@ async def test_zone_set_preset_mode(
     freezer.move_to("2024-07-10T12:00:00Z")
     results = []
 
-    async for _ in setup_evohome(hass, config, install=install):
-        zone = get_zone_entity(hass)
+    # SERVICE_SET_PRESET_MODE(none)
+    with patch("evohomeasync2.zone.Zone.reset_mode") as mock_fcn:
+        await hass.services.async_call(
+            Platform.CLIMATE,
+            SERVICE_SET_PRESET_MODE,
+            {
+                ATTR_ENTITY_ID: zone_id,
+                ATTR_PRESET_MODE: "none",
+            },
+            blocking=True,
+        )
 
-        assert zone.preset_modes == ["none", "temporary", "permanent"]
+        assert mock_fcn.await_count == 1
+        assert mock_fcn.await_args.args == ()
+        assert mock_fcn.await_args.kwargs == {}
 
-        # set_preset_mode(none): FollowSchedule
-        with patch("evohomeasync2.zone.Zone._set_mode") as mock_fcn:
-            await zone.async_set_preset_mode("none")
+    # SERVICE_SET_PRESET_MODE(permanent)
+    with patch("evohomeasync2.zone.Zone.set_temperature") as mock_fcn:
+        await hass.services.async_call(
+            Platform.CLIMATE,
+            SERVICE_SET_PRESET_MODE,
+            {
+                ATTR_ENTITY_ID: zone_id,
+                ATTR_PRESET_MODE: "permanent",
+            },
+            blocking=True,
+        )
 
-            assert mock_fcn.await_count == 1
-            assert mock_fcn.await_args.args == (
-                {
-                    "setpointMode": "FollowSchedule",
-                },
-            )
-            assert mock_fcn.await_args.kwargs == {}
+        assert mock_fcn.await_count == 1
 
-        # set_preset_mode(permanent): PermanentOverride
-        with patch("evohomeasync2.zone.Zone._set_mode") as mock_fcn:
-            await zone.async_set_preset_mode("permanent")
+        results.append(mock_fcn.await_args.args)
+        results.append(mock_fcn.await_args.kwargs)
 
-            assert mock_fcn.await_count == 1
-            assert install != "default" or mock_fcn.await_args.args == (
-                {
-                    "setpointMode": "PermanentOverride",
-                    "HeatSetpointValue": 17.0,  # varies by install
-                },
-            )
-            assert mock_fcn.await_args.kwargs == {}
+    # SERVICE_SET_PRESET_MODE(temporary)
+    with patch("evohomeasync2.zone.Zone.set_temperature") as mock_fcn:
+        await hass.services.async_call(
+            Platform.CLIMATE,
+            SERVICE_SET_PRESET_MODE,
+            {
+                ATTR_ENTITY_ID: zone_id,
+                ATTR_PRESET_MODE: "temporary",
+            },
+            blocking=True,
+        )
 
-            results.append(mock_fcn.await_args.args)
+        assert mock_fcn.await_count == 1
 
-        # set_preset_mode(permanent): TemporaryOverride
-        with patch("evohomeasync2.zone.Zone._set_mode") as mock_fcn:
-            await zone.async_set_preset_mode("temporary")
-
-            assert mock_fcn.await_count == 1
-            assert install != "default" or mock_fcn.await_args.args == (
-                {
-                    "setpointMode": "TemporaryOverride",
-                    "HeatSetpointValue": 17.0,  # varies by install
-                    "timeUntil": "2024-07-10T21:10:00Z",  # varies by install
-                },
-            )
-            assert mock_fcn.await_args.kwargs == {}
-
-            results.append(mock_fcn.await_args.args)
+        results.append(mock_fcn.await_args.args)
+        results.append(mock_fcn.await_args.kwargs)
 
     assert results == snapshot
 
@@ -154,8 +139,7 @@ async def test_zone_set_preset_mode(
 @pytest.mark.parametrize("install", TEST_INSTALLS)
 async def test_zone_set_temperature(
     hass: HomeAssistant,
-    config: dict[str, str],
-    install: str,
+    zone_id: str,
     freezer: FrozenDateTimeFactory,
     snapshot: SnapshotAssertion,
 ) -> None:
@@ -164,40 +148,21 @@ async def test_zone_set_temperature(
     freezer.move_to("2024-07-10T12:00:00Z")
     results = []
 
-    async for _ in setup_evohome(hass, config, install=install):
-        zone = get_zone_entity(hass)
+    # SERVICE_SET_TEMPERATURE(temp)
+    with patch("evohomeasync2.zone.Zone.set_temperature") as mock_fcn:
+        await hass.services.async_call(
+            Platform.CLIMATE,
+            SERVICE_SET_TEMPERATURE,
+            {
+                ATTR_ENTITY_ID: zone_id,
+                ATTR_TEMPERATURE: 19.1,
+            },
+            blocking=True,
+        )
 
-        # set_temperature(temp): TemporaryOverride, advanced
-        with patch("evohomeasync2.zone.Zone._set_mode") as mock_fcn:
-            await zone.async_set_temperature(temperature=19.1)
+        assert mock_fcn.await_count == 1
 
-            assert mock_fcn.await_count == 1
-            assert install != "default" or mock_fcn.await_args.args == (
-                {
-                    "setpointMode": "TemporaryOverride",
-                    "HeatSetpointValue": 19.1,
-                    "timeUntil": "2024-07-10T21:10:00Z",  # varies by install
-                },
-            )
-            assert mock_fcn.await_args.kwargs == {}
-
-            results.append(mock_fcn.await_args.args)
-
-        # set_temperature(temp, until): TemporaryOverride, until
-        with patch("evohomeasync2.zone.Zone._set_mode") as mock_fcn:
-            await zone.async_set_temperature(
-                temperature=19.2,
-                until=dt_util.parse_datetime("2024-07-10T13:30:00Z"),
-            )
-
-            assert mock_fcn.await_count == 1
-            assert mock_fcn.await_args.args == (
-                {
-                    "setpointMode": "TemporaryOverride",
-                    "HeatSetpointValue": 19.2,
-                    "timeUntil": "2024-07-10T13:30:00Z",
-                },
-            )
-            assert mock_fcn.await_args.kwargs == {}
+        results.append(mock_fcn.await_args.args)
+        results.append(mock_fcn.await_args.kwargs)
 
     assert results == snapshot


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR greatly simplifies the tests of evohome's Climate entity, by passing in `zone_id` as a fixture rather than using `setup_evohome()` and `get_zone_entity()` (the latter function is removed).

It also adds two new tests, for `SERVICE_TURN OFF` and `SERVICE_TURN_ON`.

It is based upon PR #127701.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
