### PR TITLE
Bump python-linkplay to 0.0.17

### DIFF
--- a/homeassistant/components/linkplay/manifest.json
+++ b/homeassistant/components/linkplay/manifest.json
@@ -7,6 +7,6 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "loggers": ["linkplay"],
-  "requirements": ["python-linkplay==0.0.15"],
+  "requirements": ["python-linkplay==0.0.17"],
   "zeroconf": ["_linkplay._tcp.local."]
 }

--- a/homeassistant/components/linkplay/media_player.py
+++ b/homeassistant/components/linkplay/media_player.py
@@ -48,6 +48,7 @@ STATE_MAP: dict[PlayingStatus, MediaPlayerState] = {
 }
 
 SOURCE_MAP: dict[PlayingMode, str] = {
+    PlayingMode.NETWORK: "Wifi",
     PlayingMode.LINE_IN: "Line In",
     PlayingMode.BLUETOOTH: "Bluetooth",
     PlayingMode.OPTICAL: "Optical",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2359,7 +2359,7 @@ python-juicenet==1.1.0
 python-kasa[speedups]==0.7.6
 
 # homeassistant.components.linkplay
-python-linkplay==0.0.15
+python-linkplay==0.0.17
 
 # homeassistant.components.lirc
 # python-lirc==1.2.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1886,7 +1886,7 @@ python-juicenet==1.1.0
 python-kasa[speedups]==0.7.6
 
 # homeassistant.components.linkplay
-python-linkplay==0.0.15
+python-linkplay==0.0.17
 
 # homeassistant.components.matter
 python-matter-server==6.6.0


### PR DESCRIPTION
## Proposed change
3 fixes: 
* Includes a bugfix for the multiroom introduced during this beta where the wrong IP address was accessed. 
* It also includes a fix to take into account if a linkplay device contains more than 10 presets. This was enforced to 10 at library and in the integration. The integration will need an additional PR. 
* Pushes "wifi" to the input sources, just like the companion app for LinkPlay and the web application. When playing over network (streaming), it will show up as "wifi" as input source. The input map was adjusted in the integration already to prevent an error. 

Also includes the neccessary changes to support time syncing, but this feature needs integration changes. 
Python requirements have been set a little bit lower to cause less conflicts with other integrations. 

https://github.com/Velleman/python-linkplay/releases/tag/v0.0.16
https://github.com/Velleman/python-linkplay/releases/tag/v0.0.17
https://github.com/Velleman/python-linkplay/compare/v0.0.15...v0.0.17
Please backport this change to the current beta. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
