### PR TITLE
Add checks for translation placeholders

### DIFF
--- a/tests/components/conftest.py
+++ b/tests/components/conftest.py
@@ -526,7 +526,7 @@ def _validate_translation_placeholders(
             description_placeholders is None
             or placeholder not in description_placeholders
         ):
-            pytest.fail(f"Placeholder not found for `{placeholder}` in {full_key}")
+            pytest.fail(f"Description not found for placeholder `{placeholder}` in {full_key}")
 
 
 async def _ensure_translation_exists(

--- a/tests/components/conftest.py
+++ b/tests/components/conftest.py
@@ -512,7 +512,7 @@ def supervisor_client() -> Generator[AsyncMock]:
         yield supervisor_client
 
 
-async def _validate_translation_placeholders(
+def _validate_translation_placeholders(
     full_key: str,
     translation: str,
     description_placeholders: dict[str, str] | None,

--- a/tests/components/conftest.py
+++ b/tests/components/conftest.py
@@ -517,7 +517,7 @@ def _validate_translation_placeholders(
     translation: str,
     description_placeholders: dict[str, str] | None,
 ) -> str | None:
-    """Raise if translation exist with missing placeholders."""
+    """Raise if translation exists with missing placeholders."""
     tuples = list(string.Formatter().parse(translation))
     for _, placeholder, _, _ in tuples:
         if placeholder is None:

--- a/tests/components/conftest.py
+++ b/tests/components/conftest.py
@@ -526,7 +526,9 @@ def _validate_translation_placeholders(
             description_placeholders is None
             or placeholder not in description_placeholders
         ):
-            pytest.fail(f"Description not found for placeholder `{placeholder}` in {full_key}")
+            pytest.fail(
+                f"Description not found for placeholder `{placeholder}` in {full_key}"
+            )
 
 
 async def _ensure_translation_exists(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The validation routine for config flow translations currently checks if a translation exists, but does not check if the description place holders are correctly passed through.
I realised this whilst reviewing https://github.com/home-assistant/core/pull/129859

See https://github.com/home-assistant/core/actions/runs/11708902931/job/32612139961 for sample bad run

eg.
```
=========================== short test summary info ============================
FAILED tests/components/twitch/test_config_flow.py::test_reauth_wrong_account 
- Failed: Description not found for placeholder `username` in component.twitch.config.abort.wrong_account
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
