### PR TITLE
Reboot host to aiohasupervisor

### DIFF
--- a/homeassistant/components/hassio/__init__.py
+++ b/homeassistant/components/hassio/__init__.py
@@ -119,7 +119,6 @@ from .handler import (  # noqa: F401
     async_create_backup,
     async_get_green_settings,
     async_get_yellow_settings,
-    async_reboot_host,
     async_set_green_settings,
     async_set_yellow_settings,
     async_update_diagnostics,

--- a/homeassistant/components/hassio/handler.py
+++ b/homeassistant/components/hassio/handler.py
@@ -133,16 +133,6 @@ async def async_set_yellow_settings(
     )
 
 
-@api_data
-async def async_reboot_host(hass: HomeAssistant) -> dict:
-    """Reboot the host.
-
-    Returns an empty dict.
-    """
-    hassio: HassIO = hass.data[DOMAIN]
-    return await hassio.send_command("/host/reboot", method="post", timeout=60)
-
-
 class HassIO:
     """Small API wrapper for Hass.io."""
 

--- a/homeassistant/components/homeassistant_yellow/config_flow.py
+++ b/homeassistant/components/homeassistant_yellow/config_flow.py
@@ -14,8 +14,8 @@ import voluptuous as vol
 from homeassistant.components.hassio import (
     HassioAPIError,
     async_get_yellow_settings,
-    async_reboot_host,
     async_set_yellow_settings,
+    get_supervisor_client,
 )
 from homeassistant.components.homeassistant_hardware.firmware_config_flow import (
     BaseFirmwareConfigFlow,
@@ -31,7 +31,7 @@ from homeassistant.config_entries import (
     ConfigFlowResult,
     OptionsFlow,
 )
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, async_get_hass, callback
 from homeassistant.helpers import discovery_flow, selector
 
 from .const import DOMAIN, FIRMWARE, RADIO_DEVICE, ZHA_DOMAIN, ZHA_HW_DISCOVERY_DATA
@@ -67,11 +67,12 @@ class HomeAssistantYellowConfigFlow(BaseFirmwareConfigFlow, domain=DOMAIN):
     ) -> OptionsFlow:
         """Return the options flow."""
         firmware_type = ApplicationType(config_entry.data[FIRMWARE])
+        hass = async_get_hass()
 
         if firmware_type is ApplicationType.CPC:
-            return HomeAssistantYellowMultiPanOptionsFlowHandler(config_entry)
+            return HomeAssistantYellowMultiPanOptionsFlowHandler(hass, config_entry)
 
-        return HomeAssistantYellowOptionsFlowHandler(config_entry)
+        return HomeAssistantYellowOptionsFlowHandler(hass, config_entry)
 
     async def async_step_system(
         self, data: dict[str, Any] | None = None
@@ -106,6 +107,11 @@ class BaseHomeAssistantYellowOptionsFlow(OptionsFlow, ABC):
     """Base Home Assistant Yellow options flow shared between firmware and multi-PAN."""
 
     _hw_settings: dict[str, bool] | None = None
+
+    def __init__(self, hass: HomeAssistant, *args: Any, **kwargs: Any) -> None:
+        """Instantiate options flow."""
+        super().__init__(*args, **kwargs)
+        self._supervisor_client = get_supervisor_client(hass)
 
     @abstractmethod
     async def async_step_main_menu(self, _: None = None) -> ConfigFlowResult:
@@ -172,7 +178,7 @@ class BaseHomeAssistantYellowOptionsFlow(OptionsFlow, ABC):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Reboot now."""
-        await async_reboot_host(self.hass)
+        await self._supervisor_client.host.reboot()
         return self.async_create_entry(data={})
 
     async def async_step_reboot_later(
@@ -186,6 +192,11 @@ class HomeAssistantYellowMultiPanOptionsFlowHandler(
     BaseHomeAssistantYellowOptionsFlow, MultiprotocolOptionsFlowHandler
 ):
     """Handle a multi-PAN options flow for Home Assistant Yellow."""
+
+    def __init__(self, hass: HomeAssistant, *args: Any, **kwargs: Any) -> None:
+        """Instantiate options flow."""
+        super().__init__(hass, *args, **kwargs)
+        super(BaseHomeAssistantYellowOptionsFlow, self).__init__(*args, **kwargs)
 
     async def async_step_main_menu(self, _: None = None) -> ConfigFlowResult:
         """Show the main menu."""
@@ -251,9 +262,10 @@ class HomeAssistantYellowOptionsFlowHandler(
 ):
     """Handle a firmware options flow for Home Assistant Yellow."""
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
+    def __init__(self, hass: HomeAssistant, *args: Any, **kwargs: Any) -> None:
         """Instantiate options flow."""
-        super().__init__(*args, **kwargs)
+        super().__init__(hass, *args, **kwargs)
+        super(BaseHomeAssistantYellowOptionsFlow, self).__init__(*args, **kwargs)
 
         self._hardware_name = BOARD_NAME
         self._device = RADIO_DEVICE

--- a/homeassistant/components/homeassistant_yellow/config_flow.py
+++ b/homeassistant/components/homeassistant_yellow/config_flow.py
@@ -193,11 +193,6 @@ class HomeAssistantYellowMultiPanOptionsFlowHandler(
 ):
     """Handle a multi-PAN options flow for Home Assistant Yellow."""
 
-    def __init__(self, hass: HomeAssistant, *args: Any, **kwargs: Any) -> None:
-        """Instantiate options flow."""
-        super().__init__(hass, *args, **kwargs)
-        super(BaseHomeAssistantYellowOptionsFlow, self).__init__(*args, **kwargs)
-
     async def async_step_main_menu(self, _: None = None) -> ConfigFlowResult:
         """Show the main menu."""
         return self.async_show_menu(
@@ -265,7 +260,6 @@ class HomeAssistantYellowOptionsFlowHandler(
     def __init__(self, hass: HomeAssistant, *args: Any, **kwargs: Any) -> None:
         """Instantiate options flow."""
         super().__init__(hass, *args, **kwargs)
-        super(BaseHomeAssistantYellowOptionsFlow, self).__init__(*args, **kwargs)
 
         self._hardware_name = BOARD_NAME
         self._device = RADIO_DEVICE

--- a/tests/components/conftest.py
+++ b/tests/components/conftest.py
@@ -507,6 +507,7 @@ def supervisor_client() -> Generator[AsyncMock]:
     supervisor_client.addons = AsyncMock()
     supervisor_client.discovery = AsyncMock()
     supervisor_client.homeassistant = AsyncMock()
+    supervisor_client.host = AsyncMock()
     supervisor_client.os = AsyncMock()
     supervisor_client.resolution = AsyncMock()
     supervisor_client.supervisor = AsyncMock()

--- a/tests/components/hassio/test_handler.py
+++ b/tests/components/hassio/test_handler.py
@@ -342,20 +342,6 @@ async def test_api_set_yellow_settings(
 
 
 @pytest.mark.usefixtures("hassio_stubs")
-async def test_api_reboot_host(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
-) -> None:
-    """Test setup with API ping."""
-    aioclient_mock.post(
-        "http://127.0.0.1/host/reboot",
-        json={"result": "ok", "data": {}},
-    )
-
-    assert await handler.async_reboot_host(hass) == {}
-    assert aioclient_mock.call_count == 1
-
-
-@pytest.mark.usefixtures("hassio_stubs")
 async def test_send_command_invalid_command(hass: HomeAssistant) -> None:
     """Test send command fails when command is invalid."""
     hassio: HassIO = hass.data["hassio"]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

Migrate Supervisor's reboot host API to `aiohasupervisor`


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
