### PR TITLE
Fix devolo_home_network DataCoordinator arguments

### DIFF
--- a/homeassistant/components/devolo_home_network/coordinator.py
+++ b/homeassistant/components/devolo_home_network/coordinator.py
@@ -5,6 +5,7 @@ from collections.abc import Awaitable, Callable
 from datetime import timedelta
 from logging import Logger
 
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
@@ -17,6 +18,7 @@ class DevoloDataUpdateCoordinator[_DataT](DataUpdateCoordinator[_DataT]):
         hass: HomeAssistant,
         logger: Logger,
         *,
+        config_entry: ConfigEntry,
         name: str,
         semaphore: Semaphore,
         update_interval: timedelta,
@@ -26,6 +28,7 @@ class DevoloDataUpdateCoordinator[_DataT](DataUpdateCoordinator[_DataT]):
         super().__init__(
             hass,
             logger,
+            config_entry=config_entry,
             name=name,
             update_interval=update_interval,
             update_method=update_method,


### PR DESCRIPTION
## Proposed change
Fix mypy failures introduced with #128159 and #128080.
```py
homeassistant/components/devolo_home_network/__init__.py:171: error: Unexpected keyword argument "config_entry" for "DevoloDataUpdateCoordinator"  [call-arg]
homeassistant/components/devolo_home_network/__init__.py:181: error: Unexpected keyword argument "config_entry" for "DevoloDataUpdateCoordinator"  [call-arg]
homeassistant/components/devolo_home_network/__init__.py:191: error: Unexpected keyword argument "config_entry" for "DevoloDataUpdateCoordinator"  [call-arg]
homeassistant/components/devolo_home_network/__init__.py:201: error: Unexpected keyword argument "config_entry" for "DevoloDataUpdateCoordinator"  [call-arg]
homeassistant/components/devolo_home_network/__init__.py:211: error: Unexpected keyword argument "config_entry" for "DevoloDataUpdateCoordinator"  [call-arg]
homeassistant/components/devolo_home_network/__init__.py:220: error: Unexpected keyword argument "config_entry" for "DevoloDataUpdateCoordinator"  [call-arg]
homeassistant/components/devolo_home_network/__init__.py:229: error: Unexpected keyword argument "config_entry" for "DevoloDataUpdateCoordinator"  [call-arg]
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
