### PR TITLE
Fix unifiprotect supported features being set too late

### DIFF
--- a/homeassistant/components/unifiprotect/camera.py
+++ b/homeassistant/components/unifiprotect/camera.py
@@ -156,7 +156,8 @@ async def async_setup_entry(
     async_add_entities(_async_camera_entities(hass, entry, data))
 
 
-_EMPTY_CAMERA_FEATURES = CameraEntityFeature(0)
+_DISABLE_FEATURE = CameraEntityFeature(0)
+_ENABLE_FEATURE = CameraEntityFeature.STREAM
 
 
 class ProtectCamera(ProtectDeviceEntity, Camera):
@@ -195,24 +196,20 @@ class ProtectCamera(ProtectDeviceEntity, Camera):
             self._attr_name = f"{camera_name} (insecure)"
         # only the default (first) channel is enabled by default
         self._attr_entity_registry_enabled_default = is_default and secure
+        # Set the stream source before finishing the init
+        # because async_added_to_hass is too late and camera
+        # integration uses async_internal_added_to_hass to access
+        # the stream source which is called before async_added_to_hass
+        self._async_set_stream_source()
 
     @callback
     def _async_set_stream_source(self) -> None:
-        disable_stream = self._disable_stream
         channel = self.channel
-
-        if not channel.is_rtsp_enabled:
-            disable_stream = False
-
+        enable_stream = not self._disable_stream and channel.is_rtsp_enabled
         rtsp_url = channel.rtsps_url if self._secure else channel.rtsp_url
-
-        # _async_set_stream_source called by __init__
-        # pylint: disable-next=attribute-defined-outside-init
-        self._stream_source = None if disable_stream else rtsp_url
-        if self._stream_source:
-            self._attr_supported_features = CameraEntityFeature.STREAM
-        else:
-            self._attr_supported_features = _EMPTY_CAMERA_FEATURES
+        source = rtsp_url if enable_stream else None
+        self._attr_supported_features = _ENABLE_FEATURE if source else _DISABLE_FEATURE
+        self._stream_source = source
 
     @callback
     def _async_update_device_from_protect(self, device: ProtectDeviceType) -> None:

--- a/tests/components/unifiprotect/test_camera.py
+++ b/tests/components/unifiprotect/test_camera.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, Mock
 
+import pytest
 from uiprotect.api import DEVICE_UPDATE_INTERVAL
 from uiprotect.data import Camera as ProtectCamera, CameraChannel, StateType
 from uiprotect.exceptions import NvrError
@@ -12,8 +13,13 @@ from uiprotect.websocket import WebsocketState
 from homeassistant.components.camera import (
     CameraEntityFeature,
     CameraState,
+    CameraWebRTCProvider,
+    RTCIceCandidate,
+    StreamType,
+    WebRTCSendMessage,
     async_get_image,
     async_get_stream_source,
+    async_register_webrtc_provider,
 )
 from homeassistant.components.unifiprotect.const import (
     ATTR_BITRATE,
@@ -22,6 +28,7 @@ from homeassistant.components.unifiprotect.const import (
     ATTR_HEIGHT,
     ATTR_WIDTH,
     DEFAULT_ATTRIBUTION,
+    DOMAIN,
 )
 from homeassistant.components.unifiprotect.utils import get_camera_base_name
 from homeassistant.const import (
@@ -31,11 +38,12 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
     Platform,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
 
 from .utils import (
+    Camera,
     MockUFPFixture,
     adopt_devices,
     assert_entity_counts,
@@ -44,6 +52,45 @@ from .utils import (
     remove_entities,
     time_changed,
 )
+
+
+class MockWebRTCProvider(CameraWebRTCProvider):
+    """WebRTC provider."""
+
+    @property
+    def domain(self) -> str:
+        """Return the integration domain of the provider."""
+        return DOMAIN
+
+    @callback
+    def async_is_supported(self, stream_source: str) -> bool:
+        """Return if this provider is supports the Camera as source."""
+        return True
+
+    async def async_handle_async_webrtc_offer(
+        self,
+        camera: Camera,
+        offer_sdp: str,
+        session_id: str,
+        send_message: WebRTCSendMessage,
+    ) -> None:
+        """Handle the WebRTC offer and return the answer via the provided callback."""
+
+    async def async_on_webrtc_candidate(
+        self, session_id: str, candidate: RTCIceCandidate
+    ) -> None:
+        """Handle the WebRTC candidate."""
+
+    @callback
+    def async_close_session(self, session_id: str) -> None:
+        """Close the session."""
+
+
+@pytest.fixture
+async def web_rtc_provider(hass: HomeAssistant) -> None:
+    """Fixture to enable WebRTC provider for camera entities."""
+    await async_setup_component(hass, "camera", {})
+    async_register_webrtc_provider(hass, MockWebRTCProvider())
 
 
 def validate_default_camera_entity(
@@ -281,6 +328,26 @@ async def test_basic_setup(
 
     entity_id = validate_default_camera_entity(hass, doorbell, 3)
     await validate_no_stream_camera_state(hass, doorbell, 3, entity_id, features=0)
+
+
+@pytest.mark.usefixtures("web_rtc_provider")
+async def test_webrtc_support(
+    hass: HomeAssistant,
+    ufp: MockUFPFixture,
+    camera_all: ProtectCamera,
+) -> None:
+    """Test webrtc support is available."""
+    camera_high_only = camera_all.copy()
+    camera_high_only.channels = [c.copy() for c in camera_all.channels]
+    camera_high_only.name = "Test Camera 1"
+    camera_high_only.channels[0].is_rtsp_enabled = True
+    camera_high_only.channels[1].is_rtsp_enabled = False
+    camera_high_only.channels[2].is_rtsp_enabled = False
+    await init_entry(hass, ufp, [camera_high_only])
+    entity_id = validate_default_camera_entity(hass, camera_high_only, 0)
+    state = hass.states.get(entity_id)
+    assert state
+    assert StreamType.WEB_RTC in state.attributes["frontend_stream_type"]
 
 
 async def test_adopt(


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
`_attr_supported_features` must be set in` __init__` because
camera accesses it in `async_internal_added_to_hass` before
`async_added_to_hass` is called


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
