### PR TITLE
Make Hydrawise poll non-critical data less frequently

### DIFF
--- a/homeassistant/components/hydrawise/__init__.py
+++ b/homeassistant/components/hydrawise/__init__.py
@@ -8,7 +8,11 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 
 from .const import DOMAIN
-from .coordinator import HydrawiseDataUpdateCoordinator
+from .coordinator import (
+    HydrawiseMainDataUpdateCoordinator,
+    HydrawiseUpdateCoordinators,
+    HydrawiseWaterUseDataUpdateCoordinator,
+)
 
 PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
@@ -29,9 +33,18 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         auth.Auth(config_entry.data[CONF_USERNAME], config_entry.data[CONF_PASSWORD])
     )
 
-    coordinator = HydrawiseDataUpdateCoordinator(hass, hydrawise)
-    await coordinator.async_config_entry_first_refresh()
-    hass.data.setdefault(DOMAIN, {})[config_entry.entry_id] = coordinator
+    main_coordinator = HydrawiseMainDataUpdateCoordinator(hass, hydrawise)
+    await main_coordinator.async_config_entry_first_refresh()
+    water_use_coordinator = HydrawiseWaterUseDataUpdateCoordinator(
+        hass, hydrawise, main_coordinator
+    )
+    await water_use_coordinator.async_config_entry_first_refresh()
+    hass.data.setdefault(DOMAIN, {})[config_entry.entry_id] = (
+        HydrawiseUpdateCoordinators(
+            main=main_coordinator,
+            water_use=water_use_coordinator,
+        )
+    )
     await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
     return True
 

--- a/homeassistant/components/hydrawise/__init__.py
+++ b/homeassistant/components/hydrawise/__init__.py
@@ -7,7 +7,7 @@ from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 
-from .const import DOMAIN, SCAN_INTERVAL
+from .const import DOMAIN
 from .coordinator import HydrawiseDataUpdateCoordinator
 
 PLATFORMS: list[Platform] = [
@@ -29,7 +29,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         auth.Auth(config_entry.data[CONF_USERNAME], config_entry.data[CONF_PASSWORD])
     )
 
-    coordinator = HydrawiseDataUpdateCoordinator(hass, hydrawise, SCAN_INTERVAL)
+    coordinator = HydrawiseDataUpdateCoordinator(hass, hydrawise)
     await coordinator.async_config_entry_first_refresh()
     hass.data.setdefault(DOMAIN, {})[config_entry.entry_id] = coordinator
     await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)

--- a/homeassistant/components/hydrawise/binary_sensor.py
+++ b/homeassistant/components/hydrawise/binary_sensor.py
@@ -21,7 +21,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import VolDictType
 
 from .const import DOMAIN, SERVICE_RESUME, SERVICE_START_WATERING, SERVICE_SUSPEND
-from .coordinator import HydrawiseDataUpdateCoordinator
+from .coordinator import HydrawiseUpdateCoordinators
 from .entity import HydrawiseEntity
 
 
@@ -81,18 +81,16 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the Hydrawise binary_sensor platform."""
-    coordinator: HydrawiseDataUpdateCoordinator = hass.data[DOMAIN][
-        config_entry.entry_id
-    ]
+    coordinators: HydrawiseUpdateCoordinators = hass.data[DOMAIN][config_entry.entry_id]
     entities: list[HydrawiseBinarySensor] = []
-    for controller in coordinator.data.controllers.values():
+    for controller in coordinators.main.data.controllers.values():
         entities.extend(
-            HydrawiseBinarySensor(coordinator, description, controller)
+            HydrawiseBinarySensor(coordinators.main, description, controller)
             for description in CONTROLLER_BINARY_SENSORS
         )
         entities.extend(
             HydrawiseBinarySensor(
-                coordinator,
+                coordinators.main,
                 description,
                 controller,
                 sensor_id=sensor.id,
@@ -103,7 +101,7 @@ async def async_setup_entry(
         )
         entities.extend(
             HydrawiseZoneBinarySensor(
-                coordinator, description, controller, zone_id=zone.id
+                coordinators.main, description, controller, zone_id=zone.id
             )
             for zone in controller.zones
             for description in ZONE_BINARY_SENSORS

--- a/homeassistant/components/hydrawise/const.py
+++ b/homeassistant/components/hydrawise/const.py
@@ -10,7 +10,8 @@ DEFAULT_WATERING_TIME = timedelta(minutes=15)
 
 MANUFACTURER = "Hydrawise"
 
-SCAN_INTERVAL = timedelta(seconds=60)
+MAIN_SCAN_INTERVAL = timedelta(seconds=60)
+WATER_USAGE_SCAN_INTERVAL = timedelta(minutes=60)
 
 SIGNAL_UPDATE_HYDRAWISE = "hydrawise_update"
 

--- a/homeassistant/components/hydrawise/const.py
+++ b/homeassistant/components/hydrawise/const.py
@@ -11,7 +11,7 @@ DEFAULT_WATERING_TIME = timedelta(minutes=15)
 MANUFACTURER = "Hydrawise"
 
 MAIN_SCAN_INTERVAL = timedelta(seconds=60)
-WATER_USAGE_SCAN_INTERVAL = timedelta(minutes=60)
+WATER_USE_SCAN_INTERVAL = timedelta(minutes=60)
 
 SIGNAL_UPDATE_HYDRAWISE = "hydrawise_update"
 

--- a/homeassistant/components/hydrawise/coordinator.py
+++ b/homeassistant/components/hydrawise/coordinator.py
@@ -2,18 +2,16 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from datetime import datetime
+from dataclasses import dataclass, field
 
-from aiohttp import ClientError
 from pydrawise import Hydrawise
 from pydrawise.schema import Controller, ControllerWaterUseSummary, Sensor, User, Zone
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
-from homeassistant.util.dt import now, utcnow
+from homeassistant.util.dt import now
 
-from .const import DOMAIN, LOGGER, MAIN_SCAN_INTERVAL, WATER_USAGE_SCAN_INTERVAL
+from .const import DOMAIN, LOGGER, MAIN_SCAN_INTERVAL, WATER_USE_SCAN_INTERVAL
 
 
 @dataclass
@@ -21,70 +19,94 @@ class HydrawiseData:
     """Container for data fetched from the Hydrawise API."""
 
     user: User
-    controllers: dict[int, Controller]
-    zones: dict[int, Zone]
-    sensors: dict[int, Sensor]
-    daily_water_summary: dict[int, ControllerWaterUseSummary]
+    controllers: dict[int, Controller] = field(default_factory=dict)
+    zones: dict[int, Zone] = field(default_factory=dict)
+    sensors: dict[int, Sensor] = field(default_factory=dict)
+    daily_water_summary: dict[int, ControllerWaterUseSummary] = field(
+        default_factory=dict
+    )
+
+
+@dataclass
+class HydrawiseUpdateCoordinators:
+    """Container for all Hydrawise DataUpdateCoordinator instances."""
+
+    main: HydrawiseMainDataUpdateCoordinator
+    water_use: HydrawiseWaterUseDataUpdateCoordinator
 
 
 class HydrawiseDataUpdateCoordinator(DataUpdateCoordinator[HydrawiseData]):
-    """The Hydrawise Data Update Coordinator."""
+    """Base class for Hydrawise Data Update Coordinators."""
 
     api: Hydrawise
+
+
+class HydrawiseMainDataUpdateCoordinator(HydrawiseDataUpdateCoordinator):
+    """The main Hydrawise Data Update Coordinator.
+
+    This fetches the primary state data for Hydrawise controllers and zones
+    at a relatively frequent interval so that the primary functions of the
+    integration are updated in a timely manner.
+    """
 
     def __init__(self, hass: HomeAssistant, api: Hydrawise) -> None:
         """Initialize HydrawiseDataUpdateCoordinator."""
         super().__init__(hass, LOGGER, name=DOMAIN, update_interval=MAIN_SCAN_INTERVAL)
         self.api = api
-        self._last_usage_refresh: datetime | None = None
 
     async def _async_update_data(self) -> HydrawiseData:
         """Fetch the latest data from Hydrawise."""
-        _utcnow = utcnow()
-        old_data = self.data
         # Don't fetch zones. We'll fetch them for each controller later.
         # This is to prevent 502 errors in some cases.
         # See: https://github.com/home-assistant/core/issues/120128
-        user = await self.api.get_user(fetch_zones=False)
-        controllers = {}
-        zones = {}
-        sensors = {}
-        daily_water_summary: dict[int, ControllerWaterUseSummary] = {}
-        for controller in user.controllers:
-            controllers[controller.id] = controller
+        data = HydrawiseData(
+            user=await self.api.get_user(fetch_zones=False),
+            daily_water_summary=self.data.daily_water_summary if self.data else {},
+        )
+        for controller in data.user.controllers:
+            data.controllers[controller.id] = controller
             controller.zones = await self.api.get_zones(controller)
             for zone in controller.zones:
-                zones[zone.id] = zone
+                data.zones[zone.id] = zone
             for sensor in controller.sensors:
-                sensors[sensor.id] = sensor
+                data.sensors[sensor.id] = sensor
+        return data
 
-            usage_summary: ControllerWaterUseSummary | None = None
-            if (
-                self._last_usage_refresh is None
-                or _utcnow - self._last_usage_refresh > WATER_USAGE_SCAN_INTERVAL
-            ):
-                # Refresh water usage summaries at a reduced rate to prevent
-                # server-side throttling errors.
-                try:
-                    usage_summary = await self.api.get_water_use_summary(
-                        controller,
-                        now().replace(hour=0, minute=0, second=0, microsecond=0),
-                        now(),
-                    )
-                    self._last_usage_refresh = _utcnow
-                except ClientError as ex:
-                    # Ignore the error because it's not critical.
-                    LOGGER.warning("Failed to fetch water usage summaries: %s", ex)
-            elif controller.id in old_data.daily_water_summary:
-                usage_summary = old_data.daily_water_summary[controller.id]
 
-            if usage_summary is not None:
-                daily_water_summary[controller.id] = usage_summary
+class HydrawiseWaterUseDataUpdateCoordinator(HydrawiseDataUpdateCoordinator):
+    """Data Update Coordinator for Hydrawise Water Use.
 
-        return HydrawiseData(
-            user=user,
-            controllers=controllers,
-            zones=zones,
-            sensors=sensors,
-            daily_water_summary=daily_water_summary,
+    This fetches data that is more expensive for the Hydrawise API to compute
+    at a less frequent interval as to not overload the Hydrawise servers.
+    """
+
+    _main_coordinator: HydrawiseMainDataUpdateCoordinator
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        api: Hydrawise,
+        main_coordinator: HydrawiseMainDataUpdateCoordinator,
+    ) -> None:
+        """Initialize HydrawiseWaterUseDataUpdateCoordinator."""
+        super().__init__(
+            hass,
+            LOGGER,
+            name=f"{DOMAIN} water use",
+            update_interval=WATER_USE_SCAN_INTERVAL,
         )
+        self.api = api
+        self._main_coordinator = main_coordinator
+
+    async def _async_update_data(self) -> HydrawiseData:
+        """Fetch the latest data from Hydrawise."""
+        daily_water_summary: dict[int, ControllerWaterUseSummary] = {}
+        for controller in self._main_coordinator.data.controllers.values():
+            daily_water_summary[controller.id] = await self.api.get_water_use_summary(
+                controller,
+                now().replace(hour=0, minute=0, second=0, microsecond=0),
+                now(),
+            )
+        self._main_coordinator.data.daily_water_summary = daily_water_summary
+        self._main_coordinator.async_set_updated_data(self._main_coordinator.data)
+        return self._main_coordinator.data

--- a/homeassistant/components/hydrawise/coordinator.py
+++ b/homeassistant/components/hydrawise/coordinator.py
@@ -67,8 +67,6 @@ class HydrawiseMainDataUpdateCoordinator(HydrawiseDataUpdateCoordinator):
                 data.zones[zone.id] = zone
             for sensor in controller.sensors:
                 data.sensors[sensor.id] = sensor
-        if self.data:
-            data.daily_water_summary = self.data.daily_water_summary
         return data
 
 
@@ -106,7 +104,11 @@ class HydrawiseWaterUseDataUpdateCoordinator(HydrawiseDataUpdateCoordinator):
                 now().replace(hour=0, minute=0, second=0, microsecond=0),
                 now(),
             )
-        data = self._main_coordinator.data
-        data.daily_water_summary = daily_water_summary
-        self._main_coordinator.async_set_updated_data(data)
-        return data
+        main_data = self._main_coordinator.data
+        return HydrawiseData(
+            user=main_data.user,
+            controllers=main_data.controllers,
+            zones=main_data.zones,
+            sensors=main_data.sensors,
+            daily_water_summary=daily_water_summary,
+        )

--- a/homeassistant/components/hydrawise/sensor.py
+++ b/homeassistant/components/hydrawise/sensor.py
@@ -92,7 +92,7 @@ def _get_controller_daily_total_water_use(sensor: HydrawiseSensor) -> float | No
     return daily_water_summary.total_use
 
 
-CONTROLLER_SENSORS: tuple[HydrawiseSensorEntityDescription, ...] = (
+WATER_USE_CONTROLLER_SENSORS: tuple[HydrawiseSensorEntityDescription, ...] = (
     HydrawiseSensorEntityDescription(
         key="daily_active_water_time",
         translation_key="daily_active_water_time",
@@ -102,6 +102,16 @@ CONTROLLER_SENSORS: tuple[HydrawiseSensorEntityDescription, ...] = (
     ),
 )
 
+
+WATER_USE_ZONE_SENSORS: tuple[HydrawiseSensorEntityDescription, ...] = (
+    HydrawiseSensorEntityDescription(
+        key="daily_active_water_time",
+        translation_key="daily_active_water_time",
+        device_class=SensorDeviceClass.DURATION,
+        native_unit_of_measurement=UnitOfTime.SECONDS,
+        value_fn=_get_zone_daily_active_water_time,
+    ),
+)
 
 FLOW_CONTROLLER_SENSORS: tuple[HydrawiseSensorEntityDescription, ...] = (
     HydrawiseSensorEntityDescription(
@@ -150,13 +160,6 @@ ZONE_SENSORS: tuple[HydrawiseSensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfTime.MINUTES,
         value_fn=_get_zone_watering_time,
     ),
-    HydrawiseSensorEntityDescription(
-        key="daily_active_water_time",
-        translation_key="daily_active_water_time",
-        device_class=SensorDeviceClass.DURATION,
-        native_unit_of_measurement=UnitOfTime.SECONDS,
-        value_fn=_get_zone_daily_active_water_time,
-    ),
 )
 
 FLOW_MEASUREMENT_KEYS = [x.key for x in FLOW_CONTROLLER_SENSORS]
@@ -172,8 +175,15 @@ async def async_setup_entry(
     entities: list[HydrawiseSensor] = []
     for controller in coordinators.main.data.controllers.values():
         entities.extend(
-            HydrawiseSensor(coordinators.main, description, controller)
-            for description in CONTROLLER_SENSORS
+            HydrawiseSensor(coordinators.water_use, description, controller)
+            for description in WATER_USE_CONTROLLER_SENSORS
+        )
+        entities.extend(
+            HydrawiseSensor(
+                coordinators.water_use, description, controller, zone_id=zone.id
+            )
+            for zone in controller.zones
+            for description in WATER_USE_ZONE_SENSORS
         )
         entities.extend(
             HydrawiseSensor(coordinators.main, description, controller, zone_id=zone.id)

--- a/homeassistant/components/hydrawise/switch.py
+++ b/homeassistant/components/hydrawise/switch.py
@@ -20,7 +20,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util import dt as dt_util
 
 from .const import DEFAULT_WATERING_TIME, DOMAIN
-from .coordinator import HydrawiseDataUpdateCoordinator
+from .coordinator import HydrawiseUpdateCoordinators
 from .entity import HydrawiseEntity
 
 
@@ -66,12 +66,10 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the Hydrawise switch platform."""
-    coordinator: HydrawiseDataUpdateCoordinator = hass.data[DOMAIN][
-        config_entry.entry_id
-    ]
+    coordinators: HydrawiseUpdateCoordinators = hass.data[DOMAIN][config_entry.entry_id]
     async_add_entities(
-        HydrawiseSwitch(coordinator, description, controller, zone_id=zone.id)
-        for controller in coordinator.data.controllers.values()
+        HydrawiseSwitch(coordinators.main, description, controller, zone_id=zone.id)
+        for controller in coordinators.main.data.controllers.values()
         for zone in controller.zones
         for description in SWITCH_TYPES
     )

--- a/homeassistant/components/hydrawise/valve.py
+++ b/homeassistant/components/hydrawise/valve.py
@@ -17,7 +17,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
-from .coordinator import HydrawiseDataUpdateCoordinator
+from .coordinator import HydrawiseUpdateCoordinators
 from .entity import HydrawiseEntity
 
 VALVE_TYPES: tuple[ValveEntityDescription, ...] = (
@@ -34,12 +34,10 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the Hydrawise valve platform."""
-    coordinator: HydrawiseDataUpdateCoordinator = hass.data[DOMAIN][
-        config_entry.entry_id
-    ]
+    coordinators: HydrawiseUpdateCoordinators = hass.data[DOMAIN][config_entry.entry_id]
     async_add_entities(
-        HydrawiseValve(coordinator, description, controller, zone_id=zone.id)
-        for controller in coordinator.data.controllers.values()
+        HydrawiseValve(coordinators.main, description, controller, zone_id=zone.id)
+        for controller in coordinators.main.data.controllers.values()
         for zone in controller.zones
         for description in VALVE_TYPES
     )

--- a/tests/components/hydrawise/test_binary_sensor.py
+++ b/tests/components/hydrawise/test_binary_sensor.py
@@ -9,7 +9,7 @@ from freezegun.api import FrozenDateTimeFactory
 from pydrawise.schema import Controller
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.components.hydrawise.const import SCAN_INTERVAL
+from homeassistant.components.hydrawise.const import MAIN_SCAN_INTERVAL
 from homeassistant.const import STATE_OFF, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -42,7 +42,7 @@ async def test_update_data_fails(
     # Make the coordinator refresh data.
     mock_pydrawise.get_user.reset_mock(return_value=True)
     mock_pydrawise.get_user.side_effect = ClientError
-    freezer.tick(SCAN_INTERVAL + timedelta(seconds=30))
+    freezer.tick(MAIN_SCAN_INTERVAL + timedelta(seconds=30))
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
@@ -61,7 +61,7 @@ async def test_controller_offline(
     """Test the binary_sensor for the controller being online."""
     # Make the coordinator refresh data.
     controller.online = False
-    freezer.tick(SCAN_INTERVAL + timedelta(seconds=30))
+    freezer.tick(MAIN_SCAN_INTERVAL + timedelta(seconds=30))
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 

--- a/tests/components/hydrawise/test_binary_sensor.py
+++ b/tests/components/hydrawise/test_binary_sensor.py
@@ -42,6 +42,7 @@ async def test_update_data_fails(
     # Make the coordinator refresh data.
     mock_pydrawise.get_user.reset_mock(return_value=True)
     mock_pydrawise.get_user.side_effect = ClientError
+    mock_pydrawise.get_water_use_summary.side_effect = ClientError
     freezer.tick(MAIN_SCAN_INTERVAL + timedelta(seconds=30))
     async_fire_time_changed(hass)
     await hass.async_block_till_done()

--- a/tests/components/hydrawise/test_entity_availability.py
+++ b/tests/components/hydrawise/test_entity_availability.py
@@ -8,7 +8,7 @@ from aiohttp import ClientError
 from freezegun.api import FrozenDateTimeFactory
 from pydrawise.schema import Controller
 
-from homeassistant.components.hydrawise.const import MAIN_SCAN_INTERVAL
+from homeassistant.components.hydrawise.const import WATER_USE_SCAN_INTERVAL
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_OFF, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
@@ -42,7 +42,8 @@ async def test_api_offline(
     config_entry = await mock_add_config_entry()
     mock_pydrawise.get_user.reset_mock(return_value=True)
     mock_pydrawise.get_user.side_effect = ClientError
-    freezer.tick(MAIN_SCAN_INTERVAL + timedelta(seconds=30))
+    mock_pydrawise.get_water_use_summary.side_effect = ClientError
+    freezer.tick(WATER_USE_SCAN_INTERVAL + timedelta(seconds=30))
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
     _test_availability(hass, config_entry, entity_registry)

--- a/tests/components/hydrawise/test_entity_availability.py
+++ b/tests/components/hydrawise/test_entity_availability.py
@@ -8,7 +8,7 @@ from aiohttp import ClientError
 from freezegun.api import FrozenDateTimeFactory
 from pydrawise.schema import Controller
 
-from homeassistant.components.hydrawise.const import SCAN_INTERVAL
+from homeassistant.components.hydrawise.const import MAIN_SCAN_INTERVAL
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_OFF, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
@@ -42,7 +42,7 @@ async def test_api_offline(
     config_entry = await mock_add_config_entry()
     mock_pydrawise.get_user.reset_mock(return_value=True)
     mock_pydrawise.get_user.side_effect = ClientError
-    freezer.tick(SCAN_INTERVAL + timedelta(seconds=30))
+    freezer.tick(MAIN_SCAN_INTERVAL + timedelta(seconds=30))
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
     _test_availability(hass, config_entry, entity_registry)


### PR DESCRIPTION
## Proposed change
This attempts to fix a problem with rate-limiting of API calls by making non-critical data fetches happen at a reduced frequency.

In particular, this targets "Water Usage Summaries", which get dynamically computed server-side for a given interval (which we request as "current day"). It's not critical that we have this data updated at the same rate as other sensor data, and by reducing the frequency of which we have the server compute the data, we should be able to buy some leniency from the Hydrawise server for regular data polls.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #130131
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
