### PR TITLE
Add IQS to lamarzocco

### DIFF
--- a/homeassistant/components/lamarzocco/manifest.json
+++ b/homeassistant/components/lamarzocco/manifest.json
@@ -33,5 +33,6 @@
   "integration_type": "device",
   "iot_class": "cloud_polling",
   "loggers": ["pylamarzocco"],
+  "quality_scale": "platinum",
   "requirements": ["pylamarzocco==1.2.3"]
 }

--- a/homeassistant/components/lamarzocco/quality_scale.yaml
+++ b/homeassistant/components/lamarzocco/quality_scale.yaml
@@ -1,0 +1,89 @@
+rules:
+  config_flow: 
+    status: done
+    comment: >
+      data_description, ConfigEntry.data & options
+  test_before_configure: done
+  unique_config_entry: done
+  config_flow_test_coverage: done
+  runtime_data: done
+  test_before_setup: done
+  appropriate_polling: done
+  entity_unique_id: done
+  has_entity_name: done
+  entity_event_setup: done
+  dependency_transparency: done
+  action_setup: 
+    status: exempted
+    comment: >
+      No custom actions
+  common_modules: done
+  docs_high_level_description: done
+  docs_installation_instructions: done
+  docs_removal_instructions: done
+  docs_actions: 
+    status: exempted
+    comment: >
+      No custom actions
+  brands: done
+  config_entry_unloading: done
+  log_when_unavailable: 
+    status: todo
+    comment: >
+      Handled by coordinator
+  entity_unavailable: done
+  action_exceptions: 
+    status: exempted
+    comment: >
+      No custom actions
+  reauthentication_flow: done
+  parallel_updates: 
+    status: done
+    comment: >
+      Handled by coordinator
+  test_coverage: 
+    status: done
+    comment: >
+      100% test coverage
+  integration_owner: done
+  docs_installation_parameters: done
+  docs_configuration_parameters: done
+  entity_translations: done
+  entity_device_class: done
+  devices: done
+  entity_category: done
+  entity_disabled_by_default: 
+    status: done
+    comment: >
+      For certain number entities
+  discovery: 
+    status: done
+    comment: >
+      DHCP and Bluetooth
+  stale_devices: 
+    status: exempted
+    comment: >
+      Device type integration
+  diagnostics: done
+  exception_translations: done
+  icon_translations: done
+  reconfiguration_flow: done
+  dynamic_devices: 
+    status: exempted
+    comment: >
+      Device type integration
+  discovery_update_info: todo
+  repair_issues: done
+  docs_use_cases: done
+  docs_supported_devices: done
+  docs_supported_functions: done
+  docs_data_update: done
+  docs_known_limitations: done
+  docs_troubleshooting: done
+  docs_examples: done
+  async_dependency: done
+  inject_websession: 
+    status: done
+    comment: >
+      httpx injected
+  strict_typing: done

--- a/homeassistant/components/lamarzocco/quality_scale.yaml
+++ b/homeassistant/components/lamarzocco/quality_scale.yaml
@@ -28,7 +28,7 @@ rules:
   brands: done
   config_entry_unloading: done
   log_when_unavailable: 
-    status: todo
+    status: done
     comment: >
       Handled by coordinator
   entity_unavailable: done


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
### 🥉 Bronze
- ✅ **IQS001 - Integration needs to be able to be set up via the UI**
    - [x] Uses `data_description` to give context to fields
    - [x] Uses `ConfigEntry.data` and `ConfigEntry.options` correctly
- ✅ **IQS002 - Test a connection in the config flow** - https://github.com/home-assistant/core/blob/dev/homeassistant/components/lamarzocco/config_flow.py#L157
- ✅ **IQS003 - Don't allow the same device or service to be set up twice** - https://github.com/home-assistant/core/blob/dev/homeassistant/components/lamarzocco/config_flow.py#L149
- ✅ **IQS004 - Full test coverage for the config flow**
- ✅ **IQS006 - Use ConfigEntry.runtime_data to store runtime data** - https://github.com/home-assistant/core/blob/dev/homeassistant/components/lamarzocco/__init__.py#L111
- ✅ **IQS007 - Check during integration setup if we can set up correctly** - https://github.com/home-assistant/core/blob/dev/homeassistant/components/lamarzocco/coordinator.py#L134
- ✅ **IQS008 - If it's a polling integration, set an appropriate polling interval** - https://github.com/home-assistant/core/blob/dev/homeassistant/components/lamarzocco/coordinator.py#L25-L27
- ✅ **IQS011 - Entities have a unique ID** - https://github.com/home-assistant/core/blob/dev/homeassistant/components/lamarzocco/entity.py#L40
- ✅ **IQS012 - Entities use has_entity_name = True** - https://github.com/home-assistant/core/blob/dev/homeassistant/components/lamarzocco/entity.py#L30
- ✅ **IQS022 - Entities event setup**
- ✅ **IQS034 - Dependency transparency** - https://github.com/zweckj/pylamarzocco
- 🆗 **IQS035 - Service actions are registered in async_setup** - N/A, no services
- ✅ **IQS036 - Place common patterns in common modules**
- ✅ **IQS039 - The documentation includes a high-level description of the brand, product, or service it integrates with; if available, with links to the brand, product, or service website.**
- ✅ **IQS041 - The documentation provides step-by-step installation instructions for the integration, including, if needed, prerequisites.**
- ✅  **IQS042 - The documentation provides removal instructions.** - standard integration removal
- 🆗 **IQS047 - The documentation describes the provided service actions that can be used.** - no services
- ✅ **IQS052 - Has branding assets available for the integration**

### 🥈 Silver
- ✅ **IQS005 - Support config entry unloading** - https://github.com/home-assistant/core/blob/dev/homeassistant/components/lamarzocco/__init__.py#L136
- ✅ **IQS009 - If internet/device/service is unavailable, log a warning once unavailable and once when back connected** - `DataUpdateCoordinator`
- ✅ **IQS010 - Mark entity unavailable if appropriate** - https://github.com/home-assistant/core/blob/dev/homeassistant/components/lamarzocco/entity.py#L58
- 🆗 **IQS017 - Services raise errors when encountering failures** - N/A, no services
- ✅ **IQS020 - Reauthentication** - https://github.com/home-assistant/core/blob/dev/homeassistant/components/lamarzocco/config_flow.py#L293
- ✅ **IQS023 - Set Parallel updates** - `DataUpdateCoordinator`
- ✅ **IQS024 - Above 95% test coverage for all integration modules** - ![image](https://github.com/user-attachments/assets/5ad193a5-5d26-4365-a1cd-96bde059aa63)
- ✅ **IQS025 - Has a code owner** - https://github.com/home-assistant/core/blob/dev/homeassistant/components/lamarzocco/manifest.json#L18
- ✅ **IQS037 - Keep the config flow understandable and validate where needed**
- ✅ **IQS043 - The documentation describes all integration installation parameters.**
- ✅ **IQS044 - The documentation describes all integration configuration options.**

### 🥇 Gold
- ✅ **IQS013 - Entities have translated names** - https://github.com/home-assistant/core/blob/dev/homeassistant/components/lamarzocco/strings.json
- ✅ **IQS014 - Entities use device classes where possible**
- ✅ **IQS015 - Entities use DeviceInfo correctly** - https://github.com/home-assistant/core/blob/dev/homeassistant/components/lamarzocco/entity.py#L41
- ✅ **IQS016 - Entities are assigned an appropriate EntityCategory**
- ✅ **IQS018 - Integration disables less popular (or noisy) entities** - https://github.com/home-assistant/core/blob/dev/homeassistant/components/lamarzocco/number.py#L278
- ✅ **IQS019 - Is discoverable when possible** - BT and DHCP
- 🆗 **IQS021 - Clean up stale devices** - N/A, device type integration
- ✅ **IQS026 - Implements diagnostics** - https://github.com/home-assistant/core/blob/dev/homeassistant/components/lamarzocco/diagnostics.py
- ✅ **IQS030 - Exception messages are translatable** - https://github.com/home-assistant/core/blob/dev/homeassistant/components/lamarzocco/strings.json#L198-L222 
- ✅ **IQS031 - Icon translations** - https://github.com/home-assistant/core/blob/dev/homeassistant/components/lamarzocco/icons.json
- ✅ **IQS032 -  Integrations should have a reconfigure flow** - https://github.com/home-assistant/core/blob/dev/homeassistant/components/lamarzocco/config_flow.py#L315
- 🆗 **IQS033 - Devices added after integration setup** - N/A, device type integration
- ✅ **IQS038 - Repair issues and repair flows are used when user intervention is needed** - https://github.com/home-assistant/core/blob/dev/homeassistant/components/lamarzocco/__init__.py#L114-L124
- ✅ **IQS040 - The documentation describes use cases to illustrate how this integration can be used.**
- ✅ **IQS045 - The documentation provides a list of known supported / unsupported devices.**
- ✅ **IQS046 - The documentation describes the supported functionality, including entities, and platforms**
- ✅ **IQS048 - The documentation describes how data is updated.**
- ✅ **IQS049 - The documentation describes known limitations of the integrations (not to be confused with bugs).**
- ✅ **IQS050 - The documentation provides troubleshooting information.**
- ✅ **IQS051 - The documentation provides examples the user can use. For example (snippets of) configuration, automations, blueprints, scripts, or dashboards.**

### 🏆 Platinum
- ✅ **IQS027 - Dependency is async**
- ✅ **IQS028 - If making HTTP requests, support passing in websession** - httpx https://github.com/home-assistant/core/blob/dev/homeassistant/components/lamarzocco/__init__.py#L54
- ✅ **IQS029 - Strict typing**


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
