### PR TITLE
Update codeowners of Fritz integration

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -496,8 +496,8 @@ build.json @home-assistant/supervisor
 /tests/components/freebox/ @hacf-fr @Quentame
 /homeassistant/components/freedompro/ @stefano055415
 /tests/components/freedompro/ @stefano055415
-/homeassistant/components/fritz/ @mammuth @AaronDavidSchneider @chemelli74 @mib1185
-/tests/components/fritz/ @mammuth @AaronDavidSchneider @chemelli74 @mib1185
+/homeassistant/components/fritz/ @AaronDavidSchneider @chemelli74 @mib1185
+/tests/components/fritz/ @AaronDavidSchneider @chemelli74 @mib1185
 /homeassistant/components/fritzbox/ @mib1185 @flabbamann
 /tests/components/fritzbox/ @mib1185 @flabbamann
 /homeassistant/components/fritzbox_callmonitor/ @cdce8p

--- a/homeassistant/components/fritz/manifest.json
+++ b/homeassistant/components/fritz/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "fritz",
   "name": "AVM FRITZ!Box Tools",
-  "codeowners": ["@mammuth", "@AaronDavidSchneider", "@chemelli74", "@mib1185"],
+  "codeowners": ["@AaronDavidSchneider", "@chemelli74", "@mib1185"],
   "config_flow": true,
   "dependencies": ["network"],
   "documentation": "https://www.home-assistant.io/integrations/fritz",


### PR DESCRIPTION
Removing myself from the list of codeowners because I'm not actively maintaining the component.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->
None of the below, just a manifest.json update.
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] ~~The code change is tested and works locally.~~
- [ ] ~~Local tests pass.~~
- [ ] ~~There is no commented out code in this PR.~~
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] ~~The code has been formatted using Ruff (`ruff format homeassistant tests`)~~
- [ ] ~~Tests have been added to verify that the new code works.~~

If user exposed functionality or configuration variables are added/changed:

- [ ] ~~Documentation added/updated for [www.home-assistant.io][docs-repository]~~

If the code communicates with devices, web services, or third-party tools:

- [ ] ~~The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.~~
- [ ] ~~New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.~~
- [ ] ~~For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.~~

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure