### PR TITLE
Fix `KeyError` in nest integration when the old key format does not exist

### DIFF
--- a/homeassistant/components/nest/api.py
+++ b/homeassistant/components/nest/api.py
@@ -114,14 +114,9 @@ async def new_subscriber(
         implementation, config_entry_oauth2_flow.LocalOAuth2Implementation
     ):
         raise TypeError(f"Unexpected auth implementation {implementation}")
-    if not (
-        subscription_name := entry.data.get(
-            CONF_SUBSCRIPTION_NAME, entry.data.get(CONF_SUBSCRIBER_ID)
-        )
-    ):
-        raise ValueError(
-            "Configuration option 'subscription_name' or 'subscriber_id' missing"
-        )
+    subscription_name = entry.data.get(CONF_SUBSCRIPTION_NAME)
+    if subscription_name is None:
+        subscription_name = entry.data[CONF_SUBSCRIBER_ID]
     auth = AsyncConfigEntryAuth(
         aiohttp_client.async_get_clientsession(hass),
         config_entry_oauth2_flow.OAuth2Session(hass, entry, implementation),

--- a/homeassistant/components/nest/api.py
+++ b/homeassistant/components/nest/api.py
@@ -114,9 +114,14 @@ async def new_subscriber(
         implementation, config_entry_oauth2_flow.LocalOAuth2Implementation
     ):
         raise TypeError(f"Unexpected auth implementation {implementation}")
-    subscription_name = entry.data.get(
-        CONF_SUBSCRIPTION_NAME, entry.data[CONF_SUBSCRIBER_ID]
-    )
+    if not (
+        subscription_name := entry.data.get(
+            CONF_SUBSCRIPTION_NAME, entry.data.get(CONF_SUBSCRIBER_ID)
+        )
+    ):
+        raise ValueError(
+            "Configuration option 'subscription_name' or 'subscriber_id' missing"
+        )
     auth = AsyncConfigEntryAuth(
         aiohttp_client.async_get_clientsession(hass),
         config_entry_oauth2_flow.OAuth2Session(hass, entry, implementation),

--- a/homeassistant/components/nest/api.py
+++ b/homeassistant/components/nest/api.py
@@ -114,8 +114,7 @@ async def new_subscriber(
         implementation, config_entry_oauth2_flow.LocalOAuth2Implementation
     ):
         raise TypeError(f"Unexpected auth implementation {implementation}")
-    subscription_name = entry.data.get(CONF_SUBSCRIPTION_NAME)
-    if subscription_name is None:
+    if (subscription_name := entry.data.get(CONF_SUBSCRIPTION_NAME)) is None:
         subscription_name = entry.data[CONF_SUBSCRIBER_ID]
     auth = AsyncConfigEntryAuth(
         aiohttp_client.async_get_clientsession(hass),

--- a/tests/components/nest/common.py
+++ b/tests/components/nest/common.py
@@ -30,6 +30,7 @@ CLIENT_ID = "some-client-id"
 CLIENT_SECRET = "some-client-secret"
 CLOUD_PROJECT_ID = "cloud-id-9876"
 SUBSCRIBER_ID = "projects/cloud-id-9876/subscriptions/subscriber-id-9876"
+SUBSCRIPTION_NAME = "projects/cloud-id-9876/subscriptions/subscriber-id-9876"
 
 
 @dataclass
@@ -84,6 +85,17 @@ TEST_CONFIG_ENTRY_LEGACY = NestTestConfig(
             },
         },
     },
+)
+
+TEST_CONFIG_NEW_SUBSCRIPTION = NestTestConfig(
+    config_entry_data={
+        "sdm": {},
+        "project_id": PROJECT_ID,
+        "cloud_project_id": CLOUD_PROJECT_ID,
+        "subscription_name": SUBSCRIPTION_NAME,
+        "auth_implementation": "imported-cred",
+    },
+    credential=ClientCredential(CLIENT_ID, CLIENT_SECRET),
 )
 
 

--- a/tests/components/nest/test_init.py
+++ b/tests/components/nest/test_init.py
@@ -31,6 +31,7 @@ from .common import (
     SUBSCRIBER_ID,
     TEST_CONFIG_ENTRY_LEGACY,
     TEST_CONFIG_LEGACY,
+    TEST_CONFIG_NEW_SUBSCRIPTION,
     TEST_CONFIGFLOW_APP_CREDS,
     FakeSubscriber,
     PlatformSetup,
@@ -86,6 +87,19 @@ def failing_subscriber(
 
 
 async def test_setup_success(
+    hass: HomeAssistant, error_caplog: pytest.LogCaptureFixture, setup_platform
+) -> None:
+    """Test successful setup."""
+    await setup_platform()
+    assert not error_caplog.records
+
+    entries = hass.config_entries.async_entries(DOMAIN)
+    assert len(entries) == 1
+    assert entries[0].state is ConfigEntryState.LOADED
+
+
+@pytest.mark.parametrize("nest_test_config", [(TEST_CONFIG_NEW_SUBSCRIPTION)])
+async def test_setup_success_new_subscription_format(
     hass: HomeAssistant, error_caplog: pytest.LogCaptureFixture, setup_platform
 ) -> None:
     """Test successful setup."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix bug in nest setup when the old key format does not exist causing a `KeyError`. This was a change made during PR to [simplify code](https://github.com/home-assistant/core/pull/128909/files/cdd61b43522b6a0e09195f86fbfaabca588a427b#r1816732708) but I missed test coverage for this case.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
