### PR TITLE
Support additional media player states for Russound RIO

### DIFF
--- a/homeassistant/components/russound_rio/entity.py
+++ b/homeassistant/components/russound_rio/entity.py
@@ -96,6 +96,4 @@ class RussoundBaseEntity(Entity):
 
     async def async_will_remove_from_hass(self) -> None:
         """Remove callbacks."""
-        await self._client.unregister_state_update_callbacks(
-            self._state_update_callback
-        )
+        self._client.unregister_state_update_callbacks(self._state_update_callback)

--- a/homeassistant/components/russound_rio/media_player.py
+++ b/homeassistant/components/russound_rio/media_player.py
@@ -132,7 +132,16 @@ class RussoundZoneDevice(RussoundBaseEntity, MediaPlayerEntity):
     def state(self) -> MediaPlayerState | None:
         """Return the state of the device."""
         status = self._zone.status
+        mode = self._source.mode
         if status == "ON":
+            if mode == "playing":
+                return MediaPlayerState.PLAYING
+            if mode == "paused":
+                return MediaPlayerState.PAUSED
+            if mode == "transitioning":
+                return MediaPlayerState.BUFFERING
+            if mode == "stopped":
+                return MediaPlayerState.IDLE
             return MediaPlayerState.ON
         if status == "OFF":
             return MediaPlayerState.OFF

--- a/tests/components/russound_rio/conftest.py
+++ b/tests/components/russound_rio/conftest.py
@@ -28,11 +28,9 @@ def mock_setup_entry():
 @pytest.fixture
 def mock_config_entry(hass: HomeAssistant) -> MockConfigEntry:
     """Mock a Russound RIO config entry."""
-    entry = MockConfigEntry(
+    return MockConfigEntry(
         domain=DOMAIN, data=MOCK_CONFIG, unique_id=HARDWARE_MAC, title=MODEL
     )
-    entry.add_to_hass(hass)
-    return entry
 
 
 @pytest.fixture
@@ -70,4 +68,6 @@ def mock_russound_client() -> Generator[AsyncMock]:
             )
         }
         client.connection_handler = RussoundTcpConnectionHandler(HOST, PORT)
+        client.is_connected = Mock(return_value=True)
+        client.unregister_state_update_callbacks.return_value = True
         yield client

--- a/tests/components/russound_rio/const.py
+++ b/tests/components/russound_rio/const.py
@@ -2,6 +2,8 @@
 
 from collections import namedtuple
 
+from homeassistant.components.media_player import DOMAIN as MP_DOMAIN
+
 HOST = "127.0.0.1"
 PORT = 9621
 MODEL = "MCA-C5"
@@ -14,3 +16,7 @@ MOCK_CONFIG = {
 
 _CONTROLLER = namedtuple("Controller", ["mac_address", "controller_type"])  # noqa: PYI024
 MOCK_CONTROLLERS = {1: _CONTROLLER(mac_address=HARDWARE_MAC, controller_type=MODEL)}
+
+DEVICE_NAME = "mca_c5"
+NAME_ZONE_1 = "backyard"
+ENTITY_ID_ZONE_1 = f"{MP_DOMAIN}.{DEVICE_NAME}_{NAME_ZONE_1}"

--- a/tests/components/russound_rio/test_media_player.py
+++ b/tests/components/russound_rio/test_media_player.py
@@ -1,0 +1,58 @@
+"""Tests for the Russound RIO media player."""
+
+from unittest.mock import AsyncMock
+
+from aiorussound.models import CallbackType
+import pytest
+
+from homeassistant.const import (
+    STATE_BUFFERING,
+    STATE_IDLE,
+    STATE_OFF,
+    STATE_ON,
+    STATE_PAUSED,
+    STATE_PLAYING,
+)
+from homeassistant.core import HomeAssistant
+
+from . import setup_integration
+from .const import ENTITY_ID_ZONE_1
+
+from tests.common import MockConfigEntry
+
+
+async def mock_state_update(client: AsyncMock) -> None:
+    """Trigger a callback in the media player."""
+    for callback in client.register_state_update_callbacks.call_args_list:
+        await callback[0][0](client, CallbackType.STATE)
+
+
+@pytest.mark.parametrize(
+    ("zone_status", "source_mode", "media_player_state"),
+    [
+        ("ON", None, STATE_ON),
+        ("ON", "playing", STATE_PLAYING),
+        ("ON", "paused", STATE_PAUSED),
+        ("ON", "transitioning", STATE_BUFFERING),
+        ("ON", "stopped", STATE_IDLE),
+        ("OFF", None, STATE_OFF),
+        ("OFF", "stopped", STATE_OFF),
+    ],
+)
+async def test_entity_state(
+    hass: HomeAssistant,
+    mock_russound_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    zone_status: str,
+    source_mode: str | None,
+    media_player_state: str,
+) -> None:
+    """Test media player state."""
+    await setup_integration(hass, mock_config_entry)
+    mock_russound_client.controllers[1].zones[1].status = zone_status
+    mock_russound_client.sources[1].mode = source_mode
+    await mock_state_update(mock_russound_client)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(ENTITY_ID_ZONE_1)
+    assert state.state == media_player_state


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds support for additional media player states based upon current source mode. Tests were added to support. An additional bug in the base entity was resolved which prevented the tests from working properly.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
