### PR TITLE
Add ability to pass integration domain to report_usage

### DIFF
--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -2889,9 +2889,9 @@ class ConfigFlow(ConfigEntryBaseFlow):
         if self.source in {SOURCE_REAUTH, SOURCE_RECONFIGURE}:
             report_usage(
                 f"creates a new entry in a '{self.source}' flow, "
-                "when it is expected to update an existing entry and abort. "
-                "This will stop working in 2025.11",
+                "when it is expected to update an existing entry and abort",
                 core_behavior=ReportBehavior.LOG,
+                breaks_in_ha_version="2025.11",
                 integration_domain=self.handler,
             )
         result = super().async_create_entry(

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -2887,18 +2887,12 @@ class ConfigFlow(ConfigEntryBaseFlow):
     ) -> ConfigFlowResult:
         """Finish config flow and create a config entry."""
         if self.source in {SOURCE_REAUTH, SOURCE_RECONFIGURE}:
-            report_issue = async_suggest_report_issue(
-                self.hass, integration_domain=self.handler
-            )
-            _LOGGER.warning(
-                (
-                    "Detected %s config flow creating a new entry, "
-                    "when it is expected to update an existing entry and abort. "
-                    "This will stop working in %s, please %s"
-                ),
-                self.source,
-                "2025.11",
-                report_issue,
+            report_usage(
+                f"creates a new entry in a '{self.source}' flow, "
+                "when it is expected to update an existing entry and abort. "
+                "This will stop working in 2025.11",
+                core_behavior=ReportBehavior.LOG,
+                integration_domain=self.handler,
             )
         result = super().async_create_entry(
             title=title,

--- a/homeassistant/helpers/frame.py
+++ b/homeassistant/helpers/frame.py
@@ -262,7 +262,7 @@ def _report_integration_domain(
     Async friendly.
     """
     integration_behavior = core_integration_behavior
-    if integration.is_built_in:
+    if not integration.is_built_in:
         integration_behavior = custom_integration_behavior
 
     if integration_behavior is ReportBehavior.IGNORE:

--- a/homeassistant/helpers/frame.py
+++ b/homeassistant/helpers/frame.py
@@ -249,7 +249,7 @@ def _report_integration_domain(
     hass: HomeAssistant | None,
     what: str,
     breaks_in_ha_version: str | None,
-    integration: Integration | None,
+    integration: Integration,
     core_integration_behavior: ReportBehavior,
     custom_integration_behavior: ReportBehavior,
     exclude_integrations: set[str] | None,
@@ -287,10 +287,11 @@ def _report_integration_domain(
         report_issue,
     )
 
-    raise RuntimeError(
-        f"Detected that {integration_type}integration "
-        f"'{integration.domain}' {what}. Please {report_issue}"
-    )
+    if integration_behavior is ReportBehavior.ERROR:
+        raise RuntimeError(
+            f"Detected that {integration_type}integration "
+            f"'{integration.domain}' {what}. Please {report_issue}"
+        )
 
 
 def _report_integration_frame(

--- a/homeassistant/helpers/frame.py
+++ b/homeassistant/helpers/frame.py
@@ -257,6 +257,10 @@ def _report_integration_domain(
     exclude_integrations: set[str] | None,
     level: int,
 ) -> None:
+    """Report incorrect usage in an integration (identified via domain).
+
+    Async friendly.
+    """
     integration_behavior = core_integration_behavior
     if integration.is_built_in:
         integration_behavior = custom_integration_behavior
@@ -303,7 +307,7 @@ def _report_integration_frame(
     level: int = logging.WARNING,
     error: bool = False,
 ) -> None:
-    """Report incorrect usage in an integration.
+    """Report incorrect usage in an integration (identified via frame).
 
     Async friendly.
     """

--- a/homeassistant/helpers/frame.py
+++ b/homeassistant/helpers/frame.py
@@ -199,6 +199,8 @@ def report_usage(
     Please create a bug report at https://..."
     :param breaks_in_ha_version: if set, the report will be adjusted to specify the
     breaking version
+    :param integration_domain: fallback for identifying the integration if the
+    frame is not found
     """
     try:
         integration_frame = get_integration_frame(

--- a/homeassistant/helpers/frame.py
+++ b/homeassistant/helpers/frame.py
@@ -199,6 +199,8 @@ def report_usage(
     Please create a bug report at https://..."
     :param breaks_in_ha_version: if set, the report will be adjusted to specify the
     breaking version
+    :param exclude_integrations: skip specified integration when reviewing the stack.
+    If no integration is found, the core behavior will be applied
     :param integration_domain: fallback for identifying the integration if the
     frame is not found
     """
@@ -217,7 +219,6 @@ def report_usage(
                 integration,
                 core_integration_behavior,
                 custom_integration_behavior,
-                exclude_integrations,
                 level,
             )
             return
@@ -254,7 +255,6 @@ def _report_integration_domain(
     integration: Integration,
     core_integration_behavior: ReportBehavior,
     custom_integration_behavior: ReportBehavior,
-    exclude_integrations: set[str] | None,
     level: int,
 ) -> None:
     """Report incorrect usage in an integration (identified via domain).
@@ -265,9 +265,7 @@ def _report_integration_domain(
     if integration.is_built_in:
         integration_behavior = custom_integration_behavior
 
-    if integration_behavior is ReportBehavior.IGNORE or (
-        exclude_integrations and integration.domain in exclude_integrations
-    ):
+    if integration_behavior is ReportBehavior.IGNORE:
         return
 
     # Keep track of integrations already reported to prevent flooding

--- a/tests/helpers/test_frame.py
+++ b/tests/helpers/test_frame.py
@@ -6,9 +6,8 @@ from unittest.mock import ANY, Mock, patch
 import pytest
 
 from homeassistant.core import HomeAssistant
-from homeassistant.loader import Integration
 from homeassistant.helpers import frame
-from homeassistant.setup import async_setup_component
+from homeassistant.loader import Integration
 
 from tests.common import extract_stack_to_frame
 

--- a/tests/helpers/test_frame.py
+++ b/tests/helpers/test_frame.py
@@ -449,27 +449,24 @@ async def test_report(
 
 
 @pytest.mark.parametrize(
-    ("integration", "integration_domain", "source", "expected_log"),
+    ("integration", "integration_domain", "source"),
     [
         pytest.param(
             None,
             None,
             "code that",
-            1,
             id="core",
         ),
         pytest.param(
             None,
             "sensor",
             "that integration 'sensor'",
-            1,
             id="core integration",
         ),
         pytest.param(
             None,
             "hue",
             "that custom integration 'hue'",
-            1,
             id="custom integration",
         ),
     ],
@@ -479,7 +476,6 @@ async def test_report_integration_domain(
     integration: Integration | None,
     integration_domain: str | None,
     source: str,
-    expected_log: int,
 ) -> None:
     """Test report."""
     what = "test_report_string"

--- a/tests/helpers/test_frame.py
+++ b/tests/helpers/test_frame.py
@@ -454,17 +454,20 @@ async def test_report(
     [
         pytest.param(
             None,
+            None,
             "code that",
             1,
             id="core",
         ),
         pytest.param(
+            None,
             "sensor",
             "that integration 'sensor'",
             1,
             id="core integration",
         ),
         pytest.param(
+            None,
             "hue",
             "that custom integration 'hue'",
             1,
@@ -480,9 +483,6 @@ async def test_report_integration_domain(
     expected_log: int,
 ) -> None:
     """Test report."""
-    for comp in ("hue", "sensor"):
-        assert await async_setup_component(hass, comp, {})
-
     what = "test_report_string"
 
     with (

--- a/tests/helpers/test_frame.py
+++ b/tests/helpers/test_frame.py
@@ -484,8 +484,17 @@ async def test_report_integration_domain(
     with patch.object(frame, "_REPORTED_INTEGRATIONS", set()):
         frame.report_usage(
             what,
+            core_behavior=frame.ReportBehavior.IGNORE,
+            integration_domain=integration_domain,
+            exclude_integrations={"sensor", "test_package"},
+        )
+
+    assert f"Detected {source} {what}" not in caplog.text
+
+    with patch.object(frame, "_REPORTED_INTEGRATIONS", set()):
+        frame.report_usage(
+            what,
             core_behavior=frame.ReportBehavior.LOG,
-            exclude_integrations={"mobile_app"},
             integration_domain=integration_domain,
         )
 

--- a/tests/helpers/test_frame.py
+++ b/tests/helpers/test_frame.py
@@ -473,7 +473,7 @@ async def test_report(
 )
 async def test_report_integration_domain(
     caplog: pytest.LogCaptureFixture,
-    integration: Integration,
+    integration: Integration | None,
     integration_domain: str | None,
     source: str,
     expected_log: int,

--- a/tests/helpers/test_frame.py
+++ b/tests/helpers/test_frame.py
@@ -6,6 +6,7 @@ from unittest.mock import ANY, Mock, patch
 import pytest
 
 from homeassistant.core import HomeAssistant
+from homeassistant.loader import Integration
 from homeassistant.helpers import frame
 from homeassistant.setup import async_setup_component
 
@@ -485,7 +486,7 @@ async def test_report_integration_domain(
     what = "test_report_string"
 
     with (
-        patch.object(frame, "_REPORTED_INTEGRATIONS", set()), 
+        patch.object(frame, "_REPORTED_INTEGRATIONS", set()),
         patch("homeassistant.loader.async_get_issue_integration", integration),
     ):
         frame.report_usage(

--- a/tests/helpers/test_frame.py
+++ b/tests/helpers/test_frame.py
@@ -449,7 +449,7 @@ async def test_report(
 
 
 @pytest.mark.parametrize(
-    ("integration_domain", "source", "expected_log"),
+    ("integration", "integration_domain", "source", "expected_log"),
     [
         pytest.param(
             None,
@@ -471,10 +471,9 @@ async def test_report(
         ),
     ],
 )
-@pytest.mark.usefixtures("enable_custom_integrations")
 async def test_report_integration_domain(
-    hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
+    integration: Integration,
     integration_domain: str | None,
     source: str,
     expected_log: int,
@@ -485,7 +484,10 @@ async def test_report_integration_domain(
 
     what = "test_report_string"
 
-    with patch.object(frame, "_REPORTED_INTEGRATIONS", set()):
+    with (
+        patch.object(frame, "_REPORTED_INTEGRATIONS", set()), 
+        patch("homeassistant.loader.async_get_issue_integration", integration),
+    ):
         frame.report_usage(
             what,
             core_behavior=frame.ReportBehavior.LOG,

--- a/tests/helpers/test_frame.py
+++ b/tests/helpers/test_frame.py
@@ -485,8 +485,9 @@ async def test_report_integration_domain(
         frame.report_usage(
             what,
             core_behavior=frame.ReportBehavior.IGNORE,
+            core_integration_behavior=frame.ReportBehavior.IGNORE,
+            custom_integration_behavior=frame.ReportBehavior.IGNORE,
             integration_domain=integration_domain,
-            exclude_integrations={"sensor", "test_package"},
         )
 
     assert f"Detected {source} {what}" not in caplog.text
@@ -495,6 +496,8 @@ async def test_report_integration_domain(
         frame.report_usage(
             what,
             core_behavior=frame.ReportBehavior.LOG,
+            core_integration_behavior=frame.ReportBehavior.LOG,
+            custom_integration_behavior=frame.ReportBehavior.LOG,
             integration_domain=integration_domain,
         )
 

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -7157,7 +7157,10 @@ async def test_create_entry_reauth_reconfigure(
 
     assert len(hass.config_entries.async_entries("test")) == 1
 
-    with mock_config_flow("test", TestFlow):
+    with (
+        mock_config_flow("test", TestFlow),
+        patch.object(frame, "_REPORTED_INTEGRATIONS", set()),
+    ):
         result = await getattr(entry, f"start_{source}_flow")(hass)
         await hass.async_block_till_done()
     assert result["type"] is FlowResultType.CREATE_ENTRY
@@ -7169,9 +7172,9 @@ async def test_create_entry_reauth_reconfigure(
         assert entries[0].entry_id != entry.entry_id
 
     assert (
-        f"Detected {source} config flow creating a new entry, when it is expected "
-        "to update an existing entry and abort. This will stop working in "
-        "2025.11, please create a bug report at https://github.com/home"
+        f"Detected that integration 'test' creates a new entry in a '{source}' flow, "
+        "when it is expected to update an existing entry and abort. This will stop "
+        "working in 2025.11, please create a bug report at https://github.com/home"
         "-assistant/core/issues?q=is%3Aopen+is%3Aissue+"
         "label%3A%22integration%3A+test%22"
     ) in caplog.text

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -7174,8 +7174,8 @@ async def test_create_entry_reauth_reconfigure(
     assert (
         f"Detected that integration 'test' creates a new entry in a '{source}' flow, "
         "when it is expected to update an existing entry and abort. This will stop "
-        "working in 2025.11, please create a bug report at https://github.com/home"
-        "-assistant/core/issues?q=is%3Aopen+is%3Aissue+"
+        "working in Home Assistant 2025.11, please create a bug report at "
+        "https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue+"
         "label%3A%22integration%3A+test%22"
     ) in caplog.text
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Sometimes it's hard to know if the code is going to trace back to the integration.
As I was working on https://github.com/home-assistant/core/pull/130567, I realised that it always reports as "core" even though we know the offending integration.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
