### PR TITLE
Fix correct handling in ManualTriggerEntity

### DIFF
--- a/homeassistant/components/command_line/sensor.py
+++ b/homeassistant/components/command_line/sensor.py
@@ -177,23 +177,18 @@ class CommandSensor(ManualTriggerSensorEntity):
 
         self._attr_native_value = None
         if self._value_template is not None and value is not None:
-            value = self._value_template.async_render_with_possible_json_value(
-                value,
-                None,
-            )
+            value = self._value_template.async_render_with_possible_json_value(value)
 
         if self.device_class not in {
             SensorDeviceClass.DATE,
             SensorDeviceClass.TIMESTAMP,
         }:
             self._attr_native_value = value
-            self._process_manual_data(value)
-            return
-
-        if value is not None:
+        elif value is not None:
             self._attr_native_value = async_parse_date_datetime(
                 value, self.entity_id, self.device_class
             )
+
         self._process_manual_data(value)
         self.async_write_ha_state()
 

--- a/homeassistant/components/command_line/sensor.py
+++ b/homeassistant/components/command_line/sensor.py
@@ -177,7 +177,9 @@ class CommandSensor(ManualTriggerSensorEntity):
 
         self._attr_native_value = None
         if self._value_template is not None and value is not None:
-            value = self._value_template.async_render_with_possible_json_value(value)
+            value = self._value_template.async_render_with_possible_json_value(
+                value, None
+            )
 
         if self.device_class not in {
             SensorDeviceClass.DATE,

--- a/homeassistant/components/command_line/sensor.py
+++ b/homeassistant/components/command_line/sensor.py
@@ -178,7 +178,8 @@ class CommandSensor(ManualTriggerSensorEntity):
         self._attr_native_value = None
         if self._value_template is not None and value is not None:
             value = self._value_template.async_render_with_possible_json_value(
-                value, None
+                value,
+                None,
             )
 
         if self.device_class not in {

--- a/homeassistant/helpers/trigger_template_entity.py
+++ b/homeassistant/helpers/trigger_template_entity.py
@@ -30,7 +30,7 @@ from homeassistant.util.json import JSON_DECODE_EXCEPTIONS, json_loads
 
 from . import config_validation as cv
 from .entity import Entity
-from .template import render_complex
+from .template import TemplateStateFromEntityId, render_complex
 from .typing import ConfigType
 
 CONF_AVAILABILITY = "availability"
@@ -231,16 +231,14 @@ class ManualTriggerEntity(TriggerBaseEntity):
         Ex: self._process_manual_data(payload)
         """
 
-        self.async_write_ha_state()
-        this = None
-        if state := self.hass.states.get(self.entity_id):
-            this = state.as_dict()
-
         run_variables: dict[str, Any] = {"value": value}
         # Silently try if variable is a json and store result in `value_json` if it is.
         with contextlib.suppress(*JSON_DECODE_EXCEPTIONS):
             run_variables["value_json"] = json_loads(run_variables["value"])
-        variables = {"this": this, **(run_variables or {})}
+        variables = {
+            "this": TemplateStateFromEntityId(self.hass, self.entity_id),
+            **(run_variables or {}),
+        }
 
         self._render_templates(variables)
 

--- a/tests/components/command_line/test_binary_sensor.py
+++ b/tests/components/command_line/test_binary_sensor.py
@@ -101,7 +101,7 @@ async def test_template(hass: HomeAssistant, load_yaml_integration: None) -> Non
     entity_state = hass.states.get("binary_sensor.test")
     assert entity_state
     assert entity_state.state == STATE_ON
-    assert entity_state.attributes.get("icon") == "mdi:on"
+    assert entity_state.attributes.get("icon") == "mdi:off"
 
 
 @pytest.mark.parametrize(

--- a/tests/components/command_line/test_binary_sensor.py
+++ b/tests/components/command_line/test_binary_sensor.py
@@ -87,7 +87,7 @@ async def test_setup_platform_yaml(hass: HomeAssistant) -> None:
                         "payload_off": "0",
                         "value_template": "{{ value | multiply(0.1) }}",
                         "icon": (
-                            '{% if this.state=="on" %} mdi:on {% else %} mdi:off {% endif %}'
+                            '{% if this.state=="unknown" %} mdi:airplane-takeoff {% else %} mdi:airplane-check {% endif %}'
                         ),
                     }
                 }
@@ -101,7 +101,7 @@ async def test_template(hass: HomeAssistant, load_yaml_integration: None) -> Non
     entity_state = hass.states.get("binary_sensor.test")
     assert entity_state
     assert entity_state.state == STATE_ON
-    assert entity_state.attributes.get("icon") == "mdi:off"
+    assert entity_state.attributes.get("icon") == "mdi:airplane-takeoff"
 
 
 @pytest.mark.parametrize(

--- a/tests/components/command_line/test_binary_sensor.py
+++ b/tests/components/command_line/test_binary_sensor.py
@@ -87,7 +87,7 @@ async def test_setup_platform_yaml(hass: HomeAssistant) -> None:
                         "payload_off": "0",
                         "value_template": "{{ value | multiply(0.1) }}",
                         "icon": (
-                            '{% if this.state!="on" and value=="1.0" %} mdi:airplane-takeoff {% elif value=="1.0" %} mdi:on {% else %} mdi:off {% endif %}'
+                            '{% if this.attributes.icon=="mdi:icon2" %} mdi:icon1 {% else %} mdi:icon2 {% endif %}'
                         ),
                     }
                 }
@@ -101,7 +101,15 @@ async def test_template(hass: HomeAssistant, load_yaml_integration: None) -> Non
     entity_state = hass.states.get("binary_sensor.test")
     assert entity_state
     assert entity_state.state == STATE_ON
-    assert entity_state.attributes.get("icon") == "mdi:airplane-takeoff"
+    assert entity_state.attributes.get("icon") == "mdi:icon2"
+
+    async_fire_time_changed(hass, dt_util.now() + timedelta(seconds=30))
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    entity_state = hass.states.get("binary_sensor.test")
+    assert entity_state
+    assert entity_state.state == STATE_ON
+    assert entity_state.attributes.get("icon") == "mdi:icon1"
 
 
 @pytest.mark.parametrize(

--- a/tests/components/command_line/test_binary_sensor.py
+++ b/tests/components/command_line/test_binary_sensor.py
@@ -87,7 +87,7 @@ async def test_setup_platform_yaml(hass: HomeAssistant) -> None:
                         "payload_off": "0",
                         "value_template": "{{ value | multiply(0.1) }}",
                         "icon": (
-                            '{% if this.state=="unknown" %} mdi:airplane-takeoff {% else %} mdi:airplane-check {% endif %}'
+                            '{% if this.state!="on" and value=="1.0" %} mdi:airplane-takeoff {% elif value=="1.0" %} mdi:on {% else %} mdi:off {% endif %}'
                         ),
                     }
                 }

--- a/tests/components/command_line/test_cover.py
+++ b/tests/components/command_line/test_cover.py
@@ -422,7 +422,7 @@ async def test_icon_template(hass: HomeAssistant) -> None:
                             "command_close": f"echo 0 > {path}",
                             "command_stop": f"echo 0 > {path}",
                             "name": "Test",
-                            "icon": "{% if this.state=='open' and value=='0' %} mdi:closed {% elif this.state=='closed' and value=='100' %} mdi:opened {% else %} mdi:window {% endif %}",
+                            "icon": '{% if this.attributes.icon=="mdi:icon2" %} mdi:icon1 {% else %} mdi:icon2 {% endif %}',
                         }
                     }
                 ]
@@ -444,7 +444,7 @@ async def test_icon_template(hass: HomeAssistant) -> None:
         )
         entity_state = hass.states.get("cover.test")
         assert entity_state
-        assert entity_state.attributes.get("icon") == "mdi:closed"
+        assert entity_state.attributes.get("icon") == "mdi:icon1"
 
         await hass.services.async_call(
             COVER_DOMAIN,
@@ -454,4 +454,4 @@ async def test_icon_template(hass: HomeAssistant) -> None:
         )
         entity_state = hass.states.get("cover.test")
         assert entity_state
-        assert entity_state.attributes.get("icon") == "mdi:opened"
+        assert entity_state.attributes.get("icon") == "mdi:icon2"

--- a/tests/components/command_line/test_cover.py
+++ b/tests/components/command_line/test_cover.py
@@ -422,13 +422,19 @@ async def test_icon_template(hass: HomeAssistant) -> None:
                             "command_close": f"echo 0 > {path}",
                             "command_stop": f"echo 0 > {path}",
                             "name": "Test",
-                            "icon": "{% if this.state=='open' %} mdi:open {% else %} mdi:closed {% endif %}",
+                            "icon": "{% if this.state=='open' and value=='0' %} mdi:closed {% elif this.state=='closed' and value=='100' %} mdi:opened {% else %} mdi:window {% endif %}",
                         }
                     }
                 ]
             },
         )
         await hass.async_block_till_done()
+        await hass.services.async_call(
+            COVER_DOMAIN,
+            SERVICE_OPEN_COVER,
+            {ATTR_ENTITY_ID: "cover.test"},
+            blocking=True,
+        )
 
         await hass.services.async_call(
             COVER_DOMAIN,
@@ -448,4 +454,4 @@ async def test_icon_template(hass: HomeAssistant) -> None:
         )
         entity_state = hass.states.get("cover.test")
         assert entity_state
-        assert entity_state.attributes.get("icon") == "mdi:closed"
+        assert entity_state.attributes.get("icon") == "mdi:opened"

--- a/tests/components/command_line/test_cover.py
+++ b/tests/components/command_line/test_cover.py
@@ -448,4 +448,4 @@ async def test_icon_template(hass: HomeAssistant) -> None:
         )
         entity_state = hass.states.get("cover.test")
         assert entity_state
-        assert entity_state.attributes.get("icon") == "mdi:open"
+        assert entity_state.attributes.get("icon") == "mdi:closed"

--- a/tests/components/command_line/test_switch.py
+++ b/tests/components/command_line/test_switch.py
@@ -595,9 +595,9 @@ async def test_templating(hass: HomeAssistant) -> None:
         entity_state = hass.states.get("switch.test")
         entity_state2 = hass.states.get("switch.test2")
         assert entity_state.state == STATE_ON
-        assert entity_state.attributes.get("icon") == "mdi:on"
+        assert entity_state.attributes.get("icon") == "mdi:off"
         assert entity_state2.state == STATE_ON
-        assert entity_state2.attributes.get("icon") == "mdi:on"
+        assert entity_state2.attributes.get("icon") == "mdi:off"
 
 
 async def test_updating_to_often(

--- a/tests/components/command_line/test_switch.py
+++ b/tests/components/command_line/test_switch.py
@@ -552,7 +552,7 @@ async def test_templating(hass: HomeAssistant) -> None:
                             "command_off": f"echo 0 > {path}",
                             "value_template": '{{ value=="1" }}',
                             "icon": (
-                                '{% if this.state=="on" %} mdi:on {% else %} mdi:off {% endif %}'
+                                '{% if this.state=="off" and value=="1" %} mdi:rocket {% elif value=="1" %} mdi:on {% else %} mdi:off {% endif %}'
                             ),
                             "name": "Test",
                         }
@@ -564,7 +564,7 @@ async def test_templating(hass: HomeAssistant) -> None:
                             "command_off": f"echo 0 > {path}",
                             "value_template": '{{ value=="1" }}',
                             "icon": (
-                                '{% if states("switch.test2")=="on" %} mdi:on {% else %} mdi:off {% endif %}'
+                                '{% if states("switch.test2")=="off" and value=="1" %} mdi:rocket {% elif value=="1" %} mdi:on {% else %} mdi:off {% endif %}'
                             ),
                             "name": "Test2",
                         },
@@ -595,9 +595,9 @@ async def test_templating(hass: HomeAssistant) -> None:
         entity_state = hass.states.get("switch.test")
         entity_state2 = hass.states.get("switch.test2")
         assert entity_state.state == STATE_ON
-        assert entity_state.attributes.get("icon") == "mdi:off"
+        assert entity_state.attributes.get("icon") == "mdi:rocket"
         assert entity_state2.state == STATE_ON
-        assert entity_state2.attributes.get("icon") == "mdi:off"
+        assert entity_state2.attributes.get("icon") == "mdi:rocket"
 
 
 async def test_updating_to_often(

--- a/tests/components/command_line/test_switch.py
+++ b/tests/components/command_line/test_switch.py
@@ -552,7 +552,7 @@ async def test_templating(hass: HomeAssistant) -> None:
                             "command_off": f"echo 0 > {path}",
                             "value_template": '{{ value=="1" }}',
                             "icon": (
-                                '{% if this.state=="off" and value=="1" %} mdi:rocket {% elif value=="1" %} mdi:on {% else %} mdi:off {% endif %}'
+                                '{% if this.attributes.icon=="mdi:icon2" %} mdi:icon1 {% else %} mdi:icon2 {% endif %}'
                             ),
                             "name": "Test",
                         }
@@ -564,7 +564,7 @@ async def test_templating(hass: HomeAssistant) -> None:
                             "command_off": f"echo 0 > {path}",
                             "value_template": '{{ value=="1" }}',
                             "icon": (
-                                '{% if states("switch.test2")=="off" and value=="1" %} mdi:rocket {% elif value=="1" %} mdi:on {% else %} mdi:off {% endif %}'
+                                '{% if states("switch.test")=="off" %} mdi:off {% else %} mdi:on {% endif %}'
                             ),
                             "name": "Test2",
                         },
@@ -595,9 +595,9 @@ async def test_templating(hass: HomeAssistant) -> None:
         entity_state = hass.states.get("switch.test")
         entity_state2 = hass.states.get("switch.test2")
         assert entity_state.state == STATE_ON
-        assert entity_state.attributes.get("icon") == "mdi:rocket"
+        assert entity_state.attributes.get("icon") == "mdi:icon2"
         assert entity_state2.state == STATE_ON
-        assert entity_state2.attributes.get("icon") == "mdi:rocket"
+        assert entity_state2.attributes.get("icon") == "mdi:on"
 
 
 async def test_updating_to_often(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change

The `this` template variable which is available in some templatable helpers was previously based on the new state instead of the current state.
The change affects the following integrations, if templates the use the `this` variable.
The user might have to update their templates to reflect the above change using the `value` variable instead, which holds the new value.

- `command_line`
- `rest`
- `scrape`
- `snmp`
- `sql`

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Use TemplateStateFromEntityId in ManualTriggerEntity.
- Fix correct use of `this` variable.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/35730

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 