### PR TITLE
Map "stop" to MediaPlayerState.IDLE in bluesound integration

### DIFF
--- a/homeassistant/components/bluesound/media_player.py
+++ b/homeassistant/components/bluesound/media_player.py
@@ -369,8 +369,6 @@ class BluesoundPlayer(MediaPlayerEntity):
                 return MediaPlayerState.PAUSED
             case "stream" | "play":
                 return MediaPlayerState.PLAYING
-            case "stop":
-                return MediaPlayerState.IDLE
             case _:
                 return MediaPlayerState.IDLE
 

--- a/homeassistant/components/bluesound/media_player.py
+++ b/homeassistant/components/bluesound/media_player.py
@@ -364,12 +364,15 @@ class BluesoundPlayer(MediaPlayerEntity):
         if self.is_grouped and not self.is_master:
             return MediaPlayerState.IDLE
 
-        status = self._status.state
-        if status in ("pause", "stop"):
-            return MediaPlayerState.PAUSED
-        if status in ("stream", "play"):
-            return MediaPlayerState.PLAYING
-        return MediaPlayerState.IDLE
+        match self._status.state:
+            case "pause":
+                return MediaPlayerState.PAUSED
+            case "stream" | "play":
+                return MediaPlayerState.PLAYING
+            case "stop":
+                return MediaPlayerState.IDLE
+            case _:
+                return MediaPlayerState.IDLE
 
     @property
     def media_title(self) -> str | None:

--- a/tests/components/bluesound/test_media_player.py
+++ b/tests/components/bluesound/test_media_player.py
@@ -129,6 +129,7 @@ async def test_attributes_set(
     state = hass.states.get("media_player.player_name1111")
     assert state == snapshot(exclude=props("media_position_updated_at"))
 
+
 async def test_stop_maps_to_idle(
     hass: HomeAssistant,
     setup_config_entry: None,
@@ -144,7 +145,9 @@ async def test_stop_maps_to_idle(
     # give the long polling loop a chance to update the state; this could be any async call
     await hass.async_block_till_done()
 
-    assert hass.states.get("media_player.player_name1111").state == MediaPlayerState.IDLE
+    assert (
+        hass.states.get("media_player.player_name1111").state == MediaPlayerState.IDLE
+    )
 
 
 async def test_status_updated(

--- a/tests/components/bluesound/test_media_player.py
+++ b/tests/components/bluesound/test_media_player.py
@@ -129,6 +129,23 @@ async def test_attributes_set(
     state = hass.states.get("media_player.player_name1111")
     assert state == snapshot(exclude=props("media_position_updated_at"))
 
+async def test_stop_maps_to_idle(
+    hass: HomeAssistant,
+    setup_config_entry: None,
+    player_mocks: PlayerMocks,
+) -> None:
+    """Test the media player stop maps to idle."""
+    player_mocks.player_data.status_long_polling_mock.set(
+        dataclasses.replace(
+            player_mocks.player_data.status_long_polling_mock.get(), state="stop"
+        )
+    )
+
+    # give the long polling loop a chance to update the state; this could be any async call
+    await hass.async_block_till_done()
+
+    assert hass.states.get("media_player.player_name1111").state == MediaPlayerState.IDLE
+
 
 async def test_status_updated(
     hass: HomeAssistant,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
<!-- ## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The player states "pause" and "stop" from the media player were both mapped to PAUSED in home assistant. "stop" is now mapped to IDLE.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
"stop" was mapped to MediaPlayerState.PAUSED before. It is now mapped to MediaPlayerState.IDLE, which seems to be the common mapping.

**This is a breaking change. See issue for reasoning.**

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #129728 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
