### PR TITLE
Fix esphome mqtt discovery by handling case where payload is a empty string

### DIFF
--- a/homeassistant/components/esphome/config_flow.py
+++ b/homeassistant/components/esphome/config_flow.py
@@ -257,6 +257,9 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
         self, discovery_info: MqttServiceInfo
     ) -> ConfigFlowResult:
         """Handle MQTT discovery."""
+        if discovery_info.payload is None or len(discovery_info.payload) == 0:
+            return self.async_abort(reason="unknown")
+
         device_info = json_loads_object(discovery_info.payload)
         if "mac" not in device_info:
             return self.async_abort(reason="mqtt_missing_mac")

--- a/homeassistant/components/esphome/config_flow.py
+++ b/homeassistant/components/esphome/config_flow.py
@@ -257,8 +257,8 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
         self, discovery_info: MqttServiceInfo
     ) -> ConfigFlowResult:
         """Handle MQTT discovery."""
-        if discovery_info.payload is None or len(discovery_info.payload) == 0:
-            return self.async_abort(reason="unknown")
+        if not discovery_info.payload:
+            return self.async_abort(reason="mqtt_missing_payload")
 
         device_info = json_loads_object(discovery_info.payload)
         if "mac" not in device_info:

--- a/homeassistant/components/esphome/strings.json
+++ b/homeassistant/components/esphome/strings.json
@@ -1,7 +1,6 @@
 {
   "config": {
     "abort": {
-      "unknown": "[%key:common::config_flow::error::unknown%]",
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
       "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
@@ -9,7 +8,8 @@
       "service_received": "Action received",
       "mqtt_missing_mac": "Missing MAC address in MQTT properties.",
       "mqtt_missing_api": "Missing API port in MQTT properties.",
-      "mqtt_missing_ip": "Missing IP address in MQTT properties."
+      "mqtt_missing_ip": "Missing IP address in MQTT properties.",
+      "mqtt_missing_payload": "Missing MQTT Payload."
     },
     "error": {
       "resolve_error": "Can't resolve address of the ESP. If this error persists, please set a static IP address",

--- a/homeassistant/components/esphome/strings.json
+++ b/homeassistant/components/esphome/strings.json
@@ -1,6 +1,7 @@
 {
   "config": {
     "abort": {
+      "unknown": "[%key:common::config_flow::error::unknown%]",
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
       "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",

--- a/tests/components/esphome/test_config_flow.py
+++ b/tests/components/esphome/test_config_flow.py
@@ -1401,6 +1401,14 @@ async def test_discovery_mqtt_no_mac(
 
 
 @pytest.mark.usefixtures("mock_zeroconf")
+async def test_discovery_mqtt_empty_payload(
+    hass: HomeAssistant, mock_client, mock_setup_entry: None
+) -> None:
+    """Test discovery aborted if MQTT payload is empty."""
+    await mqtt_discovery_test_abort(hass, "", "unknown")
+
+
+@pytest.mark.usefixtures("mock_zeroconf")
 async def test_discovery_mqtt_no_api(
     hass: HomeAssistant, mock_client, mock_setup_entry: None
 ) -> None:

--- a/tests/components/esphome/test_config_flow.py
+++ b/tests/components/esphome/test_config_flow.py
@@ -1405,7 +1405,7 @@ async def test_discovery_mqtt_empty_payload(
     hass: HomeAssistant, mock_client, mock_setup_entry: None
 ) -> None:
     """Test discovery aborted if MQTT payload is empty."""
-    await mqtt_discovery_test_abort(hass, "", "unknown")
+    await mqtt_discovery_test_abort(hass, "", "mqtt_missing_payload")
 
 
 @pytest.mark.usefixtures("mock_zeroconf")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

fix a python stack trace when the payload of the mqtt message is a empty string.
currently this results in a stack trace like:

```
home-assistant-5498756784-28qmg home-assistant 2024-11-06 18:08:38.853 ERROR (MainThread) [homeassistant] Error doing job: Task exception was never retrieved (None)
home-assistant-5498756784-28qmg home-assistant Traceback (most recent call last):
home-assistant-5498756784-28qmg home-assistant   File "/usr/src/homeassistant/homeassistant/util/logging.py", line 105, in _async_wrapper
home-assistant-5498756784-28qmg home-assistant     await async_func(*args)
home-assistant-5498756784-28qmg home-assistant   File "/usr/src/homeassistant/homeassistant/components/mqtt/discovery.py", line 390, in async_integration_message_received
home-assistant-5498756784-28qmg home-assistant     result = await hass.config_entries.flow.async_init(
home-assistant-5498756784-28qmg home-assistant              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
home-assistant-5498756784-28qmg home-assistant   File "/usr/src/homeassistant/homeassistant/config_entries.py", line 1287, in async_init
home-assistant-5498756784-28qmg home-assistant     flow, result = await self._async_init(flow_id, handler, context, data)
home-assistant-5498756784-28qmg home-assistant                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
home-assistant-5498756784-28qmg home-assistant   File "/usr/src/homeassistant/homeassistant/config_entries.py", line 1322, in _async_init
home-assistant-5498756784-28qmg home-assistant     result = await self._async_handle_step(flow, flow.init_step, data)
home-assistant-5498756784-28qmg home-assistant              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
home-assistant-5498756784-28qmg home-assistant   File "/usr/src/homeassistant/homeassistant/data_entry_flow.py", line 520, in _async_handle_step
home-assistant-5498756784-28qmg home-assistant     result: _FlowResultT = await getattr(flow, method)(user_input)
home-assistant-5498756784-28qmg home-assistant                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
home-assistant-5498756784-28qmg home-assistant   File "/usr/src/homeassistant/homeassistant/components/esphome/config_flow.py", line 259, in async_step_mqtt
home-assistant-5498756784-28qmg home-assistant     device_info = json_loads_object(discovery_info.payload)
home-assistant-5498756784-28qmg home-assistant                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
home-assistant-5498756784-28qmg home-assistant   File "/usr/src/homeassistant/homeassistant/util/json.py", line 58, in json_loads_object
home-assistant-5498756784-28qmg home-assistant     value: JsonValueType = json_loads(__obj)
home-assistant-5498756784-28qmg home-assistant                            ^^^^^^^^^^^^^^^^^
home-assistant-5498756784-28qmg home-assistant   File "/usr/src/homeassistant/homeassistant/util/json.py", line 44, in json_loads
home-assistant-5498756784-28qmg home-assistant     return orjson.loads(__obj)  # type:ignore[no-any-return]
home-assistant-5498756784-28qmg home-assistant            ^^^^^^^^^^^^^^^^^^^
home-assistant-5498756784-28qmg home-assistant orjson.JSONDecodeError: Input is a zero-length, empty document: line 1 column 1 (char 0)
home-assistant-5498756784-28qmg home-assistant 
home-assistant-5498756784-28qmg home-assistant During handling of the above exception, another exception occurred:
home-assistant-5498756784-28qmg home-assistant 
home-assistant-5498756784-28qmg home-assistant Traceback (most recent call last):
home-assistant-5498756784-28qmg home-assistant   File "/usr/src/homeassistant/homeassistant/util/logging.py", line 107, in _async_wrapper
home-assistant-5498756784-28qmg home-assistant     log_exception(format_err, *args)
home-assistant-5498756784-28qmg home-assistant   File "/usr/src/homeassistant/homeassistant/util/logging.py", line 94, in log_exception
home-assistant-5498756784-28qmg home-assistant     friendly_msg = format_err(*args)
home-assistant-5498756784-28qmg home-assistant                    ^^^^^^^^^^^^^^^^^
home-assistant-5498756784-28qmg home-assistant   File "/usr/src/homeassistant/homeassistant/components/mqtt/client.py", line 804, in _exception_message
home-assistant-5498756784-28qmg home-assistant     call_back_name = getattr(msg_callback.args[0], "__name__")
home-assistant-5498756784-28qmg home-assistant                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
home-assistant-5498756784-28qmg home-assistant AttributeError: 'str' object has no attribute '__name__'. Did you mean: '__ne__'?

```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
