### PR TITLE
Use shorthand attribute for extra state attributes in statistics

### DIFF
--- a/homeassistant/components/statistics/sensor.py
+++ b/homeassistant/components/statistics/sensor.py
@@ -364,7 +364,7 @@ class StatisticsSensor(SensorEntity):
 
         self.states: deque[float | bool] = deque(maxlen=self._samples_max_buffer_size)
         self.ages: deque[datetime] = deque(maxlen=self._samples_max_buffer_size)
-        self.attributes: dict[str, StateType] = {}
+        self._attr_extra_state_attributes = {}
 
         self._state_characteristic_fn: Callable[[], float | int | datetime | None] = (
             self._callable_characteristic_fn(self._state_characteristic)
@@ -462,10 +462,10 @@ class StatisticsSensor(SensorEntity):
         # Here we make a copy the current value, which is okay.
         self._attr_available = new_state.state != STATE_UNAVAILABLE
         if new_state.state == STATE_UNAVAILABLE:
-            self.attributes[STAT_SOURCE_VALUE_VALID] = None
+            self._attr_extra_state_attributes[STAT_SOURCE_VALUE_VALID] = None
             return
         if new_state.state in (STATE_UNKNOWN, None, ""):
-            self.attributes[STAT_SOURCE_VALUE_VALID] = False
+            self._attr_extra_state_attributes[STAT_SOURCE_VALUE_VALID] = False
             return
 
         try:
@@ -475,9 +475,9 @@ class StatisticsSensor(SensorEntity):
             else:
                 self.states.append(float(new_state.state))
             self.ages.append(new_state.last_reported)
-            self.attributes[STAT_SOURCE_VALUE_VALID] = True
+            self._attr_extra_state_attributes[STAT_SOURCE_VALUE_VALID] = True
         except ValueError:
-            self.attributes[STAT_SOURCE_VALUE_VALID] = False
+            self._attr_extra_state_attributes[STAT_SOURCE_VALUE_VALID] = False
             _LOGGER.error(
                 "%s: parsing error. Expected number or binary state, but received '%s'",
                 self.entity_id,
@@ -584,13 +584,6 @@ class StatisticsSensor(SensorEntity):
             return None
         return SensorStateClass.MEASUREMENT
 
-    @property
-    def extra_state_attributes(self) -> dict[str, StateType] | None:
-        """Return the state attributes of the sensor."""
-        return {
-            key: value for key, value in self.attributes.items() if value is not None
-        }
-
     def _purge_old_states(self, max_age: timedelta) -> None:
         """Remove states which are older than a given age."""
         now = dt_util.utcnow()
@@ -657,7 +650,7 @@ class StatisticsSensor(SensorEntity):
         if self._samples_max_age is not None:
             self._purge_old_states(self._samples_max_age)
 
-        self._update_attributes()
+        self._update_extra_state_attributes()
         self._update_value()
 
         # If max_age is set, ensure to update again after the defined interval.
@@ -738,22 +731,22 @@ class StatisticsSensor(SensorEntity):
             self.async_write_ha_state()
         _LOGGER.debug("%s: initializing from database completed", self.entity_id)
 
-    def _update_attributes(self) -> None:
+    def _update_extra_state_attributes(self) -> None:
         """Calculate and update the various attributes."""
         if self._samples_max_buffer_size is not None:
-            self.attributes[STAT_BUFFER_USAGE_RATIO] = round(
+            self._attr_extra_state_attributes[STAT_BUFFER_USAGE_RATIO] = round(
                 len(self.states) / self._samples_max_buffer_size, 2
             )
 
         if self._samples_max_age is not None:
             if len(self.states) >= 1:
-                self.attributes[STAT_AGE_COVERAGE_RATIO] = round(
+                self._attr_extra_state_attributes[STAT_AGE_COVERAGE_RATIO] = round(
                     (self.ages[-1] - self.ages[0]).total_seconds()
                     / self._samples_max_age.total_seconds(),
                     2,
                 )
             else:
-                self.attributes[STAT_AGE_COVERAGE_RATIO] = None
+                self._attr_extra_state_attributes[STAT_AGE_COVERAGE_RATIO] = None
 
     def _update_value(self) -> None:
         """Front to call the right statistical characteristics functions.

--- a/homeassistant/components/statistics/sensor.py
+++ b/homeassistant/components/statistics/sensor.py
@@ -734,7 +734,7 @@ class StatisticsSensor(SensorEntity):
     def _update_extra_state_attributes(self) -> None:
         """Calculate and update the various attributes."""
         self._attr_extra_state_attributes[STAT_BUFFER_USAGE_RATIO] = None
-        self._attr_extra_state_attributes[STAT_AGE_COVERAGE_RATIO] = None
+        self._attr_extra_state_attributes[STAT_AGE_COVERAGE_RATIO] = 0
         if self._samples_max_buffer_size is not None:
             self._attr_extra_state_attributes[STAT_BUFFER_USAGE_RATIO] = round(
                 len(self.states) / self._samples_max_buffer_size, 2

--- a/homeassistant/components/statistics/sensor.py
+++ b/homeassistant/components/statistics/sensor.py
@@ -733,6 +733,8 @@ class StatisticsSensor(SensorEntity):
 
     def _update_extra_state_attributes(self) -> None:
         """Calculate and update the various attributes."""
+        self._attr_extra_state_attributes[STAT_BUFFER_USAGE_RATIO] = None
+        self._attr_extra_state_attributes[STAT_AGE_COVERAGE_RATIO] = None
         if self._samples_max_buffer_size is not None:
             self._attr_extra_state_attributes[STAT_BUFFER_USAGE_RATIO] = round(
                 len(self.states) / self._samples_max_buffer_size, 2
@@ -745,8 +747,6 @@ class StatisticsSensor(SensorEntity):
                     / self._samples_max_age.total_seconds(),
                     2,
                 )
-            else:
-                self._attr_extra_state_attributes[STAT_AGE_COVERAGE_RATIO] = None
 
     def _update_value(self) -> None:
         """Front to call the right statistical characteristics functions.

--- a/homeassistant/components/statistics/sensor.py
+++ b/homeassistant/components/statistics/sensor.py
@@ -733,8 +733,6 @@ class StatisticsSensor(SensorEntity):
 
     def _update_extra_state_attributes(self) -> None:
         """Calculate and update the various attributes."""
-        self._attr_extra_state_attributes[STAT_BUFFER_USAGE_RATIO] = None
-        self._attr_extra_state_attributes[STAT_AGE_COVERAGE_RATIO] = 0
         if self._samples_max_buffer_size is not None:
             self._attr_extra_state_attributes[STAT_BUFFER_USAGE_RATIO] = round(
                 len(self.states) / self._samples_max_buffer_size, 2
@@ -747,6 +745,8 @@ class StatisticsSensor(SensorEntity):
                     / self._samples_max_age.total_seconds(),
                     2,
                 )
+            else:
+                self._attr_extra_state_attributes[STAT_AGE_COVERAGE_RATIO] = 0
 
     def _update_value(self) -> None:
         """Front to call the right statistical characteristics functions.

--- a/tests/components/statistics/snapshots/test_config_flow.ambr
+++ b/tests/components/statistics/snapshots/test_config_flow.ambr
@@ -11,7 +11,7 @@
 # name: test_config_flow_preview_success[success]
   dict({
     'attributes': dict({
-      'age_coverage_ratio': None,
+      'age_coverage_ratio': 0,
       'buffer_usage_ratio': 0.1,
       'friendly_name': 'Statistical characteristic',
       'icon': 'mdi:calculator',

--- a/tests/components/statistics/snapshots/test_config_flow.ambr
+++ b/tests/components/statistics/snapshots/test_config_flow.ambr
@@ -11,6 +11,7 @@
 # name: test_config_flow_preview_success[success]
   dict({
     'attributes': dict({
+      'age_coverage_ratio': None,
       'buffer_usage_ratio': 0.1,
       'friendly_name': 'Statistical characteristic',
       'icon': 'mdi:calculator',

--- a/tests/components/statistics/snapshots/test_config_flow.ambr
+++ b/tests/components/statistics/snapshots/test_config_flow.ambr
@@ -11,7 +11,6 @@
 # name: test_config_flow_preview_success[success]
   dict({
     'attributes': dict({
-      'age_coverage_ratio': 0,
       'buffer_usage_ratio': 0.1,
       'friendly_name': 'Statistical characteristic',
       'icon': 'mdi:calculator',

--- a/tests/components/statistics/test_sensor.py
+++ b/tests/components/statistics/test_sensor.py
@@ -117,7 +117,7 @@ async def test_sensor_defaults_numeric(hass: HomeAssistant) -> None:
     assert state.attributes.get(ATTR_STATE_CLASS) is SensorStateClass.MEASUREMENT
     assert state.attributes.get("buffer_usage_ratio") == round(9 / 20, 2)
     assert state.attributes.get("source_value_valid") is True
-    assert "age_coverage_ratio" not in state.attributes
+    assert state.attributes.get("age_coverage_ratio") is None
 
     # Source sensor turns unavailable, then available with valid value,
     # statistics sensor should follow
@@ -210,7 +210,7 @@ async def test_sensor_loaded_from_config_entry(
     assert state.attributes.get(ATTR_STATE_CLASS) is SensorStateClass.MEASUREMENT
     assert state.attributes.get("buffer_usage_ratio") == round(9 / 20, 2)
     assert state.attributes.get("source_value_valid") is True
-    assert "age_coverage_ratio" not in state.attributes
+    assert state.attributes.get("age_coverage_ratio") is None
 
 
 async def test_sensor_defaults_binary(hass: HomeAssistant) -> None:
@@ -247,7 +247,7 @@ async def test_sensor_defaults_binary(hass: HomeAssistant) -> None:
     assert state.attributes.get(ATTR_STATE_CLASS) is SensorStateClass.MEASUREMENT
     assert state.attributes.get("buffer_usage_ratio") == round(9 / 20, 2)
     assert state.attributes.get("source_value_valid") is True
-    assert "age_coverage_ratio" not in state.attributes
+    assert state.attributes.get("age_coverage_ratio") is None
 
 
 async def test_sensor_state_reported(hass: HomeAssistant) -> None:
@@ -2032,3 +2032,63 @@ async def test_not_valid_device_class(hass: HomeAssistant) -> None:
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) is None
     assert state.attributes.get(ATTR_DEVICE_CLASS) is None
     assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
+
+
+async def test_attributes_remains(recorder_mock: Recorder, hass: HomeAssistant) -> None:
+    """Test attributes are always present."""
+    for value in VALUES_NUMERIC:
+        hass.states.async_set(
+            "sensor.test_monitored",
+            str(value),
+            {ATTR_UNIT_OF_MEASUREMENT: UnitOfTemperature.CELSIUS},
+        )
+    await hass.async_block_till_done()
+    await async_wait_recording_done(hass)
+
+    current_time = dt_util.utcnow()
+    with freeze_time(current_time) as freezer:
+        assert await async_setup_component(
+            hass,
+            "sensor",
+            {
+                "sensor": [
+                    {
+                        "platform": "statistics",
+                        "name": "test",
+                        "entity_id": "sensor.test_monitored",
+                        "state_characteristic": "mean",
+                        "max_age": {"seconds": 10},
+                    },
+                ]
+            },
+        )
+        await hass.async_block_till_done()
+
+        state = hass.states.get("sensor.test")
+        assert state is not None
+        assert state.state == str(round(sum(VALUES_NUMERIC) / len(VALUES_NUMERIC), 2))
+        assert state.attributes == {
+            "age_coverage_ratio": 0.0,
+            "buffer_usage_ratio": None,
+            "friendly_name": "test",
+            "icon": "mdi:calculator",
+            "source_value_valid": True,
+            "state_class": SensorStateClass.MEASUREMENT,
+            "unit_of_measurement": "°C",
+        }
+
+        freezer.move_to(current_time + timedelta(minutes=1))
+        async_fire_time_changed(hass)
+
+        state = hass.states.get("sensor.test")
+        assert state is not None
+        assert state.state == STATE_UNKNOWN
+        assert state.attributes == {
+            "age_coverage_ratio": None,
+            "buffer_usage_ratio": None,
+            "friendly_name": "test",
+            "icon": "mdi:calculator",
+            "source_value_valid": True,
+            "state_class": SensorStateClass.MEASUREMENT,
+            "unit_of_measurement": "°C",
+        }

--- a/tests/components/statistics/test_sensor.py
+++ b/tests/components/statistics/test_sensor.py
@@ -117,8 +117,7 @@ async def test_sensor_defaults_numeric(hass: HomeAssistant) -> None:
     assert state.attributes.get(ATTR_STATE_CLASS) is SensorStateClass.MEASUREMENT
     assert state.attributes.get("buffer_usage_ratio") == round(9 / 20, 2)
     assert state.attributes.get("source_value_valid") is True
-    assert state.attributes.get("age_coverage_ratio") is None
-
+    assert state.attributes.get("age_coverage_ratio") == 0
     # Source sensor turns unavailable, then available with valid value,
     # statistics sensor should follow
     state = hass.states.get("sensor.test")
@@ -210,7 +209,7 @@ async def test_sensor_loaded_from_config_entry(
     assert state.attributes.get(ATTR_STATE_CLASS) is SensorStateClass.MEASUREMENT
     assert state.attributes.get("buffer_usage_ratio") == round(9 / 20, 2)
     assert state.attributes.get("source_value_valid") is True
-    assert state.attributes.get("age_coverage_ratio") is None
+    assert state.attributes.get("age_coverage_ratio") == 0
 
 
 async def test_sensor_defaults_binary(hass: HomeAssistant) -> None:
@@ -247,7 +246,7 @@ async def test_sensor_defaults_binary(hass: HomeAssistant) -> None:
     assert state.attributes.get(ATTR_STATE_CLASS) is SensorStateClass.MEASUREMENT
     assert state.attributes.get("buffer_usage_ratio") == round(9 / 20, 2)
     assert state.attributes.get("source_value_valid") is True
-    assert state.attributes.get("age_coverage_ratio") is None
+    assert state.attributes.get("age_coverage_ratio") == 0
 
 
 async def test_sensor_state_reported(hass: HomeAssistant) -> None:
@@ -576,7 +575,7 @@ async def test_age_limit_expiry(hass: HomeAssistant) -> None:
         assert state is not None
         assert state.state == STATE_UNKNOWN
         assert state.attributes.get("buffer_usage_ratio") == round(0 / 20, 2)
-        assert state.attributes.get("age_coverage_ratio") is None
+        assert state.attributes.get("age_coverage_ratio") == 0
 
 
 async def test_age_limit_expiry_with_keep_last_sample(hass: HomeAssistant) -> None:
@@ -2084,7 +2083,7 @@ async def test_attributes_remains(recorder_mock: Recorder, hass: HomeAssistant) 
         assert state is not None
         assert state.state == STATE_UNKNOWN
         assert state.attributes == {
-            "age_coverage_ratio": None,
+            "age_coverage_ratio": 0,
             "buffer_usage_ratio": None,
             "friendly_name": "test",
             "icon": "mdi:calculator",

--- a/tests/components/statistics/test_sensor.py
+++ b/tests/components/statistics/test_sensor.py
@@ -117,7 +117,7 @@ async def test_sensor_defaults_numeric(hass: HomeAssistant) -> None:
     assert state.attributes.get(ATTR_STATE_CLASS) is SensorStateClass.MEASUREMENT
     assert state.attributes.get("buffer_usage_ratio") == round(9 / 20, 2)
     assert state.attributes.get("source_value_valid") is True
-    assert state.attributes.get("age_coverage_ratio") == 0
+    assert "age_coverage_ratio" not in state.attributes
     # Source sensor turns unavailable, then available with valid value,
     # statistics sensor should follow
     state = hass.states.get("sensor.test")
@@ -209,7 +209,7 @@ async def test_sensor_loaded_from_config_entry(
     assert state.attributes.get(ATTR_STATE_CLASS) is SensorStateClass.MEASUREMENT
     assert state.attributes.get("buffer_usage_ratio") == round(9 / 20, 2)
     assert state.attributes.get("source_value_valid") is True
-    assert state.attributes.get("age_coverage_ratio") == 0
+    assert "age_coverage_ratio" not in state.attributes
 
 
 async def test_sensor_defaults_binary(hass: HomeAssistant) -> None:
@@ -246,7 +246,7 @@ async def test_sensor_defaults_binary(hass: HomeAssistant) -> None:
     assert state.attributes.get(ATTR_STATE_CLASS) is SensorStateClass.MEASUREMENT
     assert state.attributes.get("buffer_usage_ratio") == round(9 / 20, 2)
     assert state.attributes.get("source_value_valid") is True
-    assert state.attributes.get("age_coverage_ratio") == 0
+    assert "age_coverage_ratio" not in state.attributes
 
 
 async def test_sensor_state_reported(hass: HomeAssistant) -> None:
@@ -2068,7 +2068,6 @@ async def test_attributes_remains(recorder_mock: Recorder, hass: HomeAssistant) 
         assert state.state == str(round(sum(VALUES_NUMERIC) / len(VALUES_NUMERIC), 2))
         assert state.attributes == {
             "age_coverage_ratio": 0.0,
-            "buffer_usage_ratio": None,
             "friendly_name": "test",
             "icon": "mdi:calculator",
             "source_value_valid": True,
@@ -2084,7 +2083,6 @@ async def test_attributes_remains(recorder_mock: Recorder, hass: HomeAssistant) 
         assert state.state == STATE_UNKNOWN
         assert state.attributes == {
             "age_coverage_ratio": 0,
-            "buffer_usage_ratio": None,
             "friendly_name": "test",
             "icon": "mdi:calculator",
             "source_value_valid": True,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Previously the attributes was only provided when they had a non `None` value. This has now changed so the attributes are always provided even with `None` values. If automations or scripts was depending on these attributes was present or not needs to be modified accordingly.


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Make use of `_attr_extra_state_attributes` in statistics.

Avoid confusion of state attributes (`state_class`, `device_class` and `unit_of_measurement`) vs. additional state attributes which is set by the `statistics` helper.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 