### PR TITLE
Make BackupSyncMetadata model a dataclass

### DIFF
--- a/homeassistant/components/backup/manager.py
+++ b/homeassistant/components/backup/manager.py
@@ -32,7 +32,7 @@ from homeassistant.util import dt as dt_util
 from homeassistant.util.json import json_loads_object
 
 from .const import DOMAIN, EXCLUDE_FROM_BACKUP, LOGGER
-from .models import BaseBackup
+from .models import BackupSyncMetadata, BaseBackup
 from .sync_agent import BackupPlatformAgentProtocol, BackupSyncAgent
 
 BUF_SIZE = 2**20 * 4  # 4MB
@@ -238,13 +238,13 @@ class BackupManager(BaseBackupManager[Backup]):
             *(
                 agent.async_upload_backup(
                     path=backup.path,
-                    metadata={
-                        "homeassistant": HAVERSION,
-                        "size": backup.size,
-                        "date": backup.date,
-                        "slug": backup.slug,
-                        "name": backup.name,
-                    },
+                    metadata=BackupSyncMetadata(
+                        homeassistant=HAVERSION,
+                        size=backup.size,
+                        date=backup.date,
+                        slug=backup.slug,
+                        name=backup.name,
+                    ),
                 )
                 for agent in self.sync_agents.values()
             ),

--- a/homeassistant/components/backup/models.py
+++ b/homeassistant/components/backup/models.py
@@ -1,7 +1,6 @@
 """Models for the backup integration."""
 
 from dataclasses import asdict, dataclass
-from typing import TypedDict
 
 
 @dataclass()
@@ -18,8 +17,9 @@ class BaseBackup:
         return asdict(self)
 
 
-class BackupSyncMetadata(TypedDict):
-    """Dictionary type for backup sync metadata."""
+@dataclass()
+class BackupSyncMetadata:
+    """Backup sync metadata."""
 
     date: str  # The date the backup was created
     slug: str  # The slug of the backup

--- a/homeassistant/components/kitchen_sink/backup.py
+++ b/homeassistant/components/kitchen_sink/backup.py
@@ -62,10 +62,10 @@ class KitchenSinkBackupSyncAgent(BackupSyncAgent):
         self._uploads.append(
             SyncedBackup(
                 id=uuid4().hex,
-                name=metadata["name"],
-                slug=metadata["slug"],
-                size=metadata["size"],
-                date=metadata["date"],
+                name=metadata.name,
+                slug=metadata.slug,
+                size=metadata.size,
+                date=metadata.date,
             )
         )
 

--- a/tests/components/backup/test_manager.py
+++ b/tests/components/backup/test_manager.py
@@ -10,7 +10,7 @@ import aiohttp
 from multidict import CIMultiDict, CIMultiDictProxy
 import pytest
 
-from homeassistant.components.backup import BackupManager
+from homeassistant.components.backup import BackupManager, BackupSyncMetadata
 from homeassistant.components.backup.manager import (
     BackupPlatformProtocol,
     BackupProgress,
@@ -299,13 +299,13 @@ async def test_syncing_backup(
         assert mocked_upload.call_count == 2
         first_call = mocked_upload.call_args_list[0]
         assert first_call[1]["path"] == backup.path
-        assert first_call[1]["metadata"] == {
-            "date": backup.date,
-            "homeassistant": "2025.1.0",
-            "name": backup.name,
-            "size": backup.size,
-            "slug": backup.slug,
-        }
+        assert first_call[1]["metadata"] == BackupSyncMetadata(
+            date=backup.date,
+            homeassistant="2025.1.0",
+            name=backup.name,
+            size=backup.size,
+            slug=backup.slug,
+        )
 
     assert "Error during backup sync" not in caplog.text
 
@@ -361,13 +361,13 @@ async def test_syncing_backup_with_exception(
         assert mocked_upload.call_count == 2
         first_call = mocked_upload.call_args_list[0]
         assert first_call[1]["path"] == backup.path
-        assert first_call[1]["metadata"] == {
-            "date": backup.date,
-            "homeassistant": "2025.1.0",
-            "name": backup.name,
-            "size": backup.size,
-            "slug": backup.slug,
-        }
+        assert first_call[1]["metadata"] == BackupSyncMetadata(
+            date=backup.date,
+            homeassistant="2025.1.0",
+            name=backup.name,
+            size=backup.size,
+            slug=backup.slug,
+        )
 
     assert "Error during backup sync - Test exception" in caplog.text
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- A dataclass has a nicer interface than a dict. We don't need any dict-features for this model.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
