### PR TITLE
Add smarty reset filters timer button

### DIFF
--- a/homeassistant/components/smarty/__init__.py
+++ b/homeassistant/components/smarty/__init__.py
@@ -30,7 +30,13 @@ CONFIG_SCHEMA = vol.Schema(
     extra=vol.ALLOW_EXTRA,
 )
 
-PLATFORMS = [Platform.BINARY_SENSOR, Platform.FAN, Platform.SENSOR, Platform.SWITCH]
+PLATFORMS = [
+    Platform.BINARY_SENSOR,
+    Platform.BUTTON,
+    Platform.FAN,
+    Platform.SENSOR,
+    Platform.SWITCH,
+]
 
 
 async def async_setup(hass: HomeAssistant, hass_config: ConfigType) -> bool:

--- a/homeassistant/components/smarty/button.py
+++ b/homeassistant/components/smarty/button.py
@@ -1,0 +1,74 @@
+"""Platform to control a Salda Smarty XP/XV ventilation unit."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+import logging
+from typing import Any
+
+from pysmarty2 import Smarty
+
+from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .coordinator import SmartyConfigEntry, SmartyCoordinator
+from .entity import SmartyEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, kw_only=True)
+class SmartyButtonDescription(ButtonEntityDescription):
+    """Class describing Smarty button."""
+
+    press_fn: Callable[[Smarty], bool | None]
+
+
+ENTITIES: tuple[SmartyButtonDescription, ...] = (
+    SmartyButtonDescription(
+        key="reset_filters_timer",
+        translation_key="reset_filters_timer",
+        press_fn=lambda smarty: smarty.reset_filters_timer(),
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: SmartyConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the Smarty Button Platform."""
+
+    coordinator = entry.runtime_data
+
+    async_add_entities(
+        SmartyButton(coordinator, description) for description in ENTITIES
+    )
+
+
+class SmartyButton(SmartyEntity, ButtonEntity):
+    """Representation of a Smarty Button."""
+
+    entity_description: SmartyButtonDescription
+
+    def __init__(
+        self,
+        coordinator: SmartyCoordinator,
+        entity_description: SmartyButtonDescription,
+    ) -> None:
+        """Initialize the entity."""
+        super().__init__(coordinator)
+        self.entity_description = entity_description
+        self._attr_unique_id = (
+            f"{coordinator.config_entry.entry_id}_{entity_description.key}"
+        )
+
+    async def async_press(self, **kwargs: Any) -> None:
+        """Press the button."""
+        await self.hass.async_add_executor_job(
+            self.entity_description.press_fn, self.coordinator.client
+        )
+        await self.coordinator.async_refresh()

--- a/homeassistant/components/smarty/strings.json
+++ b/homeassistant/components/smarty/strings.json
@@ -42,6 +42,11 @@
         "name": "Boost state"
       }
     },
+    "button": {
+      "reset_filters_timer": {
+        "name": "Reset filters timer"
+      }
+    },
     "sensor": {
       "supply_air_temperature": {
         "name": "Supply air temperature"

--- a/tests/components/smarty/conftest.py
+++ b/tests/components/smarty/conftest.py
@@ -50,6 +50,7 @@ def mock_smarty() -> Generator[AsyncMock]:
         client.filter_timer = 31
         client.get_configuration_version.return_value = 111
         client.get_software_version.return_value = 127
+        client.reset_filters_timer.return_value = True
         yield client
 
 

--- a/tests/components/smarty/snapshots/test_button.ambr
+++ b/tests/components/smarty/snapshots/test_button.ambr
@@ -1,0 +1,47 @@
+# serializer version: 1
+# name: test_all_entities[button.mock_title_reset_filters_timer-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': None,
+    'entity_id': 'button.mock_title_reset_filters_timer',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Reset filters timer',
+    'platform': 'smarty',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'reset_filters_timer',
+    'unique_id': '01JAZ5DPW8C62D620DGYNG2R8H_reset_filters_timer',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[button.mock_title_reset_filters_timer-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Mock Title Reset filters timer',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.mock_title_reset_filters_timer',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---

--- a/tests/components/smarty/test_button.py
+++ b/tests/components/smarty/test_button.py
@@ -1,0 +1,45 @@
+"""Tests for the Smarty button platform."""
+
+from unittest.mock import AsyncMock, patch
+
+from syrupy import SnapshotAssertion
+
+from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
+from homeassistant.const import ATTR_ENTITY_ID, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from . import setup_integration
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+
+async def test_all_entities(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    mock_smarty: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test all entities."""
+    with patch("homeassistant.components.smarty.PLATFORMS", [Platform.BUTTON]):
+        await setup_integration(hass, mock_config_entry)
+
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+async def test_setting_value(
+    hass: HomeAssistant,
+    mock_smarty: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test setting value."""
+    await setup_integration(hass, mock_config_entry)
+
+    await hass.services.async_call(
+        BUTTON_DOMAIN,
+        SERVICE_PRESS,
+        target={ATTR_ENTITY_ID: "button.mock_title_reset_filters_timer"},
+        blocking=True,
+    )
+    mock_smarty.reset_filters_timer.assert_called_once_with()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Smarty has the possibility to reset the filters timer when filters are changed. This function can now be used from HA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/35527

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
