### PR TITLE
Refactor eq3btsmart to use data coordinator

### DIFF
--- a/homeassistant/components/eq3btsmart/__init__.py
+++ b/homeassistant/components/eq3btsmart/__init__.py
@@ -22,6 +22,7 @@ PLATFORMS = [
     Platform.BINARY_SENSOR,
     Platform.CLIMATE,
     Platform.NUMBER,
+    Platform.SENSOR,
     Platform.SWITCH,
 ]
 

--- a/homeassistant/components/eq3btsmart/__init__.py
+++ b/homeassistant/components/eq3btsmart/__init__.py
@@ -1,22 +1,17 @@
 """Support for EQ3 devices."""
 
-import asyncio
-import logging
 from typing import TYPE_CHECKING
 
 from eq3btsmart import Thermostat
-from eq3btsmart.exceptions import Eq3Exception
 from eq3btsmart.thermostat_config import ThermostatConfig
 
 from homeassistant.components import bluetooth
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.helpers.dispatcher import async_dispatcher_send
 
-from .const import SIGNAL_THERMOSTAT_CONNECTED, SIGNAL_THERMOSTAT_DISCONNECTED
-from .models import Eq3Config, Eq3ConfigEntryData
+from .coordinator import Eq3ConfigEntry, Eq3ConfigEntryData, Eq3Coordinator
+from .models import Eq3Config
 
 PLATFORMS = [
     Platform.BINARY_SENSOR,
@@ -25,11 +20,6 @@ PLATFORMS = [
     Platform.SENSOR,
     Platform.SWITCH,
 ]
-
-_LOGGER = logging.getLogger(__name__)
-
-
-type Eq3ConfigEntry = ConfigEntry[Eq3ConfigEntryData]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: Eq3ConfigEntry) -> bool:
@@ -59,15 +49,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: Eq3ConfigEntry) -> bool:
         ),
         ble_device=device,
     )
+    coordinator = Eq3Coordinator(hass, entry, eq3_config.mac_address)
 
     entry.runtime_data = Eq3ConfigEntryData(
-        eq3_config=eq3_config, thermostat=thermostat
+        eq3_config=eq3_config, thermostat=thermostat, coordinator=coordinator
     )
     entry.async_on_unload(entry.add_update_listener(update_listener))
+
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-    entry.async_create_background_task(
-        hass, _async_run_thermostat(hass, entry), entry.entry_id
-    )
+    await coordinator.async_config_entry_first_refresh()
 
     return True
 
@@ -85,66 +75,3 @@ async def update_listener(hass: HomeAssistant, entry: Eq3ConfigEntry) -> None:
     """Handle config entry update."""
 
     await hass.config_entries.async_reload(entry.entry_id)
-
-
-async def _async_run_thermostat(hass: HomeAssistant, entry: Eq3ConfigEntry) -> None:
-    """Run the thermostat."""
-
-    thermostat = entry.runtime_data.thermostat
-    mac_address = entry.runtime_data.eq3_config.mac_address
-    scan_interval = entry.runtime_data.eq3_config.scan_interval
-
-    await _async_reconnect_thermostat(hass, entry)
-
-    while True:
-        try:
-            await thermostat.async_get_status()
-        except Eq3Exception as e:
-            if not thermostat.is_connected:
-                _LOGGER.error(
-                    "[%s] eQ-3 device disconnected",
-                    mac_address,
-                )
-                async_dispatcher_send(
-                    hass,
-                    f"{SIGNAL_THERMOSTAT_DISCONNECTED}_{mac_address}",
-                )
-                await _async_reconnect_thermostat(hass, entry)
-                continue
-
-            _LOGGER.error(
-                "[%s] Error updating eQ-3 device: %s",
-                mac_address,
-                e,
-            )
-
-        await asyncio.sleep(scan_interval)
-
-
-async def _async_reconnect_thermostat(
-    hass: HomeAssistant, entry: Eq3ConfigEntry
-) -> None:
-    """Reconnect the thermostat."""
-
-    thermostat = entry.runtime_data.thermostat
-    mac_address = entry.runtime_data.eq3_config.mac_address
-    scan_interval = entry.runtime_data.eq3_config.scan_interval
-
-    while True:
-        try:
-            await thermostat.async_connect()
-        except Eq3Exception:
-            await asyncio.sleep(scan_interval)
-            continue
-
-        _LOGGER.debug(
-            "[%s] eQ-3 device connected",
-            mac_address,
-        )
-
-        async_dispatcher_send(
-            hass,
-            f"{SIGNAL_THERMOSTAT_CONNECTED}_{mac_address}",
-        )
-
-        return

--- a/homeassistant/components/eq3btsmart/const.py
+++ b/homeassistant/components/eq3btsmart/const.py
@@ -29,6 +29,8 @@ ENTITY_KEY_ECO = "eco"
 ENTITY_KEY_OFFSET = "offset"
 ENTITY_KEY_WINDOW_OPEN_TEMPERATURE = "window_open_temperature"
 ENTITY_KEY_WINDOW_OPEN_TIMEOUT = "window_open_timeout"
+ENTITY_KEY_VALVE = "valve"
+ENTITY_KEY_AWAY_UNTIL = "away_until"
 
 GET_DEVICE_TIMEOUT = 5  # seconds
 

--- a/homeassistant/components/eq3btsmart/const.py
+++ b/homeassistant/components/eq3btsmart/const.py
@@ -80,7 +80,8 @@ class TargetTemperatureSelector(str, Enum):
 
 DEFAULT_CURRENT_TEMP_SELECTOR = CurrentTemperatureSelector.DEVICE
 DEFAULT_TARGET_TEMP_SELECTOR = TargetTemperatureSelector.TARGET
-DEFAULT_SCAN_INTERVAL = 10  # seconds
+SCAN_INTERVAL = 10  # seconds
+RECONNECT_INTERVAL = 10  # seconds
 
 SIGNAL_THERMOSTAT_DISCONNECTED = f"{DOMAIN}.thermostat_disconnected"
 SIGNAL_THERMOSTAT_CONNECTED = f"{DOMAIN}.thermostat_connected"

--- a/homeassistant/components/eq3btsmart/coordinator.py
+++ b/homeassistant/components/eq3btsmart/coordinator.py
@@ -1,0 +1,128 @@
+"""Coordinator for the eq3btsmart integration."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from datetime import timedelta
+import logging
+from typing import Any
+
+from eq3btsmart import Thermostat
+from eq3btsmart.exceptions import Eq3Exception
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import format_mac
+from homeassistant.helpers.dispatcher import async_dispatcher_send
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import (
+    RECONNECT_INTERVAL,
+    SCAN_INTERVAL,
+    SIGNAL_THERMOSTAT_CONNECTED,
+    SIGNAL_THERMOSTAT_DISCONNECTED,
+)
+from .models import Eq3Config
+
+_LOGGER = logging.getLogger(__name__)
+
+type Eq3ConfigEntry = ConfigEntry[Eq3ConfigEntryData]
+
+
+@dataclass(slots=True)
+class Eq3ConfigEntryData:
+    """Config entry for a single eQ-3 device."""
+
+    eq3_config: Eq3Config
+    thermostat: Thermostat
+    coordinator: Eq3Coordinator
+
+
+class Eq3Coordinator(DataUpdateCoordinator[dict[str, Any]]):
+    """Coordinator for the eq3btsmart integration."""
+
+    config_entry: Eq3ConfigEntry
+
+    def __init__(
+        self, hass: HomeAssistant, entry: Eq3ConfigEntry, mac_address: str
+    ) -> None:
+        """Initialize the coordinator."""
+
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=format_mac(mac_address),
+            update_interval=timedelta(seconds=SCAN_INTERVAL),
+            config_entry=entry,
+            always_update=True,
+        )
+
+        self._mac_address = mac_address
+
+    async def _async_setup(self) -> None:
+        """Connect to the thermostat."""
+
+        self.config_entry.runtime_data.thermostat.register_update_callback(
+            self._async_on_update_received
+        )
+
+        await self._async_reconnect_thermostat()
+
+    async def async_shutdown(self) -> None:
+        """Disconnect from the thermostat."""
+
+        self.config_entry.runtime_data.thermostat.unregister_update_callback(
+            self._async_on_update_received
+        )
+
+        await super().async_shutdown()
+
+    async def _async_update_data(self) -> dict[str, Any]:
+        """Request status update from thermostat."""
+
+        try:
+            await self.config_entry.runtime_data.thermostat.async_get_status()
+        except Eq3Exception as e:
+            if not self.config_entry.runtime_data.thermostat.is_connected:
+                _LOGGER.error(
+                    "[%s] eQ-3 device disconnected",
+                    self._mac_address,
+                )
+                async_dispatcher_send(
+                    self.hass,
+                    f"{SIGNAL_THERMOSTAT_DISCONNECTED}_{self._mac_address}",
+                )
+                await self._async_reconnect_thermostat()
+                return {}
+
+            raise UpdateFailed(f"Error updating eQ-3 device: {e}") from e
+
+        return {}
+
+    async def _async_reconnect_thermostat(self) -> None:
+        """Reconnect the thermostat."""
+
+        while True:
+            try:
+                await self.config_entry.runtime_data.thermostat.async_connect()
+            except Eq3Exception:
+                await asyncio.sleep(RECONNECT_INTERVAL)
+                continue
+
+            _LOGGER.debug(
+                "[%s] eQ-3 device connected",
+                self._mac_address,
+            )
+
+            async_dispatcher_send(
+                self.hass,
+                f"{SIGNAL_THERMOSTAT_CONNECTED}_{self._mac_address}",
+            )
+
+            return
+
+    def _async_on_update_received(self) -> None:
+        """Handle updated data from the thermostat."""
+
+        self.async_set_updated_data({})

--- a/homeassistant/components/eq3btsmart/icons.json
+++ b/homeassistant/components/eq3btsmart/icons.json
@@ -25,11 +25,19 @@
         "default": "mdi:timer-refresh"
       }
     },
+    "sensor": {
+      "away_until": {
+        "default": "mdi:home-export-outline"
+      },
+      "valve": {
+        "default": "mdi:pipe-valve"
+      }
+    },
     "switch": {
       "away": {
         "default": "mdi:home-account",
         "state": {
-          "on": "mdi:home-export"
+          "on": "mdi:home-export-outline"
         }
       },
       "lock": {

--- a/homeassistant/components/eq3btsmart/icons.json
+++ b/homeassistant/components/eq3btsmart/icons.json
@@ -33,6 +33,14 @@
         "default": "mdi:pipe-valve"
       }
     },
+    "sensor": {
+      "away_until": {
+        "default": "mdi:home-export-outline"
+      },
+      "valve": {
+        "default": "mdi:pipe-valve"
+      }
+    },
     "switch": {
       "away": {
         "default": "mdi:home-account",

--- a/homeassistant/components/eq3btsmart/icons.json
+++ b/homeassistant/components/eq3btsmart/icons.json
@@ -33,14 +33,6 @@
         "default": "mdi:pipe-valve"
       }
     },
-    "sensor": {
-      "away_until": {
-        "default": "mdi:home-export-outline"
-      },
-      "valve": {
-        "default": "mdi:pipe-valve"
-      }
-    },
     "switch": {
       "away": {
         "default": "mdi:home-account",

--- a/homeassistant/components/eq3btsmart/models.py
+++ b/homeassistant/components/eq3btsmart/models.py
@@ -2,11 +2,8 @@
 
 from dataclasses import dataclass
 
-from eq3btsmart.thermostat import Thermostat
-
 from .const import (
     DEFAULT_CURRENT_TEMP_SELECTOR,
-    DEFAULT_SCAN_INTERVAL,
     DEFAULT_TARGET_TEMP_SELECTOR,
     CurrentTemperatureSelector,
     TargetTemperatureSelector,
@@ -21,12 +18,3 @@ class Eq3Config:
     current_temp_selector: CurrentTemperatureSelector = DEFAULT_CURRENT_TEMP_SELECTOR
     target_temp_selector: TargetTemperatureSelector = DEFAULT_TARGET_TEMP_SELECTOR
     external_temp_sensor: str = ""
-    scan_interval: int = DEFAULT_SCAN_INTERVAL
-
-
-@dataclass(slots=True)
-class Eq3ConfigEntryData:
-    """Config entry for a single eQ-3 device."""
-
-    eq3_config: Eq3Config
-    thermostat: Thermostat

--- a/homeassistant/components/eq3btsmart/number.py
+++ b/homeassistant/components/eq3btsmart/number.py
@@ -23,7 +23,6 @@ from homeassistant.const import EntityCategory, UnitOfTemperature, UnitOfTime
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import Eq3ConfigEntry
 from .const import (
     ENTITY_KEY_COMFORT,
     ENTITY_KEY_ECO,
@@ -32,6 +31,7 @@ from .const import (
     ENTITY_KEY_WINDOW_OPEN_TIMEOUT,
     EQ3BT_STEP,
 )
+from .coordinator import Eq3ConfigEntry
 from .entity import Eq3Entity
 
 

--- a/homeassistant/components/eq3btsmart/sensor.py
+++ b/homeassistant/components/eq3btsmart/sensor.py
@@ -19,8 +19,8 @@ from homeassistant.const import PERCENTAGE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import Eq3ConfigEntry
 from .const import ENTITY_KEY_AWAY_UNTIL, ENTITY_KEY_VALVE
+from .coordinator import Eq3ConfigEntry
 from .entity import Eq3Entity
 
 

--- a/homeassistant/components/eq3btsmart/sensor.py
+++ b/homeassistant/components/eq3btsmart/sensor.py
@@ -1,0 +1,86 @@
+"""Platform for eq3 sensor entities."""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import date, datetime
+from decimal import Decimal
+from typing import TYPE_CHECKING
+
+from eq3btsmart.models import Status
+
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorEntityDescription,
+    StateType,
+)
+from homeassistant.components.sensor.const import SensorStateClass
+from homeassistant.const import PERCENTAGE
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import Eq3ConfigEntry
+from .const import ENTITY_KEY_AWAY_UNTIL, ENTITY_KEY_VALVE
+from .entity import Eq3Entity
+
+
+@dataclass(frozen=True, kw_only=True)
+class Eq3SensorEntityDescription(SensorEntityDescription):
+    """Entity description for eq3 sensor entities."""
+
+    value_func: Callable[[Status], StateType | date | datetime | Decimal]
+
+
+SENSOR_ENTITY_DESCRIPTIONS = [
+    Eq3SensorEntityDescription(
+        key=ENTITY_KEY_VALVE,
+        translation_key=ENTITY_KEY_VALVE,
+        value_func=lambda status: status.valve,
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    Eq3SensorEntityDescription(
+        key=ENTITY_KEY_AWAY_UNTIL,
+        translation_key=ENTITY_KEY_AWAY_UNTIL,
+        value_func=lambda status: status.away_until.value
+        if status.away_until
+        else None,
+        device_class=SensorDeviceClass.DATE,
+    ),
+]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: Eq3ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the entry."""
+
+    async_add_entities(
+        Eq3SensorEntity(entry, entity_description)
+        for entity_description in SENSOR_ENTITY_DESCRIPTIONS
+    )
+
+
+class Eq3SensorEntity(Eq3Entity, SensorEntity):
+    """Base class for eq3 sensor entities."""
+
+    entity_description: Eq3SensorEntityDescription
+
+    def __init__(
+        self, entry: Eq3ConfigEntry, entity_description: Eq3SensorEntityDescription
+    ) -> None:
+        """Initialize the entity."""
+
+        super().__init__(entry, entity_description.key)
+        self.entity_description = entity_description
+
+    @property
+    def native_value(self) -> StateType | date | datetime | Decimal:
+        """Return the value reported by the sensor."""
+
+        if TYPE_CHECKING:
+            assert self._thermostat.status is not None
+
+        return self.entity_description.value_func(self._thermostat.status)

--- a/homeassistant/components/eq3btsmart/strings.json
+++ b/homeassistant/components/eq3btsmart/strings.json
@@ -42,6 +42,14 @@
         "name": "Window open timeout"
       }
     },
+    "sensor": {
+      "away_until": {
+        "name": "Away until"
+      },
+      "valve": {
+        "name": "Valve"
+      }
+    },
     "switch": {
       "lock": {
         "name": "Lock"

--- a/homeassistant/components/eq3btsmart/strings.json
+++ b/homeassistant/components/eq3btsmart/strings.json
@@ -50,6 +50,14 @@
         "name": "Valve"
       }
     },
+    "sensor": {
+      "away_until": {
+        "name": "Away until"
+      },
+      "valve": {
+        "name": "Valve"
+      }
+    },
     "switch": {
       "lock": {
         "name": "Lock"

--- a/homeassistant/components/eq3btsmart/strings.json
+++ b/homeassistant/components/eq3btsmart/strings.json
@@ -50,14 +50,6 @@
         "name": "Valve"
       }
     },
-    "sensor": {
-      "away_until": {
-        "name": "Away until"
-      },
-      "valve": {
-        "name": "Valve"
-      }
-    },
     "switch": {
       "lock": {
         "name": "Lock"

--- a/homeassistant/components/eq3btsmart/switch.py
+++ b/homeassistant/components/eq3btsmart/switch.py
@@ -11,8 +11,8 @@ from homeassistant.components.switch import SwitchEntity, SwitchEntityDescriptio
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import Eq3ConfigEntry
 from .const import ENTITY_KEY_AWAY, ENTITY_KEY_BOOST, ENTITY_KEY_LOCK
+from .coordinator import Eq3ConfigEntry
 from .entity import Eq3Entity
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR refactors the `eq3btsmart` integration to use a `DataUpdateCoordinator` instead of hardcoding the data update process. This way the user can disable automatic polling and use an automation to update the entities if needed.

Needs #130438 to be merged first.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
