### PR TITLE
Revert "Disable cleanup_closed on python 3.12.7+ and 3.13.1+"

### DIFF
--- a/homeassistant/helpers/aiohttp_client.py
+++ b/homeassistant/helpers/aiohttp_client.py
@@ -44,13 +44,11 @@ SERVER_SOFTWARE = (
     f"aiohttp/{aiohttp.__version__} Python/{sys.version_info[0]}.{sys.version_info[1]}"
 )
 
-ENABLE_CLEANUP_CLOSED = (3, 13, 0) <= sys.version_info < (
-    3,
-    13,
-    1,
-) or sys.version_info < (3, 12, 7)
-# Cleanup closed is no longer needed after https://github.com/python/cpython/pull/118960
-# which first appeared in Python 3.12.7 and 3.13.1
+ENABLE_CLEANUP_CLOSED = not (3, 11, 1) <= sys.version_info < (3, 11, 4)
+# Enabling cleanup closed on python 3.11.1+ leaks memory relatively quickly
+# see https://github.com/aio-libs/aiohttp/issues/7252
+# aiohttp interacts poorly with https://github.com/python/cpython/pull/98540
+# The issue was fixed in 3.11.4 via https://github.com/python/cpython/pull/104485
 
 WARN_CLOSE_MSG = "closes the Home Assistant aiohttp session"
 


### PR DESCRIPTION
The test was flakey in the past so I didn't connect the dots. Looks like that test isn't might be mocking a bit more than it expects. @epenet fixed the test in https://github.com/home-assistant/core/pull/129735, but we can't merge https://github.com/home-assistant/core/pull/129735 because it requires code owner approval.

So revert home-assistant/core#129645 instead