### PR TITLE
Suggest area for NUT based on device location

### DIFF
--- a/homeassistant/components/nut/__init__.py
+++ b/homeassistant/components/nut/__init__.py
@@ -132,6 +132,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: NutConfigEntry) -> bool:
         model=data.device_info.model,
         sw_version=data.device_info.firmware,
         serial_number=data.device_info.serial,
+        suggested_area=data.device_info.device_location,
     )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
@@ -211,6 +212,7 @@ class NUTDeviceInfo:
     model: str | None = None
     firmware: str | None = None
     serial: str | None = None
+    device_location: str | None = None
 
 
 class PyNUTData:
@@ -271,7 +273,8 @@ class PyNUTData:
         model = _model_from_status(self._status)
         firmware = _firmware_from_status(self._status)
         serial = _serial_from_status(self._status)
-        return NUTDeviceInfo(manufacturer, model, firmware, serial)
+        device_location: str | None = self._status.get("device.location")
+        return NUTDeviceInfo(manufacturer, model, firmware, serial, device_location)
 
     async def _async_get_status(self) -> dict[str, str]:
         """Get the ups status from NUT."""

--- a/tests/components/nut/test_init.py
+++ b/tests/components/nut/test_init.py
@@ -120,3 +120,30 @@ async def test_serial_number(hass: HomeAssistant) -> None:
 
     assert device_entry is not None
     assert device_entry.serial_number == mock_serial_number
+
+
+async def test_device_location(hass: HomeAssistant) -> None:
+    """Test for suggested location on device."""
+    mock_serial_number = "A00000000000"
+    mock_device_location = "XYZ Location"
+    await async_init_integration(
+        hass,
+        username="someuser",
+        password="somepassword",
+        list_vars={
+            "ups.serial": mock_serial_number,
+            "device.location": mock_device_location,
+        },
+        list_ups={"ups1": "UPS 1"},
+        list_commands_return_value=[],
+    )
+
+    device_registry = dr.async_get(hass)
+    assert device_registry is not None
+
+    device_entry = device_registry.async_get_device(
+        identifiers={(DOMAIN, mock_serial_number)}
+    )
+
+    assert device_entry is not None
+    assert device_entry.suggested_area == mock_device_location


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
Suggest area using the NUT's device location if specified.  The device location uses the value provided by NUT "device.location".  The suggested area is then provided to the user for confirmation.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
