### PR TITLE
Use read-only options in emoncms options flow

### DIFF
--- a/homeassistant/components/emoncms/config_flow.py
+++ b/homeassistant/components/emoncms/config_flow.py
@@ -72,7 +72,7 @@ class EmoncmsConfigFlow(ConfigFlow, domain=DOMAIN):
         config_entry: ConfigEntry,
     ) -> EmoncmsOptionsFlow:
         """Get the options flow for this handler."""
-        return EmoncmsOptionsFlow()
+        return EmoncmsOptionsFlow(config_entry)
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -175,20 +175,23 @@ class EmoncmsConfigFlow(ConfigFlow, domain=DOMAIN):
 class EmoncmsOptionsFlow(OptionsFlow):
     """Emoncms Options flow handler."""
 
+    def __init__(self, config_entry: ConfigEntry) -> None:
+        """Initialize emoncms options flow."""
+        self._url = config_entry.data[CONF_URL]
+        self._api_key = config_entry.data[CONF_API_KEY]
+
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Manage the options."""
         errors: dict[str, str] = {}
         description_placeholders = {}
-        data = self.config_entry.data
-        if current_options := self.config_entry.options:
-            data = current_options
-        url = data[CONF_URL]
-        api_key = data[CONF_API_KEY]
-        include_only_feeds = data.get(CONF_ONLY_INCLUDE_FEEDID, [])
+        include_only_feeds = self.config_entry.options.get(
+            CONF_ONLY_INCLUDE_FEEDID,
+            self.config_entry.data.get(CONF_ONLY_INCLUDE_FEEDID, []),
+        )
         options: list = include_only_feeds
-        result = await get_feed_list(self.hass, url, api_key)
+        result = await get_feed_list(self.hass, self._url, self._api_key)
         if not result[CONF_SUCCESS]:
             errors["base"] = "api_error"
             description_placeholders = {"details": result[CONF_MESSAGE]}
@@ -198,10 +201,7 @@ class EmoncmsOptionsFlow(OptionsFlow):
         if user_input:
             include_only_feeds = user_input[CONF_ONLY_INCLUDE_FEEDID]
             return self.async_create_entry(
-                title=sensor_name(url),
                 data={
-                    CONF_URL: url,
-                    CONF_API_KEY: api_key,
                     CONF_ONLY_INCLUDE_FEEDID: include_only_feeds,
                 },
             )

--- a/homeassistant/components/emoncms/config_flow.py
+++ b/homeassistant/components/emoncms/config_flow.py
@@ -181,7 +181,9 @@ class EmoncmsOptionsFlow(OptionsFlow):
         """Manage the options."""
         errors: dict[str, str] = {}
         description_placeholders = {}
-        data = self.options if self.options else self.config_entry.data
+        data = self.config_entry.data
+        if current_options := self.config_entry.options:
+            data = current_options
         url = data[CONF_URL]
         api_key = data[CONF_API_KEY]
         include_only_feeds = data.get(CONF_ONLY_INCLUDE_FEEDID, [])

--- a/homeassistant/components/emoncms/sensor.py
+++ b/homeassistant/components/emoncms/sensor.py
@@ -138,10 +138,11 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the emoncms sensors."""
-    config = entry.options if entry.options else entry.data
-    name = sensor_name(config[CONF_URL])
-    exclude_feeds = config.get(CONF_EXCLUDE_FEEDID)
-    include_only_feeds = config.get(CONF_ONLY_INCLUDE_FEEDID)
+    name = sensor_name(entry.data[CONF_URL])
+    exclude_feeds = entry.data.get(CONF_EXCLUDE_FEEDID)
+    include_only_feeds = entry.options.get(
+        CONF_ONLY_INCLUDE_FEEDID, entry.data.get(CONF_ONLY_INCLUDE_FEEDID)
+    )
 
     if exclude_feeds is None and include_only_feeds is None:
         return

--- a/tests/components/emoncms/test_config_flow.py
+++ b/tests/components/emoncms/test_config_flow.py
@@ -97,10 +97,6 @@ async def test_user_flow(
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-USER_OPTIONS = {
-    CONF_ONLY_INCLUDE_FEEDID: ["1"],
-}
-
 CONFIG_ENTRY = {
     CONF_API_KEY: "my_api_key",
     CONF_ONLY_INCLUDE_FEEDID: ["1"],
@@ -116,15 +112,19 @@ async def test_options_flow(
 ) -> None:
     """Options flow - success test."""
     await setup_integration(hass, config_entry)
+    assert config_entry.options == {}
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
     await hass.async_block_till_done()
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
-        user_input=USER_OPTIONS,
+        user_input={
+            CONF_ONLY_INCLUDE_FEEDID: ["1"],
+        },
     )
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["data"] == CONFIG_ENTRY
-    assert config_entry.options == CONFIG_ENTRY
+    assert config_entry.options == {
+        CONF_ONLY_INCLUDE_FEEDID: ["1"],
+    }
 
 
 async def test_options_flow_failure(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Linked to #129890

The integration doesn't need to access the mutable options.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
