### PR TITLE
Fix powerview entity unique id migration when the config entry unique id is missing

### DIFF
--- a/homeassistant/components/hunterdouglas_powerview/__init__.py
+++ b/homeassistant/components/hunterdouglas_powerview/__init__.py
@@ -3,8 +3,6 @@
 import logging
 from typing import TYPE_CHECKING
 
-from aiopvapi.helpers.aiorequest import AioRequest
-from aiopvapi.hub import Hub
 from aiopvapi.resources.model import PowerviewData
 from aiopvapi.rooms import Rooms
 from aiopvapi.scenes import Scenes
@@ -13,13 +11,13 @@ from aiopvapi.shades import Shades
 from homeassistant.const import CONF_API_VERSION, CONF_HOST, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.entity_registry as er
 
 from .const import DOMAIN, HUB_EXCEPTIONS
 from .coordinator import PowerviewShadeUpdateCoordinator
-from .model import PowerviewConfigEntry, PowerviewDeviceInfo, PowerviewEntryData
+from .model import PowerviewConfigEntry, PowerviewEntryData
 from .shade_data import PowerviewShadeData
+from .util import async_connect_hub
 
 PARALLEL_UPDATES = 1
 
@@ -37,28 +35,22 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(hass: HomeAssistant, entry: PowerviewConfigEntry) -> bool:
     """Set up Hunter Douglas PowerView from a config entry."""
-
     config = entry.data
-
-    hub_address = config[CONF_HOST]
-    api_version = config.get(CONF_API_VERSION, None)
+    hub_address: str = config[CONF_HOST]
+    api_version: int | None = config.get(CONF_API_VERSION, None)
     _LOGGER.debug("Connecting %s at %s with v%s api", DOMAIN, hub_address, api_version)
-
-    websession = async_get_clientsession(hass)
-
-    pv_request = AioRequest(
-        hub_address, loop=hass.loop, websession=websession, api_version=api_version
-    )
 
     # default 15 second timeout for each call in upstream
     try:
-        hub = Hub(pv_request)
-        await hub.query_firmware()
-        device_info = await async_get_device_info(hub)
+        api = await async_connect_hub(hass, hub_address, api_version)
     except HUB_EXCEPTIONS as err:
         raise ConfigEntryNotReady(
             f"Connection error to PowerView hub {hub_address}: {err}"
         ) from err
+
+    hub = api.hub
+    pv_request = api.pv_request
+    device_info = api.device_info
 
     if hub.role != "Primary":
         # this should be caught in config_flow, but account for a hub changing roles
@@ -94,6 +86,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: PowerviewConfigEntry) ->
         new_data[CONF_API_VERSION] = hub.api_version
         hass.config_entries.async_update_entry(entry, data=new_data)
 
+    if entry.unique_id is None:
+        hass.config_entries.async_update_entry(
+            entry, unique_id=device_info.serial_number
+        )
+
     coordinator = PowerviewShadeUpdateCoordinator(hass, shades, hub)
     coordinator.async_set_updated_data(PowerviewShadeData())
     # populate raw shade data into the coordinator for diagnostics
@@ -113,18 +110,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: PowerviewConfigEntry) ->
     return True
 
 
-async def async_get_device_info(hub: Hub) -> PowerviewDeviceInfo:
-    """Determine device info."""
-    return PowerviewDeviceInfo(
-        name=hub.name,
-        mac_address=hub.mac_address,
-        serial_number=hub.serial_number,
-        firmware=hub.firmware,
-        model=hub.model,
-        hub_address=hub.ip,
-    )
-
-
 async def async_unload_entry(hass: HomeAssistant, entry: PowerviewConfigEntry) -> bool:
     """Unload a config entry."""
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
@@ -138,12 +123,26 @@ async def async_migrate_entry(hass: HomeAssistant, entry: PowerviewConfigEntry) 
     if entry.version == 1:
         # 1 -> 2: Unique ID from integer to string
         if entry.minor_version == 1:
+            if entry.unique_id is None:
+                await _async_add_missing_entry_unique_id(hass, entry)
             await _migrate_unique_ids(hass, entry)
             hass.config_entries.async_update_entry(entry, minor_version=2)
 
     _LOGGER.debug("Migrated to version %s.%s", entry.version, entry.minor_version)
 
     return True
+
+
+async def _async_add_missing_entry_unique_id(
+    hass: HomeAssistant, entry: PowerviewConfigEntry
+) -> None:
+    """Add the unique id if its missing."""
+    address: str = entry.data[CONF_HOST]
+    api_version: int | None = entry.data.get(CONF_API_VERSION, None)
+    api = await async_connect_hub(hass, address, api_version)
+    hass.config_entries.async_update_entry(
+        entry, unique_id=api.device_info.serial_number
+    )
 
 
 async def _migrate_unique_ids(hass: HomeAssistant, entry: PowerviewConfigEntry) -> None:

--- a/homeassistant/components/hunterdouglas_powerview/__init__.py
+++ b/homeassistant/components/hunterdouglas_powerview/__init__.py
@@ -37,7 +37,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: PowerviewConfigEntry) ->
     """Set up Hunter Douglas PowerView from a config entry."""
     config = entry.data
     hub_address: str = config[CONF_HOST]
-    api_version: int | None = config.get(CONF_API_VERSION, None)
+    api_version: int | None = config.get(CONF_API_VERSION)
     _LOGGER.debug("Connecting %s at %s with v%s api", DOMAIN, hub_address, api_version)
 
     # default 15 second timeout for each call in upstream

--- a/homeassistant/components/hunterdouglas_powerview/__init__.py
+++ b/homeassistant/components/hunterdouglas_powerview/__init__.py
@@ -138,7 +138,7 @@ async def _async_add_missing_entry_unique_id(
 ) -> None:
     """Add the unique id if its missing."""
     address: str = entry.data[CONF_HOST]
-    api_version: int | None = entry.data.get(CONF_API_VERSION, None)
+    api_version: int | None = entry.data.get(CONF_API_VERSION)
     api = await async_connect_hub(hass, address, api_version)
     hass.config_entries.async_update_entry(
         entry, unique_id=api.device_info.serial_number

--- a/homeassistant/components/hunterdouglas_powerview/config_flow.py
+++ b/homeassistant/components/hunterdouglas_powerview/config_flow.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any, Self
 
-from aiopvapi.helpers.aiorequest import AioRequest
-from aiopvapi.hub import Hub
 import voluptuous as vol
 
 from homeassistant.components import dhcp, zeroconf
@@ -14,10 +12,9 @@ from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_API_VERSION, CONF_HOST, CONF_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from . import async_get_device_info
 from .const import DOMAIN, HUB_EXCEPTIONS
+from .util import async_connect_hub
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -31,18 +28,9 @@ async def validate_input(hass: HomeAssistant, hub_address: str) -> dict[str, str
 
     Data has the keys from DATA_SCHEMA with values provided by the user.
     """
-
-    websession = async_get_clientsession(hass)
-
-    pv_request = AioRequest(hub_address, loop=hass.loop, websession=websession)
-
-    try:
-        hub = Hub(pv_request)
-        await hub.query_firmware()
-        device_info = await async_get_device_info(hub)
-    except HUB_EXCEPTIONS as err:
-        raise CannotConnect from err
-
+    api = await async_connect_hub(hass, hub_address)
+    hub = api.hub
+    device_info = api.device_info
     if hub.role != "Primary":
         raise UnsupportedDevice(
             f"{hub.name} ({hub.hub_address}) is the {hub.role} Hub. "
@@ -111,7 +99,7 @@ class PowerviewConfigFlow(ConfigFlow, domain=DOMAIN):
 
         try:
             info = await validate_input(self.hass, host)
-        except CannotConnect:
+        except HUB_EXCEPTIONS:
             return None, "cannot_connect"
         except UnsupportedDevice:
             return None, "unsupported_device"
@@ -198,10 +186,6 @@ class PowerviewConfigFlow(ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="link", description_placeholders=self.powerview_config
         )
-
-
-class CannotConnect(HomeAssistantError):
-    """Error to indicate we cannot connect."""
 
 
 class UnsupportedDevice(HomeAssistantError):

--- a/homeassistant/components/hunterdouglas_powerview/model.py
+++ b/homeassistant/components/hunterdouglas_powerview/model.py
@@ -3,20 +3,23 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from aiopvapi.helpers.aiorequest import AioRequest
+from aiopvapi.hub import Hub
 from aiopvapi.resources.room import Room
 from aiopvapi.resources.scene import Scene
 from aiopvapi.resources.shade import BaseShade
 
 from homeassistant.config_entries import ConfigEntry
 
-from .coordinator import PowerviewShadeUpdateCoordinator
+if TYPE_CHECKING:
+    from .coordinator import PowerviewShadeUpdateCoordinator
 
 type PowerviewConfigEntry = ConfigEntry[PowerviewEntryData]
 
 
-@dataclass
+@dataclass(slots=True)
 class PowerviewEntryData:
     """Define class for main domain information."""
 
@@ -28,7 +31,7 @@ class PowerviewEntryData:
     device_info: PowerviewDeviceInfo
 
 
-@dataclass
+@dataclass(slots=True)
 class PowerviewDeviceInfo:
     """Define class for device information."""
 
@@ -38,3 +41,12 @@ class PowerviewDeviceInfo:
     firmware: str | None
     model: str
     hub_address: str
+
+
+@dataclass(slots=True)
+class PowerviewAPI:
+    """Define class to hold the Powerview Hub API data."""
+
+    hub: Hub
+    pv_request: AioRequest
+    device_info: PowerviewDeviceInfo

--- a/homeassistant/components/hunterdouglas_powerview/util.py
+++ b/homeassistant/components/hunterdouglas_powerview/util.py
@@ -5,12 +5,38 @@ from __future__ import annotations
 from collections.abc import Iterable
 from typing import Any
 
+from aiopvapi.helpers.aiorequest import AioRequest
 from aiopvapi.helpers.constants import ATTR_ID
+from aiopvapi.hub import Hub
 
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+from .model import PowerviewAPI, PowerviewDeviceInfo
 
 
 @callback
 def async_map_data_by_id(data: Iterable[dict[str | int, Any]]):
     """Return a dict with the key being the id for a list of entries."""
     return {entry[ATTR_ID]: entry for entry in data}
+
+
+async def async_connect_hub(
+    hass: HomeAssistant, address: str, api_version: int | None = None
+) -> PowerviewAPI:
+    """Create the hub and fetch the device info address."""
+    websession = async_get_clientsession(hass)
+    pv_request = AioRequest(
+        address, loop=hass.loop, websession=websession, api_version=api_version
+    )
+    hub = Hub(pv_request)
+    await hub.query_firmware()
+    info = PowerviewDeviceInfo(
+        name=hub.name,
+        mac_address=hub.mac_address,
+        serial_number=hub.serial_number,
+        firmware=hub.firmware,
+        model=hub.model,
+        hub_address=hub.ip,
+    )
+    return PowerviewAPI(hub, pv_request, info)

--- a/tests/components/hunterdouglas_powerview/conftest.py
+++ b/tests/components/hunterdouglas_powerview/conftest.py
@@ -33,15 +33,15 @@ def mock_hunterdouglas_hub(
     """Return a mocked Powerview Hub with all data populated."""
     with (
         patch(
-            "homeassistant.components.hunterdouglas_powerview.Hub.request_raw_data",
+            "homeassistant.components.hunterdouglas_powerview.util.Hub.request_raw_data",
             return_value=load_json_object_fixture(device_json, DOMAIN),
         ),
         patch(
-            "homeassistant.components.hunterdouglas_powerview.Hub.request_home_data",
+            "homeassistant.components.hunterdouglas_powerview.util.Hub.request_home_data",
             return_value=load_json_object_fixture(home_json, DOMAIN),
         ),
         patch(
-            "homeassistant.components.hunterdouglas_powerview.Hub.request_raw_firmware",
+            "homeassistant.components.hunterdouglas_powerview.util.Hub.request_raw_firmware",
             return_value=load_json_object_fixture(firmware_json, DOMAIN),
         ),
         patch(

--- a/tests/components/hunterdouglas_powerview/test_config_flow.py
+++ b/tests/components/hunterdouglas_powerview/test_config_flow.py
@@ -76,7 +76,7 @@ async def test_form_homekit_and_dhcp_cannot_connect(
     ignored_config_entry.add_to_hass(hass)
 
     with patch(
-        "homeassistant.components.hunterdouglas_powerview.Hub.query_firmware",
+        "homeassistant.components.hunterdouglas_powerview.util.Hub.query_firmware",
         side_effect=TimeoutError,
     ):
         result = await hass.config_entries.flow.async_init(
@@ -206,7 +206,7 @@ async def test_form_cannot_connect(
 
     # Simulate a timeout error
     with patch(
-        "homeassistant.components.hunterdouglas_powerview.Hub.query_firmware",
+        "homeassistant.components.hunterdouglas_powerview.util.Hub.query_firmware",
         side_effect=TimeoutError,
     ):
         result2 = await hass.config_entries.flow.async_configure(
@@ -245,11 +245,11 @@ async def test_form_no_data(
 
     with (
         patch(
-            "homeassistant.components.hunterdouglas_powerview.Hub.request_raw_data",
+            "homeassistant.components.hunterdouglas_powerview.util.Hub.request_raw_data",
             return_value={},
         ),
         patch(
-            "homeassistant.components.hunterdouglas_powerview.Hub.request_home_data",
+            "homeassistant.components.hunterdouglas_powerview.util.Hub.request_home_data",
             return_value={},
         ),
     ):
@@ -289,7 +289,7 @@ async def test_form_unknown_exception(
 
     # Simulate a transient error
     with patch(
-        "homeassistant.components.hunterdouglas_powerview.config_flow.Hub.query_firmware",
+        "homeassistant.components.hunterdouglas_powerview.util.Hub.query_firmware",
         side_effect=SyntaxError,
     ):
         result2 = await hass.config_entries.flow.async_configure(
@@ -328,7 +328,7 @@ async def test_form_unsupported_device(
 
     # Simulate a gen 3 secondary hub
     with patch(
-        "homeassistant.components.hunterdouglas_powerview.Hub.request_raw_data",
+        "homeassistant.components.hunterdouglas_powerview.util.Hub.request_raw_data",
         return_value=load_json_object_fixture("gen3/gateway/secondary.json", DOMAIN),
     ):
         result2 = await hass.config_entries.flow.async_configure(


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

https://github.com/home-assistant/core/pull/128131#issuecomment-2438748851

Fixes
```
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/config_entries.py", line 987, in async_migrate
    result = await component.async_migrate_entry(hass, self)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/hunterdouglas_powerview/__init__.py", line 141, in async_migrate_entry
    await _migrate_unique_ids(hass, entry)
  File "/usr/src/homeassistant/homeassistant/components/hunterdouglas_powerview/__init__.py", line 160, in _migrate_unique_ids
    and not reg_entry.unique_id.startswith(entry.unique_id)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: startswith first arg must be str or a tuple of str, not NoneType
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
