### PR TITLE
Use new helper properties in motioneye options flow

### DIFF
--- a/homeassistant/components/motioneye/config_flow.py
+++ b/homeassistant/components/motioneye/config_flow.py
@@ -179,17 +179,15 @@ class MotionEyeConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
-    def async_get_options_flow(config_entry: ConfigEntry) -> MotionEyeOptionsFlow:
+    def async_get_options_flow(
+        config_entry: ConfigEntry,
+    ) -> MotionEyeOptionsFlow:
         """Get the Hyperion Options flow."""
-        return MotionEyeOptionsFlow(config_entry)
+        return MotionEyeOptionsFlow()
 
 
 class MotionEyeOptionsFlow(OptionsFlow):
     """motionEye options flow."""
-
-    def __init__(self, config_entry: ConfigEntry) -> None:
-        """Initialize a motionEye options flow."""
-        self._config_entry = config_entry
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
@@ -201,14 +199,14 @@ class MotionEyeOptionsFlow(OptionsFlow):
         schema: dict[vol.Marker, type] = {
             vol.Required(
                 CONF_WEBHOOK_SET,
-                default=self._config_entry.options.get(
+                default=self.config_entry.options.get(
                     CONF_WEBHOOK_SET,
                     DEFAULT_WEBHOOK_SET,
                 ),
             ): bool,
             vol.Required(
                 CONF_WEBHOOK_SET_OVERWRITE,
-                default=self._config_entry.options.get(
+                default=self.config_entry.options.get(
                     CONF_WEBHOOK_SET_OVERWRITE,
                     DEFAULT_WEBHOOK_SET_OVERWRITE,
                 ),
@@ -219,9 +217,9 @@ class MotionEyeOptionsFlow(OptionsFlow):
             # The input URL is not validated as being a URL, to allow for the possibility
             # the template input won't be a valid URL until after it's rendered
             description: dict[str, str] | None = None
-            if CONF_STREAM_URL_TEMPLATE in self._config_entry.options:
+            if CONF_STREAM_URL_TEMPLATE in self.config_entry.options:
                 description = {
-                    "suggested_value": self._config_entry.options[
+                    "suggested_value": self.config_entry.options[
                         CONF_STREAM_URL_TEMPLATE
                     ]
                 }


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, make use of new `self.config_entry` and `self.options` properties available in option flows.

Follow-up to #129562 and #129718

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
