### PR TITLE
Add optional category in OptionsFlow to holiday

### DIFF
--- a/homeassistant/components/holiday/__init__.py
+++ b/homeassistant/components/holiday/__init__.py
@@ -11,7 +11,7 @@ from homeassistant.const import CONF_COUNTRY, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import SetupPhases, async_pause_setup
 
-from .const import CONF_PROVINCE
+from .const import CONF_CATEGORIES, CONF_PROVINCE
 
 PLATFORMS: list[Platform] = [Platform.CALENDAR]
 
@@ -20,6 +20,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Holiday from a config entry."""
     country: str = entry.data[CONF_COUNTRY]
     province: str | None = entry.data.get(CONF_PROVINCE)
+    categories: list[str] | None = entry.data.get(CONF_CATEGORIES)
 
     # We only import here to ensure that that its not imported later
     # in the event loop since the platforms will call country_holidays
@@ -29,7 +30,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # the holidays library and it is not thread safe to import it in parallel
         # https://github.com/python/cpython/issues/83065
         await hass.async_add_import_executor_job(
-            partial(country_holidays, country, subdiv=province)
+            partial(country_holidays, country, subdiv=province, categories=categories)
         )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/homeassistant/components/holiday/__init__.py
+++ b/homeassistant/components/holiday/__init__.py
@@ -34,8 +34,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    entry.async_on_unload(entry.add_update_listener(update_listener))
 
     return True
+
+
+async def update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Handle options update."""
+    await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/holiday/__init__.py
+++ b/homeassistant/components/holiday/__init__.py
@@ -20,7 +20,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Holiday from a config entry."""
     country: str = entry.data[CONF_COUNTRY]
     province: str | None = entry.data.get(CONF_PROVINCE)
-    categories: list[str] | None = entry.data.get(CONF_CATEGORIES)
+    categories: list[str] | None = entry.options.get(CONF_CATEGORIES)
 
     # We only import here to ensure that that its not imported later
     # in the event loop since the platforms will call country_holidays

--- a/homeassistant/components/holiday/calendar.py
+++ b/homeassistant/components/holiday/calendar.py
@@ -15,11 +15,14 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_track_point_in_utc_time
 from homeassistant.util import dt as dt_util
 
-from .const import CONF_PROVINCE, DOMAIN
+from .const import CONF_CATEGORIES, CONF_PROVINCE, DOMAIN
 
 
 def _get_obj_holidays_and_language(
-    country: str, province: str | None, language: str
+    country: str,
+    province: str | None,
+    language: str,
+    categories: list[str] | None,
 ) -> tuple[HolidayBase, str]:
     """Get the object for the requested country and year."""
     obj_holidays = country_holidays(
@@ -27,6 +30,7 @@ def _get_obj_holidays_and_language(
         subdiv=province,
         years={dt_util.now().year, dt_util.now().year + 1},
         language=language,
+        categories=categories,
     )
     if language == "en":
         for lang in obj_holidays.supported_languages:
@@ -36,6 +40,7 @@ def _get_obj_holidays_and_language(
                     subdiv=province,
                     years={dt_util.now().year, dt_util.now().year + 1},
                     language=lang,
+                    categories=categories,
                 )
                 language = lang
                 break
@@ -49,6 +54,7 @@ def _get_obj_holidays_and_language(
             subdiv=province,
             years={dt_util.now().year, dt_util.now().year + 1},
             language=default_language,
+            categories=categories,
         )
         language = default_language
 
@@ -63,10 +69,11 @@ async def async_setup_entry(
     """Set up the Holiday Calendar config entry."""
     country: str = config_entry.data[CONF_COUNTRY]
     province: str | None = config_entry.data.get(CONF_PROVINCE)
+    categories: list[str] | None = config_entry.data.get(CONF_CATEGORIES)
     language = hass.config.language
 
     obj_holidays, language = await hass.async_add_executor_job(
-        _get_obj_holidays_and_language, country, province, language
+        _get_obj_holidays_and_language, country, province, language, categories
     )
 
     async_add_entities(

--- a/homeassistant/components/holiday/config_flow.py
+++ b/homeassistant/components/holiday/config_flow.py
@@ -12,7 +12,7 @@ from homeassistant.config_entries import (
     ConfigEntry,
     ConfigFlow,
     ConfigFlowResult,
-    OptionsFlowWithConfigEntry,
+    OptionsFlow,
 )
 from homeassistant.const import CONF_COUNTRY
 from homeassistant.core import callback
@@ -77,7 +77,7 @@ class HolidayConfigFlow(ConfigFlow, domain=DOMAIN):
     @callback
     def async_get_options_flow(config_entry: ConfigEntry) -> HolidayOptionsFlowHandler:
         """Get the options flow for this handler."""
-        return HolidayOptionsFlowHandler(config_entry)
+        return HolidayOptionsFlowHandler()
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -200,7 +200,7 @@ class HolidayConfigFlow(ConfigFlow, domain=DOMAIN):
         )
 
 
-class HolidayOptionsFlowHandler(OptionsFlowWithConfigEntry):
+class HolidayOptionsFlowHandler(OptionsFlow):
     """Handle Holiday options."""
 
     async def async_step_init(
@@ -216,7 +216,7 @@ class HolidayOptionsFlowHandler(OptionsFlowWithConfigEntry):
         if not categories:
             return self.async_abort(reason="no_categories")
 
-        options_schema = vol.Schema(
+        schema = vol.Schema(
             {
                 vol.Optional(CONF_CATEGORIES): SelectSelector(
                     SelectSelectorConfig(
@@ -230,9 +230,7 @@ class HolidayOptionsFlowHandler(OptionsFlowWithConfigEntry):
         )
 
         return self.async_show_form(
-            data_schema=self.add_suggested_values_to_schema(
-                options_schema, self.config_entry.options
-            ),
+            data_schema=self.add_suggested_values_to_schema(schema, self.options),
             description_placeholders={
                 CONF_COUNTRY: self.config_entry.data[CONF_COUNTRY]
             },

--- a/homeassistant/components/holiday/config_flow.py
+++ b/homeassistant/components/holiday/config_flow.py
@@ -230,7 +230,9 @@ class HolidayOptionsFlowHandler(OptionsFlow):
         )
 
         return self.async_show_form(
-            data_schema=self.add_suggested_values_to_schema(schema, self.options),
+            data_schema=self.add_suggested_values_to_schema(
+                schema, self.config_entry.options
+            ),
             description_placeholders={
                 CONF_COUNTRY: self.config_entry.data[CONF_COUNTRY]
             },

--- a/homeassistant/components/holiday/config_flow.py
+++ b/homeassistant/components/holiday/config_flow.py
@@ -45,10 +45,10 @@ def get_optional_categories(country: str) -> list[str]:
 def get_options_schema(country: str) -> vol.Schema:
     """Return the options schema."""
     schema = {}
-    if SUPPORTED_COUNTRIES[country]:
+    if provinces := SUPPORTED_COUNTRIES[country]:
         schema[vol.Optional(CONF_PROVINCE)] = SelectSelector(
             SelectSelectorConfig(
-                options=SUPPORTED_COUNTRIES[country],
+                options=provinces,
                 mode=SelectSelectorMode.DROPDOWN,
             )
         )

--- a/homeassistant/components/holiday/const.py
+++ b/homeassistant/components/holiday/const.py
@@ -5,3 +5,4 @@ from typing import Final
 DOMAIN: Final = "holiday"
 
 CONF_PROVINCE: Final = "province"
+CONF_CATEGORIES: Final = "categories"

--- a/homeassistant/components/holiday/strings.json
+++ b/homeassistant/components/holiday/strings.json
@@ -2,7 +2,7 @@
   "title": "Holiday",
   "config": {
     "abort": {
-      "already_configured": "Already configured. Only a single configuration for country/province combination possible.",
+      "already_configured": "Already configured. Only a single configuration for country/province/categories combination is possible.",
       "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
     },
     "step": {
@@ -25,6 +25,26 @@
         "data": {
           "province": "[%key:component::holiday::config::step::options::data::province%]",
           "categories": "[%key:component::holiday::config::step::options::data::categories%]"
+        },
+        "data_description": {
+          "province": "[%key:component::holiday::config::step::options::data_description::province%]",
+          "categories": "[%key:component::holiday::config::step::options::data_description::categories%]"
+        }
+      }
+    }
+  },
+  "options": {
+    "abort": {
+      "already_configured": "[%key:component::holiday::config::abort::already_configured%]",
+      "no_categories": "The country has no additional categories to configure."
+    },
+    "step": {
+      "init": {
+        "data": {
+          "categories": "[%key:component::holiday::config::step::options::data::categories%]"
+        },
+        "data_description": {
+          "categories": "[%key:component::holiday::config::step::options::data_description::categories%]"
         }
       }
     }
@@ -34,18 +54,18 @@
       "options": {
         "armed_forces": "Armed forces",
         "bank": "Bank",
-        "government": "Government",
-        "half_day": "Half day",
-        "optional": "Optional",
-        "school": "School",
-        "unofficial": "Unofficial",
-        "workday": "Workday",
         "catholic": "Catholic",
         "chinese": "Chinese",
         "christian": "Christian",
+        "government": "Government",
+        "half_day": "Half day",
         "hebrew": "Hebrew",
         "hindu": "Hindu",
-        "islamic": "Islamic"
+        "islamic": "Islamic",
+        "optional": "Optional",
+        "school": "School",
+        "unofficial": "Unofficial",
+        "workday": "Workday"
       }
     }
   }

--- a/homeassistant/components/holiday/strings.json
+++ b/homeassistant/components/holiday/strings.json
@@ -11,15 +11,41 @@
           "country": "Country"
         }
       },
-      "province": {
+      "options": {
         "data": {
-          "province": "Province"
+          "province": "Province",
+          "categories": "Categories"
+        },
+        "data_description": {
+          "province": "Optionally choose a province / subdivision of {country}",
+          "categories": "Optionally choose additional holiday categories, public holidays are already included"
         }
       },
       "reconfigure": {
         "data": {
-          "province": "[%key:component::holiday::config::step::province::data::province%]"
+          "province": "[%key:component::holiday::config::step::options::data::province%]",
+          "categories": "[%key:component::holiday::config::step::options::data::categories%]"
         }
+      }
+    }
+  },
+  "selector": {
+    "device_class": {
+      "options": {
+        "armed_forces": "Armed forces",
+        "bank": "Bank",
+        "government": "Government",
+        "half_day": "Half day",
+        "optional": "Optional",
+        "school": "School",
+        "unofficial": "Unofficial",
+        "workday": "Workday",
+        "catholic": "Catholic",
+        "chinese": "Chinese",
+        "christian": "Christian",
+        "hebrew": "Hebrew",
+        "hindu": "Hindu",
+        "islamic": "Islamic"
       }
     }
   }

--- a/tests/components/holiday/test_config_flow.py
+++ b/tests/components/holiday/test_config_flow.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock
 
 from freezegun.api import FrozenDateTimeFactory
 from holidays import UNOFFICIAL
+import pytest
 
 from homeassistant import config_entries
 from homeassistant.components.holiday.const import (
@@ -12,7 +13,7 @@ from homeassistant.components.holiday.const import (
     CONF_PROVINCE,
     DOMAIN,
 )
-from homeassistant.const import CONF_COUNTRY
+from homeassistant.const import CONF_COUNTRY, STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.util import dt as dt_util
@@ -54,9 +55,8 @@ async def test_form(hass: HomeAssistant, mock_setup_entry: AsyncMock) -> None:
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_no_subdivision(
-    hass: HomeAssistant, mock_setup_entry: AsyncMock
-) -> None:
+@pytest.mark.usefixtures("mock_setup_entry")
+async def test_form_no_subdivision(hass: HomeAssistant) -> None:
     """Test we get the forms correctly without subdivision."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -78,9 +78,8 @@ async def test_form_no_subdivision(
     }
 
 
-async def test_form_translated_title(
-    hass: HomeAssistant, mock_setup_entry: AsyncMock
-) -> None:
+@pytest.mark.usefixtures("mock_setup_entry")
+async def test_form_translated_title(hass: HomeAssistant) -> None:
     """Test the title gets translated."""
     hass.config.language = "de"
 
@@ -99,9 +98,8 @@ async def test_form_translated_title(
     assert result2["title"] == "Schweden"
 
 
-async def test_single_combination_country_province(
-    hass: HomeAssistant, mock_setup_entry: AsyncMock
-) -> None:
+@pytest.mark.usefixtures("mock_setup_entry")
+async def test_single_combination_country_province(hass: HomeAssistant) -> None:
     """Test that configuring more than one instance is rejected."""
     data_de = {
         CONF_COUNTRY: "DE",
@@ -140,9 +138,8 @@ async def test_single_combination_country_province(
     assert result_de_step2["reason"] == "already_configured"
 
 
-async def test_form_babel_unresolved_language(
-    hass: HomeAssistant, mock_setup_entry: AsyncMock
-) -> None:
+@pytest.mark.usefixtures("mock_setup_entry")
+async def test_form_babel_unresolved_language(hass: HomeAssistant) -> None:
     """Test the config flow if using not babel supported language."""
     hass.config.language = "en-XX"
 
@@ -188,9 +185,8 @@ async def test_form_babel_unresolved_language(
     }
 
 
-async def test_form_babel_replace_dash_with_underscore(
-    hass: HomeAssistant, mock_setup_entry: AsyncMock
-) -> None:
+@pytest.mark.usefixtures("mock_setup_entry")
+async def test_form_babel_replace_dash_with_underscore(hass: HomeAssistant) -> None:
     """Test the config flow if using language with dash."""
     hass.config.language = "en-GB"
 
@@ -236,7 +232,8 @@ async def test_form_babel_replace_dash_with_underscore(
     }
 
 
-async def test_reconfigure(hass: HomeAssistant, mock_setup_entry: AsyncMock) -> None:
+@pytest.mark.usefixtures("mock_setup_entry")
+async def test_reconfigure(hass: HomeAssistant) -> None:
     """Test reconfigure flow."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -263,9 +260,8 @@ async def test_reconfigure(hass: HomeAssistant, mock_setup_entry: AsyncMock) -> 
     assert entry.data == {"country": "DE", "province": "NW"}
 
 
-async def test_reconfigure_with_categories(
-    hass: HomeAssistant, mock_setup_entry: AsyncMock
-) -> None:
+@pytest.mark.usefixtures("mock_setup_entry")
+async def test_reconfigure_with_categories(hass: HomeAssistant) -> None:
     """Test reconfigure flow with categories."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -294,9 +290,8 @@ async def test_reconfigure_with_categories(
     assert entry.options == {CONF_CATEGORIES: ["unofficial"]}
 
 
-async def test_reconfigure_incorrect_language(
-    hass: HomeAssistant, mock_setup_entry: AsyncMock
-) -> None:
+@pytest.mark.usefixtures("mock_setup_entry")
+async def test_reconfigure_incorrect_language(hass: HomeAssistant) -> None:
     """Test reconfigure flow default to English."""
     hass.config.language = "en-XX"
 
@@ -325,9 +320,8 @@ async def test_reconfigure_incorrect_language(
     assert entry.data == {"country": "DE", "province": "NW"}
 
 
-async def test_reconfigure_entry_exists(
-    hass: HomeAssistant, mock_setup_entry: AsyncMock
-) -> None:
+@pytest.mark.usefixtures("mock_setup_entry")
+async def test_reconfigure_entry_exists(hass: HomeAssistant) -> None:
     """Test reconfigure flow stops if other entry already exist."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -406,7 +400,7 @@ async def test_form_with_options(
 
     state = hass.states.get("calendar.united_states_tx")
     assert state
-    assert state.state == "on"
+    assert state.state == STATE_ON
 
     entries = hass.config_entries.async_entries(DOMAIN)
     entry = entries[0]
@@ -428,12 +422,11 @@ async def test_form_with_options(
 
     state = hass.states.get("calendar.united_states_tx")
     assert state
-    assert state.state == "off"
+    assert state.state == STATE_OFF
 
 
-async def test_options_abort_no_categories(
-    hass: HomeAssistant, mock_setup_entry: AsyncMock
-) -> None:
+@pytest.mark.usefixtures("mock_setup_entry")
+async def test_options_abort_no_categories(hass: HomeAssistant) -> None:
     """Test the options flow abort if no categories to select."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds `OptonsFlow` to configure optional categories in holiday integration.
Public holidays are always included

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/35493

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 