### PR TITLE
weatherkit: use stale data for up to an hour if updates fail

### DIFF
--- a/homeassistant/components/weatherkit/const.py
+++ b/homeassistant/components/weatherkit/const.py
@@ -21,3 +21,5 @@ CONF_KEY_PEM = "key_pem"
 ATTR_CURRENT_WEATHER = "currentWeather"
 ATTR_FORECAST_HOURLY = "forecastHourly"
 ATTR_FORECAST_DAILY = "forecastDaily"
+
+STALE_DATA_THRESHOLD_SEC = 3600  # 1 hour

--- a/homeassistant/components/weatherkit/const.py
+++ b/homeassistant/components/weatherkit/const.py
@@ -21,5 +21,3 @@ CONF_KEY_PEM = "key_pem"
 ATTR_CURRENT_WEATHER = "currentWeather"
 ATTR_FORECAST_HOURLY = "forecastHourly"
 ATTR_FORECAST_DAILY = "forecastDaily"
-
-STALE_DATA_THRESHOLD_SEC = 3600  # 1 hour

--- a/homeassistant/components/weatherkit/coordinator.py
+++ b/homeassistant/components/weatherkit/coordinator.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta
-from typing import Any
 
 from apple_weatherkit import DataSetType
 from apple_weatherkit.client import WeatherKitApiClient, WeatherKitApiClientError
@@ -27,7 +26,6 @@ class WeatherKitDataUpdateCoordinator(DataUpdateCoordinator):
 
     config_entry: ConfigEntry
     supported_data_sets: list[DataSetType] | None = None
-    cached_data: Any | None = None
     last_updated_at: datetime | None = None
 
     def __init__(
@@ -65,7 +63,7 @@ class WeatherKitDataUpdateCoordinator(DataUpdateCoordinator):
             if not self.supported_data_sets:
                 await self.update_supported_data_sets()
 
-            self.cached_data = await self.client.get_weather_data(
+            self.data = await self.client.get_weather_data(
                 self.config_entry.data[CONF_LATITUDE],
                 self.config_entry.data[CONF_LONGITUDE],
                 self.supported_data_sets,
@@ -73,7 +71,7 @@ class WeatherKitDataUpdateCoordinator(DataUpdateCoordinator):
 
             self.last_updated_at = datetime.now()
         except WeatherKitApiClientError as exception:
-            if self.cached_data is None or (
+            if self.data is None or (
                 self.last_updated_at is not None
                 and datetime.now() - self.last_updated_at
                 > timedelta(seconds=STALE_DATA_THRESHOLD_SEC)
@@ -82,4 +80,4 @@ class WeatherKitDataUpdateCoordinator(DataUpdateCoordinator):
 
             LOGGER.warning("Using stale data because update failed: %s", exception)
 
-        return self.cached_data
+        return self.data

--- a/homeassistant/components/weatherkit/coordinator.py
+++ b/homeassistant/components/weatherkit/coordinator.py
@@ -63,7 +63,7 @@ class WeatherKitDataUpdateCoordinator(DataUpdateCoordinator):
             if not self.supported_data_sets:
                 await self.update_supported_data_sets()
 
-            self.data = await self.client.get_weather_data(
+            updated_data = await self.client.get_weather_data(
                 self.config_entry.data[CONF_LATITUDE],
                 self.config_entry.data[CONF_LONGITUDE],
                 self.supported_data_sets,
@@ -79,5 +79,6 @@ class WeatherKitDataUpdateCoordinator(DataUpdateCoordinator):
                 raise UpdateFailed(exception) from exception
 
             LOGGER.warning("Using stale data because update failed: %s", exception)
+            return self.data
 
-        return self.data
+        return updated_data

--- a/tests/components/weatherkit/__init__.py
+++ b/tests/components/weatherkit/__init__.py
@@ -1,5 +1,6 @@
 """Tests for the Apple WeatherKit integration."""
 
+from contextlib import contextmanager
 from unittest.mock import patch
 
 from apple_weatherkit import DataSetType
@@ -26,20 +27,13 @@ EXAMPLE_CONFIG_DATA = {
 }
 
 
-async def init_integration(
-    hass: HomeAssistant,
+@contextmanager
+def mock_weather_response(
     is_night_time: bool = False,
     has_hourly_forecast: bool = True,
     has_daily_forecast: bool = True,
-) -> MockConfigEntry:
-    """Set up the WeatherKit integration in Home Assistant."""
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        title="Home",
-        unique_id="0123456",
-        data=EXAMPLE_CONFIG_DATA,
-    )
-
+):
+    """Mock a successful WeatherKit API response."""
     weather_response = load_json_object_fixture("weatherkit/weather_response.json")
 
     available_data_sets = [DataSetType.CURRENT_WEATHER]
@@ -68,8 +62,22 @@ async def init_integration(
             return_value=available_data_sets,
         ),
     ):
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
+        yield
+
+
+async def init_integration(
+    hass: HomeAssistant,
+) -> MockConfigEntry:
+    """Set up the WeatherKit integration in Home Assistant."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Home",
+        unique_id="0123456",
+        data=EXAMPLE_CONFIG_DATA,
+    )
+
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
 
     return entry

--- a/tests/components/weatherkit/test_coordinator.py
+++ b/tests/components/weatherkit/test_coordinator.py
@@ -14,11 +14,11 @@ from . import init_integration, mock_weather_response
 from tests.common import async_fire_time_changed
 
 
-async def test_failed_updates(
+async def test_update_uses_stale_data_before_threshold(
     hass: HomeAssistant,
     freezer: FrozenDateTimeFactory,
 ) -> None:
-    """Test that we properly handle failed updates and recover from them."""
+    """Test that stale data from the last successful update is used if an update failure occurs before the threshold."""
     with mock_weather_response():
         await init_integration(hass)
 
@@ -34,7 +34,7 @@ async def test_failed_updates(
         "homeassistant.components.weatherkit.WeatherKitApiClient.get_weather_data",
         side_effect=WeatherKitApiClientError,
     ):
-        freezer.tick(timedelta(minutes=5))
+        freezer.tick(timedelta(minutes=59))
         async_fire_time_changed(hass)
         await hass.async_block_till_done()
 
@@ -42,13 +42,22 @@ async def test_failed_updates(
     assert state
     assert state.state == initial_state
 
+
+async def test_update_becomes_unavailable_after_threshold(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test that the entity becomes unavailable if an update failure occurs after the threshold."""
+    with mock_weather_response():
+        await init_integration(hass)
+
     # Expect state to be unavailable after one hour
 
     with patch(
         "homeassistant.components.weatherkit.WeatherKitApiClient.get_weather_data",
         side_effect=WeatherKitApiClientError,
     ):
-        freezer.tick(timedelta(hours=1))
+        freezer.tick(timedelta(hours=1, minutes=5))
         async_fire_time_changed(hass)
         await hass.async_block_till_done()
 
@@ -56,7 +65,26 @@ async def test_failed_updates(
     assert state
     assert state.state == STATE_UNAVAILABLE
 
-    # Expect state to be available if we can recover
+
+async def test_update_recovers_after_failure(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test that a successful update after repeated failures recovers the entity's state."""
+    with mock_weather_response():
+        await init_integration(hass)
+
+    # Trigger a failure after threshold
+
+    with patch(
+        "homeassistant.components.weatherkit.WeatherKitApiClient.get_weather_data",
+        side_effect=WeatherKitApiClientError,
+    ):
+        freezer.tick(timedelta(hours=1, minutes=5))
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+
+    # Expect that a successful update recovers the entity
 
     with mock_weather_response():
         freezer.tick(timedelta(minutes=5))

--- a/tests/components/weatherkit/test_sensor.py
+++ b/tests/components/weatherkit/test_sensor.py
@@ -6,7 +6,7 @@ import pytest
 
 from homeassistant.core import HomeAssistant
 
-from . import init_integration
+from . import init_integration, mock_weather_response
 
 
 @pytest.mark.parametrize(
@@ -20,7 +20,8 @@ async def test_sensor_values(
     hass: HomeAssistant, entity_name: str, expected_value: Any
 ) -> None:
     """Test that various sensor values match what we expect."""
-    await init_integration(hass)
+    with mock_weather_response():
+        await init_integration(hass)
 
     state = hass.states.get(entity_name)
     assert state

--- a/tests/components/weatherkit/test_weather.py
+++ b/tests/components/weatherkit/test_weather.py
@@ -23,12 +23,13 @@ from homeassistant.components.weatherkit.const import ATTRIBUTION
 from homeassistant.const import ATTR_ATTRIBUTION, ATTR_SUPPORTED_FEATURES
 from homeassistant.core import HomeAssistant
 
-from . import init_integration
+from . import init_integration, mock_weather_response
 
 
 async def test_current_weather(hass: HomeAssistant) -> None:
     """Test states of the current weather."""
-    await init_integration(hass)
+    with mock_weather_response():
+        await init_integration(hass)
 
     state = hass.states.get("weather.home")
     assert state
@@ -49,7 +50,8 @@ async def test_current_weather(hass: HomeAssistant) -> None:
 
 async def test_current_weather_nighttime(hass: HomeAssistant) -> None:
     """Test that the condition is clear-night when it's sunny and night time."""
-    await init_integration(hass, is_night_time=True)
+    with mock_weather_response(is_night_time=True):
+        await init_integration(hass)
 
     state = hass.states.get("weather.home")
     assert state
@@ -58,7 +60,8 @@ async def test_current_weather_nighttime(hass: HomeAssistant) -> None:
 
 async def test_daily_forecast_missing(hass: HomeAssistant) -> None:
     """Test that daily forecast is not supported when WeatherKit doesn't support it."""
-    await init_integration(hass, has_daily_forecast=False)
+    with mock_weather_response(has_daily_forecast=False):
+        await init_integration(hass)
 
     state = hass.states.get("weather.home")
     assert state
@@ -69,7 +72,8 @@ async def test_daily_forecast_missing(hass: HomeAssistant) -> None:
 
 async def test_hourly_forecast_missing(hass: HomeAssistant) -> None:
     """Test that hourly forecast is not supported when WeatherKit doesn't support it."""
-    await init_integration(hass, has_hourly_forecast=False)
+    with mock_weather_response(has_hourly_forecast=False):
+        await init_integration(hass)
 
     state = hass.states.get("weather.home")
     assert state
@@ -86,7 +90,8 @@ async def test_hourly_forecast(
     hass: HomeAssistant, snapshot: SnapshotAssertion, service: str
 ) -> None:
     """Test states of the hourly forecast."""
-    await init_integration(hass)
+    with mock_weather_response():
+        await init_integration(hass)
 
     response = await hass.services.async_call(
         WEATHER_DOMAIN,
@@ -109,7 +114,8 @@ async def test_daily_forecast(
     hass: HomeAssistant, snapshot: SnapshotAssertion, service: str
 ) -> None:
     """Test states of the daily forecast."""
-    await init_integration(hass)
+    with mock_weather_response():
+        await init_integration(hass)
 
     response = await hass.services.async_call(
         WEATHER_DOMAIN,


### PR DESCRIPTION
## Proposed change

This PR introduces a change to the WeatherKit integration to use stale data for up to an hour if updates fail.

The WeatherKit API can be very unreliable in unpredictable ways at times (see #124052), and since weather data is not incredibly time-sensitive, it's acceptable to use the most recent data for up to an hour. If failures still occur after an hour, the entity will become unavailable.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #124052
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
