### PR TITLE
Inline hydrawise sensor value_fn definitions as lambdas

### DIFF
--- a/homeassistant/components/hydrawise/sensor.py
+++ b/homeassistant/components/hydrawise/sensor.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import timedelta
 from typing import Any
+
+from pydrawise.schema import ControllerWaterUseSummary
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -30,66 +32,8 @@ class HydrawiseSensorEntityDescription(SensorEntityDescription):
     value_fn: Callable[[HydrawiseSensor], Any]
 
 
-def _get_zone_watering_time(sensor: HydrawiseSensor) -> int:
-    if (current_run := sensor.zone.scheduled_runs.current_run) is not None:
-        return int(current_run.remaining_time.total_seconds() / 60)
-    return 0
-
-
-def _get_zone_next_cycle(sensor: HydrawiseSensor) -> datetime | None:
-    if (next_run := sensor.zone.scheduled_runs.next_run) is not None:
-        return dt_util.as_utc(next_run.start_time)
-    return None
-
-
-def _get_zone_daily_active_water_use(sensor: HydrawiseSensor) -> float:
-    """Get active water use for the zone."""
-    daily_water_summary = sensor.coordinator.data.daily_water_summary[
-        sensor.controller.id
-    ]
-    return float(daily_water_summary.active_use_by_zone_id.get(sensor.zone.id, 0.0))
-
-
-def _get_zone_daily_active_water_time(sensor: HydrawiseSensor) -> float | None:
-    """Get active water time for the zone."""
-    daily_water_summary = sensor.coordinator.data.daily_water_summary[
-        sensor.controller.id
-    ]
-    return daily_water_summary.active_time_by_zone_id.get(
-        sensor.zone.id, timedelta()
-    ).total_seconds()
-
-
-def _get_controller_daily_active_water_use(sensor: HydrawiseSensor) -> float | None:
-    """Get active water use for the controller."""
-    daily_water_summary = sensor.coordinator.data.daily_water_summary[
-        sensor.controller.id
-    ]
-    return daily_water_summary.total_active_use
-
-
-def _get_controller_daily_inactive_water_use(sensor: HydrawiseSensor) -> float | None:
-    """Get inactive water use for the controller."""
-    daily_water_summary = sensor.coordinator.data.daily_water_summary[
-        sensor.controller.id
-    ]
-    return daily_water_summary.total_inactive_use
-
-
-def _get_controller_daily_active_water_time(sensor: HydrawiseSensor) -> float:
-    """Get active water time for the controller."""
-    daily_water_summary = sensor.coordinator.data.daily_water_summary[
-        sensor.controller.id
-    ]
-    return daily_water_summary.total_active_time.total_seconds()
-
-
-def _get_controller_daily_total_water_use(sensor: HydrawiseSensor) -> float | None:
-    """Get inactive water use for the controller."""
-    daily_water_summary = sensor.coordinator.data.daily_water_summary[
-        sensor.controller.id
-    ]
-    return daily_water_summary.total_use
+def _get_water_use(sensor: HydrawiseSensor) -> ControllerWaterUseSummary:
+    return sensor.coordinator.data.daily_water_summary[sensor.controller.id]
 
 
 WATER_USE_CONTROLLER_SENSORS: tuple[HydrawiseSensorEntityDescription, ...] = (
@@ -98,7 +42,9 @@ WATER_USE_CONTROLLER_SENSORS: tuple[HydrawiseSensorEntityDescription, ...] = (
         translation_key="daily_active_water_time",
         device_class=SensorDeviceClass.DURATION,
         native_unit_of_measurement=UnitOfTime.SECONDS,
-        value_fn=_get_controller_daily_active_water_time,
+        value_fn=lambda sensor: _get_water_use(
+            sensor
+        ).total_active_time.total_seconds(),
     ),
 )
 
@@ -109,7 +55,11 @@ WATER_USE_ZONE_SENSORS: tuple[HydrawiseSensorEntityDescription, ...] = (
         translation_key="daily_active_water_time",
         device_class=SensorDeviceClass.DURATION,
         native_unit_of_measurement=UnitOfTime.SECONDS,
-        value_fn=_get_zone_daily_active_water_time,
+        value_fn=lambda sensor: (
+            _get_water_use(sensor)
+            .active_time_by_zone_id.get(sensor.zone.id, timedelta())
+            .total_seconds()
+        ),
     ),
 )
 
@@ -119,21 +69,21 @@ FLOW_CONTROLLER_SENSORS: tuple[HydrawiseSensorEntityDescription, ...] = (
         translation_key="daily_total_water_use",
         device_class=SensorDeviceClass.VOLUME,
         suggested_display_precision=1,
-        value_fn=_get_controller_daily_total_water_use,
+        value_fn=lambda sensor: _get_water_use(sensor).total_use,
     ),
     HydrawiseSensorEntityDescription(
         key="daily_active_water_use",
         translation_key="daily_active_water_use",
         device_class=SensorDeviceClass.VOLUME,
         suggested_display_precision=1,
-        value_fn=_get_controller_daily_active_water_use,
+        value_fn=lambda sensor: _get_water_use(sensor).total_active_use,
     ),
     HydrawiseSensorEntityDescription(
         key="daily_inactive_water_use",
         translation_key="daily_inactive_water_use",
         device_class=SensorDeviceClass.VOLUME,
         suggested_display_precision=1,
-        value_fn=_get_controller_daily_inactive_water_use,
+        value_fn=lambda sensor: _get_water_use(sensor).total_inactive_use,
     ),
 )
 
@@ -143,7 +93,9 @@ FLOW_ZONE_SENSORS: tuple[SensorEntityDescription, ...] = (
         translation_key="daily_active_water_use",
         device_class=SensorDeviceClass.VOLUME,
         suggested_display_precision=1,
-        value_fn=_get_zone_daily_active_water_use,
+        value_fn=lambda sensor: float(
+            _get_water_use(sensor).active_use_by_zone_id.get(sensor.zone.id, 0.0)
+        ),
     ),
 )
 
@@ -152,13 +104,24 @@ ZONE_SENSORS: tuple[HydrawiseSensorEntityDescription, ...] = (
         key="next_cycle",
         translation_key="next_cycle",
         device_class=SensorDeviceClass.TIMESTAMP,
-        value_fn=_get_zone_next_cycle,
+        value_fn=lambda sensor: (
+            dt_util.as_utc(sensor.zone.scheduled_runs.next_run.start_time)
+            if sensor.zone.scheduled_runs.next_run is not None
+            else None
+        ),
     ),
     HydrawiseSensorEntityDescription(
         key="watering_time",
         translation_key="watering_time",
         native_unit_of_measurement=UnitOfTime.MINUTES,
-        value_fn=_get_zone_watering_time,
+        value_fn=lambda sensor: (
+            int(
+                sensor.zone.scheduled_runs.current_run.remaining_time.total_seconds()
+                / 60
+            )
+            if sensor.zone.scheduled_runs.current_run is not None
+            else 0
+        ),
     ),
 )
 


### PR DESCRIPTION
## Proposed change
Improve the readability of the hydrawise sensor entity descriptions by inlining each `value_fn` as a lambda. A lot of these sensors are returning very similar data, so having to jump back-and-forth between the entity description and its `value_fn` definition makes it difficult for the code reader.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
