### PR TITLE
Fix webrtc async_get_supported_provider

### DIFF
--- a/tests/components/camera/test_webrtc.py
+++ b/tests/components/camera/test_webrtc.py
@@ -52,6 +52,8 @@ TEST_INTEGRATION_DOMAIN = "test"
 class TestProvider(CameraWebRTCProvider):
     """Test provider."""
 
+    __test__ = False  # prevent test collection of class by pytest
+
     def __init__(self) -> None:
         """Initialize the provider."""
         self._is_supported = True


### PR DESCRIPTION
## Proposed change
`provider.async_is_supported` changed from an async method to a normal one. Therefore `_async_get_supported_provider` needs to check if the provider is `CameraWebRTCLegacyProvider` or `CameraWebRTCProvider` before calling `async_is_supported`.

The issue was introduced in #127981.

Fixes

```py
tests/components/rtsp_to_webrtc/test_init.py::test_offer_for_stream_source
tests/components/rtsp_to_webrtc/test_init.py::test_offer_failure
  /home/runner/work/ha-core/ha-core/homeassistant/components/camera/webrtc.py:345:
      RuntimeWarning: coroutine '_CameraRtspToWebRTCProvider.async_is_supported' was never awaited
    ...
    File "/home/runner/work/ha-core/ha-core/homeassistant/components/camera/webrtc.py",
    line 345, in _async_get_supported_provider
      if provider.async_is_supported(stream_source):
    if provider.async_is_supported(stream_source):

tests/components/camera/test_webrtc.py::test_rtsp_to_webrtc_offer
tests/components/camera/test_webrtc.py::test_rtsp_to_webrtc_provider_unregistered
tests/components/camera/test_webrtc.py::test_rtsp_to_webrtc_offer_not_accepted
  /home/runner/work/ha-core/ha-core/homeassistant/components/camera/webrtc.py:345:
      RuntimeWarning: coroutine '_CameraRtspToWebRTCProvider.async_is_supported' was never awaited
    ...
    File "/home/runner/work/ha-core/ha-core/homeassistant/components/camera/webrtc.py",
    line 345, in _async_get_supported_provider
      if provider.async_is_supported(stream_source):
    if provider.async_is_supported(stream_source):


tests/components/camera/test_webrtc.py:52
  /home/runner/work/ha-core/ha-core/tests/components/camera/test_webrtc.py:52:
      PytestCollectionWarning: cannot collect test class 'TestProvider' because
      it has a __init__ constructor (from: tests/components/camera/test_webrtc.py)
    class TestProvider(CameraWebRTCProvider):
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
