### PR TITLE
Fix "home" route in Tesla Fleet & Teslemetry

### DIFF
--- a/homeassistant/components/tesla_fleet/device_tracker.py
+++ b/homeassistant/components/tesla_fleet/device_tracker.py
@@ -84,4 +84,7 @@ class TeslaFleetDeviceTrackerRouteEntity(TeslaFleetDeviceTrackerEntity):
     @property
     def location_name(self) -> str | None:
         """Return a location name for the current location of the device."""
-        return self.get("drive_state_active_route_destination")
+        if location := self.get("drive_state_active_route_name") == "Home":
+            # Return the translatable name for home
+            return "home"
+        return location

--- a/homeassistant/components/tesla_fleet/device_tracker.py
+++ b/homeassistant/components/tesla_fleet/device_tracker.py
@@ -85,7 +85,7 @@ class TeslaFleetDeviceTrackerRouteEntity(TeslaFleetDeviceTrackerEntity):
     @property
     def location_name(self) -> str | None:
         """Return a location name for the current location of the device."""
-        location = self.get("drive_state_active_route_name")
+        location = self.get("drive_state_active_route_destination")
         if location == "Home":
             return STATE_HOME
         return location

--- a/homeassistant/components/tesla_fleet/device_tracker.py
+++ b/homeassistant/components/tesla_fleet/device_tracker.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from homeassistant.components.device_tracker.config_entry import TrackerEntity
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import STATE_HOME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
@@ -84,7 +85,7 @@ class TeslaFleetDeviceTrackerRouteEntity(TeslaFleetDeviceTrackerEntity):
     @property
     def location_name(self) -> str | None:
         """Return a location name for the current location of the device."""
-        if location := self.get("drive_state_active_route_name") == "Home":
-            # Return the translatable name for home
-            return "home"
+        location = self.get("drive_state_active_route_name")
+        if location == "Home":
+            return STATE_HOME
         return location

--- a/homeassistant/components/teslemetry/device_tracker.py
+++ b/homeassistant/components/teslemetry/device_tracker.py
@@ -81,7 +81,7 @@ class TeslemetryDeviceTrackerRouteEntity(TeslemetryDeviceTrackerEntity):
     @property
     def location_name(self) -> str | None:
         """Return a location name for the current location of the device."""
-        location = self.get("drive_state_active_route_name")
+        location = self.get("drive_state_active_route_destination")
         if location == "Home":
             return STATE_HOME
         return location

--- a/homeassistant/components/teslemetry/device_tracker.py
+++ b/homeassistant/components/teslemetry/device_tracker.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from homeassistant.components.device_tracker.config_entry import TrackerEntity
+from homeassistant.const import STATE_HOME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -80,4 +81,7 @@ class TeslemetryDeviceTrackerRouteEntity(TeslemetryDeviceTrackerEntity):
     @property
     def location_name(self) -> str | None:
         """Return a location name for the current location of the device."""
-        return self.get("drive_state_active_route_destination")
+        location = self.get("drive_state_active_route_name")
+        if location == "Home":
+            return STATE_HOME
+        return location

--- a/tests/components/tesla_fleet/fixtures/vehicle_data.json
+++ b/tests/components/tesla_fleet/fixtures/vehicle_data.json
@@ -112,6 +112,7 @@
       "wiper_blade_heater": false
     },
     "drive_state": {
+      "active_route_destination": "Home",
       "active_route_latitude": 30.2226265,
       "active_route_longitude": -97.6236871,
       "active_route_miles_to_arrival": 0.039491,

--- a/tests/components/tesla_fleet/snapshots/test_device_tracker.ambr
+++ b/tests/components/tesla_fleet/snapshots/test_device_tracker.ambr
@@ -96,6 +96,6 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'not_home',
+    'state': 'home',
   })
 # ---

--- a/tests/components/tesla_fleet/snapshots/test_diagnostics.ambr
+++ b/tests/components/tesla_fleet/snapshots/test_diagnostics.ambr
@@ -269,6 +269,7 @@
           'climate_state_timestamp': 1705707520649,
           'climate_state_wiper_blade_heater': False,
           'color': None,
+          'drive_state_active_route_destination': 'Home',
           'drive_state_active_route_latitude': '**REDACTED**',
           'drive_state_active_route_longitude': '**REDACTED**',
           'drive_state_active_route_miles_to_arrival': 0.039491,

--- a/tests/components/teslemetry/fixtures/vehicle_data.json
+++ b/tests/components/teslemetry/fixtures/vehicle_data.json
@@ -112,6 +112,7 @@
       "wiper_blade_heater": false
     },
     "drive_state": {
+      "active_route_destination": "Home",
       "active_route_latitude": 30.2226265,
       "active_route_longitude": -97.6236871,
       "active_route_miles_to_arrival": 0.039491,

--- a/tests/components/teslemetry/snapshots/test_device_tracker.ambr
+++ b/tests/components/teslemetry/snapshots/test_device_tracker.ambr
@@ -96,6 +96,6 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'not_home',
+    'state': 'home',
   })
 # ---

--- a/tests/components/teslemetry/snapshots/test_diagnostics.ambr
+++ b/tests/components/teslemetry/snapshots/test_diagnostics.ambr
@@ -270,6 +270,7 @@
           'climate_state_timestamp': 1705707520649,
           'climate_state_wiper_blade_heater': False,
           'color': None,
+          'drive_state_active_route_destination': 'Home',
           'drive_state_active_route_latitude': '**REDACTED**',
           'drive_state_active_route_longitude': '**REDACTED**',
           'drive_state_active_route_miles_to_arrival': 0.039491,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Tesla vehicles return the name of the location they are navigating to, and this is passed to the device tracker entity. However this causes an issue with the "Home" location. The vehicle tells Home Assistant is navigating `Home` but the entity expects the special value of `home`. So certain automation conditions checking if the state == `home` failed because its actually `Home`, despite the location being the same.

This PR forces location names of `Home` to `home` so they they can be translated and work on the device tracker device condition.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #129533
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
