### PR TITLE
Add binary sensor platform to Habitica integration

### DIFF
--- a/homeassistant/components/habitica/__init__.py
+++ b/homeassistant/components/habitica/__init__.py
@@ -30,6 +30,7 @@ CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 
 PLATFORMS = [
+    Platform.BINARY_SENSOR,
     Platform.BUTTON,
     Platform.CALENDAR,
     Platform.SENSOR,

--- a/homeassistant/components/habitica/binary_sensor.py
+++ b/homeassistant/components/habitica/binary_sensor.py
@@ -1,0 +1,85 @@
+"""Binary sensor platform for Habitica integration."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorEntity,
+    BinarySensorEntityDescription,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import ASSETS_URL
+from .entity import HabiticaBase
+from .types import HabiticaConfigEntry
+
+
+@dataclass(kw_only=True, frozen=True)
+class HabiticaBinarySensorEntityDescription(BinarySensorEntityDescription):
+    """Habitica Binary Sensor Description."""
+
+    value_fn: Callable[[dict[str, Any]], bool | None]
+    entity_picture: Callable[[dict[str, Any]], str | None]
+
+
+class HabiticaBinarySensor(StrEnum):
+    """Habitica Entities."""
+
+    PENDING_QUEST = "pending_quest"
+
+
+BINARY_SENSOR_DESCRIPTIONS: tuple[HabiticaBinarySensorEntityDescription, ...] = (
+    HabiticaBinarySensorEntityDescription(
+        key=HabiticaBinarySensor.PENDING_QUEST,
+        translation_key=HabiticaBinarySensor.PENDING_QUEST,
+        value_fn=lambda user: user["party"]["quest"]["RSVPNeeded"],
+        entity_picture=(
+            lambda user: f"inventory_quest_scroll_{key}.png"
+            if (key := user["party"]["quest"].get("key"))
+            and user["party"]["quest"]["RSVPNeeded"]
+            else None
+        ),
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: HabiticaConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the habitica binary sensors."""
+
+    coordinator = config_entry.runtime_data
+
+    async_add_entities(
+        [
+            HabiticaBinarySensorEntity(coordinator, description)
+            for description in BINARY_SENSOR_DESCRIPTIONS
+        ]
+    )
+
+
+class HabiticaBinarySensorEntity(HabiticaBase, BinarySensorEntity):
+    """Representation of a Habitica binary sensor."""
+
+    entity_description: HabiticaBinarySensorEntityDescription
+
+    @property
+    def is_on(self) -> bool | None:
+        """If the binary sensor is on."""
+        return self.entity_description.value_fn(self.coordinator.data.user)
+
+    @property
+    def entity_picture(self) -> str | None:
+        """Return the entity picture to use in the frontend, if any."""
+        if entity_picture := self.entity_description.entity_picture(
+            self.coordinator.data.user
+        ):
+            return f"{ASSETS_URL}{entity_picture}"
+        return None

--- a/homeassistant/components/habitica/binary_sensor.py
+++ b/homeassistant/components/habitica/binary_sensor.py
@@ -60,10 +60,8 @@ async def async_setup_entry(
     coordinator = config_entry.runtime_data
 
     async_add_entities(
-        [
-            HabiticaBinarySensorEntity(coordinator, description)
-            for description in BINARY_SENSOR_DESCRIPTIONS
-        ]
+        HabiticaBinarySensorEntity(coordinator, description)
+        for description in BINARY_SENSOR_DESCRIPTIONS
     )
 
 

--- a/homeassistant/components/habitica/binary_sensor.py
+++ b/homeassistant/components/habitica/binary_sensor.py
@@ -33,17 +33,19 @@ class HabiticaBinarySensor(StrEnum):
     PENDING_QUEST = "pending_quest"
 
 
+def get_scroll_image_for_pending_quest_invitation(user: dict[str, Any]) -> str | None:
+    """Entity picture for pending quest invitation."""
+    if user["party"]["quest"].get("key") and user["party"]["quest"]["RSVPNeeded"]:
+        return f"inventory_quest_scroll_{user["party"]["quest"]["key"]}.png"
+    return None
+
+
 BINARY_SENSOR_DESCRIPTIONS: tuple[HabiticaBinarySensorEntityDescription, ...] = (
     HabiticaBinarySensorEntityDescription(
         key=HabiticaBinarySensor.PENDING_QUEST,
         translation_key=HabiticaBinarySensor.PENDING_QUEST,
         value_fn=lambda user: user["party"]["quest"]["RSVPNeeded"],
-        entity_picture=(
-            lambda user: f"inventory_quest_scroll_{key}.png"
-            if (key := user["party"]["quest"].get("key"))
-            and user["party"]["quest"]["RSVPNeeded"]
-            else None
-        ),
+        entity_picture=get_scroll_image_for_pending_quest_invitation,
     ),
 )
 

--- a/homeassistant/components/habitica/icons.json
+++ b/homeassistant/components/habitica/icons.json
@@ -135,6 +135,14 @@
           "on": "mdi:sleep"
         }
       }
+    },
+    "binary_sensor": {
+      "pending_quest": {
+        "default": "mdi:script-outline",
+        "state": {
+          "on": "mdi:script-text-outline"
+        }
+      }
     }
   },
   "services": {

--- a/homeassistant/components/habitica/strings.json
+++ b/homeassistant/components/habitica/strings.json
@@ -38,6 +38,11 @@
     }
   },
   "entity": {
+    "binary_sensor": {
+      "pending_quest": {
+        "name": "Pending quest invitation"
+      }
+    },
     "button": {
       "run_cron": {
         "name": "Start my day"

--- a/tests/components/habitica/fixtures/quest_invitation_off.json
+++ b/tests/components/habitica/fixtures/quest_invitation_off.json
@@ -1,0 +1,64 @@
+{
+  "data": {
+    "api_user": "test-api-user",
+    "profile": { "name": "test-user" },
+    "stats": {
+      "buffs": {
+        "str": 0,
+        "int": 0,
+        "per": 0,
+        "con": 0,
+        "stealth": 0,
+        "streaks": false,
+        "seafoam": false,
+        "shinySeed": false,
+        "snowball": false,
+        "spookySparkles": false
+      },
+      "hp": 0,
+      "mp": 50.89999999999998,
+      "exp": 737,
+      "gp": 137.62587214609795,
+      "lvl": 38,
+      "class": "wizard",
+      "maxHealth": 50,
+      "maxMP": 166,
+      "toNextLevel": 880,
+      "points": 5
+    },
+    "preferences": {
+      "sleep": false,
+      "automaticAllocation": true,
+      "disableClasses": false
+    },
+    "flags": {
+      "classSelected": true
+    },
+    "tasksOrder": {
+      "rewards": ["5e2ea1df-f6e6-4ba3-bccb-97c5ec63e99b"],
+      "todos": [
+        "88de7cd9-af2b-49ce-9afd-bf941d87336b",
+        "2f6fcabc-f670-4ec3-ba65-817e8deea490",
+        "1aa3137e-ef72-4d1f-91ee-41933602f438",
+        "86ea2475-d1b5-4020-bdcc-c188c7996afa"
+      ],
+      "dailys": [
+        "f21fa608-cfc6-4413-9fc7-0eb1b48ca43a",
+        "bc1d1855-b2b8-4663-98ff-62e7b763dfc4",
+        "e97659e0-2c42-4599-a7bb-00282adc410d",
+        "564b9ac9-c53d-4638-9e7f-1cd96fe19baa",
+        "f2c85972-1a19-4426-bc6d-ce3337b9d99f",
+        "2c6d136c-a1c3-4bef-b7c4-fa980784b1e1"
+      ],
+      "habits": ["1d147de6-5c02-4740-8e2f-71d3015a37f4"]
+    },
+    "party": {
+      "quest": {
+        "RSVPNeeded": false,
+        "key": null
+      }
+    },
+    "needsCron": true,
+    "lastCron": "2024-09-21T22:01:55.586Z"
+  }
+}

--- a/tests/components/habitica/fixtures/user.json
+++ b/tests/components/habitica/fixtures/user.json
@@ -52,6 +52,12 @@
       ],
       "habits": ["1d147de6-5c02-4740-8e2f-71d3015a37f4"]
     },
+    "party": {
+      "quest": {
+        "RSVPNeeded": true,
+        "key": "dustbunnies"
+      }
+    },
     "needsCron": true,
     "lastCron": "2024-09-21T22:01:55.586Z"
   }

--- a/tests/components/habitica/snapshots/test_binary_sensor.ambr
+++ b/tests/components/habitica/snapshots/test_binary_sensor.ambr
@@ -1,0 +1,48 @@
+# serializer version: 1
+# name: test_binary_sensors[binary_sensor.test_user_pending_quest_invitation-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.test_user_pending_quest_invitation',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Pending quest invitation',
+    'platform': 'habitica',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': <HabiticaBinarySensor.PENDING_QUEST: 'pending_quest'>,
+    'unique_id': '00000000-0000-0000-0000-000000000000_pending_quest',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_binary_sensors[binary_sensor.test_user_pending_quest_invitation-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'entity_picture': 'https://habitica-assets.s3.amazonaws.com/mobileApp/images/inventory_quest_scroll_dustbunnies.png',
+      'friendly_name': 'test-user Pending quest invitation',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.test_user_pending_quest_invitation',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---

--- a/tests/components/habitica/test_binary_sensor.py
+++ b/tests/components/habitica/test_binary_sensor.py
@@ -6,12 +6,14 @@ from unittest.mock import patch
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
+from homeassistant.components.habitica.const import ASSETS_URL, DEFAULT_URL, DOMAIN
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import Platform
+from homeassistant.const import STATE_OFF, STATE_ON, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from tests.common import MockConfigEntry, snapshot_platform
+from tests.common import MockConfigEntry, load_json_object_fixture, snapshot_platform
+from tests.test_util.aiohttp import AiohttpClientMocker
 
 
 @pytest.fixture(autouse=True)
@@ -40,3 +42,39 @@ async def test_binary_sensors(
     assert config_entry.state is ConfigEntryState.LOADED
 
     await snapshot_platform(hass, entity_registry, snapshot, config_entry.entry_id)
+
+
+@pytest.mark.parametrize(
+    ("fixture", "entity_state", "entity_picture"),
+    [
+        ("user", STATE_ON, f"{ASSETS_URL}inventory_quest_scroll_dustbunnies.png"),
+        ("quest_invitation_off", STATE_OFF, None),
+    ],
+)
+async def test_pending_quest_states(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    aioclient_mock: AiohttpClientMocker,
+    fixture: str,
+    entity_state: str,
+    entity_picture: str | None,
+) -> None:
+    """Test states of pending quest sensor."""
+
+    aioclient_mock.get(
+        f"{DEFAULT_URL}/api/v3/user",
+        json=load_json_object_fixture(f"{fixture}.json", DOMAIN),
+    )
+    aioclient_mock.get(f"{DEFAULT_URL}/api/v3/tasks/user", json={"data": []})
+
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    assert (
+        state := hass.states.get("binary_sensor.test_user_pending_quest_invitation")
+    )
+    assert state.state == entity_state
+    assert state.attributes.get("entity_picture") == entity_picture

--- a/tests/components/habitica/test_binary_sensor.py
+++ b/tests/components/habitica/test_binary_sensor.py
@@ -1,0 +1,42 @@
+"""Tests for the Habitica binary sensor platform."""
+
+from collections.abc import Generator
+from unittest.mock import patch
+
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+
+@pytest.fixture(autouse=True)
+def binary_sensor_only() -> Generator[None]:
+    """Enable only the binarty sensor platform."""
+    with patch(
+        "homeassistant.components.habitica.PLATFORMS",
+        [Platform.BINARY_SENSOR],
+    ):
+        yield
+
+
+@pytest.mark.usefixtures("mock_habitica")
+async def test_binary_sensors(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    snapshot: SnapshotAssertion,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test setup of the Habitica binary sensor platform."""
+
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    await snapshot_platform(hass, entity_registry, snapshot, config_entry.entry_id)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds binary sensor platform to Habitica integration.

Currently only 1 sensor. Indicates if there is an invitation to a quest pending and shows the according quest scroll as entity picture. Can be used in automations for auto-accepting invitations. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/35521

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
