### PR TITLE
Fix issue when timestamp is None

### DIFF
--- a/homeassistant/components/seventeentrack/services.py
+++ b/homeassistant/components/seventeentrack/services.py
@@ -1,8 +1,8 @@
 """Services for the seventeentrack integration."""
 
-from typing import Final
+from typing import Any, Final
 
-from pyseventeentrack.package import PACKAGE_STATUS_MAP
+from pyseventeentrack.package import PACKAGE_STATUS_MAP, Package
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry, ConfigEntryState
@@ -99,7 +99,7 @@ def setup_services(hass: HomeAssistant) -> None:
 
         await seventeen_coordinator.client.profile.archive_package(tracking_number)
 
-    def package_to_dict(package):
+    def package_to_dict(package: Package) -> dict[str, Any]:
         result = {
             ATTR_DESTINATION_COUNTRY: package.destination_country,
             ATTR_ORIGIN_COUNTRY: package.origin_country,

--- a/homeassistant/components/seventeentrack/services.py
+++ b/homeassistant/components/seventeentrack/services.py
@@ -110,12 +110,10 @@ def setup_services(hass: HomeAssistant) -> None:
             ATTR_STATUS: package.status,
             ATTR_INFO_TEXT: package.info_text,
             ATTR_FRIENDLY_NAME: package.friendly_name,
-            **(
-                {ATTR_TIMESTAMP: package.timestamp.isoformat()}
-                if package.timestamp
-                else {}
-            ),
         }
+        if timestamp := package.timestamp:
+            result[ATTR_TIMESTAMP] = timestamp.isoformat()
+        return result
 
     async def _validate_service(config_entry_id):
         entry: ConfigEntry | None = hass.config_entries.async_get_entry(config_entry_id)

--- a/homeassistant/components/seventeentrack/services.py
+++ b/homeassistant/components/seventeentrack/services.py
@@ -100,7 +100,7 @@ def setup_services(hass: HomeAssistant) -> None:
         await seventeen_coordinator.client.profile.archive_package(tracking_number)
 
     def package_to_dict(package):
-        return {
+        result = {
             ATTR_DESTINATION_COUNTRY: package.destination_country,
             ATTR_ORIGIN_COUNTRY: package.origin_country,
             ATTR_PACKAGE_TYPE: package.package_type,

--- a/homeassistant/components/seventeentrack/services.py
+++ b/homeassistant/components/seventeentrack/services.py
@@ -89,7 +89,9 @@ def setup_services(hass: HomeAssistant) -> None:
                     ATTR_TRACKING_NUMBER: package.tracking_number,
                     ATTR_LOCATION: package.location,
                     ATTR_STATUS: package.status,
-                    ATTR_TIMESTAMP: package.timestamp.isoformat(),
+                    ATTR_TIMESTAMP: package.timestamp.isoformat()
+                    if package.timestamp
+                    else "",
                     ATTR_INFO_TEXT: package.info_text,
                     ATTR_FRIENDLY_NAME: package.friendly_name,
                 }

--- a/homeassistant/components/seventeentrack/services.py
+++ b/homeassistant/components/seventeentrack/services.py
@@ -81,20 +81,7 @@ def setup_services(hass: HomeAssistant) -> None:
 
         return {
             "packages": [
-                {
-                    ATTR_DESTINATION_COUNTRY: package.destination_country,
-                    ATTR_ORIGIN_COUNTRY: package.origin_country,
-                    ATTR_PACKAGE_TYPE: package.package_type,
-                    ATTR_TRACKING_INFO_LANGUAGE: package.tracking_info_language,
-                    ATTR_TRACKING_NUMBER: package.tracking_number,
-                    ATTR_LOCATION: package.location,
-                    ATTR_STATUS: package.status,
-                    ATTR_TIMESTAMP: package.timestamp.isoformat()
-                    if package.timestamp
-                    else "",
-                    ATTR_INFO_TEXT: package.info_text,
-                    ATTR_FRIENDLY_NAME: package.friendly_name,
-                }
+                package_to_dict(package)
                 for package in live_packages
                 if slugify(package.status) in package_states or package_states == []
             ]
@@ -111,6 +98,24 @@ def setup_services(hass: HomeAssistant) -> None:
         ]
 
         await seventeen_coordinator.client.profile.archive_package(tracking_number)
+
+    def package_to_dict(package):
+        return {
+            ATTR_DESTINATION_COUNTRY: package.destination_country,
+            ATTR_ORIGIN_COUNTRY: package.origin_country,
+            ATTR_PACKAGE_TYPE: package.package_type,
+            ATTR_TRACKING_INFO_LANGUAGE: package.tracking_info_language,
+            ATTR_TRACKING_NUMBER: package.tracking_number,
+            ATTR_LOCATION: package.location,
+            ATTR_STATUS: package.status,
+            ATTR_INFO_TEXT: package.info_text,
+            ATTR_FRIENDLY_NAME: package.friendly_name,
+            **(
+                {ATTR_TIMESTAMP: package.timestamp.isoformat()}
+                if package.timestamp
+                else {}
+            ),
+        }
 
     async def _validate_service(config_entry_id):
         entry: ConfigEntry | None = hass.config_entries.async_get_entry(config_entry_id)

--- a/tests/components/seventeentrack/snapshots/test_services.ambr
+++ b/tests/components/seventeentrack/snapshots/test_services.ambr
@@ -71,3 +71,33 @@
     ]),
   })
 # ---
+# name: test_packages_with_none_timestamp
+  dict({
+    'packages': list([
+      dict({
+        'destination_country': 'Belgium',
+        'friendly_name': 'friendly name 1',
+        'info_text': 'info text 1',
+        'location': 'location 1',
+        'origin_country': 'Belgium',
+        'package_type': 'Registered Parcel',
+        'status': 'In Transit',
+        'timestamp': '',
+        'tracking_info_language': 'Unknown',
+        'tracking_number': '456',
+      }),
+      dict({
+        'destination_country': 'Belgium',
+        'friendly_name': 'friendly name 2',
+        'info_text': 'info text 1',
+        'location': 'location 1',
+        'origin_country': 'Belgium',
+        'package_type': 'Registered Parcel',
+        'status': 'Delivered',
+        'timestamp': '2020-08-10T10:32:00+00:00',
+        'tracking_info_language': 'Unknown',
+        'tracking_number': '789',
+      }),
+    ]),
+  })
+# ---

--- a/tests/components/seventeentrack/snapshots/test_services.ambr
+++ b/tests/components/seventeentrack/snapshots/test_services.ambr
@@ -82,7 +82,6 @@
         'origin_country': 'Belgium',
         'package_type': 'Registered Parcel',
         'status': 'In Transit',
-        'timestamp': '',
         'tracking_info_language': 'Unknown',
         'tracking_number': '456',
       }),

--- a/tests/components/seventeentrack/test_services.py
+++ b/tests/components/seventeentrack/test_services.py
@@ -150,6 +150,28 @@ async def test_archive_package(
     )
 
 
+async def test_packages_with_none_timestamp(
+    hass: HomeAssistant,
+    mock_seventeentrack: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Ensure service returns all packages when non provided."""
+    await _mock_invalid_packages(mock_seventeentrack)
+    await init_integration(hass, mock_config_entry)
+    service_response = await hass.services.async_call(
+        DOMAIN,
+        SERVICE_GET_PACKAGES,
+        {
+            CONFIG_ENTRY_ID_KEY: mock_config_entry.entry_id,
+        },
+        blocking=True,
+        return_response=True,
+    )
+
+    assert service_response == snapshot
+
+
 async def _mock_packages(mock_seventeentrack):
     package1 = get_package(status=10)
     package2 = get_package(
@@ -166,4 +188,20 @@ async def _mock_packages(mock_seventeentrack):
         package1,
         package2,
         package3,
+    ]
+
+
+async def _mock_invalid_packages(mock_seventeentrack):
+    package1 = get_package(
+        status=10,
+        timestamp=None,
+    )
+    package2 = get_package(
+        tracking_number="789",
+        friendly_name="friendly name 2",
+        status=40,
+    )
+    mock_seventeentrack.return_value.profile.packages.return_value = [
+        package1,
+        package2,
     ]


### PR DESCRIPTION
## Proposed change

Fix issue when timestamp is None. Check first for None before applying isoformat on it

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #128273

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
