### PR TITLE
Add parsec and astronomical unit for distance

### DIFF
--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -942,6 +942,8 @@ class UnitOfLength(StrEnum):
     YARDS = "yd"
     MILES = "mi"
     NAUTICAL_MILES = "nmi"
+    ASTRONOMICAL_UNIT = "au"
+    PARSEC = "pc"
 
 
 _DEPRECATED_LENGTH_MILLIMETERS: Final = DeprecatedConstantEnum(

--- a/homeassistant/util/unit_conversion.py
+++ b/homeassistant/util/unit_conversion.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from functools import lru_cache
+from math import pi
 
 from homeassistant.const import (
     CONCENTRATION_PARTS_PER_BILLION,
@@ -40,6 +41,9 @@ _YARD_TO_M = _FOOT_TO_M * 3  # 3 feet = 1 yard (0.9144 m)
 _MILE_TO_M = _YARD_TO_M * 1760  # 1760 yard = 1 mile (1609.344 m)
 
 _NAUTICAL_MILE_TO_M = 1852  # 1 nautical mile = 1852 m
+
+_AU_TO_M = 149_597_870_700  # per IAU 2009
+_PARSEC_TO_M = 648_000 * _AU_TO_M / pi  # 1 parsec ≈ 3.0857 * 10^16 m
 
 # Duration conversion constants
 _MIN_TO_SEC = 60  # 1 min = 60 seconds
@@ -159,6 +163,8 @@ class DistanceConverter(BaseUnitConverter):
         UnitOfLength.YARDS: 1 / _YARD_TO_M,
         UnitOfLength.MILES: 1 / _MILE_TO_M,
         UnitOfLength.NAUTICAL_MILES: 1 / _NAUTICAL_MILE_TO_M,
+        UnitOfLength.ASTRONOMICAL_UNIT: 1 / _AU_TO_M,
+        UnitOfLength.PARSEC: 1 / _PARSEC_TO_M,
     }
     VALID_UNITS = {
         UnitOfLength.KILOMETERS,
@@ -170,6 +176,8 @@ class DistanceConverter(BaseUnitConverter):
         UnitOfLength.MILLIMETERS,
         UnitOfLength.INCHES,
         UnitOfLength.YARDS,
+        UnitOfLength.ASTRONOMICAL_UNIT,
+        UnitOfLength.PARSEC,
     }
 
 

--- a/tests/util/test_unit_conversion.py
+++ b/tests/util/test_unit_conversion.py
@@ -301,6 +301,10 @@ _CONVERTED_VALUE: dict[
         (5000000, UnitOfLength.MILLIMETERS, 5468.066, UnitOfLength.YARDS),
         (5000000, UnitOfLength.MILLIMETERS, 16404.2, UnitOfLength.FEET),
         (5000000, UnitOfLength.MILLIMETERS, 196850.5, UnitOfLength.INCHES),
+        (1, UnitOfLength.ASTRONOMICAL_UNIT, 149_597_870_700, UnitOfLength.METERS),
+        (1, UnitOfLength.PARSEC, 206_265, UnitOfLength.ASTRONOMICAL_UNIT),
+        (1, UnitOfLength.PARSEC, 3.08567758 * 10**16, UnitOfLength.METERS),
+        (20, UnitOfLength.PARSEC, 6.17135516 * 10**17, UnitOfLength.METERS),
     ],
     DurationConverter: [
         (5, UnitOfTime.MICROSECONDS, 0.005, UnitOfTime.MILLISECONDS),

--- a/tests/util/test_unit_system.py
+++ b/tests/util/test_unit_system.py
@@ -501,6 +501,8 @@ UNCONVERTED_UNITS_METRIC_SYSTEM = {
         UnitOfLength.KILOMETERS,
         UnitOfLength.METERS,
         UnitOfLength.MILLIMETERS,
+        UnitOfLength.ASTRONOMICAL_UNIT,
+        UnitOfLength.PARSEC,
     ),
     SensorDeviceClass.GAS: (UnitOfVolume.CUBIC_METERS,),
     SensorDeviceClass.PRECIPITATION: (
@@ -728,6 +730,8 @@ UNCONVERTED_UNITS_US_SYSTEM = {
         UnitOfLength.NAUTICAL_MILES,
         UnitOfLength.MILES,
         UnitOfLength.YARDS,
+        UnitOfLength.ASTRONOMICAL_UNIT,
+        UnitOfLength.PARSEC,
     ),
     SensorDeviceClass.GAS: (UnitOfVolume.CENTUM_CUBIC_FEET, UnitOfVolume.CUBIC_FEET),
     SensorDeviceClass.PRECIPITATION: (UnitOfLength.INCHES,),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add parsec (`pc`) and astronomical unit (`au`) as distance units. These are both non-US and non-metric units, and added for completeness and because they are interesting. They are probably not applicable to most home automation installations unless you're running Home Assistant on the [International Space Station](https://www.nasa.gov/international-space-station/) or measuring distance to other galaxies. Closing or ignoring this PR will most likely have zero impact.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
