### PR TITLE
Add support for Python 3.13

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,7 +42,7 @@ env:
   MYPY_CACHE_VERSION: 9
   HA_SHORT_VERSION: "2024.12"
   DEFAULT_PYTHON: "3.12"
-  ALL_PYTHON_VERSIONS: "['3.12']"
+  ALL_PYTHON_VERSIONS: "['3.12', '3.13']"
   # 10.3 is the oldest supported version
   # - 10.3.32 is the version currently shipped with Synology (as of 17 Feb 2022)
   # 10.6 is the current long-term-support

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -112,7 +112,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        abi: ["cp312"]
+        abi: ["cp312", "cp313"]
         arch: ${{ fromJson(needs.init.outputs.architectures) }}
     steps:
       - name: Checkout the repository
@@ -156,7 +156,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        abi: ["cp312"]
+        abi: ["cp312", "cp313"]
         arch: ${{ fromJson(needs.init.outputs.architectures) }}
     steps:
       - name: Checkout the repository

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -198,6 +198,7 @@ jobs:
           split -l $(expr $(expr $(cat requirements_all.txt | wc -l) + 1) / 3) requirements_all_wheels_${{ matrix.arch }}.txt requirements_all.txt
 
       - name: Create requirements for cython<3
+        if: matrix.abi == 'cp312'
         run: |
           # Some dependencies still require 'cython<3'
           # and don't yet use isolated build environments.
@@ -209,6 +210,7 @@ jobs:
 
       - name: Build wheels (old cython)
         uses: home-assistant/wheels@2024.11.0
+        if: matrix.abi == 'cp312'
         with:
           abi: ${{ matrix.abi }}
           tag: musllinux_1_2
@@ -231,7 +233,7 @@ jobs:
           wheels-key: ${{ secrets.WHEELS_KEY }}
           env-file: true
           apk: "bluez-dev;libffi-dev;openssl-dev;glib-dev;eudev-dev;libxml2-dev;libxslt-dev;libpng-dev;libjpeg-turbo-dev;tiff-dev;cups-dev;gmp-dev;mpfr-dev;mpc1-dev;ffmpeg-dev;gammu-dev;yaml-dev;openblas-dev;fftw-dev;lapack-dev;gfortran;blas-dev;eigen-dev;freetype-dev;glew-dev;harfbuzz-dev;hdf5-dev;libdc1394-dev;libtbb-dev;mesa-dev;openexr-dev;openjpeg-dev;uchardet-dev;nasm;zlib-dev"
-          skip-binary: aiohttp;charset-normalizer;grpcio;multidict;SQLAlchemy;propcache;protobuf;pydantic;pymicro-vad;yarl
+          skip-binary: aiohttp;charset-normalizer;grpcio;multidict;SQLAlchemy;propcache;protobuf;pymicro-vad;yarl
           constraints: "homeassistant/package_constraints.txt"
           requirements-diff: "requirements_diff.txt"
           requirements: "requirements_all.txtaa"
@@ -245,7 +247,7 @@ jobs:
           wheels-key: ${{ secrets.WHEELS_KEY }}
           env-file: true
           apk: "bluez-dev;libffi-dev;openssl-dev;glib-dev;eudev-dev;libxml2-dev;libxslt-dev;libpng-dev;libjpeg-turbo-dev;tiff-dev;cups-dev;gmp-dev;mpfr-dev;mpc1-dev;ffmpeg-dev;gammu-dev;yaml-dev;openblas-dev;fftw-dev;lapack-dev;gfortran;blas-dev;eigen-dev;freetype-dev;glew-dev;harfbuzz-dev;hdf5-dev;libdc1394-dev;libtbb-dev;mesa-dev;openexr-dev;openjpeg-dev;uchardet-dev;nasm;zlib-dev"
-          skip-binary: aiohttp;charset-normalizer;grpcio;multidict;SQLAlchemy;propcache;protobuf;pydantic;pymicro-vad;yarl
+          skip-binary: aiohttp;charset-normalizer;grpcio;multidict;SQLAlchemy;propcache;protobuf;pymicro-vad;yarl
           constraints: "homeassistant/package_constraints.txt"
           requirements-diff: "requirements_diff.txt"
           requirements: "requirements_all.txtab"
@@ -259,7 +261,7 @@ jobs:
           wheels-key: ${{ secrets.WHEELS_KEY }}
           env-file: true
           apk: "bluez-dev;libffi-dev;openssl-dev;glib-dev;eudev-dev;libxml2-dev;libxslt-dev;libpng-dev;libjpeg-turbo-dev;tiff-dev;cups-dev;gmp-dev;mpfr-dev;mpc1-dev;ffmpeg-dev;gammu-dev;yaml-dev;openblas-dev;fftw-dev;lapack-dev;gfortran;blas-dev;eigen-dev;freetype-dev;glew-dev;harfbuzz-dev;hdf5-dev;libdc1394-dev;libtbb-dev;mesa-dev;openexr-dev;openjpeg-dev;uchardet-dev;nasm;zlib-dev"
-          skip-binary: aiohttp;charset-normalizer;grpcio;multidict;SQLAlchemy;propcache;protobuf;pydantic;pymicro-vad;yarl
+          skip-binary: aiohttp;charset-normalizer;grpcio;multidict;SQLAlchemy;propcache;protobuf;pymicro-vad;yarl
           constraints: "homeassistant/package_constraints.txt"
           requirements-diff: "requirements_diff.txt"
           requirements: "requirements_all.txtac"

--- a/homeassistant/components/huum/__init__.py
+++ b/homeassistant/components/huum/__init__.py
@@ -3,23 +3,30 @@
 from __future__ import annotations
 
 import logging
-
-from huum.exceptions import Forbidden, NotAuthenticated
-from huum.huum import Huum
+import sys
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import DOMAIN, PLATFORMS
+
+if sys.version_info < (3, 13):
+    from huum.exceptions import Forbidden, NotAuthenticated
+    from huum.huum import Huum
 
 _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Huum from a config entry."""
+    if sys.version_info >= (3, 13):
+        raise HomeAssistantError(
+            "Huum is not supported on Python 3.13. Please use Python 3.12."
+        )
+
     username = entry.data[CONF_USERNAME]
     password = entry.data[CONF_PASSWORD]
 

--- a/homeassistant/components/huum/climate.py
+++ b/homeassistant/components/huum/climate.py
@@ -3,12 +3,8 @@
 from __future__ import annotations
 
 import logging
+import sys
 from typing import Any
-
-from huum.const import SaunaStatus
-from huum.exceptions import SafetyException
-from huum.huum import Huum
-from huum.schemas import HuumStatusResponse
 
 from homeassistant.components.climate import (
     ClimateEntity,
@@ -23,6 +19,12 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
+
+if sys.version_info < (3, 13):
+    from huum.const import SaunaStatus
+    from huum.exceptions import SafetyException
+    from huum.huum import Huum
+    from huum.schemas import HuumStatusResponse
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/huum/config_flow.py
+++ b/homeassistant/components/huum/config_flow.py
@@ -3,10 +3,9 @@
 from __future__ import annotations
 
 import logging
+import sys
 from typing import Any
 
-from huum.exceptions import Forbidden, NotAuthenticated
-from huum.huum import Huum
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
@@ -14,6 +13,10 @@ from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import DOMAIN
+
+if sys.version_info < (3, 13):
+    from huum.exceptions import Forbidden, NotAuthenticated
+    from huum.huum import Huum
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/huum/manifest.json
+++ b/homeassistant/components/huum/manifest.json
@@ -5,5 +5,5 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/huum",
   "iot_class": "cloud_polling",
-  "requirements": ["huum==0.7.11"]
+  "requirements": ["huum==0.7.11;python_version<'3.13'"]
 }

--- a/homeassistant/components/profiler/__init__.py
+++ b/homeassistant/components/profiler/__init__.py
@@ -436,6 +436,10 @@ async def _async_generate_memory_profile(hass: HomeAssistant, call: ServiceCall)
     # Imports deferred to avoid loading modules
     # in memory since usually only one part of this
     # integration is used at a time
+    if sys.version_info >= (3, 13):
+        raise HomeAssistantError(
+            "Memory profiling is not supported on Python 3.13. Please use Python 3.12."
+        )
     from guppy import hpy  # pylint: disable=import-outside-toplevel
 
     start_time = int(time.time() * 1000000)

--- a/homeassistant/components/profiler/manifest.json
+++ b/homeassistant/components/profiler/manifest.json
@@ -7,7 +7,7 @@
   "quality_scale": "internal",
   "requirements": [
     "pyprof2calltree==1.4.5",
-    "guppy3==3.1.4.post1",
+    "guppy3==3.1.4.post1;python_version<'3.13'",
     "objgraph==3.5.0"
   ],
   "single_config_entry": true

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -13,6 +13,7 @@ async-interrupt==1.2.0
 async-upnp-client==0.41.0
 atomicwrites-homeassistant==1.4.1
 attrs==24.2.0
+audioop-lts==0.2.1;python_version>='3.13'
 av==13.1.0
 awesomeversion==24.6.0
 bcrypt==4.2.0
@@ -59,6 +60,8 @@ PyYAML==6.0.2
 requests==2.32.3
 securetar==2024.2.1
 SQLAlchemy==2.0.31
+standard-aifc==3.13.0;python_version>='3.13'
+standard-telnetlib==3.13.0;python_version>='3.13'
 typing-extensions>=4.12.2,<5.0
 ulid-transform==1.0.2
 urllib3>=1.26.5,<2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -620,6 +620,17 @@ filterwarnings = [
     # https://github.com/ssaenger/pyws66i/blob/v1.1/pyws66i/__init__.py#L2
     "ignore:'telnetlib' is deprecated and slated for removal in Python 3.13:DeprecationWarning:pyws66i",
 
+    # -- New in Python 3.13
+    # https://github.com/kurtmckee/feedparser/pull/389 - >6.0.11
+    # https://github.com/kurtmckee/feedparser/issues/481
+    "ignore:'count' is passed as positional argument:DeprecationWarning:feedparser.html",
+    # https://github.com/youknowone/python-deadlib - Backports for aifc, telnetlib
+    "ignore:aifc was removed in Python 3.13.*'standard-aifc':DeprecationWarning:speech_recognition",
+    "ignore:telnetlib was removed in Python 3.13.*'standard-telnetlib':DeprecationWarning:homeassistant.components.hddtemp.sensor",
+    "ignore:telnetlib was removed in Python 3.13.*'standard-telnetlib':DeprecationWarning:ndms2_client.connection",
+    "ignore:telnetlib was removed in Python 3.13.*'standard-telnetlib':DeprecationWarning:plumlightpad.lightpad",
+    "ignore:telnetlib was removed in Python 3.13.*'standard-telnetlib':DeprecationWarning:pyws66i",
+
     # -- unmaintained projects, last release about 2+ years
     # https://pypi.org/project/agent-py/ - v0.0.23 - 2020-06-04
     "ignore:with timeout\\(\\) is deprecated:DeprecationWarning:agent.a",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies    = [
     "async-interrupt==1.2.0",
     "attrs==24.2.0",
     "atomicwrites-homeassistant==1.4.1",
+    "audioop-lts==0.2.1;python_version>='3.13'",
     "awesomeversion==24.6.0",
     "bcrypt==4.2.0",
     "certifi>=2021.5.30",
@@ -65,6 +66,8 @@ dependencies    = [
     "requests==2.32.3",
     "securetar==2024.2.1",
     "SQLAlchemy==2.0.31",
+    "standard-aifc==3.13.0;python_version>='3.13'",
+    "standard-telnetlib==3.13.0;python_version>='3.13'",
     "typing-extensions>=4.12.2,<5.0",
     "ulid-transform==1.0.2",
     # Constrain urllib3 to ensure we deal with CVE-2020-26137 and CVE-2021-33503

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ astral==2.2
 async-interrupt==1.2.0
 attrs==24.2.0
 atomicwrites-homeassistant==1.4.1
+audioop-lts==0.2.1;python_version>='3.13'
 awesomeversion==24.6.0
 bcrypt==4.2.0
 certifi>=2021.5.30
@@ -37,6 +38,8 @@ PyYAML==6.0.2
 requests==2.32.3
 securetar==2024.2.1
 SQLAlchemy==2.0.31
+standard-aifc==3.13.0;python_version>='3.13'
+standard-telnetlib==3.13.0;python_version>='3.13'
 typing-extensions>=4.12.2,<5.0
 ulid-transform==1.0.2
 urllib3>=1.26.5,<2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1066,7 +1066,7 @@ gspread==5.5.0
 gstreamer-player==1.1.2
 
 # homeassistant.components.profiler
-guppy3==3.1.4.post1
+guppy3==3.1.4.post1;python_version<'3.13'
 
 # homeassistant.components.iaqualink
 h2==4.1.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1148,7 +1148,7 @@ httplib2==0.20.4
 huawei-lte-api==1.10.0
 
 # homeassistant.components.huum
-huum==0.7.11
+huum==0.7.11;python_version<'3.13'
 
 # homeassistant.components.hyperion
 hyperion-py==0.7.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -904,7 +904,7 @@ growattServer==1.5.0
 gspread==5.5.0
 
 # homeassistant.components.profiler
-guppy3==3.1.4.post1
+guppy3==3.1.4.post1;python_version<'3.13'
 
 # homeassistant.components.iaqualink
 h2==4.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -971,7 +971,7 @@ httplib2==0.20.4
 huawei-lte-api==1.10.0
 
 # homeassistant.components.huum
-huum==0.7.11
+huum==0.7.11;python_version<'3.13'
 
 # homeassistant.components.hyperion
 hyperion-py==0.7.5

--- a/tests/components/huum/conftest.py
+++ b/tests/components/huum/conftest.py
@@ -1,0 +1,6 @@
+"""Skip test collection for Python 3.13."""
+
+import sys
+
+if sys.version_info >= (3, 13):
+    collect_ignore_glob = ["test_*.py"]

--- a/tests/components/profiler/test_init.py
+++ b/tests/components/profiler/test_init.py
@@ -5,6 +5,7 @@ from functools import lru_cache
 import logging
 import os
 from pathlib import Path
+import sys
 from unittest.mock import patch
 
 from freezegun.api import FrozenDateTimeFactory
@@ -70,6 +71,9 @@ async def test_basic_usage(hass: HomeAssistant, tmp_path: Path) -> None:
     await hass.async_block_till_done()
 
 
+@pytest.mark.skipif(
+    sys.version_info >= (3, 13), reason="not yet available on Python 3.13"
+)
 async def test_memory_usage(hass: HomeAssistant, tmp_path: Path) -> None:
     """Test we can setup and the service is registered."""
     test_dir = tmp_path / "profiles"
@@ -99,6 +103,24 @@ async def test_memory_usage(hass: HomeAssistant, tmp_path: Path) -> None:
 
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
+
+
+@pytest.mark.skipif(sys.version_info < (3, 13), reason="still works on python 3.12")
+async def test_memory_usage_py313(hass: HomeAssistant, tmp_path: Path) -> None:
+    """Test raise an error on python3.13."""
+    entry = MockConfigEntry(domain=DOMAIN)
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    assert hass.services.has_service(DOMAIN, SERVICE_MEMORY)
+    with pytest.raises(
+        HomeAssistantError,
+        match="Memory profiling is not supported on Python 3.13. Please use Python 3.12.",
+    ):
+        await hass.services.async_call(
+            DOMAIN, SERVICE_MEMORY, {CONF_SECONDS: 0.000001}, blocking=True
+        )
 
 
 async def test_object_growth_logging(


### PR DESCRIPTION
## Breaking change
The `profiler.memory` service is not available when using Python 3.13. It will return if and when `guppy3` becomes Python 3.13 compatible.

## Proposed change
Add initial support for Python 3.13.
The following integrations don't work yet.
- [x] `Anthropic` depends on `tokenizers` => fixed with `0.20.3`
https://github.com/huggingface/tokenizers/issues/1639
https://github.com/huggingface/tokenizers/pull/1665
https://github.com/huggingface/tokenizers/issues/1672
- [x] `Comelit SimpleHome` and `WeatherFlow` depend on `Pint`
https://github.com/hgrecco/pint/issues/1969
https://github.com/hgrecco/pint/issues/2065
https://github.com/hgrecco/pint/issues/2074
https://github.com/hgrecco/pint/pull/2037
https://github.com/hgrecco/flexparser/issues/12
#130070
- [ ] `Profiler` depends (partially) on `guppy3==3.1.3`
Error building wheel for Python 3.13
https://github.com/zhuyifei1999/guppy3
- [x] `Environment Canada`, `EZVIZ`, `Kraken`, `NOAA Tides` depend on `pandas>=2.2.0`
which can't be build on `armv7`, `i386`.
https://github.com/pandas-dev/pandas/issues/59905
https://github.com/pandas-dev/pandas/pull/59906
https://github.com/pandas-dev/pandas/pull/59937
https://github.com/pandas-dev/pandas/issues/59664
https://github.com/home-assistant/core/pull/129958
- [x] `Huum` depends on `huum==0.7.11` => fixed with `0.7.12`
https://github.com/frwickst/pyhuum/pull/10
https://github.com/home-assistant/core/pull/130527


[PEP 594](https://peps.python.org/pep-0594/) removed a lot of "dead" batteries from the stdlib. Unfortunately, those are not quite dead yet and a lot of integrations and dependencies still use them. Fortunately there are backport libraries available which we can use instead. At some point, we might want to remove them as well, but they certainly make the transition easier.

**Additional dependencies**
- [x] `audioop-lts`
https://github.com/AbstractUmbra/audioop
  - [ ] `Assist pipeline`
  - [ ] `Tami4 Edge / Edge+` -> `Tami4EdgeAPI` -> `PyPasser` -> `pydub==0.25.1`
https://github.com/jiaaro/pydub/issues/725
  - [ ] `Voice over IP` -> `voip-utils==0.1.0`
https://github.com/home-assistant-libs/voip-utils

- [x] `standard-aifc`, ~~`standard-imghdr`~~ and `standard-telnetlib`
https://github.com/youknowone/python-deadlib
  - [ ] `aifc` used by:
    - [ ] `Tami4 Edge / Edge+` -> `Tami4EdgeAPI` -> `PyPasser` -> `SpeechRecognition==3.8.1`
    => fixed with `3.12.0`
https://github.com/Uberi/speech_recognition/issues/775
https://github.com/Uberi/speech_recognition/pull/781
  - [x] `imghdr` used by:
    - [x] `Apple TV` -> `pyatv` -> `mediafile==0.12.0` => fixed with `0.13.0`
https://github.com/beetbox/mediafile/issues/67
https://github.com/beetbox/mediafile/pull/75
  - [ ] `telnetlib` used by:
    - [ ] `Discord` -> `nextcord==2.6.0`
https://github.com/nextcord/nextcord/issues/1174
    - [ ] `Keenetic NDMS2 Router` -> `ndms2-client==0.1.2`
https://github.com/foxel/python_ndms2_client/issues/6
https://github.com/foxel/python_ndms2_client/pull/8
    - [ ] `Plum Lightpad` -> `plumlightpad==0.0.11`
https://github.com/heathbar/plum-lightpad-python/issues/7
    - [ ] `Soundavo WS66i 6-Zone Amplifier` -> `pyws66i==1.1`
https://github.com/ssaenger/pyws66i
    - [ ] `Actiontec`
    - [ ] `Denon Network Receivers`
    - [ ] `hddtemp`
    - [ ] `Pioneer`
    - [ ] `Telnet`
    - [ ] `Thomson`

--
For reference the Python 3.12 update:
- https://github.com/home-assistant/core/pull/101651

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
