### PR TITLE
Log a warning when replacing existing config entry with same unique id

### DIFF
--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -35,7 +35,6 @@ from .const import (
     CONF_NAME,
     EVENT_HOMEASSISTANT_STARTED,
     EVENT_HOMEASSISTANT_STOP,
-    PATCH_VERSION,
     Platform,
 )
 from .core import (

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1487,9 +1487,9 @@ class ConfigEntriesFlowManager(
                 result["handler"], flow.unique_id
             )
 
-        if existing_entry is not None and PATCH_VERSION == "0.dev0":
-            # We temporarily restrict this to `dev` to get a feel for how many
-            # integrations this concerns
+        if existing_entry is not None:
+            # `mobile_app` does this on purpose
+            # if too many integrations are impacted, we may need to reconsider
             report_usage(
                 "creates a config entry when another entry with the same unique ID "
                 "exists, causing the old entry to be removed and replaced when it "

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1494,7 +1494,7 @@ class ConfigEntriesFlowManager(
                 "exists",
                 core_behavior=ReportBehavior.LOG,
                 core_integration_behavior=ReportBehavior.LOG,
-                custom_integration_behavior=ReportBehavior.IGNORE,
+                custom_integration_behavior=ReportBehavior.LOG,
                 integration_domain=flow.handler,
             )
 

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1486,9 +1486,8 @@ class ConfigEntriesFlowManager(
                 result["handler"], flow.unique_id
             )
 
-        if existing_entry is not None:
+        if existing_entry is not None and self.handler != "mobile_app":
             # `mobile_app` does this on purpose
-            # if too many integrations are impacted, we may need to reconsider
             report_usage(
                 "creates a config entry when another entry with the same unique ID "
                 "exists, causing the old entry to be removed and replaced when it "
@@ -1496,7 +1495,7 @@ class ConfigEntriesFlowManager(
                 core_behavior=ReportBehavior.LOG,
                 core_integration_behavior=ReportBehavior.LOG,
                 custom_integration_behavior=ReportBehavior.IGNORE,
-                exclude_integrations={"mobile_app"},
+                integration_domain=self.handler,
             )
 
         # Unload the entry before setting up the new one.

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1487,8 +1487,12 @@ class ConfigEntriesFlowManager(
             )
 
         if existing_entry is not None and flow.handler != "mobile_app":
-            # This causes the old entry to be removed and replaced when it
-            # should most likely update the previous entry and abort the flow
+            # This causes the old entry to be removed and replaced, when the flow
+            # should instead be aborted.
+            # In case of manual flows, integrations should implement options, reauth,
+            # reconfigure to allow the user to change settings.
+            # In case of non user visible flows, the integration should optionally
+            # update the existing entry before aborting.
             # see https://developers.home-assistant.io/blog/2024/11/22/config-flow-unique-id/
             report_usage(
                 "creates a config entry when another entry with the same unique ID "

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1493,7 +1493,7 @@ class ConfigEntriesFlowManager(
             # reconfigure to allow the user to change settings.
             # In case of non user visible flows, the integration should optionally
             # update the existing entry before aborting.
-            # see https://developers.home-assistant.io/blog/2024/11/22/config-flow-unique-id/
+            # see https://developers.home-assistant.io/blog/2024/12/19/config-flow-unique-id/
             report_usage(
                 "creates a config entry when another entry with the same unique ID "
                 "exists",

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -35,6 +35,7 @@ from .const import (
     CONF_NAME,
     EVENT_HOMEASSISTANT_STARTED,
     EVENT_HOMEASSISTANT_STOP,
+    PATCH_VERSION,
     Platform,
 )
 from .core import (
@@ -1484,6 +1485,16 @@ class ConfigEntriesFlowManager(
             # Find existing entry.
             existing_entry = self.config_entries.async_entry_for_domain_unique_id(
                 result["handler"], flow.unique_id
+            )
+
+        if existing_entry is not None and PATCH_VERSION == "0.dev0":
+            # We temporarily restrict this to `dev` to get a feel for how many
+            # integrations this concerns
+            report_usage(
+                "creates a config entry when another entry with the same unique ID "
+                "exists, causing the old entry to be removed and replaced when it "
+                "should most likely update the previous entry and abort the flow",
+                core_behavior=ReportBehavior.LOG,
             )
 
         # Unload the entry before setting up the new one.

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1487,11 +1487,11 @@ class ConfigEntriesFlowManager(
             )
 
         if existing_entry is not None and flow.handler != "mobile_app":
-            # `mobile_app` does this on purpose
+            # This causes the old entry to be removed and replaced when it
+            # should most likely update the previous entry and abort the flow
             report_usage(
                 "creates a config entry when another entry with the same unique ID "
-                "exists, causing the old entry to be removed and replaced when it "
-                "should most likely update the previous entry and abort the flow",
+                "exists",
                 core_behavior=ReportBehavior.LOG,
                 core_integration_behavior=ReportBehavior.LOG,
                 custom_integration_behavior=ReportBehavior.IGNORE,

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1495,6 +1495,8 @@ class ConfigEntriesFlowManager(
                 "exists, causing the old entry to be removed and replaced when it "
                 "should most likely update the previous entry and abort the flow",
                 core_behavior=ReportBehavior.LOG,
+                core_integration_behavior=ReportBehavior.LOG,
+                custom_integration_behavior=ReportBehavior.IGNORE,
                 exclude_integrations={"mobile_app"},
             )
 

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1486,7 +1486,7 @@ class ConfigEntriesFlowManager(
                 result["handler"], flow.unique_id
             )
 
-        if existing_entry is not None and self.handler != "mobile_app":
+        if existing_entry is not None and flow.handler != "mobile_app":
             # `mobile_app` does this on purpose
             report_usage(
                 "creates a config entry when another entry with the same unique ID "
@@ -1495,7 +1495,7 @@ class ConfigEntriesFlowManager(
                 core_behavior=ReportBehavior.LOG,
                 core_integration_behavior=ReportBehavior.LOG,
                 custom_integration_behavior=ReportBehavior.IGNORE,
-                integration_domain=self.handler,
+                integration_domain=flow.handler,
             )
 
         # Unload the entry before setting up the new one.

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1489,6 +1489,7 @@ class ConfigEntriesFlowManager(
         if existing_entry is not None and flow.handler != "mobile_app":
             # This causes the old entry to be removed and replaced when it
             # should most likely update the previous entry and abort the flow
+            # see https://developers.home-assistant.io/blog/2024/11/22/config-flow-unique-id/
             report_usage(
                 "creates a config entry when another entry with the same unique ID "
                 "exists",

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1495,6 +1495,7 @@ class ConfigEntriesFlowManager(
                 "exists, causing the old entry to be removed and replaced when it "
                 "should most likely update the previous entry and abort the flow",
                 core_behavior=ReportBehavior.LOG,
+                exclude_integrations={"mobile_app"},
             )
 
         # Unload the entry before setting up the new one.

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1493,7 +1493,7 @@ class ConfigEntriesFlowManager(
             # reconfigure to allow the user to change settings.
             # In case of non user visible flows, the integration should optionally
             # update the existing entry before aborting.
-            # see https://developers.home-assistant.io/blog/2024/12/19/config-flow-unique-id/
+            # see https://developers.home-assistant.io/blog/2025/01/16/config-flow-unique-id/
             report_usage(
                 "creates a config entry when another entry with the same unique ID "
                 "exists",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
When a config flow creates an entry with a colliding unique ID, the old entry is currently automatically removed and replaced with the new config entry.
This can lead to unexpected behavior, and is deprecated.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As follow-up to #130062

cc @emontnemery

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/2467

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
