### PR TITLE
Ensure entry_id is set on reauth/reconfigure flows

### DIFF
--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1266,16 +1266,11 @@ class ConfigEntriesFlowManager(
             SOURCE_RECONFIGURE,
         } and "entry_id" not in context:
             # Deprecated in 2024.11, should fail in 2025.11
-            report_issue = async_suggest_report_issue(
-                self.hass, integration_domain=handler
-            )
-            _LOGGER.error(
-                (
-                    "Initialising a '%s' flow without a link to the config entry,"
-                    " which will stop working in 2025.11; please %s"
-                ),
-                source,
-                report_issue,
+            report(
+                f"initialises a {source} flow for integration {handler} without "
+                "a link to the config entry. This will stop working in 2025.11",
+                error_if_integration=False,
+                error_if_core=False,
             )
 
         flow_id = ulid_util.ulid_now()

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1271,7 +1271,7 @@ class ConfigEntriesFlowManager(
             )
             _LOGGER.error(
                 (
-                    "Initialising a '%s' flow without an `entry_id` in the context"
+                    "Initialising a '%s' flow without a link to the config entry,"
                     " please %s"
                 ),
                 source,

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1267,8 +1267,7 @@ class ConfigEntriesFlowManager(
         } and "entry_id" not in context:
             # Deprecated in 2024.12, should fail in 2025.12
             report(
-                f"initialises a {source} flow for integration {handler} without "
-                "a link to the config entry. This will stop working in 2025.12",
+                f"initialises a {source} flow without a link to the config entry",
                 error_if_integration=False,
                 error_if_core=True,
             )

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1272,7 +1272,7 @@ class ConfigEntriesFlowManager(
             _LOGGER.error(
                 (
                     "Initialising a '%s' flow without a link to the config entry,"
-                    " please %s"
+                    " which will stop working in 2025.11; please %s"
                 ),
                 source,
                 report_issue,

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1260,13 +1260,30 @@ class ConfigEntriesFlowManager(
         if not context or "source" not in context:
             raise KeyError("Context not set or doesn't have a source set")
 
+        # reauth/reconfigure flows should be linked to a config entry
+        if (source := context["source"]) in {
+            SOURCE_REAUTH,
+            SOURCE_RECONFIGURE,
+        } and "entry_id" not in context:
+            # Deprecated in 2024.11, should fail in 2025.11
+            report_issue = async_suggest_report_issue(
+                self.hass, integration_domain=handler
+            )
+            _LOGGER.error(
+                (
+                    "Initialising a '%s' flow without an `entry_id` in the context"
+                    " please %s"
+                ),
+                source,
+                report_issue,
+            )
+
         flow_id = ulid_util.ulid_now()
 
         # Avoid starting a config flow on an integration that only supports
         # a single config entry, but which already has an entry
         if (
-            context.get("source")
-            not in {SOURCE_IGNORE, SOURCE_REAUTH, SOURCE_RECONFIGURE}
+            source not in {SOURCE_IGNORE, SOURCE_REAUTH, SOURCE_RECONFIGURE}
             and self.config_entries.async_has_entries(handler, include_ignore=False)
             and await _support_single_config_entry_only(self.hass, handler)
         ):
@@ -1280,7 +1297,7 @@ class ConfigEntriesFlowManager(
 
         loop = self.hass.loop
 
-        if context["source"] == SOURCE_IMPORT:
+        if source == SOURCE_IMPORT:
             self._pending_import_flows[handler][flow_id] = loop.create_future()
 
         cancel_init_future = loop.create_future()

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1270,7 +1270,7 @@ class ConfigEntriesFlowManager(
                 f"initialises a {source} flow for integration {handler} without "
                 "a link to the config entry. This will stop working in 2025.12",
                 error_if_integration=False,
-                error_if_core=False,
+                error_if_core=True,
             )
 
         flow_id = ulid_util.ulid_now()

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1265,10 +1265,10 @@ class ConfigEntriesFlowManager(
             SOURCE_REAUTH,
             SOURCE_RECONFIGURE,
         } and "entry_id" not in context:
-            # Deprecated in 2024.11, should fail in 2025.11
+            # Deprecated in 2024.12, should fail in 2025.12
             report(
                 f"initialises a {source} flow for integration {handler} without "
-                "a link to the config entry. This will stop working in 2025.11",
+                "a link to the config entry. This will stop working in 2025.12",
                 error_if_integration=False,
                 error_if_core=False,
             )

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -4779,6 +4779,41 @@ async def test_reauth(
     assert len(hass.config_entries.flow.async_progress()) == 1
 
 
+@pytest.mark.parametrize(
+    "source", [config_entries.SOURCE_REAUTH, config_entries.SOURCE_RECONFIGURE]
+)
+async def test_reauth_reconfigure_missing_entry(
+    hass: HomeAssistant,
+    manager: config_entries.ConfigEntries,
+    source: str,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test the async_reauth_helper."""
+    entry = MockConfigEntry(title="test_title", domain="test")
+    entry.add_to_hass(hass)
+
+    mock_setup_entry = AsyncMock(return_value=True)
+    mock_integration(hass, MockModule("test", async_setup_entry=mock_setup_entry))
+    mock_platform(hass, "test.config_flow", None)
+
+    await manager.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    await manager.flow.async_init("test", context={"source": source})
+    await hass.async_block_till_done()
+
+    # Flow still created, but deprecation logged
+    flows = hass.config_entries.flow.async_progress()
+    assert len(flows) == 1
+    assert flows[0]["context"]["source"] == source
+
+    assert (
+        f"Initialising a '{source}' flow without a link to the config entry,"
+        " which will stop working in 2025.11; please create a bug report at "
+        in caplog.text
+    )
+
+
 async def test_reconfigure(
     hass: HomeAssistant, manager: config_entries.ConfigEntries
 ) -> None:

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -4809,7 +4809,7 @@ async def test_reauth_reconfigure_missing_entry(
 
     assert (
         f"Detected code that initialises a {source} flow for integration "
-        "test without a link to the config entry. This will stop working in 2025.11."
+        "test without a link to the config entry. This will stop working in 2025.12."
         " Please report this issue." in caplog.text
     )
 

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -4808,9 +4808,9 @@ async def test_reauth_reconfigure_missing_entry(
     assert flows[0]["context"]["source"] == source
 
     assert (
-        f"Initialising a '{source}' flow without a link to the config entry,"
-        " which will stop working in 2025.11; please create a bug report at "
-        in caplog.text
+        f"Detected code that initialises a {source} flow for integration "
+        "test without a link to the config entry. This will stop working in 2025.11."
+        " Please report this issue." in caplog.text
     )
 
 

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -37,7 +37,7 @@ from homeassistant.exceptions import (
     ConfigEntryNotReady,
     HomeAssistantError,
 )
-from homeassistant.helpers import entity_registry as er, issue_registry as ir
+from homeassistant.helpers import entity_registry as er, frame, issue_registry as ir
 from homeassistant.helpers.discovery_flow import DiscoveryKey
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.json import json_dumps
@@ -4799,8 +4799,43 @@ async def test_reauth_reconfigure_missing_entry(
     await manager.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    await manager.flow.async_init("test", context={"source": source})
+    with pytest.raises(
+        RuntimeError,
+        match=f"Detected code that initialises a {source} flow without a link "
+        "to the config entry. Please report this issue.",
+    ):
+        await manager.flow.async_init("test", context={"source": source})
     await hass.async_block_till_done()
+
+    # Flow still created, but deprecation logged
+    flows = hass.config_entries.flow.async_progress()
+    assert len(flows) == 0
+
+
+@pytest.mark.usefixtures("mock_integration_frame")
+@pytest.mark.parametrize(
+    "source", [config_entries.SOURCE_REAUTH, config_entries.SOURCE_RECONFIGURE]
+)
+async def test_reauth_reconfigure_missing_entry_component(
+    hass: HomeAssistant,
+    manager: config_entries.ConfigEntries,
+    source: str,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test the async_reauth_helper."""
+    entry = MockConfigEntry(title="test_title", domain="test")
+    entry.add_to_hass(hass)
+
+    mock_setup_entry = AsyncMock(return_value=True)
+    mock_integration(hass, MockModule("test", async_setup_entry=mock_setup_entry))
+    mock_platform(hass, "test.config_flow", None)
+
+    await manager.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    with patch.object(frame, "_REPORTED_INTEGRATIONS", set()):
+        await manager.flow.async_init("test", context={"source": source})
+        await hass.async_block_till_done()
 
     # Flow still created, but deprecation logged
     flows = hass.config_entries.flow.async_progress()
@@ -4808,9 +4843,8 @@ async def test_reauth_reconfigure_missing_entry(
     assert flows[0]["context"]["source"] == source
 
     assert (
-        f"Detected code that initialises a {source} flow for integration "
-        "test without a link to the config entry. This will stop working in 2025.12."
-        " Please report this issue." in caplog.text
+        f"Detected that integration 'hue' initialises a {source} flow"
+        " without a link to the config entry at homeassistant/components" in caplog.text
     )
 
 
@@ -5047,7 +5081,9 @@ async def test_initializing_flows_canceled_on_shutdown(
         config_entries.HANDLERS, {"comp": MockFlowHandler, "test": MockFlowHandler}
     ):
         task = asyncio.create_task(
-            manager.flow.async_init("test", context={"source": "reauth"})
+            manager.flow.async_init(
+                "test", context={"source": "reauth", "entry_id": "abc"}
+            )
         )
         await hass.async_block_till_done()
         manager.flow.async_shutdown()

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -4807,7 +4807,6 @@ async def test_reauth_reconfigure_missing_entry(
         await manager.flow.async_init("test", context={"source": source})
     await hass.async_block_till_done()
 
-    # Flow still created, but deprecation logged
     flows = hass.config_entries.flow.async_progress()
     assert len(flows) == 0
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Failing to provide a link to a config entry when initialising a reauth/reconfigure flow will fail from 2025.11


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
A reauth/reconfigure flow should be linked to a config entry

cc @gjohansson-ST


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
