### PR TITLE
Use new helper properties in crownstone options flow

### DIFF
--- a/homeassistant/components/crownstone/config_flow.py
+++ b/homeassistant/components/crownstone/config_flow.py
@@ -143,7 +143,7 @@ class CrownstoneConfigFlowHandler(BaseCrownstoneFlowHandler, ConfigFlow, domain=
         config_entry: ConfigEntry,
     ) -> CrownstoneOptionsFlowHandler:
         """Return the Crownstone options."""
-        return CrownstoneOptionsFlowHandler(config_entry)
+        return CrownstoneOptionsFlowHandler()
 
     def __init__(self) -> None:
         """Initialize the flow."""
@@ -210,21 +210,21 @@ class CrownstoneConfigFlowHandler(BaseCrownstoneFlowHandler, ConfigFlow, domain=
 class CrownstoneOptionsFlowHandler(BaseCrownstoneFlowHandler, OptionsFlow):
     """Handle Crownstone options."""
 
-    def __init__(self, config_entry: ConfigEntry) -> None:
+    def __init__(self) -> None:
         """Initialize Crownstone options."""
         super().__init__(OPTIONS_FLOW, self.async_create_new_entry)
-        self.entry = config_entry
-        self.updated_options = config_entry.options.copy()
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Manage Crownstone options."""
-        self.cloud: CrownstoneCloud = self.hass.data[DOMAIN][self.entry.entry_id].cloud
+        self.cloud: CrownstoneCloud = self.hass.data[DOMAIN][
+            self.config_entry.entry_id
+        ].cloud
 
         spheres = {sphere.name: sphere.cloud_id for sphere in self.cloud.cloud_data}
-        usb_path = self.entry.options.get(CONF_USB_PATH)
-        usb_sphere = self.entry.options.get(CONF_USB_SPHERE)
+        usb_path = self.config_entry.options.get(CONF_USB_PATH)
+        usb_sphere = self.config_entry.options.get(CONF_USB_SPHERE)
 
         options_schema = vol.Schema(
             {vol.Optional(CONF_USE_USB_OPTION, default=usb_path is not None): bool}
@@ -243,14 +243,14 @@ class CrownstoneOptionsFlowHandler(BaseCrownstoneFlowHandler, OptionsFlow):
             if user_input[CONF_USE_USB_OPTION] and usb_path is None:
                 return await self.async_step_usb_config()
             if not user_input[CONF_USE_USB_OPTION] and usb_path is not None:
-                self.updated_options[CONF_USB_PATH] = None
-                self.updated_options[CONF_USB_SPHERE] = None
+                self.options[CONF_USB_PATH] = None
+                self.options[CONF_USB_SPHERE] = None
             elif (
                 CONF_USB_SPHERE_OPTION in user_input
                 and spheres[user_input[CONF_USB_SPHERE_OPTION]] != usb_sphere
             ):
                 sphere_id = spheres[user_input[CONF_USB_SPHERE_OPTION]]
-                self.updated_options[CONF_USB_SPHERE] = sphere_id
+                self.options[CONF_USB_SPHERE] = sphere_id
 
             return self.async_create_new_entry()
 
@@ -260,7 +260,7 @@ class CrownstoneOptionsFlowHandler(BaseCrownstoneFlowHandler, OptionsFlow):
         """Create a new entry."""
         # these attributes will only change when a usb was configured
         if self.usb_path is not None and self.usb_sphere_id is not None:
-            self.updated_options[CONF_USB_PATH] = self.usb_path
-            self.updated_options[CONF_USB_SPHERE] = self.usb_sphere_id
+            self.options[CONF_USB_PATH] = self.usb_path
+            self.options[CONF_USB_SPHERE] = self.usb_sphere_id
 
-        return super().async_create_entry(title="", data=self.updated_options)
+        return super().async_create_entry(title="", data=self.options)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, make use of new `self.config_entry` and `self.options` properties available in option flows.

Follow-up to #129562 and #129718

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
