### PR TITLE
Add checks for flow title/description placeholders

### DIFF
--- a/tests/components/conftest.py
+++ b/tests/components/conftest.py
@@ -632,6 +632,9 @@ def check_config_translations(ignore_translations: str | list[str]) -> Generator
 
         if result["type"] is FlowResultType.FORM:
             if step_id := result.get("step_id"):
+                # neither title nor description are required
+                # - title defaults to integration name
+                # - description is optional
                 for header in ("title", "description"):
                     await _ensure_translation_exists(
                         flow.hass,
@@ -640,8 +643,6 @@ def check_config_translations(ignore_translations: str | list[str]) -> Generator
                         component,
                         f"step.{step_id}.{header}",
                         result["description_placeholders"],
-                        # title is not compulsory
-                        # description is optional
                         translation_required=False,
                     )
             if errors := result.get("errors"):

--- a/tests/components/conftest.py
+++ b/tests/components/conftest.py
@@ -632,15 +632,18 @@ def check_config_translations(ignore_translations: str | list[str]) -> Generator
 
         if result["type"] is FlowResultType.FORM:
             if step_id := result.get("step_id"):
-                await _ensure_translation_exists(
-                    flow.hass,
-                    _ignore_translations,
-                    category,
-                    component,
-                    f"step.{step_id}.title",
-                    result["description_placeholders"],
-                    translation_required=False,
-                )
+                for header in ("title", "description"):
+                    await _ensure_translation_exists(
+                        flow.hass,
+                        _ignore_translations,
+                        category,
+                        component,
+                        f"step.{step_id}.{header}",
+                        result["description_placeholders"],
+                        # title is not compulsory
+                        # description is optional
+                        translation_required=False,
+                    )
             if errors := result.get("errors"):
                 for error in errors.values():
                     await _ensure_translation_exists(

--- a/tests/components/conftest.py
+++ b/tests/components/conftest.py
@@ -569,6 +569,8 @@ async def _ensure_translation_exists(
     component: str,
     key: str,
     description_placeholders: dict[str, str] | None,
+    *,
+    translation_required: bool = True,
 ) -> None:
     """Raise if translation doesn't exist."""
     full_key = f"component.{component}.{category}.{key}"
@@ -577,6 +579,9 @@ async def _ensure_translation_exists(
         _validate_translation_placeholders(
             full_key, translation, description_placeholders
         )
+        return
+
+    if not translation_required:
         return
 
     if full_key in ignore_translations:
@@ -626,6 +631,16 @@ def check_config_translations(ignore_translations: str | list[str]) -> Generator
         setattr(flow, "__flow_seen_before", hasattr(flow, "__flow_seen_before"))
 
         if result["type"] is FlowResultType.FORM:
+            if step_id := result.get("step_id"):
+                await _ensure_translation_exists(
+                    flow.hass,
+                    _ignore_translations,
+                    category,
+                    component,
+                    f"step.{step_id}.title",
+                    result["description_placeholders"],
+                    translation_required=False,
+                )
             if errors := result.get("errors"):
                 for error in errors.values():
                     await _ensure_translation_exists(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
It is often the case that config flow strings are set but the corresponding description_placeholder is missing.

This checks should help prevent those instances.

Spotted in https://github.com/home-assistant/core/pull/129134 and #129803

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
