### PR TITLE
Improve tests for frame helper

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1772,10 +1772,29 @@ def mock_bleak_scanner_start() -> Generator[MagicMock]:
 
 
 @pytest.fixture
-def mock_integration_frame() -> Generator[Mock]:
-    """Mock as if we're calling code from inside an integration."""
+def integration_frame_path() -> str:
+    """Return the path to the integration frame.
+
+    Can be parametrized with
+    `@pytest.mark.parametrize("integration_frame_path", ["path_to_frame"])`
+
+    - "custom_components/XYZ" for a custom component
+    - "homeassistant/components/XYZ" for a core component
+    - "homeassistant/XYZ" for no component
+
+    Defaults to core component "hue"
+    """
+    return "homeassistant/components/hue"
+
+
+@pytest.fixture
+def mock_integration_frame(integration_frame_path: str) -> Generator[Mock]:
+    """Mock as if we're calling code from inside an integration.
+
+    Can be parametrized with `integration_frame_path`.
+    """
     correct_frame = Mock(
-        filename="/home/paulus/homeassistant/components/hue/light.py",
+        filename=f"/home/paulus/{integration_frame_path}/light.py",
         lineno="23",
         line="self.light.is_on",
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1778,20 +1778,21 @@ def integration_frame_path() -> str:
     Can be parametrized with
     `@pytest.mark.parametrize("integration_frame_path", ["path_to_frame"])`
 
-    - "custom_components/XYZ" for a custom component
-    - "homeassistant/components/XYZ" for a core component
-    - "homeassistant/XYZ" for no component
+    - "custom_components/XYZ" for a custom integration
+    - "homeassistant/components/XYZ" for a core integration
+    - "homeassistant/XYZ" for core (no integration)
 
-    Defaults to core component "hue"
+    Defaults to core component `hue`
     """
     return "homeassistant/components/hue"
 
 
 @pytest.fixture
 def mock_integration_frame(integration_frame_path: str) -> Generator[Mock]:
-    """Mock as if we're calling code from inside an integration.
+    """Mock where we are calling code from.
 
-    Can be parametrized with `integration_frame_path`.
+    Defaults to calling from `hue` core integration, and can be parametrized
+    with `integration_frame_path`.
     """
     correct_frame = Mock(
         filename=f"/home/paulus/{integration_frame_path}/light.py",

--- a/tests/helpers/test_frame.py
+++ b/tests/helpers/test_frame.py
@@ -1,5 +1,6 @@
 """Test the frame helper."""
 
+from typing import Any
 from unittest.mock import ANY, Mock, patch
 
 import pytest
@@ -247,3 +248,88 @@ async def test_report_error_if_integration(
         ),
     ):
         frame.report("did a bad thing", error_if_integration=True)
+
+
+@pytest.mark.parametrize(
+    ("integration_frame_path", "keywords", "expected_error", "expected_log"),
+    [
+        pytest.param(
+            "homeassistant/test_core",
+            {},
+            True,
+            0,
+            id="core default",
+        ),
+        pytest.param(
+            "homeassistant/components/test_core_integration",
+            {},
+            False,
+            1,
+            id="core integration default",
+        ),
+        pytest.param(
+            "custom_components/test_custom_integration",
+            {},
+            False,
+            1,
+            id="custom integration default",
+        ),
+        pytest.param(
+            "custom_components/test_integration_frame",
+            {"log_custom_component_only": True},
+            False,
+            1,
+            id="log_custom_component_only with custom integration",
+        ),
+        pytest.param(
+            "homeassistant/components/test_integration_frame",
+            {"log_custom_component_only": True},
+            False,
+            0,
+            id="log_custom_component_only with core integration",
+        ),
+        pytest.param(
+            "homeassistant/test_integration_frame",
+            {"error_if_core": False},
+            False,
+            1,
+            id="disable error_if_core",
+        ),
+        pytest.param(
+            "custom_components/test_integration_frame",
+            {"error_if_integration": True},
+            True,
+            1,
+            id="error_if_integration with custom integration",
+        ),
+        pytest.param(
+            "homeassistant/components/test_integration_frame",
+            {"error_if_integration": True},
+            True,
+            1,
+            id="error_if_integration with core integration",
+        ),
+    ],
+)
+@pytest.mark.usefixtures("mock_integration_frame")
+async def test_report(
+    caplog: pytest.LogCaptureFixture,
+    mock_integration_frame: Mock,
+    keywords: dict[str, Any],
+    expected_error: bool,
+    expected_log: int,
+) -> None:
+    """Test report."""
+
+    what = "test_report_string"
+
+    errored = False
+    try:
+        with patch.object(frame, "_REPORTED_INTEGRATIONS", set()):
+            frame.report(what, **keywords)
+    except RuntimeError:
+        errored = True
+
+    assert errored == expected_error
+
+    assert caplog.text.count(what) == expected_log

--- a/tests/helpers/test_frame.py
+++ b/tests/helpers/test_frame.py
@@ -314,7 +314,6 @@ async def test_report_error_if_integration(
 @pytest.mark.usefixtures("mock_integration_frame")
 async def test_report(
     caplog: pytest.LogCaptureFixture,
-    mock_integration_frame: Mock,
     keywords: dict[str, Any],
     expected_error: bool,
     expected_log: int,

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -6,7 +6,7 @@ import pathlib
 import sys
 import threading
 from typing import Any
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, patch
 
 from awesomeversion import AwesomeVersion
 import pytest
@@ -1295,26 +1295,23 @@ async def test_config_folder_not_in_path() -> None:
     import tests.testing_config.check_config_not_in_path  # noqa: F401
 
 
+@pytest.mark.parametrize(
+    ("integration_frame_path", "expected"),
+    [
+        ("custom_components/test_integration_frame", True),
+        ("homeassistant/components/test_integration_frame", False),
+        ("homeassistant/test_integration_frame", False),
+    ],
+)
+@pytest.mark.usefixtures("mock_integration_frame")
+@patch.object(frame, "_REPORTED_INTEGRATIONS", set())
 async def test_hass_components_use_reported(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, mock_integration_frame: Mock
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    expected: bool,
 ) -> None:
-    """Test that use of hass.components is reported."""
-    mock_integration_frame.filename = (
-        "/home/paulus/homeassistant/custom_components/demo/light.py"
-    )
-    integration_frame = frame.IntegrationFrame(
-        custom_integration=True,
-        frame=mock_integration_frame,
-        integration="test_integration_frame",
-        module="custom_components.test_integration_frame",
-        relative_filename="custom_components/test_integration_frame/__init__.py",
-    )
-
+    """Test whether use of hass.components is reported."""
     with (
-        patch(
-            "homeassistant.helpers.frame.get_integration_frame",
-            return_value=integration_frame,
-        ),
         patch(
             "homeassistant.components.http.start_http_server_and_save_config",
             return_value=None,
@@ -1322,10 +1319,11 @@ async def test_hass_components_use_reported(
     ):
         await hass.components.http.start_http_server_and_save_config(hass, [], None)
 
-        assert (
+        reported = (
             "Detected that custom integration 'test_integration_frame'"
             " accesses hass.components.http. This is deprecated"
         ) in caplog.text
+        assert reported == expected
 
 
 async def test_async_get_component_preloads_config_and_config_flow(
@@ -1987,24 +1985,23 @@ async def test_has_services(hass: HomeAssistant) -> None:
     assert integration.has_services is True
 
 
+@pytest.mark.parametrize(
+    ("integration_frame_path", "expected"),
+    [
+        ("custom_components/test_integration_frame", True),
+        ("homeassistant/components/test_integration_frame", False),
+        ("homeassistant/test_integration_frame", False),
+    ],
+)
+@pytest.mark.usefixtures("mock_integration_frame")
+@patch.object(frame, "_REPORTED_INTEGRATIONS", set())
 async def test_hass_helpers_use_reported(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, mock_integration_frame: Mock
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    expected: bool,
 ) -> None:
-    """Test that use of hass.components is reported."""
-    integration_frame = frame.IntegrationFrame(
-        custom_integration=True,
-        frame=mock_integration_frame,
-        integration="test_integration_frame",
-        module="custom_components.test_integration_frame",
-        relative_filename="custom_components/test_integration_frame/__init__.py",
-    )
-
+    """Test whether use of hass.helpers is reported."""
     with (
-        patch.object(frame, "_REPORTED_INTEGRATIONS", new=set()),
-        patch(
-            "homeassistant.helpers.frame.get_integration_frame",
-            return_value=integration_frame,
-        ),
         patch(
             "homeassistant.helpers.aiohttp_client.async_get_clientsession",
             return_value=None,
@@ -2012,10 +2009,11 @@ async def test_hass_helpers_use_reported(
     ):
         hass.helpers.aiohttp_client.async_get_clientsession()
 
-        assert (
+        reported = (
             "Detected that custom integration 'test_integration_frame' "
             "accesses hass.helpers.aiohttp_client. This is deprecated"
         ) in caplog.text
+        assert reported == expected
 
 
 async def test_manifest_json_fragment_round_trip(hass: HomeAssistant) -> None:

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1298,9 +1298,15 @@ async def test_config_folder_not_in_path() -> None:
 @pytest.mark.parametrize(
     ("integration_frame_path", "expected"),
     [
-        ("custom_components/test_integration_frame", True),
-        ("homeassistant/components/test_integration_frame", False),
-        ("homeassistant/test_integration_frame", False),
+        pytest.param(
+            "custom_components/test_integration_frame", True, id="custom integration"
+        ),
+        pytest.param(
+            "homeassistant/components/test_integration_frame",
+            False,
+            id="core integration",
+        ),
+        pytest.param("homeassistant/test_integration_frame", False, id="core"),
     ],
 )
 @pytest.mark.usefixtures("mock_integration_frame")
@@ -1988,9 +1994,15 @@ async def test_has_services(hass: HomeAssistant) -> None:
 @pytest.mark.parametrize(
     ("integration_frame_path", "expected"),
     [
-        ("custom_components/test_integration_frame", True),
-        ("homeassistant/components/test_integration_frame", False),
-        ("homeassistant/test_integration_frame", False),
+        pytest.param(
+            "custom_components/test_integration_frame", True, id="custom integration"
+        ),
+        pytest.param(
+            "homeassistant/components/test_integration_frame",
+            False,
+            id="core integration",
+        ),
+        pytest.param("homeassistant/test_integration_frame", False, id="core"),
     ],
 )
 @pytest.mark.usefixtures("mock_integration_frame")


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add tests for `log_custom_component_only`

Add ability to parametrize the `mock_integration_frame`:
- add ability to set a different core integration
- add ability to set a custom integration
- add ability to set a non-integration path

Default is still core integration "hue"

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
