### PR TITLE
Optionally process media_id in universal media player

### DIFF
--- a/homeassistant/components/universal/media_player.py
+++ b/homeassistant/components/universal/media_player.py
@@ -517,7 +517,7 @@ class UniversalMediaPlayer(MediaPlayerEntity):
         if SERVICE_PLAY_MEDIA in self._cmds:
             flags |= MediaPlayerEntityFeature.PLAY_MEDIA
 
-        if self._browse_media_entity:
+        if self._browse_media_entity or self._process_media_id:
             flags |= MediaPlayerEntityFeature.BROWSE_MEDIA
 
         if SERVICE_CLEAR_PLAYLIST in self._cmds:
@@ -679,6 +679,11 @@ class UniversalMediaPlayer(MediaPlayerEntity):
         ]
         if entity_id and (entity := component.get_entity(entity_id)):
             return await entity.async_browse_media(media_content_type, media_content_id)
+        if self._process_media_id:
+            return await media_source.async_browse_media(
+                self.hass,
+                media_content_id,
+            )
         raise NotImplementedError
 
     @callback

--- a/tests/components/universal/test_media_player.py
+++ b/tests/components/universal/test_media_player.py
@@ -937,6 +937,40 @@ async def test_overrides(hass: HomeAssistant, config_children_and_attr) -> None:
     assert len(service) == 19
 
 
+async def test_process_media_id(hass: HomeAssistant, config_children_and_attr) -> None:
+    """Test play_media override with process_media_id."""
+    config = {
+        "name": "test",
+        "platform": "universal",
+        "process_media_id": "true",
+        "commands": {
+            "play_media": {
+                "service": "test.override",
+                "data": {
+                    "media_content_id": "{{ media_content_id }}",
+                },
+            },
+        },
+    }
+    await async_setup_component(hass, "media_player", {"media_player": config})
+    await async_setup_component(hass, "media_source", {})
+    await hass.async_block_till_done()
+
+    service = async_mock_service(hass, "test", "override")
+    await hass.services.async_call(
+        "media_player",
+        "play_media",
+        service_data={
+            "entity_id": "media_player.test",
+            "media_content_id": "media-source://media_source/local/test.ogg",
+            "media_content_type": "url",
+        },
+        blocking=True,
+    )
+    assert len(service) == 1
+    assert "/media/local/test.ogg?authSig=" in service[0].data["media_content_id"]
+
+
 async def test_supported_features_play_pause(
     hass: HomeAssistant, config_children_and_attr, mock_states
 ) -> None:
@@ -1166,6 +1200,33 @@ async def test_browse_media_override(hass: HomeAssistant) -> None:
         ),
         patch(
             "homeassistant.components.demo.media_player.MediaPlayerEntity.async_browse_media",
+            return_value=MOCK_BROWSE_MEDIA,
+        ),
+    ):
+        result = await ump.async_browse_media()
+        assert result == MOCK_BROWSE_MEDIA
+
+
+async def test_browse_media_fallback(hass: HomeAssistant) -> None:
+    """Test browse media fallback with process_media_id."""
+    await async_setup_component(hass, "homeassistant", {})
+    await async_setup_component(hass, "media_player", {})
+    await async_setup_component(hass, "media_source", {})
+    await hass.async_block_till_done()
+
+    config = {
+        "name": "test",
+        "platform": "universal",
+        "process_media_id": "true",
+    }
+    config = validate_config(config)
+    ump = universal.UniversalMediaPlayer(hass, config)
+    ump.entity_id = media_player.ENTITY_ID_FORMAT.format(config["name"])
+    await ump.async_update()
+
+    with (
+        patch(
+            "homeassistant.components.media_source.async_browse_media",
             return_value=MOCK_BROWSE_MEDIA,
         ),
     ):


### PR DESCRIPTION
Universal media player currently passes through its `media_id` argument unchanged to its children or the `play_media` action sequence which means that a single player in the aggregation not supporting `media_source` or unable to get authenticated urls will be problematic.

In particular, using the universal media player platform to interface with a player controlled by http calls or mqtt messages is rather hard without writing a full integration.

Add a new configuration setting to optionally make universal player resolve internal urls to temporary authenticated ones before delegating to children or scripts. When using that option without a `browse_media_entity`, also provide a default media browsing implementation.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
