### PR TITLE
Temporary fix for syrupy unused snapshots

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -159,7 +159,7 @@ def pytest_configure(config: pytest.Config) -> None:
     # Temporary workaround until it is finalised inside syrupy
     # See https://github.com/syrupy-project/syrupy/pull/901
     SnapshotSession.finish = override_syrupy_finish
-    # Override default report match location when location are provided, for example:
+    # Override default report match location for unused snapshots
     # Temporary workaround until it is finalised inside syrupy
     # See https://github.com/syrupy-project/syrupy/issues/918
     SnapshotReport._ran_items_match_location = (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,6 +36,7 @@ import pytest_socket
 import requests_mock
 import respx
 from syrupy.assertion import SnapshotAssertion
+from syrupy.report import SnapshotReport
 from syrupy.session import SnapshotSession
 
 from homeassistant import block_async_io
@@ -93,7 +94,11 @@ from homeassistant.util.async_ import create_eager_task, get_scheduled_timer_han
 from homeassistant.util.json import json_loads
 
 from .ignore_uncaught_exceptions import IGNORE_UNCAUGHT_EXCEPTIONS
-from .syrupy import HomeAssistantSnapshotExtension, override_syrupy_finish
+from .syrupy import (
+    HomeAssistantSnapshotExtension,
+    override_syrupy_finish,
+    override_syrupy_report_ran_items_match_location,
+)
 from .typing import (
     ClientSessionGenerator,
     MockHAClientWebSocket,
@@ -154,6 +159,12 @@ def pytest_configure(config: pytest.Config) -> None:
     # Temporary workaround until it is finalised inside syrupy
     # See https://github.com/syrupy-project/syrupy/pull/901
     SnapshotSession.finish = override_syrupy_finish
+    # Override default report match location when location are provided, for example:
+    # Temporary workaround until it is finalised inside syrupy
+    # See https://github.com/syrupy-project/syrupy/issues/918
+    SnapshotReport._ran_items_match_location = (
+        override_syrupy_report_ran_items_match_location
+    )
 
 
 def pytest_runtest_setup() -> None:

--- a/tests/syrupy.py
+++ b/tests/syrupy.py
@@ -432,20 +432,7 @@ def override_syrupy_finish(self: SnapshotSession) -> int:
             for i in range(int(worker_count)):
                 with open(f".pytest_syrupy_gw{i}_result", encoding="utf-8") as f:
                     _merge_serialized_report(self.report, json.load(f))
-                # os.remove(f".pytest_syrupy_gw{i}_result")
-        else:
-            with open(
-                ".pytest_syrupy_no_xdist_result",
-                "w",
-                encoding="utf-8",
-            ) as f:
-                json.dump(
-                    _serialize_report(
-                        self.report, self._collected_items, self._selected_items
-                    ),
-                    f,
-                    indent=2,
-                )
+                os.remove(f".pytest_syrupy_gw{i}_result")
 
     if self.report.num_unused:
         if self.update_snapshots:

--- a/tests/syrupy.py
+++ b/tests/syrupy.py
@@ -272,16 +272,13 @@ def override_syrupy_report_ran_items_match_location(
 
     # Advanced check, to remove false-positives
     # We check that at least one assertion would have hit the snapshot location
-    for assertion in self.assertions:
-        if (
-            assertion.extension.get_location(
-                test_location=assertion.test_location, index=assertion.index
-            )
-            == snapshot_location
-        ):
-            return True
-
-    return False
+    return any(
+        assertion.extension.get_location(
+            test_location=assertion.test_location, index=assertion.index
+        )
+        == snapshot_location
+        for assertion in self.assertions
+    )
 
 
 # Classes and Methods to override default finish behavior in syrupy


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Temporary fix for https://github.com/syrupy-project/syrupy/issues/918 until it is fixed in syrupy

Running `pytest --snapshot-details tests/components/config/test_config_entries.py tests/test_config.py` incorrectly assumes that `tests/snapshots/test_config_entries.ambr` contains unused snapshots.

Sample bad run: <https://github.com/home-assistant/core/actions/runs/11679325591/job/32520481944?pr=123563>

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
