### PR TITLE
Add UnitOfVolumetricMassDensity enumerator

### DIFF
--- a/homeassistant/components/air_quality/__init__.py
+++ b/homeassistant/components/air_quality/__init__.py
@@ -7,7 +7,7 @@ import logging
 from typing import Final, final
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
+from homeassistant.const import UnitOfVolumetricMassDensity
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity import Entity
@@ -151,4 +151,4 @@ class AirQualityEntity(Entity):
     @property
     def unit_of_measurement(self) -> str:
         """Return the unit of measurement of this entity."""
-        return CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
+        return UnitOfVolumetricMassDensity.MICROGRAMS_PER_CUBIC_METER

--- a/homeassistant/components/isy994/const.py
+++ b/homeassistant/components/isy994/const.py
@@ -17,7 +17,6 @@ from homeassistant.components.climate import (
 )
 from homeassistant.components.lock import LockState
 from homeassistant.const import (
-    CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
     CONCENTRATION_PARTS_PER_MILLION,
     CURRENCY_CENT,
     CURRENCY_DOLLAR,
@@ -56,6 +55,7 @@ from homeassistant.const import (
     UnitOfVolume,
     UnitOfVolumeFlowRate,
     UnitOfVolumetricFlux,
+    UnitOfVolumetricMassDensity,
 )
 
 _LOGGER = logging.getLogger(__package__)
@@ -423,7 +423,7 @@ UOM_FRIENDLY_NAME = {
     "118": UnitOfPressure.HPA,
     "119": UnitOfEnergy.WATT_HOUR,
     "120": UnitOfVolumetricFlux.INCHES_PER_DAY,
-    "122": CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,  # Microgram per cubic meter
+    "122": UnitOfVolumetricMassDensity.MICROGRAMS_PER_CUBIC_METER,  # Microgram per cubic meter
     "123": f"bq/{UnitOfVolume.CUBIC_METERS}",  # Becquerel per cubic meter
     "124": f"pCi/{UnitOfVolume.LITERS}",  # Picocuries per liter
     "125": "pH",

--- a/homeassistant/components/number/const.py
+++ b/homeassistant/components/number/const.py
@@ -9,7 +9,6 @@ from typing import Final
 import voluptuous as vol
 
 from homeassistant.const import (
-    CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
     CONCENTRATION_PARTS_PER_BILLION,
     CONCENTRATION_PARTS_PER_MILLION,
     LIGHT_LUX,
@@ -38,6 +37,7 @@ from homeassistant.const import (
     UnitOfVolume,
     UnitOfVolumeFlowRate,
     UnitOfVolumetricFlux,
+    UnitOfVolumetricMassDensity,
 )
 from homeassistant.helpers.deprecation import (
     DeprecatedConstantEnum,
@@ -455,14 +455,20 @@ DEVICE_CLASS_UNITS: dict[NumberDeviceClass, set[type[StrEnum] | str | None]] = {
     NumberDeviceClass.ILLUMINANCE: {LIGHT_LUX},
     NumberDeviceClass.IRRADIANCE: set(UnitOfIrradiance),
     NumberDeviceClass.MOISTURE: {PERCENTAGE},
-    NumberDeviceClass.NITROGEN_DIOXIDE: {CONCENTRATION_MICROGRAMS_PER_CUBIC_METER},
-    NumberDeviceClass.NITROGEN_MONOXIDE: {CONCENTRATION_MICROGRAMS_PER_CUBIC_METER},
-    NumberDeviceClass.NITROUS_OXIDE: {CONCENTRATION_MICROGRAMS_PER_CUBIC_METER},
-    NumberDeviceClass.OZONE: {CONCENTRATION_MICROGRAMS_PER_CUBIC_METER},
+    NumberDeviceClass.NITROGEN_DIOXIDE: {
+        UnitOfVolumetricMassDensity.MICROGRAMS_PER_CUBIC_METER
+    },
+    NumberDeviceClass.NITROGEN_MONOXIDE: {
+        UnitOfVolumetricMassDensity.MICROGRAMS_PER_CUBIC_METER
+    },
+    NumberDeviceClass.NITROUS_OXIDE: {
+        UnitOfVolumetricMassDensity.MICROGRAMS_PER_CUBIC_METER
+    },
+    NumberDeviceClass.OZONE: {UnitOfVolumetricMassDensity.MICROGRAMS_PER_CUBIC_METER},
     NumberDeviceClass.PH: {None},
-    NumberDeviceClass.PM1: {CONCENTRATION_MICROGRAMS_PER_CUBIC_METER},
-    NumberDeviceClass.PM10: {CONCENTRATION_MICROGRAMS_PER_CUBIC_METER},
-    NumberDeviceClass.PM25: {CONCENTRATION_MICROGRAMS_PER_CUBIC_METER},
+    NumberDeviceClass.PM1: {UnitOfVolumetricMassDensity.MICROGRAMS_PER_CUBIC_METER},
+    NumberDeviceClass.PM10: {UnitOfVolumetricMassDensity.MICROGRAMS_PER_CUBIC_METER},
+    NumberDeviceClass.PM25: {UnitOfVolumetricMassDensity.MICROGRAMS_PER_CUBIC_METER},
     NumberDeviceClass.POWER_FACTOR: {PERCENTAGE, None},
     NumberDeviceClass.POWER: {UnitOfPower.WATT, UnitOfPower.KILO_WATT},
     NumberDeviceClass.PRECIPITATION: set(UnitOfPrecipitationDepth),
@@ -475,10 +481,12 @@ DEVICE_CLASS_UNITS: dict[NumberDeviceClass, set[type[StrEnum] | str | None]] = {
     },
     NumberDeviceClass.SOUND_PRESSURE: set(UnitOfSoundPressure),
     NumberDeviceClass.SPEED: set(UnitOfSpeed).union(set(UnitOfVolumetricFlux)),
-    NumberDeviceClass.SULPHUR_DIOXIDE: {CONCENTRATION_MICROGRAMS_PER_CUBIC_METER},
+    NumberDeviceClass.SULPHUR_DIOXIDE: {
+        UnitOfVolumetricMassDensity.MICROGRAMS_PER_CUBIC_METER
+    },
     NumberDeviceClass.TEMPERATURE: set(UnitOfTemperature),
     NumberDeviceClass.VOLATILE_ORGANIC_COMPOUNDS: {
-        CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
+        UnitOfVolumetricMassDensity.MICROGRAMS_PER_CUBIC_METER
     },
     NumberDeviceClass.VOLATILE_ORGANIC_COMPOUNDS_PARTS: {
         CONCENTRATION_PARTS_PER_BILLION,

--- a/homeassistant/components/sensor/const.py
+++ b/homeassistant/components/sensor/const.py
@@ -9,7 +9,6 @@ from typing import Final
 import voluptuous as vol
 
 from homeassistant.const import (
-    CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
     CONCENTRATION_PARTS_PER_BILLION,
     CONCENTRATION_PARTS_PER_MILLION,
     LIGHT_LUX,
@@ -38,6 +37,7 @@ from homeassistant.const import (
     UnitOfVolume,
     UnitOfVolumeFlowRate,
     UnitOfVolumetricFlux,
+    UnitOfVolumetricMassDensity,
 )
 from homeassistant.helpers.deprecation import (
     DeprecatedConstantEnum,
@@ -550,14 +550,20 @@ DEVICE_CLASS_UNITS: dict[SensorDeviceClass, set[type[StrEnum] | str | None]] = {
     SensorDeviceClass.ILLUMINANCE: {LIGHT_LUX},
     SensorDeviceClass.IRRADIANCE: set(UnitOfIrradiance),
     SensorDeviceClass.MOISTURE: {PERCENTAGE},
-    SensorDeviceClass.NITROGEN_DIOXIDE: {CONCENTRATION_MICROGRAMS_PER_CUBIC_METER},
-    SensorDeviceClass.NITROGEN_MONOXIDE: {CONCENTRATION_MICROGRAMS_PER_CUBIC_METER},
-    SensorDeviceClass.NITROUS_OXIDE: {CONCENTRATION_MICROGRAMS_PER_CUBIC_METER},
-    SensorDeviceClass.OZONE: {CONCENTRATION_MICROGRAMS_PER_CUBIC_METER},
+    SensorDeviceClass.NITROGEN_DIOXIDE: {
+        UnitOfVolumetricMassDensity.MICROGRAMS_PER_CUBIC_METER
+    },
+    SensorDeviceClass.NITROGEN_MONOXIDE: {
+        UnitOfVolumetricMassDensity.MICROGRAMS_PER_CUBIC_METER
+    },
+    SensorDeviceClass.NITROUS_OXIDE: {
+        UnitOfVolumetricMassDensity.MICROGRAMS_PER_CUBIC_METER
+    },
+    SensorDeviceClass.OZONE: {UnitOfVolumetricMassDensity.MICROGRAMS_PER_CUBIC_METER},
     SensorDeviceClass.PH: {None},
-    SensorDeviceClass.PM1: {CONCENTRATION_MICROGRAMS_PER_CUBIC_METER},
-    SensorDeviceClass.PM10: {CONCENTRATION_MICROGRAMS_PER_CUBIC_METER},
-    SensorDeviceClass.PM25: {CONCENTRATION_MICROGRAMS_PER_CUBIC_METER},
+    SensorDeviceClass.PM1: {UnitOfVolumetricMassDensity.MICROGRAMS_PER_CUBIC_METER},
+    SensorDeviceClass.PM10: {UnitOfVolumetricMassDensity.MICROGRAMS_PER_CUBIC_METER},
+    SensorDeviceClass.PM25: {UnitOfVolumetricMassDensity.MICROGRAMS_PER_CUBIC_METER},
     SensorDeviceClass.POWER_FACTOR: {PERCENTAGE, None},
     SensorDeviceClass.POWER: {UnitOfPower.WATT, UnitOfPower.KILO_WATT},
     SensorDeviceClass.PRECIPITATION: set(UnitOfPrecipitationDepth),
@@ -570,10 +576,12 @@ DEVICE_CLASS_UNITS: dict[SensorDeviceClass, set[type[StrEnum] | str | None]] = {
     },
     SensorDeviceClass.SOUND_PRESSURE: set(UnitOfSoundPressure),
     SensorDeviceClass.SPEED: set(UnitOfSpeed).union(set(UnitOfVolumetricFlux)),
-    SensorDeviceClass.SULPHUR_DIOXIDE: {CONCENTRATION_MICROGRAMS_PER_CUBIC_METER},
+    SensorDeviceClass.SULPHUR_DIOXIDE: {
+        UnitOfVolumetricMassDensity.MICROGRAMS_PER_CUBIC_METER
+    },
     SensorDeviceClass.TEMPERATURE: set(UnitOfTemperature),
     SensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS: {
-        CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
+        UnitOfVolumetricMassDensity.MICROGRAMS_PER_CUBIC_METER
     },
     SensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS_PARTS: {
         CONCENTRATION_PARTS_PER_BILLION,

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -1344,10 +1344,35 @@ _DEPRECATED_PRECIPITATION_INCHES_PER_HOUR: Final = DeprecatedConstantEnum(
 )
 """Deprecated: please use UnitOfVolumetricFlux.INCHES_PER_HOUR"""
 
+
+class UnitOfVolumetricMassDensity(StrEnum):
+    """Volumetric mass density.
+
+    A substance's mass per unit of volume.
+    """
+
+    MICROGRAMS_PER_CUBIC_METER = "µg/m³"
+    MILLIGRAMS_PER_CUBIC_METER = "mg/m³"
+    MICROGRAMS_PER_CUBIC_FOOT = "μg/ft³"
+
+
 # Concentration units
-CONCENTRATION_MICROGRAMS_PER_CUBIC_METER: Final = "µg/m³"
-CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER: Final = "mg/m³"
-CONCENTRATION_MICROGRAMS_PER_CUBIC_FOOT: Final = "μg/ft³"
+_DEPRECATED_CONCENTRATION_MICROGRAMS_PER_CUBIC_METER: Final = DeprecatedConstantEnum(
+    UnitOfVolumetricMassDensity.MICROGRAMS_PER_CUBIC_METER,
+    "2025.11",
+)
+"""Deprecated: please use UnitOfDensity.MICROGRAMS_PER_CUBIC_METER"""
+_DEPRECATED_CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER: Final = DeprecatedConstantEnum(
+    UnitOfVolumetricMassDensity.MILLIGRAMS_PER_CUBIC_METER,
+    "2025.11",
+)
+"""Deprecated: please use UnitOfDensity.MILLIGRAMS_PER_CUBIC_METER"""
+_DEPRECATED_CONCENTRATION_MICROGRAMS_PER_CUBIC_FOOT: Final = DeprecatedConstantEnum(
+    UnitOfVolumetricMassDensity.MICROGRAMS_PER_CUBIC_FOOT,
+    "2025.11",
+)
+"""Deprecated: please use UnitOfDensity.MICROGRAMS_PER_CUBIC_FOOT"""
+
 CONCENTRATION_PARTS_PER_CUBIC_METER: Final = "p/m³"
 CONCENTRATION_PARTS_PER_MILLION: Final = "ppm"
 CONCENTRATION_PARTS_PER_BILLION: Final = "ppb"

--- a/tests/components/air_quality/test_air_quality.py
+++ b/tests/components/air_quality/test_air_quality.py
@@ -6,7 +6,7 @@ from homeassistant.components.air_quality import ATTR_N2O, ATTR_OZONE, ATTR_PM_1
 from homeassistant.const import (
     ATTR_ATTRIBUTION,
     ATTR_UNIT_OF_MEASUREMENT,
-    CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+    UnitOfVolumetricMassDensity,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
@@ -47,5 +47,6 @@ async def test_attributes(hass: HomeAssistant) -> None:
     assert data.get(ATTR_OZONE) is None
     assert data.get(ATTR_ATTRIBUTION) == "Powered by Home Assistant"
     assert (
-        data.get(ATTR_UNIT_OF_MEASUREMENT) == CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
+        data.get(ATTR_UNIT_OF_MEASUREMENT)
+        == UnitOfVolumetricMassDensity.MICROGRAMS_PER_CUBIC_METER
     )

--- a/tests/components/sensor/common.py
+++ b/tests/components/sensor/common.py
@@ -6,7 +6,6 @@ from homeassistant.components.sensor import (
     SensorEntity,
 )
 from homeassistant.const import (
-    CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
     CONCENTRATION_PARTS_PER_MILLION,
     LIGHT_LUX,
     PERCENTAGE,
@@ -16,6 +15,7 @@ from homeassistant.const import (
     UnitOfPressure,
     UnitOfReactivePower,
     UnitOfVolume,
+    UnitOfVolumetricMassDensity,
 )
 
 from tests.common import MockEntity
@@ -28,15 +28,15 @@ UNITS_OF_MEASUREMENT = {
     SensorDeviceClass.HUMIDITY: PERCENTAGE,  # % of humidity in the air
     SensorDeviceClass.ILLUMINANCE: LIGHT_LUX,  # current light level lx
     SensorDeviceClass.MOISTURE: PERCENTAGE,  # % of water in a substance
-    SensorDeviceClass.NITROGEN_DIOXIDE: CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,  # µg/m³ of nitrogen dioxide
-    SensorDeviceClass.NITROGEN_MONOXIDE: CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,  # µg/m³ of nitrogen monoxide
-    SensorDeviceClass.NITROUS_OXIDE: CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,  # µg/m³ of nitrogen oxide
-    SensorDeviceClass.OZONE: CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,  # µg/m³ of ozone
-    SensorDeviceClass.PM1: CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,  # µg/m³ of PM1
-    SensorDeviceClass.PM10: CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,  # µg/m³ of PM10
-    SensorDeviceClass.PM25: CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,  # µg/m³ of PM2.5
+    SensorDeviceClass.NITROGEN_DIOXIDE: UnitOfVolumetricMassDensity.MICROGRAMS_PER_CUBIC_METER,  # µg/m³ of nitrogen dioxide
+    SensorDeviceClass.NITROGEN_MONOXIDE: UnitOfVolumetricMassDensity.MICROGRAMS_PER_CUBIC_METER,  # µg/m³ of nitrogen monoxide
+    SensorDeviceClass.NITROUS_OXIDE: UnitOfVolumetricMassDensity.MICROGRAMS_PER_CUBIC_METER,  # µg/m³ of nitrogen oxide
+    SensorDeviceClass.OZONE: UnitOfVolumetricMassDensity.MICROGRAMS_PER_CUBIC_METER,  # µg/m³ of ozone
+    SensorDeviceClass.PM1: UnitOfVolumetricMassDensity.MICROGRAMS_PER_CUBIC_METER,  # µg/m³ of PM1
+    SensorDeviceClass.PM10: UnitOfVolumetricMassDensity.MICROGRAMS_PER_CUBIC_METER,  # µg/m³ of PM10
+    SensorDeviceClass.PM25: UnitOfVolumetricMassDensity.MICROGRAMS_PER_CUBIC_METER,  # µg/m³ of PM2.5
     SensorDeviceClass.SIGNAL_STRENGTH: SIGNAL_STRENGTH_DECIBELS,  # signal strength (dB/dBm)
-    SensorDeviceClass.SULPHUR_DIOXIDE: CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,  # µg/m³ of sulphur dioxide
+    SensorDeviceClass.SULPHUR_DIOXIDE: UnitOfVolumetricMassDensity.MICROGRAMS_PER_CUBIC_METER,  # µg/m³ of sulphur dioxide
     SensorDeviceClass.TEMPERATURE: "C",  # temperature (C/F)
     SensorDeviceClass.PRESSURE: UnitOfPressure.HPA,  # pressure (hPa/mbar)
     SensorDeviceClass.POWER: "kW",  # power (W/kW)
@@ -45,7 +45,7 @@ UNITS_OF_MEASUREMENT = {
     SensorDeviceClass.FREQUENCY: UnitOfFrequency.GIGAHERTZ,  # energy (Hz/kHz/MHz/GHz)
     SensorDeviceClass.POWER_FACTOR: PERCENTAGE,  # power factor (no unit, min: -1.0, max: 1.0)
     SensorDeviceClass.REACTIVE_POWER: UnitOfReactivePower.VOLT_AMPERE_REACTIVE,  # reactive power (var)
-    SensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS: CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,  # µg/m³ of vocs
+    SensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS: UnitOfVolumetricMassDensity.MICROGRAMS_PER_CUBIC_METER,  # µg/m³ of vocs
     SensorDeviceClass.VOLTAGE: "V",  # voltage (V)
     SensorDeviceClass.GAS: UnitOfVolume.CUBIC_METERS,  # gas (m³)
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
For developers only:
`CONCENTRATION_MICROGRAMS_PER_CUBIC_METER`, `CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER` and `CONCENTRATION_MICROGRAMS_PER_CUBIC_FOOT` constants are deprecated.
Please use `UnitOfVolumetricMassDensity` enumerator members instead.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Linked to https://github.com/home-assistant/architecture/discussions/1147

If approved:
- [ ] needs dev docs
- [ ] need to update the components

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
