### PR TITLE
Refactor translation checks

### DIFF
--- a/tests/components/conftest.py
+++ b/tests/components/conftest.py
@@ -610,17 +610,17 @@ def ignore_translations() -> str | list[str]:
 
 
 async def _check_config_flow_result_translations(
-    self: FlowManager,
+    manager: FlowManager,
     flow: FlowHandler,
     result: FlowResult[FlowContext, str],
     ignore_translations: dict[str, str],
 ) -> None:
-    if isinstance(self, ConfigEntriesFlowManager):
+    if isinstance(manager, ConfigEntriesFlowManager):
         category = "config"
-        component = flow.handler
-    elif isinstance(self, OptionsFlowManager):
+        integration = flow.handler
+    elif isinstance(manager, OptionsFlowManager):
         category = "options"
-        component = flow.hass.config_entries.async_get_entry(flow.handler).domain
+        integration = flow.hass.config_entries.async_get_entry(flow.handler).domain
     else:
         return
 
@@ -638,7 +638,7 @@ async def _check_config_flow_result_translations(
                     flow.hass,
                     ignore_translations,
                     category,
-                    component,
+                    integration,
                     f"step.{step_id}.{header}",
                     result["description_placeholders"],
                     translation_required=False,
@@ -649,7 +649,7 @@ async def _check_config_flow_result_translations(
                     flow.hass,
                     ignore_translations,
                     category,
-                    component,
+                    integration,
                     f"error.{error}",
                     result["description_placeholders"],
                 )
@@ -664,7 +664,7 @@ async def _check_config_flow_result_translations(
             flow.hass,
             ignore_translations,
             category,
-            component,
+            integration,
             f"abort.{result["reason"]}",
             result["description_placeholders"],
         )

--- a/tests/components/conftest.py
+++ b/tests/components/conftest.py
@@ -690,7 +690,9 @@ def check_translations(ignore_translations: str | list[str]) -> Generator[None]:
         self: FlowManager, flow: FlowHandler, *args
     ) -> FlowResult:
         result = await _original_flow_manager_async_handle_step(self, flow, *args)
-        _check_config_flow_result_translations(self, flow, result, _ignore_translations)
+        await _check_config_flow_result_translations(
+            self, flow, result, _ignore_translations
+        )
         return result
 
     # Use override functions

--- a/tests/components/conftest.py
+++ b/tests/components/conftest.py
@@ -562,7 +562,7 @@ def _validate_translation_placeholders(
             description_placeholders is None
             or placeholder not in description_placeholders
         ):
-            pytest.fail(
+            ignore_translations[full_key] = (
                 f"Description not found for placeholder `{placeholder}` in {full_key}"
             )
 
@@ -593,7 +593,7 @@ async def _validate_translation(
         ignore_translations[full_key] = "used"
         return
 
-    pytest.fail(
+    ignore_translations[full_key] = (
         f"Translation not found for {component}: `{category}.{key}`. "
         f"Please add to homeassistant/components/{component}/strings.json"
     )
@@ -709,3 +709,6 @@ def check_translations(ignore_translations: str | list[str]) -> Generator[None]:
             f"Unused ignore translations: {', '.join(unused_ignore)}. "
             "Please remove them from the ignore_translations fixture."
         )
+    for description in _ignore_translations.values():
+        if description not in {"used", "unused"}:
+            pytest.fail(description)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
No new functionnality - just moving code around.

The functionnality inside `check_config_translations` has grown quite large, and before adding new checks I think it is better to split the code:
- rename `check_config_translations` to be more generic `check_translations`
- rename `_async_handle_step` to `_flow_manager_async_handle_step`, and move the logic out to a module function `_check_config_flow_result_translations`
- rename cached reference `_original` to `_original_flow_manager_async_handle_step`
- rename `_ensure_translation_exists` to `_validate_translation`

I have also noticed that having the `pytest.fail` could cause the test fail early, even if the test logic was sound.
Instead, it is better if we cache the failure, let the test succeed, and fail on teardown.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
