### PR TITLE
switchbot_cloud: Present state for Lock Pro

### DIFF
--- a/homeassistant/components/switchbot_cloud/__init__.py
+++ b/homeassistant/components/switchbot_cloud/__init__.py
@@ -102,7 +102,10 @@ def make_device_data(
                 prepare_device(hass, api, device, coordinators_by_id)
             )
 
-        if isinstance(device, Device) and device.device_type.startswith("Smart Lock"):
+        if isinstance(device, Device) and device.device_type in [
+            "Smart Lock",
+            "Smart Lock Pro",
+        ]:
             devices_data.locks.append(
                 prepare_device(hass, api, device, coordinators_by_id)
             )

--- a/homeassistant/components/switchbot_cloud/lock.py
+++ b/homeassistant/components/switchbot_cloud/lock.py
@@ -6,12 +6,16 @@ from switchbot_api import LockCommands
 
 from homeassistant.components.lock import LockEntity
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import ATTR_BATTERY_LEVEL, ATTR_SW_VERSION
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import SwitchbotCloudData
 from .const import DOMAIN
 from .entity import SwitchBotCloudEntity
+
+ATTR_CALIBRATED = "calibrated"
+ATTR_DOOR_STATE = "door_state"
 
 
 async def async_setup_entry(
@@ -30,6 +34,10 @@ async def async_setup_entry(
 class SwitchBotCloudLock(SwitchBotCloudEntity, LockEntity):
     """Representation of a SwitchBot lock."""
 
+    _sw_version: str | None = None
+    _battery_level = -1
+    _calibrated: bool | None = None
+    _door_state: str | None = None
     _attr_name = None
 
     @callback
@@ -37,6 +45,13 @@ class SwitchBotCloudLock(SwitchBotCloudEntity, LockEntity):
         """Handle updated data from the coordinator."""
         if coord_data := self.coordinator.data:
             self._attr_is_locked = coord_data["lockState"] == "locked"
+            self._attr_is_locking = coord_data["lockState"] == "locking"
+            self._attr_is_unlocking = coord_data["lockState"] == "unlocking"
+            self._attr_is_jammed = coord_data["lockState"] == "jammed"
+            self._battery_level = coord_data["battery"]
+            self._sw_version = coord_data["version"]
+            self._calibrated = coord_data["calibrate"]
+            self._door_state = coord_data["doorState"]
             self.async_write_ha_state()
 
     async def async_lock(self, **kwargs: Any) -> None:
@@ -51,3 +66,13 @@ class SwitchBotCloudLock(SwitchBotCloudEntity, LockEntity):
         await self.send_api_command(LockCommands.UNLOCK)
         self._attr_is_locked = False
         self.async_write_ha_state()
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return the state attributes."""
+        return {
+            ATTR_SW_VERSION: self._sw_version,
+            ATTR_BATTERY_LEVEL: self._battery_level,
+            ATTR_CALIBRATED: self._calibrated,
+            ATTR_DOOR_STATE: self._door_state,
+        }

--- a/tests/components/switchbot_cloud/test_lock.py
+++ b/tests/components/switchbot_cloud/test_lock.py
@@ -19,12 +19,21 @@ async def test_lock(hass: HomeAssistant, mock_list_devices, mock_get_status) -> 
         Device(
             deviceId="lock-id-1",
             deviceName="lock-1",
-            deviceType="Smart Lock",
+            deviceType="Smart Lock Pro",
             hubDeviceId="test-hub-id",
         ),
     ]
 
-    mock_get_status.return_value = {"lockState": "locked"}
+    mock_get_status.return_value = {
+        "deviceId": "lock-id-1",
+        "deviceType": "Smart Lock Pro",
+        "hubDeviceId": "test-hub-id",
+        "lockState": "locked",
+        "doorState": "opened",
+        "calibrate": True,
+        "version": "V2.3",
+        "battery": 86,
+    }
 
     entry = configure_integration(hass)
     await hass.config_entries.async_setup(entry.entry_id)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
This adds more information about the current state of the lock based on https://github.com/OpenWonderLabs/SwitchBotAPI?tab=readme-ov-file#lock-pro-1

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
