### PR TITLE
Add sensor platform to eq3btsmart

### DIFF
--- a/homeassistant/components/eq3btsmart/__init__.py
+++ b/homeassistant/components/eq3btsmart/__init__.py
@@ -22,6 +22,7 @@ PLATFORMS = [
     Platform.BINARY_SENSOR,
     Platform.CLIMATE,
     Platform.NUMBER,
+    Platform.SENSOR,
     Platform.SWITCH,
 ]
 

--- a/homeassistant/components/eq3btsmart/const.py
+++ b/homeassistant/components/eq3btsmart/const.py
@@ -29,6 +29,8 @@ ENTITY_KEY_ECO = "eco"
 ENTITY_KEY_OFFSET = "offset"
 ENTITY_KEY_WINDOW_OPEN_TEMPERATURE = "window_open_temperature"
 ENTITY_KEY_WINDOW_OPEN_TIMEOUT = "window_open_timeout"
+ENTITY_KEY_VALVE = "valve"
+ENTITY_KEY_AWAY_UNTIL = "away_until"
 
 GET_DEVICE_TIMEOUT = 5  # seconds
 

--- a/homeassistant/components/eq3btsmart/icons.json
+++ b/homeassistant/components/eq3btsmart/icons.json
@@ -25,11 +25,19 @@
         "default": "mdi:timer-refresh"
       }
     },
+    "sensor": {
+      "away_until": {
+        "default": "mdi:home-export-outline"
+      },
+      "valve": {
+        "default": "mdi:pipe-valve"
+      }
+    },
     "switch": {
       "away": {
         "default": "mdi:home-account",
         "state": {
-          "on": "mdi:home-export"
+          "on": "mdi:home-export-outline"
         }
       },
       "lock": {

--- a/homeassistant/components/eq3btsmart/sensor.py
+++ b/homeassistant/components/eq3btsmart/sensor.py
@@ -1,0 +1,84 @@
+"""Platform for eq3 sensor entities."""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from eq3btsmart.models import Status
+
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorEntityDescription,
+)
+from homeassistant.components.sensor.const import SensorStateClass
+from homeassistant.const import PERCENTAGE
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import Eq3ConfigEntry
+from .const import ENTITY_KEY_AWAY_UNTIL, ENTITY_KEY_VALVE
+from .entity import Eq3Entity
+
+
+@dataclass(frozen=True, kw_only=True)
+class Eq3SensorEntityDescription(SensorEntityDescription):
+    """Entity description for eq3 sensor entities."""
+
+    value_func: Callable[[Status], int | datetime | None]
+
+
+SENSOR_ENTITY_DESCRIPTIONS = [
+    Eq3SensorEntityDescription(
+        key=ENTITY_KEY_VALVE,
+        translation_key=ENTITY_KEY_VALVE,
+        value_func=lambda status: status.valve,
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    Eq3SensorEntityDescription(
+        key=ENTITY_KEY_AWAY_UNTIL,
+        translation_key=ENTITY_KEY_AWAY_UNTIL,
+        value_func=lambda status: (
+            status.away_until.value if status.away_until else None
+        ),
+        device_class=SensorDeviceClass.DATE,
+    ),
+]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: Eq3ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the entry."""
+
+    async_add_entities(
+        Eq3SensorEntity(entry, entity_description)
+        for entity_description in SENSOR_ENTITY_DESCRIPTIONS
+    )
+
+
+class Eq3SensorEntity(Eq3Entity, SensorEntity):
+    """Base class for eq3 sensor entities."""
+
+    entity_description: Eq3SensorEntityDescription
+
+    def __init__(
+        self, entry: Eq3ConfigEntry, entity_description: Eq3SensorEntityDescription
+    ) -> None:
+        """Initialize the entity."""
+
+        super().__init__(entry, entity_description.key)
+        self.entity_description = entity_description
+
+    @property
+    def native_value(self) -> int | datetime | None:
+        """Return the value reported by the sensor."""
+
+        if TYPE_CHECKING:
+            assert self._thermostat.status is not None
+
+        return self.entity_description.value_func(self._thermostat.status)

--- a/homeassistant/components/eq3btsmart/strings.json
+++ b/homeassistant/components/eq3btsmart/strings.json
@@ -42,6 +42,14 @@
         "name": "Window open timeout"
       }
     },
+    "sensor": {
+      "away_until": {
+        "name": "Away until"
+      },
+      "valve": {
+        "name": "Valve"
+      }
+    },
     "switch": {
       "lock": {
         "name": "Lock"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds the `sensor` platform to the `eq3btsmart` integration. The new entities allow the user to observe the valve open percentage and the away until date of the thermostat.

Needs https://github.com/home-assistant/core/pull/130429 to get merged first.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/35723

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
