### PR TITLE
Fix webrtc provider interface and tests

### DIFF
--- a/homeassistant/components/camera/webrtc.py
+++ b/homeassistant/components/camera/webrtc.py
@@ -135,6 +135,7 @@ class CameraWebRTCProvider(Protocol):
     @callback
     def async_close_session(self, session_id: str) -> None:
         """Close the session."""
+        return  ## This is an optional method so we need a default here.
 
 
 class CameraWebRTCLegacyProvider(Protocol):

--- a/homeassistant/components/go2rtc/__init__.py
+++ b/homeassistant/components/go2rtc/__init__.py
@@ -128,6 +128,7 @@ class WebRTCProvider(CameraWebRTCProvider):
         self._rest_client = Go2RtcRestClient(self._session, url)
         self._sessions: dict[str, Go2RtcWsClient] = {}
 
+    @callback
     def async_is_supported(self, stream_source: str) -> bool:
         """Return if this provider is supports the Camera as source."""
         return stream_source.partition(":")[0] in _SUPPORTED_STREAMS

--- a/tests/components/camera/common.py
+++ b/tests/components/camera/common.py
@@ -6,13 +6,6 @@ components. Instead call the service directly.
 
 from unittest.mock import Mock
 
-from homeassistant.components.camera import Camera
-from homeassistant.components.camera.webrtc import (
-    CameraWebRTCProvider,
-    async_register_webrtc_provider,
-)
-from homeassistant.core import HomeAssistant
-
 EMPTY_8_6_JPEG = b"empty_8_6"
 WEBRTC_ANSWER = "a=sendonly"
 STREAM_SOURCE = "rtsp://127.0.0.1/stream"
@@ -30,25 +23,3 @@ def mock_turbo_jpeg(
     mocked_turbo_jpeg.scale_with_quality.return_value = EMPTY_8_6_JPEG
     mocked_turbo_jpeg.encode.return_value = EMPTY_8_6_JPEG
     return mocked_turbo_jpeg
-
-
-async def add_webrtc_provider(hass: HomeAssistant) -> CameraWebRTCProvider:
-    """Add test WebRTC provider."""
-
-    class SomeTestProvider(CameraWebRTCProvider):
-        """Test provider."""
-
-        async def async_is_supported(self, stream_source: str) -> bool:
-            """Determine if the provider supports the stream source."""
-            return True
-
-        async def async_handle_web_rtc_offer(
-            self, camera: Camera, offer_sdp: str
-        ) -> str | None:
-            """Handle the WebRTC offer and return an answer."""
-            return "answer"
-
-    provider = SomeTestProvider()
-    async_register_webrtc_provider(hass, provider)
-    await hass.async_block_till_done()
-    return provider

--- a/tests/components/camera/test_init.py
+++ b/tests/components/camera/test_init.py
@@ -938,11 +938,6 @@ async def _test_capabilities(
     class SomeTestProvider(CameraWebRTCProvider):
         """Test provider."""
 
-        @property
-        def domain(self) -> str:
-            """Return the integration domain of the provider."""
-            return "test"
-
         @callback
         def async_is_supported(self, stream_source: str) -> bool:
             """Determine if the provider supports the stream source."""

--- a/tests/components/camera/test_init.py
+++ b/tests/components/camera/test_init.py
@@ -9,6 +9,13 @@ import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components import camera
+from homeassistant.components.camera import (
+    Camera,
+    CameraWebRTCProvider,
+    WebRTCAnswer,
+    WebRTCSendMessage,
+    async_register_webrtc_provider,
+)
 from homeassistant.components.camera.const import (
     DOMAIN,
     PREF_ORIENTATION,
@@ -23,20 +30,14 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_STARTED,
     STATE_UNAVAILABLE,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.core_config import async_process_ha_core_config
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er, issue_registry as ir
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
-from .common import (
-    EMPTY_8_6_JPEG,
-    STREAM_SOURCE,
-    WEBRTC_ANSWER,
-    add_webrtc_provider,
-    mock_turbo_jpeg,
-)
+from .common import EMPTY_8_6_JPEG, STREAM_SOURCE, WEBRTC_ANSWER, mock_turbo_jpeg
 
 from tests.common import (
     MockConfigEntry,
@@ -933,7 +934,38 @@ async def _test_capabilities(
     await test(expected_stream_types)
 
     # Test with WebRTC provider
-    await add_webrtc_provider(hass)
+
+    class SomeTestProvider(CameraWebRTCProvider):
+        """Test provider."""
+
+        @property
+        def domain(self) -> str:
+            """Return the integration domain of the provider."""
+            return "test"
+
+        @callback
+        def async_is_supported(self, stream_source: str) -> bool:
+            """Determine if the provider supports the stream source."""
+            return True
+
+        async def async_handle_async_webrtc_offer(
+            self,
+            camera: Camera,
+            offer_sdp: str,
+            session_id: str,
+            send_message: WebRTCSendMessage,
+        ) -> None:
+            """Handle the WebRTC offer and return the answer via the provided callback."""
+            send_message(WebRTCAnswer("answer"))
+
+        async def async_on_webrtc_candidate(
+            self, session_id: str, candidate: str
+        ) -> None:
+            """Handle the WebRTC candidate."""
+
+    provider = SomeTestProvider()
+    async_register_webrtc_provider(hass, provider)
+    await hass.async_block_till_done()
     await test(expected_stream_types_with_webrtc_provider)
 
 

--- a/tests/components/camera/test_webrtc.py
+++ b/tests/components/camera/test_webrtc.py
@@ -1086,3 +1086,42 @@ async def test_ws_webrtc_candidate_invalid_stream_type(
         "code": "webrtc_candidate_failed",
         "message": "Camera does not support WebRTC, frontend_stream_type=hls",
     }
+
+
+async def test_webrtc_provider_optional_interface(hass: HomeAssistant) -> None:
+    """Test optional interface for WebRTC provider."""
+
+    class OnlyRequiredInterfaceProvider(CameraWebRTCProvider):
+        """Test provider."""
+
+        @callback
+        def async_is_supported(self, stream_source: str) -> bool:
+            """Determine if the provider supports the stream source."""
+            return True
+
+        async def async_handle_async_webrtc_offer(
+            self,
+            camera: Camera,
+            offer_sdp: str,
+            session_id: str,
+            send_message: WebRTCSendMessage,
+        ) -> None:
+            """Handle the WebRTC offer and return the answer via the provided callback.
+
+            Return value determines if the offer was handled successfully.
+            """
+            send_message(WebRTCAnswer(answer="answer"))
+
+        async def async_on_webrtc_candidate(
+            self, session_id: str, candidate: str
+        ) -> None:
+            """Handle the WebRTC candidate."""
+
+    provider = OnlyRequiredInterfaceProvider()
+    # Call all interface methods
+    assert provider.async_is_supported("stream_source") is True
+    await provider.async_handle_async_webrtc_offer(
+        Mock(), "offer_sdp", "session_id", Mock()
+    )
+    await provider.async_on_webrtc_candidate("session_id", "candidate")
+    provider.async_close_session("session_id")

--- a/tests/components/camera/test_webrtc.py
+++ b/tests/components/camera/test_webrtc.py
@@ -56,6 +56,7 @@ class TestProvider(CameraWebRTCProvider):
         """Initialize the provider."""
         self._is_supported = True
 
+    @callback
     def async_is_supported(self, stream_source: str) -> bool:
         """Determine if the provider supports the stream source."""
         return self._is_supported


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Decorate `async_is_supported` with `@callback` in all places except legacy provider.
- Fix test that didn't create a valid provider.
- We're still not awaiting the legacy provider `async_is_supported` properly but that will be fixed by my other PR and I didn't want to cause more merge conflicts around that code. https://github.com/home-assistant/core/pull/129334

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
