### PR TITLE
Revert "Update numpy to 2.1.2 and pandas to 2.2.3"

### DIFF
--- a/homeassistant/components/compensation/manifest.json
+++ b/homeassistant/components/compensation/manifest.json
@@ -4,5 +4,5 @@
   "codeowners": ["@Petro31"],
   "documentation": "https://www.home-assistant.io/integrations/compensation",
   "iot_class": "calculated",
-  "requirements": ["numpy==2.1.2"]
+  "requirements": ["numpy==1.26.4"]
 }

--- a/homeassistant/components/iqvia/manifest.json
+++ b/homeassistant/components/iqvia/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "service",
   "iot_class": "cloud_polling",
   "loggers": ["pyiqvia"],
-  "requirements": ["numpy==2.1.2", "pyiqvia==2022.04.0"]
+  "requirements": ["numpy==1.26.4", "pyiqvia==2022.04.0"]
 }

--- a/homeassistant/components/stream/manifest.json
+++ b/homeassistant/components/stream/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "system",
   "iot_class": "local_push",
   "quality_scale": "internal",
-  "requirements": ["PyTurboJPEG==1.7.5", "av==13.1.0", "numpy==2.1.2"]
+  "requirements": ["PyTurboJPEG==1.7.5", "av==13.1.0", "numpy==1.26.4"]
 }

--- a/homeassistant/components/tensorflow/manifest.json
+++ b/homeassistant/components/tensorflow/manifest.json
@@ -9,7 +9,7 @@
     "tensorflow==2.5.0",
     "tf-models-official==2.5.0",
     "pycocotools==2.0.6",
-    "numpy==2.1.2",
+    "numpy==1.26.4",
     "Pillow==10.4.0"
   ]
 }

--- a/homeassistant/components/trend/manifest.json
+++ b/homeassistant/components/trend/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "helper",
   "iot_class": "calculated",
   "quality_scale": "internal",
-  "requirements": ["numpy==2.1.2"]
+  "requirements": ["numpy==1.26.4"]
 }

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -112,8 +112,7 @@ httpcore==1.0.5
 hyperframe>=5.2.0
 
 # Ensure we run compatible with musllinux build env
-numpy==2.1.2
-pandas~=2.2.3
+numpy==1.26.4
 
 # Constrain multidict to avoid typing issues
 # https://github.com/home-assistant/core/pull/67046
@@ -170,6 +169,9 @@ charset-normalizer==3.4.0
 # dacite: Ensure we have a version that is able to handle type unions for
 # Roborock, NAM, Brother, and GIOS.
 dacite>=1.7.0
+
+# Musle wheels for pandas 2.2.0 cannot be build for any architecture.
+pandas==2.1.4
 
 # chacha20poly1305-reuseable==0.12.x is incompatible with cryptography==43.0.x
 chacha20poly1305-reuseable>=0.13.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1491,7 +1491,7 @@ numato-gpio==0.13.0
 # homeassistant.components.stream
 # homeassistant.components.tensorflow
 # homeassistant.components.trend
-numpy==2.1.2
+numpy==1.26.4
 
 # homeassistant.components.nyt_games
 nyt_games==0.4.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1239,7 +1239,7 @@ numato-gpio==0.13.0
 # homeassistant.components.stream
 # homeassistant.components.tensorflow
 # homeassistant.components.trend
-numpy==2.1.2
+numpy==1.26.4
 
 # homeassistant.components.nyt_games
 nyt_games==0.4.4

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -127,8 +127,7 @@ httpcore==1.0.5
 hyperframe>=5.2.0
 
 # Ensure we run compatible with musllinux build env
-numpy==2.1.2
-pandas~=2.2.3
+numpy==1.26.4
 
 # Constrain multidict to avoid typing issues
 # https://github.com/home-assistant/core/pull/67046
@@ -185,6 +184,9 @@ charset-normalizer==3.4.0
 # dacite: Ensure we have a version that is able to handle type unions for
 # Roborock, NAM, Brother, and GIOS.
 dacite>=1.7.0
+
+# Musle wheels for pandas 2.2.0 cannot be build for any architecture.
+pandas==2.1.4
 
 # chacha20poly1305-reuseable==0.12.x is incompatible with cryptography==43.0.x
 chacha20poly1305-reuseable>=0.13.0


### PR DESCRIPTION
Reverts home-assistant/core#129958

Breaks our CI: https://github.com/home-assistant/core/actions/runs/11716301319/job/32634642240?pr=130005

Causes:

```
$ uv pip install -r requirements_all.txt
...
 - numpy==1.26.4
 + numpy==2.1.2
...
$ pytest tests/components/weatherflow
E   AttributeError: module 'numpy' has no attribute 'cumproduct'. Did you mean: 'cumprod'?
```

Origin: https://github.com/hgrecco/pint/issues/1969

/CC @cdce8p 