### PR TITLE
Bump ZHA to 0.0.36

### DIFF
--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -21,7 +21,7 @@
     "zha",
     "universal_silabs_flasher"
   ],
-  "requirements": ["universal-silabs-flasher==0.0.23", "zha==0.0.35"],
+  "requirements": ["universal-silabs-flasher==0.0.23", "zha==0.0.36"],
   "usb": [
     {
       "vid": "10C4",

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -767,6 +767,21 @@
       },
       "regulation_setpoint_offset": {
         "name": "Regulation setpoint offset"
+      },
+      "irrigation_cycles": {
+        "name": "Irrigation cycles"
+      },
+      "irrigation_target": {
+        "name": "Irrigation target"
+      },
+      "irrigation_interval": {
+        "name": "Irrigation interval"
+      },
+      "valve_countdown_1": {
+        "name": "Irrigation time 1"
+      },
+      "valve_countdown_2": {
+        "name": "Irrigation time 2"
       }
     },
     "select": {
@@ -853,6 +868,12 @@
       },
       "setpoint_response_time": {
         "name": "Setpoint response time"
+      },
+      "irrigation_mode": {
+        "name": "Irrigation mode"
+      },
+      "weather_delay": {
+        "name": "Weather delay"
       }
     },
     "sensor": {
@@ -1023,6 +1044,27 @@
       },
       "motor_stepcount": {
         "name": "Motor stepcount"
+      },
+      "irrigation_duration": {
+        "name": "Last irrigation duration"
+      },
+      "irrigation_start_time": {
+        "name": "Irrigation start time"
+      },
+      "irrigation_end_time": {
+        "name": "Irrigation end time"
+      },
+      "irrigation_duration_1": {
+        "name": "Irrigation duration 1"
+      },
+      "irriation_duration_2": {
+        "name": "Irrigation duration 2"
+      },
+      "valve_status_1": {
+        "name": "Status 1"
+      },
+      "valve_status_2": {
+        "name": "Status 2"
       }
     },
     "switch": {
@@ -1127,6 +1169,12 @@
       },
       "adaptation_run_enabled": {
         "name": "Adaptation run enabled"
+      },
+      "valve_on_off_1": {
+        "name": "Valve 1"
+      },
+      "valve_on_off_2": {
+        "name": "Valve 2"
       }
     }
   }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3060,7 +3060,7 @@ zeroconf==0.136.0
 zeversolar==0.3.2
 
 # homeassistant.components.zha
-zha==0.0.35
+zha==0.0.36
 
 # homeassistant.components.zhong_hong
 zhong-hong-hvac==1.0.13

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2443,7 +2443,7 @@ zeroconf==0.136.0
 zeversolar==0.3.2
 
 # homeassistant.components.zha
-zha==0.0.35
+zha==0.0.36
 
 # homeassistant.components.zwave_js
 zwave-js-server-python==0.58.1


### PR DESCRIPTION
## Proposed change
This bumps ZHA to [0.0.36](https://github.com/zigpy/zha/releases/tag/0.0.36). These dependency upgrades are bundled with it: 
- `zha-quirks` [0.0.124](https://github.com/zigpy/zha-device-handlers/releases/tag/0.0.124)
- `zigpy` [0.70.0](https://github.com/zigpy/zigpy/releases/tag/0.70.0)

This is the first zha-quirks release that adds a few entities for (mostly) Tuya devices via the quirks v2 API.
For the entities using a `translation_key`, the entity names are added to `strings.json`. Do note that the entity for the Hue tamper binary sensor uses the device class name and doesn't need a dedicated translation.

### Note

In the future, I'll publish the script to generate `strings.json` changes for newly added entities via the quirks v2 API and also improve tests in HA to make sure there are no missing translations for entities added via the quirks v2 API.

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue:
  Closes #128867 (The strings are bundled in this PR, since the entities are already added with this bump. We'll always bundle any strings for v2 quirks in ZHA bumps. Dedicated PRs for just the translations are not needed.)
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
