### PR TITLE
Add reconfigure flow to Nord Pool

### DIFF
--- a/homeassistant/components/nordpool/config_flow.py
+++ b/homeassistant/components/nordpool/config_flow.py
@@ -90,3 +90,22 @@ class NordpoolConfigFlow(ConfigFlow, domain=DOMAIN):
             data_schema=DATA_SCHEMA,
             errors=errors,
         )
+
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the reconfiguration step."""
+        errors: dict[str, str] = {}
+        if user_input:
+            errors = await test_api(self.hass, user_input)
+            reconfigure_entry = self._get_reconfigure_entry()
+            if not errors:
+                return self.async_update_reload_and_abort(
+                    reconfigure_entry, data_updates=user_input
+                )
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=DATA_SCHEMA,
+            errors=errors,
+        )

--- a/homeassistant/components/nordpool/strings.json
+++ b/homeassistant/components/nordpool/strings.json
@@ -1,5 +1,8 @@
 {
   "config": {
+    "abort": {
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
+    },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "no_data": "API connected but the response was empty"
@@ -9,6 +12,12 @@
         "data": {
           "currency": "Currency",
           "areas": "Areas"
+        }
+      },
+      "reconfigure": {
+        "data": {
+          "currency": "[%key:component::nordpool::config::step::user::data::currency%]",
+          "areas": "[%key:component::nordpool::config::step::user::data::areas%]"
         }
       }
     }

--- a/tests/components/nordpool/test_config_flow.py
+++ b/tests/components/nordpool/test_config_flow.py
@@ -15,11 +15,14 @@ from pynordpool import (
 import pytest
 
 from homeassistant import config_entries
-from homeassistant.components.nordpool.const import DOMAIN
+from homeassistant.components.nordpool.const import CONF_AREAS, DOMAIN
+from homeassistant.const import CONF_CURRENCY
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 from . import ENTRY_CONFIG
+
+from tests.common import MockConfigEntry
 
 
 @pytest.mark.freeze_time("2024-11-05T18:00:00+00:00")
@@ -149,3 +152,94 @@ async def test_empty_data(hass: HomeAssistant, get_data: DeliveryPeriodData) -> 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == "Nord Pool"
     assert result["data"] == {"areas": ["SE3", "SE4"], "currency": "SEK"}
+
+
+@pytest.mark.freeze_time("2024-11-05T18:00:00+00:00")
+async def test_reconfigure(
+    hass: HomeAssistant,
+    load_int: MockConfigEntry,
+    get_data: DeliveryPeriodData,
+) -> None:
+    """Test reconfiguration."""
+
+    result = await load_int.start_reconfigure_flow(hass)
+
+    with (
+        patch(
+            "homeassistant.components.nordpool.coordinator.NordPoolClient.async_get_delivery_period",
+            return_value=get_data,
+        ),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_AREAS: ["SE3"],
+                CONF_CURRENCY: "EUR",
+            },
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert load_int.data == {
+        "areas": [
+            "SE3",
+        ],
+        "currency": "EUR",
+    }
+
+
+@pytest.mark.freeze_time("2024-11-05T18:00:00+00:00")
+@pytest.mark.parametrize(
+    ("error_message", "p_error"),
+    [
+        (NordPoolConnectionError, "cannot_connect"),
+        (NordPoolAuthenticationError, "cannot_connect"),
+        (NordPoolError, "cannot_connect"),
+        (NordPoolResponseError, "cannot_connect"),
+    ],
+)
+async def test_reconfigure_cannot_connect(
+    hass: HomeAssistant,
+    load_int: MockConfigEntry,
+    get_data: DeliveryPeriodData,
+    error_message: Exception,
+    p_error: str,
+) -> None:
+    """Test cannot connect error in a reeconfigure flow."""
+
+    result = await load_int.start_reconfigure_flow(hass)
+
+    with patch(
+        "homeassistant.components.nordpool.coordinator.NordPoolClient.async_get_delivery_period",
+        side_effect=error_message,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_AREAS: ["SE3"],
+                CONF_CURRENCY: "EUR",
+            },
+        )
+
+    assert result["errors"] == {"base": p_error}
+
+    with patch(
+        "homeassistant.components.nordpool.coordinator.NordPoolClient.async_get_delivery_period",
+        return_value=get_data,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_AREAS: ["SE3"],
+                CONF_CURRENCY: "EUR",
+            },
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert load_int.data == {
+        "areas": [
+            "SE3",
+        ],
+        "currency": "EUR",
+    }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/35660

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 