### PR TITLE
Bump automower-ble to 0.2.0

### DIFF
--- a/homeassistant/components/husqvarna_automower_ble/coordinator.py
+++ b/homeassistant/components/husqvarna_automower_ble/coordinator.py
@@ -75,19 +75,19 @@ class HusqvarnaCoordinator(DataUpdateCoordinator[dict[str, bytes]]):
 
         try:
             data["battery_level"] = await self.mower.battery_level()
-            LOGGER.debug(data["battery_level"])
+            LOGGER.debug("battery_level" + str(data["battery_level"]))
             if data["battery_level"] is None:
                 await self._async_find_device()
                 raise UpdateFailed("Error getting data from device")
 
             data["activity"] = await self.mower.mower_activity()
-            LOGGER.debug(data["activity"])
+            LOGGER.debug("activity:" + str(data["activity"]))
             if data["activity"] is None:
                 await self._async_find_device()
                 raise UpdateFailed("Error getting data from device")
 
             data["state"] = await self.mower.mower_state()
-            LOGGER.debug(data["state"])
+            LOGGER.debug("state:" + str(data["state"]))
             if data["state"] is None:
                 await self._async_find_device()
                 raise UpdateFailed("Error getting data from device")

--- a/homeassistant/components/husqvarna_automower_ble/lawn_mower.py
+++ b/homeassistant/components/husqvarna_automower_ble/lawn_mower.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from automower_ble.protocol import MowerActivity, MowerState
+
 from homeassistant.components import bluetooth
 from homeassistant.components.lawn_mower import (
     LawnMowerActivity,
@@ -60,29 +62,31 @@ class AutomowerLawnMower(HusqvarnaAutomowerBleEntity, LawnMowerEntity):
         if self.coordinator.data is None:
             return None
 
-        state = str(self.coordinator.data["state"])
-        activity = str(self.coordinator.data["activity"])
+        state = self.coordinator.data["state"]
+        activity = self.coordinator.data["activity"]
 
         if state is None or activity is None:
             return None
 
-        if state == "paused":
+        if state == MowerState.PAUSED:
             return LawnMowerActivity.PAUSED
-        if state in ("stopped", "off", "waitForSafetyPin"):
+        if state in (MowerState.STOPPED, MowerState.OFF, MowerState.WAIT_FOR_SAFETYPIN):
             # This is actually stopped, but that isn't an option
             return LawnMowerActivity.ERROR
         if state in (
-            "restricted",
-            "inOperation",
-            "unknown",
-            "checkSafety",
-            "pendingStart",
+            MowerState.RESTRICTED,
+            MowerState.IN_OPERATION,
+            MowerState.PENDING_START,
         ):
-            if activity in ("charging", "parked", "none"):
+            if activity in (
+                MowerActivity.CHARGING,
+                MowerActivity.PARKED,
+                MowerActivity.NONE,
+            ):
                 return LawnMowerActivity.DOCKED
-            if activity in ("goingOut", "mowing"):
+            if activity in (MowerActivity.GOING_OUT, MowerActivity.MOWING):
                 return LawnMowerActivity.MOWING
-            if activity in ("goingHome"):
+            if activity == MowerActivity.GOING_HOME:
                 return LawnMowerActivity.RETURNING
         return LawnMowerActivity.ERROR
 

--- a/homeassistant/components/husqvarna_automower_ble/manifest.json
+++ b/homeassistant/components/husqvarna_automower_ble/manifest.json
@@ -12,5 +12,5 @@
   "dependencies": ["bluetooth_adapters"],
   "documentation": "https://www.home-assistant.io/integrations/???",
   "iot_class": "local_polling",
-  "requirements": ["automower-ble==0.1.35"]
+  "requirements": ["automower-ble==0.2.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -524,7 +524,7 @@ aurorapy==0.2.7
 autarco==3.0.0
 
 # homeassistant.components.husqvarna_automower_ble
-automower-ble==0.1.35
+automower-ble==0.2.0
 
 # homeassistant.components.avea
 # avea==1.5.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -479,7 +479,7 @@ aurorapy==0.2.7
 autarco==3.0.0
 
 # homeassistant.components.husqvarna_automower_ble
-automower-ble==0.1.35
+automower-ble==0.2.0
 
 # homeassistant.components.axis
 axis==63


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Update the dependency for husqvarna_automower_ble and support the new API.

The 0.2.0 version of the automower-ble library includes the following key changes:
 * Full rewrite of protocol to use a generic json file instead of Python array
     * This includes support for more commands
 * Verified support for a range of Gardena, Flymo and Husqvarna mowers
 * A lot of fixed to be more robust with flaky connections and strange mower responses

A full list of commits can be seen here: https://github.com/alistair23/AutoMower-BLE/compare/0.1.35...0.2.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
