### PR TITLE
Add OptionsFlow helper for a mutable copy of the config entry options

### DIFF
--- a/homeassistant/components/mqtt/config_flow.py
+++ b/homeassistant/components/mqtt/config_flow.py
@@ -220,7 +220,7 @@ class FlowHandler(ConfigFlow, domain=DOMAIN):
         config_entry: ConfigEntry,
     ) -> MQTTOptionsFlowHandler:
         """Get the options flow for this handler."""
-        return MQTTOptionsFlowHandler(config_entry)
+        return MQTTOptionsFlowHandler()
 
     async def _async_install_addon(self) -> None:
         """Install the Mosquitto Mqtt broker add-on."""
@@ -543,11 +543,9 @@ class FlowHandler(ConfigFlow, domain=DOMAIN):
 class MQTTOptionsFlowHandler(OptionsFlow):
     """Handle MQTT options."""
 
-    def __init__(self, config_entry: ConfigEntry) -> None:
+    def __init__(self) -> None:
         """Initialize MQTT options flow."""
-        self.config_entry = config_entry
         self.broker_config: dict[str, str | int] = {}
-        self.options = config_entry.options
 
     async def async_step_init(self, user_input: None = None) -> ConfigFlowResult:
         """Manage the MQTT options."""

--- a/homeassistant/components/onvif/config_flow.py
+++ b/homeassistant/components/onvif/config_flow.py
@@ -109,7 +109,7 @@ class OnvifFlowHandler(ConfigFlow, domain=DOMAIN):
         config_entry: ConfigEntry,
     ) -> OnvifOptionsFlowHandler:
         """Get the options flow for this handler."""
-        return OnvifOptionsFlowHandler(config_entry)
+        return OnvifOptionsFlowHandler()
 
     def __init__(self) -> None:
         """Initialize the ONVIF config flow."""
@@ -388,11 +388,6 @@ class OnvifFlowHandler(ConfigFlow, domain=DOMAIN):
 
 class OnvifOptionsFlowHandler(OptionsFlow):
     """Handle ONVIF options."""
-
-    def __init__(self, config_entry: ConfigEntry) -> None:
-        """Initialize ONVIF options flow."""
-        self.config_entry = config_entry
-        self.options = dict(config_entry.options)
 
     async def async_step_init(self, user_input: None = None) -> ConfigFlowResult:
         """Manage the ONVIF options."""

--- a/homeassistant/components/webostv/config_flow.py
+++ b/homeassistant/components/webostv/config_flow.py
@@ -170,8 +170,6 @@ class OptionsFlowHandler(OptionsFlow):
 
     def __init__(self, config_entry: ConfigEntry) -> None:
         """Initialize options flow."""
-        self.config_entry = config_entry
-        self.options = config_entry.options
         self.host = config_entry.data[CONF_HOST]
         self.key = config_entry.data[CONF_CLIENT_SECRET]
 
@@ -188,7 +186,11 @@ class OptionsFlowHandler(OptionsFlow):
         if not sources_list:
             errors["base"] = "cannot_retrieve"
 
-        sources = [s for s in self.options.get(CONF_SOURCES, []) if s in sources_list]
+        sources = [
+            s
+            for s in self.config_entry.options.get(CONF_SOURCES, [])
+            if s in sources_list
+        ]
         if not sources:
             sources = sources_list
 

--- a/homeassistant/components/webostv/config_flow.py
+++ b/homeassistant/components/webostv/config_flow.py
@@ -186,11 +186,8 @@ class OptionsFlowHandler(OptionsFlow):
         if not sources_list:
             errors["base"] = "cannot_retrieve"
 
-        sources = [
-            s
-            for s in self.config_entry.options.get(CONF_SOURCES, [])
-            if s in sources_list
-        ]
+        option_sources = self.config_entry.options.get(CONF_SOURCES, [])
+        sources = [s for s in option_sources if s in sources_list]
         if not sources:
             sources = sources_list
 

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -3151,8 +3151,8 @@ class OptionsFlowWithConfigEntry(OptionsFlow):
         self._config_entry = config_entry
         self._options = deepcopy(dict(config_entry.options))
         report(
-            "inherits OptionsFlowWithConfigEntry, which is deprecated "
-            "and will stop working in 2025.12",
+            "inherits from OptionsFlowWithConfigEntry, which is deprecated "
+            "and will stop working in 2025.12,",
             error_if_integration=False,
             error_if_core=True,
         )

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -3152,7 +3152,7 @@ class OptionsFlowWithConfigEntry(OptionsFlow):
         self._options = deepcopy(dict(config_entry.options))
         report(
             "inherits from OptionsFlowWithConfigEntry, which is deprecated "
-            "and will stop working in 2025.12,",
+            "and will stop working in 2025.12",
             error_if_integration=False,
             error_if_core=False,
         )

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -3053,6 +3053,7 @@ class OptionsFlowManager(
 class OptionsFlow(ConfigEntryBaseFlow):
     """Base class for config options flows."""
 
+    _options: dict[str, Any]
     handler: str
 
     _config_entry: ConfigEntry
@@ -3119,6 +3120,28 @@ class OptionsFlow(ConfigEntryBaseFlow):
         )
         self._config_entry = value
 
+    @property
+    def options(self) -> dict[str, Any]:
+        """Return a mutable copy of the config entry options.
+
+        Please note that this is not available inside `__init__` method, and
+        can only be referenced after initialisation.
+        """
+        if not hasattr(self, "_options"):
+            self._options = deepcopy(dict(self.config_entry.options))
+        return self._options
+
+    @options.setter
+    def options(self, value: dict[str, Any]) -> None:
+        """Set the options value."""
+        report(
+            "sets option flow options explicitly, which is deprecated "
+            "and will stop working in 2025.12",
+            error_if_integration=False,
+            error_if_core=True,
+        )
+        self._options = value
+
 
 class OptionsFlowWithConfigEntry(OptionsFlow):
     """Base class for options flows with config entry and options."""
@@ -3127,11 +3150,12 @@ class OptionsFlowWithConfigEntry(OptionsFlow):
         """Initialize options flow."""
         self._config_entry = config_entry
         self._options = deepcopy(dict(config_entry.options))
-
-    @property
-    def options(self) -> dict[str, Any]:
-        """Return a mutable copy of the config entry options."""
-        return self._options
+        report(
+            "inherits OptionsFlowWithConfigEntry, which is deprecated "
+            "and will stop working in 2025.12",
+            error_if_integration=False,
+            error_if_core=True,
+        )
 
 
 class EntityRegistryDisabledHandler:

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -3154,7 +3154,7 @@ class OptionsFlowWithConfigEntry(OptionsFlow):
             "inherits from OptionsFlowWithConfigEntry, which is deprecated "
             "and will stop working in 2025.12,",
             error_if_integration=False,
-            error_if_core=True,
+            error_if_core=False,
         )
 
 

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -4812,6 +4812,7 @@ async def test_reauth_reconfigure_missing_entry(
 
 
 @pytest.mark.usefixtures("mock_integration_frame")
+@patch.object(frame, "_REPORTED_INTEGRATIONS", set())
 @pytest.mark.parametrize(
     "source", [config_entries.SOURCE_REAUTH, config_entries.SOURCE_RECONFIGURE]
 )
@@ -5040,6 +5041,7 @@ async def test_async_wait_component_startup(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.usefixtures("mock_integration_frame")
+@patch.object(frame, "_REPORTED_INTEGRATIONS", set())
 async def test_options_flow_with_config_entry(caplog: pytest.LogCaptureFixture) -> None:
     """Test that OptionsFlowWithConfigEntry doesn't mutate entry options."""
     entry = MockConfigEntry(
@@ -5066,6 +5068,7 @@ async def test_options_flow_with_config_entry(caplog: pytest.LogCaptureFixture) 
 
 
 @pytest.mark.usefixtures("mock_integration_frame")
+@patch.object(frame, "_REPORTED_INTEGRATIONS", set())
 async def test_options_flow_options_not_mutated(hass: HomeAssistant) -> None:
     """Test that OptionsFlow doesn't mutate entry options."""
     entry = MockConfigEntry(
@@ -7435,7 +7438,6 @@ async def test_options_flow_config_entry(
 
 
 @pytest.mark.usefixtures("mock_integration_frame")
-@patch.object(frame, "_REPORTED_INTEGRATIONS", set())
 async def test_options_flow_deprecated_config_entry_setter(
     hass: HomeAssistant,
     manager: config_entries.ConfigEntries,
@@ -7463,7 +7465,10 @@ async def test_options_flow_deprecated_config_entry_setter(
 
                 def __init__(self, entry) -> None:
                     """Test initialisation."""
-                    self.config_entry = entry
+                    with patch.object(frame, "_REPORTED_INTEGRATIONS", set()):
+                        self.config_entry = entry
+                    with patch.object(frame, "_REPORTED_INTEGRATIONS", set()):
+                        self.options = entry.options
 
                 async def async_step_init(self, user_input=None):
                     """Test user step."""
@@ -7490,6 +7495,10 @@ async def test_options_flow_deprecated_config_entry_setter(
 
     assert (
         "Detected that integration 'hue' sets option flow config_entry explicitly, "
+        "which is deprecated and will stop working in 2025.12" in caplog.text
+    )
+    assert (
+        "Detected that integration 'hue' sets option flow options explicitly, "
         "which is deprecated and will stop working in 2025.12" in caplog.text
     )
 

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -5053,8 +5053,7 @@ async def test_options_flow_with_config_entry(caplog: pytest.LogCaptureFixture) 
     options_flow = config_entries.OptionsFlowWithConfigEntry(entry)
     assert (
         "Detected that integration 'hue' inherits from OptionsFlowWithConfigEntry,"
-        " which is deprecated and will stop working in 2025.12, at homeassistant/"
-        in caplog.text
+        " which is deprecated and will stop working in 2025.12" in caplog.text
     )
 
     options_flow._options["sub_dict"]["2"] = "two"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
For developpers only: 
- ~assigning a value to `self.options` in an option flow is deprecated, please use the read-only property instead.~
- ~the class `OptionsFlowWithConfigEntry` is also deprecated, please use the standard `OptionsFlow` class~

~Both will stop working in 2025.12.~

Partially reverted in #130054
- setting `self.options` is still allowed, and there are no plans to remove it
- `OptionsFlowWithConfigEntry` is deprecated, but kept for compatibility in custom components and there are no plans to remove it

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add `self.options` property to `OptionsFlow`

The property was originally added to the `OptionsFlowWithConfigEntry` sub-class, but it could/should have been added directly to the OptionsFlow class.

As follow-up to #129562


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/2435

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
