### PR TITLE
Add OptionsFlow helpers to get the current config entry

### DIFF
--- a/homeassistant/components/airnow/config_flow.py
+++ b/homeassistant/components/airnow/config_flow.py
@@ -1,5 +1,7 @@
 """Config flow for AirNow integration."""
 
+from __future__ import annotations
+
 import logging
 from typing import Any
 
@@ -12,7 +14,6 @@ from homeassistant.config_entries import (
     ConfigFlow,
     ConfigFlowResult,
     OptionsFlow,
-    OptionsFlowWithConfigEntry,
 )
 from homeassistant.const import CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE, CONF_RADIUS
 from homeassistant.core import HomeAssistant, callback
@@ -120,12 +121,12 @@ class AirNowConfigFlow(ConfigFlow, domain=DOMAIN):
     @callback
     def async_get_options_flow(
         config_entry: ConfigEntry,
-    ) -> OptionsFlow:
+    ) -> AirNowOptionsFlowHandler:
         """Return the options flow."""
-        return AirNowOptionsFlowHandler(config_entry)
+        return AirNowOptionsFlowHandler()
 
 
-class AirNowOptionsFlowHandler(OptionsFlowWithConfigEntry):
+class AirNowOptionsFlowHandler(OptionsFlow):
     """Handle an options flow for AirNow."""
 
     async def async_step_init(
@@ -136,18 +137,13 @@ class AirNowOptionsFlowHandler(OptionsFlowWithConfigEntry):
             return self.async_create_entry(data=user_input)
 
         options_schema = vol.Schema(
-            {
-                vol.Optional(CONF_RADIUS): vol.All(
-                    int,
-                    vol.Range(min=5),
-                ),
-            }
+            {vol.Optional(CONF_RADIUS): vol.All(int, vol.Range(min=5))}
         )
 
         return self.async_show_form(
             step_id="init",
             data_schema=self.add_suggested_values_to_schema(
-                options_schema, self.config_entry.options
+                options_schema, self._get_config_entry().options
             ),
         )
 

--- a/homeassistant/components/airnow/config_flow.py
+++ b/homeassistant/components/airnow/config_flow.py
@@ -143,7 +143,7 @@ class AirNowOptionsFlowHandler(OptionsFlow):
         return self.async_show_form(
             step_id="init",
             data_schema=self.add_suggested_values_to_schema(
-                options_schema, self._get_config_entry().options
+                options_schema, self._config_entry.options
             ),
         )
 

--- a/homeassistant/components/airnow/config_flow.py
+++ b/homeassistant/components/airnow/config_flow.py
@@ -143,7 +143,7 @@ class AirNowOptionsFlowHandler(OptionsFlow):
         return self.async_show_form(
             step_id="init",
             data_schema=self.add_suggested_values_to_schema(
-                options_schema, self._config_entry.options
+                options_schema, self.config_entry.options
             ),
         )
 

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -3043,6 +3043,9 @@ class OptionsFlow(ConfigEntryBaseFlow):
 
     handler: str
 
+    _config_entry: ConfigEntry
+    """For compatibility only - to be removed in 2025.12"""
+
     @callback
     def _async_abort_entries_match(
         self, match_dict: dict[str, Any] | None = None
@@ -3083,11 +3086,21 @@ class OptionsFlow(ConfigEntryBaseFlow):
         Please note that this is not available inside `__init__` method, and
         can only be referenced after initialisation.
         """
+        # For compatibility only - to be removed in 2025.12
+        if hasattr(self, "_config_entry"):
+            return self._config_entry
+
         if self.hass is None:
             raise ValueError("The config entry is not available during initialisation")
         if entry := self.hass.config_entries.async_get_entry(self._config_entry_id):
             return entry
         raise UnknownEntry
+
+    @config_entry.setter
+    def config_entry(self, value: ConfigEntry) -> None:
+        """Set the config entry value."""
+        # TODO: add deprecation warning
+        self._config_entry = value
 
 
 class OptionsFlowWithConfigEntry(OptionsFlow):
@@ -3097,11 +3110,6 @@ class OptionsFlowWithConfigEntry(OptionsFlow):
         """Initialize options flow."""
         self._config_entry = config_entry
         self._options = deepcopy(dict(config_entry.options))
-
-    @property
-    def config_entry(self) -> ConfigEntry:
-        """Return the config entry."""
-        return self._config_entry
 
     @property
     def options(self) -> dict[str, Any]:

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -3052,9 +3052,7 @@ class OptionsFlow(ConfigEntryBaseFlow):
         Requires `already_configured` in strings.json in user visible flows.
         """
 
-        config_entry = cast(
-            ConfigEntry, self.hass.config_entries.async_get_entry(self.handler)
-        )
+        config_entry = self._get_config_entry()
         _async_abort_entries_match(
             [
                 entry

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -3064,6 +3064,19 @@ class OptionsFlow(ConfigEntryBaseFlow):
             match_dict,
         )
 
+    @property
+    def _config_entry_id(self) -> str:
+        """Return config entry id."""
+        # This is the same as handler, but that's an implementation detail
+        return self.handler
+
+    @callback
+    def _get_config_entry(self) -> ConfigEntry:
+        """Return the config entry linked to the current options flow."""
+        if entry := self.hass.config_entries.async_get_entry(self._config_entry_id):
+            return entry
+        raise UnknownEntry
+
 
 class OptionsFlowWithConfigEntry(OptionsFlow):
     """Base class for options flows with config entry and options."""

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -3051,13 +3051,11 @@ class OptionsFlow(ConfigEntryBaseFlow):
 
         Requires `already_configured` in strings.json in user visible flows.
         """
-
-        config_entry = self._get_config_entry()
         _async_abort_entries_match(
             [
                 entry
-                for entry in self.hass.config_entries.async_entries(config_entry.domain)
-                if entry is not config_entry and entry.source != SOURCE_IGNORE
+                for entry in self.hass.config_entries.async_entries(self._config_entry.domain)
+                if entry is not self._config_entry and entry.source != SOURCE_IGNORE
             ],
             match_dict,
         )
@@ -3095,13 +3093,13 @@ class OptionsFlowWithConfigEntry(OptionsFlow):
 
     def __init__(self, config_entry: ConfigEntry) -> None:
         """Initialize options flow."""
-        self._config_entry = config_entry
+        self.__config_entry = config_entry
         self._options = deepcopy(dict(config_entry.options))
 
     @property
     def config_entry(self) -> ConfigEntry:
         """Return the config entry."""
-        return self._config_entry
+        return self.__config_entry
 
     @property
     def options(self) -> dict[str, Any]:

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -3099,7 +3099,12 @@ class OptionsFlow(ConfigEntryBaseFlow):
     @config_entry.setter
     def config_entry(self, value: ConfigEntry) -> None:
         """Set the config entry value."""
-        # TODO: add deprecation warning
+        report(
+            "sets option flow config_entry explicitly, which is deprecated "
+            "and will stop working in 2025.12",
+            error_if_integration=False,
+            error_if_core=False,
+        )
         self._config_entry = value
 
 

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -3054,7 +3054,9 @@ class OptionsFlow(ConfigEntryBaseFlow):
         _async_abort_entries_match(
             [
                 entry
-                for entry in self.hass.config_entries.async_entries(self.config_entry.domain)
+                for entry in self.hass.config_entries.async_entries(
+                    self.config_entry.domain
+                )
                 if entry is not self.config_entry and entry.source != SOURCE_IGNORE
             ],
             match_dict,

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -3103,7 +3103,7 @@ class OptionsFlow(ConfigEntryBaseFlow):
             "sets option flow config_entry explicitly, which is deprecated "
             "and will stop working in 2025.12",
             error_if_integration=False,
-            error_if_core=False,
+            error_if_core=True,
         )
         self._config_entry = value
 

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -3054,8 +3054,8 @@ class OptionsFlow(ConfigEntryBaseFlow):
         _async_abort_entries_match(
             [
                 entry
-                for entry in self.hass.config_entries.async_entries(self._config_entry.domain)
-                if entry is not self._config_entry and entry.source != SOURCE_IGNORE
+                for entry in self.hass.config_entries.async_entries(self.config_entry.domain)
+                if entry is not self.config_entry and entry.source != SOURCE_IGNORE
             ],
             match_dict,
         )
@@ -3075,7 +3075,7 @@ class OptionsFlow(ConfigEntryBaseFlow):
         return self.handler
 
     @property
-    def _config_entry(self) -> ConfigEntry:
+    def config_entry(self) -> ConfigEntry:
         """Return the config entry linked to the current options flow.
 
         Please note that this is not available inside `__init__` method, and
@@ -3093,13 +3093,13 @@ class OptionsFlowWithConfigEntry(OptionsFlow):
 
     def __init__(self, config_entry: ConfigEntry) -> None:
         """Initialize options flow."""
-        self.__config_entry = config_entry
+        self._config_entry = config_entry
         self._options = deepcopy(dict(config_entry.options))
 
     @property
     def config_entry(self) -> ConfigEntry:
         """Return the config entry."""
-        return self.__config_entry
+        return self._config_entry
 
     @property
     def options(self) -> dict[str, Any]:

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -3064,13 +3064,27 @@ class OptionsFlow(ConfigEntryBaseFlow):
 
     @property
     def _config_entry_id(self) -> str:
-        """Return config entry id."""
+        """Return config entry id.
+
+        Please note that this is not available inside `__init__` method, and
+        can only be referenced after initialisation.
+        """
         # This is the same as handler, but that's an implementation detail
+        if self.handler is None:
+            raise ValueError(
+                "The config entry id is not available during initialisation"
+            )
         return self.handler
 
     @callback
     def _get_config_entry(self) -> ConfigEntry:
-        """Return the config entry linked to the current options flow."""
+        """Return the config entry linked to the current options flow.
+
+        Please note that this is not available inside `__init__` method, and
+        can only be referenced after initialisation.
+        """
+        if self.hass is None:
+            raise ValueError("The config entry is not available during initialisation")
         if entry := self.hass.config_entries.async_get_entry(self._config_entry_id):
             return entry
         raise UnknownEntry

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -3076,8 +3076,8 @@ class OptionsFlow(ConfigEntryBaseFlow):
             )
         return self.handler
 
-    @callback
-    def _get_config_entry(self) -> ConfigEntry:
+    @property
+    def _config_entry(self) -> ConfigEntry:
         """Return the config entry linked to the current options flow.
 
         Please note that this is not available inside `__init__` method, and

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -7266,7 +7266,7 @@ async def test_options_flow_config_entry(
                     except ValueError as err:
                         self.init_entry_id = err
                     try:
-                        self.init_entry = self._config_entry
+                        self.init_entry = self.config_entry
                     except ValueError as err:
                         self.init_entry = err
 
@@ -7279,7 +7279,7 @@ async def test_options_flow_config_entry(
 
                         errors["entry_id"] = self._config_entry_id
                         try:
-                            errors["entry"] = self._config_entry
+                            errors["entry"] = self.config_entry
                         except config_entries.UnknownEntry as err:
                             errors["entry"] = err
 

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -37,7 +37,7 @@ from homeassistant.exceptions import (
     ConfigEntryNotReady,
     HomeAssistantError,
 )
-from homeassistant.helpers import entity_registry as er, issue_registry as ir
+from homeassistant.helpers import entity_registry as er, frame, issue_registry as ir
 from homeassistant.helpers.discovery_flow import DiscoveryKey
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.json import json_dumps
@@ -7239,7 +7239,7 @@ async def test_context_no_leak(hass: HomeAssistant) -> None:
 async def test_options_flow_config_entry(
     hass: HomeAssistant, manager: config_entries.ConfigEntries
 ) -> None:
-    """Test _get_context_entry behavior."""
+    """Test _config_entry_id and config_entry properties in options flow."""
     original_entry = MockConfigEntry(domain="test", data={})
     original_entry.add_to_hass(hass)
 
@@ -7330,6 +7330,66 @@ async def test_options_flow_config_entry(
     )
     assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "abort"
+
+
+@pytest.mark.usefixtures("mock_integration_frame")
+@patch.object(frame, "_REPORTED_INTEGRATIONS", set())
+async def test_options_flow_deprecated_config_entry_setter(
+    hass: HomeAssistant,
+    manager: config_entries.ConfigEntries,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that setting config_entry explicitly still works."""
+    original_entry = MockConfigEntry(domain="test", data={})
+    original_entry.add_to_hass(hass)
+
+    mock_setup_entry = AsyncMock(return_value=True)
+
+    mock_integration(hass, MockModule("test", async_setup_entry=mock_setup_entry))
+    mock_platform(hass, "test.config_flow", None)
+
+    class TestFlow(config_entries.ConfigFlow):
+        """Test flow."""
+
+        @staticmethod
+        @callback
+        def async_get_options_flow(config_entry):
+            """Test options flow."""
+
+            class _OptionsFlow(config_entries.OptionsFlow):
+                """Test flow."""
+
+                def __init__(self, entry) -> None:
+                    """Test initialisation."""
+                    self.config_entry = entry
+
+                async def async_step_init(self, user_input=None):
+                    """Test user step."""
+                    errors = {}
+                    if user_input is not None:
+                        if user_input.get("abort"):
+                            return self.async_abort(reason="abort")
+
+                        errors["entry_id"] = self._config_entry_id
+                        try:
+                            errors["entry"] = self.config_entry
+                        except config_entries.UnknownEntry as err:
+                            errors["entry"] = err
+
+                    return self.async_show_form(step_id="init", errors=errors)
+
+            return _OptionsFlow(config_entry)
+
+    with mock_config_flow("test", TestFlow):
+        result = await hass.config_entries.options.async_init(original_entry.entry_id)
+
+    options_flow = hass.config_entries.options._progress.get(result["flow_id"])
+    assert options_flow.config_entry is original_entry
+
+    assert (
+        "Detected that integration 'hue' sets option flow config_entry explicitly, "
+        "which is deprecated and will stop working in 2025.12" in caplog.text
+    )
 
 
 async def test_add_description_placeholder_automatically(

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -7259,6 +7259,17 @@ async def test_options_flow_config_entry(
             class _OptionsFlow(config_entries.OptionsFlow):
                 """Test flow."""
 
+                def __init__(self) -> None:
+                    """Test initialisation."""
+                    try:
+                        self.init_entry_id = self._config_entry_id
+                    except ValueError as err:
+                        self.init_entry_id = err
+                    try:
+                        self.init_entry = self._get_config_entry()
+                    except ValueError as err:
+                        self.init_entry = err
+
                 async def async_step_init(self, user_input=None):
                     """Test user step."""
                     errors = {}
@@ -7282,6 +7293,16 @@ async def test_options_flow_config_entry(
     options_flow = hass.config_entries.options._progress.get(result["flow_id"])
     assert isinstance(options_flow, config_entries.OptionsFlow)
     assert options_flow.handler == original_entry.entry_id
+    assert isinstance(options_flow.init_entry_id, ValueError)
+    assert (
+        str(options_flow.init_entry_id)
+        == "The config entry id is not available during initialisation"
+    )
+    assert isinstance(options_flow.init_entry, ValueError)
+    assert (
+        str(options_flow.init_entry)
+        == "The config entry is not available during initialisation"
+    )
 
     assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "init"

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -7266,7 +7266,7 @@ async def test_options_flow_config_entry(
                     except ValueError as err:
                         self.init_entry_id = err
                     try:
-                        self.init_entry = self._get_config_entry()
+                        self.init_entry = self._config_entry
                     except ValueError as err:
                         self.init_entry = err
 
@@ -7279,7 +7279,7 @@ async def test_options_flow_config_entry(
 
                         errors["entry_id"] = self._config_entry_id
                         try:
-                            errors["entry"] = self._get_config_entry()
+                            errors["entry"] = self._config_entry
                         except config_entries.UnknownEntry as err:
                             errors["entry"] = err
 

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -7340,13 +7340,13 @@ async def test_options_flow_deprecated_config_entry_setter(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test that setting config_entry explicitly still works."""
-    original_entry = MockConfigEntry(domain="test", data={})
+    original_entry = MockConfigEntry(domain="hue", data={})
     original_entry.add_to_hass(hass)
 
     mock_setup_entry = AsyncMock(return_value=True)
 
-    mock_integration(hass, MockModule("test", async_setup_entry=mock_setup_entry))
-    mock_platform(hass, "test.config_flow", None)
+    mock_integration(hass, MockModule("hue", async_setup_entry=mock_setup_entry))
+    mock_platform(hass, "hue.config_flow", None)
 
     class TestFlow(config_entries.ConfigFlow):
         """Test flow."""
@@ -7380,7 +7380,7 @@ async def test_options_flow_deprecated_config_entry_setter(
 
             return _OptionsFlow(config_entry)
 
-    with mock_config_flow("test", TestFlow):
+    with mock_config_flow("hue", TestFlow):
         result = await hass.config_entries.options.async_init(original_entry.entry_id)
 
     options_flow = hass.config_entries.options._progress.get(result["flow_id"])

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -7236,6 +7236,81 @@ async def test_context_no_leak(hass: HomeAssistant) -> None:
     assert config_entries.current_entry.get() is None
 
 
+async def test_options_flow_config_entry(
+    hass: HomeAssistant, manager: config_entries.ConfigEntries
+) -> None:
+    """Test _get_context_entry behavior."""
+    original_entry = MockConfigEntry(domain="test", data={})
+    original_entry.add_to_hass(hass)
+
+    mock_setup_entry = AsyncMock(return_value=True)
+
+    mock_integration(hass, MockModule("test", async_setup_entry=mock_setup_entry))
+    mock_platform(hass, "test.config_flow", None)
+
+    class TestFlow(config_entries.ConfigFlow):
+        """Test flow."""
+
+        @staticmethod
+        @callback
+        def async_get_options_flow(config_entry):
+            """Test options flow."""
+
+            class _OptionsFlow(config_entries.OptionsFlow):
+                """Test flow."""
+
+                async def async_step_init(self, user_input=None):
+                    """Test user step."""
+                    errors = {}
+                    if user_input is not None:
+                        if user_input.get("abort"):
+                            return self.async_abort(reason="abort")
+
+                        errors["entry_id"] = self._config_entry_id
+                        try:
+                            errors["entry"] = self._get_config_entry()
+                        except config_entries.UnknownEntry as err:
+                            errors["entry"] = err
+
+                    return self.async_show_form(step_id="init", errors=errors)
+
+            return _OptionsFlow()
+
+    with mock_config_flow("test", TestFlow):
+        result = await hass.config_entries.options.async_init(original_entry.entry_id)
+
+    options_flow = hass.config_entries.options._progress.get(result["flow_id"])
+    assert isinstance(options_flow, config_entries.OptionsFlow)
+    assert options_flow.handler == original_entry.entry_id
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "init"
+    assert result["errors"] == {}
+
+    result = await hass.config_entries.options.async_configure(result["flow_id"], {})
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "init"
+    assert result["errors"]["entry_id"] == original_entry.entry_id
+    assert result["errors"]["entry"] is original_entry
+
+    # Bad handler - not linked to a config entry
+    options_flow.handler = "123"
+    result = await hass.config_entries.options.async_configure(result["flow_id"], {})
+    result = await hass.config_entries.options.async_configure(result["flow_id"], {})
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "init"
+    assert result["errors"]["entry_id"] == "123"
+    assert isinstance(result["errors"]["entry"], config_entries.UnknownEntry)
+    # Reset handler
+    options_flow.handler = original_entry.entry_id
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], {"abort": True}
+    )
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "abort"
+
+
 async def test_add_description_placeholder_automatically(
     hass: HomeAssistant,
     manager: config_entries.ConfigEntries,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
For developpers only: assigning a value to `self.config_entry` in an option flow is deprecated, and will stop working in 2025.12.
Please use the read-only property instead.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add `self._config_entry_id` and `self.config_entry` properties to `OptionsFlow`

Most option flows use `OptionsFlowWithConfigEntry` for the sole purpose of gaining access ot the config entry, without realising it's available already via `self.handler`

As a follow-up, when we have considered the mutable `options` property and all integrations have been updated, we should be able to deprecate/remove the `OptionsFlowWithConfigEntry`

cc @MartinHjelmare / @gjohansson-ST

Needs:
- [x] tests for the deprecation
- [x] blog post

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/2435

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
