### PR TITLE
Bump zwave-js-server-python to 0.59.0

### DIFF
--- a/homeassistant/components/zwave_js/manifest.json
+++ b/homeassistant/components/zwave_js/manifest.json
@@ -9,7 +9,7 @@
   "iot_class": "local_push",
   "loggers": ["zwave_js_server"],
   "quality_scale": "platinum",
-  "requirements": ["pyserial==3.5", "zwave-js-server-python==0.58.1"],
+  "requirements": ["pyserial==3.5", "zwave-js-server-python==0.59.0"],
   "usb": [
     {
       "vid": "0658",

--- a/homeassistant/components/zwave_js/services.py
+++ b/homeassistant/components/zwave_js/services.py
@@ -529,8 +529,15 @@ class ZWaveServices:
             for node_or_endpoint, result in get_valid_responses_from_results(
                 nodes_or_endpoints_list, _results
             ):
-                zwave_value = result[0]
-                cmd_status = result[1]
+                if value_size is None:
+                    # async_set_config_parameter still returns (Value, SetConfigParameterResult)
+                    zwave_value = result[0]
+                    cmd_status = result[1]
+                else:
+                    # async_set_raw_config_parameter_value now returns just SetConfigParameterResult
+                    cmd_status = result
+                    zwave_value = f"parameter {property_or_property_name}"
+
                 if cmd_status.status == CommandStatus.ACCEPTED:
                     msg = "Set configuration parameter %s on Node %s with value %s"
                 else:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3078,7 +3078,7 @@ ziggo-mediabox-xl==1.1.0
 zm-py==0.5.4
 
 # homeassistant.components.zwave_js
-zwave-js-server-python==0.58.1
+zwave-js-server-python==0.59.0
 
 # homeassistant.components.zwave_me
 zwave-me-ws==0.4.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2452,7 +2452,7 @@ zeversolar==0.3.2
 zha==0.0.36
 
 # homeassistant.components.zwave_js
-zwave-js-server-python==0.58.1
+zwave-js-server-python==0.59.0
 
 # homeassistant.components.zwave_me
 zwave-me-ws==0.4.3

--- a/tests/components/zwave_js/test_services.py
+++ b/tests/components/zwave_js/test_services.py
@@ -497,13 +497,12 @@ async def test_set_config_parameter(
 
     caplog.clear()
 
-    config_value = aeotec_zw164_siren.values["2-112-0-32"]
     cmd_result = SetConfigParameterResult("accepted", {"status": 255})
 
     # Test accepted return
     with patch(
         "homeassistant.components.zwave_js.services.Endpoint.async_set_raw_config_parameter_value",
-        return_value=(config_value, cmd_result),
+        return_value=cmd_result,
     ) as mock_set_raw_config_parameter_value:
         await hass.services.async_call(
             DOMAIN,
@@ -534,7 +533,7 @@ async def test_set_config_parameter(
     cmd_result.status = "queued"
     with patch(
         "homeassistant.components.zwave_js.services.Endpoint.async_set_raw_config_parameter_value",
-        return_value=(config_value, cmd_result),
+        return_value=cmd_result,
     ) as mock_set_raw_config_parameter_value:
         await hass.services.async_call(
             DOMAIN,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
With this release, you will need to update your zwave-js-server instance. You must use zwave-js-server 1.39.0 or greater (schema 39).
- If you use the Z-Wave JS add-on, you need at least version 0.9.0.
- If you use the Z-Wave JS UI add-on, you need at least version [3.17.0](https://github.com/hassio-addons/addon-zwave-js-ui/releases/tag/v3.17.0).
- If you use the Z-Wave JS UI Docker container, you need at least version [9.26.0](https://github.com/zwave-js/zwave-js-ui/releases/tag/v9.26.0).
- If you run your own Docker container or some other installation method, you will need to update your zwave-js-server instance to at least 1.39.0.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update zwave-js-server-python and tweak async_set_config_parameter service to match the update

https://github.com/home-assistant-libs/zwave-js-server-python/releases/tag/0.59.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
