### PR TITLE
Simplify modern_forms config flow

### DIFF
--- a/homeassistant/components/modern_forms/config_flow.py
+++ b/homeassistant/components/modern_forms/config_flow.py
@@ -9,7 +9,7 @@ import voluptuous as vol
 
 from homeassistant.components import zeroconf
 from homeassistant.config_entries import SOURCE_ZEROCONF, ConfigFlow, ConfigFlowResult
-from homeassistant.const import CONF_HOST, CONF_MAC, CONF_NAME
+from homeassistant.const import CONF_HOST, CONF_MAC
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import DOMAIN
@@ -89,7 +89,6 @@ class ModernFormsFlowHandler(ConfigFlow, domain=DOMAIN):
                     errors={"base": "cannot_connect"},
                 )
             user_input[CONF_MAC] = device.info.mac_address
-            user_input[CONF_NAME] = device.info.device_name
 
         # Check if already configured
         await self.async_set_unique_id(user_input[CONF_MAC])

--- a/homeassistant/components/modern_forms/config_flow.py
+++ b/homeassistant/components/modern_forms/config_flow.py
@@ -14,6 +14,8 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import DOMAIN
 
+DATA_SCHEMA = vol.Schema({vol.Required(CONF_HOST): str})
+
 
 class ModernFormsFlowHandler(ConfigFlow, domain=DOMAIN):
     """Handle a ModernForms config flow."""
@@ -55,17 +57,21 @@ class ModernFormsFlowHandler(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None, prepare: bool = False
     ) -> ConfigFlowResult:
         """Config flow handler for ModernForms."""
-        source = self.context["source"]
-
         # Request user input, unless we are preparing discovery flow
         if user_input is None:
             user_input = {}
             if not prepare:
-                if source == SOURCE_ZEROCONF:
-                    return self._show_confirm_dialog()
-                return self._show_setup_form()
+                if self.source == SOURCE_ZEROCONF:
+                    return self.async_show_form(
+                        step_id="zeroconf_confirm",
+                        description_placeholders={"name": self.name},
+                    )
+                return self.async_show_form(
+                    step_id="user",
+                    data_schema=DATA_SCHEMA,
+                )
 
-        if source == SOURCE_ZEROCONF:
+        if self.source == SOURCE_ZEROCONF:
             user_input[CONF_HOST] = self.host
             user_input[CONF_MAC] = self.mac
 
@@ -75,9 +81,13 @@ class ModernFormsFlowHandler(ConfigFlow, domain=DOMAIN):
             try:
                 device = await device.update()
             except ModernFormsConnectionError:
-                if source == SOURCE_ZEROCONF:
+                if self.source == SOURCE_ZEROCONF:
                     return self.async_abort(reason="cannot_connect")
-                return self._show_setup_form({"base": "cannot_connect"})
+                return self.async_show_form(
+                    step_id="user",
+                    data_schema=DATA_SCHEMA,
+                    errors={"base": "cannot_connect"},
+                )
             user_input[CONF_MAC] = device.info.mac_address
             user_input[CONF_NAME] = device.info.device_name
 
@@ -86,7 +96,7 @@ class ModernFormsFlowHandler(ConfigFlow, domain=DOMAIN):
         self._abort_if_unique_id_configured(updates={CONF_HOST: user_input[CONF_HOST]})
 
         title = device.info.device_name
-        if source == SOURCE_ZEROCONF:
+        if self.source == SOURCE_ZEROCONF:
             title = self.name
 
         if prepare:
@@ -95,20 +105,4 @@ class ModernFormsFlowHandler(ConfigFlow, domain=DOMAIN):
         return self.async_create_entry(
             title=title,
             data={CONF_HOST: user_input[CONF_HOST], CONF_MAC: user_input[CONF_MAC]},
-        )
-
-    def _show_setup_form(self, errors: dict | None = None) -> ConfigFlowResult:
-        """Show the setup form to the user."""
-        return self.async_show_form(
-            step_id="user",
-            data_schema=vol.Schema({vol.Required(CONF_HOST): str}),
-            errors=errors or {},
-        )
-
-    def _show_confirm_dialog(self, errors: dict | None = None) -> ConfigFlowResult:
-        """Show the confirm dialog to the user."""
-        return self.async_show_form(
-            step_id="zeroconf_confirm",
-            description_placeholders={"name": self.name},
-            errors=errors or {},
         )

--- a/homeassistant/components/modern_forms/config_flow.py
+++ b/homeassistant/components/modern_forms/config_flow.py
@@ -14,7 +14,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import DOMAIN
 
-DATA_SCHEMA = vol.Schema({vol.Required(CONF_HOST): str})
+USER_SCHEMA = vol.Schema({vol.Required(CONF_HOST): str})
 
 
 class ModernFormsFlowHandler(ConfigFlow, domain=DOMAIN):
@@ -68,7 +68,7 @@ class ModernFormsFlowHandler(ConfigFlow, domain=DOMAIN):
                     )
                 return self.async_show_form(
                     step_id="user",
-                    data_schema=DATA_SCHEMA,
+                    data_schema=USER_SCHEMA,
                 )
 
         if self.source == SOURCE_ZEROCONF:
@@ -85,7 +85,7 @@ class ModernFormsFlowHandler(ConfigFlow, domain=DOMAIN):
                     return self.async_abort(reason="cannot_connect")
                 return self.async_show_form(
                     step_id="user",
-                    data_schema=DATA_SCHEMA,
+                    data_schema=USER_SCHEMA,
                     errors={"base": "cannot_connect"},
                 )
             user_input[CONF_MAC] = device.info.mac_address


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As I was looking at #127103, I found that `_handle_config_flow` is (I think) unnecessarily complicated.

As a first step towards simplification:
- move the schema to a `USER_SCHEMA` constant
- replace `self._show_setup_form` and `self._show_confirm_dialog` with standard `self.async_show_form`
- remove `CONF_NAME` as it is never read
- replace `self.context["source"]` with `self.source`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
