### PR TITLE
Add todo.remove_all_items action

### DIFF
--- a/homeassistant/components/todo/__init__.py
+++ b/homeassistant/components/todo/__init__.py
@@ -190,6 +190,12 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         _async_remove_completed_items,
         required_features=[TodoListEntityFeature.DELETE_TODO_ITEM],
     )
+    component.async_register_entity_service(
+        TodoServices.REMOVE_ALL_ITEMS,
+        None,
+        _async_remove_all_items,
+        required_features=[TodoListEntityFeature.DELETE_TODO_ITEM],
+    )
 
     await component.async_setup(config)
     return True
@@ -540,5 +546,12 @@ async def _async_remove_completed_items(entity: TodoListEntity, _: ServiceCall) 
         for item in entity.todo_items or ()
         if item.status == TodoItemStatus.COMPLETED and item.uid
     ]
+    if uids:
+        await entity.async_delete_todo_items(uids=uids)
+
+
+async def _async_remove_all_items(entity: TodoListEntity, _: ServiceCall) -> None:
+    """Remove all items from the To-do list."""
+    uids = [item.uid for item in entity.todo_items or () if item.uid]
     if uids:
         await entity.async_delete_todo_items(uids=uids)

--- a/homeassistant/components/todo/const.py
+++ b/homeassistant/components/todo/const.py
@@ -32,6 +32,7 @@ class TodoServices(StrEnum):
     REMOVE_ITEM = "remove_item"
     GET_ITEMS = "get_items"
     REMOVE_COMPLETED_ITEMS = "remove_completed_items"
+    REMOVE_ALL_ITEMS = "remove_all_items"
 
 
 class TodoListEntityFeature(IntFlag):

--- a/homeassistant/components/todo/icons.json
+++ b/homeassistant/components/todo/icons.json
@@ -14,6 +14,9 @@
     "remove_completed_items": {
       "service": "mdi:clipboard-remove"
     },
+    "remove_all_items": {
+      "service": "mdi:clipboard-off"
+    },
     "remove_item": {
       "service": "mdi:clipboard-minus"
     },

--- a/homeassistant/components/todo/services.yaml
+++ b/homeassistant/components/todo/services.yaml
@@ -109,3 +109,9 @@ remove_completed_items:
       domain: todo
       supported_features:
         - todo.TodoListEntityFeature.DELETE_TODO_ITEM
+remove_all_items:
+  target:
+    entity:
+      domain: todo
+      supported_features:
+        - todo.TodoListEntityFeature.DELETE_TODO_ITEM

--- a/homeassistant/components/todo/strings.json
+++ b/homeassistant/components/todo/strings.json
@@ -72,6 +72,10 @@
       "name": "Remove all completed to-do list items",
       "description": "Remove all to-do list items that have been completed."
     },
+    "remove_all_items": {
+      "name": "Remove all to-do list items",
+      "description": "Remove all to-do list items, clearing the to-do list."
+    },
     "remove_item": {
       "name": "Remove a to-do list item",
       "description": "Remove an existing to-do list item by its name.",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add a "remove_all_items" action to the todo integration. It is pretty much a copy-paste of the "remove_completed_items", just without the filter for whether items are completed.

Rationale: This will make automation of todo list resets a lot cleaner, see how people suggest doing this today https://community.home-assistant.io/t/todo-list-update-multiple-items-in-automation-reset-whole-list/635304 / https://www.reddit.com/r/homeassistant/comments/18xthx7/resetting_todo_lists/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/35462

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository] [PR #129456](https://github.com/home-assistant/home-assistant.io/pull/35462)

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
