### PR TITLE
Simplify modern_forms config flow (part 2)

### DIFF
--- a/homeassistant/components/modern_forms/config_flow.py
+++ b/homeassistant/components/modern_forms/config_flow.py
@@ -30,6 +30,11 @@ class ModernFormsFlowHandler(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle setup by user for Modern Forms integration."""
+        if user_input is None:
+            return self.async_show_form(
+                step_id="user",
+                data_schema=USER_SCHEMA,
+            )
         return await self._handle_config_flow(user_input)
 
     async def async_step_zeroconf(
@@ -66,10 +71,6 @@ class ModernFormsFlowHandler(ConfigFlow, domain=DOMAIN):
                         step_id="zeroconf_confirm",
                         description_placeholders={"name": self.name},
                     )
-                return self.async_show_form(
-                    step_id="user",
-                    data_schema=USER_SCHEMA,
-                )
 
         if self.source == SOURCE_ZEROCONF:
             user_input[CONF_HOST] = self.host

--- a/homeassistant/components/modern_forms/config_flow.py
+++ b/homeassistant/components/modern_forms/config_flow.py
@@ -56,22 +56,18 @@ class ModernFormsFlowHandler(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle a flow initiated by zeroconf."""
+        if user_input is None:
+            return self.async_show_form(
+                step_id="zeroconf_confirm",
+                description_placeholders={"name": self.name},
+            )
         return await self._handle_config_flow(user_input)
 
     async def _handle_config_flow(
-        self, user_input: dict[str, Any] | None = None, prepare: bool = False
+        self, user_input: dict[str, Any], prepare: bool = False
     ) -> ConfigFlowResult:
         """Config flow handler for ModernForms."""
         # Request user input, unless we are preparing discovery flow
-        if user_input is None:
-            user_input = {}
-            if not prepare:
-                if self.source == SOURCE_ZEROCONF:
-                    return self.async_show_form(
-                        step_id="zeroconf_confirm",
-                        description_placeholders={"name": self.name},
-                    )
-
         if self.source == SOURCE_ZEROCONF:
             user_input[CONF_HOST] = self.host
             user_input[CONF_MAC] = self.mac

--- a/homeassistant/components/modern_forms/config_flow.py
+++ b/homeassistant/components/modern_forms/config_flow.py
@@ -22,7 +22,7 @@ class ModernFormsFlowHandler(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
-    host: str | None = None
+    host: str
     mac: str | None = None
     name: str
 
@@ -35,7 +35,8 @@ class ModernFormsFlowHandler(ConfigFlow, domain=DOMAIN):
                 step_id="user",
                 data_schema=USER_SCHEMA,
             )
-        return await self._handle_config_flow(user_input)
+        self.host = user_input[CONF_HOST]
+        return await self._handle_config_flow()
 
     async def async_step_zeroconf(
         self, discovery_info: zeroconf.ZeroconfServiceInfo
@@ -49,32 +50,26 @@ class ModernFormsFlowHandler(ConfigFlow, domain=DOMAIN):
         self.mac = discovery_info.properties.get(CONF_MAC)
         self.name = name
 
-        # Prepare configuration flow
-        return await self._handle_config_flow({}, True)
+        # Loop through self._handle_config_flow to ensure we load the
+        # MAC if it is missing, and abort if already configured
+        return await self._handle_config_flow(True)
 
     async def async_step_zeroconf_confirm(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle a flow initiated by zeroconf."""
-        if user_input is None:
-            return self.async_show_form(
-                step_id="zeroconf_confirm",
-                description_placeholders={"name": self.name},
-            )
-        return await self._handle_config_flow(user_input)
+        return await self._handle_config_flow()
 
     async def _handle_config_flow(
-        self, user_input: dict[str, Any], prepare: bool = False
+        self, initial_zeroconf: bool = False
     ) -> ConfigFlowResult:
         """Config flow handler for ModernForms."""
-        # Request user input, unless we are preparing discovery flow
-        if self.source == SOURCE_ZEROCONF:
-            user_input[CONF_HOST] = self.host
-            user_input[CONF_MAC] = self.mac
-
-        if user_input.get(CONF_MAC) is None or not prepare:
+        if self.mac is None or not initial_zeroconf:
+            # User flow
+            # Or zeroconf without MAC
+            # Or zeroconf with MAC, but need to ensure device is still available
             session = async_get_clientsession(self.hass)
-            device = ModernFormsDevice(user_input[CONF_HOST], session=session)
+            device = ModernFormsDevice(self.host, session=session)
             try:
                 device = await device.update()
             except ModernFormsConnectionError:
@@ -85,20 +80,21 @@ class ModernFormsFlowHandler(ConfigFlow, domain=DOMAIN):
                     data_schema=USER_SCHEMA,
                     errors={"base": "cannot_connect"},
                 )
-            user_input[CONF_MAC] = device.info.mac_address
+            self.mac = device.info.mac_address
+            if self.source != SOURCE_ZEROCONF:
+                self.name = device.info.device_name
 
         # Check if already configured
-        await self.async_set_unique_id(user_input[CONF_MAC])
-        self._abort_if_unique_id_configured(updates={CONF_HOST: user_input[CONF_HOST]})
+        await self.async_set_unique_id(self.mac)
+        self._abort_if_unique_id_configured(updates={CONF_HOST: self.host})
 
-        title = device.info.device_name
-        if self.source == SOURCE_ZEROCONF:
-            title = self.name
-
-        if prepare:
-            return await self.async_step_zeroconf_confirm()
+        if initial_zeroconf:
+            return self.async_show_form(
+                step_id="zeroconf_confirm",
+                description_placeholders={"name": self.name},
+            )
 
         return self.async_create_entry(
-            title=title,
-            data={CONF_HOST: user_input[CONF_HOST], CONF_MAC: user_input[CONF_MAC]},
+            title=self.name,
+            data={CONF_HOST: self.host, CONF_MAC: self.mac},
         )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow-up to #130441

As I was looking at #127103, I found that `_handle_config_flow` is (I think) unnecessarily complicated.

This second step finalises the simplification:
- add comments
- move `user_input is None` check out of `_handle_config_flow` into `async_step_user`
- replace `user_input` with `self.mac` / `self.host` within `_handle_config_flow`
- move `async_show_form("zeroconf_confirm")` from top to bottom of `_handle_config_flow` to avoid secondary loop into `_handle_config_flow`
- adjust type hints for `host` and `name` (to resolve #127103)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
