### PR TITLE
Properly validate License-Expression data for licenses check

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -10,6 +10,7 @@
 astroid==3.3.5
 coverage==7.6.1
 freezegun==1.5.1
+license-expression==30.4.0
 mock-open==1.4.0
 mypy-dev==1.13.0a1
 pre-commit==4.0.0

--- a/script/licenses.py
+++ b/script/licenses.py
@@ -86,8 +86,7 @@ OSI_APPROVED_LICENSES_SPDX = {
     "MIT",
     "MPL-1.1",
     "MPL-2.0",
-    "PSF-2.0",  # not approved
-    "Python-2.0.1",  # not approved
+    "PSF-2.0",
     "Unlicense",
     "Zlib",
     "ZPL-2.1",

--- a/script/licenses.py
+++ b/script/licenses.py
@@ -12,6 +12,16 @@ import sys
 from typing import TypedDict, cast
 
 from awesomeversion import AwesomeVersion
+from license_expression import (
+    AND,
+    OR,
+    ExpressionError,
+    LicenseExpression,
+    LicenseSymbol,
+    get_spdx_licensing,
+)
+
+licensing = get_spdx_licensing()
 
 
 class PackageMetadata(TypedDict):
@@ -29,6 +39,9 @@ class PackageDefinition:
     """Package definition."""
 
     license: str
+    license_expression: str | None
+    license_metadata: str | None
+    license_classifier: list[str]
     name: str
     version: AwesomeVersion
 
@@ -36,15 +49,49 @@ class PackageDefinition:
     def from_dict(cls, data: PackageMetadata) -> PackageDefinition:
         """Create a package definition from PackageMetadata."""
         if not (license_str := "; ".join(data["license_classifier"])):
-            license_str = (
-                data["license_metadata"] or data["license_expression"] or "UNKNOWN"
-            )
+            license_str = data["license_metadata"] or "UNKNOWN"
         return cls(
             license=license_str,
+            license_expression=data["license_expression"],
+            license_metadata=data["license_metadata"],
+            license_classifier=data["license_classifier"],
             name=data["name"],
             version=AwesomeVersion(data["version"]),
         )
 
+
+# Incomplete list of OSI approved SPDX identifiers
+# Add more as needed, see https://spdx.org/licenses/
+OSI_APPROVED_LICENSES_SPDX = {
+    "0BSD",
+    "AFL-2.1",
+    "AGPL-3.0-only",
+    "AGPL-3.0-or-later",
+    "Apache-2.0",
+    "BSD-1-Clause",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "EPL-1.0",
+    "EPL-2.0",
+    "GPL-2.0-only",
+    "GPL-2.0-or-later",
+    "GPL-3.0-only",
+    "GPL-3.0-or-later",
+    "HPND",
+    "ISC",
+    "LGPL-2.1-only",
+    "LGPL-2.1-or-later",
+    "LGPL-3.0-only",
+    "LGPL-3.0-or-later",
+    "MIT",
+    "MPL-1.1",
+    "MPL-2.0",
+    "PSF-2.0",  # not approved
+    "Python-2.0.1",  # not approved
+    "Unlicense",
+    "Zlib",
+    "ZPL-2.1",
+}
 
 OSI_APPROVED_LICENSES = {
     "Academic Free License (AFL)",
@@ -114,13 +161,10 @@ OSI_APPROVED_LICENSES = {
     "Zero-Clause BSD (0BSD)",
     "Zope Public License",
     "zlib/libpng License",
+    # End license classifier
     "Apache License",
     "MIT",
-    "apache-2.0",
-    "GPL-3.0",
-    "GPLv3+",
     "MPL2",
-    "MPL-2.0",
     "Apache 2",
     "LGPL v3",
     "BSD",
@@ -128,14 +172,8 @@ OSI_APPROVED_LICENSES = {
     "GPLv3",
     "Eclipse Public License v2.0",
     "ISC",
-    "GPL-2.0-only",
-    "mit",
     "GNU General Public License v3",
-    "Unlicense",
-    "Apache-2",
     "GPLv2",
-    "Python-2.0.1",
-    "LGPL-2.1-or-later",
 }
 
 EXCEPTIONS = {
@@ -144,7 +182,6 @@ EXCEPTIONS = {
     "PyXiaomiGateway",  # https://github.com/Danielhiversen/PyXiaomiGateway/pull/201
     "aioecowitt",  # https://github.com/home-assistant-libs/aioecowitt/pull/180
     "chacha20poly1305",  # LGPL
-    "chacha20poly1305-reuseable",  # Apache 2.0 or BSD 3-Clause
     "commentjson",  # https://github.com/vaidik/commentjson/pull/55
     "crownstone-cloud",  # https://github.com/crownstone/crownstone-lib-python-cloud/pull/5
     "crownstone-core",  # https://github.com/crownstone/crownstone-lib-python-core/pull/6
@@ -169,7 +206,6 @@ EXCEPTIONS = {
     "repoze.lru",
     "sharp_aquos_rc",  # https://github.com/jmoore987/sharp_aquos_rc/pull/14
     "tapsaff",  # https://github.com/bazwilliams/python-taps-aff/pull/5
-    "vincenty",  # Public domain
 }
 
 TODO = {
@@ -238,15 +274,53 @@ def check_licenses(args: CheckArgs) -> int:
 
 def check_license_status(package: PackageDefinition) -> bool:
     """Check if package licenses is OSI approved."""
+    if package.license_expression:
+        # Prefer 'License-Expression' if it exists
+        return check_license_expression(package.license_expression) or False
+
+    if (
+        package.license_metadata
+        and (check := check_license_expression(package.license_metadata)) is not None
+    ):
+        # Check license metadata if it's a valid SPDX license expression
+        return check
+
     for approved_license in OSI_APPROVED_LICENSES:
         if approved_license in package.license:
             return True
     return False
 
 
+def check_license_expression(license_str: str) -> bool | None:
+    """Check if license expression is a valid and approved SPDX license string."""
+    if license_str == "UNKNOWN" or "\n" in license_str:
+        # Ignore common errors for license metadata values
+        return None
+
+    try:
+        expr = licensing.parse(license_str, validate=True)
+    except ExpressionError:
+        return None
+    return check_spdx_license(expr)
+
+
+def check_spdx_license(expr: LicenseExpression) -> bool:
+    """Check a SPDX license expression."""
+    if isinstance(expr, LicenseSymbol):
+        return expr.key in OSI_APPROVED_LICENSES_SPDX
+    if isinstance(expr, OR):
+        return any(check_spdx_license(arg) for arg in expr.args)
+    if isinstance(expr, AND):
+        return all(check_spdx_license(arg) for arg in expr.args)
+    return False
+
+
 def get_license_str(package: PackageDefinition) -> str:
     """Return license string."""
-    return f"{package.license}"
+    return (
+        f"{package.license_expression} -- {package.license_metadata} "
+        f"-- {package.license_classifier}"
+    )
 
 
 def extract_licenses(args: ExtractArgs) -> int:

--- a/script/licenses.py
+++ b/script/licenses.py
@@ -235,7 +235,7 @@ def check_licenses(args: CheckArgs) -> int:
 
         if status is True:
             print(
-                f"Approved license detected for "
+                "Approved license detected for "
                 f"{pkg.name}@{pkg.version}: {get_license_str(pkg)}\n"
                 "Please remove the package from the TODO list.\n"
             )
@@ -256,9 +256,9 @@ def check_licenses(args: CheckArgs) -> int:
             exit_code = 1
         if status is True and pkg.name in EXCEPTIONS:
             print(
-                f"Approved license detected for "
+                "Approved license detected for "
                 f"{pkg.name}@{pkg.version}: {get_license_str(pkg)}\n"
-                f"Please remove the package from the EXCEPTIONS list.\n"
+                "Please remove the package from the EXCEPTIONS list.\n"
             )
             exit_code = 1
 


### PR DESCRIPTION
## Proposed change
Modify license check to validate `License-Expression` data probably. The new logic:
1. If `License-Expression` is set, it `must` be on of the approved SPDX identifiers defined in `licenses.py`.
2. `Only if` `License` (metadata) is a valid SPDX identifier, it `must` also be in the list of approved SPDX identifiers.
_Useful as quite a few packages have started adopting the SPDX identifiers even before PEP 639 was approved and most build backends don't yet set `License-Expression`._
3. Fallback to previous check where string of approved licenses just needs to be somewhere in the license string.

A new dependency for `license-expression` was added. The package is used to parse the `License-Expression` data and check if it's a valid SPDX identifier.
https://github.com/aboutcode-org/license-expression


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
