### PR TITLE
Remove all ice_servers on native sync WebRTC cameras

### DIFF
--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -827,16 +827,17 @@ class Camera(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
         """Return the WebRTC client configuration and extend it with the registered ice servers."""
         config = self._async_get_webrtc_client_configuration()
 
-        ice_servers = [
-            server
-            for servers in self.hass.data.get(DATA_ICE_SERVERS, [])
-            for server in servers()
-        ]
-        config.configuration.ice_servers.extend(ice_servers)
+        if not self._webrtc_sync_offer:
+            # Until 2024.11, the frontend was not resolving any ice servers
+            # The async approach was added 2024.11 and new integrations need to use it
+            ice_servers = [
+                server
+                for servers in self.hass.data.get(DATA_ICE_SERVERS, [])
+                for server in servers()
+            ]
+            config.configuration.ice_servers.extend(ice_servers)
 
-        config.get_candidates_upfront = (
-            self._webrtc_sync_offer or self._legacy_webrtc_provider is not None
-        )
+        config.get_candidates_upfront = self._legacy_webrtc_provider is not None
 
         return config
 

--- a/tests/components/camera/conftest.py
+++ b/tests/components/camera/conftest.py
@@ -1,19 +1,29 @@
 """Test helpers for camera."""
 
 from collections.abc import AsyncGenerator, Generator
-from unittest.mock import AsyncMock, PropertyMock, patch
+from unittest.mock import AsyncMock, Mock, PropertyMock, patch
 
 import pytest
 
 from homeassistant.components import camera
 from homeassistant.components.camera.const import StreamType
 from homeassistant.components.camera.webrtc import WebRTCAnswer, WebRTCSendMessage
+from homeassistant.config_entries import ConfigEntry, ConfigFlow
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.setup import async_setup_component
 
 from .common import STREAM_SOURCE, WEBRTC_ANSWER
+
+from tests.common import (
+    MockConfigEntry,
+    MockModule,
+    mock_config_flow,
+    mock_integration,
+    mock_platform,
+    setup_test_component_platform,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -142,3 +152,66 @@ def mock_stream_source_fixture() -> Generator[AsyncMock]:
         return_value=STREAM_SOURCE,
     ) as mock_stream_source:
         yield mock_stream_source
+
+
+@pytest.fixture
+async def mock_camera_webrtc_native_sync_offer(hass: HomeAssistant) -> None:
+    """Initialize a test camera with native sync WebRTC support."""
+
+    # Cannot use the fixture mock_camera_web_rtc as it's mocking Camera.async_handle_web_rtc_offer
+    # and native support is checked by verify the function "async_handle_web_rtc_offer" was
+    # overwritten(implemented) or not
+    class MockCamera(camera.Camera):
+        """Mock Camera Entity."""
+
+        _attr_name = "Test"
+        _attr_supported_features: camera.CameraEntityFeature = (
+            camera.CameraEntityFeature.STREAM
+        )
+        _attr_frontend_stream_type: camera.StreamType = camera.StreamType.WEB_RTC
+
+        async def stream_source(self) -> str | None:
+            return STREAM_SOURCE
+
+        async def async_handle_web_rtc_offer(self, offer_sdp: str) -> str | None:
+            return WEBRTC_ANSWER
+
+    domain = "test"
+
+    entry = MockConfigEntry(domain=domain)
+    entry.add_to_hass(hass)
+
+    async def async_setup_entry_init(
+        hass: HomeAssistant, config_entry: ConfigEntry
+    ) -> bool:
+        """Set up test config entry."""
+        await hass.config_entries.async_forward_entry_setups(
+            config_entry, [camera.DOMAIN]
+        )
+        return True
+
+    async def async_unload_entry_init(
+        hass: HomeAssistant, config_entry: ConfigEntry
+    ) -> bool:
+        """Unload test config entry."""
+        await hass.config_entries.async_forward_entry_unload(
+            config_entry, camera.DOMAIN
+        )
+        return True
+
+    mock_integration(
+        hass,
+        MockModule(
+            domain,
+            async_setup_entry=async_setup_entry_init,
+            async_unload_entry=async_unload_entry_init,
+        ),
+    )
+    setup_test_component_platform(
+        hass, camera.DOMAIN, [MockCamera()], from_config_entry=True
+    )
+    mock_platform(hass, f"{domain}.config_flow", Mock())
+
+    with mock_config_flow(domain, ConfigFlow):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()

--- a/tests/components/camera/test_init.py
+++ b/tests/components/camera/test_init.py
@@ -25,7 +25,6 @@ from homeassistant.components.camera.const import (
 )
 from homeassistant.components.camera.helper import get_camera_from_entity_id
 from homeassistant.components.websocket_api import TYPE_RESULT
-from homeassistant.config_entries import ConfigEntry, ConfigFlow
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     EVENT_HOMEASSISTANT_STARTED,
@@ -38,18 +37,12 @@ from homeassistant.helpers import entity_registry as er, issue_registry as ir
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
-from .common import EMPTY_8_6_JPEG, STREAM_SOURCE, WEBRTC_ANSWER, mock_turbo_jpeg
+from .common import EMPTY_8_6_JPEG, STREAM_SOURCE, mock_turbo_jpeg
 
 from tests.common import (
-    MockConfigEntry,
-    MockModule,
     async_fire_time_changed,
     help_test_all,
     import_and_test_deprecated_constant_enum,
-    mock_config_flow,
-    mock_integration,
-    mock_platform,
-    setup_test_component_platform,
 )
 from tests.typing import ClientSessionGenerator, WebSocketGenerator
 
@@ -986,61 +979,12 @@ async def test_camera_capabilities_hls(
     )
 
 
+@pytest.mark.usefixtures("mock_camera_webrtc_native_sync_offer")
 async def test_camera_capabilities_webrtc(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test WebRTC camera capabilities."""
-
-    # Cannot use the fixture mock_camera_web_rtc as it's mocking Camera.async_handle_web_rtc_offer
-    # Camera capabilities are determined by by checking if the function was overwritten(implemented) or not
-    class MockCamera(camera.Camera):
-        """Mock Camera Entity."""
-
-        _attr_name = "Test"
-        _attr_supported_features: camera.CameraEntityFeature = (
-            camera.CameraEntityFeature.STREAM
-        )
-
-        async def stream_source(self) -> str | None:
-            return STREAM_SOURCE
-
-        async def async_handle_web_rtc_offer(self, offer_sdp: str) -> str | None:
-            return WEBRTC_ANSWER
-
-    domain = "test"
-
-    entry = MockConfigEntry(domain=domain)
-    entry.add_to_hass(hass)
-
-    async def async_setup_entry_init(
-        hass: HomeAssistant, config_entry: ConfigEntry
-    ) -> bool:
-        """Set up test config entry."""
-        await hass.config_entries.async_forward_entry_setups(config_entry, [DOMAIN])
-        return True
-
-    async def async_unload_entry_init(
-        hass: HomeAssistant, config_entry: ConfigEntry
-    ) -> bool:
-        """Unload test config entry."""
-        await hass.config_entries.async_forward_entry_unload(config_entry, DOMAIN)
-        return True
-
-    mock_integration(
-        hass,
-        MockModule(
-            domain,
-            async_setup_entry=async_setup_entry_init,
-            async_unload_entry=async_unload_entry_init,
-        ),
-    )
-    setup_test_component_platform(hass, DOMAIN, [MockCamera()], from_config_entry=True)
-    mock_platform(hass, f"{domain}.config_flow", Mock())
-
-    with mock_config_flow(domain, ConfigFlow):
-        assert await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
 
     await _test_capabilities(
         hass, hass_ws_client, "camera.test", {StreamType.WEB_RTC}, {StreamType.WEB_RTC}

--- a/tests/components/camera/test_webrtc.py
+++ b/tests/components/camera/test_webrtc.py
@@ -393,6 +393,29 @@ async def test_ws_get_client_config(
     }
 
 
+@pytest.mark.usefixtures("mock_camera_webrtc_native_sync_offer")
+async def test_ws_get_client_config_sync_offer(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
+    """Test get WebRTC client config, when camera is supporting sync offer."""
+    await async_setup_component(hass, "camera", {})
+    await hass.async_block_till_done()
+
+    client = await hass_ws_client(hass)
+    await client.send_json_auto_id(
+        {"type": "camera/webrtc/get_client_config", "entity_id": "camera.test"}
+    )
+    msg = await client.receive_json()
+
+    # Assert WebSocket response
+    assert msg["type"] == TYPE_RESULT
+    assert msg["success"]
+    assert msg["result"] == {
+        "configuration": {},
+        "getCandidatesUpfront": False,
+    }
+
+
 @pytest.mark.usefixtures("mock_camera_webrtc")
 async def test_ws_get_client_config_custom_config(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Ice servers will be added in HA 2024.11, which led to a bug. The native sync WebRTC camera had a start delay of up to 40 seconds due to resolving all candidates upfront. To have backward compatibility and offer the same experience as before, we will not add any ice_servers on native sync WebRTC cameras.
Integrations must migrate to the async one to use ice_severs and have a better WebRTC experience.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/frontend/issues/22650
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
