### PR TITLE
Add yue language support to Google Translate TTS

### DIFF
--- a/homeassistant/components/google_translate/const.py
+++ b/homeassistant/components/google_translate/const.py
@@ -88,6 +88,7 @@ SUPPORT_LANGUAGES = [
     "uk",
     "ur",
     "vi",
+    "yue",
     # dialects
     "zh-CN",
     "zh-cn",

--- a/homeassistant/components/google_translate/manifest.json
+++ b/homeassistant/components/google_translate/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/google_translate",
   "iot_class": "cloud_push",
   "loggers": ["gtts"],
-  "requirements": ["gTTS==2.2.4"]
+  "requirements": ["gTTS==2.5.3"]
 }


### PR DESCRIPTION
Fixes #130280

Add support for the 'yue' language (Cantonese) in Google Translate text-to-speech integration.

* **Update supported languages**: Add 'yue' to `SUPPORT_LANGUAGES` list in `homeassistant/components/google_translate/const.py`.
* **Update gTTS library version**: Change `gTTS` version to 2.5.3 in `homeassistant/components/google_translate/manifest.json`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/home-assistant/core/pull/130688?shareId=2802f5e5-9e4f-4f2c-b749-33a4442c3561).

I tried Copilot Workspace here. So far, it's pretty impressive. However, it seems to have ignored the PR template here. I'll fix that soon.