### PR TITLE
Replace AVError with FFmpegError

### DIFF
--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -47,7 +47,7 @@ class StreamWorkerError(Exception):
     """An exception thrown while processing a stream."""
 
 
-def redact_av_error_string(err: av.AVError) -> str:
+def redact_av_error_string(err: av.FFmpegError) -> str:
     """Return an error string with credentials redacted from the url."""
     parts = [str(err.type), err.strerror]
     if err.filename is not None:
@@ -524,7 +524,7 @@ def stream_worker(
         del pyav_options["stimeout"]
     try:
         container = av.open(source, options=pyav_options, timeout=SOURCE_TIMEOUT)
-    except av.AVError as err:
+    except av.FFmpegError as err:
         raise StreamWorkerError(
             f"Error opening stream ({redact_av_error_string(err)})"
         ) from err
@@ -598,7 +598,7 @@ def stream_worker(
     except StopIteration as ex:
         container.close()
         raise StreamEndedError("Stream ended; no additional packets") from ex
-    except av.AVError as ex:
+    except av.FFmpegError as ex:
         container.close()
         raise StreamWorkerError(
             f"Error demuxing stream while finding first packet ({redact_av_error_string(ex)})"
@@ -625,7 +625,7 @@ def stream_worker(
                 raise
             except StopIteration as ex:
                 raise StreamEndedError("Stream ended; no additional packets") from ex
-            except av.AVError as ex:
+            except av.FFmpegError as ex:
                 raise StreamWorkerError(
                     f"Error demuxing stream ({redact_av_error_string(ex)})"
                 ) from ex


### PR DESCRIPTION
## Proposed change
`AVError` is an alias for `FFmpegError` and will be removed in a future version.
https://github.com/uvjustin/PyAV/blob/70deb1cdbe27a6c4c802fb392b4fdefcb22bea38/av/__init__.py#L46-L47

_Preparation for the switch back to `av` version `13.1.0`._

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
