### PR TITLE
Add go2rtc workaround for HA managed one until upstream fixes it

### DIFF
--- a/homeassistant/components/go2rtc/const.py
+++ b/homeassistant/components/go2rtc/const.py
@@ -6,3 +6,4 @@ CONF_DEBUG_UI = "debug_ui"
 DEBUG_UI_URL_MESSAGE = "Url and debug_ui cannot be set at the same time."
 HA_MANAGED_API_PORT = 11984
 HA_MANAGED_URL = f"http://localhost:{HA_MANAGED_API_PORT}/"
+HA_MANAGED_RTSP_PORT = 18554

--- a/homeassistant/components/go2rtc/server.py
+++ b/homeassistant/components/go2rtc/server.py
@@ -12,7 +12,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import HA_MANAGED_API_PORT, HA_MANAGED_URL
+from .const import HA_MANAGED_API_PORT, HA_MANAGED_RTSP_PORT, HA_MANAGED_URL
 
 _LOGGER = logging.getLogger(__name__)
 _TERMINATE_TIMEOUT = 5
@@ -24,15 +24,16 @@ _RESPAWN_COOLDOWN = 1
 
 # Default configuration for HA
 # - Api is listening only on localhost
-# - Disable rtsp listener
+# - Enable rtsp for localhost only as ffmpeg needs it
 # - Clear default ice servers
-_GO2RTC_CONFIG_FORMAT = r"""
+_GO2RTC_CONFIG_FORMAT = r"""# This file is managed by Home Assistant
+# Do not edit it manually
+
 api:
   listen: "{api_ip}:{api_port}"
 
 rtsp:
-  # ffmpeg needs rtsp for opus audio transcoding
-  listen: "127.0.0.1:18554"
+  listen: "127.0.0.1:{rtsp_port}"
 
 webrtc:
   listen: ":18555/tcp"
@@ -67,7 +68,9 @@ def _create_temp_file(api_ip: str) -> str:
     with NamedTemporaryFile(prefix="go2rtc_", suffix=".yaml", delete=False) as file:
         file.write(
             _GO2RTC_CONFIG_FORMAT.format(
-                api_ip=api_ip, api_port=HA_MANAGED_API_PORT
+                api_ip=api_ip,
+                api_port=HA_MANAGED_API_PORT,
+                rtsp_port=HA_MANAGED_RTSP_PORT,
             ).encode()
         )
         return file.name

--- a/tests/components/go2rtc/test_server.py
+++ b/tests/components/go2rtc/test_server.py
@@ -105,12 +105,13 @@ async def test_server_run_success(
 
     # Verify that the config file was written
     mock_tempfile.write.assert_called_once_with(
-        f"""
+        f"""# This file is managed by Home Assistant
+# Do not edit it manually
+
 api:
   listen: "{api_ip}:11984"
 
 rtsp:
-  # ffmpeg needs rtsp for opus audio transcoding
   listen: "127.0.0.1:18554"
 
 webrtc:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently, there exists a go2rtc endless loop with the config we use it.
The problem is the following line: `f"ffmpeg:{camera.entity_id}#audio=opus"`. By specifying the go2rtc name, go2rtc calls the ffmpeg in an endless loop as it is using itself as a source for the stream, which, of course, will not work.
Until the problem is fixed upstream, I have added with this PR a workaround for the go2rtc instance managed by HA.

It's not possible to add this workaround for self-hosted instances, as we would need to know the port where the internal RTSP server is running. This is not straightforward, as the port can be changed with the config. Getting the config and parsing it is out of the scope of this bug fix. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/issues/129988 https://github.com/home-assistant/core/issues/130009
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
