### PR TITLE
Fix kitchen_sink options flow defaults

### DIFF
--- a/homeassistant/components/kitchen_sink/config_flow.py
+++ b/homeassistant/components/kitchen_sink/config_flow.py
@@ -15,11 +15,18 @@ from homeassistant.config_entries import (
     OptionsFlowWithConfigEntry,
 )
 from homeassistant.core import callback
+from homeassistant.helpers.selector import (
+    SelectSelector,
+    SelectSelectorConfig,
+    SelectSelectorMode,
+)
 
 from . import DOMAIN
 
 CONF_BOOLEAN = "bool"
 CONF_INT = "int"
+CONF_SELECT_POWER = "select_power"
+CONF_SELECT_POWER_MODES = ["normal", "high", "awesome"]
 
 
 class KitchenSinkConfigFlow(ConfigFlow, domain=DOMAIN):
@@ -71,6 +78,8 @@ class OptionsFlowHandler(OptionsFlowWithConfigEntry):
             self.options.update(user_input)
             return await self._update_options()
 
+        section_1 = self.config_entry.options.get("section_1", {})
+
         return self.async_show_form(
             step_id="options_1",
             data_schema=vol.Schema(
@@ -80,14 +89,25 @@ class OptionsFlowHandler(OptionsFlowWithConfigEntry):
                             {
                                 vol.Optional(
                                     CONF_BOOLEAN,
-                                    default=self.config_entry.options.get(
-                                        CONF_BOOLEAN, False
-                                    ),
+                                    default=section_1.get(CONF_BOOLEAN, False),
                                 ): bool,
                                 vol.Optional(
                                     CONF_INT,
-                                    default=self.config_entry.options.get(CONF_INT, 10),
+                                    default=section_1.get(CONF_INT, 10),
                                 ): int,
+                                vol.Optional(
+                                    CONF_SELECT_POWER,
+                                    default=section_1.get(
+                                        CONF_SELECT_POWER, CONF_SELECT_POWER_MODES[0]
+                                    ),
+                                ): SelectSelector(
+                                    SelectSelectorConfig(
+                                        options=CONF_SELECT_POWER_MODES,
+                                        translation_key=CONF_SELECT_POWER,
+                                        multiple=False,
+                                        mode=SelectSelectorMode.LIST,
+                                    )
+                                ),
                             }
                         ),
                         {"collapsed": False},

--- a/homeassistant/components/kitchen_sink/strings.json
+++ b/homeassistant/components/kitchen_sink/strings.json
@@ -19,13 +19,26 @@
           "section_1": {
             "data": {
               "bool": "Optional boolean",
-              "int": "Numeric input"
+              "int": "Numeric input",
+              "select_power": "Garbage disposal power mode"
+            },
+            "data_description": {
+              "select_power": "Select a mode of operation for the disposal"
             },
             "description": "This section allows input of some extra data",
             "name": "Collapsible section"
           }
         },
         "submit": "Save!"
+      }
+    }
+  },
+  "selector": {
+    "select_power": {
+      "options": {
+        "normal": "Normal power",
+        "high": "High power",
+        "awesome": "Awesome power"
       }
     }
   },

--- a/script/hassfest/translations.py
+++ b/script/hassfest/translations.py
@@ -172,6 +172,9 @@ def gen_data_entry_schema(
                 vol.Optional("sections"): {
                     str: {
                         vol.Optional("data"): {str: translation_value_validator},
+                        vol.Optional("data_description"): {
+                            str: translation_value_validator
+                        },
                         vol.Optional("description"): translation_value_validator,
                         vol.Optional("name"): translation_value_validator,
                     },

--- a/tests/components/kitchen_sink/test_config_flow.py
+++ b/tests/components/kitchen_sink/test_config_flow.py
@@ -98,9 +98,11 @@ async def test_options_flow(hass: HomeAssistant) -> None:
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
-        user_input={"section_1": {"bool": True, "int": 15}},
+        user_input={"section_1": {"bool": True, "int": 15, "select_power": "high"}},
     )
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert config_entry.options == {"section_1": {"bool": True, "int": 15}}
+    assert config_entry.options == {
+        "section_1": {"bool": True, "int": 15, "select_power": "high"}
+    }
 
     await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

- Kitchen sink options flow sections demo was not correctly restoring the previously saved values (even though it seemed to be attempting to do so). I have fixed this to retrieve the previously saved value.

- Add a select selector for purposes of testing https://github.com/home-assistant/frontend/issues/22590, also to exhibit an example usage of selectors and more translations in config flow sections. 

- Fix hassfest script which was blocking me from adding a data_description to a section, which I believe should be allowed per https://developers.home-assistant.io/docs/data_entry_flow_index#labels--descriptions

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
