### PR TITLE
Add audio output select to Cambridge Audio

### DIFF
--- a/homeassistant/components/cambridge_audio/icons.json
+++ b/homeassistant/components/cambridge_audio/icons.json
@@ -8,6 +8,9 @@
           "dim": "mdi:brightness-6",
           "off": "mdi:brightness-3"
         }
+      },
+      "audio_output": {
+        "default": "mdi:audio-input-stereo-minijack"
       }
     },
     "switch": {

--- a/homeassistant/components/cambridge_audio/select.py
+++ b/homeassistant/components/cambridge_audio/select.py
@@ -1,7 +1,7 @@
 """Support for Cambridge Audio select entities."""
 
 from collections.abc import Awaitable, Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from aiostreammagic import StreamMagicClient
 from aiostreammagic.models import DisplayBrightness
@@ -19,8 +19,32 @@ from .entity import CambridgeAudioEntity
 class CambridgeAudioSelectEntityDescription(SelectEntityDescription):
     """Describes Cambridge Audio select entity."""
 
+    options_fn: Callable[[StreamMagicClient], list[str]] = field(default=lambda _: [])
+    load_fn: Callable[[StreamMagicClient], bool] = field(default=lambda _: True)
     value_fn: Callable[[StreamMagicClient], str | None]
     set_value_fn: Callable[[StreamMagicClient, str], Awaitable[None]]
+
+
+async def _audio_output_set_value_fn(client: StreamMagicClient, value: str) -> None:
+    """Set the audio output using the display name."""
+    audio_output_id = next(
+        (output.id for output in client.audio_output.outputs if value == output.name),
+        None,
+    )
+    if audio_output_id:
+        await client.set_audio_output(audio_output_id)
+
+
+def _audio_output_value_fn(client: StreamMagicClient) -> str | None:
+    """Convert the current audio output id to name."""
+    return next(
+        (
+            output.name
+            for output in client.audio_output.outputs
+            if client.state.audio_output == output.id
+        ),
+        None,
+    )
 
 
 CONTROL_ENTITIES: tuple[CambridgeAudioSelectEntityDescription, ...] = (
@@ -34,6 +58,17 @@ CONTROL_ENTITIES: tuple[CambridgeAudioSelectEntityDescription, ...] = (
             DisplayBrightness(value)
         ),
     ),
+    CambridgeAudioSelectEntityDescription(
+        key="audio_output",
+        translation_key="audio_output",
+        entity_category=EntityCategory.CONFIG,
+        options_fn=lambda client: [
+            output.name for output in client.audio_output.outputs
+        ],
+        load_fn=lambda client: len(client.audio_output.outputs) > 0,
+        value_fn=_audio_output_value_fn,
+        set_value_fn=_audio_output_set_value_fn,
+    ),
 )
 
 
@@ -46,7 +81,9 @@ async def async_setup_entry(
 
     client: StreamMagicClient = entry.runtime_data
     entities: list[CambridgeAudioSelect] = [
-        CambridgeAudioSelect(client, description) for description in CONTROL_ENTITIES
+        CambridgeAudioSelect(client, description)
+        for description in CONTROL_ENTITIES
+        if description.load_fn(client)
     ]
     async_add_entities(entities)
 
@@ -65,6 +102,9 @@ class CambridgeAudioSelect(CambridgeAudioEntity, SelectEntity):
         super().__init__(client)
         self.entity_description = description
         self._attr_unique_id = f"{client.info.unit_id}-{description.key}"
+        options_fn = description.options_fn(client)
+        if options_fn:
+            self._attr_options = options_fn
 
     @property
     def current_option(self) -> str | None:

--- a/homeassistant/components/cambridge_audio/select.py
+++ b/homeassistant/components/cambridge_audio/select.py
@@ -31,8 +31,8 @@ async def _audio_output_set_value_fn(client: StreamMagicClient, value: str) -> N
         (output.id for output in client.audio_output.outputs if value == output.name),
         None,
     )
-    if audio_output_id:
-        await client.set_audio_output(audio_output_id)
+    assert audio_output_id is not None
+    await client.set_audio_output(audio_output_id)
 
 
 def _audio_output_value_fn(client: StreamMagicClient) -> str | None:

--- a/homeassistant/components/cambridge_audio/strings.json
+++ b/homeassistant/components/cambridge_audio/strings.json
@@ -32,6 +32,9 @@
           "dim": "Dim",
           "off": "[%key:common::state::off%]"
         }
+      },
+      "audio_output": {
+        "name": "Audio output"
       }
     },
     "switch": {

--- a/tests/components/cambridge_audio/conftest.py
+++ b/tests/components/cambridge_audio/conftest.py
@@ -4,6 +4,7 @@ from collections.abc import Generator
 from unittest.mock import AsyncMock, Mock, patch
 
 from aiostreammagic.models import (
+    AudioOutput,
     Display,
     Info,
     NowPlaying,
@@ -62,6 +63,9 @@ def mock_stream_magic_client() -> Generator[AsyncMock]:
         client.update = Update.from_json(load_fixture("get_update.json", DOMAIN))
         client.preset_list = PresetList.from_json(
             load_fixture("get_presets_list.json", DOMAIN)
+        )
+        client.audio_output = AudioOutput.from_json(
+            load_fixture("get_audio_output.json", DOMAIN)
         )
         client.is_connected = Mock(return_value=True)
         client.position_last_updated = client.play_state.position

--- a/tests/components/cambridge_audio/fixtures/get_audio_output.json
+++ b/tests/components/cambridge_audio/fixtures/get_audio_output.json
@@ -1,0 +1,16 @@
+{
+  "outputs": [
+    {
+      "id": "speaker_a",
+      "name": "Speaker A"
+    },
+    {
+      "id": "speaker_b",
+      "name": "Speaker B"
+    },
+    {
+      "id": "headphones",
+      "name": "Headphones"
+    }
+  ]
+}

--- a/tests/components/cambridge_audio/snapshots/test_select.ambr
+++ b/tests/components/cambridge_audio/snapshots/test_select.ambr
@@ -1,4 +1,61 @@
 # serializer version: 1
+# name: test_all_entities[select.cambridge_audio_cxnv2_audio_output-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'speaker_a',
+        'speaker_b',
+        'headphones',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'select.cambridge_audio_cxnv2_audio_output',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Audio output',
+    'platform': 'cambridge_audio',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'audio_output',
+    'unique_id': '0020c2d8-audio_output',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[select.cambridge_audio_cxnv2_audio_output-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Cambridge Audio CXNv2 Audio output',
+      'options': list([
+        'speaker_a',
+        'speaker_b',
+        'headphones',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.cambridge_audio_cxnv2_audio_output',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
 # name: test_all_entities[select.cambridge_audio_cxnv2_display_brightness-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({

--- a/tests/components/cambridge_audio/snapshots/test_select.ambr
+++ b/tests/components/cambridge_audio/snapshots/test_select.ambr
@@ -6,9 +6,9 @@
     'area_id': None,
     'capabilities': dict({
       'options': list([
-        'speaker_a',
-        'speaker_b',
-        'headphones',
+        'Speaker A',
+        'Speaker B',
+        'Headphones',
       ]),
     }),
     'config_entry_id': <ANY>,
@@ -43,9 +43,9 @@
     'attributes': ReadOnlyDict({
       'friendly_name': 'Cambridge Audio CXNv2 Audio output',
       'options': list([
-        'speaker_a',
-        'speaker_b',
-        'headphones',
+        'Speaker A',
+        'Speaker B',
+        'Headphones',
       ]),
     }),
     'context': <ANY>,

--- a/tests/components/cambridge_audio/test_select.py
+++ b/tests/components/cambridge_audio/test_select.py
@@ -51,3 +51,14 @@ async def test_setting_value(
         blocking=True,
     )
     mock_stream_magic_client.set_display_brightness.assert_called_once_with("dim")
+
+    await hass.services.async_call(
+        SELECT_DOMAIN,
+        SERVICE_SELECT_OPTION,
+        {
+            ATTR_ENTITY_ID: "select.cambridge_audio_cxnv2_audio_output",
+            ATTR_OPTION: "Speaker A",
+        },
+        blocking=True,
+    )
+    mock_stream_magic_client.set_audio_output.assert_called_once_with("speaker_a")


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds a select entity to control audio output for Cambridge Audio. Currently, the list of available values for the field are not known. Since the device provides both the id and name, the name is being displayed in the box and being mapped back to the id. 

Once more info about available values are gathered from the community / device models, this can be converted to use translations.

Two additional functions were added to the abstract select entity,
`load_fn` which will decide if the entity should be loaded. Default to True.
`options_fn` which allows for a list of possible select options to be loaded from the device instead of from a defined enum.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/35444

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
