### PR TITLE
Ensure that all files in a folder are in the same test bucket

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -447,6 +447,7 @@ testpaths = [
 norecursedirs = [
     ".git",
     "testing_config",
+    "components",
 ]
 log_format = "%(asctime)s.%(msecs)03d %(levelname)-8s %(threadName)s %(name)s:%(filename)s:%(lineno)s %(message)s"
 log_date_format = "%Y-%m-%d %H:%M:%S"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -447,7 +447,6 @@ testpaths = [
 norecursedirs = [
     ".git",
     "testing_config",
-    "components",
 ]
 log_format = "%(asctime)s.%(msecs)03d %(levelname)-8s %(threadName)s %(name)s:%(filename)s:%(lineno)s %(message)s"
 log_date_format = "%Y-%m-%d %H:%M:%S"

--- a/script/split_tests.py
+++ b/script/split_tests.py
@@ -57,7 +57,9 @@ class BucketHolder:
             if (
                 smallest_bucket.total_tests + tests.total_tests < self._tests_per_bucket
             ) or (is_file := isinstance(tests, TestFile)):
-                print(f"{tests.total_tests:>{digits}} tests in {tests.path}")
+                print(
+                    f"{tests.total_tests:>{digits}} tests in {tests.path} (is file: {is_file})"
+                )
                 smallest_bucket.add(tests)
                 if is_file:
                     # Ensure all files from the same folder are in the same bucket

--- a/script/split_tests.py
+++ b/script/split_tests.py
@@ -55,24 +55,25 @@ class BucketHolder:
 
             print(f"{tests.total_tests:>{digits}} tests in {tests.path}")
             smallest_bucket = min(self._buckets, key=lambda x: x.total_tests)
-            if smallest_bucket.total_tests + tests.total_tests < self._tests_per_bucket:
-                smallest_bucket.add(tests)
-                continue
-            if isinstance(tests, TestFile):
+            is_file = isinstance(tests, TestFile)
+            if (
+                smallest_bucket.total_tests + tests.total_tests < self._tests_per_bucket
+            ) or is_file:
                 smallest_bucket.add(tests)
                 # Ensure all files from the same folder are in the same bucket
                 # to ensure that syrupy correctly identifies unused snapshots
-                for other_test in sorted_tests:
-                    if (
-                        isinstance(other_test, TestFolder)
-                        or other_test.added_to_bucket
-                        or other_test.path.parent != tests.path.parent
-                    ):
-                        continue
-                    print(
-                        f"{other_test.total_tests:>{digits}} tests in {other_test.path} (same bucket)"
-                    )
-                    smallest_bucket.add(other_test)
+                if is_file:
+                    for other_test in sorted_tests:
+                        if (
+                            isinstance(other_test, TestFolder)
+                            or other_test.added_to_bucket
+                            or other_test.path.parent != tests.path.parent
+                        ):
+                            continue
+                        print(
+                            f"{other_test.total_tests:>{digits}} tests in {other_test.path} (same bucket)"
+                        )
+                        smallest_bucket.add(other_test)
 
         # verify that all tests are added to a bucket
         if not test_folder.added_to_bucket:

--- a/script/split_tests.py
+++ b/script/split_tests.py
@@ -49,7 +49,6 @@ class BucketHolder:
             test_folder.get_all_flatten(), reverse=True, key=lambda x: x.total_tests
         )
         for tests in sorted_tests:
-            print(f"{tests.total_tests:>{digits}} tests in {tests.path}")
             if tests.added_to_bucket:
                 # Already added to bucket
                 continue
@@ -58,6 +57,7 @@ class BucketHolder:
             if (
                 smallest_bucket.total_tests + tests.total_tests < self._tests_per_bucket
             ) or (is_file := isinstance(tests, TestFile)):
+                print(f"{tests.total_tests:>{digits}} tests in {tests.path}")
                 smallest_bucket.add(tests)
                 if is_file:
                     # Ensure all files from the same folder are in the same bucket
@@ -69,6 +69,9 @@ class BucketHolder:
                             or other_test.path.parent != tests.path.parent
                         ):
                             continue
+                        print(
+                            f"{other_test.total_tests:>{digits}} tests in {other_test.path}"
+                        )
                         smallest_bucket.add(other_test)
 
         # verify that all tests are added to a bucket

--- a/script/split_tests.py
+++ b/script/split_tests.py
@@ -63,12 +63,8 @@ class BucketHolder:
                 # Ensure all files from the same folder are in the same bucket
                 # to ensure that syrupy correctly identifies unused snapshots
                 if is_file:
-                    for other_test in sorted_tests:
-                        if (
-                            isinstance(other_test, TestFolder)
-                            or other_test.added_to_bucket
-                            or other_test.path.parent != tests.path.parent
-                        ):
+                    for other_test in tests.parent.children.values():
+                        if other_test is tests or isinstance(other_test, TestFolder):
                             continue
                         print(
                             f"{other_test.total_tests:>{digits}} tests in {other_test.path} (same bucket)"
@@ -94,6 +90,7 @@ class TestFile:
     total_tests: int
     path: Path
     added_to_bucket: bool = field(default=False, init=False)
+    parent: TestFolder | None = field(default=None, init=False)
 
     def add_to_bucket(self) -> None:
         """Add test file to bucket."""
@@ -140,6 +137,7 @@ class TestFolder:
     def add_test_file(self, file: TestFile) -> None:
         """Add test file to folder."""
         path = file.path
+        file.parent = self
         relative_path = path.relative_to(self.path)
         if not relative_path.parts:
             raise ValueError("Path is not a child of this folder")

--- a/script/split_tests.py
+++ b/script/split_tests.py
@@ -75,6 +75,10 @@ class BucketHolder:
                             f"{other_test.total_tests:>{digits}} tests in {other_test.path}"
                         )
                         smallest_bucket.add(other_test)
+                elif tests.path.endswith(".py"):
+                    print(
+                        f"{other_test.total_tests:>{digits}} tests in {other_test.path}"
+                    )
 
         # verify that all tests are added to a bucket
         if not test_folder.added_to_bucket:
@@ -235,6 +239,8 @@ def main() -> None:
     print(f"Estimated tests per bucket: {tests_per_bucket}")
 
     bucket_holder.create_ouput_file()
+
+    raise ("Stop now")
 
 
 if __name__ == "__main__":

--- a/script/split_tests.py
+++ b/script/split_tests.py
@@ -55,20 +55,21 @@ class BucketHolder:
                 continue
 
             smallest_bucket = min(self._buckets, key=lambda x: x.total_tests)
-            if smallest_bucket.total_tests + tests.total_tests < self._tests_per_bucket:
+            if (
+                smallest_bucket.total_tests + tests.total_tests < self._tests_per_bucket
+            ) or (is_file := isinstance(tests, TestFile)):
                 smallest_bucket.add(tests)
-            if isinstance(tests, TestFile):
-                smallest_bucket.add(tests)
-                # Ensure all files from the same folder are in the same bucket
-                # to ensure that syrupy correctly identifies unused snapshots
-                for other_test in sorted_tests:
-                    if (
-                        isinstance(other_test, TestFolder)
-                        or other_test.added_to_bucket
-                        or other_test.path.parent != tests.path.parent
-                    ):
-                        continue
-                    smallest_bucket.add(other_test)
+                if is_file:
+                    # Ensure all files from the same folder are in the same bucket
+                    # to ensure that syrupy correctly identifies unused snapshots
+                    for other_test in sorted_tests:
+                        if (
+                            isinstance(other_test, TestFolder)
+                            or other_test.added_to_bucket
+                            or other_test.path.parent != tests.path.parent
+                        ):
+                            continue
+                        smallest_bucket.add(other_test)
 
         # verify that all tests are added to a bucket
         if not test_folder.added_to_bucket:

--- a/script/split_tests.py
+++ b/script/split_tests.py
@@ -53,32 +53,26 @@ class BucketHolder:
                 # Already added to bucket
                 continue
 
+            print(f"{tests.total_tests:>{digits}} tests in {tests.path}")
             smallest_bucket = min(self._buckets, key=lambda x: x.total_tests)
-            if (
-                smallest_bucket.total_tests + tests.total_tests < self._tests_per_bucket
-            ) or (is_file := isinstance(tests, TestFile)):
-                print(
-                    f"{tests.total_tests:>{digits}} tests in {tests.path} (is file: {is_file})"
-                )
+            if smallest_bucket.total_tests + tests.total_tests < self._tests_per_bucket:
                 smallest_bucket.add(tests)
-                if is_file:
-                    # Ensure all files from the same folder are in the same bucket
-                    # to ensure that syrupy correctly identifies unused snapshots
-                    for other_test in sorted_tests:
-                        if (
-                            isinstance(other_test, TestFolder)
-                            or other_test.added_to_bucket
-                            or other_test.path.parent != tests.path.parent
-                        ):
-                            continue
-                        print(
-                            f"{other_test.total_tests:>{digits}} tests in {other_test.path}"
-                        )
-                        smallest_bucket.add(other_test)
-                elif tests.path.endswith(".py"):
+                continue
+            if isinstance(tests, TestFile):
+                smallest_bucket.add(tests)
+                # Ensure all files from the same folder are in the same bucket
+                # to ensure that syrupy correctly identifies unused snapshots
+                for other_test in sorted_tests:
+                    if (
+                        isinstance(other_test, TestFolder)
+                        or other_test.added_to_bucket
+                        or other_test.path.parent != tests.path.parent
+                    ):
+                        continue
                     print(
-                        f"{other_test.total_tests:>{digits}} tests in {other_test.path}"
+                        f"{other_test.total_tests:>{digits}} tests in {other_test.path} (same bucket)"
                     )
+                    smallest_bucket.add(other_test)
 
         # verify that all tests are added to a bucket
         if not test_folder.added_to_bucket:
@@ -239,8 +233,6 @@ def main() -> None:
     print(f"Estimated tests per bucket: {tests_per_bucket}")
 
     bucket_holder.create_ouput_file()
-
-    raise ("Stop now")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Running `pytest --snapshot-details tests/components/config/test_config_entries.py tests/test_config.py` incorrectly assumes that `tests/snapshots/test_config_entries.ambr` contains unused snapshots.

This is because `tests/test_config.py` has caused the ambr file to be "discovered", and `tests/components/config/test_config_entries.py` has caused the "discovered" entries to be marked as unused.

To prevent this, we need to ensure that if  `tests/test_config.py` is tested, then `tests/test_config_entries.py` is also tested in the same bucket.

Since this scenario could occur elsewhere, I have adjusted so that all test files if a folder are always run in the same bucket.

Sample bad run: <https://github.com/home-assistant/core/actions/runs/11679325591/job/32520481944?pr=123563>

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
