### PR TITLE
Fix translation missing errors in supervisor tests

### DIFF
--- a/tests/components/hassio/test_issues.py
+++ b/tests/components/hassio/test_issues.py
@@ -323,6 +323,17 @@ async def test_reset_issues_supervisor_restart(
                 uuid=(uuid := uuid4()),
             )
         ],
+        suggestions_by_issue={
+            uuid: [
+                Suggestion(
+                    SuggestionType.EXECUTE_REBOOT,
+                    context=ContextType.SYSTEM,
+                    reference=None,
+                    uuid=uuid4(),
+                    auto=False,
+                )
+            ]
+        },
     )
 
     result = await async_setup_component(hass, "hassio", {})
@@ -341,7 +352,7 @@ async def test_reset_issues_supervisor_restart(
         uuid=uuid.hex,
         context="system",
         type_="reboot_required",
-        fixable=False,
+        fixable=True,
         reference=None,
     )
 
@@ -510,9 +521,9 @@ async def test_supervisor_issues(
         supervisor_client,
         issues=[
             Issue(
-                type=IssueType.REBOOT_REQUIRED,
-                context=ContextType.SYSTEM,
-                reference=None,
+                type=IssueType.DETACHED_ADDON_MISSING,
+                context=ContextType.ADDON,
+                reference="test",
                 uuid=(uuid_issue1 := uuid4()),
             ),
             Issue(
@@ -553,10 +564,11 @@ async def test_supervisor_issues(
     assert_issue_repair_in_list(
         msg["result"]["issues"],
         uuid=uuid_issue1.hex,
-        context="system",
-        type_="reboot_required",
+        context="addon",
+        type_="detached_addon_missing",
         fixable=False,
-        reference=None,
+        reference="test",
+        placeholders={"addon_url": "/hassio/addon/test", "addon": "test"},
     )
     assert_issue_repair_in_list(
         msg["result"]["issues"],
@@ -582,13 +594,21 @@ async def test_supervisor_issues_initial_failure(
         ResolutionInfo(
             unsupported=[],
             unhealthy=[],
-            suggestions=[],
             issues=[
                 Issue(
                     type=IssueType.REBOOT_REQUIRED,
                     context=ContextType.SYSTEM,
                     reference=None,
                     uuid=uuid4(),
+                )
+            ],
+            suggestions=[
+                Suggestion(
+                    SuggestionType.EXECUTE_REBOOT,
+                    context=ContextType.SYSTEM,
+                    reference=None,
+                    uuid=uuid4(),
+                    auto=False,
                 )
             ],
             checks=[
@@ -643,6 +663,14 @@ async def test_supervisor_issues_add_remove(
                     "type": "reboot_required",
                     "context": "system",
                     "reference": None,
+                    "suggestions": [
+                        {
+                            "uuid": uuid4().hex,
+                            "type": "execute_reboot",
+                            "context": "system",
+                            "reference": None,
+                        }
+                    ],
                 },
             },
         }
@@ -660,53 +688,13 @@ async def test_supervisor_issues_add_remove(
         uuid=issue_uuid,
         context="system",
         type_="reboot_required",
-        fixable=False,
-        reference=None,
-    )
-
-    await client.send_json(
-        {
-            "id": 3,
-            "type": "supervisor/event",
-            "data": {
-                "event": "issue_changed",
-                "data": {
-                    "uuid": issue_uuid,
-                    "type": "reboot_required",
-                    "context": "system",
-                    "reference": None,
-                    "suggestions": [
-                        {
-                            "uuid": uuid4().hex,
-                            "type": "execute_reboot",
-                            "context": "system",
-                            "reference": None,
-                        }
-                    ],
-                },
-            },
-        }
-    )
-    msg = await client.receive_json()
-    assert msg["success"]
-    await hass.async_block_till_done()
-
-    await client.send_json({"id": 4, "type": "repairs/list_issues"})
-    msg = await client.receive_json()
-    assert msg["success"]
-    assert len(msg["result"]["issues"]) == 1
-    assert_issue_repair_in_list(
-        msg["result"]["issues"],
-        uuid=issue_uuid,
-        context="system",
-        type_="reboot_required",
         fixable=True,
         reference=None,
     )
 
     await client.send_json(
         {
-            "id": 5,
+            "id": 3,
             "type": "supervisor/event",
             "data": {
                 "event": "issue_removed",
@@ -723,7 +711,7 @@ async def test_supervisor_issues_add_remove(
     assert msg["success"]
     await hass.async_block_till_done()
 
-    await client.send_json({"id": 6, "type": "repairs/list_issues"})
+    await client.send_json({"id": 4, "type": "repairs/list_issues"})
     msg = await client.receive_json()
     assert msg["success"]
     assert msg["result"] == {"issues": []}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

Some tests in the supervisor were using the `REBOOT_REQUIRED` issues as though it had no suggestions when testing other behaviors unrelated to that specific issue. #130593 makes this a test failure for missing translation string so adjusting these to stick to real scenarios.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
