### PR TITLE
Add number platform to eq3btsmart

### DIFF
--- a/homeassistant/components/eq3btsmart/__init__.py
+++ b/homeassistant/components/eq3btsmart/__init__.py
@@ -21,6 +21,7 @@ from .models import Eq3Config, Eq3ConfigEntryData
 PLATFORMS = [
     Platform.BINARY_SENSOR,
     Platform.CLIMATE,
+    Platform.NUMBER,
     Platform.SWITCH,
 ]
 

--- a/homeassistant/components/eq3btsmart/const.py
+++ b/homeassistant/components/eq3btsmart/const.py
@@ -24,6 +24,13 @@ ENTITY_KEY_WINDOW = "window"
 ENTITY_KEY_LOCK = "lock"
 ENTITY_KEY_BOOST = "boost"
 ENTITY_KEY_AWAY = "away"
+ENTITY_KEY_COMFORT = "comfort"
+ENTITY_KEY_ECO = "eco"
+ENTITY_KEY_OFFSET = "offset"
+ENTITY_KEY_WINDOW_OPEN_TEMPERATURE = "window_open_temperature"
+ENTITY_KEY_WINDOW_OPEN_TIMEOUT = "window_open_timeout"
+ENTITY_KEY_AWAY_HOURS = "away_hours"
+ENTITY_KEY_AWAY_TEMPERATURE = "away_temperature"
 
 GET_DEVICE_TIMEOUT = 5  # seconds
 
@@ -77,3 +84,5 @@ DEFAULT_SCAN_INTERVAL = 10  # seconds
 
 SIGNAL_THERMOSTAT_DISCONNECTED = f"{DOMAIN}.thermostat_disconnected"
 SIGNAL_THERMOSTAT_CONNECTED = f"{DOMAIN}.thermostat_connected"
+
+EQ3BT_STEP = 0.5

--- a/homeassistant/components/eq3btsmart/const.py
+++ b/homeassistant/components/eq3btsmart/const.py
@@ -29,8 +29,6 @@ ENTITY_KEY_ECO = "eco"
 ENTITY_KEY_OFFSET = "offset"
 ENTITY_KEY_WINDOW_OPEN_TEMPERATURE = "window_open_temperature"
 ENTITY_KEY_WINDOW_OPEN_TIMEOUT = "window_open_timeout"
-ENTITY_KEY_AWAY_HOURS = "away_hours"
-ENTITY_KEY_AWAY_TEMPERATURE = "away_temperature"
 
 GET_DEVICE_TIMEOUT = 5  # seconds
 

--- a/homeassistant/components/eq3btsmart/icons.json
+++ b/homeassistant/components/eq3btsmart/icons.json
@@ -8,6 +8,29 @@
         }
       }
     },
+    "number": {
+      "comfort": {
+        "default": "mdi:sun-thermometer"
+      },
+      "eco": {
+        "default": "mdi:snowflake-thermometer"
+      },
+      "offset": {
+        "default": "mdi:thermometer-plus"
+      },
+      "window_open_temperature": {
+        "default": "mdi:window-open-variant"
+      },
+      "window_open_timeout": {
+        "default": "mdi:timer-refresh"
+      },
+      "away_hours": {
+        "default": "mdi:home-clock-outline"
+      },
+      "away_temperature": {
+        "default": "mdi:home-thermometer-outline"
+      }
+    },
     "switch": {
       "away": {
         "default": "mdi:home-account",

--- a/homeassistant/components/eq3btsmart/icons.json
+++ b/homeassistant/components/eq3btsmart/icons.json
@@ -23,12 +23,6 @@
       },
       "window_open_timeout": {
         "default": "mdi:timer-refresh"
-      },
-      "away_hours": {
-        "default": "mdi:home-clock-outline"
-      },
-      "away_temperature": {
-        "default": "mdi:home-thermometer-outline"
       }
     },
     "switch": {

--- a/homeassistant/components/eq3btsmart/models.py
+++ b/homeassistant/components/eq3btsmart/models.py
@@ -2,7 +2,6 @@
 
 from dataclasses import dataclass
 
-from eq3btsmart.const import DEFAULT_AWAY_HOURS, DEFAULT_AWAY_TEMP
 from eq3btsmart.thermostat import Thermostat
 
 from .const import (
@@ -23,8 +22,6 @@ class Eq3Config:
     target_temp_selector: TargetTemperatureSelector = DEFAULT_TARGET_TEMP_SELECTOR
     external_temp_sensor: str = ""
     scan_interval: int = DEFAULT_SCAN_INTERVAL
-    default_away_hours: float = DEFAULT_AWAY_HOURS
-    default_away_temperature: float = DEFAULT_AWAY_TEMP
 
 
 @dataclass(slots=True)

--- a/homeassistant/components/eq3btsmart/number.py
+++ b/homeassistant/components/eq3btsmart/number.py
@@ -1,0 +1,224 @@
+"""Platform for eq3 number entities."""
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from eq3btsmart import Thermostat
+from eq3btsmart.const import (
+    EQ3BT_MAX_OFFSET,
+    EQ3BT_MAX_TEMP,
+    EQ3BT_MIN_OFFSET,
+    EQ3BT_MIN_TEMP,
+)
+from eq3btsmart.models import Presets
+from eq3btsmart.thermostat_config import ThermostatConfig
+
+from homeassistant.components.number import (
+    NumberDeviceClass,
+    NumberEntity,
+    NumberEntityDescription,
+    NumberMode,
+    RestoreNumber,
+)
+from homeassistant.const import EntityCategory, UnitOfTemperature, UnitOfTime
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import Eq3ConfigEntry
+from .const import (
+    ENTITY_KEY_AWAY_HOURS,
+    ENTITY_KEY_AWAY_TEMPERATURE,
+    ENTITY_KEY_COMFORT,
+    ENTITY_KEY_ECO,
+    ENTITY_KEY_OFFSET,
+    ENTITY_KEY_WINDOW_OPEN_TEMPERATURE,
+    ENTITY_KEY_WINDOW_OPEN_TIMEOUT,
+    EQ3BT_STEP,
+)
+from .entity import Eq3Entity
+
+
+@dataclass(frozen=True, kw_only=True)
+class Eq3NumberEntityDescription(NumberEntityDescription):
+    """Entity description for eq3 number entities."""
+
+    value_func: Callable[[Presets], float]
+    value_set_func: Callable[
+        [Thermostat],
+        Callable[[float], Awaitable[None]],
+    ]
+    device_class: NumberDeviceClass | None = NumberDeviceClass.TEMPERATURE
+    native_unit_of_measurement: str = UnitOfTemperature.CELSIUS
+    native_min_value: float = EQ3BT_MIN_TEMP
+    native_max_value: float = EQ3BT_MAX_TEMP
+    native_step: float = EQ3BT_STEP
+    mode: NumberMode = NumberMode.BOX
+    entity_category: EntityCategory | None = EntityCategory.CONFIG
+
+
+@dataclass(frozen=True, kw_only=True)
+class Eq3RestoreNumberEntityDescription(Eq3NumberEntityDescription):
+    """Entity description for eq3 number entities that should be restored."""
+
+    value_func: Callable[[ThermostatConfig], float | int]
+
+
+NUMBER_ENTITY_DESCRIPTIONS = [
+    Eq3NumberEntityDescription(
+        key=ENTITY_KEY_COMFORT,
+        value_func=lambda presets: presets.comfort_temperature.value,
+        value_set_func=lambda thermostat: thermostat.async_configure_comfort_temperature,
+        translation_key=ENTITY_KEY_COMFORT,
+    ),
+    Eq3NumberEntityDescription(
+        key=ENTITY_KEY_ECO,
+        value_func=lambda presets: presets.eco_temperature.value,
+        value_set_func=lambda thermostat: thermostat.async_configure_eco_temperature,
+        translation_key=ENTITY_KEY_ECO,
+    ),
+    Eq3NumberEntityDescription(
+        key=ENTITY_KEY_WINDOW_OPEN_TEMPERATURE,
+        value_func=lambda presets: presets.window_open_temperature.value,
+        value_set_func=lambda thermostat: thermostat.async_configure_window_open_temperature,
+        translation_key=ENTITY_KEY_WINDOW_OPEN_TEMPERATURE,
+    ),
+    Eq3NumberEntityDescription(
+        key=ENTITY_KEY_OFFSET,
+        value_func=lambda presets: presets.offset_temperature.value,
+        value_set_func=lambda thermostat: thermostat.async_configure_temperature_offset,
+        translation_key=ENTITY_KEY_OFFSET,
+        native_min_value=EQ3BT_MIN_OFFSET,
+        native_max_value=EQ3BT_MAX_OFFSET,
+    ),
+    Eq3NumberEntityDescription(
+        key=ENTITY_KEY_WINDOW_OPEN_TIMEOUT,
+        value_set_func=lambda thermostat: thermostat.async_configure_window_open_duration,
+        value_func=lambda presets: presets.window_open_time.value.total_seconds() / 60,
+        translation_key=ENTITY_KEY_WINDOW_OPEN_TIMEOUT,
+        device_class=None,
+        native_unit_of_measurement=UnitOfTime.MINUTES,
+        native_min_value=0,
+        native_max_value=60,
+        native_step=5,
+    ),
+]
+
+
+RESTORE_NUMBER_ENTITY_DESCRIPTIONS = [
+    Eq3RestoreNumberEntityDescription(
+        key=ENTITY_KEY_AWAY_TEMPERATURE,
+        value_func=lambda thermostat_config: thermostat_config.away_temperature,
+        value_set_func=lambda thermostat: thermostat.async_configure_away_temperature,
+        translation_key=ENTITY_KEY_AWAY_TEMPERATURE,
+    ),
+    Eq3RestoreNumberEntityDescription(
+        key=ENTITY_KEY_AWAY_HOURS,
+        value_func=lambda thermostat_config: thermostat_config.away_hours,
+        value_set_func=lambda thermostat: thermostat.async_configure_away_hours,
+        translation_key=ENTITY_KEY_AWAY_HOURS,
+        device_class=None,
+        native_unit_of_measurement=UnitOfTime.HOURS,
+        native_min_value=0.5,
+        native_max_value=1000000,
+    ),
+]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: Eq3ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the entry."""
+
+    entities_to_add = [
+        Eq3NumberEntity(entry, entity_description)
+        for entity_description in NUMBER_ENTITY_DESCRIPTIONS
+    ] + [
+        Eq3RestoreNumberEntity(entry, entity_description)
+        for entity_description in RESTORE_NUMBER_ENTITY_DESCRIPTIONS
+    ]
+
+    async_add_entities(entities_to_add)
+
+
+class Eq3NumberEntity(Eq3Entity, NumberEntity):
+    """Base class for all eq3 number entities."""
+
+    entity_description: Eq3NumberEntityDescription
+
+    def __init__(
+        self, entry: Eq3ConfigEntry, entity_description: Eq3NumberEntityDescription
+    ) -> None:
+        """Initialize the entity."""
+
+        super().__init__(entry, entity_description.key)
+        self.entity_description = entity_description
+
+    @property
+    def native_value(self) -> float:
+        """Return the state of the entity."""
+
+        if TYPE_CHECKING:
+            assert self._thermostat.status is not None
+            assert self._thermostat.status.presets is not None
+
+        return self.entity_description.value_func(self._thermostat.status.presets)
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set the state of the entity."""
+
+        await self.entity_description.value_set_func(self._thermostat)(value)
+
+    @property
+    def available(self) -> bool:
+        """Return whether the entity is available."""
+
+        return (
+            self._thermostat.status is not None
+            and self._thermostat.status.presets is not None
+            and self._attr_available
+        )
+
+
+class Eq3RestoreNumberEntity(Eq3Entity, RestoreNumber):
+    """Base class for all eq3 number entities that should be restored."""
+
+    entity_description: Eq3RestoreNumberEntityDescription
+
+    def __init__(
+        self,
+        entry: Eq3ConfigEntry,
+        entity_description: Eq3RestoreNumberEntityDescription,
+    ) -> None:
+        """Initialize the entity."""
+
+        super().__init__(entry, entity_description.key)
+        self.entity_description = entity_description
+
+    async def async_added_to_hass(self) -> None:
+        """Restore last state."""
+
+        await super().async_added_to_hass()
+
+        if (
+            last_number_data := await self.async_get_last_number_data()
+        ) and last_number_data.native_value is not None:
+            await self.async_set_native_value(last_number_data.native_value)
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set the state of the entity."""
+
+        self._attr_native_value = value
+        await self.entity_description.value_set_func(self._thermostat)(value)
+
+    @property
+    def available(self) -> bool:
+        """Return whether the entity is available."""
+
+        return (
+            self._thermostat.status is not None
+            and self._thermostat.status.presets is not None
+            and self._attr_available
+        )

--- a/homeassistant/components/eq3btsmart/number.py
+++ b/homeassistant/components/eq3btsmart/number.py
@@ -12,14 +12,12 @@ from eq3btsmart.const import (
     EQ3BT_MIN_TEMP,
 )
 from eq3btsmart.models import Presets
-from eq3btsmart.thermostat_config import ThermostatConfig
 
 from homeassistant.components.number import (
     NumberDeviceClass,
     NumberEntity,
     NumberEntityDescription,
     NumberMode,
-    RestoreNumber,
 )
 from homeassistant.const import EntityCategory, UnitOfTemperature, UnitOfTime
 from homeassistant.core import HomeAssistant
@@ -27,8 +25,6 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import Eq3ConfigEntry
 from .const import (
-    ENTITY_KEY_AWAY_HOURS,
-    ENTITY_KEY_AWAY_TEMPERATURE,
     ENTITY_KEY_COMFORT,
     ENTITY_KEY_ECO,
     ENTITY_KEY_OFFSET,
@@ -48,20 +44,8 @@ class Eq3NumberEntityDescription(NumberEntityDescription):
         [Thermostat],
         Callable[[float], Awaitable[None]],
     ]
-    device_class: NumberDeviceClass | None = NumberDeviceClass.TEMPERATURE
-    native_unit_of_measurement: str = UnitOfTemperature.CELSIUS
-    native_min_value: float = EQ3BT_MIN_TEMP
-    native_max_value: float = EQ3BT_MAX_TEMP
-    native_step: float = EQ3BT_STEP
     mode: NumberMode = NumberMode.BOX
     entity_category: EntityCategory | None = EntityCategory.CONFIG
-
-
-@dataclass(frozen=True, kw_only=True)
-class Eq3RestoreNumberEntityDescription(Eq3NumberEntityDescription):
-    """Entity description for eq3 number entities that should be restored."""
-
-    value_func: Callable[[ThermostatConfig], float | int]
 
 
 NUMBER_ENTITY_DESCRIPTIONS = [
@@ -70,18 +54,33 @@ NUMBER_ENTITY_DESCRIPTIONS = [
         value_func=lambda presets: presets.comfort_temperature.value,
         value_set_func=lambda thermostat: thermostat.async_configure_comfort_temperature,
         translation_key=ENTITY_KEY_COMFORT,
+        native_min_value=EQ3BT_MIN_TEMP,
+        native_max_value=EQ3BT_MAX_TEMP,
+        native_step=EQ3BT_STEP,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        device_class=NumberDeviceClass.TEMPERATURE,
     ),
     Eq3NumberEntityDescription(
         key=ENTITY_KEY_ECO,
         value_func=lambda presets: presets.eco_temperature.value,
         value_set_func=lambda thermostat: thermostat.async_configure_eco_temperature,
         translation_key=ENTITY_KEY_ECO,
+        native_min_value=EQ3BT_MIN_TEMP,
+        native_max_value=EQ3BT_MAX_TEMP,
+        native_step=EQ3BT_STEP,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        device_class=NumberDeviceClass.TEMPERATURE,
     ),
     Eq3NumberEntityDescription(
         key=ENTITY_KEY_WINDOW_OPEN_TEMPERATURE,
         value_func=lambda presets: presets.window_open_temperature.value,
         value_set_func=lambda thermostat: thermostat.async_configure_window_open_temperature,
         translation_key=ENTITY_KEY_WINDOW_OPEN_TEMPERATURE,
+        native_min_value=EQ3BT_MIN_TEMP,
+        native_max_value=EQ3BT_MAX_TEMP,
+        native_step=EQ3BT_STEP,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        device_class=NumberDeviceClass.TEMPERATURE,
     ),
     Eq3NumberEntityDescription(
         key=ENTITY_KEY_OFFSET,
@@ -90,37 +89,19 @@ NUMBER_ENTITY_DESCRIPTIONS = [
         translation_key=ENTITY_KEY_OFFSET,
         native_min_value=EQ3BT_MIN_OFFSET,
         native_max_value=EQ3BT_MAX_OFFSET,
+        native_step=EQ3BT_STEP,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        device_class=NumberDeviceClass.TEMPERATURE,
     ),
     Eq3NumberEntityDescription(
         key=ENTITY_KEY_WINDOW_OPEN_TIMEOUT,
         value_set_func=lambda thermostat: thermostat.async_configure_window_open_duration,
         value_func=lambda presets: presets.window_open_time.value.total_seconds() / 60,
         translation_key=ENTITY_KEY_WINDOW_OPEN_TIMEOUT,
-        device_class=None,
-        native_unit_of_measurement=UnitOfTime.MINUTES,
         native_min_value=0,
         native_max_value=60,
         native_step=5,
-    ),
-]
-
-
-RESTORE_NUMBER_ENTITY_DESCRIPTIONS = [
-    Eq3RestoreNumberEntityDescription(
-        key=ENTITY_KEY_AWAY_TEMPERATURE,
-        value_func=lambda thermostat_config: thermostat_config.away_temperature,
-        value_set_func=lambda thermostat: thermostat.async_configure_away_temperature,
-        translation_key=ENTITY_KEY_AWAY_TEMPERATURE,
-    ),
-    Eq3RestoreNumberEntityDescription(
-        key=ENTITY_KEY_AWAY_HOURS,
-        value_func=lambda thermostat_config: thermostat_config.away_hours,
-        value_set_func=lambda thermostat: thermostat.async_configure_away_hours,
-        translation_key=ENTITY_KEY_AWAY_HOURS,
-        device_class=None,
-        native_unit_of_measurement=UnitOfTime.HOURS,
-        native_min_value=0.5,
-        native_max_value=1000000,
+        native_unit_of_measurement=UnitOfTime.MINUTES,
     ),
 ]
 
@@ -132,15 +113,10 @@ async def async_setup_entry(
 ) -> None:
     """Set up the entry."""
 
-    entities_to_add = [
+    async_add_entities(
         Eq3NumberEntity(entry, entity_description)
         for entity_description in NUMBER_ENTITY_DESCRIPTIONS
-    ] + [
-        Eq3RestoreNumberEntity(entry, entity_description)
-        for entity_description in RESTORE_NUMBER_ENTITY_DESCRIPTIONS
-    ]
-
-    async_add_entities(entities_to_add)
+    )
 
 
 class Eq3NumberEntity(Eq3Entity, NumberEntity):
@@ -169,48 +145,6 @@ class Eq3NumberEntity(Eq3Entity, NumberEntity):
     async def async_set_native_value(self, value: float) -> None:
         """Set the state of the entity."""
 
-        await self.entity_description.value_set_func(self._thermostat)(value)
-
-    @property
-    def available(self) -> bool:
-        """Return whether the entity is available."""
-
-        return (
-            self._thermostat.status is not None
-            and self._thermostat.status.presets is not None
-            and self._attr_available
-        )
-
-
-class Eq3RestoreNumberEntity(Eq3Entity, RestoreNumber):
-    """Base class for all eq3 number entities that should be restored."""
-
-    entity_description: Eq3RestoreNumberEntityDescription
-
-    def __init__(
-        self,
-        entry: Eq3ConfigEntry,
-        entity_description: Eq3RestoreNumberEntityDescription,
-    ) -> None:
-        """Initialize the entity."""
-
-        super().__init__(entry, entity_description.key)
-        self.entity_description = entity_description
-
-    async def async_added_to_hass(self) -> None:
-        """Restore last state."""
-
-        await super().async_added_to_hass()
-
-        if (
-            last_number_data := await self.async_get_last_number_data()
-        ) and last_number_data.native_value is not None:
-            await self.async_set_native_value(last_number_data.native_value)
-
-    async def async_set_native_value(self, value: float) -> None:
-        """Set the state of the entity."""
-
-        self._attr_native_value = value
         await self.entity_description.value_set_func(self._thermostat)(value)
 
     @property

--- a/homeassistant/components/eq3btsmart/strings.json
+++ b/homeassistant/components/eq3btsmart/strings.json
@@ -25,6 +25,29 @@
         "name": "Daylight saving time"
       }
     },
+    "number": {
+      "comfort": {
+        "name": "Comfort temperature"
+      },
+      "eco": {
+        "name": "Eco temperature"
+      },
+      "offset": {
+        "name": "Offset temperature"
+      },
+      "window_open_temperature": {
+        "name": "Window open temperature"
+      },
+      "window_open_timeout": {
+        "name": "Window open timeout"
+      },
+      "away_hours": {
+        "name": "Away hours"
+      },
+      "away_temperature": {
+        "name": "Away temperature"
+      }
+    },
     "switch": {
       "lock": {
         "name": "Lock"

--- a/homeassistant/components/eq3btsmart/strings.json
+++ b/homeassistant/components/eq3btsmart/strings.json
@@ -40,12 +40,6 @@
       },
       "window_open_timeout": {
         "name": "Window open timeout"
-      },
-      "away_hours": {
-        "name": "Away hours"
-      },
-      "away_temperature": {
-        "name": "Away temperature"
       }
     },
     "switch": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds the `number` platform to the `eq3btsmart` integration. The new entities allow the user to configure temperature presets and other settings regarding the away, window and offset functions of the device.

Needs https://github.com/home-assistant/core/pull/130426 to get merged first.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/35721

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
