### PR TITLE
Allow a fixed number of ffmpeg proxy conversions per device

### DIFF
--- a/tests/components/esphome/test_ffmpeg_proxy.py
+++ b/tests/components/esphome/test_ffmpeg_proxy.py
@@ -2,6 +2,7 @@
 
 from http import HTTPStatus
 import io
+import os
 import tempfile
 from unittest.mock import patch
 from urllib.request import pathname2url
@@ -232,3 +233,55 @@ async def test_request_same_url_multiple_times(
             num_frames += len(chunk) // (2 * 2)  # 2 channels, 16-bit samples
 
         assert num_frames == 22050 * 10  # 10s
+
+
+async def test_max_conversions_per_device(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+) -> None:
+    """Test that each device has a maximum number of conversions (currently 2)."""
+    max_conversions = 2
+    device_ids = ["1234", "5678"]
+
+    await async_setup_component(hass, esphome.DOMAIN, {esphome.DOMAIN: {}})
+    client = await hass_client()
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        wav_paths = [
+            os.path.join(temp_dir, f"{i}.wav") for i in range(max_conversions + 1)
+        ]
+        for wav_path in wav_paths:
+            with wave.open(wav_path, "wb") as wav_file:
+                wav_file.setframerate(16000)
+                wav_file.setsampwidth(2)
+                wav_file.setnchannels(1)
+                wav_file.writeframes(bytes(16000 * 2 * 10))  # 10s
+
+        wav_urls = [pathname2url(p) for p in wav_paths]
+
+        # Each device will have max + 1 conversions
+        device_urls = {
+            device_id: [
+                async_create_proxy_url(
+                    hass,
+                    device_id,
+                    wav_url,
+                    media_format="wav",
+                    rate=22050,
+                    channels=2,
+                    width=2,
+                )
+                for wav_url in wav_urls
+            ]
+            for device_id in device_ids
+        }
+
+        for urls in device_urls.values():
+            # First URL should fail because it was overwritten by the others
+            req = await client.get(urls[0])
+            assert req.status == HTTPStatus.BAD_REQUEST
+
+            # All other URLs should succeed
+            for url in urls[1:]:
+                req = await client.get(url)
+                assert req.status == HTTPStatus.OK


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allows for 2 simultaneous ffmpeg proxy conversions per ESPHome device. This is needed if the device is playing music and making an announcement at the same time (both requiring media format conversion).

Additionally, `close_fds=False` was added to the subprocess args per https://github.com/home-assistant/core/pull/129196

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
