### PR TITLE
Bump `pysnmp` to v7 and `brother` to v5

### DIFF
--- a/homeassistant/components/brother/manifest.json
+++ b/homeassistant/components/brother/manifest.json
@@ -8,7 +8,7 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "loggers": ["brother", "pyasn1", "pysmi", "pysnmp"],
-  "requirements": ["brother==4.3.1"],
+  "requirements": ["brother==5.0.0"],
   "zeroconf": [
     {
       "type": "_printer._tcp.local.",

--- a/homeassistant/components/snmp/manifest.json
+++ b/homeassistant/components/snmp/manifest.json
@@ -6,5 +6,5 @@
   "iot_class": "local_polling",
   "loggers": ["pyasn1", "pysmi", "pysnmp"],
   "quality_scale": "legacy",
-  "requirements": ["pysnmp==7.1.9"]
+  "requirements": ["pysnmp==7.1.16"]
 }

--- a/homeassistant/components/snmp/manifest.json
+++ b/homeassistant/components/snmp/manifest.json
@@ -6,5 +6,5 @@
   "iot_class": "local_polling",
   "loggers": ["pyasn1", "pysmi", "pysnmp"],
   "quality_scale": "legacy",
-  "requirements": ["pysnmp==6.2.6"]
+  "requirements": ["pysnmp==7.1.9"]
 }

--- a/homeassistant/components/snmp/manifest.json
+++ b/homeassistant/components/snmp/manifest.json
@@ -6,5 +6,5 @@
   "iot_class": "local_polling",
   "loggers": ["pyasn1", "pysmi", "pysnmp"],
   "quality_scale": "legacy",
-  "requirements": ["pysnmp==7.1.16"]
+  "requirements": ["pysnmp==7.1.21"]
 }

--- a/homeassistant/components/snmp/sensor.py
+++ b/homeassistant/components/snmp/sensor.py
@@ -8,13 +8,13 @@ from struct import unpack
 
 from pyasn1.codec.ber import decoder
 from pysnmp.error import PySnmpError
-import pysnmp.hlapi.asyncio as hlapi
-from pysnmp.hlapi.asyncio import (
+import pysnmp.hlapi.v3arch.asyncio as hlapi
+from pysnmp.hlapi.v3arch.asyncio import (
     CommunityData,
     Udp6TransportTarget,
     UdpTransportTarget,
     UsmUserData,
-    getCmd,
+    get_cmd,
 )
 from pysnmp.proto.rfc1902 import Opaque
 from pysnmp.proto.rfc1905 import NoSuchObject
@@ -131,7 +131,7 @@ async def async_setup_platform(
 
     try:
         # Try IPv4 first.
-        target = UdpTransportTarget((host, port), timeout=DEFAULT_TIMEOUT)
+        target = await UdpTransportTarget.create((host, port), timeout=DEFAULT_TIMEOUT)
     except PySnmpError:
         # Then try IPv6.
         try:
@@ -156,7 +156,7 @@ async def async_setup_platform(
         auth_data = CommunityData(community, mpModel=SNMP_VERSIONS[version])
 
     request_args = await async_create_request_cmd_args(hass, auth_data, target, baseoid)
-    get_result = await getCmd(*request_args)
+    get_result = await get_cmd(*request_args)
     errindication, _, _, _ = get_result
 
     if errindication and not accept_errors:
@@ -233,7 +233,7 @@ class SnmpData:
     async def async_update(self):
         """Get the latest data from the remote SNMP capable host."""
 
-        get_result = await getCmd(*self._request_args)
+        get_result = await get_cmd(*self._request_args)
         errindication, errstatus, errindex, restable = get_result
 
         if errindication and not self._accept_errors:

--- a/homeassistant/components/snmp/util.py
+++ b/homeassistant/components/snmp/util.py
@@ -93,4 +93,5 @@ def _get_snmp_engine() -> SnmpEngine:
     mib_view_controller = MibViewControllerManager.get_mib_view_controller(engine.cache)
     if "PYSNMP-MIB" not in mib_view_controller.mibBuilder.mibSymbols:
         mib_view_controller.mibBuilder.load_modules()
+    engine.cache["mibViewController"] = mib_view_controller
     return engine

--- a/homeassistant/components/snmp/util.py
+++ b/homeassistant/components/snmp/util.py
@@ -93,5 +93,4 @@ def _get_snmp_engine() -> SnmpEngine:
     mib_view_controller = MibViewControllerManager.get_mib_view_controller(engine.cache)
     if "PYSNMP-MIB" not in mib_view_controller.mibBuilder.mibSymbols:
         mib_view_controller.mibBuilder.load_modules()
-    engine.cache["mibViewController"] = mib_view_controller
     return engine

--- a/homeassistant/components/snmp/util.py
+++ b/homeassistant/components/snmp/util.py
@@ -15,7 +15,7 @@ from pysnmp.hlapi.v3arch.asyncio import (
     UsmUserData,
 )
 from pysnmp.hlapi.v3arch.asyncio.cmdgen import LCD
-from pysnmp.hlapi.varbinds import MibViewControllerManager
+from pysnmp.smi import view
 
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import Event, HomeAssistant, callback
@@ -90,7 +90,9 @@ def _get_snmp_engine() -> SnmpEngine:
     """Return a cached instance of SnmpEngine."""
     engine = SnmpEngine()
     # Actually load the MIBs from disk so we do not do it in the event loop
-    mib_view_controller = MibViewControllerManager.get_mib_view_controller(engine.cache)
-    if "PYSNMP-MIB" not in mib_view_controller.mibBuilder.mibSymbols:
-        mib_view_controller.mibBuilder.load_modules()
+     mib_view_controller = view.MibViewController(
+        engine.message_dispatcher.mib_instrum_controller.get_mib_builder()
+    )
+    engine.cache["mibViewController"] = mib_view_controller
+    mib_view_controller.mibBuilder.load_modules()
     return engine

--- a/homeassistant/components/snmp/util.py
+++ b/homeassistant/components/snmp/util.py
@@ -90,7 +90,7 @@ def _get_snmp_engine() -> SnmpEngine:
     """Return a cached instance of SnmpEngine."""
     engine = SnmpEngine()
     # Actually load the MIBs from disk so we do not do it in the event loop
-     mib_view_controller = view.MibViewController(
+    mib_view_controller = view.MibViewController(
         engine.message_dispatcher.mib_instrum_controller.get_mib_builder()
     )
     engine.cache["mibViewController"] = mib_view_controller

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -662,7 +662,7 @@ bring-api==1.0.2
 broadlink==0.19.0
 
 # homeassistant.components.brother
-brother==4.3.1
+brother==5.0.0
 
 # homeassistant.components.brottsplatskartan
 brottsplatskartan==1.0.5

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2328,7 +2328,7 @@ pysml==0.0.12
 pysmlight==0.2.3
 
 # homeassistant.components.snmp
-pysnmp==7.1.9
+pysnmp==7.1.16
 
 # homeassistant.components.snooz
 pysnooz==0.8.6

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2328,7 +2328,7 @@ pysml==0.0.12
 pysmlight==0.2.3
 
 # homeassistant.components.snmp
-pysnmp==6.2.6
+pysnmp==7.1.9
 
 # homeassistant.components.snooz
 pysnooz==0.8.6

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2328,7 +2328,7 @@ pysml==0.0.12
 pysmlight==0.2.3
 
 # homeassistant.components.snmp
-pysnmp==7.1.16
+pysnmp==7.1.21
 
 # homeassistant.components.snooz
 pysnooz==0.8.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -582,7 +582,7 @@ bring-api==1.0.2
 broadlink==0.19.0
 
 # homeassistant.components.brother
-brother==4.3.1
+brother==5.0.0
 
 # homeassistant.components.brottsplatskartan
 brottsplatskartan==1.0.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1897,7 +1897,7 @@ pysml==0.0.12
 pysmlight==0.2.3
 
 # homeassistant.components.snmp
-pysnmp==6.2.6
+pysnmp==7.1.9
 
 # homeassistant.components.snooz
 pysnooz==0.8.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1897,7 +1897,7 @@ pysml==0.0.12
 pysmlight==0.2.3
 
 # homeassistant.components.snmp
-pysnmp==7.1.9
+pysnmp==7.1.16
 
 # homeassistant.components.snooz
 pysnooz==0.8.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1897,7 +1897,7 @@ pysml==0.0.12
 pysmlight==0.2.3
 
 # homeassistant.components.snmp
-pysnmp==7.1.16
+pysnmp==7.1.21
 
 # homeassistant.components.snooz
 pysnooz==0.8.6

--- a/tests/components/snmp/test_float_sensor.py
+++ b/tests/components/snmp/test_float_sensor.py
@@ -16,7 +16,7 @@ def hlapi_mock():
     """Mock out 3rd party API."""
     mock_data = Opaque(value=b"\x9fx\x04=\xa4\x00\x00")
     with patch(
-        "homeassistant.components.snmp.sensor.getCmd",
+        "homeassistant.components.snmp.sensor.get_cmd",
         return_value=(None, None, None, [[mock_data]]),
     ):
         yield

--- a/tests/components/snmp/test_init.py
+++ b/tests/components/snmp/test_init.py
@@ -2,8 +2,8 @@
 
 from unittest.mock import patch
 
-from pysnmp.hlapi.asyncio import SnmpEngine
-from pysnmp.hlapi.asyncio.cmdgen import lcd
+from pysnmp.hlapi.v3arch.asyncio import SnmpEngine
+from pysnmp.hlapi.v3arch.asyncio.cmdgen import LCD
 
 from homeassistant.components import snmp
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
@@ -16,7 +16,7 @@ async def test_async_get_snmp_engine(hass: HomeAssistant) -> None:
     assert isinstance(engine, SnmpEngine)
     engine2 = await snmp.async_get_snmp_engine(hass)
     assert engine is engine2
-    with patch.object(lcd, "unconfigure") as mock_unconfigure:
+    with patch.object(LCD, "unconfigure") as mock_unconfigure:
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
         await hass.async_block_till_done()
     assert mock_unconfigure.called

--- a/tests/components/snmp/test_integer_sensor.py
+++ b/tests/components/snmp/test_integer_sensor.py
@@ -16,7 +16,7 @@ def hlapi_mock():
     """Mock out 3rd party API."""
     mock_data = Integer32(13)
     with patch(
-        "homeassistant.components.snmp.sensor.getCmd",
+        "homeassistant.components.snmp.sensor.get_cmd",
         return_value=(None, None, None, [[mock_data]]),
     ):
         yield

--- a/tests/components/snmp/test_negative_sensor.py
+++ b/tests/components/snmp/test_negative_sensor.py
@@ -16,7 +16,7 @@ def hlapi_mock():
     """Mock out 3rd party API."""
     mock_data = Integer32(-13)
     with patch(
-        "homeassistant.components.snmp.sensor.getCmd",
+        "homeassistant.components.snmp.sensor.get_cmd",
         return_value=(None, None, None, [[mock_data]]),
     ):
         yield

--- a/tests/components/snmp/test_string_sensor.py
+++ b/tests/components/snmp/test_string_sensor.py
@@ -16,7 +16,7 @@ def hlapi_mock():
     """Mock out 3rd party API."""
     mock_data = OctetString("98F")
     with patch(
-        "homeassistant.components.snmp.sensor.getCmd",
+        "homeassistant.components.snmp.sensor.get_cmd",
         return_value=(None, None, None, [[mock_data]]),
     ):
         yield

--- a/tests/components/snmp/test_switch.py
+++ b/tests/components/snmp/test_switch.py
@@ -27,7 +27,7 @@ async def test_snmp_integer_switch_off(hass: HomeAssistant) -> None:
 
     mock_data = Integer32(0)
     with patch(
-        "homeassistant.components.snmp.switch.getCmd",
+        "homeassistant.components.snmp.switch.get_cmd",
         return_value=(None, None, None, [[mock_data]]),
     ):
         assert await async_setup_component(hass, SWITCH_DOMAIN, config)
@@ -41,7 +41,7 @@ async def test_snmp_integer_switch_on(hass: HomeAssistant) -> None:
 
     mock_data = Integer32(1)
     with patch(
-        "homeassistant.components.snmp.switch.getCmd",
+        "homeassistant.components.snmp.switch.get_cmd",
         return_value=(None, None, None, [[mock_data]]),
     ):
         assert await async_setup_component(hass, SWITCH_DOMAIN, config)
@@ -57,7 +57,7 @@ async def test_snmp_integer_switch_unknown(
 
     mock_data = Integer32(3)
     with patch(
-        "homeassistant.components.snmp.switch.getCmd",
+        "homeassistant.components.snmp.switch.get_cmd",
         return_value=(None, None, None, [[mock_data]]),
     ):
         assert await async_setup_component(hass, SWITCH_DOMAIN, config)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Spurred by #129685, this PR updates the `pysnmp` dependency to its most recent next major version, v7.1.21.
I have tested these changes in my setup using the device_tracker platform only, but the synthetic tests for the other platforms (sensor, switch) look okay.

I can't seem to get the MIBs to cache properly, though: I tried to update the old mechanism by looking at [pysnmp's own tests](https://github.com/lextudio/pysnmp/blob/eb68a472ad9b9594e9b596137cc689ebcdebf381/tests/hlapi/v3arch/asyncio/manager/cmdgen/test_v1_walk.py#L44) but I keep getting a couple of `Detected blocking call` warnings logged when the first SNMP scan starts.

<details>
  <summary>Logged warnings</summary>

```plaintext
Recorder: homeassistant.util.loop
Source: util/loop.py:136

Detected blocking call to listdir with args ('/root/venv_hass/lib/python3.12/site-packages/pysnmp/smi/mibs',) inside the event loop by integration 'snmp' at homeassistant/components/snmp/device_tracker.py, line 185: async for errindication, errstatus, errindex, res in walker: (offender: /root/venv_hass/lib/python3.12/site-packages/pysnmp/smi/builder.py, line 237: if f in os.listdir(self._srcName): # make FS case-sensitive), please create a bug report at https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue+label%3A%22integration%3A+snmp%22 For developers, please see https://developers.home-assistant.io/docs/asyncio_blocking_operations/#listdir Traceback (most recent call last): File "/root/venv_hass/bin/hass", line 8, in <module> sys.exit(main()) File "/root/venv_hass/lib/python3.12/site-packages/homeassistant/__main__.py", line 209, in main exit_code = runner.run(runtime_conf) File "/root/venv_hass/lib/python3.12/site-packages/homeassistant/runner.py", line 189, in run return loop.run_until_complete(setup_and_run_hass(runtime_config)) File "/usr/lib/python3.12/asyncio/base_events.py", line 651, in run_until_complete self.run_forever() File "/usr/lib/python3.12/asyncio/base_events.py", line 618, in run_forever self._run_once() File "/usr/lib/python3.12/asyncio/base_events.py", line 1951, in _run_once handle._run() File "/usr/lib/python3.12/asyncio/events.py", line 84, in _run self._context.run(self._callback, *self._args) File "/root/venv_hass/lib/python3.12/site-packages/homeassistant/components/device_tracker/legacy.py", line 331, in async_setup_legacy scanner = await self.platform.async_get_scanner( File "/root/venv_hass/lib/python3.12/site-packages/homeassistant/components/snmp/device_tracker.py", line 63, in async_get_scanner await scanner.async_init(hass) File "/root/venv_hass/lib/python3.12/site-packages/homeassistant/components/snmp/device_tracker.py", line 141, in async_init data = await self.async_get_snmp_data() File "/root/venv_hass/lib/python3.12/site-packages/homeassistant/components/snmp/device_tracker.py", line 185, in async_get_snmp_data async for errindication, errstatus, errindex, res in walker:
Detected blocking call to open with args ('/root/venv_hass/lib/python3.12/site-packages/pysnmp/smi/mibs/PYSNMP-SOURCE-MIB.py', 'r') inside the event loop by integration 'snmp' at homeassistant/components/snmp/device_tracker.py, line 185: async for errindication, errstatus, errindex, res in walker: (offender: /root/venv_hass/lib/python3.12/site-packages/pysnmp/smi/builder.py, line 239: fp = open(p, mode)), please create a bug report at https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue+label%3A%22integration%3A+snmp%22 For developers, please see https://developers.home-assistant.io/docs/asyncio_blocking_operations/#open Traceback (most recent call last): File "/root/venv_hass/bin/hass", line 8, in <module> sys.exit(main()) File "/root/venv_hass/lib/python3.12/site-packages/homeassistant/__main__.py", line 209, in main exit_code = runner.run(runtime_conf) File "/root/venv_hass/lib/python3.12/site-packages/homeassistant/runner.py", line 189, in run return loop.run_until_complete(setup_and_run_hass(runtime_config)) File "/usr/lib/python3.12/asyncio/base_events.py", line 651, in run_until_complete self.run_forever() File "/usr/lib/python3.12/asyncio/base_events.py", line 618, in run_forever self._run_once() File "/usr/lib/python3.12/asyncio/base_events.py", line 1951, in _run_once handle._run() File "/usr/lib/python3.12/asyncio/events.py", line 84, in _run self._context.run(self._callback, *self._args) File "/root/venv_hass/lib/python3.12/site-packages/homeassistant/components/device_tracker/legacy.py", line 331, in async_setup_legacy scanner = await self.platform.async_get_scanner( File "/root/venv_hass/lib/python3.12/site-packages/homeassistant/components/snmp/device_tracker.py", line 63, in async_get_scanner await scanner.async_init(hass) File "/root/venv_hass/lib/python3.12/site-packages/homeassistant/components/snmp/device_tracker.py", line 141, in async_init data = await self.async_get_snmp_data() File "/root/venv_hass/lib/python3.12/site-packages/homeassistant/components/snmp/device_tracker.py", line 185, in async_get_snmp_data async for errindication, errstatus, errindex, res in walker:
```  
</details>

~~Since the `brother` component also depends on pysnmp, @bieniu may want to chime in.~~
`brother` updated to `5.0.0`.

+ Changes to pysnmp: https://github.com/lextudio/pysnmp/compare/v6.2.6...v7.1.21 ([changelog](https://github.com/lextudio/pysnmp/blob/c306480d925a3a88fc518711de38b4119051b24e/CHANGES.rst))
+ Changes to brother: https://github.com/bieniu/brother/compare/4.3.1...5.0.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #129685

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] ~~Documentation added/updated for [www.home-assistant.io][docs-repository])~~

If the code communicates with devices, web services, or third-party tools:

- [ ] ~~The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.~~
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
