### PR TITLE
KNX: Cache last telegram for each group address

### DIFF
--- a/homeassistant/components/knx/const.py
+++ b/homeassistant/components/knx/const.py
@@ -52,8 +52,8 @@ CONF_KNX_DEFAULT_RATE_LIMIT: Final = 0
 DEFAULT_ROUTING_IA: Final = "0.0.240"
 
 CONF_KNX_TELEGRAM_LOG_SIZE: Final = "telegram_log_size"
-TELEGRAM_LOG_DEFAULT: Final = 200
-TELEGRAM_LOG_MAX: Final = 5000  # ~2 MB or ~5 hours of reasonable bus load
+TELEGRAM_LOG_DEFAULT: Final = 1000
+TELEGRAM_LOG_MAX: Final = 25000  # ~10 MB or ~25 hours of reasonable bus load
 
 ##
 # Secure constants

--- a/homeassistant/components/knx/telegrams.py
+++ b/homeassistant/components/knx/telegrams.py
@@ -75,6 +75,7 @@ class Telegrams:
             )
         )
         self.recent_telegrams: deque[TelegramDict] = deque(maxlen=log_size)
+        self.last_ga_telegrams: dict[str, TelegramDict] = {}
 
     async def load_history(self) -> None:
         """Load history from store."""
@@ -88,6 +89,9 @@ class Telegrams:
             if isinstance(telegram["payload"], list):
                 telegram["payload"] = tuple(telegram["payload"])  # type: ignore[unreachable]
         self.recent_telegrams.extend(telegrams)
+        self.last_ga_telegrams = {
+            t["source"]: t for t in telegrams if t["payload"] is not None
+        }
 
     async def save_history(self) -> None:
         """Save history to store."""
@@ -98,6 +102,9 @@ class Telegrams:
         """Handle incoming and outgoing telegrams from xknx."""
         telegram_dict = self.telegram_to_dict(telegram)
         self.recent_telegrams.append(telegram_dict)
+        if telegram_dict["payload"] is not None:
+            # exclude GroupValueRead telegrams
+            self.last_ga_telegrams[telegram_dict["destination"]] = telegram_dict
         async_dispatcher_send(self.hass, SIGNAL_KNX_TELEGRAM, telegram, telegram_dict)
 
     def telegram_to_dict(self, telegram: Telegram) -> TelegramDict:

--- a/homeassistant/components/knx/telegrams.py
+++ b/homeassistant/components/knx/telegrams.py
@@ -90,7 +90,7 @@ class Telegrams:
                 telegram["payload"] = tuple(telegram["payload"])  # type: ignore[unreachable]
         self.recent_telegrams.extend(telegrams)
         self.last_ga_telegrams = {
-            t["source"]: t for t in telegrams if t["payload"] is not None
+            t["destination"]: t for t in telegrams if t["payload"] is not None
         }
 
     async def save_history(self) -> None:

--- a/homeassistant/components/knx/websocket.py
+++ b/homeassistant/components/knx/websocket.py
@@ -47,6 +47,7 @@ async def register_panel(hass: HomeAssistant) -> None:
     websocket_api.async_register_command(hass, ws_project_file_process)
     websocket_api.async_register_command(hass, ws_project_file_remove)
     websocket_api.async_register_command(hass, ws_group_monitor_info)
+    websocket_api.async_register_command(hass, ws_group_telegrams)
     websocket_api.async_register_command(hass, ws_subscribe_telegram)
     websocket_api.async_register_command(hass, ws_get_knx_project)
     websocket_api.async_register_command(hass, ws_validate_entity)
@@ -284,6 +285,27 @@ def ws_group_monitor_info(
             "project_loaded": knx.project.loaded,
             "recent_telegrams": recent_telegrams,
         },
+    )
+
+
+@websocket_api.require_admin
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "knx/group_telegrams",
+    }
+)
+@provide_knx
+@callback
+def ws_group_telegrams(
+    hass: HomeAssistant,
+    knx: KNXModule,
+    connection: websocket_api.ActiveConnection,
+    msg: dict,
+) -> None:
+    """Handle get group telegrams command."""
+    connection.send_result(
+        msg["id"],
+        knx.telegrams.last_ga_telegrams,
     )
 
 

--- a/tests/components/knx/test_config_flow.py
+++ b/tests/components/knx/test_config_flow.py
@@ -913,7 +913,7 @@ async def test_form_with_automatic_connection_handling(
         CONF_KNX_ROUTE_BACK: False,
         CONF_KNX_TUNNEL_ENDPOINT_IA: None,
         CONF_KNX_STATE_UPDATER: True,
-        CONF_KNX_TELEGRAM_LOG_SIZE: 200,
+        CONF_KNX_TELEGRAM_LOG_SIZE: 1000,
     }
     knx_setup.assert_called_once()
 
@@ -1210,7 +1210,7 @@ async def test_options_flow_connection_type(
             CONF_KNX_SECURE_DEVICE_AUTHENTICATION: None,
             CONF_KNX_SECURE_USER_ID: None,
             CONF_KNX_SECURE_USER_PASSWORD: None,
-            CONF_KNX_TELEGRAM_LOG_SIZE: 200,
+            CONF_KNX_TELEGRAM_LOG_SIZE: 1000,
         }
 
 

--- a/tests/components/knx/test_websocket.py
+++ b/tests/components/knx/test_websocket.py
@@ -180,6 +180,37 @@ async def test_knx_group_monitor_info_command(
     assert res["result"]["recent_telegrams"] == []
 
 
+async def test_knx_group_telegrams_command(
+    hass: HomeAssistant, knx: KNXTestKit, hass_ws_client: WebSocketGenerator
+) -> None:
+    """Test knx/group_telegrams command."""
+    await knx.setup_integration({})
+    client = await hass_ws_client(hass)
+
+    await client.send_json_auto_id({"type": "knx/group_telegrams"})
+    res = await client.receive_json()
+    assert res["success"], res
+    assert res["result"] == {}
+
+    # # get some telegrams to populate the cache
+    await knx.receive_write("1/1/1", True)
+    await knx.receive_read("2/2/2")  # read telegram shall be ignored
+    await knx.receive_write("3/3/3", 0x34)
+
+    await client.send_json_auto_id({"type": "knx/group_telegrams"})
+    res = await client.receive_json()
+    assert res["success"], res
+    assert len(res["result"]) == 2
+    assert "1/1/1" in res["result"]
+    assert res["result"]["1/1/1"]["destination"] == "1/1/1"
+    assert "3/3/3" in res["result"]
+    assert res["result"]["3/3/3"]["payload"] == 52
+    assert res["result"]["3/3/3"]["telegramtype"] == "GroupValueWrite"
+    assert res["result"]["3/3/3"]["source"] == "1.2.3"
+    assert res["result"]["3/3/3"]["direction"] == "Incoming"
+    assert res["result"]["3/3/3"]["timestamp"] is not None
+
+
 async def test_knx_subscribe_telegrams_command_recent_telegrams(
     hass: HomeAssistant, knx: KNXTestKit, hass_ws_client: WebSocketGenerator
 ) -> None:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Cache last telegram for each group address
- Add new WS command to fetch the telegram cache. This will be used by the next `knx-frontend` update. See https://github.com/XKNX/knx-frontend/pull/181
- Increase maximum telegram log size by 5x and default value to 1000 telegrams

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
