### PR TITLE
add support for axis network speaker

### DIFF
--- a/homeassistant/components/axis/const.py
+++ b/homeassistant/components/axis/const.py
@@ -18,4 +18,10 @@ DEFAULT_STREAM_PROFILE = "No stream profile"
 DEFAULT_TRIGGER_TIME = 0
 DEFAULT_VIDEO_SOURCE = "No video source"
 
-PLATFORMS = [Platform.BINARY_SENSOR, Platform.CAMERA, Platform.LIGHT, Platform.SWITCH]
+PLATFORMS = [
+    Platform.BINARY_SENSOR,
+    Platform.CAMERA,
+    Platform.LIGHT,
+    Platform.MEDIA_PLAYER,
+    Platform.SWITCH,
+]

--- a/homeassistant/components/axis/manifest.json
+++ b/homeassistant/components/axis/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "axis",
   "name": "Axis",
-  "after_dependencies": ["mqtt"],
+  "after_dependencies": ["mqtt", "ffmpeg"],
   "codeowners": ["@Kane610"],
   "config_flow": true,
   "dhcp": [

--- a/homeassistant/components/axis/media_player.py
+++ b/homeassistant/components/axis/media_player.py
@@ -1,0 +1,146 @@
+"""Support for Axis network speakers."""
+
+import asyncio
+import logging
+from typing import Any
+
+import httpx
+
+from homeassistant.components import ffmpeg, media_source
+from homeassistant.components.media_player import (
+    BrowseMedia,
+    MediaPlayerDeviceClass,
+    MediaPlayerEntity,
+    MediaPlayerEntityDescription,
+    MediaPlayerEntityFeature,
+    MediaPlayerState,
+    MediaType,
+    async_process_play_media_url,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.httpx_client import get_async_client
+
+from . import AxisConfigEntry
+from .entity import AxisEntity
+from .hub import AxisHub
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: AxisConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Add media player for an Axis Network Speaker."""
+    hub = config_entry.runtime_data
+    async_add_entities([AxisSpeaker(hub)])
+
+
+class AxisSpeaker(AxisEntity, MediaPlayerEntity):
+    """Axis Network Speaker."""
+
+    _attr_has_entity_name = True
+    _attr_name = None
+    _attr_device_class = MediaPlayerDeviceClass.SPEAKER
+    _attr_media_content_type = MediaType.MUSIC
+    _attr_supported_features = (
+        MediaPlayerEntityFeature.PLAY_MEDIA
+        | MediaPlayerEntityFeature.VOLUME_SET
+        | MediaPlayerEntityFeature.VOLUME_STEP
+        | MediaPlayerEntityFeature.STOP
+        | MediaPlayerEntityFeature.BROWSE_MEDIA
+    )
+    entity_description: MediaPlayerEntityDescription
+
+    def __init__(self, hub: AxisHub) -> None:
+        """Initialize the entity."""
+        super().__init__(hub)
+        self._attr_unique_id = f"{hub.unique_id}_mediaplayer"
+        self._attr_state = MediaPlayerState.IDLE
+
+    async def async_browse_media(
+        self,
+        media_content_type: MediaType | str | None = None,
+        media_content_id: str | None = None,
+    ) -> BrowseMedia:
+        """Implement the websocket media browsing helper."""
+        return await media_source.async_browse_media(
+            self.hass,
+            media_content_id,
+            content_filter=lambda item: item.media_content_type.startswith("audio/"),
+        )
+
+    async def async_play_media(
+        self, media_type: MediaType | str, media_id: str, **kwargs: Any
+    ) -> None:
+        """Play a piece of media."""
+        if media_source.is_media_source_id(media_id):
+            media_type = MediaType.MUSIC
+            play_item = await media_source.async_resolve_media(
+                self.hass, media_id, self.entity_id
+            )
+            media_id = async_process_play_media_url(self.hass, play_item.url)
+
+        if media_type != MediaType.MUSIC:
+            raise HomeAssistantError("Only music media type is supported")
+
+        _LOGGER.debug("playing media %s for axis speaker", media_id)
+
+        ffmpeg_manager = ffmpeg.get_ffmpeg_manager(self.hass)
+        output = await ffmpeg_cmd(ffmpeg_manager.binary, media_id)
+
+        uri = "/axis-cgi/audio/transmit.cgi"
+        conf = self.hub.config
+        url = f"{conf.protocol}://{conf.host}:{conf.port}{uri}"
+        auth = httpx.DigestAuth(self.hub.config.username, self.hub.config.password)
+        headers = {"Content-Type": "audio/axis-mulaw-128"}
+
+        client = get_async_client(self.hass, verify_ssl=False)
+        await client.post(url, headers=headers, content=output, auth=auth)
+
+    async def async_media_stop(self) -> None:
+        """Send stop command."""
+
+    async def async_set_volume_level(self, volume: float) -> None:
+        """Set volume level, range 0..1."""
+
+
+async def ffmpeg_cmd(ffmpeg_path: str, media_id: str) -> bytes:
+    """Convert media to Axis-compatible format."""
+    args = [
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-i",
+        media_id,
+        "-vn",
+        "-probesize",
+        "32",
+        "-analyzeduration",
+        "32",
+        "-c:a",
+        "pcm_mulaw",
+        "-ab",
+        "128k",
+        "-ac",
+        "1",
+        "-ar",
+        "16000",
+        "-f",
+        "wav",
+        "-",
+    ]
+
+    _LOGGER.debug("ffmpeg_cmd: %s %s", ffmpeg_path, " ".join(args))
+
+    process = await asyncio.create_subprocess_exec(
+        ffmpeg_path,
+        *args,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    stdout, stderr = await process.communicate()
+    return stdout

--- a/homeassistant/components/axis/media_player.py
+++ b/homeassistant/components/axis/media_player.py
@@ -127,4 +127,7 @@ class AxisSpeaker(AxisEntity, MediaPlayerEntity):
 
         ffmpeg_manager = ffmpeg.get_ffmpeg_manager(self.hass)
         data = await axis.ffmpeg.to_axis_mulaw(media_id, ffmpeg_manager.binary)
+        if not data:
+            raise HomeAssistantError(f"Failed to convert media: {media_id}")
+
         await self.hub.api.vapix.audio.transmit(data)

--- a/homeassistant/components/axis/media_player.py
+++ b/homeassistant/components/axis/media_player.py
@@ -93,13 +93,8 @@ class AxisSpeaker(AxisEntity, MediaPlayerEntity):
         output = await ffmpeg_cmd(ffmpeg_manager.binary, media_id)
 
         uri = "/axis-cgi/audio/transmit.cgi"
-        conf = self.hub.config
-        url = f"{conf.protocol}://{conf.host}:{conf.port}{uri}"
-        auth = httpx.DigestAuth(self.hub.config.username, self.hub.config.password)
         headers = {"Content-Type": "audio/axis-mulaw-128"}
-
-        client = get_async_client(self.hass, verify_ssl=False)
-        await client.post(url, headers=headers, content=output, auth=auth)
+        await self.hub.api.vapix.request("post", uri, headers=headers, content=output)
 
     async def async_media_stop(self) -> None:
         """Send stop command."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

Hi! First-time HA developer here, so (1) adding this support took a lot longer/more learning than the LOC may indicate, and (2) open to feedback on anything I may have done incorrectly.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add support for Axis Network Speakers, exposing the device as a Media Player.

Tested on the Axis C1410 Mk II Network Mini Speaker.

@Kane610 Right now this is just adding the basic support to broadcast audio via the Axis speaker and the Audio API transmit.cgi. There is little/no state tracking, no event updates from the device, etc. I am guessing this would work with any Axis devices that support the Audio API (eg. a camera that also has a built-in speaker), but I've only tested it on the dedicated C1410 speaker device.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.