### PR TITLE
Add new frame helper to better distinguish custom and core integrations

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -656,12 +656,12 @@ class HomeAssistant:
         # late import to avoid circular imports
         from .helpers import frame  # pylint: disable=import-outside-toplevel
 
-        frame.report(
+        frame.report_usage(
             "calls `async_add_job`, which is deprecated and will be removed in Home "
             "Assistant 2025.4; Please review "
             "https://developers.home-assistant.io/blog/2024/03/13/deprecate_add_run_job"
             " for replacement options",
-            error_if_core=False,
+            core_behavior=frame.ReportBehavior.LOG,
         )
 
         if target is None:
@@ -712,12 +712,12 @@ class HomeAssistant:
         # late import to avoid circular imports
         from .helpers import frame  # pylint: disable=import-outside-toplevel
 
-        frame.report(
+        frame.report_usage(
             "calls `async_add_hass_job`, which is deprecated and will be removed in Home "
             "Assistant 2025.5; Please review "
             "https://developers.home-assistant.io/blog/2024/04/07/deprecate_add_hass_job"
             " for replacement options",
-            error_if_core=False,
+            core_behavior=frame.ReportBehavior.LOG,
         )
 
         return self._async_add_hass_job(hassjob, *args, background=background)
@@ -986,12 +986,12 @@ class HomeAssistant:
         # late import to avoid circular imports
         from .helpers import frame  # pylint: disable=import-outside-toplevel
 
-        frame.report(
+        frame.report_usage(
             "calls `async_run_job`, which is deprecated and will be removed in Home "
             "Assistant 2025.4; Please review "
             "https://developers.home-assistant.io/blog/2024/03/13/deprecate_add_run_job"
             " for replacement options",
-            error_if_core=False,
+            core_behavior=frame.ReportBehavior.LOG,
         )
 
         if asyncio.iscoroutine(target):
@@ -1635,10 +1635,10 @@ class EventBus:
             # late import to avoid circular imports
             from .helpers import frame  # pylint: disable=import-outside-toplevel
 
-            frame.report(
+            frame.report_usage(
                 "calls `async_listen` with run_immediately, which is"
                 " deprecated and will be removed in Home Assistant 2025.5",
-                error_if_core=False,
+                core_behavior=frame.ReportBehavior.LOG,
             )
 
         if event_filter is not None and not is_callback_check_partial(event_filter):
@@ -1705,10 +1705,10 @@ class EventBus:
             # late import to avoid circular imports
             from .helpers import frame  # pylint: disable=import-outside-toplevel
 
-            frame.report(
+            frame.report_usage(
                 "calls `async_listen_once` with run_immediately, which is "
                 "deprecated and will be removed in Home Assistant 2025.5",
-                error_if_core=False,
+                core_behavior=frame.ReportBehavior.LOG,
             )
 
         one_time_listener: _OneTimeListener[_DataT] = _OneTimeListener(

--- a/homeassistant/core_config.py
+++ b/homeassistant/core_config.py
@@ -60,7 +60,7 @@ from .core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant
 from .generated.currencies import HISTORIC_CURRENCIES
 from .helpers import config_validation as cv, issue_registry as ir
 from .helpers.entity_values import EntityValues
-from .helpers.frame import report
+from .helpers.frame import ReportBehavior, report_usage
 from .helpers.storage import Store
 from .helpers.typing import UNDEFINED, UndefinedType
 from .util import dt as dt_util, location
@@ -695,11 +695,11 @@ class Config:
 
         It will be removed in Home Assistant 2025.6.
         """
-        report(
+        report_usage(
             "set the time zone using set_time_zone instead of async_set_time_zone"
             " which will stop working in Home Assistant 2025.6",
-            error_if_core=True,
-            error_if_integration=True,
+            core_integration_behavior=ReportBehavior.ERROR,
+            custom_integration_behavior=ReportBehavior.ERROR,
         )
         if time_zone := dt_util.get_time_zone(time_zone_str):
             self.time_zone = time_zone_str

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -26,7 +26,7 @@ from .helpers.deprecation import (
     check_if_deprecated_constant,
     dir_with_deprecated_constants,
 )
-from .helpers.frame import report
+from .helpers.frame import ReportBehavior, report_usage
 from .loader import async_suggest_report_issue
 from .util import uuid as uuid_util
 
@@ -530,12 +530,12 @@ class FlowManager(abc.ABC, Generic[_FlowContextT, _FlowResultT, _HandlerT]):
 
         if not isinstance(result["type"], FlowResultType):
             result["type"] = FlowResultType(result["type"])  # type: ignore[unreachable]
-            report(
+            report_usage(
                 (
                     "does not use FlowResultType enum for data entry flow result type. "
                     "This is deprecated and will stop working in Home Assistant 2025.1"
                 ),
-                error_if_core=False,
+                core_behavior=ReportBehavior.LOG,
             )
 
         if (

--- a/homeassistant/helpers/frame.py
+++ b/homeassistant/helpers/frame.py
@@ -151,8 +151,11 @@ def report(
     )
     custom_integration_behavior = core_integration_behavior
 
-    if log_custom_component_only and not error_if_integration:
-        core_integration_behavior = ReportBehavior.IGNORE
+    if log_custom_component_only:
+        if core_behavior == ReportBehavior.LOG:
+            core_behavior = ReportBehavior.IGNORE
+        if core_integration_behavior == ReportBehavior.LOG:
+            core_integration_behavior = ReportBehavior.IGNORE
 
     report_usage(
         what,
@@ -196,7 +199,7 @@ def report_usage(
         msg = f"Detected code that {what}. Please report this issue."
         if core_behavior == ReportBehavior.ERROR:
             raise RuntimeError(msg) from err
-        if core_integration_behavior != ReportBehavior.IGNORE:
+        if core_behavior == ReportBehavior.LOG:
             _LOGGER.warning(msg, stack_info=True)
         return
 

--- a/homeassistant/helpers/frame.py
+++ b/homeassistant/helpers/frame.py
@@ -149,12 +149,10 @@ def report(
     core_integration_behavior = (
         ReportBehavior.ERROR if error_if_integration else ReportBehavior.LOG
     )
-    custom_integration_behavior = (
-        ReportBehavior.ERROR if error_if_integration else ReportBehavior.LOG
-    )
+    custom_integration_behavior = core_integration_behavior
 
     if log_custom_component_only and not error_if_integration:
-        custom_integration_behavior = ReportBehavior.IGNORE
+        core_integration_behavior = ReportBehavior.IGNORE
 
     report_usage(
         what,
@@ -198,7 +196,7 @@ def report_usage(
         msg = f"Detected code that {what}. Please report this issue."
         if core_behavior == ReportBehavior.ERROR:
             raise RuntimeError(msg) from err
-        if custom_integration_behavior != ReportBehavior.IGNORE:
+        if core_integration_behavior != ReportBehavior.IGNORE:
             _LOGGER.warning(msg, stack_info=True)
         return
 

--- a/homeassistant/helpers/frame.py
+++ b/homeassistant/helpers/frame.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Callable
 from dataclasses import dataclass
+from enum import Enum
 import functools
 import linecache
 import logging
@@ -144,24 +145,71 @@ def report(
     If error_if_integration is True, raise instead of log if an integration is found
     when unwinding the stack frame.
     """
+    core_behavior = ReportBehavior.ERROR if error_if_core else ReportBehavior.LOG
+    core_integration_behavior = (
+        ReportBehavior.ERROR if error_if_integration else ReportBehavior.LOG
+    )
+    custom_integration_behavior = (
+        ReportBehavior.ERROR if error_if_integration else ReportBehavior.LOG
+    )
+
+    if log_custom_component_only and not error_if_integration:
+        custom_integration_behavior = ReportBehavior.IGNORE
+
+    report_usage(
+        what,
+        core_behavior=core_behavior,
+        core_integration_behavior=core_integration_behavior,
+        custom_integration_behavior=custom_integration_behavior,
+        exclude_integrations=exclude_integrations,
+        level=level,
+    )
+
+
+class ReportBehavior(Enum):
+    """Enum for behavior on code usage."""
+
+    IGNORE = 1
+    """Ignore the code usage."""
+    LOG = 2
+    """Log the code usage."""
+    ERROR = 3
+    """Raise an error on code usage."""
+
+
+def report_usage(
+    what: str,
+    *,
+    core_behavior: ReportBehavior = ReportBehavior.ERROR,
+    core_integration_behavior: ReportBehavior = ReportBehavior.LOG,
+    custom_integration_behavior: ReportBehavior = ReportBehavior.LOG,
+    exclude_integrations: set[str] | None = None,
+    level: int = logging.WARNING,
+) -> None:
+    """Report incorrect code usage.
+
+    Similar to `report` but allows more fine-grained reporting.
+    """
     try:
         integration_frame = get_integration_frame(
             exclude_integrations=exclude_integrations
         )
     except MissingIntegrationFrame as err:
         msg = f"Detected code that {what}. Please report this issue."
-        if error_if_core:
+        if core_behavior == ReportBehavior.ERROR:
             raise RuntimeError(msg) from err
-        if not log_custom_component_only:
+        if custom_integration_behavior != ReportBehavior.IGNORE:
             _LOGGER.warning(msg, stack_info=True)
         return
 
-    if (
-        error_if_integration
-        or not log_custom_component_only
-        or integration_frame.custom_integration
-    ):
-        _report_integration(what, integration_frame, level, error_if_integration)
+    integration_behavior = core_integration_behavior
+    if integration_frame.custom_integration:
+        integration_behavior = custom_integration_behavior
+
+    if integration_behavior != ReportBehavior.IGNORE:
+        _report_integration(
+            what, integration_frame, level, integration_behavior == ReportBehavior.ERROR
+        )
 
 
 def _report_integration(

--- a/homeassistant/helpers/frame.py
+++ b/homeassistant/helpers/frame.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Callable
 from dataclasses import dataclass
-from enum import Enum
+import enum
 import functools
 import linecache
 import logging
@@ -167,14 +167,14 @@ def report(
     )
 
 
-class ReportBehavior(Enum):
+class ReportBehavior(enum.Enum):
     """Enum for behavior on code usage."""
 
-    IGNORE = 1
+    IGNORE = enum.auto()
     """Ignore the code usage."""
-    LOG = 2
+    LOG = enum.auto()
     """Log the code usage."""
-    ERROR = 3
+    ERROR = enum.auto()
     """Raise an error on code usage."""
 
 
@@ -209,7 +209,7 @@ def report_usage(
 
     if integration_behavior is not ReportBehavior.IGNORE:
         _report_integration(
-            what, integration_frame, level, integration_behavior == ReportBehavior.ERROR
+            what, integration_frame, level, integration_behavior is ReportBehavior.ERROR
         )
 
 

--- a/homeassistant/helpers/frame.py
+++ b/homeassistant/helpers/frame.py
@@ -152,9 +152,9 @@ def report(
     custom_integration_behavior = core_integration_behavior
 
     if log_custom_component_only:
-        if core_behavior == ReportBehavior.LOG:
+        if core_behavior is ReportBehavior.LOG:
             core_behavior = ReportBehavior.IGNORE
-        if core_integration_behavior == ReportBehavior.LOG:
+        if core_integration_behavior is ReportBehavior.LOG:
             core_integration_behavior = ReportBehavior.IGNORE
 
     report_usage(
@@ -197,9 +197,9 @@ def report_usage(
         )
     except MissingIntegrationFrame as err:
         msg = f"Detected code that {what}. Please report this issue."
-        if core_behavior == ReportBehavior.ERROR:
+        if core_behavior is ReportBehavior.ERROR:
             raise RuntimeError(msg) from err
-        if core_behavior == ReportBehavior.LOG:
+        if core_behavior is ReportBehavior.LOG:
             _LOGGER.warning(msg, stack_info=True)
         return
 
@@ -207,7 +207,7 @@ def report_usage(
     if integration_frame.custom_integration:
         integration_behavior = custom_integration_behavior
 
-    if integration_behavior != ReportBehavior.IGNORE:
+    if integration_behavior is not ReportBehavior.IGNORE:
         _report_integration(
             what, integration_frame, level, integration_behavior == ReportBehavior.ERROR
         )

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -1556,16 +1556,18 @@ class Components:
             raise ImportError(f"Unable to load {comp_name}")
 
         # Local import to avoid circular dependencies
-        from .helpers.frame import report  # pylint: disable=import-outside-toplevel
+        # pylint: disable-next=import-outside-toplevel
+        from .helpers.frame import ReportBehavior, report_usage
 
-        report(
+        report_usage(
             (
                 f"accesses hass.components.{comp_name}."
                 " This is deprecated and will stop working in Home Assistant 2025.3, it"
                 f" should be updated to import functions used from {comp_name} directly"
             ),
-            error_if_core=False,
-            log_custom_component_only=True,
+            core_behavior=ReportBehavior.IGNORE,
+            core_integration_behavior=ReportBehavior.IGNORE,
+            custom_integration_behavior=ReportBehavior.LOG,
         )
 
         wrapped = ModuleWrapper(self._hass, component)
@@ -1585,16 +1587,18 @@ class Helpers:
         helper = importlib.import_module(f"homeassistant.helpers.{helper_name}")
 
         # Local import to avoid circular dependencies
-        from .helpers.frame import report  # pylint: disable=import-outside-toplevel
+        # pylint: disable-next=import-outside-toplevel
+        from .helpers.frame import ReportBehavior, report_usage
 
-        report(
+        report_usage(
             (
                 f"accesses hass.helpers.{helper_name}."
                 " This is deprecated and will stop working in Home Assistant 2025.5, it"
                 f" should be updated to import functions used from {helper_name} directly"
             ),
-            error_if_core=False,
-            log_custom_component_only=True,
+            core_behavior=ReportBehavior.IGNORE,
+            core_integration_behavior=ReportBehavior.IGNORE,
+            custom_integration_behavior=ReportBehavior.LOG,
         )
 
         wrapped = ModuleWrapper(self._hass, helper)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The current arguments are very confusing when you want to implement a different behavior for core components and custom components.

As an example, it is currently impossible to ignore a report for custom integrations, but raise/log in both core code and core integrations

~Should be rebased over #130046~

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
