### PR TITLE
Use runtime data for eq3btsmart

### DIFF
--- a/homeassistant/components/eq3btsmart/__init__.py
+++ b/homeassistant/components/eq3btsmart/__init__.py
@@ -15,7 +15,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
-from .const import DOMAIN, SIGNAL_THERMOSTAT_CONNECTED, SIGNAL_THERMOSTAT_DISCONNECTED
+from .const import SIGNAL_THERMOSTAT_CONNECTED, SIGNAL_THERMOSTAT_DISCONNECTED
 from .models import Eq3Config, Eq3ConfigEntryData
 
 PLATFORMS = [
@@ -25,7 +25,10 @@ PLATFORMS = [
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+type Eq3ConfigEntry = ConfigEntry[Eq3ConfigEntryData]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: Eq3ConfigEntry) -> bool:
     """Handle config entry setup."""
 
     mac_address: str | None = entry.unique_id
@@ -53,12 +56,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         ble_device=device,
     )
 
-    eq3_config_entry = Eq3ConfigEntryData(eq3_config=eq3_config, thermostat=thermostat)
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = eq3_config_entry
-
+    entry.runtime_data = Eq3ConfigEntryData(
+        eq3_config=eq3_config, thermostat=thermostat
+    )
     entry.async_on_unload(entry.add_update_listener(update_listener))
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-
     entry.async_create_background_task(
         hass, _async_run_thermostat(hass, entry), entry.entry_id
     )
@@ -66,29 +68,27 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: Eq3ConfigEntry) -> bool:
     """Handle config entry unload."""
 
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        eq3_config_entry: Eq3ConfigEntryData = hass.data[DOMAIN].pop(entry.entry_id)
-        await eq3_config_entry.thermostat.async_disconnect()
+        await entry.runtime_data.thermostat.async_disconnect()
 
     return unload_ok
 
 
-async def update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
+async def update_listener(hass: HomeAssistant, entry: Eq3ConfigEntry) -> None:
     """Handle config entry update."""
 
     await hass.config_entries.async_reload(entry.entry_id)
 
 
-async def _async_run_thermostat(hass: HomeAssistant, entry: ConfigEntry) -> None:
+async def _async_run_thermostat(hass: HomeAssistant, entry: Eq3ConfigEntry) -> None:
     """Run the thermostat."""
 
-    eq3_config_entry: Eq3ConfigEntryData = hass.data[DOMAIN][entry.entry_id]
-    thermostat = eq3_config_entry.thermostat
-    mac_address = eq3_config_entry.eq3_config.mac_address
-    scan_interval = eq3_config_entry.eq3_config.scan_interval
+    thermostat = entry.runtime_data.thermostat
+    mac_address = entry.runtime_data.eq3_config.mac_address
+    scan_interval = entry.runtime_data.eq3_config.scan_interval
 
     await _async_reconnect_thermostat(hass, entry)
 
@@ -117,13 +117,14 @@ async def _async_run_thermostat(hass: HomeAssistant, entry: ConfigEntry) -> None
         await asyncio.sleep(scan_interval)
 
 
-async def _async_reconnect_thermostat(hass: HomeAssistant, entry: ConfigEntry) -> None:
+async def _async_reconnect_thermostat(
+    hass: HomeAssistant, entry: Eq3ConfigEntry
+) -> None:
     """Reconnect the thermostat."""
 
-    eq3_config_entry: Eq3ConfigEntryData = hass.data[DOMAIN][entry.entry_id]
-    thermostat = eq3_config_entry.thermostat
-    mac_address = eq3_config_entry.eq3_config.mac_address
-    scan_interval = eq3_config_entry.eq3_config.scan_interval
+    thermostat = entry.runtime_data.thermostat
+    mac_address = entry.runtime_data.eq3_config.mac_address
+    scan_interval = entry.runtime_data.eq3_config.scan_interval
 
     while True:
         try:

--- a/homeassistant/components/eq3btsmart/climate.py
+++ b/homeassistant/components/eq3btsmart/climate.py
@@ -3,7 +3,6 @@
 import logging
 from typing import Any
 
-from eq3btsmart import Thermostat
 from eq3btsmart.const import EQ3BT_MAX_TEMP, EQ3BT_OFF_TEMP, Eq3Preset, OperationMode
 from eq3btsmart.exceptions import Eq3Exception
 
@@ -25,9 +24,9 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util import slugify
 
+from . import Eq3ConfigEntry
 from .const import (
     DEVICE_MODEL,
-    DOMAIN,
     EQ_TO_HA_HVAC,
     HA_TO_EQ_HVAC,
     MANUFACTURER,
@@ -38,22 +37,19 @@ from .const import (
     TargetTemperatureSelector,
 )
 from .entity import Eq3Entity
-from .models import Eq3Config, Eq3ConfigEntryData
 
 _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Handle config entry setup."""
 
-    eq3_config_entry: Eq3ConfigEntryData = hass.data[DOMAIN][config_entry.entry_id]
-
     async_add_entities(
-        [Eq3Climate(eq3_config_entry.eq3_config, eq3_config_entry.thermostat)],
+        [Eq3Climate(entry)],
     )
 
 
@@ -80,11 +76,11 @@ class Eq3Climate(Eq3Entity, ClimateEntity):
     _attr_preset_mode: str | None = None
     _target_temperature: float | None = None
 
-    def __init__(self, eq3_config: Eq3Config, thermostat: Thermostat) -> None:
+    def __init__(self, entry: Eq3ConfigEntry) -> None:
         """Initialize the climate entity."""
 
-        super().__init__(eq3_config, thermostat)
-        self._attr_unique_id = dr.format_mac(eq3_config.mac_address)
+        super().__init__(entry)
+        self._attr_unique_id = dr.format_mac(self._eq3_config.mac_address)
         self._attr_device_info = DeviceInfo(
             name=slugify(self._eq3_config.mac_address),
             manufacturer=MANUFACTURER,

--- a/homeassistant/components/eq3btsmart/climate.py
+++ b/homeassistant/components/eq3btsmart/climate.py
@@ -14,7 +14,6 @@ from homeassistant.components.climate import (
     HVACAction,
     HVACMode,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_TEMPERATURE, PRECISION_HALVES, UnitOfTemperature
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ServiceValidationError
@@ -43,7 +42,7 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: Eq3ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Handle config entry setup."""

--- a/homeassistant/components/eq3btsmart/entity.py
+++ b/homeassistant/components/eq3btsmart/entity.py
@@ -1,10 +1,8 @@
 """Base class for all eQ-3 entities."""
 
-from eq3btsmart.thermostat import Thermostat
-
 from homeassistant.helpers.entity import Entity
 
-from .models import Eq3Config
+from . import Eq3ConfigEntry
 
 
 class Eq3Entity(Entity):
@@ -12,8 +10,8 @@ class Eq3Entity(Entity):
 
     _attr_has_entity_name = True
 
-    def __init__(self, eq3_config: Eq3Config, thermostat: Thermostat) -> None:
+    def __init__(self, entry: Eq3ConfigEntry) -> None:
         """Initialize the eq3 entity."""
 
-        self._eq3_config = eq3_config
-        self._thermostat = thermostat
+        self._eq3_config = entry.runtime_data.eq3_config
+        self._thermostat = entry.runtime_data.thermostat


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR refactors the `eq3btsmart` integration to use runtime data to hold the references to it's data coordinator and config instances.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
