### PR TITLE
Add device_id parameter to LCN actions (service calls)

### DIFF
--- a/homeassistant/components/lcn/__init__.py
+++ b/homeassistant/components/lcn/__init__.py
@@ -31,6 +31,7 @@ from .const import (
     CONF_SK_NUM_TRIES,
     CONF_TRANSITION,
     CONNECTION,
+    DEVICE_CONNECTIONS,
     DOMAIN,
     PLATFORMS,
 )
@@ -102,6 +103,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     _LOGGER.debug('LCN connected to "%s"', config_entry.title)
     hass.data[DOMAIN][config_entry.entry_id] = {
         CONNECTION: lcn_connection,
+        DEVICE_CONNECTIONS: {},
         ADD_ENTITIES_CALLBACKS: {},
     }
     # Update config_entry with LCN device serials

--- a/homeassistant/components/lcn/const.py
+++ b/homeassistant/components/lcn/const.py
@@ -20,6 +20,7 @@ DEFAULT_NAME = "pchk"
 
 ADD_ENTITIES_CALLBACKS = "add_entities_callbacks"
 CONNECTION = "connection"
+DEVICE_CONNECTIONS = "device_connections"
 CONF_HARDWARE_SERIAL = "hardware_serial"
 CONF_SOFTWARE_SERIAL = "software_serial"
 CONF_HARDWARE_TYPE = "hardware_type"

--- a/homeassistant/components/lcn/const.py
+++ b/homeassistant/components/lcn/const.py
@@ -26,6 +26,10 @@ CONF_SOFTWARE_SERIAL = "software_serial"
 CONF_HARDWARE_TYPE = "hardware_type"
 CONF_DOMAIN_DATA = "domain_data"
 
+CONF_SEGMENT_ID = "segment_id"
+CONF_MODULE = "module"
+CONF_GROUP = "group"
+
 CONF_ACKNOWLEDGE = "acknowledge"
 CONF_CONNECTIONS = "connections"
 CONF_SK_NUM_TRIES = "sk_num_tries"

--- a/homeassistant/components/lcn/const.py
+++ b/homeassistant/components/lcn/const.py
@@ -26,10 +26,6 @@ CONF_SOFTWARE_SERIAL = "software_serial"
 CONF_HARDWARE_TYPE = "hardware_type"
 CONF_DOMAIN_DATA = "domain_data"
 
-CONF_SEGMENT_ID = "segment_id"
-CONF_MODULE = "module"
-CONF_GROUP = "group"
-
 CONF_ACKNOWLEDGE = "acknowledge"
 CONF_CONNECTIONS = "connections"
 CONF_SK_NUM_TRIES = "sk_num_tries"

--- a/homeassistant/components/lcn/helpers.py
+++ b/homeassistant/components/lcn/helpers.py
@@ -345,6 +345,25 @@ def is_address(value: str) -> tuple[AddressType, str]:
     raise ValueError(f"{value} is not a valid address string")
 
 
+def address_to_device_id(
+    hass: HomeAssistant, address: AddressType, host_name: str
+) -> str | None:
+    """Convert LCN address to device_id."""
+    for config_entry in hass.config_entries.async_entries(DOMAIN):
+        if (host_name is None) or (config_entry.title == host_name):
+            break
+    else:
+        return None
+
+    device_connections: dict[str, DeviceConnectionType] = hass.data[DOMAIN][
+        config_entry.entry_id
+    ][DEVICE_CONNECTIONS]
+    for device_id, device_connection in device_connections.items():
+        if device_connection.addr == pypck.lcn_addr.LcnAddr(*address):
+            return device_id
+    return None
+
+
 def is_states_string(states_string: str) -> list[str]:
     """Validate the given states string and return states list."""
     if len(states_string) != 8:

--- a/homeassistant/components/lcn/helpers.py
+++ b/homeassistant/components/lcn/helpers.py
@@ -38,6 +38,7 @@ from .const import (
     CONF_SCENES,
     CONF_SOFTWARE_SERIAL,
     CONNECTION,
+    DEVICE_CONNECTIONS,
     DOMAIN,
     LED_PORTS,
     LOGICOP_PORTS,
@@ -248,7 +249,7 @@ def register_lcn_address_devices(
             device_model = f"{hardware_name} (m{address[0]:03d}{address[1]:03d})"
             sw_version = f"{device_config[CONF_SOFTWARE_SERIAL]:06X}"
 
-        device_registry.async_get_or_create(
+        device_entry = device_registry.async_get_or_create(
             config_entry_id=config_entry.entry_id,
             identifiers=identifiers,
             via_device=host_identifiers,
@@ -257,6 +258,10 @@ def register_lcn_address_devices(
             name=device_name,
             model=device_model,
         )
+
+        hass.data[DOMAIN][config_entry.entry_id][DEVICE_CONNECTIONS][
+            device_entry.id
+        ] = get_device_connection(hass, address, config_entry)
 
 
 async def async_update_device_config(

--- a/homeassistant/components/lcn/helpers.py
+++ b/homeassistant/components/lcn/helpers.py
@@ -346,7 +346,7 @@ def is_address(value: str) -> tuple[AddressType, str]:
 
 
 def address_to_device_id(
-    hass: HomeAssistant, address: AddressType, host_name: str
+    hass: HomeAssistant, address: AddressType, host_name: str | None = None
 ) -> str | None:
     """Convert LCN address to device_id."""
     for config_entry in hass.config_entries.async_entries(DOMAIN):

--- a/homeassistant/components/lcn/helpers.py
+++ b/homeassistant/components/lcn/helpers.py
@@ -238,7 +238,7 @@ def register_lcn_address_devices(
         identifiers = {(DOMAIN, generate_unique_id(config_entry.entry_id, address))}
 
         if device_config[CONF_ADDRESS][2]:  # is group
-            device_model = f"LCN group (g{address[0]:03d}{address[1]:03d})"
+            device_model = "LCN group"
             sw_version = None
         else:  # is module
             hardware_type = device_config[CONF_HARDWARE_TYPE]
@@ -246,7 +246,7 @@ def register_lcn_address_devices(
                 hardware_name = pypck.lcn_defs.HARDWARE_DESCRIPTIONS[hardware_type]
             else:
                 hardware_name = pypck.lcn_defs.HARDWARE_DESCRIPTIONS[-1]
-            device_model = f"{hardware_name} (m{address[0]:03d}{address[1]:03d})"
+            device_model = f"{hardware_name}"
             sw_version = f"{device_config[CONF_SOFTWARE_SERIAL]:06X}"
 
         device_entry = device_registry.async_get_or_create(

--- a/homeassistant/components/lcn/helpers.py
+++ b/homeassistant/components/lcn/helpers.py
@@ -345,25 +345,6 @@ def is_address(value: str) -> tuple[AddressType, str]:
     raise ValueError(f"{value} is not a valid address string")
 
 
-def address_to_device_id(
-    hass: HomeAssistant, address: AddressType, host_name: str | None = None
-) -> str | None:
-    """Convert LCN address to device_id."""
-    for config_entry in hass.config_entries.async_entries(DOMAIN):
-        if (host_name is None) or (config_entry.title == host_name):
-            break
-    else:
-        return None
-
-    device_connections: dict[str, DeviceConnectionType] = hass.data[DOMAIN][
-        config_entry.entry_id
-    ][DEVICE_CONNECTIONS]
-    for device_id, device_connection in device_connections.items():
-        if device_connection.addr == pypck.lcn_addr.LcnAddr(*address):
-            return device_id
-    return None
-
-
 def is_states_string(states_string: str) -> list[str]:
     """Validate the given states string and return states list."""
     if len(states_string) != 8:

--- a/homeassistant/components/lcn/icons.json
+++ b/homeassistant/components/lcn/icons.json
@@ -38,6 +38,9 @@
     },
     "pck": {
       "service": "mdi:package-variant-closed"
+    },
+    "address_to_device_id": {
+      "service": "mdi:calculator"
     }
   }
 }

--- a/homeassistant/components/lcn/icons.json
+++ b/homeassistant/components/lcn/icons.json
@@ -38,9 +38,6 @@
     },
     "pck": {
       "service": "mdi:package-variant-closed"
-    },
-    "address_to_device_id": {
-      "service": "mdi:calculator"
     }
   }
 }

--- a/homeassistant/components/lcn/services.py
+++ b/homeassistant/components/lcn/services.py
@@ -101,7 +101,7 @@ class LcnServiceCall:
             self.hass,
             DOMAIN,
             "deprecated_address_parameter",
-            breaks_in_ha_version="2025.5.0",
+            breaks_in_ha_version="2025.6.0",
             is_fixable=False,
             severity=IssueSeverity.WARNING,
             translation_key="deprecated_address_parameter",

--- a/homeassistant/components/lcn/services.py
+++ b/homeassistant/components/lcn/services.py
@@ -10,10 +10,7 @@ from homeassistant.const import (
     CONF_ADDRESS,
     CONF_BRIGHTNESS,
     CONF_DEVICE_ID,
-    CONF_HOST,
-    CONF_ID,
     CONF_STATE,
-    CONF_TYPE,
     CONF_UNIT_OF_MEASUREMENT,
 )
 from homeassistant.core import (
@@ -28,15 +25,12 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 
 from .const import (
-    CONF_GROUP,
     CONF_KEYS,
     CONF_LED,
-    CONF_MODULE,
     CONF_OUTPUT,
     CONF_PCK,
     CONF_RELVARREF,
     CONF_ROW,
-    CONF_SEGMENT_ID,
     CONF_SETPOINT,
     CONF_TABLE,
     CONF_TEXT,
@@ -59,7 +53,6 @@ from .const import (
     VARIABLES,
 )
 from .helpers import (
-    AddressType,
     DeviceConnectionType,
     address_to_device_id,
     is_address,
@@ -450,32 +443,6 @@ class Pck(LcnServiceCall):
         await device_connection.pck(pck)
 
 
-class AddressToDeviceId(LcnServiceCall):
-    """Get device_id from LCN address."""
-
-    schema = vol.Schema(
-        {
-            vol.Required(CONF_ID): cv.positive_int,
-            vol.Optional(CONF_SEGMENT_ID, default=0): cv.positive_int,
-            vol.Optional(CONF_TYPE, default=CONF_MODULE): vol.Any(
-                CONF_MODULE, CONF_GROUP
-            ),
-            vol.Optional(CONF_HOST, default=None): vol.Any(cv.string, None),
-        }
-    )
-    supports_response = SupportsResponse.ONLY
-
-    async def async_call_service(self, service: ServiceCall) -> ServiceResponse:
-        """Execute service call."""
-        address: AddressType = (
-            service.data[CONF_SEGMENT_ID],
-            service.data[CONF_ID],
-            service.data[CONF_TYPE] == CONF_GROUP,
-        )
-        device_id = address_to_device_id(self.hass, address, service.data[CONF_HOST])
-        return {CONF_DEVICE_ID: device_id}
-
-
 class LcnService(StrEnum):
     """LCN service names."""
 
@@ -492,7 +459,6 @@ class LcnService(StrEnum):
     LOCK_KEYS = auto()
     DYN_TEXT = auto()
     PCK = auto()
-    ADDRESS_TO_DEVICE_ID = auto()
 
 
 SERVICES = (
@@ -509,7 +475,6 @@ SERVICES = (
     (LcnService.LOCK_KEYS, LockKeys),
     (LcnService.DYN_TEXT, DynText),
     (LcnService.PCK, Pck),
-    (LcnService.ADDRESS_TO_DEVICE_ID, AddressToDeviceId),
 )
 
 

--- a/homeassistant/components/lcn/services.py
+++ b/homeassistant/components/lcn/services.py
@@ -16,12 +16,16 @@ from homeassistant.const import (
     CONF_TYPE,
     CONF_UNIT_OF_MEASUREMENT,
 )
-from homeassistant.core import HomeAssistant, ServiceCall, SupportsResponse
+from homeassistant.core import (
+    HomeAssistant,
+    ServiceCall,
+    ServiceResponse,
+    SupportsResponse,
+)
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import device_registry as dr
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
-from homeassistant.util.json import JsonObjectType
 
 from .const import (
     CONF_GROUP,
@@ -123,7 +127,7 @@ class LcnServiceCall:
             device_id
         ]
 
-    async def async_call_service(self, service: ServiceCall) -> JsonObjectType | None:
+    async def async_call_service(self, service: ServiceCall) -> ServiceResponse:
         """Execute service call."""
         raise NotImplementedError
 
@@ -447,7 +451,7 @@ class Pck(LcnServiceCall):
 
 
 class AddressToDeviceId(LcnServiceCall):
-    """Get device_id from LCN address string."""
+    """Get device_id from LCN address."""
 
     schema = vol.Schema(
         {
@@ -461,7 +465,7 @@ class AddressToDeviceId(LcnServiceCall):
     )
     supports_response = SupportsResponse.ONLY
 
-    async def async_call_service(self, service: ServiceCall) -> JsonObjectType:
+    async def async_call_service(self, service: ServiceCall) -> ServiceResponse:
         """Execute service call."""
         address: AddressType = (
             service.data[CONF_SEGMENT_ID],

--- a/homeassistant/components/lcn/services.yaml
+++ b/homeassistant/components/lcn/services.yaml
@@ -566,27 +566,3 @@ pck:
       example: "PIN4"
       selector:
         text:
-
-address_to_device_id:
-  fields:
-    id:
-      required: true
-      selector:
-        number:
-          min: 0
-          max: 255
-    segment_id:
-      selector:
-        number:
-          min: 0
-          max: 255
-    type:
-      selector:
-        select:
-          options:
-            - "module"
-            - "group"
-    host:
-      example: "pchk"
-      selector:
-        text:

--- a/homeassistant/components/lcn/services.yaml
+++ b/homeassistant/components/lcn/services.yaml
@@ -2,9 +2,9 @@
 
 output_abs:
   fields:
-    address:
+    device_id:
       required: true
-      example: "myhome.s0.m7"
+      example: "91aa039a2fb6e0b9f9ec7eb219a6b7d2"
       selector:
         text:
     output:
@@ -34,9 +34,9 @@ output_abs:
 
 output_rel:
   fields:
-    address:
+    device_id:
       required: true
-      example: "myhome.s0.m7"
+      example: "91aa039a2fb6e0b9f9ec7eb219a6b7d2"
       selector:
         text:
     output:
@@ -58,9 +58,9 @@ output_rel:
 
 output_toggle:
   fields:
-    address:
+    device_id:
       required: true
-      example: "myhome.s0.m7"
+      example: "91aa039a2fb6e0b9f9ec7eb219a6b7d2"
       selector:
         text:
     output:
@@ -83,9 +83,9 @@ output_toggle:
 
 relays:
   fields:
-    address:
+    device_id:
       required: true
-      example: "myhome.s0.m7"
+      example: "91aa039a2fb6e0b9f9ec7eb219a6b7d2"
       selector:
         text:
     state:
@@ -96,9 +96,9 @@ relays:
 
 led:
   fields:
-    address:
+    device_id:
       required: true
-      example: "myhome.s0.m7"
+      example: "91aa039a2fb6e0b9f9ec7eb219a6b7d2"
       selector:
         text:
     led:
@@ -130,9 +130,9 @@ led:
 
 var_abs:
   fields:
-    address:
+    device_id:
       required: true
-      example: "myhome.s0.m7"
+      example: "91aa039a2fb6e0b9f9ec7eb219a6b7d2"
       selector:
         text:
     variable:
@@ -197,9 +197,9 @@ var_abs:
 
 var_reset:
   fields:
-    address:
+    device_id:
       required: true
-      example: "myhome.s0.m7"
+      example: "91aa039a2fb6e0b9f9ec7eb219a6b7d2"
       selector:
         text:
     variable:
@@ -230,9 +230,9 @@ var_reset:
 
 var_rel:
   fields:
-    address:
+    device_id:
       required: true
-      example: "myhome.s0.m7"
+      example: "91aa039a2fb6e0b9f9ec7eb219a6b7d2"
       selector:
         text:
     variable:
@@ -321,9 +321,9 @@ var_rel:
 
 lock_regulator:
   fields:
-    address:
+    device_id:
       required: true
-      example: "myhome.s0.m7"
+      example: "91aa039a2fb6e0b9f9ec7eb219a6b7d2"
       selector:
         text:
     setpoint:
@@ -355,9 +355,9 @@ lock_regulator:
 
 send_keys:
   fields:
-    address:
+    device_id:
       required: true
-      example: "myhome.s0.m7"
+      example: "91aa039a2fb6e0b9f9ec7eb219a6b7d2"
       selector:
         text:
     keys:
@@ -402,9 +402,9 @@ send_keys:
 
 lock_keys:
   fields:
-    address:
+    device_id:
       required: true
-      example: "myhome.s0.m7"
+      example: "91aa039a2fb6e0b9f9ec7eb219a6b7d2"
       selector:
         text:
     table:
@@ -445,9 +445,9 @@ lock_keys:
 
 dyn_text:
   fields:
-    address:
+    device_id:
       required: true
-      example: "myhome.s0.m7"
+      example: "91aa039a2fb6e0b9f9ec7eb219a6b7d2"
       selector:
         text:
     row:
@@ -464,13 +464,21 @@ dyn_text:
 
 pck:
   fields:
-    address:
+    device_id:
       required: true
-      example: "myhome.s0.m7"
+      example: "91aa039a2fb6e0b9f9ec7eb219a6b7d2"
       selector:
         text:
     pck:
       required: true
       example: "PIN4"
+      selector:
+        text:
+
+address_to_device_id:
+  fields:
+    address:
+      required: true
+      example: "myhome.s0.m7"
       selector:
         text:

--- a/homeassistant/components/lcn/services.yaml
+++ b/homeassistant/components/lcn/services.yaml
@@ -3,8 +3,11 @@
 output_abs:
   fields:
     device_id:
-      required: true
       example: "91aa039a2fb6e0b9f9ec7eb219a6b7d2"
+      selector:
+        text:
+    address:
+      example: "myhome.s0.m7"
       selector:
         text:
     output:
@@ -35,8 +38,11 @@ output_abs:
 output_rel:
   fields:
     device_id:
-      required: true
       example: "91aa039a2fb6e0b9f9ec7eb219a6b7d2"
+      selector:
+        text:
+    address:
+      example: "myhome.s0.m7"
       selector:
         text:
     output:
@@ -59,8 +65,11 @@ output_rel:
 output_toggle:
   fields:
     device_id:
-      required: true
       example: "91aa039a2fb6e0b9f9ec7eb219a6b7d2"
+      selector:
+        text:
+    address:
+      example: "myhome.s0.m7"
       selector:
         text:
     output:
@@ -84,8 +93,11 @@ output_toggle:
 relays:
   fields:
     device_id:
-      required: true
       example: "91aa039a2fb6e0b9f9ec7eb219a6b7d2"
+      selector:
+        text:
+    address:
+      example: "myhome.s0.m7"
       selector:
         text:
     state:
@@ -97,8 +109,11 @@ relays:
 led:
   fields:
     device_id:
-      required: true
       example: "91aa039a2fb6e0b9f9ec7eb219a6b7d2"
+      selector:
+        text:
+    address:
+      example: "myhome.s0.m7"
       selector:
         text:
     led:
@@ -131,8 +146,11 @@ led:
 var_abs:
   fields:
     device_id:
-      required: true
       example: "91aa039a2fb6e0b9f9ec7eb219a6b7d2"
+      selector:
+        text:
+    address:
+      example: "myhome.s0.m7"
       selector:
         text:
     variable:
@@ -198,8 +216,11 @@ var_abs:
 var_reset:
   fields:
     device_id:
-      required: true
       example: "91aa039a2fb6e0b9f9ec7eb219a6b7d2"
+      selector:
+        text:
+    address:
+      example: "myhome.s0.m7"
       selector:
         text:
     variable:
@@ -231,8 +252,11 @@ var_reset:
 var_rel:
   fields:
     device_id:
-      required: true
       example: "91aa039a2fb6e0b9f9ec7eb219a6b7d2"
+      selector:
+        text:
+    address:
+      example: "myhome.s0.m7"
       selector:
         text:
     variable:
@@ -322,8 +346,11 @@ var_rel:
 lock_regulator:
   fields:
     device_id:
-      required: true
       example: "91aa039a2fb6e0b9f9ec7eb219a6b7d2"
+      selector:
+        text:
+    address:
+      example: "myhome.s0.m7"
       selector:
         text:
     setpoint:
@@ -356,8 +383,11 @@ lock_regulator:
 send_keys:
   fields:
     device_id:
-      required: true
       example: "91aa039a2fb6e0b9f9ec7eb219a6b7d2"
+      selector:
+        text:
+    address:
+      example: "myhome.s0.m7"
       selector:
         text:
     keys:
@@ -403,8 +433,11 @@ send_keys:
 lock_keys:
   fields:
     device_id:
-      required: true
       example: "91aa039a2fb6e0b9f9ec7eb219a6b7d2"
+      selector:
+        text:
+    address:
+      example: "myhome.s0.m7"
       selector:
         text:
     table:
@@ -446,8 +479,11 @@ lock_keys:
 dyn_text:
   fields:
     device_id:
-      required: true
       example: "91aa039a2fb6e0b9f9ec7eb219a6b7d2"
+      selector:
+        text:
+    address:
+      example: "myhome.s0.m7"
       selector:
         text:
     row:
@@ -465,8 +501,11 @@ dyn_text:
 pck:
   fields:
     device_id:
-      required: true
       example: "91aa039a2fb6e0b9f9ec7eb219a6b7d2"
+      selector:
+        text:
+    address:
+      example: "myhome.s0.m7"
       selector:
         text:
     pck:

--- a/homeassistant/components/lcn/services.yaml
+++ b/homeassistant/components/lcn/services.yaml
@@ -4,8 +4,73 @@ output_abs:
   fields:
     device_id:
       example: "91aa039a2fb6e0b9f9ec7eb219a6b7d2"
-      selector:
-        text:
+      selector: &device_selector
+        device:
+          filter:
+            - integration: lcn
+              model: LCN group
+            - integration: lcn
+              model: UnknownModuleType
+            - integration: lcn
+              model: LCN-SW1.0
+            - integration: lcn
+              model: LCN-SW1.1
+            - integration: lcn
+              model: LCN-UP1.0
+            - integration: lcn
+              model: LCN-UP2
+            - integration: lcn
+              model: LCN-SW2
+            - integration: lcn
+              model: LCN-UP-Profi1-Plus
+            - integration: lcn
+              model: LCN-DI12
+            - integration: lcn
+              model: LCN-HU
+            - integration: lcn
+              model: LCN-SH
+            - integration: lcn
+              model: LCN-UP2
+            - integration: lcn
+              model: LCN-UPP
+            - integration: lcn
+              model: LCN-SK
+            - integration: lcn
+              model: LCN-LD
+            - integration: lcn
+              model: LCN-SH-Plus
+            - integration: lcn
+              model: LCN-UPS
+            - integration: lcn
+              model: LCN_UPS24V
+            - integration: lcn
+              model: LCN-GTM
+            - integration: lcn
+              model: LCN-SHS
+            - integration: lcn
+              model: LCN-ESD
+            - integration: lcn
+              model: LCN-EB2
+            - integration: lcn
+              model: LCN-MRS
+            - integration: lcn
+              model: LCN-EB11
+            - integration: lcn
+              model: LCN-UMR
+            - integration: lcn
+              model: LCN-UPU
+            - integration: lcn
+              model: LCN-UMR24V
+            - integration: lcn
+              model: LCN-SHD
+            - integration: lcn
+              model: LCN-SHU
+            - integration: lcn
+              model: LCN-SR6
+            - integration: lcn
+              model: LCN-UMF
+            - integration: lcn
+              model: LCN-WBH
     address:
       example: "myhome.s0.m7"
       selector:
@@ -39,8 +104,7 @@ output_rel:
   fields:
     device_id:
       example: "91aa039a2fb6e0b9f9ec7eb219a6b7d2"
-      selector:
-        text:
+      selector: *device_selector
     address:
       example: "myhome.s0.m7"
       selector:
@@ -66,8 +130,7 @@ output_toggle:
   fields:
     device_id:
       example: "91aa039a2fb6e0b9f9ec7eb219a6b7d2"
-      selector:
-        text:
+      selector: *device_selector
     address:
       example: "myhome.s0.m7"
       selector:
@@ -94,8 +157,7 @@ relays:
   fields:
     device_id:
       example: "91aa039a2fb6e0b9f9ec7eb219a6b7d2"
-      selector:
-        text:
+      selector: *device_selector
     address:
       example: "myhome.s0.m7"
       selector:
@@ -110,8 +172,7 @@ led:
   fields:
     device_id:
       example: "91aa039a2fb6e0b9f9ec7eb219a6b7d2"
-      selector:
-        text:
+      selector: *device_selector
     address:
       example: "myhome.s0.m7"
       selector:
@@ -147,8 +208,7 @@ var_abs:
   fields:
     device_id:
       example: "91aa039a2fb6e0b9f9ec7eb219a6b7d2"
-      selector:
-        text:
+      selector: *device_selector
     address:
       example: "myhome.s0.m7"
       selector:
@@ -217,8 +277,7 @@ var_reset:
   fields:
     device_id:
       example: "91aa039a2fb6e0b9f9ec7eb219a6b7d2"
-      selector:
-        text:
+      selector: *device_selector
     address:
       example: "myhome.s0.m7"
       selector:
@@ -253,8 +312,7 @@ var_rel:
   fields:
     device_id:
       example: "91aa039a2fb6e0b9f9ec7eb219a6b7d2"
-      selector:
-        text:
+      selector: *device_selector
     address:
       example: "myhome.s0.m7"
       selector:
@@ -347,8 +405,7 @@ lock_regulator:
   fields:
     device_id:
       example: "91aa039a2fb6e0b9f9ec7eb219a6b7d2"
-      selector:
-        text:
+      selector: *device_selector
     address:
       example: "myhome.s0.m7"
       selector:
@@ -384,8 +441,7 @@ send_keys:
   fields:
     device_id:
       example: "91aa039a2fb6e0b9f9ec7eb219a6b7d2"
-      selector:
-        text:
+      selector: *device_selector
     address:
       example: "myhome.s0.m7"
       selector:
@@ -434,8 +490,7 @@ lock_keys:
   fields:
     device_id:
       example: "91aa039a2fb6e0b9f9ec7eb219a6b7d2"
-      selector:
-        text:
+      selector: *device_selector
     address:
       example: "myhome.s0.m7"
       selector:
@@ -480,8 +535,7 @@ dyn_text:
   fields:
     device_id:
       example: "91aa039a2fb6e0b9f9ec7eb219a6b7d2"
-      selector:
-        text:
+      selector: *device_selector
     address:
       example: "myhome.s0.m7"
       selector:
@@ -502,8 +556,7 @@ pck:
   fields:
     device_id:
       example: "91aa039a2fb6e0b9f9ec7eb219a6b7d2"
-      selector:
-        text:
+      selector: *device_selector
     address:
       example: "myhome.s0.m7"
       selector:

--- a/homeassistant/components/lcn/services.yaml
+++ b/homeassistant/components/lcn/services.yaml
@@ -516,8 +516,24 @@ pck:
 
 address_to_device_id:
   fields:
-    address:
+    id:
       required: true
-      example: "myhome.s0.m7"
+      selector:
+        number:
+          min: 0
+          max: 255
+    segment_id:
+      selector:
+        number:
+          min: 0
+          max: 255
+    type:
+      selector:
+        select:
+          options:
+            - "module"
+            - "group"
+    host:
+      example: "pchk"
       selector:
         text:

--- a/homeassistant/components/lcn/strings.json
+++ b/homeassistant/components/lcn/strings.json
@@ -77,9 +77,9 @@
       "name": "Output absolute brightness",
       "description": "Sets absolute brightness of output port in percent.",
       "fields": {
-        "address": {
-          "name": "Address",
-          "description": "Module address."
+        "device_id": {
+          "name": "[%key:common::config_flow::data::device%]",
+          "description": "The device_id of the LCN module or group."
         },
         "output": {
           "name": "Output",
@@ -99,9 +99,9 @@
       "name": "Output relative brightness",
       "description": "Sets relative brightness of output port in percent.",
       "fields": {
-        "address": {
-          "name": "Address",
-          "description": "[%key:component::lcn::services::output_abs::fields::address::description%]"
+        "device_id": {
+          "name": "[%key:common::config_flow::data::device%]",
+          "description": "[%key:component::lcn::services::output_abs::fields::device_id::description%]"
         },
         "output": {
           "name": "[%key:component::lcn::services::output_abs::fields::output::name%]",
@@ -117,9 +117,9 @@
       "name": "Toggle output",
       "description": "Toggles output port.",
       "fields": {
-        "address": {
-          "name": "Address",
-          "description": "[%key:component::lcn::services::output_abs::fields::address::description%]"
+        "device_id": {
+          "name": "[%key:common::config_flow::data::device%]",
+          "description": "[%key:component::lcn::services::output_abs::fields::device_id::description%]"
         },
         "output": {
           "name": "[%key:component::lcn::services::output_abs::fields::output::name%]",
@@ -135,9 +135,9 @@
       "name": "Relays",
       "description": "Sets the relays status.",
       "fields": {
-        "address": {
-          "name": "Address",
-          "description": "[%key:component::lcn::services::output_abs::fields::address::description%]"
+        "device_id": {
+          "name": "[%key:common::config_flow::data::device%]",
+          "description": "[%key:component::lcn::services::output_abs::fields::device_id::description%]"
         },
         "state": {
           "name": "State",
@@ -149,9 +149,9 @@
       "name": "LED",
       "description": "Sets the led state.",
       "fields": {
-        "address": {
-          "name": "Address",
-          "description": "[%key:component::lcn::services::output_abs::fields::address::description%]"
+        "device_id": {
+          "name": "[%key:common::config_flow::data::device%]",
+          "description": "[%key:component::lcn::services::output_abs::fields::device_id::description%]"
         },
         "led": {
           "name": "[%key:component::lcn::services::led::name%]",
@@ -167,9 +167,9 @@
       "name": "Set absolute variable",
       "description": "Sets absolute value of a variable or setpoint.",
       "fields": {
-        "address": {
-          "name": "Address",
-          "description": "[%key:component::lcn::services::output_abs::fields::address::description%]"
+        "device_id": {
+          "name": "[%key:common::config_flow::data::device%]",
+          "description": "[%key:component::lcn::services::output_abs::fields::device_id::description%]"
         },
         "variable": {
           "name": "Variable",
@@ -189,9 +189,9 @@
       "name": "Reset variable",
       "description": "Resets value of variable or setpoint.",
       "fields": {
-        "address": {
-          "name": "Address",
-          "description": "[%key:component::lcn::services::output_abs::fields::address::description%]"
+        "device_id": {
+          "name": "[%key:common::config_flow::data::device%]",
+          "description": "[%key:component::lcn::services::output_abs::fields::device_id::description%]"
         },
         "variable": {
           "name": "[%key:component::lcn::services::var_abs::fields::variable::name%]",
@@ -203,9 +203,9 @@
       "name": "Shift variable",
       "description": "Shift value of a variable, setpoint or threshold.",
       "fields": {
-        "address": {
-          "name": "Address",
-          "description": "[%key:component::lcn::services::output_abs::fields::address::description%]"
+        "device_id": {
+          "name": "[%key:common::config_flow::data::device%]",
+          "description": "[%key:component::lcn::services::output_abs::fields::device_id::description%]"
         },
         "variable": {
           "name": "[%key:component::lcn::services::var_abs::fields::variable::name%]",
@@ -229,9 +229,9 @@
       "name": "Lock regulator",
       "description": "Locks a regulator setpoint.",
       "fields": {
-        "address": {
-          "name": "Address",
-          "description": "[%key:component::lcn::services::output_abs::fields::address::description%]"
+        "device_id": {
+          "name": "[%key:common::config_flow::data::device%]",
+          "description": "[%key:component::lcn::services::output_abs::fields::device_id::description%]"
         },
         "setpoint": {
           "name": "Setpoint",
@@ -247,9 +247,9 @@
       "name": "Send keys",
       "description": "Sends keys (which executes bound commands).",
       "fields": {
-        "address": {
-          "name": "Address",
-          "description": "[%key:component::lcn::services::output_abs::fields::address::description%]"
+        "device_id": {
+          "name": "[%key:common::config_flow::data::device%]",
+          "description": "[%key:component::lcn::services::output_abs::fields::device_id::description%]"
         },
         "keys": {
           "name": "Keys",
@@ -273,9 +273,9 @@
       "name": "Lock keys",
       "description": "Locks keys.",
       "fields": {
-        "address": {
-          "name": "Address",
-          "description": "[%key:component::lcn::services::output_abs::fields::address::description%]"
+        "device_id": {
+          "name": "[%key:common::config_flow::data::device%]",
+          "description": "[%key:component::lcn::services::output_abs::fields::device_id::description%]"
         },
         "table": {
           "name": "Table",
@@ -299,9 +299,9 @@
       "name": "Dynamic text",
       "description": "Sends dynamic text to LCN-GTxD displays.",
       "fields": {
-        "address": {
-          "name": "Address",
-          "description": "[%key:component::lcn::services::output_abs::fields::address::description%]"
+        "device_id": {
+          "name": "[%key:common::config_flow::data::device%]",
+          "description": "[%key:component::lcn::services::output_abs::fields::device_id::description%]"
         },
         "row": {
           "name": "Row",
@@ -317,13 +317,23 @@
       "name": "PCK",
       "description": "Sends arbitrary PCK command.",
       "fields": {
-        "address": {
-          "name": "Address",
-          "description": "[%key:component::lcn::services::output_abs::fields::address::description%]"
+        "device_id": {
+          "name": "[%key:common::config_flow::data::device%]",
+          "description": "[%key:component::lcn::services::output_abs::fields::device_id::description%]"
         },
         "pck": {
           "name": "[%key:component::lcn::services::pck::name%]",
           "description": "PCK command (without address header)."
+        }
+      }
+    },
+    "address_to_device_id": {
+      "name": "Address to device id",
+      "description": "Convert LCN address to device id.",
+      "fields": {
+        "address": {
+          "name": "Address",
+          "description": "LCN address"
         }
       }
     }

--- a/homeassistant/components/lcn/strings.json
+++ b/homeassistant/components/lcn/strings.json
@@ -70,6 +70,10 @@
     "deprecated_keylock_sensor": {
       "title": "Deprecated LCN key lock binary sensor",
       "description": "Your LCN key lock binary sensor entity `{entity}` is beeing used in automations or scripts. A key lock switch entity is available and should be used going forward.\n\nPlease adjust your automations or scripts to fix this issue."
+    },
+    "deprecated_address_parameter": {
+      "title": "Deprecated 'address' parameter",
+      "description": "The 'address' parameter in the LCN service calls is deprecated. The 'devide_id' parameter should be used going forward.\n\nPlease adjust your automations or scripts to fix this issue."
     }
   },
   "services": {
@@ -383,9 +387,21 @@
       "name": "Address to device id",
       "description": "Convert LCN address to device id.",
       "fields": {
-        "address": {
-          "name": "Address",
-          "description": "[%key:component::lcn::services::output_abs::fields::address::description%]"
+        "id": {
+          "name": "Module or group id",
+          "description": "Target module or group id."
+        },
+        "segment_id": {
+          "name": "Segment id",
+          "description": "Target segment id."
+        },
+        "type": {
+          "name": "Type",
+          "description": "Target type."
+        },
+        "host": {
+          "name": "Host name",
+          "description": "Host name as given in the integration panel."
         }
       }
     }

--- a/homeassistant/components/lcn/strings.json
+++ b/homeassistant/components/lcn/strings.json
@@ -81,6 +81,10 @@
           "name": "[%key:common::config_flow::data::device%]",
           "description": "The device_id of the LCN module or group."
         },
+        "address": {
+          "name": "Address",
+          "description": "Module address."
+        },
         "output": {
           "name": "Output",
           "description": "Output port."
@@ -103,6 +107,10 @@
           "name": "[%key:common::config_flow::data::device%]",
           "description": "[%key:component::lcn::services::output_abs::fields::device_id::description%]"
         },
+        "address": {
+          "name": "Address",
+          "description": "[%key:component::lcn::services::output_abs::fields::address::description%]"
+        },
         "output": {
           "name": "[%key:component::lcn::services::output_abs::fields::output::name%]",
           "description": "[%key:component::lcn::services::output_abs::fields::output::description%]"
@@ -120,6 +128,10 @@
         "device_id": {
           "name": "[%key:common::config_flow::data::device%]",
           "description": "[%key:component::lcn::services::output_abs::fields::device_id::description%]"
+        },
+        "address": {
+          "name": "Address",
+          "description": "[%key:component::lcn::services::output_abs::fields::address::description%]"
         },
         "output": {
           "name": "[%key:component::lcn::services::output_abs::fields::output::name%]",
@@ -139,6 +151,10 @@
           "name": "[%key:common::config_flow::data::device%]",
           "description": "[%key:component::lcn::services::output_abs::fields::device_id::description%]"
         },
+        "address": {
+          "name": "Address",
+          "description": "[%key:component::lcn::services::output_abs::fields::address::description%]"
+        },
         "state": {
           "name": "State",
           "description": "Relays states as string (1=on, 2=off, t=toggle, -=no change)."
@@ -152,6 +168,10 @@
         "device_id": {
           "name": "[%key:common::config_flow::data::device%]",
           "description": "[%key:component::lcn::services::output_abs::fields::device_id::description%]"
+        },
+        "address": {
+          "name": "Address",
+          "description": "[%key:component::lcn::services::output_abs::fields::address::description%]"
         },
         "led": {
           "name": "[%key:component::lcn::services::led::name%]",
@@ -170,6 +190,10 @@
         "device_id": {
           "name": "[%key:common::config_flow::data::device%]",
           "description": "[%key:component::lcn::services::output_abs::fields::device_id::description%]"
+        },
+        "address": {
+          "name": "Address",
+          "description": "[%key:component::lcn::services::output_abs::fields::address::description%]"
         },
         "variable": {
           "name": "Variable",
@@ -193,6 +217,10 @@
           "name": "[%key:common::config_flow::data::device%]",
           "description": "[%key:component::lcn::services::output_abs::fields::device_id::description%]"
         },
+        "address": {
+          "name": "Address",
+          "description": "[%key:component::lcn::services::output_abs::fields::address::description%]"
+        },
         "variable": {
           "name": "[%key:component::lcn::services::var_abs::fields::variable::name%]",
           "description": "[%key:component::lcn::services::var_abs::fields::variable::description%]"
@@ -206,6 +234,10 @@
         "device_id": {
           "name": "[%key:common::config_flow::data::device%]",
           "description": "[%key:component::lcn::services::output_abs::fields::device_id::description%]"
+        },
+        "address": {
+          "name": "Address",
+          "description": "[%key:component::lcn::services::output_abs::fields::address::description%]"
         },
         "variable": {
           "name": "[%key:component::lcn::services::var_abs::fields::variable::name%]",
@@ -233,6 +265,10 @@
           "name": "[%key:common::config_flow::data::device%]",
           "description": "[%key:component::lcn::services::output_abs::fields::device_id::description%]"
         },
+        "address": {
+          "name": "Address",
+          "description": "[%key:component::lcn::services::output_abs::fields::address::description%]"
+        },
         "setpoint": {
           "name": "Setpoint",
           "description": "Setpoint name."
@@ -250,6 +286,10 @@
         "device_id": {
           "name": "[%key:common::config_flow::data::device%]",
           "description": "[%key:component::lcn::services::output_abs::fields::device_id::description%]"
+        },
+        "address": {
+          "name": "Address",
+          "description": "[%key:component::lcn::services::output_abs::fields::address::description%]"
         },
         "keys": {
           "name": "Keys",
@@ -277,6 +317,10 @@
           "name": "[%key:common::config_flow::data::device%]",
           "description": "[%key:component::lcn::services::output_abs::fields::device_id::description%]"
         },
+        "address": {
+          "name": "Address",
+          "description": "[%key:component::lcn::services::output_abs::fields::address::description%]"
+        },
         "table": {
           "name": "Table",
           "description": "Table with keys to lock (must be A for interval)."
@@ -303,6 +347,10 @@
           "name": "[%key:common::config_flow::data::device%]",
           "description": "[%key:component::lcn::services::output_abs::fields::device_id::description%]"
         },
+        "address": {
+          "name": "Address",
+          "description": "[%key:component::lcn::services::output_abs::fields::address::description%]"
+        },
         "row": {
           "name": "Row",
           "description": "Text row."
@@ -321,6 +369,10 @@
           "name": "[%key:common::config_flow::data::device%]",
           "description": "[%key:component::lcn::services::output_abs::fields::device_id::description%]"
         },
+        "address": {
+          "name": "Address",
+          "description": "[%key:component::lcn::services::output_abs::fields::address::description%]"
+        },
         "pck": {
           "name": "[%key:component::lcn::services::pck::name%]",
           "description": "PCK command (without address header)."
@@ -333,9 +385,20 @@
       "fields": {
         "address": {
           "name": "Address",
-          "description": "LCN address"
+          "description": "[%key:component::lcn::services::output_abs::fields::address::description%]"
         }
       }
+    }
+  },
+  "exceptions": {
+    "no_device_identifier": {
+      "message": "No device identifier provided. Please provide the device id."
+    },
+    "invalid_address": {
+      "message": "LCN device for given address has not been configured."
+    },
+    "invalid_device_id": {
+      "message": "LCN device for given device id has not been configured."
     }
   }
 }

--- a/tests/components/lcn/test_services.py
+++ b/tests/components/lcn/test_services.py
@@ -56,7 +56,6 @@ async def test_service_output_abs(
     hass: HomeAssistant,
     entry: MockConfigEntry,
     config_type: str,
-    issue_registry: ir.IssueRegistry,
 ) -> None:
     """Test output_abs service."""
     await async_setup_component(hass, "persistent_notification", {})
@@ -77,16 +76,12 @@ async def test_service_output_abs(
 
     dim_output.assert_awaited_with(0, 100, 9)
 
-    if config_type == CONF_ADDRESS:
-        assert issue_registry.async_get_issue(DOMAIN, "deprecated_address_parameter")
-
 
 @pytest.mark.parametrize("config_type", [CONF_ADDRESS, CONF_DEVICE_ID])
 async def test_service_output_rel(
     hass: HomeAssistant,
     entry: MockConfigEntry,
     config_type: str,
-    issue_registry: ir.IssueRegistry,
 ) -> None:
     """Test output_rel service."""
     await async_setup_component(hass, "persistent_notification", {})
@@ -106,16 +101,12 @@ async def test_service_output_rel(
 
     rel_output.assert_awaited_with(0, 25)
 
-    if config_type == CONF_ADDRESS:
-        assert issue_registry.async_get_issue(DOMAIN, "deprecated_address_parameter")
-
 
 @pytest.mark.parametrize("config_type", [CONF_ADDRESS, CONF_DEVICE_ID])
 async def test_service_output_toggle(
     hass: HomeAssistant,
     entry: MockConfigEntry,
     config_type: str,
-    issue_registry: ir.IssueRegistry,
 ) -> None:
     """Test output_toggle service."""
     await async_setup_component(hass, "persistent_notification", {})
@@ -135,16 +126,12 @@ async def test_service_output_toggle(
 
     toggle_output.assert_awaited_with(0, 9)
 
-    if config_type == CONF_ADDRESS:
-        assert issue_registry.async_get_issue(DOMAIN, "deprecated_address_parameter")
-
 
 @pytest.mark.parametrize("config_type", [CONF_ADDRESS, CONF_DEVICE_ID])
 async def test_service_relays(
     hass: HomeAssistant,
     entry: MockConfigEntry,
     config_type: str,
-    issue_registry: ir.IssueRegistry,
 ) -> None:
     """Test relays service."""
     await async_setup_component(hass, "persistent_notification", {})
@@ -163,16 +150,12 @@ async def test_service_relays(
 
     control_relays.assert_awaited_with(relay_states)
 
-    if config_type == CONF_ADDRESS:
-        assert issue_registry.async_get_issue(DOMAIN, "deprecated_address_parameter")
-
 
 @pytest.mark.parametrize("config_type", [CONF_ADDRESS, CONF_DEVICE_ID])
 async def test_service_led(
     hass: HomeAssistant,
     entry: MockConfigEntry,
     config_type: str,
-    issue_registry: ir.IssueRegistry,
 ) -> None:
     """Test led service."""
     await async_setup_component(hass, "persistent_notification", {})
@@ -195,16 +178,12 @@ async def test_service_led(
 
     control_led.assert_awaited_with(led, led_state)
 
-    if config_type == CONF_ADDRESS:
-        assert issue_registry.async_get_issue(DOMAIN, "deprecated_address_parameter")
-
 
 @pytest.mark.parametrize("config_type", [CONF_ADDRESS, CONF_DEVICE_ID])
 async def test_service_var_abs(
     hass: HomeAssistant,
     entry: MockConfigEntry,
     config_type: str,
-    issue_registry: ir.IssueRegistry,
 ) -> None:
     """Test var_abs service."""
     await async_setup_component(hass, "persistent_notification", {})
@@ -227,16 +206,12 @@ async def test_service_var_abs(
         pypck.lcn_defs.Var["VAR1"], 75, pypck.lcn_defs.VarUnit.parse("%")
     )
 
-    if config_type == CONF_ADDRESS:
-        assert issue_registry.async_get_issue(DOMAIN, "deprecated_address_parameter")
-
 
 @pytest.mark.parametrize("config_type", [CONF_ADDRESS, CONF_DEVICE_ID])
 async def test_service_var_rel(
     hass: HomeAssistant,
     entry: MockConfigEntry,
     config_type: str,
-    issue_registry: ir.IssueRegistry,
 ) -> None:
     """Test var_rel service."""
     await async_setup_component(hass, "persistent_notification", {})
@@ -263,16 +238,12 @@ async def test_service_var_rel(
         pypck.lcn_defs.RelVarRef["CURRENT"],
     )
 
-    if config_type == CONF_ADDRESS:
-        assert issue_registry.async_get_issue(DOMAIN, "deprecated_address_parameter")
-
 
 @pytest.mark.parametrize("config_type", [CONF_ADDRESS, CONF_DEVICE_ID])
 async def test_service_var_reset(
     hass: HomeAssistant,
     entry: MockConfigEntry,
     config_type: str,
-    issue_registry: ir.IssueRegistry,
 ) -> None:
     """Test var_reset service."""
     await async_setup_component(hass, "persistent_notification", {})
@@ -288,16 +259,12 @@ async def test_service_var_reset(
 
     var_reset.assert_awaited_with(pypck.lcn_defs.Var["VAR1"])
 
-    if config_type == CONF_ADDRESS:
-        assert issue_registry.async_get_issue(DOMAIN, "deprecated_address_parameter")
-
 
 @pytest.mark.parametrize("config_type", [CONF_ADDRESS, CONF_DEVICE_ID])
 async def test_service_lock_regulator(
     hass: HomeAssistant,
     entry: MockConfigEntry,
     config_type: str,
-    issue_registry: ir.IssueRegistry,
 ) -> None:
     """Test lock_regulator service."""
     await async_setup_component(hass, "persistent_notification", {})
@@ -317,16 +284,12 @@ async def test_service_lock_regulator(
 
     lock_regulator.assert_awaited_with(0, True)
 
-    if config_type == CONF_ADDRESS:
-        assert issue_registry.async_get_issue(DOMAIN, "deprecated_address_parameter")
-
 
 @pytest.mark.parametrize("config_type", [CONF_ADDRESS, CONF_DEVICE_ID])
 async def test_service_send_keys(
     hass: HomeAssistant,
     entry: MockConfigEntry,
     config_type: str,
-    issue_registry: ir.IssueRegistry,
 ) -> None:
     """Test send_keys service."""
     await async_setup_component(hass, "persistent_notification", {})
@@ -351,16 +314,12 @@ async def test_service_send_keys(
 
     send_keys.assert_awaited_with(keys, pypck.lcn_defs.SendKeyCommand["HIT"])
 
-    if config_type == CONF_ADDRESS:
-        assert issue_registry.async_get_issue(DOMAIN, "deprecated_address_parameter")
-
 
 @pytest.mark.parametrize("config_type", [CONF_ADDRESS, CONF_DEVICE_ID])
 async def test_service_send_keys_hit_deferred(
     hass: HomeAssistant,
     entry: MockConfigEntry,
     config_type: str,
-    issue_registry: ir.IssueRegistry,
 ) -> None:
     """Test send_keys (hit_deferred) service."""
     await async_setup_component(hass, "persistent_notification", {})
@@ -391,9 +350,6 @@ async def test_service_send_keys_hit_deferred(
         keys, 5, pypck.lcn_defs.TimeUnit.parse("S")
     )
 
-    if config_type == CONF_ADDRESS:
-        assert issue_registry.async_get_issue(DOMAIN, "deprecated_address_parameter")
-
     # wrong key action
     with (
         patch.object(
@@ -420,7 +376,6 @@ async def test_service_lock_keys(
     hass: HomeAssistant,
     entry: MockConfigEntry,
     config_type: str,
-    issue_registry: ir.IssueRegistry,
 ) -> None:
     """Test lock_keys service."""
     await async_setup_component(hass, "persistent_notification", {})
@@ -443,16 +398,12 @@ async def test_service_lock_keys(
 
     lock_keys.assert_awaited_with(0, lock_states)
 
-    if config_type == CONF_ADDRESS:
-        assert issue_registry.async_get_issue(DOMAIN, "deprecated_address_parameter")
-
 
 @pytest.mark.parametrize("config_type", [CONF_ADDRESS, CONF_DEVICE_ID])
 async def test_service_lock_keys_tab_a_temporary(
     hass: HomeAssistant,
     entry: MockConfigEntry,
     config_type: str,
-    issue_registry: ir.IssueRegistry,
 ) -> None:
     """Test lock_keys (tab_a_temporary) service."""
     await async_setup_component(hass, "persistent_notification", {})
@@ -481,9 +432,6 @@ async def test_service_lock_keys_tab_a_temporary(
         10, pypck.lcn_defs.TimeUnit.parse("S"), lock_states
     )
 
-    if config_type == CONF_ADDRESS:
-        assert issue_registry.async_get_issue(DOMAIN, "deprecated_address_parameter")
-
     # wrong table
     with (
         patch.object(
@@ -510,7 +458,6 @@ async def test_service_dyn_text(
     hass: HomeAssistant,
     entry: MockConfigEntry,
     config_type: str,
-    issue_registry: ir.IssueRegistry,
 ) -> None:
     """Test dyn_text service."""
     await async_setup_component(hass, "persistent_notification", {})
@@ -530,16 +477,12 @@ async def test_service_dyn_text(
 
     dyn_text.assert_awaited_with(0, "text in row 1")
 
-    if config_type == CONF_ADDRESS:
-        assert issue_registry.async_get_issue(DOMAIN, "deprecated_address_parameter")
-
 
 @pytest.mark.parametrize("config_type", [CONF_ADDRESS, CONF_DEVICE_ID])
 async def test_service_pck(
     hass: HomeAssistant,
     entry: MockConfigEntry,
     config_type: str,
-    issue_registry: ir.IssueRegistry,
 ) -> None:
     """Test pck service."""
     await async_setup_component(hass, "persistent_notification", {})
@@ -554,9 +497,6 @@ async def test_service_pck(
         )
 
     pck.assert_awaited_with("PIN4")
-
-    if config_type == CONF_ADDRESS:
-        assert issue_registry.async_get_issue(DOMAIN, "deprecated_address_parameter")
 
 
 async def test_service_called_with_invalid_host_id(
@@ -575,3 +515,20 @@ async def test_service_called_with_invalid_host_id(
         )
 
     pck.assert_not_awaited()
+
+
+async def test_service_with_deprecated_address_parameter(
+    hass: HomeAssistant, entry: MockConfigEntry, issue_registry: ir.IssueRegistry
+) -> None:
+    """Test service puts issue in registry if called with address parameter."""
+    await async_setup_component(hass, "persistent_notification", {})
+    await init_integration(hass, entry)
+
+    await hass.services.async_call(
+        DOMAIN,
+        LcnService.PCK,
+        {CONF_ADDRESS: "pchk.s0.m7", CONF_PCK: "PIN4"},
+        blocking=True,
+    )
+
+    assert issue_registry.async_get_issue(DOMAIN, "deprecated_address_parameter")

--- a/tests/components/lcn/test_services.py
+++ b/tests/components/lcn/test_services.py
@@ -9,12 +9,10 @@ from homeassistant.components.lcn import DOMAIN
 from homeassistant.components.lcn.const import (
     CONF_KEYS,
     CONF_LED,
-    CONF_MODULE,
     CONF_OUTPUT,
     CONF_PCK,
     CONF_RELVARREF,
     CONF_ROW,
-    CONF_SEGMENT_ID,
     CONF_SETPOINT,
     CONF_TABLE,
     CONF_TEXT,
@@ -29,10 +27,7 @@ from homeassistant.const import (
     CONF_ADDRESS,
     CONF_BRIGHTNESS,
     CONF_DEVICE_ID,
-    CONF_HOST,
-    CONF_ID,
     CONF_STATE,
-    CONF_TYPE,
     CONF_UNIT_OF_MEASUREMENT,
 )
 from homeassistant.core import HomeAssistant
@@ -563,24 +558,6 @@ async def test_service_pck(
 
     if config_type == CONF_ADDRESS:
         assert issue_registry.async_get_issue(DOMAIN, "deprecated_address_parameter")
-
-
-async def test_service_address_to_device_id(
-    hass: HomeAssistant, entry: MockConfigEntry
-) -> None:
-    """Test address_to_device_id service."""
-    await async_setup_component(hass, "persistent_notification", {})
-    await init_integration(hass, entry)
-
-    response = await hass.services.async_call(
-        DOMAIN,
-        LcnService.ADDRESS_TO_DEVICE_ID,
-        {CONF_ID: 7, CONF_SEGMENT_ID: 0, CONF_TYPE: CONF_MODULE, CONF_HOST: "pchk"},
-        return_response=True,
-        blocking=True,
-    )
-
-    assert response == {CONF_DEVICE_ID: get_device(hass, entry, (0, 7, False)).id}
 
 
 async def test_service_called_with_invalid_host_id(

--- a/tests/components/lcn/test_services.py
+++ b/tests/components/lcn/test_services.py
@@ -30,6 +30,7 @@ from homeassistant.const import (
     CONF_UNIT_OF_MEASUREMENT,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
 from homeassistant.setup import async_setup_component
 
 from .conftest import (
@@ -428,7 +429,10 @@ async def test_service_called_with_invalid_host_id(
     await async_setup_component(hass, "persistent_notification", {})
     await init_integration(hass, entry)
 
-    with patch.object(MockModuleConnection, "pck") as pck, pytest.raises(ValueError):
+    with (
+        patch.object(MockModuleConnection, "pck") as pck,
+        pytest.raises(ServiceValidationError),
+    ):
         await hass.services.async_call(
             DOMAIN,
             LcnService.PCK,

--- a/tests/components/lcn/test_services.py
+++ b/tests/components/lcn/test_services.py
@@ -31,7 +31,6 @@ from homeassistant.const import (
     CONF_UNIT_OF_MEASUREMENT,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ServiceValidationError
 import homeassistant.helpers.issue_registry as ir
 from homeassistant.setup import async_setup_component
 
@@ -567,10 +566,7 @@ async def test_service_called_with_invalid_host_id(
     await async_setup_component(hass, "persistent_notification", {})
     await init_integration(hass, entry)
 
-    with (
-        patch.object(MockModuleConnection, "pck") as pck,
-        pytest.raises(ServiceValidationError),
-    ):
+    with patch.object(MockModuleConnection, "pck") as pck, pytest.raises(ValueError):
         await hass.services.async_call(
             DOMAIN,
             LcnService.PCK,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
The LCN actions (service calls) are all bound to the LCN hardware modules. They call functions in these modules for which HomeAssistant has not provided any suitable entities at the time of implementation.
Due to the history of the implementation, the modules are addressed via a non-intuitive address string when defining the action, which does not fit to the rest of the configuration as this string does not appear elsewhere.

It therefore makes sense to replace the non-intuitive address string with the HomeAssistant device_id (each hardware module is already assigned one) and use this in the action (service call) definition.
I would also like to supplement (or replace) the services with device actions in the future. This requires the device_id anyway.

The device_id is therefore added as an additional parameter to each action definition. The existing address string parameter has been marked as deprecated and will be removed in a future version.

I have also added a new action that determines the device_id from the known hardware address parameters.
This is useful because the device_id is not always known when scripting automations (as opposed to the hardware address parameters which is usually known to the user).



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/35600

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
