### PR TITLE
Suez water: simplify config flow

### DIFF
--- a/homeassistant/components/suez_water/config_flow.py
+++ b/homeassistant/components/suez_water/config_flow.py
@@ -20,7 +20,7 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_USERNAME): str,
         vol.Required(CONF_PASSWORD): str,
-        vol.Required(CONF_COUNTER_ID): str,
+        vol.Optional(CONF_COUNTER_ID): str,
     }
 )
 
@@ -31,15 +31,22 @@ async def validate_input(data: dict[str, Any]) -> None:
     Data has the keys from STEP_USER_DATA_SCHEMA with values provided by the user.
     """
     try:
+        counter_id = data.get(CONF_COUNTER_ID)
         client = SuezClient(
             data[CONF_USERNAME],
             data[CONF_PASSWORD],
-            data[CONF_COUNTER_ID],
+            counter_id,
         )
         if not await client.check_credentials():
             raise InvalidAuth
     except PySuezError as ex:
         raise CannotConnect from ex
+
+    if counter_id is None:
+        try:
+            data[CONF_COUNTER_ID] = await client.find_counter()
+        except PySuezError as ex:
+            raise CounterNotFound from ex
 
 
 class SuezWaterConfigFlow(ConfigFlow, domain=DOMAIN):
@@ -61,6 +68,8 @@ class SuezWaterConfigFlow(ConfigFlow, domain=DOMAIN):
                 errors["base"] = "cannot_connect"
             except InvalidAuth:
                 errors["base"] = "invalid_auth"
+            except CounterNotFound:
+                errors["base"] = "counter_not_found"
             except Exception:
                 _LOGGER.exception("Unexpected exception")
                 errors["base"] = "unknown"
@@ -80,3 +89,7 @@ class CannotConnect(HomeAssistantError):
 
 class InvalidAuth(HomeAssistantError):
     """Error to indicate there is invalid auth."""
+
+
+class CounterNotFound(HomeAssistantError):
+    """Error to indicate we cannot automatically found the counter id."""

--- a/homeassistant/components/suez_water/strings.json
+++ b/homeassistant/components/suez_water/strings.json
@@ -12,7 +12,8 @@
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
-      "unknown": "[%key:common::config_flow::error::unknown%]"
+      "unknown": "[%key:common::config_flow::error::unknown%]",
+      "counter_not_found": "Could not find counter id automatically"
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"

--- a/tests/components/suez_water/test_config_flow.py
+++ b/tests/components/suez_water/test_config_flow.py
@@ -6,7 +6,7 @@ from pysuez.exception import PySuezError
 import pytest
 
 from homeassistant import config_entries
-from homeassistant.components.suez_water.const import DOMAIN
+from homeassistant.components.suez_water.const import CONF_COUNTER_ID, DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
@@ -125,5 +125,42 @@ async def test_form_error(
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == "test-username"
+    assert result["data"] == MOCK_DATA
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_form_auto_counter(
+    hass: HomeAssistant, mock_setup_entry: AsyncMock, suez_client: AsyncMock
+) -> None:
+    """Test we get the form."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {}
+
+    partial_form = {**MOCK_DATA}
+    partial_form.pop(CONF_COUNTER_ID)
+    suez_client.find_counter.side_effect = PySuezError("test counter not found")
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        partial_form,
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "counter_not_found"}
+
+    suez_client.find_counter.side_effect = None
+    suez_client.find_counter.return_value = MOCK_DATA[CONF_COUNTER_ID]
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        partial_form,
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "test-username"
+    assert result["result"].unique_id == "test-username"
     assert result["data"] == MOCK_DATA
     assert len(mock_setup_entry.mock_calls) == 1

--- a/tests/components/suez_water/test_config_flow.py
+++ b/tests/components/suez_water/test_config_flow.py
@@ -132,7 +132,7 @@ async def test_form_error(
 async def test_form_auto_counter(
     hass: HomeAssistant, mock_setup_entry: AsyncMock, suez_client: AsyncMock
 ) -> None:
-    """Test we get the form."""
+    """Test form set counter if not set by user."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Simplify config flow for suez water. Counter_id can now be automatically be fetched by the integration.
The value is provided only in the source code of suez website and therefore not easily accessible to user not familiar with devlopment.
Still possible to explicitly set the value for user with multiple value or value defined elsewhere.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
  - https://github.com/home-assistant/home-assistant.io/pull/35638

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
