### PR TITLE
Use report_usage for deprecation warning in alarm_control_panel

### DIFF
--- a/homeassistant/components/alarm_control_panel/__init__.py
+++ b/homeassistant/components/alarm_control_panel/__init__.py
@@ -180,9 +180,7 @@ class AlarmControlPanelEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_A
         unless already reported.
         """
         if name == "_attr_state":
-            if self.__alarm_legacy_state_reported is not True:
-                self._report_deprecated_alarm_state_handling()
-            self.__alarm_legacy_state_reported = True
+            self._report_deprecated_alarm_state_handling()
         return super().__setattr__(name, value)
 
     @callback

--- a/homeassistant/components/alarm_control_panel/__init__.py
+++ b/homeassistant/components/alarm_control_panel/__init__.py
@@ -35,7 +35,7 @@ from homeassistant.helpers.deprecation import (
 from homeassistant.helpers.entity import Entity, EntityDescription
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.entity_platform import EntityPlatform
-from homeassistant.helpers.frame import report
+from homeassistant.helpers.frame import ReportBehavior, report_usage
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.util.hass_dict import HassKey
 
@@ -203,12 +203,12 @@ class AlarmControlPanelEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_A
 
         Integrations should implement alarm_state instead of using state directly.
         """
-        report(
+        report_usage(
             "is setting state directly which will stop working in HA Core 2025.11."
             f" Entity {self.entity_id} ({type(self)}) should implement the 'alarm_state'"
             " property and return its state using the AlarmControlPanelState enum.",
-            error_if_core=True,
-            error_if_integration=False,
+            core_integration_behavior=ReportBehavior.ERROR,
+            custom_integration_behavior=ReportBehavior.ERROR,
         )
 
     @final

--- a/homeassistant/components/alarm_control_panel/__init__.py
+++ b/homeassistant/components/alarm_control_panel/__init__.py
@@ -202,12 +202,13 @@ class AlarmControlPanelEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_A
         Integrations should implement alarm_state instead of using state directly.
         """
         report_usage(
-            "is setting state directly which will stop working."
+            "is setting state directly."
             f" Entity {self.entity_id} ({type(self)}) should implement the 'alarm_state'"
-            " property and return its state using the AlarmControlPanelState enum.",
+            " property and return its state using theg AlarmControlPanelState enum",
             core_integration_behavior=ReportBehavior.ERROR,
             custom_integration_behavior=ReportBehavior.LOG,
             breaks_in_ha_version="2025.11",
+            integration_domain=self.platform.platform_name if self.platform else None,
         )
 
     @final

--- a/homeassistant/components/alarm_control_panel/__init__.py
+++ b/homeassistant/components/alarm_control_panel/__init__.py
@@ -208,7 +208,7 @@ class AlarmControlPanelEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_A
             f" Entity {self.entity_id} ({type(self)}) should implement the 'alarm_state'"
             " property and return its state using the AlarmControlPanelState enum.",
             core_integration_behavior=ReportBehavior.ERROR,
-            custom_integration_behavior=ReportBehavior.ERROR,
+            custom_integration_behavior=ReportBehavior.LOG,
         )
 
     @final

--- a/homeassistant/components/alarm_control_panel/__init__.py
+++ b/homeassistant/components/alarm_control_panel/__init__.py
@@ -204,7 +204,7 @@ class AlarmControlPanelEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_A
         report_usage(
             "is setting state directly."
             f" Entity {self.entity_id} ({type(self)}) should implement the 'alarm_state'"
-            " property and return its state using theg AlarmControlPanelState enum",
+            " property and return its state using the AlarmControlPanelState enum",
             core_integration_behavior=ReportBehavior.ERROR,
             custom_integration_behavior=ReportBehavior.LOG,
             breaks_in_ha_version="2025.11",

--- a/homeassistant/components/alarm_control_panel/__init__.py
+++ b/homeassistant/components/alarm_control_panel/__init__.py
@@ -209,6 +209,7 @@ class AlarmControlPanelEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_A
             custom_integration_behavior=ReportBehavior.LOG,
             breaks_in_ha_version="2025.11",
             integration_domain=self.platform.platform_name if self.platform else None,
+            exclude_integrations={DOMAIN},
         )
 
     @final

--- a/homeassistant/components/alarm_control_panel/__init__.py
+++ b/homeassistant/components/alarm_control_panel/__init__.py
@@ -35,6 +35,7 @@ from homeassistant.helpers.deprecation import (
 from homeassistant.helpers.entity import Entity, EntityDescription
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.entity_platform import EntityPlatform
+from homeassistant.helpers.frame import report
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.util.hass_dict import HassKey
 
@@ -163,7 +164,6 @@ class AlarmControlPanelEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_A
     _alarm_control_panel_option_default_code: str | None = None
 
     __alarm_legacy_state: bool = False
-    __alarm_legacy_state_reported: bool = False
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
         """Post initialisation processing."""
@@ -194,7 +194,7 @@ class AlarmControlPanelEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_A
     ) -> None:
         """Start adding an entity to a platform."""
         super().add_to_platform_start(hass, platform, parallel_updates)
-        if self.__alarm_legacy_state and not self.__alarm_legacy_state_reported:
+        if self.__alarm_legacy_state:
             self._report_deprecated_alarm_state_handling()
 
     @callback
@@ -203,19 +203,13 @@ class AlarmControlPanelEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_A
 
         Integrations should implement alarm_state instead of using state directly.
         """
-        self.__alarm_legacy_state_reported = True
-        if "custom_components" in type(self).__module__:
-            # Do not report on core integrations as they have been fixed.
-            report_issue = "report it to the custom integration author."
-            _LOGGER.warning(
-                "Entity %s (%s) is setting state directly"
-                " which will stop working in HA Core 2025.11."
-                " Entities should implement the 'alarm_state' property and"
-                " return its state using the AlarmControlPanelState enum, please %s",
-                self.entity_id,
-                type(self),
-                report_issue,
-            )
+        report(
+            "is setting state directly which will stop working in HA Core 2025.11."
+            f" Entity {self.entity_id} ({type(self)}) should implement the 'alarm_state'"
+            " property and return its state using the AlarmControlPanelState enum.",
+            error_if_core=True,
+            error_if_integration=False,
+        )
 
     @final
     @property

--- a/homeassistant/components/alarm_control_panel/__init__.py
+++ b/homeassistant/components/alarm_control_panel/__init__.py
@@ -202,11 +202,12 @@ class AlarmControlPanelEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_A
         Integrations should implement alarm_state instead of using state directly.
         """
         report_usage(
-            "is setting state directly which will stop working in HA Core 2025.11."
+            "is setting state directly which will stop working."
             f" Entity {self.entity_id} ({type(self)}) should implement the 'alarm_state'"
             " property and return its state using the AlarmControlPanelState enum.",
             core_integration_behavior=ReportBehavior.ERROR,
             custom_integration_behavior=ReportBehavior.LOG,
+            breaks_in_ha_version="2025.11",
         )
 
     @final

--- a/tests/components/alarm_control_panel/conftest.py
+++ b/tests/components/alarm_control_panel/conftest.py
@@ -1,7 +1,7 @@
 """Fixturs for Alarm Control Panel tests."""
 
-from collections.abc import Generator
-from unittest.mock import MagicMock
+from collections.abc import AsyncGenerator, Generator
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -13,7 +13,7 @@ from homeassistant.components.alarm_control_panel import (
 from homeassistant.components.alarm_control_panel.const import CodeFormat
 from homeassistant.config_entries import ConfigEntry, ConfigFlow
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import entity_registry as er, frame
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .common import MockAlarm
@@ -105,6 +105,22 @@ class MockAlarmControlPanel(AlarmControlPanelEntity):
 
 class MockFlow(ConfigFlow):
     """Test flow."""
+
+
+@pytest.fixture(name="mock_as_custom_component")
+async def mock_frame(hass: HomeAssistant) -> AsyncGenerator[None]:
+    """Mock frame."""
+    with patch(
+        "homeassistant.helpers.frame.get_integration_frame",
+        return_value=frame.IntegrationFrame(
+            custom_integration=True,
+            integration="alarm_control_panel",
+            module="test_init.py",
+            relative_filename="test_init.py",
+            frame=frame.get_current_frame(),
+        ),
+    ):
+        yield
 
 
 @pytest.fixture(autouse=True)

--- a/tests/components/alarm_control_panel/test_init.py
+++ b/tests/components/alarm_control_panel/test_init.py
@@ -312,6 +312,7 @@ async def test_alarm_control_panel_not_log_deprecated_state_warning(
     )
 
 
+@pytest.mark.usefixtures("mock_as_custom_component")
 @patch.object(frame, "_REPORTED_INTEGRATIONS", set())
 async def test_alarm_control_panel_log_deprecated_state_warning_using_state_prop(
     hass: HomeAssistant,
@@ -337,6 +338,7 @@ async def test_alarm_control_panel_log_deprecated_state_warning_using_state_prop
             TEST_DOMAIN,
             async_setup_entry=async_setup_entry_init,
         ),
+        built_in=False,
     )
 
     class MockLegacyAlarmControlPanel(MockAlarmControlPanel):
@@ -378,15 +380,10 @@ async def test_alarm_control_panel_log_deprecated_state_warning_using_state_prop
         MockPlatform(async_setup_entry=async_setup_entry_platform),
     )
 
-    with patch.object(
-        MockLegacyAlarmControlPanel,
-        "__module__",
-        "tests.custom_components.test.alarm_control_panel",
-    ):
-        config_entry = MockConfigEntry(domain=TEST_DOMAIN)
-        config_entry.add_to_hass(hass)
-        assert await hass.config_entries.async_setup(config_entry.entry_id)
-        await hass.async_block_till_done()
+    config_entry = MockConfigEntry(domain=TEST_DOMAIN)
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
 
     state = hass.states.get(entity.entity_id)
     assert state is not None
@@ -397,6 +394,7 @@ async def test_alarm_control_panel_log_deprecated_state_warning_using_state_prop
     )
 
 
+@pytest.mark.usefixtures("mock_as_custom_component")
 @patch.object(frame, "_REPORTED_INTEGRATIONS", set())
 async def test_alarm_control_panel_log_deprecated_state_warning_using_attr_state_attr(
     hass: HomeAssistant,
@@ -462,15 +460,10 @@ async def test_alarm_control_panel_log_deprecated_state_warning_using_attr_state
         MockPlatform(async_setup_entry=async_setup_entry_platform),
     )
 
-    with patch.object(
-        MockLegacyAlarmControlPanel,
-        "__module__",
-        "tests.custom_components.test.alarm_control_panel",
-    ):
-        config_entry = MockConfigEntry(domain=TEST_DOMAIN)
-        config_entry.add_to_hass(hass)
-        assert await hass.config_entries.async_setup(config_entry.entry_id)
-        await hass.async_block_till_done()
+    config_entry = MockConfigEntry(domain=TEST_DOMAIN)
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
 
     state = hass.states.get(entity.entity_id)
     assert state is not None
@@ -480,28 +473,18 @@ async def test_alarm_control_panel_log_deprecated_state_warning_using_attr_state
         not in caplog.text
     )
 
-    with patch.object(
-        MockLegacyAlarmControlPanel,
-        "__module__",
-        "tests.custom_components.test.alarm_control_panel",
-    ):
-        await help_test_async_alarm_control_panel_service(
-            hass, entity.entity_id, SERVICE_ALARM_DISARM
-        )
+    await help_test_async_alarm_control_panel_service(
+        hass, entity.entity_id, SERVICE_ALARM_DISARM
+    )
 
     assert (
         "the 'alarm_state' property and return its state using the AlarmControlPanelState enum"
         in caplog.text
     )
     caplog.clear()
-    with patch.object(
-        MockLegacyAlarmControlPanel,
-        "__module__",
-        "tests.custom_components.test.alarm_control_panel",
-    ):
-        await help_test_async_alarm_control_panel_service(
-            hass, entity.entity_id, SERVICE_ALARM_DISARM
-        )
+    await help_test_async_alarm_control_panel_service(
+        hass, entity.entity_id, SERVICE_ALARM_DISARM
+    )
     # Test we only log once
     assert (
         "the 'alarm_state' property and return its state using the AlarmControlPanelState enum"
@@ -509,6 +492,7 @@ async def test_alarm_control_panel_log_deprecated_state_warning_using_attr_state
     )
 
 
+@pytest.mark.usefixtures("mock_as_custom_component")
 @patch.object(frame, "_REPORTED_INTEGRATIONS", set())
 async def test_alarm_control_panel_deprecated_state_does_not_break_state(
     hass: HomeAssistant,
@@ -575,28 +559,18 @@ async def test_alarm_control_panel_deprecated_state_does_not_break_state(
         MockPlatform(async_setup_entry=async_setup_entry_platform),
     )
 
-    with patch.object(
-        MockLegacyAlarmControlPanel,
-        "__module__",
-        "tests.custom_components.test.alarm_control_panel",
-    ):
-        config_entry = MockConfigEntry(domain=TEST_DOMAIN)
-        config_entry.add_to_hass(hass)
-        assert await hass.config_entries.async_setup(config_entry.entry_id)
-        await hass.async_block_till_done()
+    config_entry = MockConfigEntry(domain=TEST_DOMAIN)
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
 
     state = hass.states.get(entity.entity_id)
     assert state is not None
     assert state.state == "armed_away"
 
-    with patch.object(
-        MockLegacyAlarmControlPanel,
-        "__module__",
-        "tests.custom_components.test.alarm_control_panel",
-    ):
-        await help_test_async_alarm_control_panel_service(
-            hass, entity.entity_id, SERVICE_ALARM_DISARM
-        )
+    await help_test_async_alarm_control_panel_service(
+        hass, entity.entity_id, SERVICE_ALARM_DISARM
+    )
 
     state = hass.states.get(entity.entity_id)
     assert state is not None

--- a/tests/components/alarm_control_panel/test_init.py
+++ b/tests/components/alarm_control_panel/test_init.py
@@ -25,7 +25,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import entity_registry as er, frame
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import UNDEFINED, UndefinedType
 
@@ -297,6 +297,7 @@ async def test_alarm_control_panel_with_default_code(
     mock_alarm_control_panel_entity.calls_disarm.assert_called_with("1234")
 
 
+@patch.object(frame, "_REPORTED_INTEGRATIONS", set())
 async def test_alarm_control_panel_not_log_deprecated_state_warning(
     hass: HomeAssistant,
     mock_alarm_control_panel_entity: MockAlarmControlPanel,
@@ -305,9 +306,13 @@ async def test_alarm_control_panel_not_log_deprecated_state_warning(
     """Test correctly using alarm_state doesn't log issue or raise repair."""
     state = hass.states.get(mock_alarm_control_panel_entity.entity_id)
     assert state is not None
-    assert "Entities should implement the 'alarm_state' property and" not in caplog.text
+    assert (
+        "the 'alarm_state' property and return its state using the AlarmControlPanelState enum"
+        not in caplog.text
+    )
 
 
+@patch.object(frame, "_REPORTED_INTEGRATIONS", set())
 async def test_alarm_control_panel_log_deprecated_state_warning_using_state_prop(
     hass: HomeAssistant,
     code_format: CodeFormat | None,
@@ -386,9 +391,13 @@ async def test_alarm_control_panel_log_deprecated_state_warning_using_state_prop
     state = hass.states.get(entity.entity_id)
     assert state is not None
 
-    assert "Entities should implement the 'alarm_state' property and" in caplog.text
+    assert (
+        "the 'alarm_state' property and return its state using the AlarmControlPanelState enum"
+        in caplog.text
+    )
 
 
+@patch.object(frame, "_REPORTED_INTEGRATIONS", set())
 async def test_alarm_control_panel_log_deprecated_state_warning_using_attr_state_attr(
     hass: HomeAssistant,
     code_format: CodeFormat | None,
@@ -466,7 +475,10 @@ async def test_alarm_control_panel_log_deprecated_state_warning_using_attr_state
     state = hass.states.get(entity.entity_id)
     assert state is not None
 
-    assert "Entities should implement the 'alarm_state' property and" not in caplog.text
+    assert (
+        "the 'alarm_state' property and return its state using the AlarmControlPanelState enum"
+        not in caplog.text
+    )
 
     with patch.object(
         MockLegacyAlarmControlPanel,
@@ -477,7 +489,10 @@ async def test_alarm_control_panel_log_deprecated_state_warning_using_attr_state
             hass, entity.entity_id, SERVICE_ALARM_DISARM
         )
 
-    assert "Entities should implement the 'alarm_state' property and" in caplog.text
+    assert (
+        "the 'alarm_state' property and return its state using the AlarmControlPanelState enum"
+        in caplog.text
+    )
     caplog.clear()
     with patch.object(
         MockLegacyAlarmControlPanel,
@@ -488,9 +503,13 @@ async def test_alarm_control_panel_log_deprecated_state_warning_using_attr_state
             hass, entity.entity_id, SERVICE_ALARM_DISARM
         )
     # Test we only log once
-    assert "Entities should implement the 'alarm_state' property and" not in caplog.text
+    assert (
+        "the 'alarm_state' property and return its state using the AlarmControlPanelState enum"
+        not in caplog.text
+    )
 
 
+@patch.object(frame, "_REPORTED_INTEGRATIONS", set())
 async def test_alarm_control_panel_deprecated_state_does_not_break_state(
     hass: HomeAssistant,
     code_format: CodeFormat | None,

--- a/tests/components/alarm_control_panel/test_init.py
+++ b/tests/components/alarm_control_panel/test_init.py
@@ -392,7 +392,7 @@ async def test_alarm_control_panel_log_deprecated_state_warning_using_state_prop
         "Detected that custom integration 'alarm_control_panel' is setting state directly."
         " Entity None (<class 'tests.components.alarm_control_panel.test_init."
         "test_alarm_control_panel_log_deprecated_state_warning_using_state_prop.<locals>.MockLegacyAlarmControlPanel'>)"
-        " should implement the 'alarm_state' property and return its state using theg AlarmControlPanelState enum"
+        " should implement the 'alarm_state' property and return its state using the AlarmControlPanelState enum"
         " at test_init.py, line 123: yield. This will stop working in Home Assistant 2025.11, please create a bug report at"
         in caplog.text
     )
@@ -486,7 +486,7 @@ async def test_alarm_control_panel_log_deprecated_state_warning_using_attr_state
         " Entity alarm_control_panel.test_alarm_control_panel"
         " (<class 'tests.components.alarm_control_panel.test_init."
         "test_alarm_control_panel_log_deprecated_state_warning_using_attr_state_attr.<locals>.MockLegacyAlarmControlPanel'>)"
-        " should implement the 'alarm_state' property and return its state using theg AlarmControlPanelState enum"
+        " should implement the 'alarm_state' property and return its state using the AlarmControlPanelState enum"
         " at test_init.py, line 123: yield. This will stop working in Home Assistant 2025.11, please create a bug report at"
         in caplog.text
     )

--- a/tests/components/alarm_control_panel/test_init.py
+++ b/tests/components/alarm_control_panel/test_init.py
@@ -389,7 +389,11 @@ async def test_alarm_control_panel_log_deprecated_state_warning_using_state_prop
     assert state is not None
 
     assert (
-        "the 'alarm_state' property and return its state using the AlarmControlPanelState enum"
+        "Detected that custom integration 'alarm_control_panel' is setting state directly."
+        " Entity None (<class 'tests.components.alarm_control_panel.test_init."
+        "test_alarm_control_panel_log_deprecated_state_warning_using_state_prop.<locals>.MockLegacyAlarmControlPanel'>)"
+        " should implement the 'alarm_state' property and return its state using theg AlarmControlPanelState enum"
+        " at test_init.py, line 123: yield. This will stop working in Home Assistant 2025.11, please create a bug report at"
         in caplog.text
     )
 
@@ -469,7 +473,7 @@ async def test_alarm_control_panel_log_deprecated_state_warning_using_attr_state
     assert state is not None
 
     assert (
-        "the 'alarm_state' property and return its state using the AlarmControlPanelState enum"
+        "Detected that custom integration 'alarm_control_panel' is setting state directly."
         not in caplog.text
     )
 
@@ -478,7 +482,12 @@ async def test_alarm_control_panel_log_deprecated_state_warning_using_attr_state
     )
 
     assert (
-        "the 'alarm_state' property and return its state using the AlarmControlPanelState enum"
+        "Detected that custom integration 'alarm_control_panel' is setting state directly."
+        " Entity alarm_control_panel.test_alarm_control_panel"
+        " (<class 'tests.components.alarm_control_panel.test_init."
+        "test_alarm_control_panel_log_deprecated_state_warning_using_attr_state_attr.<locals>.MockLegacyAlarmControlPanel'>)"
+        " should implement the 'alarm_state' property and return its state using theg AlarmControlPanelState enum"
+        " at test_init.py, line 123: yield. This will stop working in Home Assistant 2025.11, please create a bug report at"
         in caplog.text
     )
     caplog.clear()
@@ -487,7 +496,7 @@ async def test_alarm_control_panel_log_deprecated_state_warning_using_attr_state
     )
     # Test we only log once
     assert (
-        "the 'alarm_state' property and return its state using the AlarmControlPanelState enum"
+        "Detected that custom integration 'alarm_control_panel' is setting state directly."
         not in caplog.text
     )
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use `frame. report_usage ` helper instead for deprecation notice in `alarm_control_panel`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 