### PR TITLE
Add Smarty versions to device

### DIFF
--- a/homeassistant/components/smarty/coordinator.py
+++ b/homeassistant/components/smarty/coordinator.py
@@ -31,10 +31,8 @@ class SmartyCoordinator(DataUpdateCoordinator[None]):
             update_interval=timedelta(seconds=30),
         )
         self.client = Smarty(host=self.config_entry.data[CONF_HOST])
-        self.software_version = ""
-        self.configuration_version = ""
 
-    async def _async_setup(self):
+    async def _async_setup(self) -> None:
         if not await self.hass.async_add_executor_job(self.client.update):
             raise UpdateFailed("Failed to update Smarty data")
         self.software_version = self.client.get_software_version()

--- a/homeassistant/components/smarty/coordinator.py
+++ b/homeassistant/components/smarty/coordinator.py
@@ -29,6 +29,14 @@ class SmartyCoordinator(DataUpdateCoordinator[None]):
             update_interval=timedelta(seconds=30),
         )
         self.client = Smarty(host=self.config_entry.data[CONF_HOST])
+        self.software_version = ""
+        self.configuration_version = ""
+
+    async def _async_setup(self):
+        if not await self.hass.async_add_executor_job(self.client.update):
+            raise UpdateFailed("Failed to update Smarty data")
+        self.software_version = self.client.get_software_version()
+        self.configuration_version = self.client.get_configuration_version()
 
     async def _async_update_data(self) -> None:
         """Fetch data from Smarty."""

--- a/homeassistant/components/smarty/coordinator.py
+++ b/homeassistant/components/smarty/coordinator.py
@@ -19,6 +19,8 @@ class SmartyCoordinator(DataUpdateCoordinator[None]):
     """Smarty Coordinator."""
 
     config_entry: SmartyConfigEntry
+    software_version: str
+    configuration_version: str
 
     def __init__(self, hass: HomeAssistant) -> None:
         """Initialize."""

--- a/homeassistant/components/smarty/entity.py
+++ b/homeassistant/components/smarty/entity.py
@@ -18,4 +18,6 @@ class SmartyEntity(CoordinatorEntity[SmartyCoordinator]):
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, coordinator.config_entry.entry_id)},
             manufacturer="Salda",
+            sw_version=self.coordinator.software_version,
+            hw_version=self.coordinator.configuration_version,
         )

--- a/homeassistant/components/smarty/sensor.py
+++ b/homeassistant/components/smarty/sensor.py
@@ -14,7 +14,7 @@ from homeassistant.components.sensor import (
     SensorEntity,
     SensorEntityDescription,
 )
-from homeassistant.const import UnitOfTemperature
+from homeassistant.const import REVOLUTIONS_PER_MINUTE, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 import homeassistant.util.dt as dt_util
@@ -64,11 +64,13 @@ ENTITIES: tuple[SmartySensorDescription, ...] = (
     SmartySensorDescription(
         key="supply_fan_speed",
         translation_key="supply_fan_speed",
+        native_unit_of_measurement=REVOLUTIONS_PER_MINUTE,
         value_fn=lambda smarty: smarty.supply_fan_speed,
     ),
     SmartySensorDescription(
         key="extract_fan_speed",
         translation_key="extract_fan_speed",
+        native_unit_of_measurement=REVOLUTIONS_PER_MINUTE,
         value_fn=lambda smarty: smarty.extract_fan_speed,
     ),
     SmartySensorDescription(
@@ -76,6 +78,11 @@ ENTITIES: tuple[SmartySensorDescription, ...] = (
         translation_key="filter_days_left",
         device_class=SensorDeviceClass.TIMESTAMP,
         value_fn=get_filter_days_left,
+    ),
+    SmartySensorDescription(
+        key="system_state",
+        translation_key="system_state",
+        value_fn=lambda smarty: smarty.system_state,
     ),
 )
 

--- a/homeassistant/components/smarty/sensor.py
+++ b/homeassistant/components/smarty/sensor.py
@@ -79,11 +79,6 @@ ENTITIES: tuple[SmartySensorDescription, ...] = (
         device_class=SensorDeviceClass.TIMESTAMP,
         value_fn=get_filter_days_left,
     ),
-    SmartySensorDescription(
-        key="system_state",
-        translation_key="system_state",
-        value_fn=lambda smarty: smarty.system_state,
-    ),
 )
 
 

--- a/homeassistant/components/smarty/strings.json
+++ b/homeassistant/components/smarty/strings.json
@@ -60,9 +60,6 @@
       },
       "filter_days_left": {
         "name": "Filter days left"
-      },
-      "system_state": {
-        "name": "System state"
       }
     }
   }

--- a/homeassistant/components/smarty/strings.json
+++ b/homeassistant/components/smarty/strings.json
@@ -60,6 +60,9 @@
       },
       "filter_days_left": {
         "name": "Filter days left"
+      },
+      "system_state": {
+        "name": "System state"
       }
     }
   }

--- a/tests/components/smarty/conftest.py
+++ b/tests/components/smarty/conftest.py
@@ -46,6 +46,8 @@ def mock_smarty() -> Generator[AsyncMock]:
         client.supply_fan_speed = 66
         client.extract_fan_speed = 100
         client.filter_timer = 31
+        client.get_configuration_version.return_value = 111
+        client.get_software_version.return_value = 127
         yield client
 
 

--- a/tests/components/smarty/snapshots/test_init.ambr
+++ b/tests/components/smarty/snapshots/test_init.ambr
@@ -8,7 +8,7 @@
     }),
     'disabled_by': None,
     'entry_type': None,
-    'hw_version': <MagicMock name='Smarty().get_configuration_version()' id='139658502111200'>,
+    'hw_version': 111,
     'id': <ANY>,
     'identifiers': set({
       tuple(
@@ -27,7 +27,7 @@
     'primary_config_entry': <ANY>,
     'serial_number': None,
     'suggested_area': None,
-    'sw_version': <MagicMock name='Smarty().get_software_version()' id='139658502133840'>,
+    'sw_version': 127,
     'via_device_id': None,
   })
 # ---

--- a/tests/components/smarty/snapshots/test_init.ambr
+++ b/tests/components/smarty/snapshots/test_init.ambr
@@ -8,7 +8,7 @@
     }),
     'disabled_by': None,
     'entry_type': None,
-    'hw_version': None,
+    'hw_version': <MagicMock name='Smarty().get_configuration_version()' id='139658502111200'>,
     'id': <ANY>,
     'identifiers': set({
       tuple(
@@ -27,7 +27,7 @@
     'primary_config_entry': <ANY>,
     'serial_number': None,
     'suggested_area': None,
-    'sw_version': None,
+    'sw_version': <MagicMock name='Smarty().get_software_version()' id='139658502133840'>,
     'via_device_id': None,
   })
 # ---

--- a/tests/components/smarty/snapshots/test_sensor.ambr
+++ b/tests/components/smarty/snapshots/test_sensor.ambr
@@ -77,13 +77,14 @@
     'supported_features': 0,
     'translation_key': 'extract_fan_speed',
     'unique_id': '01JAZ5DPW8C62D620DGYNG2R8H_extract_fan_speed',
-    'unit_of_measurement': None,
+    'unit_of_measurement': 'rpm',
   })
 # ---
 # name: test_all_entities[sensor.mock_title_extract_fan_speed-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock Title Extract fan speed',
+      'unit_of_measurement': 'rpm',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.mock_title_extract_fan_speed',
@@ -266,13 +267,14 @@
     'supported_features': 0,
     'translation_key': 'supply_fan_speed',
     'unique_id': '01JAZ5DPW8C62D620DGYNG2R8H_supply_fan_speed',
-    'unit_of_measurement': None,
+    'unit_of_measurement': 'rpm',
   })
 # ---
 # name: test_all_entities[sensor.mock_title_supply_fan_speed-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock Title Supply fan speed',
+      'unit_of_measurement': 'rpm',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.mock_title_supply_fan_speed',


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The Smarty integration for Salda VMC devices have recently been reactivated but was missing some features that here have been added:

SoftwareVersionSensor and ConfigurationVersionSensor in Device Info.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
