### PR TITLE
Fix timeout issue on Roomba integration when adding a new device

### DIFF
--- a/homeassistant/components/roomba/config_flow.py
+++ b/homeassistant/components/roomba/config_flow.py
@@ -57,7 +57,7 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
             address=data[CONF_HOST],
             blid=data[CONF_BLID],
             password=data[CONF_PASSWORD],
-            continuous=False,
+            continuous=True,
             delay=data[CONF_DELAY],
         )
     )

--- a/homeassistant/components/roomba/const.py
+++ b/homeassistant/components/roomba/const.py
@@ -9,5 +9,5 @@ CONF_CONTINUOUS = "continuous"
 CONF_BLID = "blid"
 DEFAULT_CERT = "/etc/ssl/certs/ca-certificates.crt"
 DEFAULT_CONTINUOUS = True
-DEFAULT_DELAY = 1
+DEFAULT_DELAY = 100
 ROOMBA_SESSION = "roomba_session"

--- a/homeassistant/components/roomba/const.py
+++ b/homeassistant/components/roomba/const.py
@@ -9,5 +9,5 @@ CONF_CONTINUOUS = "continuous"
 CONF_BLID = "blid"
 DEFAULT_CERT = "/etc/ssl/certs/ca-certificates.crt"
 DEFAULT_CONTINUOUS = True
-DEFAULT_DELAY = 100
+DEFAULT_DELAY = 30
 ROOMBA_SESSION = "roomba_session"

--- a/tests/components/roomba/test_config_flow.py
+++ b/tests/components/roomba/test_config_flow.py
@@ -206,7 +206,7 @@ async def test_form_user_discovery_and_password_fetch(hass: HomeAssistant) -> No
     assert result3["data"] == {
         CONF_BLID: "BLID",
         CONF_CONTINUOUS: True,
-        CONF_DELAY: 30,
+        CONF_DELAY: DEFAULT_DELAY,
         CONF_HOST: MOCK_IP,
         CONF_PASSWORD: "password",
     }

--- a/tests/components/roomba/test_config_flow.py
+++ b/tests/components/roomba/test_config_flow.py
@@ -206,7 +206,7 @@ async def test_form_user_discovery_and_password_fetch(hass: HomeAssistant) -> No
     assert result3["data"] == {
         CONF_BLID: "BLID",
         CONF_CONTINUOUS: True,
-        CONF_DELAY: 1,
+        CONF_DELAY: 30,
         CONF_HOST: MOCK_IP,
         CONF_PASSWORD: "password",
     }
@@ -331,7 +331,7 @@ async def test_form_user_discovery_manual_and_auto_password_fetch(
     assert result4["data"] == {
         CONF_BLID: "BLID",
         CONF_CONTINUOUS: True,
-        CONF_DELAY: 1,
+        CONF_DELAY: 30,
         CONF_HOST: MOCK_IP,
         CONF_PASSWORD: "password",
     }
@@ -468,7 +468,7 @@ async def test_form_user_discovery_no_devices_found_and_auto_password_fetch(
     assert result3["data"] == {
         CONF_BLID: "BLID",
         CONF_CONTINUOUS: True,
-        CONF_DELAY: 1,
+        CONF_DELAY: 30,
         CONF_HOST: MOCK_IP,
         CONF_PASSWORD: "password",
     }
@@ -541,7 +541,7 @@ async def test_form_user_discovery_no_devices_found_and_password_fetch_fails(
     assert result4["data"] == {
         CONF_BLID: "BLID",
         CONF_CONTINUOUS: True,
-        CONF_DELAY: 1,
+        CONF_DELAY: 30,
         CONF_HOST: MOCK_IP,
         CONF_PASSWORD: "password",
     }
@@ -677,7 +677,7 @@ async def test_form_user_discovery_and_password_fetch_gets_connection_refused(
     assert result4["data"] == {
         CONF_BLID: "BLID",
         CONF_CONTINUOUS: True,
-        CONF_DELAY: 1,
+        CONF_DELAY: 30,
         CONF_HOST: MOCK_IP,
         CONF_PASSWORD: "password",
     }
@@ -738,7 +738,7 @@ async def test_dhcp_discovery_and_roomba_discovery_finds(
     assert result2["data"] == {
         CONF_BLID: "BLID",
         CONF_CONTINUOUS: True,
-        CONF_DELAY: 1,
+        CONF_DELAY: 30,
         CONF_HOST: MOCK_IP,
         CONF_PASSWORD: "password",
     }
@@ -816,7 +816,7 @@ async def test_dhcp_discovery_falls_back_to_manual(
     assert result4["data"] == {
         CONF_BLID: "BLID",
         CONF_CONTINUOUS: True,
-        CONF_DELAY: 1,
+        CONF_DELAY: 30,
         CONF_HOST: MOCK_IP,
         CONF_PASSWORD: "password",
     }
@@ -886,7 +886,7 @@ async def test_dhcp_discovery_no_devices_falls_back_to_manual(
     assert result3["data"] == {
         CONF_BLID: "BLID",
         CONF_CONTINUOUS: True,
-        CONF_DELAY: 1,
+        CONF_DELAY: 30,
         CONF_HOST: MOCK_IP,
         CONF_PASSWORD: "password",
     }
@@ -1119,10 +1119,10 @@ async def test_options_flow(
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
-        user_input={CONF_CONTINUOUS: True, CONF_DELAY: 1},
+        user_input={CONF_CONTINUOUS: True, CONF_DELAY: 30},
     )
     await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["data"] == {CONF_CONTINUOUS: True, CONF_DELAY: 1}
-    assert config_entry.options == {CONF_CONTINUOUS: True, CONF_DELAY: 1}
+    assert result["data"] == {CONF_CONTINUOUS: True, CONF_DELAY: 30}
+    assert config_entry.options == {CONF_CONTINUOUS: True, CONF_DELAY: 30}

--- a/tests/components/roomba/test_config_flow.py
+++ b/tests/components/roomba/test_config_flow.py
@@ -8,7 +8,12 @@ from roombapy import RoombaConnectionError, RoombaInfo
 
 from homeassistant.components import dhcp, zeroconf
 from homeassistant.components.roomba import config_flow
-from homeassistant.components.roomba.const import CONF_BLID, CONF_CONTINUOUS, DOMAIN
+from homeassistant.components.roomba.const import (
+    CONF_BLID,
+    CONF_CONTINUOUS,
+    DEFAULT_DELAY,
+    DOMAIN,
+)
 from homeassistant.config_entries import (
     SOURCE_DHCP,
     SOURCE_IGNORE,
@@ -331,7 +336,7 @@ async def test_form_user_discovery_manual_and_auto_password_fetch(
     assert result4["data"] == {
         CONF_BLID: "BLID",
         CONF_CONTINUOUS: True,
-        CONF_DELAY: 30,
+        CONF_DELAY: DEFAULT_DELAY,
         CONF_HOST: MOCK_IP,
         CONF_PASSWORD: "password",
     }
@@ -468,7 +473,7 @@ async def test_form_user_discovery_no_devices_found_and_auto_password_fetch(
     assert result3["data"] == {
         CONF_BLID: "BLID",
         CONF_CONTINUOUS: True,
-        CONF_DELAY: 30,
+        CONF_DELAY: DEFAULT_DELAY,
         CONF_HOST: MOCK_IP,
         CONF_PASSWORD: "password",
     }
@@ -541,7 +546,7 @@ async def test_form_user_discovery_no_devices_found_and_password_fetch_fails(
     assert result4["data"] == {
         CONF_BLID: "BLID",
         CONF_CONTINUOUS: True,
-        CONF_DELAY: 30,
+        CONF_DELAY: DEFAULT_DELAY,
         CONF_HOST: MOCK_IP,
         CONF_PASSWORD: "password",
     }
@@ -677,7 +682,7 @@ async def test_form_user_discovery_and_password_fetch_gets_connection_refused(
     assert result4["data"] == {
         CONF_BLID: "BLID",
         CONF_CONTINUOUS: True,
-        CONF_DELAY: 30,
+        CONF_DELAY: DEFAULT_DELAY,
         CONF_HOST: MOCK_IP,
         CONF_PASSWORD: "password",
     }
@@ -738,7 +743,7 @@ async def test_dhcp_discovery_and_roomba_discovery_finds(
     assert result2["data"] == {
         CONF_BLID: "BLID",
         CONF_CONTINUOUS: True,
-        CONF_DELAY: 30,
+        CONF_DELAY: DEFAULT_DELAY,
         CONF_HOST: MOCK_IP,
         CONF_PASSWORD: "password",
     }
@@ -816,7 +821,7 @@ async def test_dhcp_discovery_falls_back_to_manual(
     assert result4["data"] == {
         CONF_BLID: "BLID",
         CONF_CONTINUOUS: True,
-        CONF_DELAY: 30,
+        CONF_DELAY: DEFAULT_DELAY,
         CONF_HOST: MOCK_IP,
         CONF_PASSWORD: "password",
     }
@@ -886,7 +891,7 @@ async def test_dhcp_discovery_no_devices_falls_back_to_manual(
     assert result3["data"] == {
         CONF_BLID: "BLID",
         CONF_CONTINUOUS: True,
-        CONF_DELAY: 30,
+        CONF_DELAY: DEFAULT_DELAY,
         CONF_HOST: MOCK_IP,
         CONF_PASSWORD: "password",
     }
@@ -1119,10 +1124,10 @@ async def test_options_flow(
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
-        user_input={CONF_CONTINUOUS: True, CONF_DELAY: 30},
+        user_input={CONF_CONTINUOUS: True, CONF_DELAY: DEFAULT_DELAY},
     )
     await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["data"] == {CONF_CONTINUOUS: True, CONF_DELAY: 30}
-    assert config_entry.options == {CONF_CONTINUOUS: True, CONF_DELAY: 30}
+    assert result["data"] == {CONF_CONTINUOUS: True, CONF_DELAY: DEFAULT_DELAY}
+    assert config_entry.options == {CONF_CONTINUOUS: True, CONF_DELAY: DEFAULT_DELAY}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
Fix timeout issue on Roomba integration when adding a new device
```
const.py: DEFAULT_DELAY = 100 instead of DEFAULT_DELAY = 1
config_flow.py: continuous=True instead of continuous=False
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #117071 #117039 #112544
- This PR is related to issue: #117071 #117039 #112544 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
