### PR TITLE
Force int value on port in P1Monitor

### DIFF
--- a/homeassistant/components/p1_monitor/config_flow.py
+++ b/homeassistant/components/p1_monitor/config_flow.py
@@ -59,6 +59,7 @@ class P1MonitorFlowHandler(ConfigFlow, domain=DOMAIN):
                     vol.Required(CONF_HOST): TextSelector(),
                     vol.Required(CONF_PORT, default=80): NumberSelector(
                         NumberSelectorConfig(
+                            as_int=True,
                             mode=NumberSelectorMode.BOX,
                         )
                     ),

--- a/homeassistant/components/p1_monitor/config_flow.py
+++ b/homeassistant/components/p1_monitor/config_flow.py
@@ -57,11 +57,13 @@ class P1MonitorFlowHandler(ConfigFlow, domain=DOMAIN):
             data_schema=vol.Schema(
                 {
                     vol.Required(CONF_HOST): TextSelector(),
-                    vol.Required(CONF_PORT, default=80): NumberSelector(
-                        NumberSelectorConfig(
-                            as_int=True,
-                            mode=NumberSelectorMode.BOX,
-                        )
+                    vol.Required(CONF_PORT, default=80): vol.All(
+                        NumberSelector(
+                            NumberSelectorConfig(
+                                min=1, max=65535, mode=NumberSelectorMode.BOX
+                            ),
+                        ),
+                        vol.Coerce(int),
                     ),
                 }
             ),

--- a/homeassistant/components/p1_monitor/coordinator.py
+++ b/homeassistant/components/p1_monitor/coordinator.py
@@ -60,7 +60,7 @@ class P1MonitorDataUpdateCoordinator(DataUpdateCoordinator[P1MonitorData]):
 
         self.p1monitor = P1Monitor(
             host=self.config_entry.data[CONF_HOST],
-            port=int(self.config_entry.data[CONF_PORT]),
+            port=self.config_entry.data[CONF_PORT],
             session=async_get_clientsession(hass),
         )
 

--- a/homeassistant/components/p1_monitor/coordinator.py
+++ b/homeassistant/components/p1_monitor/coordinator.py
@@ -60,7 +60,7 @@ class P1MonitorDataUpdateCoordinator(DataUpdateCoordinator[P1MonitorData]):
 
         self.p1monitor = P1Monitor(
             host=self.config_entry.data[CONF_HOST],
-            port=self.config_entry.data[CONF_PORT],
+            port=int(self.config_entry.data[CONF_PORT]),
             session=async_get_clientsession(hass),
         )
 

--- a/tests/components/p1_monitor/test_config_flow.py
+++ b/tests/components/p1_monitor/test_config_flow.py
@@ -36,6 +36,7 @@ async def test_full_user_flow(hass: HomeAssistant) -> None:
     assert result2.get("type") is FlowResultType.CREATE_ENTRY
     assert result2.get("title") == "P1 Monitor"
     assert result2.get("data") == {CONF_HOST: "example.com", CONF_PORT: 80}
+    assert isinstance(result2["data"][CONF_PORT], int)
 
     assert len(mock_setup_entry.mock_calls) == 1
     assert len(mock_p1monitor.mock_calls) == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Force int value for port

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #130074
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
