### PR TITLE
Add button platform to LG ThinQ integration

### DIFF
--- a/homeassistant/components/lg_thinq/__init__.py
+++ b/homeassistant/components/lg_thinq/__init__.py
@@ -39,6 +39,7 @@ type ThinqConfigEntry = ConfigEntry[ThinqData]
 
 PLATFORMS = [
     Platform.BINARY_SENSOR,
+    Platform.BUTTON,
     Platform.CLIMATE,
     Platform.EVENT,
     Platform.FAN,

--- a/homeassistant/components/lg_thinq/button.py
+++ b/homeassistant/components/lg_thinq/button.py
@@ -1,0 +1,89 @@
+"""Support for button entities."""
+
+from __future__ import annotations
+
+import logging
+
+from thinqconnect import DeviceType
+from thinqconnect.integration import TimerProperty
+
+from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import ThinqConfigEntry
+from .entity import ThinQEntity
+
+TIMER_ABSOLUTE_TO_START_BUTTON_DESC = ButtonEntityDescription(
+    key=TimerProperty.ABSOLUTE_TO_START,
+    translation_key="unset_absolute_to_start",
+)
+TIMER_ABSOLUTE_TO_STOP_BUTTON_DESC = ButtonEntityDescription(
+    key=TimerProperty.ABSOLUTE_TO_STOP,
+    translation_key="unset_absolute_to_stop",
+)
+
+DEVICE_TYPE_BUTTON_MAP: dict[DeviceType, tuple[ButtonEntityDescription, ...]] = {
+    DeviceType.AIR_CONDITIONER: (
+        TIMER_ABSOLUTE_TO_START_BUTTON_DESC,
+        TIMER_ABSOLUTE_TO_STOP_BUTTON_DESC,
+    ),
+    DeviceType.AIR_PURIFIER_FAN: (
+        TIMER_ABSOLUTE_TO_START_BUTTON_DESC,
+        TIMER_ABSOLUTE_TO_STOP_BUTTON_DESC,
+    ),
+    DeviceType.AIR_PURIFIER: (
+        TIMER_ABSOLUTE_TO_START_BUTTON_DESC,
+        TIMER_ABSOLUTE_TO_STOP_BUTTON_DESC,
+    ),
+    DeviceType.HUMIDIFIER: (
+        TIMER_ABSOLUTE_TO_START_BUTTON_DESC,
+        TIMER_ABSOLUTE_TO_STOP_BUTTON_DESC,
+    ),
+    DeviceType.ROBOT_CLEANER: (TIMER_ABSOLUTE_TO_START_BUTTON_DESC,),
+}
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ThinqConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up an entry for button platform."""
+    entities: list[ButtonEntity] = []
+    for coordinator in entry.runtime_data.coordinators.values():
+        if (
+            descriptions := DEVICE_TYPE_BUTTON_MAP.get(
+                coordinator.api.device.device_type
+            )
+        ) is not None:
+            for description in descriptions:
+                entities.extend(
+                    ThinQButtonEntity(coordinator, description, property_id)
+                    for property_id in coordinator.api.get_active_idx(description.key)
+                )
+
+    if entities:
+        async_add_entities(entities)
+
+
+class ThinQButtonEntity(ThinQEntity, ButtonEntity):
+    """Represent a thinq button platform."""
+
+    entity_description: ButtonEntityDescription
+
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        return self.data.value is not None
+
+    async def async_press(self) -> None:
+        """Handle the button press."""
+        _LOGGER.debug(
+            "[%s:%s] async_press",
+            self.coordinator.device_name,
+            self.property_id,
+        )
+        await self.async_call_api(self.coordinator.api.post(self.property_id, None))

--- a/homeassistant/components/lg_thinq/icons.json
+++ b/homeassistant/components/lg_thinq/icons.json
@@ -402,6 +402,14 @@
       "power_level_for_location": {
         "default": "mdi:radiator"
       }
+    },
+    "button": {
+      "unset_absolute_to_start": {
+        "default": "mdi:timer-cancel-outline"
+      },
+      "unset_absolute_to_stop": {
+        "default": "mdi:timer-cancel-outline"
+      }
     }
   }
 }

--- a/homeassistant/components/lg_thinq/strings.json
+++ b/homeassistant/components/lg_thinq/strings.json
@@ -987,6 +987,14 @@
           "normal": "[%key:component::lg_thinq::entity::sensor::current_dish_washing_course::state::delicate%]"
         }
       }
+    },
+    "button": {
+      "unset_absolute_to_start": {
+        "name": "Unset scheduled turn-on"
+      },
+      "unset_absolute_to_stop": {
+        "name": "Unset scheduled turn-off"
+      }
     }
   }
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add button platform to LG ThinQ integration
- Button entity can unset (cancel) scheduled time
- Time entity can set or modify schedule https://github.com/home-assistant/core/pull/130669

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/pull/126245
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/35771

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
