### PR TITLE
Fix failing UniFi Protect tests on some systems

### DIFF
--- a/tests/components/unifiprotect/test_media_source.py
+++ b/tests/components/unifiprotect/test_media_source.py
@@ -669,7 +669,7 @@ async def test_browse_media_recent_truncated(
                 model=ModelType.EVENT,
                 id="test_event_id",
                 type=EventType.RING,
-                start=datetime(1000, 1, 1, 0, 0, 0),
+                start=datetime(2000, 1, 1, 0, 0, 0),
                 end=None,
                 score=100,
                 smart_detect_types=[],
@@ -683,7 +683,7 @@ async def test_browse_media_recent_truncated(
                 model=ModelType.EVENT,
                 id="test_event_id",
                 type=EventType.MOTION,
-                start=datetime(1000, 1, 1, 0, 0, 0),
+                start=datetime(2000, 1, 1, 0, 0, 0),
                 end=None,
                 score=100,
                 smart_detect_types=[],
@@ -697,7 +697,7 @@ async def test_browse_media_recent_truncated(
                 model=ModelType.EVENT,
                 id="test_event_id",
                 type=EventType.SMART_DETECT,
-                start=datetime(1000, 1, 1, 0, 0, 0),
+                start=datetime(2000, 1, 1, 0, 0, 0),
                 end=None,
                 score=100,
                 smart_detect_types=["person"],
@@ -706,7 +706,7 @@ async def test_browse_media_recent_truncated(
                 metadata={
                     "detected_thumbnails": [
                         {
-                            "clock_best_wall": datetime(1000, 1, 1, 0, 0, 0),
+                            "clock_best_wall": datetime(2000, 1, 1, 0, 0, 0),
                             "type": "person",
                             "cropped_id": "event_id",
                         }
@@ -720,7 +720,7 @@ async def test_browse_media_recent_truncated(
                 model=ModelType.EVENT,
                 id="test_event_id",
                 type=EventType.SMART_DETECT,
-                start=datetime(1000, 1, 1, 0, 0, 0),
+                start=datetime(2000, 1, 1, 0, 0, 0),
                 end=None,
                 score=100,
                 smart_detect_types=["vehicle", "person"],
@@ -734,7 +734,7 @@ async def test_browse_media_recent_truncated(
                 model=ModelType.EVENT,
                 id="test_event_id",
                 type=EventType.SMART_DETECT,
-                start=datetime(1000, 1, 1, 0, 0, 0),
+                start=datetime(2000, 1, 1, 0, 0, 0),
                 end=None,
                 score=100,
                 smart_detect_types=["vehicle", "licensePlate"],
@@ -748,7 +748,7 @@ async def test_browse_media_recent_truncated(
                 model=ModelType.EVENT,
                 id="test_event_id",
                 type=EventType.SMART_DETECT,
-                start=datetime(1000, 1, 1, 0, 0, 0),
+                start=datetime(2000, 1, 1, 0, 0, 0),
                 end=None,
                 score=100,
                 smart_detect_types=["vehicle", "licensePlate"],
@@ -758,7 +758,7 @@ async def test_browse_media_recent_truncated(
                     "license_plate": {"name": "ABC1234", "confidence_level": 95},
                     "detected_thumbnails": [
                         {
-                            "clock_best_wall": datetime(1000, 1, 1, 0, 0, 0),
+                            "clock_best_wall": datetime(2000, 1, 1, 0, 0, 0),
                             "type": "vehicle",
                             "cropped_id": "event_id",
                         }
@@ -772,7 +772,7 @@ async def test_browse_media_recent_truncated(
                 model=ModelType.EVENT,
                 id="test_event_id",
                 type=EventType.SMART_DETECT,
-                start=datetime(1000, 1, 1, 0, 0, 0),
+                start=datetime(2000, 1, 1, 0, 0, 0),
                 end=None,
                 score=100,
                 smart_detect_types=["vehicle", "licensePlate"],
@@ -782,7 +782,7 @@ async def test_browse_media_recent_truncated(
                     "license_plate": {"name": "ABC1234", "confidence_level": 95},
                     "detected_thumbnails": [
                         {
-                            "clock_best_wall": datetime(1000, 1, 1, 0, 0, 0),
+                            "clock_best_wall": datetime(2000, 1, 1, 0, 0, 0),
                             "type": "vehicle",
                             "cropped_id": "event_id",
                             "attributes": {
@@ -802,7 +802,7 @@ async def test_browse_media_recent_truncated(
                 model=ModelType.EVENT,
                 id="test_event_id",
                 type=EventType.SMART_DETECT,
-                start=datetime(1000, 1, 1, 0, 0, 0),
+                start=datetime(2000, 1, 1, 0, 0, 0),
                 end=None,
                 score=100,
                 smart_detect_types=["vehicle", "licensePlate"],
@@ -812,7 +812,7 @@ async def test_browse_media_recent_truncated(
                     "license_plate": {"name": "ABC1234", "confidence_level": 95},
                     "detected_thumbnails": [
                         {
-                            "clock_best_wall": datetime(1000, 1, 1, 0, 0, 0),
+                            "clock_best_wall": datetime(2000, 1, 1, 0, 0, 0),
                             "type": "vehicle",
                             "cropped_id": "event_id",
                             "attributes": {
@@ -823,7 +823,7 @@ async def test_browse_media_recent_truncated(
                             },
                         },
                         {
-                            "clock_best_wall": datetime(1000, 1, 1, 0, 0, 0),
+                            "clock_best_wall": datetime(2000, 1, 1, 0, 0, 0),
                             "type": "person",
                             "cropped_id": "event_id",
                         },
@@ -837,7 +837,7 @@ async def test_browse_media_recent_truncated(
                 model=ModelType.EVENT,
                 id="test_event_id",
                 type=EventType.SMART_DETECT,
-                start=datetime(1000, 1, 1, 0, 0, 0),
+                start=datetime(2000, 1, 1, 0, 0, 0),
                 end=None,
                 score=100,
                 smart_detect_types=["vehicle"],
@@ -846,7 +846,7 @@ async def test_browse_media_recent_truncated(
                 metadata={
                     "detected_thumbnails": [
                         {
-                            "clock_best_wall": datetime(1000, 1, 1, 0, 0, 0),
+                            "clock_best_wall": datetime(2000, 1, 1, 0, 0, 0),
                             "type": "vehicle",
                             "cropped_id": "event_id",
                             "attributes": {
@@ -870,7 +870,7 @@ async def test_browse_media_recent_truncated(
                 model=ModelType.EVENT,
                 id="test_event_id",
                 type=EventType.SMART_AUDIO_DETECT,
-                start=datetime(1000, 1, 1, 0, 0, 0),
+                start=datetime(2000, 1, 1, 0, 0, 0),
                 end=None,
                 score=100,
                 smart_detect_types=["alrmSpeak"],


### PR DESCRIPTION
## Proposed change
This changes the year used in UniFi Protect media source tests from 1000 to 2000. The latter being after the Unix epoch to fix issues on some platforms where tests previously failed with "mktime argument out of range".

This is only a small change in tests and in reality, these numbers will always be in the current time (so definitely after 1970).


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
