### PR TITLE
Improve entity test coverage for Russound RIO

### DIFF
--- a/tests/components/russound_rio/__init__.py
+++ b/tests/components/russound_rio/__init__.py
@@ -1,1 +1,13 @@
 """Tests for the Russound RIO integration."""
+
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+async def setup_integration(hass: HomeAssistant, config_entry: MockConfigEntry) -> None:
+    """Fixture for setting up the component."""
+    config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()

--- a/tests/components/russound_rio/conftest.py
+++ b/tests/components/russound_rio/conftest.py
@@ -1,16 +1,19 @@
 """Test fixtures for Russound RIO integration."""
 
 from collections.abc import Generator
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
+from aiorussound import Controller, RussoundTcpConnectionHandler, Source
+from aiorussound.rio import ZoneControlSurface
+from aiorussound.util import controller_device_str, zone_device_str
 import pytest
 
 from homeassistant.components.russound_rio.const import DOMAIN
 from homeassistant.core import HomeAssistant
 
-from .const import HARDWARE_MAC, MOCK_CONFIG, MOCK_CONTROLLERS, MODEL
+from .const import HARDWARE_MAC, HOST, MOCK_CONFIG, MODEL, PORT
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, load_json_object_fixture
 
 
 @pytest.fixture
@@ -33,7 +36,7 @@ def mock_config_entry(hass: HomeAssistant) -> MockConfigEntry:
 
 
 @pytest.fixture
-def mock_russound() -> Generator[AsyncMock]:
+def mock_russound_client() -> Generator[AsyncMock]:
     """Mock the Russound RIO client."""
     with (
         patch(
@@ -41,8 +44,30 @@ def mock_russound() -> Generator[AsyncMock]:
         ) as mock_client,
         patch(
             "homeassistant.components.russound_rio.config_flow.RussoundClient",
-            return_value=mock_client,
+            new=mock_client,
         ),
     ):
-        mock_client.controllers = MOCK_CONTROLLERS
-        yield mock_client
+        client = mock_client.return_value
+        zones = {
+            int(k): ZoneControlSurface.from_dict(v)
+            for k, v in load_json_object_fixture("get_zones.json", DOMAIN).items()
+        }
+        client.sources = {
+            int(k): Source.from_dict(v)
+            for k, v in load_json_object_fixture("get_sources.json", DOMAIN).items()
+        }
+        for k, v in zones.items():
+            v.device_str = zone_device_str(1, k)
+            v.fetch_current_source = Mock(
+                side_effect=lambda current_source=v.current_source: client.sources.get(
+                    int(current_source)
+                )
+            )
+
+        client.controllers = {
+            1: Controller(
+                1, "MCA-C5", client, controller_device_str(1), HARDWARE_MAC, None, zones
+            )
+        }
+        client.connection_handler = RussoundTcpConnectionHandler(HOST, PORT)
+        yield client

--- a/tests/components/russound_rio/fixtures/get_sources.json
+++ b/tests/components/russound_rio/fixtures/get_sources.json
@@ -1,0 +1,10 @@
+{
+  "1": {
+    "name": "Aux",
+    "type": "Miscellaneous Audio"
+  },
+  "2": {
+    "name": "Spotify",
+    "type": "Russound Media Streamer"
+  }
+}

--- a/tests/components/russound_rio/fixtures/get_zones.json
+++ b/tests/components/russound_rio/fixtures/get_zones.json
@@ -1,0 +1,22 @@
+{
+  "1": {
+    "name": "Backyard",
+    "volume": "10",
+    "status": "ON",
+    "enabled": "True",
+    "current_source": "1"
+  },
+  "2": {
+    "name": "Kitchen",
+    "volume": "50",
+    "status": "OFF",
+    "enabled": "True",
+    "current_source": "2"
+  },
+  "3": {
+    "name": "Bedroom",
+    "volume": "10",
+    "status": "OFF",
+    "enabled": "False"
+  }
+}

--- a/tests/components/russound_rio/snapshots/test_init.ambr
+++ b/tests/components/russound_rio/snapshots/test_init.ambr
@@ -1,0 +1,37 @@
+# serializer version: 1
+# name: test_device_info
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'configuration_url': 'http://127.0.0.1',
+    'connections': set({
+      tuple(
+        'mac',
+        '00:11:22:33:44:55',
+      ),
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'russound_rio',
+        '00:11:22:33:44:55',
+      ),
+    }),
+    'is_new': False,
+    'labels': set({
+    }),
+    'manufacturer': 'Russound',
+    'model': 'MCA-C5',
+    'model_id': None,
+    'name': 'MCA-C5',
+    'name_by_user': None,
+    'primary_config_entry': <ANY>,
+    'serial_number': None,
+    'suggested_area': None,
+    'sw_version': None,
+    'via_device_id': None,
+  })
+# ---

--- a/tests/components/russound_rio/test_config_flow.py
+++ b/tests/components/russound_rio/test_config_flow.py
@@ -11,7 +11,7 @@ from .const import MOCK_CONFIG, MODEL
 
 
 async def test_form(
-    hass: HomeAssistant, mock_setup_entry: AsyncMock, mock_russound: AsyncMock
+    hass: HomeAssistant, mock_setup_entry: AsyncMock, mock_russound_client: AsyncMock
 ) -> None:
     """Test we get the form."""
     result = await hass.config_entries.flow.async_init(
@@ -32,13 +32,13 @@ async def test_form(
 
 
 async def test_form_cannot_connect(
-    hass: HomeAssistant, mock_setup_entry: AsyncMock, mock_russound: AsyncMock
+    hass: HomeAssistant, mock_setup_entry: AsyncMock, mock_russound_client: AsyncMock
 ) -> None:
     """Test we handle cannot connect error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    mock_russound.connect.side_effect = TimeoutError
+    mock_russound_client.connect.side_effect = TimeoutError
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         MOCK_CONFIG,
@@ -48,7 +48,7 @@ async def test_form_cannot_connect(
     assert result["errors"] == {"base": "cannot_connect"}
 
     # Recover with correct information
-    mock_russound.connect.side_effect = None
+    mock_russound_client.connect.side_effect = None
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         MOCK_CONFIG,
@@ -61,7 +61,7 @@ async def test_form_cannot_connect(
 
 
 async def test_import(
-    hass: HomeAssistant, mock_setup_entry: AsyncMock, mock_russound: AsyncMock
+    hass: HomeAssistant, mock_setup_entry: AsyncMock, mock_russound_client: AsyncMock
 ) -> None:
     """Test we import a config entry."""
     result = await hass.config_entries.flow.async_init(
@@ -77,10 +77,10 @@ async def test_import(
 
 
 async def test_import_cannot_connect(
-    hass: HomeAssistant, mock_russound: AsyncMock
+    hass: HomeAssistant, mock_russound_client: AsyncMock
 ) -> None:
     """Test we handle import cannot connect error."""
-    mock_russound.connect.side_effect = TimeoutError
+    mock_russound_client.connect.side_effect = TimeoutError
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_IMPORT}, data=MOCK_CONFIG

--- a/tests/components/russound_rio/test_init.py
+++ b/tests/components/russound_rio/test_init.py
@@ -1,0 +1,44 @@
+"""Tests for the Russound RIO integration."""
+
+from unittest.mock import AsyncMock
+
+from syrupy import SnapshotAssertion
+
+from homeassistant.components.russound_rio.const import DOMAIN
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+
+from . import setup_integration
+
+from tests.common import MockConfigEntry
+
+
+async def test_config_entry_not_ready(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_russound_client: AsyncMock,
+) -> None:
+    """Test the Cambridge Audio configuration entry not ready."""
+    mock_russound_client.connect.side_effect = TimeoutError
+    await setup_integration(hass, mock_config_entry)
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+
+    mock_russound_client.connect = AsyncMock(return_value=True)
+
+
+async def test_device_info(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    mock_russound_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test device registry integration."""
+    await setup_integration(hass, mock_config_entry)
+    device_entry = device_registry.async_get_device(
+        identifiers={(DOMAIN, mock_config_entry.unique_id)}
+    )
+    assert device_entry is not None
+    assert device_entry == snapshot


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds tests to load the entity and check the device info of a Russound device. This will act as the base for adding the media player test coverage.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
