### PR TITLE
Bump eq3btsmart to 1.2.1

### DIFF
--- a/homeassistant/components/eq3btsmart/climate.py
+++ b/homeassistant/components/eq3btsmart/climate.py
@@ -143,6 +143,9 @@ class Eq3Climate(Eq3Entity, ClimateEntity):
     def _async_on_status_updated(self) -> None:
         """Handle updated status from the thermostat."""
 
+        if self._thermostat.status is None:
+            return
+
         self._target_temperature = self._thermostat.status.target_temperature.value
         self._attr_hvac_mode = EQ_TO_HA_HVAC[self._thermostat.status.operation_mode]
         self._attr_current_temperature = self._get_current_temperature()
@@ -154,13 +157,16 @@ class Eq3Climate(Eq3Entity, ClimateEntity):
     def _async_on_device_updated(self) -> None:
         """Handle updated device data from the thermostat."""
 
+        if self._thermostat.device_data is None:
+            return
+
         device_registry = dr.async_get(self.hass)
         if device := device_registry.async_get_device(
             connections={(CONNECTION_BLUETOOTH, self._eq3_config.mac_address)},
         ):
             device_registry.async_update_device(
                 device.id,
-                sw_version=self._thermostat.device_data.firmware_version,
+                sw_version=str(self._thermostat.device_data.firmware_version),
                 serial_number=self._thermostat.device_data.device_serial.value,
             )
 
@@ -265,7 +271,7 @@ class Eq3Climate(Eq3Entity, ClimateEntity):
         self.async_write_ha_state()
 
         try:
-            await self._thermostat.async_set_temperature(self._target_temperature)
+            await self._thermostat.async_set_temperature(temperature)
         except Eq3Exception:
             _LOGGER.error(
                 "[%s] Failed setting temperature", self._eq3_config.mac_address

--- a/homeassistant/components/eq3btsmart/manifest.json
+++ b/homeassistant/components/eq3btsmart/manifest.json
@@ -23,5 +23,5 @@
   "iot_class": "local_polling",
   "loggers": ["eq3btsmart"],
   "quality_scale": "silver",
-  "requirements": ["eq3btsmart==1.2.0", "bleak-esphome==1.1.0"]
+  "requirements": ["eq3btsmart==1.2.1", "bleak-esphome==1.1.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -860,7 +860,7 @@ epion==0.0.3
 epson-projector==0.5.1
 
 # homeassistant.components.eq3btsmart
-eq3btsmart==1.2.0
+eq3btsmart==1.2.1
 
 # homeassistant.components.esphome
 esphome-dashboard-api==1.2.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -729,7 +729,7 @@ epion==0.0.3
 epson-projector==0.5.1
 
 # homeassistant.components.eq3btsmart
-eq3btsmart==1.2.0
+eq3btsmart==1.2.1
 
 # homeassistant.components.esphome
 esphome-dashboard-api==1.2.3


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR bumps the `eq3btsmart` dependency to `1.2.1`. The new version adds a missing `py.typed` file indicating to `mypy` that this library is typed.

Changelog: https://github.com/EuleMitKeule/eq3btsmart/releases/tag/1.2.1


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
