### PR TITLE
Bump aiohttp to 3.10.11

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -5,7 +5,7 @@ aiodiscover==2.1.0
 aiodns==3.2.0
 aiohasupervisor==0.2.1
 aiohttp-fast-zlib==0.1.1
-aiohttp==3.10.11rc0
+aiohttp==3.10.11
 aiohttp_cors==0.7.0
 aiozoneinfo==0.2.1
 astral==2.2

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -5,7 +5,7 @@ aiodiscover==2.1.0
 aiodns==3.2.0
 aiohasupervisor==0.2.1
 aiohttp-fast-zlib==0.1.1
-aiohttp==3.10.10
+aiohttp==3.10.11rc0
 aiohttp_cors==0.7.0
 aiozoneinfo==0.2.1
 astral==2.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies    = [
     # change behavior based on presence of supervisor. Deprecated with #127228
     # Lib can be removed with 2025.11
     "aiohasupervisor==0.2.1",
-    "aiohttp==3.10.11rc0",
+    "aiohttp==3.10.11",
     "aiohttp_cors==0.7.0",
     "aiohttp-fast-zlib==0.1.1",
     "aiozoneinfo==0.2.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies    = [
     # change behavior based on presence of supervisor. Deprecated with #127228
     # Lib can be removed with 2025.11
     "aiohasupervisor==0.2.1",
-    "aiohttp==3.10.10",
+    "aiohttp==3.10.11rc0",
     "aiohttp_cors==0.7.0",
     "aiohttp-fast-zlib==0.1.1",
     "aiozoneinfo==0.2.1",

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@
 # Home Assistant Core
 aiodns==3.2.0
 aiohasupervisor==0.2.1
-aiohttp==3.10.11rc0
+aiohttp==3.10.11
 aiohttp_cors==0.7.0
 aiohttp-fast-zlib==0.1.1
 aiozoneinfo==0.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@
 # Home Assistant Core
 aiodns==3.2.0
 aiohasupervisor==0.2.1
-aiohttp==3.10.10
+aiohttp==3.10.11rc0
 aiohttp_cors==0.7.0
 aiohttp-fast-zlib==0.1.1
 aiozoneinfo==0.2.1

--- a/tests/components/advantage_air/test_binary_sensor.py
+++ b/tests/components/advantage_air/test_binary_sensor.py
@@ -1,10 +1,8 @@
 """Test the Advantage Air Binary Sensor Platform."""
 
 from datetime import timedelta
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
-from homeassistant.components.advantage_air import ADVANTAGE_AIR_SYNC_INTERVAL
-from homeassistant.config_entries import RELOAD_AFTER_UPDATE_DELAY
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -70,22 +68,14 @@ async def test_binary_sensor_async_setup_entry(
     assert not hass.states.get(entity_id)
 
     mock_get.reset_mock()
-    entity_registry.async_update_entity(entity_id=entity_id, disabled_by=None)
-    await hass.async_block_till_done()
 
-    async_fire_time_changed(
-        hass,
-        dt_util.utcnow() + timedelta(seconds=ADVANTAGE_AIR_SYNC_INTERVAL + 1),
-    )
-    await hass.async_block_till_done(wait_background_tasks=True)
-    assert len(mock_get.mock_calls) == 1
+    with patch("homeassistant.config_entries.RELOAD_AFTER_UPDATE_DELAY", 1):
+        entity_registry.async_update_entity(entity_id=entity_id, disabled_by=None)
+        await hass.async_block_till_done()
 
-    async_fire_time_changed(
-        hass,
-        dt_util.utcnow() + timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
-    )
-    await hass.async_block_till_done(wait_background_tasks=True)
-    assert len(mock_get.mock_calls) == 2
+        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=2))
+        await hass.async_block_till_done(wait_background_tasks=True)
+        assert len(mock_get.mock_calls) == 1
 
     state = hass.states.get(entity_id)
     assert state
@@ -101,22 +91,14 @@ async def test_binary_sensor_async_setup_entry(
     assert not hass.states.get(entity_id)
 
     mock_get.reset_mock()
-    entity_registry.async_update_entity(entity_id=entity_id, disabled_by=None)
-    await hass.async_block_till_done()
 
-    async_fire_time_changed(
-        hass,
-        dt_util.utcnow() + timedelta(seconds=ADVANTAGE_AIR_SYNC_INTERVAL + 1),
-    )
-    await hass.async_block_till_done(wait_background_tasks=True)
-    assert len(mock_get.mock_calls) == 1
+    with patch("homeassistant.config_entries.RELOAD_AFTER_UPDATE_DELAY", 1):
+        entity_registry.async_update_entity(entity_id=entity_id, disabled_by=None)
+        await hass.async_block_till_done()
 
-    async_fire_time_changed(
-        hass,
-        dt_util.utcnow() + timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
-    )
-    await hass.async_block_till_done(wait_background_tasks=True)
-    assert len(mock_get.mock_calls) == 2
+        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=2))
+        await hass.async_block_till_done(wait_background_tasks=True)
+        assert len(mock_get.mock_calls) == 1
 
     state = hass.states.get(entity_id)
     assert state

--- a/tests/components/advantage_air/test_sensor.py
+++ b/tests/components/advantage_air/test_sensor.py
@@ -1,15 +1,13 @@
 """Test the Advantage Air Sensor Platform."""
 
 from datetime import timedelta
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
-from homeassistant.components.advantage_air import ADVANTAGE_AIR_SYNC_INTERVAL
 from homeassistant.components.advantage_air.const import DOMAIN as ADVANTAGE_AIR_DOMAIN
 from homeassistant.components.advantage_air.sensor import (
     ADVANTAGE_AIR_SERVICE_SET_TIME_TO,
     ADVANTAGE_AIR_SET_COUNTDOWN_VALUE,
 )
-from homeassistant.config_entries import RELOAD_AFTER_UPDATE_DELAY
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -124,23 +122,15 @@ async def test_sensor_platform_disabled_entity(
 
     assert not hass.states.get(entity_id)
 
-    entity_registry.async_update_entity(entity_id=entity_id, disabled_by=None)
-    await hass.async_block_till_done(wait_background_tasks=True)
     mock_get.reset_mock()
 
-    async_fire_time_changed(
-        hass,
-        dt_util.utcnow() + timedelta(seconds=ADVANTAGE_AIR_SYNC_INTERVAL + 1),
-    )
-    await hass.async_block_till_done(wait_background_tasks=True)
-    assert len(mock_get.mock_calls) == 1
+    with patch("homeassistant.config_entries.RELOAD_AFTER_UPDATE_DELAY", 1):
+        entity_registry.async_update_entity(entity_id=entity_id, disabled_by=None)
+        await hass.async_block_till_done(wait_background_tasks=True)
 
-    async_fire_time_changed(
-        hass,
-        dt_util.utcnow() + timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
-    )
-    await hass.async_block_till_done(wait_background_tasks=True)
-    assert len(mock_get.mock_calls) == 2
+        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=2))
+        await hass.async_block_till_done(wait_background_tasks=True)
+        assert len(mock_get.mock_calls) == 1
 
     state = hass.states.get(entity_id)
     assert state

--- a/tests/components/generic/test_camera.py
+++ b/tests/components/generic/test_camera.py
@@ -275,7 +275,9 @@ async def test_limit_refetch(
 
     with (
         pytest.raises(aiohttp.ServerTimeoutError),
-        patch("asyncio.timeout", side_effect=TimeoutError()),
+        patch.object(
+            client.session._connector, "connect", side_effect=asyncio.TimeoutError
+        ),
     ):
         resp = await client.get("/api/camera_proxy/camera.config_test")
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR is directly to `rc` since `dev` is tracking aiohttp `3.11.x`

Note that there is a fix for the flakey [advantage_air test](https://github.com/home-assistant/core/pull/130483/commits/716c9590c7fdf6c9d1977882ec7874424e21aeee) https://github.com/home-assistant/core/commit/f11aba96486743ca4e8ab40c4d430b840d649a05 while the test has been flakey, some of the internal timing changes in `aiohttp` 3.10.11 (and 3.11.x) made it more likely to fail.

Alternatively https://github.com/home-assistant/core/pull/129735 and https://github.com/home-assistant/core/pull/129758  could be cherry-picked separately.  I included it here to make sure we can get a clean run before proceeding to release aiohttp 3.10.11

changelog: https://github.com/aio-libs/aiohttp/compare/v3.10.10...v3.10.11

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
