### PR TITLE
Expose light color state to LLM context

### DIFF
--- a/homeassistant/helpers/llm.py
+++ b/homeassistant/helpers/llm.py
@@ -422,6 +422,19 @@ class AssistAPI(API):
         return tools
 
 
+def _convert_attributes(value: Any) -> Any:
+    """Convert value to be YAML-serializable."""
+    if isinstance(value, dict):
+        return {k: _convert_attributes(v) for k, v in value.items()}
+    if isinstance(value, (tuple, list)):
+        return [_convert_attributes(v) for v in value]
+    if isinstance(value, Enum):
+        return value.name
+    if isinstance(value, (Decimal, int)):
+        return str(value)
+    return value
+
+
 def _get_exposed_entities(
     hass: HomeAssistant, assistant: str
 ) -> dict[str, dict[str, Any]]:
@@ -434,6 +447,10 @@ def _get_exposed_entities(
         "current_temperature",
         "temperature_unit",
         "brightness",
+        "color_temp_kelvin",
+        "rgb_color",
+        "color_mode",
+        "supported_color_modes",
         "humidity",
         "unit_of_measurement",
         "device_class",
@@ -493,13 +510,13 @@ def _get_exposed_entities(
         if area_names:
             info["areas"] = ", ".join(area_names)
 
-        if attributes := {
-            attr_name: str(attr_value)
-            if isinstance(attr_value, (Enum, Decimal, int))
-            else attr_value
-            for attr_name, attr_value in state.attributes.items()
-            if attr_name in interesting_attributes
-        }:
+        if attributes := _convert_attributes(
+            {
+                attr_name: str(attr_value)
+                for attr_name, attr_value in state.attributes.items()
+                if attr_name in interesting_attributes
+            }
+        ):
             info["attributes"] = attributes
 
         entities[state.entity_id] = info

--- a/tests/helpers/test_llm.py
+++ b/tests/helpers/test_llm.py
@@ -1,6 +1,7 @@
 """Tests for the llm helpers."""
 
 from decimal import Decimal
+from enum import StrEnum
 from unittest.mock import patch
 
 import pytest
@@ -332,6 +333,25 @@ async def test_assist_api_description(
     tool = api.tools[0]
     assert tool.name == "test_intent"
     assert tool.description == "my intent handler"
+
+
+def test_convert_attributes() -> None:
+    """Test attribute conversion for YAML presentation."""
+
+    class MyEnum(StrEnum):
+        VALUE = "some_value"
+
+    assert llm._convert_attributes(
+        {
+            "list": [1, 2, 3],
+            "nested": {"other_key": 7},
+            "enum": MyEnum.VALUE,
+        }
+    ) == {
+        "list": ["1", "2", "3"],
+        "nested": {"other_key": "7"},
+        "enum": "VALUE",
+    }
 
 
 async def test_assist_api_prompt(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Only the brightness of color lights is exposed to the LLM prompt. This results in frustrating experiences where the LLM can set the color per a user prompt but is then unaware of the actual state of the lights (i.e. it only controls their brightness). This change exposes the following light attributes and adjusts the "state to YAML" preprocessing to account for the new data types:

 - `color_temp_kelvin`
 - `rgb_color`
 - `color_mode`
 - `supported_color_modes`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
