### PR TITLE
2024.11.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -90,7 +90,7 @@ repos:
         pass_filenames: false
         language: script
         types: [text]
-        files: ^(script/hassfest/metadata\.py|homeassistant/const\.py$|pyproject\.toml)$
+        files: ^(script/hassfest/metadata\.py|homeassistant/const\.py$|pyproject\.toml|homeassistant/components/go2rtc/const\.py)$
       - id: hassfest-mypy-config
         name: hassfest-mypy-config
         entry: script/run-in-env.sh python3 -m script.hassfest -p mypy_config

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ RUN \
         "armv7") go2rtc_suffix='arm' ;; \
         *) go2rtc_suffix=${BUILD_ARCH} ;; \
     esac \
-    && curl -L https://github.com/AlexxIT/go2rtc/releases/download/v1.9.6/go2rtc_linux_${go2rtc_suffix} --output /bin/go2rtc \
+    && curl -L https://github.com/AlexxIT/go2rtc/releases/download/v1.9.7/go2rtc_linux_${go2rtc_suffix} --output /bin/go2rtc \
     && chmod +x /bin/go2rtc \
     # Verify go2rtc can be executed
     && go2rtc --version

--- a/homeassistant/components/alarm_control_panel/__init__.py
+++ b/homeassistant/components/alarm_control_panel/__init__.py
@@ -6,7 +6,7 @@ import asyncio
 from datetime import timedelta
 from functools import partial
 import logging
-from typing import Any, Final, final
+from typing import TYPE_CHECKING, Any, Final, final
 
 from propcache import cached_property
 import voluptuous as vol
@@ -221,9 +221,15 @@ class AlarmControlPanelEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_A
     @property
     def state(self) -> str | None:
         """Return the current state."""
-        if (alarm_state := self.alarm_state) is None:
-            return None
-        return alarm_state
+        if (alarm_state := self.alarm_state) is not None:
+            return alarm_state
+        if self._attr_state is not None:
+            # Backwards compatibility for integrations that set state directly
+            # Should be removed in 2025.11
+            if TYPE_CHECKING:
+                assert isinstance(self._attr_state, str)
+            return self._attr_state
+        return None
 
     @cached_property
     def alarm_state(self) -> AlarmControlPanelState | None:

--- a/homeassistant/components/cambridge_audio/manifest.json
+++ b/homeassistant/components/cambridge_audio/manifest.json
@@ -7,6 +7,6 @@
   "integration_type": "device",
   "iot_class": "local_push",
   "loggers": ["aiostreammagic"],
-  "requirements": ["aiostreammagic==2.8.4"],
+  "requirements": ["aiostreammagic==2.8.5"],
   "zeroconf": ["_stream-magic._tcp.local.", "_smoip._tcp.local."]
 }

--- a/homeassistant/components/cambridge_audio/select.py
+++ b/homeassistant/components/cambridge_audio/select.py
@@ -51,8 +51,13 @@ CONTROL_ENTITIES: tuple[CambridgeAudioSelectEntityDescription, ...] = (
     CambridgeAudioSelectEntityDescription(
         key="display_brightness",
         translation_key="display_brightness",
-        options=[x.value for x in DisplayBrightness],
+        options=[
+            DisplayBrightness.BRIGHT.value,
+            DisplayBrightness.DIM.value,
+            DisplayBrightness.OFF.value,
+        ],
         entity_category=EntityCategory.CONFIG,
+        load_fn=lambda client: client.display.brightness != DisplayBrightness.NONE,
         value_fn=lambda client: client.display.brightness,
         set_value_fn=lambda client, value: client.set_display_brightness(
             DisplayBrightness(value)

--- a/homeassistant/components/co2signal/config_flow.py
+++ b/homeassistant/components/co2signal/config_flow.py
@@ -168,7 +168,7 @@ class ElectricityMapsConfigFlow(ConfigFlow, domain=DOMAIN):
                     )
 
                 return self.async_create_entry(
-                    title=get_extra_name(data) or "CO2 Signal",
+                    title=get_extra_name(data) or "Electricity Maps",
                     data=data,
                 )
 

--- a/homeassistant/components/conversation/default_agent.py
+++ b/homeassistant/components/conversation/default_agent.py
@@ -294,7 +294,7 @@ class DefaultAgent(ConversationEntity):
                     self.hass, language, DOMAIN, [DOMAIN]
                 )
                 response_text = translations.get(
-                    f"component.{DOMAIN}.agent.done", "Done"
+                    f"component.{DOMAIN}.conversation.agent.done", "Done"
                 )
 
             response.async_set_speech(response_text)

--- a/homeassistant/components/emulated_kasa/manifest.json
+++ b/homeassistant/components/emulated_kasa/manifest.json
@@ -6,5 +6,5 @@
   "iot_class": "local_push",
   "loggers": ["sense_energy"],
   "quality_scale": "internal",
-  "requirements": ["sense-energy==0.13.3"]
+  "requirements": ["sense-energy==0.13.4"]
 }

--- a/homeassistant/components/file/strings.json
+++ b/homeassistant/components/file/strings.json
@@ -18,7 +18,7 @@
         },
         "data_description": {
           "file_path": "The local file path to retrieve the sensor value from",
-          "value_template": "A template to render the the sensors value based on the file content",
+          "value_template": "A template to render the sensors value based on the file content",
           "unit_of_measurement": "Unit of measurement for the sensor"
         }
       },

--- a/homeassistant/components/generic/config_flow.py
+++ b/homeassistant/components/generic/config_flow.py
@@ -282,7 +282,7 @@ async def async_test_stream(
             return {CONF_STREAM_SOURCE: "timeout"}
         await stream.stop()
     except StreamWorkerError as err:
-        return {CONF_STREAM_SOURCE: str(err)}
+        return {CONF_STREAM_SOURCE: "unknown_with_details", "error_details": str(err)}
     except PermissionError:
         return {CONF_STREAM_SOURCE: "stream_not_permitted"}
     except OSError as err:
@@ -339,6 +339,7 @@ class GenericIPCamConfigFlow(ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Handle the start of the config flow."""
         errors = {}
+        description_placeholders = {}
         hass = self.hass
         if user_input:
             # Secondary validation because serialised vol can't seem to handle this complexity:
@@ -372,6 +373,8 @@ class GenericIPCamConfigFlow(ConfigFlow, domain=DOMAIN):
                     # temporary preview for user to check the image
                     self.preview_cam = user_input
                     return await self.async_step_user_confirm_still()
+                if "error_details" in errors:
+                    description_placeholders["error"] = errors.pop("error_details")
         elif self.user_input:
             user_input = self.user_input
         else:
@@ -379,6 +382,7 @@ class GenericIPCamConfigFlow(ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="user",
             data_schema=build_schema(user_input),
+            description_placeholders=description_placeholders,
             errors=errors,
         )
 

--- a/homeassistant/components/generic/strings.json
+++ b/homeassistant/components/generic/strings.json
@@ -3,6 +3,7 @@
   "config": {
     "error": {
       "unknown": "[%key:common::config_flow::error::unknown%]",
+      "unknown_with_details": "An unknown error occurred: {error}",
       "already_exists": "A camera with these URL settings already exists.",
       "unable_still_load": "Unable to load valid image from still image URL (e.g. invalid host, URL or authentication failure).  Review log for more info.",
       "unable_still_load_auth": "Unable to load valid image from still image URL: The camera may require a user name and password, or they are not correct.",

--- a/homeassistant/components/generic_thermostat/strings.json
+++ b/homeassistant/components/generic_thermostat/strings.json
@@ -3,7 +3,7 @@
   "config": {
     "step": {
       "user": {
-        "title": "Add generic thermostat helper",
+        "title": "Add generic thermostat",
         "description": "Create a climate entity that controls the temperature via a switch and sensor.",
         "data": {
           "ac_mode": "Cooling mode",
@@ -17,8 +17,8 @@
         "data_description": {
           "ac_mode": "Set the actuator specified to be treated as a cooling device instead of a heating device.",
           "heater": "Switch entity used to cool or heat depending on A/C mode.",
-          "target_sensor": "Temperature sensor that reflect the current temperature.",
-          "min_cycle_duration": "Set a minimum amount of time that the switch specified must be in its current state prior to being switched either off or on. This option will be ignored if the keep alive option is set.",
+          "target_sensor": "Temperature sensor that reflects the current temperature.",
+          "min_cycle_duration": "Set a minimum amount of time that the switch specified must be in its current state prior to being switched either off or on.",
           "cold_tolerance": "Minimum amount of difference between the temperature read by the temperature sensor the target temperature that must change prior to being switched on. For example, if the target temperature is 25 and the tolerance is 0.5 the heater will start when the sensor equals or goes below 24.5.",
           "hot_tolerance": "Minimum amount of difference between the temperature read by the temperature sensor the target temperature that must change prior to being switched off. For example, if the target temperature is 25 and the tolerance is 0.5 the heater will stop when the sensor equals or goes above 25.5."
         }

--- a/homeassistant/components/go2rtc/__init__.py
+++ b/homeassistant/components/go2rtc/__init__.py
@@ -4,6 +4,7 @@ import logging
 import shutil
 
 from aiohttp.client_exceptions import ClientConnectionError, ServerConnectionError
+from awesomeversion import AwesomeVersion
 from go2rtc_client import Go2RtcRestClient
 from go2rtc_client.exceptions import Go2RtcClientError, Go2RtcVersionError
 from go2rtc_client.ws import (
@@ -32,13 +33,23 @@ from homeassistant.config_entries import SOURCE_SYSTEM, ConfigEntry
 from homeassistant.const import CONF_URL, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.helpers import config_validation as cv, discovery_flow
+from homeassistant.helpers import (
+    config_validation as cv,
+    discovery_flow,
+    issue_registry as ir,
+)
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.util.hass_dict import HassKey
 from homeassistant.util.package import is_docker_env
 
-from .const import CONF_DEBUG_UI, DEBUG_UI_URL_MESSAGE, DOMAIN, HA_MANAGED_URL
+from .const import (
+    CONF_DEBUG_UI,
+    DEBUG_UI_URL_MESSAGE,
+    DOMAIN,
+    HA_MANAGED_URL,
+    RECOMMENDED_VERSION,
+)
 from .server import Server
 
 _LOGGER = logging.getLogger(__name__)
@@ -147,7 +158,21 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Validate the server URL
     try:
         client = Go2RtcRestClient(async_get_clientsession(hass), url)
-        await client.validate_server_version()
+        version = await client.validate_server_version()
+        if version < AwesomeVersion(RECOMMENDED_VERSION):
+            ir.async_create_issue(
+                hass,
+                DOMAIN,
+                "recommended_version",
+                is_fixable=False,
+                is_persistent=False,
+                severity=ir.IssueSeverity.WARNING,
+                translation_key="recommended_version",
+                translation_placeholders={
+                    "recommended_version": RECOMMENDED_VERSION,
+                    "current_version": str(version),
+                },
+            )
     except Go2RtcClientError as err:
         if isinstance(err.__cause__, _RETRYABLE_ERRORS):
             raise ConfigEntryNotReady(

--- a/homeassistant/components/go2rtc/__init__.py
+++ b/homeassistant/components/go2rtc/__init__.py
@@ -244,7 +244,7 @@ class WebRTCProvider(CameraWebRTCProvider):
 
         if self._data.managed:
             # HA manages the go2rtc instance
-            stream_original_name = f"{camera.entity_id}_orginal"
+            stream_original_name = f"{camera.entity_id}_original"
             stream_redirect_sources = [
                 f"rtsp://127.0.0.1:{HA_MANAGED_RTSP_PORT}/{stream_original_name}",
                 f"ffmpeg:{stream_original_name}#audio=opus",

--- a/homeassistant/components/go2rtc/__init__.py
+++ b/homeassistant/components/go2rtc/__init__.py
@@ -1,8 +1,5 @@
 """The go2rtc component."""
 
-from __future__ import annotations
-
-from dataclasses import dataclass
 import logging
 import shutil
 
@@ -41,13 +38,7 @@ from homeassistant.helpers.typing import ConfigType
 from homeassistant.util.hass_dict import HassKey
 from homeassistant.util.package import is_docker_env
 
-from .const import (
-    CONF_DEBUG_UI,
-    DEBUG_UI_URL_MESSAGE,
-    DOMAIN,
-    HA_MANAGED_RTSP_PORT,
-    HA_MANAGED_URL,
-)
+from .const import CONF_DEBUG_UI, DEBUG_UI_URL_MESSAGE, DOMAIN, HA_MANAGED_URL
 from .server import Server
 
 _LOGGER = logging.getLogger(__name__)
@@ -94,22 +85,13 @@ CONFIG_SCHEMA = vol.Schema(
     extra=vol.ALLOW_EXTRA,
 )
 
-_DATA_GO2RTC: HassKey[Go2RtcData] = HassKey(DOMAIN)
+_DATA_GO2RTC: HassKey[str] = HassKey(DOMAIN)
 _RETRYABLE_ERRORS = (ClientConnectionError, ServerConnectionError)
-
-
-@dataclass(frozen=True)
-class Go2RtcData:
-    """Data for go2rtc."""
-
-    url: str
-    managed: bool
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up WebRTC."""
     url: str | None = None
-    managed = False
     if DOMAIN not in config and DEFAULT_CONFIG_DOMAIN not in config:
         await _remove_go2rtc_entries(hass)
         return True
@@ -144,9 +126,8 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         hass.bus.async_listen(EVENT_HOMEASSISTANT_STOP, on_stop)
 
         url = HA_MANAGED_URL
-        managed = True
 
-    hass.data[_DATA_GO2RTC] = Go2RtcData(url, managed)
+    hass.data[_DATA_GO2RTC] = url
     discovery_flow.async_create_flow(
         hass, DOMAIN, context={"source": SOURCE_SYSTEM}, data={}
     )
@@ -161,32 +142,28 @@ async def _remove_go2rtc_entries(hass: HomeAssistant) -> None:
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up go2rtc from a config entry."""
-    data = hass.data[_DATA_GO2RTC]
+    url = hass.data[_DATA_GO2RTC]
 
     # Validate the server URL
     try:
-        client = Go2RtcRestClient(async_get_clientsession(hass), data.url)
+        client = Go2RtcRestClient(async_get_clientsession(hass), url)
         await client.validate_server_version()
     except Go2RtcClientError as err:
         if isinstance(err.__cause__, _RETRYABLE_ERRORS):
             raise ConfigEntryNotReady(
-                f"Could not connect to go2rtc instance on {data.url}"
+                f"Could not connect to go2rtc instance on {url}"
             ) from err
-        _LOGGER.warning(
-            "Could not connect to go2rtc instance on %s (%s)", data.url, err
-        )
+        _LOGGER.warning("Could not connect to go2rtc instance on %s (%s)", url, err)
         return False
     except Go2RtcVersionError as err:
         raise ConfigEntryNotReady(
             f"The go2rtc server version is not supported, {err}"
         ) from err
     except Exception as err:  # noqa: BLE001
-        _LOGGER.warning(
-            "Could not connect to go2rtc instance on %s (%s)", data.url, err
-        )
+        _LOGGER.warning("Could not connect to go2rtc instance on %s (%s)", url, err)
         return False
 
-    provider = WebRTCProvider(hass, data)
+    provider = WebRTCProvider(hass, url)
     async_register_webrtc_provider(hass, provider)
     return True
 
@@ -204,12 +181,12 @@ async def _get_binary(hass: HomeAssistant) -> str | None:
 class WebRTCProvider(CameraWebRTCProvider):
     """WebRTC provider."""
 
-    def __init__(self, hass: HomeAssistant, data: Go2RtcData) -> None:
+    def __init__(self, hass: HomeAssistant, url: str) -> None:
         """Initialize the WebRTC provider."""
         self._hass = hass
-        self._data = data
+        self._url = url
         self._session = async_get_clientsession(hass)
-        self._rest_client = Go2RtcRestClient(self._session, data.url)
+        self._rest_client = Go2RtcRestClient(self._session, url)
         self._sessions: dict[str, Go2RtcWsClient] = {}
 
     @property
@@ -231,7 +208,7 @@ class WebRTCProvider(CameraWebRTCProvider):
     ) -> None:
         """Handle the WebRTC offer and return the answer via the provided callback."""
         self._sessions[session_id] = ws_client = Go2RtcWsClient(
-            self._session, self._data.url, source=camera.entity_id
+            self._session, self._url, source=camera.entity_id
         )
 
         if not (stream_source := await camera.stream_source()):
@@ -242,34 +219,18 @@ class WebRTCProvider(CameraWebRTCProvider):
 
         streams = await self._rest_client.streams.list()
 
-        if self._data.managed:
-            # HA manages the go2rtc instance
-            stream_original_name = f"{camera.entity_id}_original"
-            stream_redirect_sources = [
-                f"rtsp://127.0.0.1:{HA_MANAGED_RTSP_PORT}/{stream_original_name}",
-                f"ffmpeg:{stream_original_name}#audio=opus",
-            ]
-
-            if (
-                (stream_org := streams.get(stream_original_name)) is None
-                or not any(
-                    stream_source == producer.url for producer in stream_org.producers
-                )
-                or (stream_redirect := streams.get(camera.entity_id)) is None
-                or stream_redirect_sources != [p.url for p in stream_redirect.producers]
-            ):
-                await self._rest_client.streams.add(stream_original_name, stream_source)
-                await self._rest_client.streams.add(
-                    camera.entity_id, stream_redirect_sources
-                )
-
-        # go2rtc instance is managed outside HA
-        elif (stream_org := streams.get(camera.entity_id)) is None or not any(
-            stream_source == producer.url for producer in stream_org.producers
+        if (stream := streams.get(camera.entity_id)) is None or not any(
+            stream_source == producer.url for producer in stream.producers
         ):
             await self._rest_client.streams.add(
                 camera.entity_id,
-                [stream_source, f"ffmpeg:{camera.entity_id}#audio=opus"],
+                [
+                    stream_source,
+                    # We are setting any ffmpeg rtsp related logs to debug
+                    # Connection problems to the camera will be logged by the first stream
+                    # Therefore setting it to debug will not hide any important logs
+                    f"ffmpeg:{camera.entity_id}#audio=opus#query=log_level=debug",
+                ],
             )
 
         @callback

--- a/homeassistant/components/go2rtc/__init__.py
+++ b/homeassistant/components/go2rtc/__init__.py
@@ -244,21 +244,21 @@ class WebRTCProvider(CameraWebRTCProvider):
 
         if self._data.managed:
             # HA manages the go2rtc instance
-            stream_org_name = camera.entity_id + "_orginal"
+            stream_original_name = f"{camera.entity_id}_orginal"
             stream_redirect_sources = [
-                f"rtsp://127.0.0.1:{HA_MANAGED_RTSP_PORT}/{stream_org_name}",
-                f"ffmpeg:{stream_org_name}#audio=opus",
+                f"rtsp://127.0.0.1:{HA_MANAGED_RTSP_PORT}/{stream_original_name}",
+                f"ffmpeg:{stream_original_name}#audio=opus",
             ]
 
             if (
-                (stream_org := streams.get(stream_org_name)) is None
+                (stream_org := streams.get(stream_original_name)) is None
                 or not any(
                     stream_source == producer.url for producer in stream_org.producers
                 )
                 or (stream_redirect := streams.get(camera.entity_id)) is None
                 or stream_redirect_sources != [p.url for p in stream_redirect.producers]
             ):
-                await self._rest_client.streams.add(stream_org_name, stream_source)
+                await self._rest_client.streams.add(stream_original_name, stream_source)
                 await self._rest_client.streams.add(
                     camera.entity_id, stream_redirect_sources
                 )

--- a/homeassistant/components/go2rtc/const.py
+++ b/homeassistant/components/go2rtc/const.py
@@ -6,3 +6,4 @@ CONF_DEBUG_UI = "debug_ui"
 DEBUG_UI_URL_MESSAGE = "Url and debug_ui cannot be set at the same time."
 HA_MANAGED_API_PORT = 11984
 HA_MANAGED_URL = f"http://localhost:{HA_MANAGED_API_PORT}/"
+RECOMMENDED_VERSION = "1.9.7"

--- a/homeassistant/components/go2rtc/const.py
+++ b/homeassistant/components/go2rtc/const.py
@@ -6,4 +6,3 @@ CONF_DEBUG_UI = "debug_ui"
 DEBUG_UI_URL_MESSAGE = "Url and debug_ui cannot be set at the same time."
 HA_MANAGED_API_PORT = 11984
 HA_MANAGED_URL = f"http://localhost:{HA_MANAGED_API_PORT}/"
-HA_MANAGED_RTSP_PORT = 18554

--- a/homeassistant/components/go2rtc/manifest.json
+++ b/homeassistant/components/go2rtc/manifest.json
@@ -7,6 +7,6 @@
   "documentation": "https://www.home-assistant.io/integrations/go2rtc",
   "integration_type": "system",
   "iot_class": "local_polling",
-  "requirements": ["go2rtc-client==0.1.0"],
+  "requirements": ["go2rtc-client==0.1.1"],
   "single_config_entry": true
 }

--- a/homeassistant/components/go2rtc/server.py
+++ b/homeassistant/components/go2rtc/server.py
@@ -12,7 +12,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import HA_MANAGED_API_PORT, HA_MANAGED_RTSP_PORT, HA_MANAGED_URL
+from .const import HA_MANAGED_API_PORT, HA_MANAGED_URL
 
 _LOGGER = logging.getLogger(__name__)
 _TERMINATE_TIMEOUT = 5
@@ -33,7 +33,7 @@ api:
   listen: "{api_ip}:{api_port}"
 
 rtsp:
-  listen: "127.0.0.1:{rtsp_port}"
+  listen: "127.0.0.1:18554"
 
 webrtc:
   listen: ":18555/tcp"
@@ -68,9 +68,7 @@ def _create_temp_file(api_ip: str) -> str:
     with NamedTemporaryFile(prefix="go2rtc_", suffix=".yaml", delete=False) as file:
         file.write(
             _GO2RTC_CONFIG_FORMAT.format(
-                api_ip=api_ip,
-                api_port=HA_MANAGED_API_PORT,
-                rtsp_port=HA_MANAGED_RTSP_PORT,
+                api_ip=api_ip, api_port=HA_MANAGED_API_PORT
             ).encode()
         )
         return file.name

--- a/homeassistant/components/go2rtc/strings.json
+++ b/homeassistant/components/go2rtc/strings.json
@@ -1,0 +1,8 @@
+{
+  "issues": {
+    "recommended_version": {
+      "title": "Outdated go2rtc server detected",
+      "description": "We detected that you are using an outdated go2rtc server version. For the best experience, we recommend updating the go2rtc server to version `{recommended_version}`.\nCurrently you are using version `{current_version}`."
+    }
+  }
+}

--- a/homeassistant/components/google/strings.json
+++ b/homeassistant/components/google/strings.json
@@ -87,8 +87,8 @@
       }
     },
     "create_event": {
-      "name": "Creates event",
-      "description": "Add a new calendar event.",
+      "name": "Create event",
+      "description": "Adds a new calendar event.",
       "fields": {
         "summary": {
           "name": "Summary",

--- a/homeassistant/components/homekit/type_security_systems.py
+++ b/homeassistant/components/homekit/type_security_systems.py
@@ -18,6 +18,8 @@ from homeassistant.const import (
     SERVICE_ALARM_ARM_HOME,
     SERVICE_ALARM_ARM_NIGHT,
     SERVICE_ALARM_DISARM,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
 )
 from homeassistant.core import State, callback
 
@@ -152,12 +154,12 @@ class SecuritySystem(HomeAccessory):
     @callback
     def async_update_state(self, new_state: State) -> None:
         """Update security state after state changed."""
-        hass_state = None
-        if new_state and new_state.state == "None":
-            # Bail out early for no state
+        hass_state: str | AlarmControlPanelState = new_state.state
+        if hass_state in {"None", STATE_UNKNOWN, STATE_UNAVAILABLE}:
+            # Bail out early for no state, unknown or unavailable
             return
-        if new_state and new_state.state is not None:
-            hass_state = AlarmControlPanelState(new_state.state)
+        if hass_state is not None:
+            hass_state = AlarmControlPanelState(hass_state)
         if (
             hass_state
             and (current_state := HASS_TO_HOMEKIT_CURRENT.get(hass_state)) is not None

--- a/homeassistant/components/hue/scene.py
+++ b/homeassistant/components/hue/scene.py
@@ -130,10 +130,15 @@ class HueSceneEntity(HueSceneEntityBase):
     @property
     def is_dynamic(self) -> bool:
         """Return if this scene has a dynamic color palette."""
-        if self.resource.palette.color and len(self.resource.palette.color) > 1:
+        if (
+            self.resource.palette
+            and self.resource.palette.color
+            and len(self.resource.palette.color) > 1
+        ):
             return True
         if (
-            self.resource.palette.color_temperature
+            self.resource.palette
+            and self.resource.palette.color_temperature
             and len(self.resource.palette.color_temperature) > 1
         ):
             return True

--- a/homeassistant/components/hunterdouglas_powerview/number.py
+++ b/homeassistant/components/hunterdouglas_powerview/number.py
@@ -95,7 +95,7 @@ class PowerViewNumber(ShadeEntity, RestoreNumber):
         self.entity_description = description
         self._attr_unique_id = f"{self._attr_unique_id}_{description.key}"
 
-    def set_native_value(self, value: float) -> None:
+    async def async_set_native_value(self, value: float) -> None:
         """Update the current value."""
         self._attr_native_value = value
         self.entity_description.store_value_fn(self.coordinator, self._shade.id, value)

--- a/homeassistant/components/hvv_departures/strings.json
+++ b/homeassistant/components/hvv_departures/strings.json
@@ -32,6 +32,10 @@
     }
   },
   "options": {
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]"
+    },
     "step": {
       "init": {
         "title": "Options",

--- a/homeassistant/components/hydrawise/__init__.py
+++ b/homeassistant/components/hydrawise/__init__.py
@@ -7,8 +7,12 @@ from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 
-from .const import DOMAIN, SCAN_INTERVAL
-from .coordinator import HydrawiseDataUpdateCoordinator
+from .const import DOMAIN
+from .coordinator import (
+    HydrawiseMainDataUpdateCoordinator,
+    HydrawiseUpdateCoordinators,
+    HydrawiseWaterUseDataUpdateCoordinator,
+)
 
 PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
@@ -29,9 +33,18 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         auth.Auth(config_entry.data[CONF_USERNAME], config_entry.data[CONF_PASSWORD])
     )
 
-    coordinator = HydrawiseDataUpdateCoordinator(hass, hydrawise, SCAN_INTERVAL)
-    await coordinator.async_config_entry_first_refresh()
-    hass.data.setdefault(DOMAIN, {})[config_entry.entry_id] = coordinator
+    main_coordinator = HydrawiseMainDataUpdateCoordinator(hass, hydrawise)
+    await main_coordinator.async_config_entry_first_refresh()
+    water_use_coordinator = HydrawiseWaterUseDataUpdateCoordinator(
+        hass, hydrawise, main_coordinator
+    )
+    await water_use_coordinator.async_config_entry_first_refresh()
+    hass.data.setdefault(DOMAIN, {})[config_entry.entry_id] = (
+        HydrawiseUpdateCoordinators(
+            main=main_coordinator,
+            water_use=water_use_coordinator,
+        )
+    )
     await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
     return True
 

--- a/homeassistant/components/hydrawise/binary_sensor.py
+++ b/homeassistant/components/hydrawise/binary_sensor.py
@@ -21,7 +21,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import VolDictType
 
 from .const import DOMAIN, SERVICE_RESUME, SERVICE_START_WATERING, SERVICE_SUSPEND
-from .coordinator import HydrawiseDataUpdateCoordinator
+from .coordinator import HydrawiseUpdateCoordinators
 from .entity import HydrawiseEntity
 
 
@@ -81,18 +81,16 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the Hydrawise binary_sensor platform."""
-    coordinator: HydrawiseDataUpdateCoordinator = hass.data[DOMAIN][
-        config_entry.entry_id
-    ]
+    coordinators: HydrawiseUpdateCoordinators = hass.data[DOMAIN][config_entry.entry_id]
     entities: list[HydrawiseBinarySensor] = []
-    for controller in coordinator.data.controllers.values():
+    for controller in coordinators.main.data.controllers.values():
         entities.extend(
-            HydrawiseBinarySensor(coordinator, description, controller)
+            HydrawiseBinarySensor(coordinators.main, description, controller)
             for description in CONTROLLER_BINARY_SENSORS
         )
         entities.extend(
             HydrawiseBinarySensor(
-                coordinator,
+                coordinators.main,
                 description,
                 controller,
                 sensor_id=sensor.id,
@@ -103,7 +101,7 @@ async def async_setup_entry(
         )
         entities.extend(
             HydrawiseZoneBinarySensor(
-                coordinator, description, controller, zone_id=zone.id
+                coordinators.main, description, controller, zone_id=zone.id
             )
             for zone in controller.zones
             for description in ZONE_BINARY_SENSORS

--- a/homeassistant/components/hydrawise/const.py
+++ b/homeassistant/components/hydrawise/const.py
@@ -10,7 +10,8 @@ DEFAULT_WATERING_TIME = timedelta(minutes=15)
 
 MANUFACTURER = "Hydrawise"
 
-SCAN_INTERVAL = timedelta(seconds=60)
+MAIN_SCAN_INTERVAL = timedelta(seconds=60)
+WATER_USE_SCAN_INTERVAL = timedelta(minutes=60)
 
 SIGNAL_UPDATE_HYDRAWISE = "hydrawise_update"
 

--- a/homeassistant/components/hydrawise/coordinator.py
+++ b/homeassistant/components/hydrawise/coordinator.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from datetime import timedelta
+from dataclasses import dataclass, field
 
 from pydrawise import Hydrawise
 from pydrawise.schema import Controller, ControllerWaterUseSummary, Sensor, User, Zone
@@ -12,7 +11,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.util.dt import now
 
-from .const import DOMAIN, LOGGER
+from .const import DOMAIN, LOGGER, MAIN_SCAN_INTERVAL, WATER_USE_SCAN_INTERVAL
 
 
 @dataclass
@@ -20,22 +19,39 @@ class HydrawiseData:
     """Container for data fetched from the Hydrawise API."""
 
     user: User
-    controllers: dict[int, Controller]
-    zones: dict[int, Zone]
-    sensors: dict[int, Sensor]
-    daily_water_summary: dict[int, ControllerWaterUseSummary]
+    controllers: dict[int, Controller] = field(default_factory=dict)
+    zones: dict[int, Zone] = field(default_factory=dict)
+    sensors: dict[int, Sensor] = field(default_factory=dict)
+    daily_water_summary: dict[int, ControllerWaterUseSummary] = field(
+        default_factory=dict
+    )
+
+
+@dataclass
+class HydrawiseUpdateCoordinators:
+    """Container for all Hydrawise DataUpdateCoordinator instances."""
+
+    main: HydrawiseMainDataUpdateCoordinator
+    water_use: HydrawiseWaterUseDataUpdateCoordinator
 
 
 class HydrawiseDataUpdateCoordinator(DataUpdateCoordinator[HydrawiseData]):
-    """The Hydrawise Data Update Coordinator."""
+    """Base class for Hydrawise Data Update Coordinators."""
 
     api: Hydrawise
 
-    def __init__(
-        self, hass: HomeAssistant, api: Hydrawise, scan_interval: timedelta
-    ) -> None:
+
+class HydrawiseMainDataUpdateCoordinator(HydrawiseDataUpdateCoordinator):
+    """The main Hydrawise Data Update Coordinator.
+
+    This fetches the primary state data for Hydrawise controllers and zones
+    at a relatively frequent interval so that the primary functions of the
+    integration are updated in a timely manner.
+    """
+
+    def __init__(self, hass: HomeAssistant, api: Hydrawise) -> None:
         """Initialize HydrawiseDataUpdateCoordinator."""
-        super().__init__(hass, LOGGER, name=DOMAIN, update_interval=scan_interval)
+        super().__init__(hass, LOGGER, name=DOMAIN, update_interval=MAIN_SCAN_INTERVAL)
         self.api = api
 
     async def _async_update_data(self) -> HydrawiseData:
@@ -43,28 +59,56 @@ class HydrawiseDataUpdateCoordinator(DataUpdateCoordinator[HydrawiseData]):
         # Don't fetch zones. We'll fetch them for each controller later.
         # This is to prevent 502 errors in some cases.
         # See: https://github.com/home-assistant/core/issues/120128
-        user = await self.api.get_user(fetch_zones=False)
-        controllers = {}
-        zones = {}
-        sensors = {}
-        daily_water_summary: dict[int, ControllerWaterUseSummary] = {}
-        for controller in user.controllers:
-            controllers[controller.id] = controller
+        data = HydrawiseData(user=await self.api.get_user(fetch_zones=False))
+        for controller in data.user.controllers:
+            data.controllers[controller.id] = controller
             controller.zones = await self.api.get_zones(controller)
             for zone in controller.zones:
-                zones[zone.id] = zone
+                data.zones[zone.id] = zone
             for sensor in controller.sensors:
-                sensors[sensor.id] = sensor
+                data.sensors[sensor.id] = sensor
+        return data
+
+
+class HydrawiseWaterUseDataUpdateCoordinator(HydrawiseDataUpdateCoordinator):
+    """Data Update Coordinator for Hydrawise Water Use.
+
+    This fetches data that is more expensive for the Hydrawise API to compute
+    at a less frequent interval as to not overload the Hydrawise servers.
+    """
+
+    _main_coordinator: HydrawiseMainDataUpdateCoordinator
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        api: Hydrawise,
+        main_coordinator: HydrawiseMainDataUpdateCoordinator,
+    ) -> None:
+        """Initialize HydrawiseWaterUseDataUpdateCoordinator."""
+        super().__init__(
+            hass,
+            LOGGER,
+            name=f"{DOMAIN} water use",
+            update_interval=WATER_USE_SCAN_INTERVAL,
+        )
+        self.api = api
+        self._main_coordinator = main_coordinator
+
+    async def _async_update_data(self) -> HydrawiseData:
+        """Fetch the latest data from Hydrawise."""
+        daily_water_summary: dict[int, ControllerWaterUseSummary] = {}
+        for controller in self._main_coordinator.data.controllers.values():
             daily_water_summary[controller.id] = await self.api.get_water_use_summary(
                 controller,
                 now().replace(hour=0, minute=0, second=0, microsecond=0),
                 now(),
             )
-
+        main_data = self._main_coordinator.data
         return HydrawiseData(
-            user=user,
-            controllers=controllers,
-            zones=zones,
-            sensors=sensors,
+            user=main_data.user,
+            controllers=main_data.controllers,
+            zones=main_data.zones,
+            sensors=main_data.sensors,
             daily_water_summary=daily_water_summary,
         )

--- a/homeassistant/components/hydrawise/switch.py
+++ b/homeassistant/components/hydrawise/switch.py
@@ -20,7 +20,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util import dt as dt_util
 
 from .const import DEFAULT_WATERING_TIME, DOMAIN
-from .coordinator import HydrawiseDataUpdateCoordinator
+from .coordinator import HydrawiseUpdateCoordinators
 from .entity import HydrawiseEntity
 
 
@@ -66,12 +66,10 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the Hydrawise switch platform."""
-    coordinator: HydrawiseDataUpdateCoordinator = hass.data[DOMAIN][
-        config_entry.entry_id
-    ]
+    coordinators: HydrawiseUpdateCoordinators = hass.data[DOMAIN][config_entry.entry_id]
     async_add_entities(
-        HydrawiseSwitch(coordinator, description, controller, zone_id=zone.id)
-        for controller in coordinator.data.controllers.values()
+        HydrawiseSwitch(coordinators.main, description, controller, zone_id=zone.id)
+        for controller in coordinators.main.data.controllers.values()
         for zone in controller.zones
         for description in SWITCH_TYPES
     )

--- a/homeassistant/components/hydrawise/valve.py
+++ b/homeassistant/components/hydrawise/valve.py
@@ -17,7 +17,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
-from .coordinator import HydrawiseDataUpdateCoordinator
+from .coordinator import HydrawiseUpdateCoordinators
 from .entity import HydrawiseEntity
 
 VALVE_TYPES: tuple[ValveEntityDescription, ...] = (
@@ -34,12 +34,10 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the Hydrawise valve platform."""
-    coordinator: HydrawiseDataUpdateCoordinator = hass.data[DOMAIN][
-        config_entry.entry_id
-    ]
+    coordinators: HydrawiseUpdateCoordinators = hass.data[DOMAIN][config_entry.entry_id]
     async_add_entities(
-        HydrawiseValve(coordinator, description, controller, zone_id=zone.id)
-        for controller in coordinator.data.controllers.values()
+        HydrawiseValve(coordinators.main, description, controller, zone_id=zone.id)
+        for controller in coordinators.main.data.controllers.values()
         for zone in controller.zones
         for description in VALVE_TYPES
     )

--- a/homeassistant/components/lg_netcast/strings.json
+++ b/homeassistant/components/lg_netcast/strings.json
@@ -25,7 +25,8 @@
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
-      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_host": "[%key:common::config_flow::error::invalid_host%]"
     }
   },
   "device_automation": {

--- a/homeassistant/components/lg_thinq/fan.py
+++ b/homeassistant/components/lg_thinq/fan.py
@@ -72,8 +72,11 @@ class ThinQFanEntity(ThinQEntity, FanEntity):
         super().__init__(coordinator, entity_description, property_id)
 
         self._ordered_named_fan_speeds = []
-        self._attr_supported_features |= FanEntityFeature.SET_SPEED
-
+        self._attr_supported_features = (
+            FanEntityFeature.SET_SPEED
+            | FanEntityFeature.TURN_ON
+            | FanEntityFeature.TURN_OFF
+        )
         if (fan_modes := self.data.fan_modes) is not None:
             self._attr_speed_count = len(fan_modes)
             if self.speed_count == 4:
@@ -98,7 +101,7 @@ class ThinQFanEntity(ThinQEntity, FanEntity):
             self._attr_percentage = 0
 
         _LOGGER.debug(
-            "[%s:%s] update status: %s -> %s (percntage=%s)",
+            "[%s:%s] update status: %s -> %s (percentage=%s)",
             self.coordinator.device_name,
             self.property_id,
             self.data.is_on,
@@ -120,7 +123,7 @@ class ThinQFanEntity(ThinQEntity, FanEntity):
             return
 
         _LOGGER.debug(
-            "[%s:%s] async_set_percentage. percntage=%s, value=%s",
+            "[%s:%s] async_set_percentage. percentage=%s, value=%s",
             self.coordinator.device_name,
             self.property_id,
             percentage,

--- a/homeassistant/components/linkplay/manifest.json
+++ b/homeassistant/components/linkplay/manifest.json
@@ -7,6 +7,6 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "loggers": ["linkplay"],
-  "requirements": ["python-linkplay==0.0.18"],
+  "requirements": ["python-linkplay==0.0.20"],
   "zeroconf": ["_linkplay._tcp.local."]
 }

--- a/homeassistant/components/linkplay/manifest.json
+++ b/homeassistant/components/linkplay/manifest.json
@@ -7,6 +7,6 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "loggers": ["linkplay"],
-  "requirements": ["python-linkplay==0.0.17"],
+  "requirements": ["python-linkplay==0.0.18"],
   "zeroconf": ["_linkplay._tcp.local."]
 }

--- a/homeassistant/components/linkplay/media_player.py
+++ b/homeassistant/components/linkplay/media_player.py
@@ -9,7 +9,7 @@ from typing import Any, Concatenate
 from linkplay.bridge import LinkPlayBridge
 from linkplay.consts import EqualizerMode, LoopMode, PlayingMode, PlayingStatus
 from linkplay.controller import LinkPlayController, LinkPlayMultiroom
-from linkplay.exceptions import LinkPlayException, LinkPlayRequestException
+from linkplay.exceptions import LinkPlayRequestException
 import voluptuous as vol
 
 from homeassistant.components import media_source
@@ -201,9 +201,8 @@ class LinkPlayMediaPlayerEntity(MediaPlayerEntity):
         try:
             await self._bridge.player.update_status()
             self._update_properties()
-        except LinkPlayException:
+        except LinkPlayRequestException:
             self._attr_available = False
-            raise
 
     @exception_wrap
     async def async_select_source(self, source: str) -> None:

--- a/homeassistant/components/linkplay/media_player.py
+++ b/homeassistant/components/linkplay/media_player.py
@@ -297,6 +297,11 @@ class LinkPlayMediaPlayerEntity(MediaPlayerEntity):
             raise HomeAssistantError(err) from err
 
     @exception_wrap
+    async def async_media_seek(self, position: float) -> None:
+        """Seek to a position."""
+        await self._bridge.player.seek(round(position))
+
+    @exception_wrap
     async def async_join_players(self, group_members: list[str]) -> None:
         """Join `group_members` as a player group with the current player."""
 
@@ -381,9 +386,9 @@ class LinkPlayMediaPlayerEntity(MediaPlayerEntity):
                 )
 
             self._attr_source = SOURCE_MAP.get(self._bridge.player.play_mode, "other")
-            self._attr_media_position = self._bridge.player.current_position / 1000
+            self._attr_media_position = self._bridge.player.current_position_in_seconds
             self._attr_media_position_updated_at = utcnow()
-            self._attr_media_duration = self._bridge.player.total_length / 1000
+            self._attr_media_duration = self._bridge.player.total_length_in_seconds
             self._attr_media_artist = self._bridge.player.artist
             self._attr_media_title = self._bridge.player.title
             self._attr_media_album_name = self._bridge.player.album

--- a/homeassistant/components/linkplay/media_player.py
+++ b/homeassistant/components/linkplay/media_player.py
@@ -69,6 +69,8 @@ SOURCE_MAP: dict[PlayingMode, str] = {
     PlayingMode.FM: "FM Radio",
     PlayingMode.RCA: "RCA",
     PlayingMode.UDISK: "USB",
+    PlayingMode.SPOTIFY: "Spotify",
+    PlayingMode.TIDAL: "Tidal",
     PlayingMode.FOLLOWER: "Follower",
 }
 

--- a/homeassistant/components/linkplay/media_player.py
+++ b/homeassistant/components/linkplay/media_player.py
@@ -292,7 +292,10 @@ class LinkPlayMediaPlayerEntity(MediaPlayerEntity):
     @exception_wrap
     async def async_play_preset(self, preset_number: int) -> None:
         """Play preset number."""
-        await self._bridge.player.play_preset(preset_number)
+        try:
+            await self._bridge.player.play_preset(preset_number)
+        except ValueError as err:
+            raise HomeAssistantError(err) from err
 
     @exception_wrap
     async def async_join_players(self, group_members: list[str]) -> None:

--- a/homeassistant/components/linkplay/services.yaml
+++ b/homeassistant/components/linkplay/services.yaml
@@ -11,5 +11,4 @@ play_preset:
       selector:
         number:
           min: 1
-          max: 10
           mode: box

--- a/homeassistant/components/madvr/strings.json
+++ b/homeassistant/components/madvr/strings.json
@@ -28,12 +28,12 @@
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
-      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]",
+      "set_up_new_device": "A new device was detected. Please set it up as a new entity instead of reconfiguring."
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "no_mac": "A MAC address was not found. It required to identify the device. Please ensure your device is connectable.",
-      "set_up_new_device": "A new device was detected. Please set it up as a new entity instead of reconfiguring."
+      "no_mac": "A MAC address was not found. It required to identify the device. Please ensure your device is connectable."
     }
   },
   "entity": {

--- a/homeassistant/components/myuplink/binary_sensor.py
+++ b/homeassistant/components/myuplink/binary_sensor.py
@@ -12,11 +12,12 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import MyUplinkConfigEntry, MyUplinkDataCoordinator
+from .const import F_SERIES
 from .entity import MyUplinkEntity, MyUplinkSystemEntity
-from .helpers import find_matching_platform
+from .helpers import find_matching_platform, transform_model_series
 
 CATEGORY_BASED_DESCRIPTIONS: dict[str, dict[str, BinarySensorEntityDescription]] = {
-    "F730": {
+    F_SERIES: {
         "43161": BinarySensorEntityDescription(
             key="elect_add",
             translation_key="elect_add",
@@ -50,6 +51,7 @@ def get_description(device_point: DevicePoint) -> BinarySensorEntityDescription 
     2. Default to None
     """
     prefix, _, _ = device_point.category.partition(" ")
+    prefix = transform_model_series(prefix)
     return CATEGORY_BASED_DESCRIPTIONS.get(prefix, {}).get(device_point.parameter_id)
 
 

--- a/homeassistant/components/myuplink/const.py
+++ b/homeassistant/components/myuplink/const.py
@@ -6,3 +6,5 @@ API_ENDPOINT = "https://api.myuplink.com"
 OAUTH2_AUTHORIZE = "https://api.myuplink.com/oauth/authorize"
 OAUTH2_TOKEN = "https://api.myuplink.com/oauth/token"
 OAUTH2_SCOPES = ["WRITESYSTEM", "READSYSTEM", "offline_access"]
+
+F_SERIES = "f-series"

--- a/homeassistant/components/myuplink/helpers.py
+++ b/homeassistant/components/myuplink/helpers.py
@@ -6,6 +6,8 @@ from homeassistant.components.number import NumberEntityDescription
 from homeassistant.components.sensor import SensorEntityDescription
 from homeassistant.const import Platform
 
+from .const import F_SERIES
+
 
 def find_matching_platform(
     device_point: DevicePoint,
@@ -86,8 +88,9 @@ PARAMETER_ID_TO_EXCLUDE_F730 = (
     "47941",
     "47975",
     "48009",
-    "48042",
     "48072",
+    "48442",
+    "49909",
     "50113",
 )
 
@@ -110,7 +113,7 @@ def skip_entity(model: str, device_point: DevicePoint) -> bool:
         ):
             return False
         return True
-    if "F730" in model:
+    if model.lower().startswith("f"):
         # Entity names containing weekdays are used for advanced scheduling in the
         # heat pump and should not be exposed in the integration
         if any(d in device_point.parameter_name.lower() for d in WEEKDAYS):
@@ -118,3 +121,10 @@ def skip_entity(model: str, device_point: DevicePoint) -> bool:
         if device_point.parameter_id in PARAMETER_ID_TO_EXCLUDE_F730:
             return True
     return False
+
+
+def transform_model_series(prefix: str) -> str:
+    """Remap all F-series models."""
+    if prefix.lower().startswith("f"):
+        return F_SERIES
+    return prefix

--- a/homeassistant/components/myuplink/number.py
+++ b/homeassistant/components/myuplink/number.py
@@ -10,8 +10,9 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import MyUplinkConfigEntry, MyUplinkDataCoordinator
+from .const import F_SERIES
 from .entity import MyUplinkEntity
-from .helpers import find_matching_platform, skip_entity
+from .helpers import find_matching_platform, skip_entity, transform_model_series
 
 DEVICE_POINT_UNIT_DESCRIPTIONS: dict[str, NumberEntityDescription] = {
     "DM": NumberEntityDescription(
@@ -22,7 +23,7 @@ DEVICE_POINT_UNIT_DESCRIPTIONS: dict[str, NumberEntityDescription] = {
 }
 
 CATEGORY_BASED_DESCRIPTIONS: dict[str, dict[str, NumberEntityDescription]] = {
-    "F730": {
+    F_SERIES: {
         "40940": NumberEntityDescription(
             key="degree_minutes",
             translation_key="degree_minutes",
@@ -48,6 +49,7 @@ def get_description(device_point: DevicePoint) -> NumberEntityDescription | None
     3. Default to None
     """
     prefix, _, _ = device_point.category.partition(" ")
+    prefix = transform_model_series(prefix)
     description = CATEGORY_BASED_DESCRIPTIONS.get(prefix, {}).get(
         device_point.parameter_id
     )

--- a/homeassistant/components/myuplink/sensor.py
+++ b/homeassistant/components/myuplink/sensor.py
@@ -25,8 +25,9 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
 
 from . import MyUplinkConfigEntry, MyUplinkDataCoordinator
+from .const import F_SERIES
 from .entity import MyUplinkEntity
-from .helpers import find_matching_platform, skip_entity
+from .helpers import find_matching_platform, skip_entity, transform_model_series
 
 DEVICE_POINT_UNIT_DESCRIPTIONS: dict[str, SensorEntityDescription] = {
     "°C": SensorEntityDescription(
@@ -139,7 +140,7 @@ DEVICE_POINT_UNIT_DESCRIPTIONS: dict[str, SensorEntityDescription] = {
 MARKER_FOR_UNKNOWN_VALUE = -32768
 
 CATEGORY_BASED_DESCRIPTIONS: dict[str, dict[str, SensorEntityDescription]] = {
-    "F730": {
+    F_SERIES: {
         "43108": SensorEntityDescription(
             key="fan_mode",
             translation_key="fan_mode",
@@ -200,6 +201,7 @@ def get_description(device_point: DevicePoint) -> SensorEntityDescription | None
     """
     description = None
     prefix, _, _ = device_point.category.partition(" ")
+    prefix = transform_model_series(prefix)
     description = CATEGORY_BASED_DESCRIPTIONS.get(prefix, {}).get(
         device_point.parameter_id
     )

--- a/homeassistant/components/myuplink/switch.py
+++ b/homeassistant/components/myuplink/switch.py
@@ -12,11 +12,12 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import MyUplinkConfigEntry, MyUplinkDataCoordinator
+from .const import F_SERIES
 from .entity import MyUplinkEntity
-from .helpers import find_matching_platform, skip_entity
+from .helpers import find_matching_platform, skip_entity, transform_model_series
 
 CATEGORY_BASED_DESCRIPTIONS: dict[str, dict[str, SwitchEntityDescription]] = {
-    "F730": {
+    F_SERIES: {
         "50004": SwitchEntityDescription(
             key="temporary_lux",
             translation_key="temporary_lux",
@@ -47,6 +48,7 @@ def get_description(device_point: DevicePoint) -> SwitchEntityDescription | None
     2. Default to None
     """
     prefix, _, _ = device_point.category.partition(" ")
+    prefix = transform_model_series(prefix)
     return CATEGORY_BASED_DESCRIPTIONS.get(prefix, {}).get(device_point.parameter_id)
 
 

--- a/homeassistant/components/nest/camera.py
+++ b/homeassistant/components/nest/camera.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
+from abc import ABC
 import asyncio
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 import datetime
 import functools
 import logging
@@ -46,6 +46,11 @@ PLACEHOLDER = Path(__file__).parent / "placeholder.png"
 # Used to schedule an alarm to refresh the stream before expiration
 STREAM_EXPIRATION_BUFFER = datetime.timedelta(seconds=30)
 
+# Refresh streams with a bounded interval and backoff on failure
+MIN_REFRESH_BACKOFF_INTERVAL = datetime.timedelta(minutes=1)
+MAX_REFRESH_BACKOFF_INTERVAL = datetime.timedelta(minutes=10)
+BACKOFF_MULTIPLIER = 1.5
+
 
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
@@ -67,6 +72,68 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
+class StreamRefresh:
+    """Class that will refresh an expiring stream.
+
+    This class will schedule an alarm for the next expiration time of a stream.
+    When the alarm fires, it runs the provided `refresh_cb` to extend the
+    lifetime of the stream and return a new expiration time.
+
+    A simple backoff will be applied when the refresh callback fails.
+    """
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        expires_at: datetime.datetime,
+        refresh_cb: Callable[[], Awaitable[datetime.datetime | None]],
+    ) -> None:
+        """Initialize StreamRefresh."""
+        self._hass = hass
+        self._unsub: Callable[[], None] | None = None
+        self._min_refresh_interval = MIN_REFRESH_BACKOFF_INTERVAL
+        self._refresh_cb = refresh_cb
+        self._schedule_stream_refresh(expires_at - STREAM_EXPIRATION_BUFFER)
+
+    def unsub(self) -> None:
+        """Invalidates the stream."""
+        if self._unsub:
+            self._unsub()
+
+    async def _handle_refresh(self, _: datetime.datetime) -> None:
+        """Alarm that fires to check if the stream should be refreshed."""
+        self._unsub = None
+        try:
+            expires_at = await self._refresh_cb()
+        except ApiException as err:
+            _LOGGER.debug("Failed to refresh stream: %s", err)
+            # Increase backoff until the max backoff interval is reached
+            self._min_refresh_interval = min(
+                self._min_refresh_interval * BACKOFF_MULTIPLIER,
+                MAX_REFRESH_BACKOFF_INTERVAL,
+            )
+            refresh_time = utcnow() + self._min_refresh_interval
+        else:
+            if expires_at is None:
+                return
+            self._min_refresh_interval = MIN_REFRESH_BACKOFF_INTERVAL  # Reset backoff
+            # Defend against invalid stream expiration time in the past
+            refresh_time = max(
+                expires_at - STREAM_EXPIRATION_BUFFER,
+                utcnow() + self._min_refresh_interval,
+            )
+        self._schedule_stream_refresh(refresh_time)
+
+    def _schedule_stream_refresh(self, refresh_time: datetime.datetime) -> None:
+        """Schedules an alarm to refresh any streams before expiration."""
+        _LOGGER.debug("Scheduling stream refresh for %s", refresh_time)
+        self._unsub = async_track_point_in_utc_time(
+            self._hass,
+            self._handle_refresh,
+            refresh_time,
+        )
+
+
 class NestCameraBaseEntity(Camera, ABC):
     """Devices that support cameras."""
 
@@ -86,53 +153,12 @@ class NestCameraBaseEntity(Camera, ABC):
         self.stream_options[CONF_EXTRA_PART_WAIT_TIME] = 3
         # The API "name" field is a unique device identifier.
         self._attr_unique_id = f"{self._device.name}-camera"
-        self._stream_refresh_unsub: Callable[[], None] | None = None
-
-    @abstractmethod
-    def _stream_expires_at(self) -> datetime.datetime | None:
-        """Next time when a stream expires."""
-
-    @abstractmethod
-    async def _async_refresh_stream(self) -> None:
-        """Refresh any stream to extend expiration time."""
-
-    def _schedule_stream_refresh(self) -> None:
-        """Schedules an alarm to refresh any streams before expiration."""
-        if self._stream_refresh_unsub is not None:
-            self._stream_refresh_unsub()
-
-        expiration_time = self._stream_expires_at()
-        if not expiration_time:
-            return
-        refresh_time = expiration_time - STREAM_EXPIRATION_BUFFER
-        _LOGGER.debug("Scheduled next stream refresh for %s", refresh_time)
-
-        self._stream_refresh_unsub = async_track_point_in_utc_time(
-            self.hass,
-            self._handle_stream_refresh,
-            refresh_time,
-        )
-
-    async def _handle_stream_refresh(self, _: datetime.datetime) -> None:
-        """Alarm that fires to check if the stream should be refreshed."""
-        _LOGGER.debug("Examining streams to refresh")
-        self._stream_refresh_unsub = None
-        try:
-            await self._async_refresh_stream()
-        finally:
-            self._schedule_stream_refresh()
 
     async def async_added_to_hass(self) -> None:
         """Run when entity is added to register update signal handler."""
         self.async_on_remove(
             self._device.add_update_listener(self.async_write_ha_state)
         )
-
-    async def async_will_remove_from_hass(self) -> None:
-        """Invalidates the RTSP token when unloaded."""
-        await super().async_will_remove_from_hass()
-        if self._stream_refresh_unsub:
-            self._stream_refresh_unsub()
 
 
 class NestRTSPEntity(NestCameraBaseEntity):
@@ -146,6 +172,7 @@ class NestRTSPEntity(NestCameraBaseEntity):
         super().__init__(device)
         self._create_stream_url_lock = asyncio.Lock()
         self._rtsp_live_stream_trait = device.traits[CameraLiveStreamTrait.NAME]
+        self._refresh_unsub: Callable[[], None] | None = None
 
     @property
     def use_stream_for_stills(self) -> bool:
@@ -173,20 +200,21 @@ class NestRTSPEntity(NestCameraBaseEntity):
                     )
                 except ApiException as err:
                     raise HomeAssistantError(f"Nest API error: {err}") from err
-                self._schedule_stream_refresh()
+                refresh = StreamRefresh(
+                    self.hass,
+                    self._rtsp_stream.expires_at,
+                    self._async_refresh_stream,
+                )
+                self._refresh_unsub = refresh.unsub
         assert self._rtsp_stream
         if self._rtsp_stream.expires_at < utcnow():
             _LOGGER.warning("Stream already expired")
         return self._rtsp_stream.rtsp_stream_url
 
-    def _stream_expires_at(self) -> datetime.datetime | None:
-        """Next time when a stream expires."""
-        return self._rtsp_stream.expires_at if self._rtsp_stream else None
-
-    async def _async_refresh_stream(self) -> None:
+    async def _async_refresh_stream(self) -> datetime.datetime | None:
         """Refresh stream to extend expiration time."""
         if not self._rtsp_stream:
-            return
+            return None
         _LOGGER.debug("Extending RTSP stream")
         try:
             self._rtsp_stream = await self._rtsp_stream.extend_rtsp_stream()
@@ -197,14 +225,17 @@ class NestRTSPEntity(NestCameraBaseEntity):
             if self.stream:
                 await self.stream.stop()
                 self.stream = None
-            return
+            return None
         # Update the stream worker with the latest valid url
         if self.stream:
             self.stream.update_source(self._rtsp_stream.rtsp_stream_url)
+        return self._rtsp_stream.expires_at
 
     async def async_will_remove_from_hass(self) -> None:
         """Invalidates the RTSP token when unloaded."""
         await super().async_will_remove_from_hass()
+        if self._refresh_unsub is not None:
+            self._refresh_unsub()
         if self._rtsp_stream:
             try:
                 await self._rtsp_stream.stop_stream()
@@ -220,37 +251,23 @@ class NestWebRTCEntity(NestCameraBaseEntity):
         """Initialize the camera."""
         super().__init__(device)
         self._webrtc_sessions: dict[str, WebRtcStream] = {}
+        self._refresh_unsub: dict[str, Callable[[], None]] = {}
 
     @property
     def frontend_stream_type(self) -> StreamType | None:
         """Return the type of stream supported by this camera."""
         return StreamType.WEB_RTC
 
-    def _stream_expires_at(self) -> datetime.datetime | None:
-        """Next time when a stream expires."""
-        if not self._webrtc_sessions:
-            return None
-        return min(stream.expires_at for stream in self._webrtc_sessions.values())
-
-    async def _async_refresh_stream(self) -> None:
+    async def _async_refresh_stream(self, session_id: str) -> datetime.datetime | None:
         """Refresh stream to extend expiration time."""
-        now = utcnow()
-        for session_id, webrtc_stream in list(self._webrtc_sessions.items()):
-            if session_id not in self._webrtc_sessions:
-                continue
-            if now < (webrtc_stream.expires_at - STREAM_EXPIRATION_BUFFER):
-                _LOGGER.debug(
-                    "Stream does not yet expire: %s", webrtc_stream.expires_at
-                )
-                continue
-            _LOGGER.debug("Extending WebRTC stream %s", webrtc_stream.media_session_id)
-            try:
-                webrtc_stream = await webrtc_stream.extend_stream()
-            except ApiException as err:
-                _LOGGER.debug("Failed to extend stream: %s", err)
-            else:
-                if session_id in self._webrtc_sessions:
-                    self._webrtc_sessions[session_id] = webrtc_stream
+        if not (webrtc_stream := self._webrtc_sessions.get(session_id)):
+            return None
+        _LOGGER.debug("Extending WebRTC stream %s", webrtc_stream.media_session_id)
+        webrtc_stream = await webrtc_stream.extend_stream()
+        if session_id in self._webrtc_sessions:
+            self._webrtc_sessions[session_id] = webrtc_stream
+            return webrtc_stream.expires_at
+        return None
 
     async def async_camera_image(
         self, width: int | None = None, height: int | None = None
@@ -278,7 +295,12 @@ class NestWebRTCEntity(NestCameraBaseEntity):
         )
         self._webrtc_sessions[session_id] = stream
         send_message(WebRTCAnswer(stream.answer_sdp))
-        self._schedule_stream_refresh()
+        refresh = StreamRefresh(
+            self.hass,
+            stream.expires_at,
+            functools.partial(self._async_refresh_stream, session_id),
+        )
+        self._refresh_unsub[session_id] = refresh.unsub
 
     @callback
     def close_webrtc_session(self, session_id: str) -> None:
@@ -287,6 +309,8 @@ class NestWebRTCEntity(NestCameraBaseEntity):
             _LOGGER.debug(
                 "Closing WebRTC session %s, %s", session_id, stream.media_session_id
             )
+            unsub = self._refresh_unsub.pop(session_id)
+            unsub()
 
             async def stop_stream() -> None:
                 try:

--- a/homeassistant/components/nest/camera.py
+++ b/homeassistant/components/nest/camera.py
@@ -19,6 +19,7 @@ from google_nest_sdm.camera_traits import (
 from google_nest_sdm.device import Device
 from google_nest_sdm.device_manager import DeviceManager
 from google_nest_sdm.exceptions import ApiException
+from webrtc_models import RTCIceCandidate
 
 from homeassistant.components.camera import (
     Camera,
@@ -301,6 +302,12 @@ class NestWebRTCEntity(NestCameraBaseEntity):
             functools.partial(self._async_refresh_stream, session_id),
         )
         self._refresh_unsub[session_id] = refresh.unsub
+
+    async def async_on_webrtc_candidate(
+        self, session_id: str, candidate: RTCIceCandidate
+    ) -> None:
+        """Ignore WebRTC candidates for Nest cloud based cameras."""
+        return
 
     @callback
     def close_webrtc_session(self, session_id: str) -> None:

--- a/homeassistant/components/nest/manifest.json
+++ b/homeassistant/components/nest/manifest.json
@@ -20,5 +20,5 @@
   "iot_class": "cloud_push",
   "loggers": ["google_nest_sdm"],
   "quality_scale": "platinum",
-  "requirements": ["google-nest-sdm==6.1.4"]
+  "requirements": ["google-nest-sdm==6.1.5"]
 }

--- a/homeassistant/components/nice_go/manifest.json
+++ b/homeassistant/components/nice_go/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "hub",
   "iot_class": "cloud_push",
   "loggers": ["nice_go"],
-  "requirements": ["nice-go==0.3.9"]
+  "requirements": ["nice-go==0.3.10"]
 }

--- a/homeassistant/components/ollama/strings.json
+++ b/homeassistant/components/ollama/strings.json
@@ -11,9 +11,11 @@
         "title": "Downloading model"
       }
     },
+    "abort": {
+      "download_failed": "Model downloading failed"
+    },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "download_failed": "Model downloading failed",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "progress": {

--- a/homeassistant/components/onewire/config_flow.py
+++ b/homeassistant/components/onewire/config_flow.py
@@ -137,7 +137,7 @@ class OnewireOptionsFlowHandler(OptionsFlowWithConfigEntry):
         }
 
         if not self.configurable_devices:
-            return self.async_abort(reason="No configurable devices found.")
+            return self.async_abort(reason="no_configurable_devices")
 
         return await self.async_step_device_selection(user_input=None)
 

--- a/homeassistant/components/onewire/strings.json
+++ b/homeassistant/components/onewire/strings.json
@@ -94,6 +94,9 @@
     }
   },
   "options": {
+    "abort": {
+      "no_configurable_devices": "No configurable devices found"
+    },
     "error": {
       "device_not_selected": "Select devices to configure"
     },

--- a/homeassistant/components/philips_js/strings.json
+++ b/homeassistant/components/philips_js/strings.json
@@ -18,11 +18,11 @@
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "unknown": "[%key:common::config_flow::error::unknown%]",
-      "pairing_failure": "Unable to pair: {error_id}",
       "invalid_pin": "Invalid PIN"
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "pairing_failure": "Unable to pair: {error_id}",
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     }
   },

--- a/homeassistant/components/plaato/__init__.py
+++ b/homeassistant/components/plaato/__init__.py
@@ -64,10 +64,10 @@ WEBHOOK_SCHEMA = vol.Schema(
         vol.Required(ATTR_DEVICE_NAME): cv.string,
         vol.Required(ATTR_DEVICE_ID): cv.positive_int,
         vol.Required(ATTR_TEMP_UNIT): vol.In(
-            UnitOfTemperature.CELSIUS, UnitOfTemperature.FAHRENHEIT
+            [UnitOfTemperature.CELSIUS, UnitOfTemperature.FAHRENHEIT]
         ),
         vol.Required(ATTR_VOLUME_UNIT): vol.In(
-            UnitOfVolume.LITERS, UnitOfVolume.GALLONS
+            [UnitOfVolume.LITERS, UnitOfVolume.GALLONS]
         ),
         vol.Required(ATTR_BPM): cv.positive_int,
         vol.Required(ATTR_TEMP): vol.Coerce(float),

--- a/homeassistant/components/plaato/manifest.json
+++ b/homeassistant/components/plaato/manifest.json
@@ -8,5 +8,5 @@
   "documentation": "https://www.home-assistant.io/integrations/plaato",
   "iot_class": "cloud_push",
   "loggers": ["pyplaato"],
-  "requirements": ["pyplaato==0.0.18"]
+  "requirements": ["pyplaato==0.0.19"]
 }

--- a/homeassistant/components/powerwall/config_flow.py
+++ b/homeassistant/components/powerwall/config_flow.py
@@ -251,8 +251,8 @@ class PowerwallConfigFlow(ConfigFlow, domain=DOMAIN):
         """Handle reauth confirmation."""
         errors: dict[str, str] | None = {}
         description_placeholders: dict[str, str] = {}
+        reauth_entry = self._get_reauth_entry()
         if user_input is not None:
-            reauth_entry = self._get_reauth_entry()
             errors, _, description_placeholders = await self._async_try_connect(
                 {CONF_IP_ADDRESS: reauth_entry.data[CONF_IP_ADDRESS], **user_input}
             )
@@ -261,6 +261,10 @@ class PowerwallConfigFlow(ConfigFlow, domain=DOMAIN):
                     reauth_entry, data_updates=user_input
                 )
 
+        self.context["title_placeholders"] = {
+            "name": reauth_entry.title,
+            "ip_address": reauth_entry.data[CONF_IP_ADDRESS],
+        }
         return self.async_show_form(
             step_id="reauth_confirm",
             data_schema=vol.Schema({vol.Optional(CONF_PASSWORD): str}),

--- a/homeassistant/components/reolink/manifest.json
+++ b/homeassistant/components/reolink/manifest.json
@@ -18,5 +18,5 @@
   "documentation": "https://www.home-assistant.io/integrations/reolink",
   "iot_class": "local_push",
   "loggers": ["reolink_aio"],
-  "requirements": ["reolink-aio==0.11.0"]
+  "requirements": ["reolink-aio==0.11.1"]
 }

--- a/homeassistant/components/reolink/manifest.json
+++ b/homeassistant/components/reolink/manifest.json
@@ -18,5 +18,5 @@
   "documentation": "https://www.home-assistant.io/integrations/reolink",
   "iot_class": "local_push",
   "loggers": ["reolink_aio"],
-  "requirements": ["reolink-aio==0.10.4"]
+  "requirements": ["reolink-aio==0.11.0"]
 }

--- a/homeassistant/components/ring/event.py
+++ b/homeassistant/components/ring/event.py
@@ -96,7 +96,7 @@ class RingEvent(RingBaseEntity[RingListenCoordinator, RingDeviceT], EventEntity)
 
     @callback
     def _handle_coordinator_update(self) -> None:
-        if alert := self._get_coordinator_alert():
+        if (alert := self._get_coordinator_alert()) and not alert.is_update:
             self._async_handle_event(alert.kind)
         super()._handle_coordinator_update()
 

--- a/homeassistant/components/ring/manifest.json
+++ b/homeassistant/components/ring/manifest.json
@@ -30,5 +30,5 @@
   "iot_class": "cloud_polling",
   "loggers": ["ring_doorbell"],
   "quality_scale": "silver",
-  "requirements": ["ring-doorbell==0.9.9"]
+  "requirements": ["ring-doorbell==0.9.12"]
 }

--- a/homeassistant/components/ring/manifest.json
+++ b/homeassistant/components/ring/manifest.json
@@ -30,5 +30,5 @@
   "iot_class": "cloud_polling",
   "loggers": ["ring_doorbell"],
   "quality_scale": "silver",
-  "requirements": ["ring-doorbell==0.9.8"]
+  "requirements": ["ring-doorbell==0.9.9"]
 }

--- a/homeassistant/components/roborock/__init__.py
+++ b/homeassistant/components/roborock/__init__.py
@@ -47,7 +47,6 @@ class RoborockCoordinators:
 async def async_setup_entry(hass: HomeAssistant, entry: RoborockConfigEntry) -> bool:
     """Set up roborock from a config entry."""
 
-    _LOGGER.debug("Integration async setup entry: %s", entry.as_dict())
     entry.async_on_unload(entry.add_update_listener(update_listener))
 
     user_data = UserData.from_dict(entry.data[CONF_USER_DATA])

--- a/homeassistant/components/ruckus_unleashed/manifest.json
+++ b/homeassistant/components/ruckus_unleashed/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "loggers": ["aioruckus"],
-  "requirements": ["aioruckus==0.41"]
+  "requirements": ["aioruckus==0.42"]
 }

--- a/homeassistant/components/sense/manifest.json
+++ b/homeassistant/components/sense/manifest.json
@@ -20,5 +20,5 @@
   "documentation": "https://www.home-assistant.io/integrations/sense",
   "iot_class": "cloud_polling",
   "loggers": ["sense_energy"],
-  "requirements": ["sense-energy==0.13.3"]
+  "requirements": ["sense-energy==0.13.4"]
 }

--- a/homeassistant/components/shelly/coordinator.py
+++ b/homeassistant/components/shelly/coordinator.py
@@ -603,7 +603,7 @@ class ShellyRpcCoordinator(ShellyCoordinatorBase[RpcDevice]):
 
     async def _async_update_data(self) -> None:
         """Fetch data."""
-        if self.update_sleep_period():
+        if self.update_sleep_period() or self.hass.is_stopping:
             return
 
         if self.sleep_period:

--- a/homeassistant/components/smarttub/manifest.json
+++ b/homeassistant/components/smarttub/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "cloud_polling",
   "loggers": ["smarttub"],
   "quality_scale": "platinum",
-  "requirements": ["python-smarttub==0.0.36"]
+  "requirements": ["python-smarttub==0.0.38"]
 }

--- a/homeassistant/components/smarty/strings.json
+++ b/homeassistant/components/smarty/strings.json
@@ -28,6 +28,10 @@
     "deprecated_yaml_import_issue_auth_error": {
       "title": "YAML import failed due to an authentication error",
       "description": "Configuring {integration_title} using YAML is being removed but there was an authentication error while importing your existing configuration.\nSetup will not proceed.\n\nVerify that your {integration_title} is operating correctly and restart Home Assistant to attempt the import again.\n\nAlternatively, you may remove the `{domain}` configuration from your configuration.yaml entirely, restart Home Assistant, and add the {integration_title} integration manually."
+    },
+    "deprecated_yaml_import_issue_cannot_connect": {
+      "title": "YAML import failed due to a connection error",
+      "description": "Configuring {integration_title} using YAML is being removed but there was a connect error while importing your existing configuration.\nSetup will not proceed.\n\nVerify that your {integration_title} is operating correctly and restart Home Assistant to attempt the import again.\n\nAlternatively, you may remove the `{domain}` configuration from your configuration.yaml entirely, restart Home Assistant, and add the {integration_title} integration manually."
     }
   },
   "entity": {

--- a/homeassistant/components/sonos/manifest.json
+++ b/homeassistant/components/sonos/manifest.json
@@ -8,7 +8,7 @@
   "documentation": "https://www.home-assistant.io/integrations/sonos",
   "iot_class": "local_push",
   "loggers": ["soco"],
-  "requirements": ["soco==0.30.4", "sonos-websocket==0.1.3"],
+  "requirements": ["soco==0.30.6", "sonos-websocket==0.1.3"],
   "ssdp": [
     {
       "st": "urn:schemas-upnp-org:device:ZonePlayer:1"

--- a/homeassistant/components/spotify/manifest.json
+++ b/homeassistant/components/spotify/manifest.json
@@ -9,6 +9,6 @@
   "iot_class": "cloud_polling",
   "loggers": ["spotipy"],
   "quality_scale": "silver",
-  "requirements": ["spotifyaio==0.8.7"],
+  "requirements": ["spotifyaio==0.8.8"],
   "zeroconf": ["_spotify-connect._tcp.local."]
 }

--- a/homeassistant/components/srp_energy/strings.json
+++ b/homeassistant/components/srp_energy/strings.json
@@ -17,7 +17,8 @@
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_service%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_service%]",
+      "unknown": "Unexpected error"
     }
   },
   "entity": {

--- a/homeassistant/components/statistics/strings.json
+++ b/homeassistant/components/statistics/strings.json
@@ -23,10 +23,10 @@
       "state_characteristic": {
         "description": "Read the documention for further details on available options and how to use them.",
         "data": {
-          "state_characteristic": "State_characteristic"
+          "state_characteristic": "Statistic characteristic"
         },
         "data_description": {
-          "state_characteristic": "The characteristic that should be used as the state of the statistics sensor."
+          "state_characteristic": "The statistic characteristic that should be used as the state of the sensor."
         }
       },
       "options": {

--- a/homeassistant/components/subaru/strings.json
+++ b/homeassistant/components/subaru/strings.json
@@ -37,13 +37,13 @@
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "incorrect_pin": "Incorrect PIN",
       "bad_pin_format": "PIN should be 4 digits",
-      "two_factor_request_failed": "Request for 2FA code failed, please try again",
       "bad_validation_code_format": "Validation code should be 6 digits",
       "incorrect_validation_code": "Incorrect validation code"
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
-      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "two_factor_request_failed": "Request for 2FA code failed, please try again"
     }
   },
   "options": {

--- a/homeassistant/components/tibber/manifest.json
+++ b/homeassistant/components/tibber/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "loggers": ["tibber"],
   "quality_scale": "silver",
-  "requirements": ["pyTibber==0.30.7"]
+  "requirements": ["pyTibber==0.30.8"]
 }

--- a/homeassistant/components/tibber/manifest.json
+++ b/homeassistant/components/tibber/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "loggers": ["tibber"],
   "quality_scale": "silver",
-  "requirements": ["pyTibber==0.30.4"]
+  "requirements": ["pyTibber==0.30.7"]
 }

--- a/homeassistant/components/toon/strings.json
+++ b/homeassistant/components/toon/strings.json
@@ -16,6 +16,7 @@
       "already_configured": "The selected agreement is already configured.",
       "unknown_authorize_url_generation": "[%key:common::config_flow::abort::unknown_authorize_url_generation%]",
       "authorize_url_timeout": "[%key:common::config_flow::abort::oauth2_authorize_url_timeout%]",
+      "connection_error": "[%key:common::config_flow::error::cannot_connect%]",
       "missing_configuration": "[%key:common::config_flow::abort::oauth2_missing_configuration%]",
       "no_agreements": "This account has no Toon displays.",
       "no_url_available": "[%key:common::config_flow::abort::oauth2_no_url_available%]",

--- a/homeassistant/components/tradfri/config_flow.py
+++ b/homeassistant/components/tradfri/config_flow.py
@@ -60,10 +60,7 @@ class FlowHandler(ConfigFlow, domain=DOMAIN):
                 return await self._entry_from_data(auth)
 
             except AuthError as err:
-                if err.code == "invalid_security_code":
-                    errors[KEY_SECURITY_CODE] = err.code
-                else:
-                    errors["base"] = err.code
+                errors["base"] = err.code
         else:
             user_input = {}
 

--- a/homeassistant/components/tradfri/strings.json
+++ b/homeassistant/components/tradfri/strings.json
@@ -14,7 +14,7 @@
       }
     },
     "error": {
-      "invalid_key": "Failed to register with provided key. If this keeps happening, try restarting the gateway.",
+      "invalid_security_code": "Failed to register with provided key. If this keeps happening, try restarting the gateway.",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "timeout": "Timeout validating the code.",
       "cannot_authenticate": "Cannot authenticate, is Gateway paired with another server like e.g. Homekit?"

--- a/homeassistant/components/utility_meter/strings.json
+++ b/homeassistant/components/utility_meter/strings.json
@@ -25,6 +25,9 @@
           "tariffs": "A list of supported tariffs, leave empty if only a single tariff is needed."
         }
       }
+    },
+    "error": {
+      "tariffs_not_unique": "Tariffs must be unique"
     }
   },
   "options": {

--- a/homeassistant/components/vilfo/config_flow.py
+++ b/homeassistant/components/vilfo/config_flow.py
@@ -109,7 +109,7 @@ class DomainConfigFlow(ConfigFlow, domain=DOMAIN):
             try:
                 info = await validate_input(self.hass, user_input)
             except InvalidHost:
-                errors[CONF_HOST] = "wrong_host"
+                errors["base"] = "invalid_host"
             except CannotConnect:
                 errors["base"] = "cannot_connect"
             except InvalidAuth:

--- a/homeassistant/components/vilfo/strings.json
+++ b/homeassistant/components/vilfo/strings.json
@@ -14,6 +14,7 @@
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "invalid_host": "[%key:common::config_flow::error::invalid_host%]",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {

--- a/homeassistant/components/vodafone_station/sensor.py
+++ b/homeassistant/components/vodafone_station/sensor.py
@@ -22,7 +22,7 @@ from .const import _LOGGER, DOMAIN, LINE_TYPES
 from .coordinator import VodafoneStationRouter
 
 NOT_AVAILABLE: list = ["", "N/A", "0.0.0.0"]
-UPTIME_DEVIATION = 45
+UPTIME_DEVIATION = 60
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/homeassistant/components/vodafone_station/sensor.py
+++ b/homeassistant/components/vodafone_station/sensor.py
@@ -43,12 +43,10 @@ def _calculate_uptime(
 ) -> datetime:
     """Calculate device uptime."""
 
-    assert isinstance(last_value, datetime)
-
     delta_uptime = coordinator.api.convert_uptime(coordinator.data.sensors[key])
 
     if (
-        not last_value
+        not isinstance(last_value, datetime)
         or abs((delta_uptime - last_value).total_seconds()) > UPTIME_DEVIATION
     ):
         return delta_uptime

--- a/homeassistant/components/water_heater/strings.json
+++ b/homeassistant/components/water_heater/strings.json
@@ -1,4 +1,5 @@
 {
+  "title": "Water heater",
   "device_automation": {
     "action_type": {
       "turn_on": "[%key:common::device_automation::action_type::turn_on%]",
@@ -7,7 +8,7 @@
   },
   "entity_component": {
     "_": {
-      "name": "Water heater",
+      "name": "[%key:component::water_heater::title%]",
       "state": {
         "off": "[%key:common::state::off%]",
         "eco": "Eco",

--- a/homeassistant/components/withings/manifest.json
+++ b/homeassistant/components/withings/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_push",
   "loggers": ["aiowithings"],
   "quality_scale": "platinum",
-  "requirements": ["aiowithings==3.1.2"]
+  "requirements": ["aiowithings==3.1.3"]
 }

--- a/homeassistant/components/withings/manifest.json
+++ b/homeassistant/components/withings/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_push",
   "loggers": ["aiowithings"],
   "quality_scale": "platinum",
-  "requirements": ["aiowithings==3.1.1"]
+  "requirements": ["aiowithings==3.1.2"]
 }

--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -21,7 +21,7 @@
     "zha",
     "universal_silabs_flasher"
   ],
-  "requirements": ["universal-silabs-flasher==0.0.24", "zha==0.0.37"],
+  "requirements": ["universal-silabs-flasher==0.0.25", "zha==0.0.39"],
   "usb": [
     {
       "vid": "10C4",

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
 APPLICATION_NAME: Final = "HomeAssistant"
 MAJOR_VERSION: Final = 2024
 MINOR_VERSION: Final = 11
-PATCH_VERSION: Final = "1"
+PATCH_VERSION: Final = "2"
 __short_version__: Final = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__: Final = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER: Final[tuple[int, int, int]] = (3, 12, 0)

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -5,7 +5,7 @@ aiodiscover==2.1.0
 aiodns==3.2.0
 aiohasupervisor==0.2.1
 aiohttp-fast-zlib==0.1.1
-aiohttp==3.10.10
+aiohttp==3.10.11
 aiohttp_cors==0.7.0
 aiozoneinfo==0.2.1
 astral==2.2

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -26,7 +26,7 @@ ciso8601==2.3.1
 cryptography==43.0.1
 dbus-fast==2.24.3
 fnv-hash-fast==1.0.2
-go2rtc-client==0.1.0
+go2rtc-client==0.1.1
 ha-av==10.1.1
 ha-ffmpeg==3.2.2
 habluetooth==3.6.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies    = [
     # change behavior based on presence of supervisor. Deprecated with #127228
     # Lib can be removed with 2025.11
     "aiohasupervisor==0.2.1",
-    "aiohttp==3.10.10",
+    "aiohttp==3.10.11",
     "aiohttp_cors==0.7.0",
     "aiohttp-fast-zlib==0.1.1",
     "aiozoneinfo==0.2.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name        = "homeassistant"
-version     = "2024.11.1"
+version     = "2024.11.2"
 license     = {text = "Apache-2.0"}
 description = "Open-source home automation platform running on Python 3."
 readme      = "README.rst"

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@
 # Home Assistant Core
 aiodns==3.2.0
 aiohasupervisor==0.2.1
-aiohttp==3.10.10
+aiohttp==3.10.11
 aiohttp_cors==0.7.0
 aiohttp-fast-zlib==0.1.1
 aiozoneinfo==0.2.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1454,7 +1454,7 @@ nextdns==3.3.0
 nibe==2.11.0
 
 # homeassistant.components.nice_go
-nice-go==0.3.9
+nice-go==0.3.10
 
 # homeassistant.components.niko_home_control
 niko-home-control==0.2.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2356,7 +2356,7 @@ python-juicenet==1.1.0
 python-kasa[speedups]==0.7.7
 
 # homeassistant.components.linkplay
-python-linkplay==0.0.17
+python-linkplay==0.0.18
 
 # homeassistant.components.lirc
 # python-lirc==1.2.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -354,7 +354,7 @@ aiorecollect==2023.09.0
 aioridwell==2024.01.0
 
 # homeassistant.components.ruckus_unleashed
-aioruckus==0.41
+aioruckus==0.42
 
 # homeassistant.components.russound_rio
 aiorussound==4.0.5

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -414,7 +414,7 @@ aiowatttime==0.1.1
 aiowebostv==0.4.2
 
 # homeassistant.components.withings
-aiowithings==3.1.1
+aiowithings==3.1.2
 
 # homeassistant.components.yandex_transport
 aioymaps==1.2.5

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1735,7 +1735,7 @@ pyRFXtrx==0.31.1
 pySDCP==1
 
 # homeassistant.components.tibber
-pyTibber==0.30.4
+pyTibber==0.30.7
 
 # homeassistant.components.dlink
 pyW215==0.7.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2547,7 +2547,7 @@ renault-api==0.2.7
 renson-endura-delta==1.7.1
 
 # homeassistant.components.reolink
-reolink-aio==0.10.4
+reolink-aio==0.11.0
 
 # homeassistant.components.idteck_prox
 rfk101py==0.0.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2356,7 +2356,7 @@ python-juicenet==1.1.0
 python-kasa[speedups]==0.7.7
 
 # homeassistant.components.linkplay
-python-linkplay==0.0.18
+python-linkplay==0.0.20
 
 # homeassistant.components.lirc
 # python-lirc==1.2.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2547,7 +2547,7 @@ renault-api==0.2.7
 renson-endura-delta==1.7.1
 
 # homeassistant.components.reolink
-reolink-aio==0.11.0
+reolink-aio==0.11.1
 
 # homeassistant.components.idteck_prox
 rfk101py==0.0.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2900,7 +2900,7 @@ unifi_ap==0.0.1
 unifiled==0.11
 
 # homeassistant.components.zha
-universal-silabs-flasher==0.0.24
+universal-silabs-flasher==0.0.25
 
 # homeassistant.components.upb
 upb-lib==0.5.8
@@ -3066,7 +3066,7 @@ zeroconf==0.136.0
 zeversolar==0.3.2
 
 # homeassistant.components.zha
-zha==0.0.37
+zha==0.0.39
 
 # homeassistant.components.zhong_hong
 zhong-hong-hvac==1.0.13

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -986,7 +986,7 @@ gitterpy==0.1.7
 glances-api==0.8.0
 
 # homeassistant.components.go2rtc
-go2rtc-client==0.1.0
+go2rtc-client==0.1.1
 
 # homeassistant.components.goalzero
 goalzero==0.2.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2396,7 +2396,7 @@ python-ripple-api==0.0.3
 python-roborock==2.7.2
 
 # homeassistant.components.smarttub
-python-smarttub==0.0.36
+python-smarttub==0.0.38
 
 # homeassistant.components.songpal
 python-songpal==0.16.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2707,7 +2707,7 @@ speak2mary==1.4.0
 speedtest-cli==2.1.3
 
 # homeassistant.components.spotify
-spotifyaio==0.8.7
+spotifyaio==0.8.8
 
 # homeassistant.components.sql
 sqlparse==0.5.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2155,7 +2155,7 @@ pypck==0.7.24
 pypjlink2==1.2.1
 
 # homeassistant.components.plaato
-pyplaato==0.0.18
+pyplaato==0.0.19
 
 # homeassistant.components.point
 pypoint==3.0.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2556,7 +2556,7 @@ rfk101py==0.0.1
 rflink==0.0.66
 
 # homeassistant.components.ring
-ring-doorbell==0.9.9
+ring-doorbell==0.9.12
 
 # homeassistant.components.fleetgo
 ritassist==0.9.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -414,7 +414,7 @@ aiowatttime==0.1.1
 aiowebostv==0.4.2
 
 # homeassistant.components.withings
-aiowithings==3.1.2
+aiowithings==3.1.3
 
 # homeassistant.components.yandex_transport
 aioymaps==1.2.5

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2556,7 +2556,7 @@ rfk101py==0.0.1
 rflink==0.0.66
 
 # homeassistant.components.ring
-ring-doorbell==0.9.8
+ring-doorbell==0.9.9
 
 # homeassistant.components.fleetgo
 ritassist==0.9.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1011,7 +1011,7 @@ google-cloud-texttospeech==2.17.2
 google-generativeai==0.8.2
 
 # homeassistant.components.nest
-google-nest-sdm==6.1.4
+google-nest-sdm==6.1.5
 
 # homeassistant.components.google_photos
 google-photos-library-api==0.12.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1735,7 +1735,7 @@ pyRFXtrx==0.31.1
 pySDCP==1
 
 # homeassistant.components.tibber
-pyTibber==0.30.7
+pyTibber==0.30.8
 
 # homeassistant.components.dlink
 pyW215==0.7.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2623,7 +2623,7 @@ sendgrid==6.8.2
 
 # homeassistant.components.emulated_kasa
 # homeassistant.components.sense
-sense-energy==0.13.3
+sense-energy==0.13.4
 
 # homeassistant.components.sensirion_ble
 sensirion-ble==0.1.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -381,7 +381,7 @@ aiosolaredge==0.2.0
 aiosteamist==1.0.0
 
 # homeassistant.components.cambridge_audio
-aiostreammagic==2.8.4
+aiostreammagic==2.8.5
 
 # homeassistant.components.switcher_kis
 aioswitcher==4.4.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2683,7 +2683,7 @@ smhi-pkg==1.0.18
 snapcast==2.3.6
 
 # homeassistant.components.sonos
-soco==0.30.4
+soco==0.30.6
 
 # homeassistant.components.solaredge_local
 solaredge-local==0.2.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1214,7 +1214,7 @@ nextdns==3.3.0
 nibe==2.11.0
 
 # homeassistant.components.nice_go
-nice-go==0.3.9
+nice-go==0.3.10
 
 # homeassistant.components.nfandroidtv
 notifications-android-tv==0.1.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2044,7 +2044,7 @@ reolink-aio==0.10.4
 rflink==0.0.66
 
 # homeassistant.components.ring
-ring-doorbell==0.9.9
+ring-doorbell==0.9.12
 
 # homeassistant.components.roku
 rokuecp==0.19.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -396,7 +396,7 @@ aiowatttime==0.1.1
 aiowebostv==0.4.2
 
 # homeassistant.components.withings
-aiowithings==3.1.1
+aiowithings==3.1.2
 
 # homeassistant.components.yandex_transport
 aioymaps==1.2.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -861,7 +861,7 @@ google-cloud-texttospeech==2.17.2
 google-generativeai==0.8.2
 
 # homeassistant.components.nest
-google-nest-sdm==6.1.4
+google-nest-sdm==6.1.5
 
 # homeassistant.components.google_photos
 google-photos-library-api==0.12.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2090,7 +2090,7 @@ securetar==2024.2.1
 
 # homeassistant.components.emulated_kasa
 # homeassistant.components.sense
-sense-energy==0.13.3
+sense-energy==0.13.4
 
 # homeassistant.components.sensirion_ble
 sensirion-ble==0.1.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1412,7 +1412,7 @@ pyElectra==1.2.4
 pyRFXtrx==0.31.1
 
 # homeassistant.components.tibber
-pyTibber==0.30.7
+pyTibber==0.30.8
 
 # homeassistant.components.dlink
 pyW215==0.7.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1739,7 +1739,7 @@ pypck==0.7.24
 pypjlink2==1.2.1
 
 # homeassistant.components.plaato
-pyplaato==0.0.18
+pyplaato==0.0.19
 
 # homeassistant.components.point
 pypoint==3.0.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1883,7 +1883,7 @@ python-juicenet==1.1.0
 python-kasa[speedups]==0.7.7
 
 # homeassistant.components.linkplay
-python-linkplay==0.0.18
+python-linkplay==0.0.20
 
 # homeassistant.components.matter
 python-matter-server==6.6.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1883,7 +1883,7 @@ python-juicenet==1.1.0
 python-kasa[speedups]==0.7.7
 
 # homeassistant.components.linkplay
-python-linkplay==0.0.17
+python-linkplay==0.0.18
 
 # homeassistant.components.matter
 python-matter-server==6.6.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2138,7 +2138,7 @@ smhi-pkg==1.0.18
 snapcast==2.3.6
 
 # homeassistant.components.sonos
-soco==0.30.4
+soco==0.30.6
 
 # homeassistant.components.solarlog
 solarlog_cli==0.3.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2159,7 +2159,7 @@ speak2mary==1.4.0
 speedtest-cli==2.1.3
 
 # homeassistant.components.spotify
-spotifyaio==0.8.7
+spotifyaio==0.8.8
 
 # homeassistant.components.sql
 sqlparse==0.5.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2038,7 +2038,7 @@ renault-api==0.2.7
 renson-endura-delta==1.7.1
 
 # homeassistant.components.reolink
-reolink-aio==0.10.4
+reolink-aio==0.11.0
 
 # homeassistant.components.rflink
 rflink==0.0.66

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2038,7 +2038,7 @@ renault-api==0.2.7
 renson-endura-delta==1.7.1
 
 # homeassistant.components.reolink
-reolink-aio==0.11.0
+reolink-aio==0.11.1
 
 # homeassistant.components.rflink
 rflink==0.0.66

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2044,7 +2044,7 @@ reolink-aio==0.10.4
 rflink==0.0.66
 
 # homeassistant.components.ring
-ring-doorbell==0.9.8
+ring-doorbell==0.9.9
 
 # homeassistant.components.roku
 rokuecp==0.19.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -363,7 +363,7 @@ aiosolaredge==0.2.0
 aiosteamist==1.0.0
 
 # homeassistant.components.cambridge_audio
-aiostreammagic==2.8.4
+aiostreammagic==2.8.5
 
 # homeassistant.components.switcher_kis
 aioswitcher==4.4.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -336,7 +336,7 @@ aiorecollect==2023.09.0
 aioridwell==2024.01.0
 
 # homeassistant.components.ruckus_unleashed
-aioruckus==0.41
+aioruckus==0.42
 
 # homeassistant.components.russound_rio
 aiorussound==4.0.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1412,7 +1412,7 @@ pyElectra==1.2.4
 pyRFXtrx==0.31.1
 
 # homeassistant.components.tibber
-pyTibber==0.30.4
+pyTibber==0.30.7
 
 # homeassistant.components.dlink
 pyW215==0.7.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1917,7 +1917,7 @@ python-rabbitair==0.0.8
 python-roborock==2.7.2
 
 # homeassistant.components.smarttub
-python-smarttub==0.0.36
+python-smarttub==0.0.38
 
 # homeassistant.components.songpal
 python-songpal==0.16.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -836,7 +836,7 @@ gios==5.0.0
 glances-api==0.8.0
 
 # homeassistant.components.go2rtc
-go2rtc-client==0.1.0
+go2rtc-client==0.1.1
 
 # homeassistant.components.goalzero
 goalzero==0.2.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2307,7 +2307,7 @@ ultraheat-api==0.5.7
 unifi-discovery==1.2.0
 
 # homeassistant.components.zha
-universal-silabs-flasher==0.0.24
+universal-silabs-flasher==0.0.25
 
 # homeassistant.components.upb
 upb-lib==0.5.8
@@ -2449,7 +2449,7 @@ zeroconf==0.136.0
 zeversolar==0.3.2
 
 # homeassistant.components.zha
-zha==0.0.37
+zha==0.0.39
 
 # homeassistant.components.zwave_js
 zwave-js-server-python==0.58.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -396,7 +396,7 @@ aiowatttime==0.1.1
 aiowebostv==0.4.2
 
 # homeassistant.components.withings
-aiowithings==3.1.2
+aiowithings==3.1.3
 
 # homeassistant.components.yandex_transport
 aioymaps==1.2.5

--- a/script/hassfest/docker.py
+++ b/script/hassfest/docker.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from homeassistant import core
+from homeassistant.components.go2rtc.const import RECOMMENDED_VERSION as GO2RTC_VERSION
 from homeassistant.const import Platform
 from homeassistant.util import executor, thread
 from script.gen_requirements_all import gather_recursive_requirements
@@ -112,8 +113,6 @@ LABEL "com.github.actions.icon"="terminal"
 LABEL "com.github.actions.color"="gray-dark"
 """
 
-_GO2RTC_VERSION = "1.9.7"
-
 
 def _get_package_versions(file: Path, packages: set[str]) -> dict[str, str]:
     package_versions: dict[str, str] = {}
@@ -197,7 +196,7 @@ def _generate_files(config: Config) -> list[File]:
             DOCKERFILE_TEMPLATE.format(
                 timeout=timeout,
                 **package_versions,
-                go2rtc=_GO2RTC_VERSION,
+                go2rtc=GO2RTC_VERSION,
             ),
             config.root / "Dockerfile",
         ),

--- a/script/hassfest/docker.py
+++ b/script/hassfest/docker.py
@@ -112,7 +112,7 @@ LABEL "com.github.actions.icon"="terminal"
 LABEL "com.github.actions.color"="gray-dark"
 """
 
-_GO2RTC_VERSION = "1.9.6"
+_GO2RTC_VERSION = "1.9.7"
 
 
 def _get_package_versions(file: Path, packages: set[str]) -> dict[str, str]:

--- a/script/hassfest/docker.py
+++ b/script/hassfest/docker.py
@@ -161,6 +161,8 @@ def _generate_hassfest_dockerimage(
         packages.update(
             gather_recursive_requirements(platform.value, already_checked_domains)
         )
+    # Add go2rtc requirements as this file needs the go2rtc integration
+    packages.update(gather_recursive_requirements("go2rtc", already_checked_domains))
 
     return File(
         _HASSFEST_TEMPLATE.format(

--- a/script/hassfest/docker/Dockerfile
+++ b/script/hassfest/docker/Dockerfile
@@ -23,7 +23,7 @@ RUN --mount=from=ghcr.io/astral-sh/uv:0.4.28,source=/uv,target=/bin/uv \
         -c /usr/src/homeassistant/homeassistant/package_constraints.txt \
         -r /usr/src/homeassistant/requirements.txt \
         stdlib-list==0.10.0 pipdeptree==2.23.4 tqdm==4.66.5 ruff==0.7.1 \
-        PyTurboJPEG==1.7.5 ha-ffmpeg==3.2.2 hassil==1.7.4 home-assistant-intents==2024.11.6 mutagen==1.47.0 pymicro-vad==1.0.1 pyspeex-noise==1.0.2
+        PyTurboJPEG==1.7.5 go2rtc-client==0.1.1 ha-ffmpeg==3.2.2 hassil==1.7.4 home-assistant-intents==2024.11.6 mutagen==1.47.0 pymicro-vad==1.0.1 pyspeex-noise==1.0.2
 
 LABEL "name"="hassfest"
 LABEL "maintainer"="Home Assistant <hello@home-assistant.io>"

--- a/tests/components/advantage_air/test_binary_sensor.py
+++ b/tests/components/advantage_air/test_binary_sensor.py
@@ -1,10 +1,8 @@
 """Test the Advantage Air Binary Sensor Platform."""
 
 from datetime import timedelta
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
-from homeassistant.components.advantage_air import ADVANTAGE_AIR_SYNC_INTERVAL
-from homeassistant.config_entries import RELOAD_AFTER_UPDATE_DELAY
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -70,22 +68,14 @@ async def test_binary_sensor_async_setup_entry(
     assert not hass.states.get(entity_id)
 
     mock_get.reset_mock()
-    entity_registry.async_update_entity(entity_id=entity_id, disabled_by=None)
-    await hass.async_block_till_done()
 
-    async_fire_time_changed(
-        hass,
-        dt_util.utcnow() + timedelta(seconds=ADVANTAGE_AIR_SYNC_INTERVAL + 1),
-    )
-    await hass.async_block_till_done(wait_background_tasks=True)
-    assert len(mock_get.mock_calls) == 1
+    with patch("homeassistant.config_entries.RELOAD_AFTER_UPDATE_DELAY", 1):
+        entity_registry.async_update_entity(entity_id=entity_id, disabled_by=None)
+        await hass.async_block_till_done()
 
-    async_fire_time_changed(
-        hass,
-        dt_util.utcnow() + timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
-    )
-    await hass.async_block_till_done(wait_background_tasks=True)
-    assert len(mock_get.mock_calls) == 2
+        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=2))
+        await hass.async_block_till_done(wait_background_tasks=True)
+        assert len(mock_get.mock_calls) == 1
 
     state = hass.states.get(entity_id)
     assert state
@@ -101,22 +91,14 @@ async def test_binary_sensor_async_setup_entry(
     assert not hass.states.get(entity_id)
 
     mock_get.reset_mock()
-    entity_registry.async_update_entity(entity_id=entity_id, disabled_by=None)
-    await hass.async_block_till_done()
 
-    async_fire_time_changed(
-        hass,
-        dt_util.utcnow() + timedelta(seconds=ADVANTAGE_AIR_SYNC_INTERVAL + 1),
-    )
-    await hass.async_block_till_done(wait_background_tasks=True)
-    assert len(mock_get.mock_calls) == 1
+    with patch("homeassistant.config_entries.RELOAD_AFTER_UPDATE_DELAY", 1):
+        entity_registry.async_update_entity(entity_id=entity_id, disabled_by=None)
+        await hass.async_block_till_done()
 
-    async_fire_time_changed(
-        hass,
-        dt_util.utcnow() + timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
-    )
-    await hass.async_block_till_done(wait_background_tasks=True)
-    assert len(mock_get.mock_calls) == 2
+        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=2))
+        await hass.async_block_till_done(wait_background_tasks=True)
+        assert len(mock_get.mock_calls) == 1
 
     state = hass.states.get(entity_id)
     assert state

--- a/tests/components/advantage_air/test_sensor.py
+++ b/tests/components/advantage_air/test_sensor.py
@@ -1,15 +1,13 @@
 """Test the Advantage Air Sensor Platform."""
 
 from datetime import timedelta
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
-from homeassistant.components.advantage_air import ADVANTAGE_AIR_SYNC_INTERVAL
 from homeassistant.components.advantage_air.const import DOMAIN as ADVANTAGE_AIR_DOMAIN
 from homeassistant.components.advantage_air.sensor import (
     ADVANTAGE_AIR_SERVICE_SET_TIME_TO,
     ADVANTAGE_AIR_SET_COUNTDOWN_VALUE,
 )
-from homeassistant.config_entries import RELOAD_AFTER_UPDATE_DELAY
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -124,23 +122,15 @@ async def test_sensor_platform_disabled_entity(
 
     assert not hass.states.get(entity_id)
 
-    entity_registry.async_update_entity(entity_id=entity_id, disabled_by=None)
-    await hass.async_block_till_done(wait_background_tasks=True)
     mock_get.reset_mock()
 
-    async_fire_time_changed(
-        hass,
-        dt_util.utcnow() + timedelta(seconds=ADVANTAGE_AIR_SYNC_INTERVAL + 1),
-    )
-    await hass.async_block_till_done(wait_background_tasks=True)
-    assert len(mock_get.mock_calls) == 1
+    with patch("homeassistant.config_entries.RELOAD_AFTER_UPDATE_DELAY", 1):
+        entity_registry.async_update_entity(entity_id=entity_id, disabled_by=None)
+        await hass.async_block_till_done(wait_background_tasks=True)
 
-    async_fire_time_changed(
-        hass,
-        dt_util.utcnow() + timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
-    )
-    await hass.async_block_till_done(wait_background_tasks=True)
-    assert len(mock_get.mock_calls) == 2
+        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=2))
+        await hass.async_block_till_done(wait_background_tasks=True)
+        assert len(mock_get.mock_calls) == 1
 
     state = hass.states.get(entity_id)
     assert state

--- a/tests/components/alarm_control_panel/test_init.py
+++ b/tests/components/alarm_control_panel/test_init.py
@@ -489,3 +489,96 @@ async def test_alarm_control_panel_log_deprecated_state_warning_using_attr_state
         )
     # Test we only log once
     assert "Entities should implement the 'alarm_state' property and" not in caplog.text
+
+
+async def test_alarm_control_panel_deprecated_state_does_not_break_state(
+    hass: HomeAssistant,
+    code_format: CodeFormat | None,
+    supported_features: AlarmControlPanelEntityFeature,
+    code_arm_required: bool,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test using _attr_state attribute does not break state."""
+
+    async def async_setup_entry_init(
+        hass: HomeAssistant, config_entry: ConfigEntry
+    ) -> bool:
+        """Set up test config entry."""
+        await hass.config_entries.async_forward_entry_setups(
+            config_entry, [ALARM_CONTROL_PANEL_DOMAIN]
+        )
+        return True
+
+    mock_integration(
+        hass,
+        MockModule(
+            TEST_DOMAIN,
+            async_setup_entry=async_setup_entry_init,
+        ),
+    )
+
+    class MockLegacyAlarmControlPanel(MockAlarmControlPanel):
+        """Mocked alarm control entity."""
+
+        def __init__(
+            self,
+            supported_features: AlarmControlPanelEntityFeature = AlarmControlPanelEntityFeature(
+                0
+            ),
+            code_format: CodeFormat | None = None,
+            code_arm_required: bool = True,
+        ) -> None:
+            """Initialize the alarm control."""
+            self._attr_state = "armed_away"
+            super().__init__(supported_features, code_format, code_arm_required)
+
+        def alarm_disarm(self, code: str | None = None) -> None:
+            """Mock alarm disarm calls."""
+            self._attr_state = "disarmed"
+
+    entity = MockLegacyAlarmControlPanel(
+        supported_features=supported_features,
+        code_format=code_format,
+        code_arm_required=code_arm_required,
+    )
+
+    async def async_setup_entry_platform(
+        hass: HomeAssistant,
+        config_entry: ConfigEntry,
+        async_add_entities: AddEntitiesCallback,
+    ) -> None:
+        """Set up test alarm control panel platform via config entry."""
+        async_add_entities([entity])
+
+    mock_platform(
+        hass,
+        f"{TEST_DOMAIN}.{ALARM_CONTROL_PANEL_DOMAIN}",
+        MockPlatform(async_setup_entry=async_setup_entry_platform),
+    )
+
+    with patch.object(
+        MockLegacyAlarmControlPanel,
+        "__module__",
+        "tests.custom_components.test.alarm_control_panel",
+    ):
+        config_entry = MockConfigEntry(domain=TEST_DOMAIN)
+        config_entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    state = hass.states.get(entity.entity_id)
+    assert state is not None
+    assert state.state == "armed_away"
+
+    with patch.object(
+        MockLegacyAlarmControlPanel,
+        "__module__",
+        "tests.custom_components.test.alarm_control_panel",
+    ):
+        await help_test_async_alarm_control_panel_service(
+            hass, entity.entity_id, SERVICE_ALARM_DISARM
+        )
+
+    state = hass.states.get(entity.entity_id)
+    assert state is not None
+    assert state.state == "disarmed"

--- a/tests/components/co2signal/test_config_flow.py
+++ b/tests/components/co2signal/test_config_flow.py
@@ -44,7 +44,7 @@ async def test_form_home(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     assert result2["type"] is FlowResultType.CREATE_ENTRY
-    assert result2["title"] == "CO2 Signal"
+    assert result2["title"] == "Electricity Maps"
     assert result2["data"] == {
         "api_key": "api_key",
     }
@@ -185,7 +185,7 @@ async def test_form_error_handling(
     await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == "CO2 Signal"
+    assert result["title"] == "Electricity Maps"
     assert result["data"] == {
         "api_key": "api_key",
     }

--- a/tests/components/generic/test_camera.py
+++ b/tests/components/generic/test_camera.py
@@ -275,7 +275,9 @@ async def test_limit_refetch(
 
     with (
         pytest.raises(aiohttp.ServerTimeoutError),
-        patch("asyncio.timeout", side_effect=TimeoutError()),
+        patch.object(
+            client.session._connector, "connect", side_effect=asyncio.TimeoutError
+        ),
     ):
         resp = await client.get("/api/camera_proxy/camera.config_test")
 

--- a/tests/components/generic/test_config_flow.py
+++ b/tests/components/generic/test_config_flow.py
@@ -637,10 +637,6 @@ async def test_form_stream_other_error(hass: HomeAssistant, user_flow) -> None:
     await hass.async_block_till_done()
 
 
-@pytest.mark.parametrize(  # Remove when translations fixed
-    "ignore_translations",
-    ["component.generic.config.error.Some message"],
-)
 @respx.mock
 @pytest.mark.usefixtures("fakeimg_png")
 async def test_form_stream_worker_error(
@@ -656,7 +652,8 @@ async def test_form_stream_worker_error(
             TESTDATA,
         )
     assert result2["type"] is FlowResultType.FORM
-    assert result2["errors"] == {"stream_source": "Some message"}
+    assert result2["errors"] == {"stream_source": "unknown_with_details"}
+    assert result2["description_placeholders"] == {"error": "Some message"}
 
 
 @respx.mock

--- a/tests/components/go2rtc/conftest.py
+++ b/tests/components/go2rtc/conftest.py
@@ -3,9 +3,11 @@
 from collections.abc import Generator
 from unittest.mock import AsyncMock, Mock, patch
 
+from awesomeversion import AwesomeVersion
 from go2rtc_client.rest import _StreamClient, _WebRTCClient
 import pytest
 
+from homeassistant.components.go2rtc.const import RECOMMENDED_VERSION
 from homeassistant.components.go2rtc.server import Server
 
 GO2RTC_PATH = "homeassistant.components.go2rtc"
@@ -23,7 +25,9 @@ def rest_client() -> Generator[AsyncMock]:
         client = mock_client.return_value
         client.streams = streams = Mock(spec_set=_StreamClient)
         streams.list.return_value = {}
-        client.validate_server_version = AsyncMock()
+        client.validate_server_version = AsyncMock(
+            return_value=AwesomeVersion(RECOMMENDED_VERSION)
+        )
         client.webrtc = Mock(spec_set=_WebRTCClient)
         yield client
 

--- a/tests/components/go2rtc/test_init.py
+++ b/tests/components/go2rtc/test_init.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable, Generator
 import logging
 from typing import NamedTuple
-from unittest.mock import AsyncMock, Mock, call, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 from aiohttp.client_exceptions import ClientConnectionError, ServerConnectionError
 from go2rtc_client import Stream
@@ -238,7 +238,11 @@ async def _test_setup_and_signaling(
     await test()
 
     rest_client.streams.add.assert_called_once_with(
-        entity_id, ["rtsp://stream", f"ffmpeg:{camera.entity_id}#audio=opus"]
+        entity_id,
+        [
+            "rtsp://stream",
+            f"ffmpeg:{camera.entity_id}#audio=opus#query=log_level=debug",
+        ],
     )
 
     # Stream exists but the source is different
@@ -252,7 +256,11 @@ async def _test_setup_and_signaling(
     await test()
 
     rest_client.streams.add.assert_called_once_with(
-        entity_id, ["rtsp://stream", f"ffmpeg:{camera.entity_id}#audio=opus"]
+        entity_id,
+        [
+            "rtsp://stream",
+            f"ffmpeg:{camera.entity_id}#audio=opus#query=log_level=debug",
+        ],
     )
 
     # If the stream is already added, the stream should not be added again.
@@ -296,7 +304,7 @@ async def _test_setup_and_signaling(
     ],
 )
 @pytest.mark.parametrize("has_go2rtc_entry", [True, False])
-async def test_setup_managed(
+async def test_setup_go_binary(
     hass: HomeAssistant,
     rest_client: AsyncMock,
     ws_client: Mock,
@@ -308,131 +316,15 @@ async def test_setup_managed(
     config: ConfigType,
     ui_enabled: bool,
 ) -> None:
-    """Test the go2rtc setup with managed go2rtc instance."""
+    """Test the go2rtc config entry with binary."""
     assert (len(hass.config_entries.async_entries(DOMAIN)) == 1) == has_go2rtc_entry
-    camera = init_test_integration
 
-    entity_id = camera.entity_id
-    stream_name_original = f"{camera.entity_id}_original"
-    assert camera.frontend_stream_type == StreamType.HLS
+    def after_setup() -> None:
+        server.assert_called_once_with(hass, "/usr/bin/go2rtc", enable_ui=ui_enabled)
+        server_start.assert_called_once()
 
-    assert await async_setup_component(hass, DOMAIN, config)
-    await hass.async_block_till_done(wait_background_tasks=True)
-    config_entries = hass.config_entries.async_entries(DOMAIN)
-    assert len(config_entries) == 1
-    assert config_entries[0].state == ConfigEntryState.LOADED
-    server.assert_called_once_with(hass, "/usr/bin/go2rtc", enable_ui=ui_enabled)
-    server_start.assert_called_once()
-
-    receive_message_callback = Mock(spec_set=WebRTCSendMessage)
-
-    async def test() -> None:
-        await camera.async_handle_async_webrtc_offer(
-            OFFER_SDP, "session_id", receive_message_callback
-        )
-        ws_client.send.assert_called_once_with(
-            WebRTCOffer(
-                OFFER_SDP,
-                camera.async_get_webrtc_client_configuration().configuration.ice_servers,
-            )
-        )
-        ws_client.subscribe.assert_called_once()
-
-        # Simulate the answer from the go2rtc server
-        callback = ws_client.subscribe.call_args[0][0]
-        callback(WebRTCAnswer(ANSWER_SDP))
-        receive_message_callback.assert_called_once_with(HAWebRTCAnswer(ANSWER_SDP))
-
-    await test()
-
-    stream_added_calls = [
-        call(stream_name_original, "rtsp://stream"),
-        call(
-            entity_id,
-            [
-                f"rtsp://127.0.0.1:18554/{stream_name_original}",
-                f"ffmpeg:{stream_name_original}#audio=opus",
-            ],
-        ),
-    ]
-    assert rest_client.streams.add.call_args_list == stream_added_calls
-
-    # Stream original missing
-    rest_client.streams.add.reset_mock()
-    rest_client.streams.list.return_value = {
-        entity_id: Stream(
-            [
-                Producer(f"rtsp://127.0.0.1:18554/{stream_name_original}"),
-                Producer(f"ffmpeg:{stream_name_original}#audio=opus"),
-            ]
-        )
-    }
-
-    receive_message_callback.reset_mock()
-    ws_client.reset_mock()
-    await test()
-
-    assert rest_client.streams.add.call_args_list == stream_added_calls
-
-    # Stream original source different
-    rest_client.streams.add.reset_mock()
-    rest_client.streams.list.return_value = {
-        stream_name_original: Stream([Producer("rtsp://different")]),
-        entity_id: Stream(
-            [
-                Producer(f"rtsp://127.0.0.1:18554/{stream_name_original}"),
-                Producer(f"ffmpeg:{stream_name_original}#audio=opus"),
-            ]
-        ),
-    }
-
-    receive_message_callback.reset_mock()
-    ws_client.reset_mock()
-    await test()
-
-    assert rest_client.streams.add.call_args_list == stream_added_calls
-
-    # Stream source different
-    rest_client.streams.add.reset_mock()
-    rest_client.streams.list.return_value = {
-        stream_name_original: Stream([Producer("rtsp://stream")]),
-        entity_id: Stream([Producer("rtsp://different")]),
-    }
-
-    receive_message_callback.reset_mock()
-    ws_client.reset_mock()
-    await test()
-
-    assert rest_client.streams.add.call_args_list == stream_added_calls
-
-    # If the stream is already added, the stream should not be added again.
-    rest_client.streams.add.reset_mock()
-    rest_client.streams.list.return_value = {
-        stream_name_original: Stream([Producer("rtsp://stream")]),
-        entity_id: Stream(
-            [
-                Producer(f"rtsp://127.0.0.1:18554/{stream_name_original}"),
-                Producer(f"ffmpeg:{stream_name_original}#audio=opus"),
-            ]
-        ),
-    }
-
-    receive_message_callback.reset_mock()
-    ws_client.reset_mock()
-    await test()
-
-    rest_client.streams.add.assert_not_called()
-    assert isinstance(camera._webrtc_provider, WebRTCProvider)
-
-    # Set stream source to None and provider should be skipped
-    rest_client.streams.list.return_value = {}
-    receive_message_callback.reset_mock()
-    camera.set_stream_source(None)
-    await camera.async_handle_async_webrtc_offer(
-        OFFER_SDP, "session_id", receive_message_callback
-    )
-    receive_message_callback.assert_called_once_with(
-        WebRTCError("go2rtc_webrtc_offer_failed", "Camera has no stream source")
+    await _test_setup_and_signaling(
+        hass, rest_client, ws_client, config, after_setup, init_test_integration
     )
 
     await hass.async_stop()
@@ -448,7 +340,7 @@ async def test_setup_managed(
     ],
 )
 @pytest.mark.parametrize("has_go2rtc_entry", [True, False])
-async def test_setup_self_hosted(
+async def test_setup_go(
     hass: HomeAssistant,
     rest_client: AsyncMock,
     ws_client: Mock,
@@ -458,83 +350,16 @@ async def test_setup_self_hosted(
     mock_is_docker_env: Mock,
     has_go2rtc_entry: bool,
 ) -> None:
-    """Test the go2rtc with selfhosted go2rtc instance."""
+    """Test the go2rtc config entry without binary."""
     assert (len(hass.config_entries.async_entries(DOMAIN)) == 1) == has_go2rtc_entry
 
     config = {DOMAIN: {CONF_URL: "http://localhost:1984/"}}
-    camera = init_test_integration
 
-    entity_id = camera.entity_id
-    assert camera.frontend_stream_type == StreamType.HLS
+    def after_setup() -> None:
+        server.assert_not_called()
 
-    assert await async_setup_component(hass, DOMAIN, config)
-    await hass.async_block_till_done(wait_background_tasks=True)
-    config_entries = hass.config_entries.async_entries(DOMAIN)
-    assert len(config_entries) == 1
-    assert config_entries[0].state == ConfigEntryState.LOADED
-    server.assert_not_called()
-
-    receive_message_callback = Mock(spec_set=WebRTCSendMessage)
-
-    async def test() -> None:
-        await camera.async_handle_async_webrtc_offer(
-            OFFER_SDP, "session_id", receive_message_callback
-        )
-        ws_client.send.assert_called_once_with(
-            WebRTCOffer(
-                OFFER_SDP,
-                camera.async_get_webrtc_client_configuration().configuration.ice_servers,
-            )
-        )
-        ws_client.subscribe.assert_called_once()
-
-        # Simulate the answer from the go2rtc server
-        callback = ws_client.subscribe.call_args[0][0]
-        callback(WebRTCAnswer(ANSWER_SDP))
-        receive_message_callback.assert_called_once_with(HAWebRTCAnswer(ANSWER_SDP))
-
-    await test()
-
-    rest_client.streams.add.assert_called_once_with(
-        entity_id, ["rtsp://stream", f"ffmpeg:{camera.entity_id}#audio=opus"]
-    )
-
-    # Stream exists but the source is different
-    rest_client.streams.add.reset_mock()
-    rest_client.streams.list.return_value = {
-        entity_id: Stream([Producer("rtsp://different")])
-    }
-
-    receive_message_callback.reset_mock()
-    ws_client.reset_mock()
-    await test()
-
-    rest_client.streams.add.assert_called_once_with(
-        entity_id, ["rtsp://stream", f"ffmpeg:{camera.entity_id}#audio=opus"]
-    )
-
-    # If the stream is already added, the stream should not be added again.
-    rest_client.streams.add.reset_mock()
-    rest_client.streams.list.return_value = {
-        entity_id: Stream([Producer("rtsp://stream")])
-    }
-
-    receive_message_callback.reset_mock()
-    ws_client.reset_mock()
-    await test()
-
-    rest_client.streams.add.assert_not_called()
-    assert isinstance(camera._webrtc_provider, WebRTCProvider)
-
-    # Set stream source to None and provider should be skipped
-    rest_client.streams.list.return_value = {}
-    receive_message_callback.reset_mock()
-    camera.set_stream_source(None)
-    await camera.async_handle_async_webrtc_offer(
-        OFFER_SDP, "session_id", receive_message_callback
-    )
-    receive_message_callback.assert_called_once_with(
-        WebRTCError("go2rtc_webrtc_offer_failed", "Camera has no stream source")
+    await _test_setup_and_signaling(
+        hass, rest_client, ws_client, config, after_setup, init_test_integration
     )
 
     mock_get_binary.assert_not_called()

--- a/tests/components/go2rtc/test_init.py
+++ b/tests/components/go2rtc/test_init.py
@@ -313,7 +313,7 @@ async def test_setup_managed(
     camera = init_test_integration
 
     entity_id = camera.entity_id
-    stream_name_orginal = f"{camera.entity_id}_orginal"
+    stream_name_original = f"{camera.entity_id}_original"
     assert camera.frontend_stream_type == StreamType.HLS
 
     assert await async_setup_component(hass, DOMAIN, config)
@@ -346,12 +346,12 @@ async def test_setup_managed(
     await test()
 
     stream_added_calls = [
-        call(stream_name_orginal, "rtsp://stream"),
+        call(stream_name_original, "rtsp://stream"),
         call(
             entity_id,
             [
-                f"rtsp://127.0.0.1:18554/{stream_name_orginal}",
-                f"ffmpeg:{stream_name_orginal}#audio=opus",
+                f"rtsp://127.0.0.1:18554/{stream_name_original}",
+                f"ffmpeg:{stream_name_original}#audio=opus",
             ],
         ),
     ]
@@ -362,8 +362,8 @@ async def test_setup_managed(
     rest_client.streams.list.return_value = {
         entity_id: Stream(
             [
-                Producer(f"rtsp://127.0.0.1:18554/{stream_name_orginal}"),
-                Producer(f"ffmpeg:{stream_name_orginal}#audio=opus"),
+                Producer(f"rtsp://127.0.0.1:18554/{stream_name_original}"),
+                Producer(f"ffmpeg:{stream_name_original}#audio=opus"),
             ]
         )
     }
@@ -377,11 +377,11 @@ async def test_setup_managed(
     # Stream original source different
     rest_client.streams.add.reset_mock()
     rest_client.streams.list.return_value = {
-        stream_name_orginal: Stream([Producer("rtsp://different")]),
+        stream_name_original: Stream([Producer("rtsp://different")]),
         entity_id: Stream(
             [
-                Producer(f"rtsp://127.0.0.1:18554/{stream_name_orginal}"),
-                Producer(f"ffmpeg:{stream_name_orginal}#audio=opus"),
+                Producer(f"rtsp://127.0.0.1:18554/{stream_name_original}"),
+                Producer(f"ffmpeg:{stream_name_original}#audio=opus"),
             ]
         ),
     }
@@ -395,7 +395,7 @@ async def test_setup_managed(
     # Stream source different
     rest_client.streams.add.reset_mock()
     rest_client.streams.list.return_value = {
-        stream_name_orginal: Stream([Producer("rtsp://stream")]),
+        stream_name_original: Stream([Producer("rtsp://stream")]),
         entity_id: Stream([Producer("rtsp://different")]),
     }
 
@@ -408,11 +408,11 @@ async def test_setup_managed(
     # If the stream is already added, the stream should not be added again.
     rest_client.streams.add.reset_mock()
     rest_client.streams.list.return_value = {
-        stream_name_orginal: Stream([Producer("rtsp://stream")]),
+        stream_name_original: Stream([Producer("rtsp://stream")]),
         entity_id: Stream(
             [
-                Producer(f"rtsp://127.0.0.1:18554/{stream_name_orginal}"),
-                Producer(f"ffmpeg:{stream_name_orginal}#audio=opus"),
+                Producer(f"rtsp://127.0.0.1:18554/{stream_name_original}"),
+                Producer(f"ffmpeg:{stream_name_original}#audio=opus"),
             ]
         ),
     }

--- a/tests/components/go2rtc/test_init.py
+++ b/tests/components/go2rtc/test_init.py
@@ -313,7 +313,7 @@ async def test_setup_managed(
     camera = init_test_integration
 
     entity_id = camera.entity_id
-    stream_name_orginal = camera.entity_id + "_orginal"
+    stream_name_orginal = f"{camera.entity_id}_orginal"
     assert camera.frontend_stream_type == StreamType.HLS
 
     assert await async_setup_component(hass, DOMAIN, config)

--- a/tests/components/go2rtc/test_init.py
+++ b/tests/components/go2rtc/test_init.py
@@ -6,6 +6,7 @@ from typing import NamedTuple
 from unittest.mock import AsyncMock, Mock, patch
 
 from aiohttp.client_exceptions import ClientConnectionError, ServerConnectionError
+from awesomeversion import AwesomeVersion
 from go2rtc_client import Stream
 from go2rtc_client.exceptions import Go2RtcClientError, Go2RtcVersionError
 from go2rtc_client.models import Producer
@@ -36,10 +37,12 @@ from homeassistant.components.go2rtc.const import (
     CONF_DEBUG_UI,
     DEBUG_UI_URL_MESSAGE,
     DOMAIN,
+    RECOMMENDED_VERSION,
 )
 from homeassistant.config_entries import ConfigEntry, ConfigEntryState, ConfigFlow
 from homeassistant.const import CONF_URL
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.setup import async_setup_component
 
@@ -199,6 +202,7 @@ async def init_test_integration(
 
 async def _test_setup_and_signaling(
     hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
     rest_client: AsyncMock,
     ws_client: Mock,
     config: ConfigType,
@@ -211,6 +215,7 @@ async def _test_setup_and_signaling(
 
     assert await async_setup_component(hass, DOMAIN, config)
     await hass.async_block_till_done(wait_background_tasks=True)
+    assert issue_registry.async_get_issue(DOMAIN, "recommended_version") is None
     config_entries = hass.config_entries.async_entries(DOMAIN)
     assert len(config_entries) == 1
     assert config_entries[0].state == ConfigEntryState.LOADED
@@ -306,6 +311,7 @@ async def _test_setup_and_signaling(
 @pytest.mark.parametrize("has_go2rtc_entry", [True, False])
 async def test_setup_go_binary(
     hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
     rest_client: AsyncMock,
     ws_client: Mock,
     server: AsyncMock,
@@ -324,7 +330,13 @@ async def test_setup_go_binary(
         server_start.assert_called_once()
 
     await _test_setup_and_signaling(
-        hass, rest_client, ws_client, config, after_setup, init_test_integration
+        hass,
+        issue_registry,
+        rest_client,
+        ws_client,
+        config,
+        after_setup,
+        init_test_integration,
     )
 
     await hass.async_stop()
@@ -340,8 +352,9 @@ async def test_setup_go_binary(
     ],
 )
 @pytest.mark.parametrize("has_go2rtc_entry", [True, False])
-async def test_setup_go(
+async def test_setup(
     hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
     rest_client: AsyncMock,
     ws_client: Mock,
     server: Mock,
@@ -359,7 +372,13 @@ async def test_setup_go(
         server.assert_not_called()
 
     await _test_setup_and_signaling(
-        hass, rest_client, ws_client, config, after_setup, init_test_integration
+        hass,
+        issue_registry,
+        rest_client,
+        ws_client,
+        config,
+        after_setup,
+        init_test_integration,
     )
 
     mock_get_binary.assert_not_called()
@@ -711,3 +730,30 @@ async def test_config_entry_remove(hass: HomeAssistant) -> None:
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
     assert not await hass.config_entries.async_setup(config_entry.entry_id)
     assert len(hass.config_entries.async_entries(DOMAIN)) == 0
+
+
+@pytest.mark.parametrize("config", [{DOMAIN: {CONF_URL: "http://localhost:1984"}}])
+@pytest.mark.usefixtures("server")
+async def test_setup_with_recommended_version_repair(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+    rest_client: AsyncMock,
+    config: ConfigType,
+) -> None:
+    """Test setup integration entry fails."""
+    rest_client.validate_server_version.return_value = AwesomeVersion("1.9.5")
+    assert await async_setup_component(hass, DOMAIN, config)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    # Verify the issue is created
+    issue = issue_registry.async_get_issue(DOMAIN, "recommended_version")
+    assert issue
+    assert issue.is_fixable is False
+    assert issue.is_persistent is False
+    assert issue.severity == ir.IssueSeverity.WARNING
+    assert issue.issue_id == "recommended_version"
+    assert issue.translation_key == "recommended_version"
+    assert issue.translation_placeholders == {
+        "recommended_version": RECOMMENDED_VERSION,
+        "current_version": "1.9.5",
+    }

--- a/tests/components/husqvarna_automower/conftest.py
+++ b/tests/components/husqvarna_automower/conftest.py
@@ -1,5 +1,6 @@
 """Test helpers for Husqvarna Automower."""
 
+import asyncio
 from collections.abc import Generator
 import time
 from unittest.mock import AsyncMock, patch
@@ -101,10 +102,17 @@ async def setup_credentials(hass: HomeAssistant) -> None:
 def mock_automower_client(values) -> Generator[AsyncMock]:
     """Mock a Husqvarna Automower client."""
 
+    async def listen() -> None:
+        """Mock listen."""
+        listen_block = asyncio.Event()
+        await listen_block.wait()
+        pytest.fail("Listen was not cancelled!")
+
     mock = AsyncMock(spec=AutomowerSession)
     mock.auth = AsyncMock(side_effect=ClientWebSocketResponse)
     mock.commands = AsyncMock(spec_set=_MowerCommands)
     mock.get_status.return_value = values
+    mock.start_listening = AsyncMock(side_effect=listen)
 
     with patch(
         "homeassistant.components.husqvarna_automower.AutomowerSession",

--- a/tests/components/husqvarna_automower/test_init.py
+++ b/tests/components/husqvarna_automower/test_init.py
@@ -1,14 +1,16 @@
 """Tests for init module."""
 
-from datetime import datetime, timedelta
+from asyncio import Event
+from datetime import datetime
 import http
 import time
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 from aioautomower.exceptions import (
     ApiException,
     AuthException,
     HusqvarnaWSServerHandshakeError,
+    TimeoutException,
 )
 from aioautomower.model import MowerAttributes, WorkArea
 from freezegun.api import FrozenDateTimeFactory
@@ -127,28 +129,77 @@ async def test_update_failed(
     assert entry.state is entry_state
 
 
+@patch(
+    "homeassistant.components.husqvarna_automower.coordinator.DEFAULT_RECONNECT_TIME", 0
+)
+@pytest.mark.parametrize(
+    ("method_path", "exception", "error_msg"),
+    [
+        (
+            ["auth", "websocket_connect"],
+            HusqvarnaWSServerHandshakeError,
+            "Failed to connect to websocket.",
+        ),
+        (
+            ["start_listening"],
+            TimeoutException,
+            "Failed to listen to websocket.",
+        ),
+    ],
+)
 async def test_websocket_not_available(
     hass: HomeAssistant,
     mock_automower_client: AsyncMock,
     mock_config_entry: MockConfigEntry,
     caplog: pytest.LogCaptureFixture,
     freezer: FrozenDateTimeFactory,
+    method_path: list[str],
+    exception: type[Exception],
+    error_msg: str,
 ) -> None:
-    """Test trying reload the websocket."""
-    mock_automower_client.start_listening.side_effect = HusqvarnaWSServerHandshakeError(
-        "Boom"
-    )
+    """Test trying to reload the websocket."""
+    calls = []
+    mock_called = Event()
+    mock_stall = Event()
+
+    async def mock_function():
+        mock_called.set()
+        await mock_stall.wait()
+        # Raise the first time the method is awaited
+        if not calls:
+            calls.append(None)
+            raise exception("Boom")
+        if mock_side_effect:
+            await mock_side_effect()
+
+    # Find the method to mock
+    mock = mock_automower_client
+    for itm in method_path:
+        mock = getattr(mock, itm)
+    mock_side_effect = mock.side_effect
+    mock.side_effect = mock_function
+
+    # Setup integration and verify log error message
     await setup_integration(hass, mock_config_entry)
-    assert "Failed to connect to websocket. Trying to reconnect: Boom" in caplog.text
-    assert mock_automower_client.auth.websocket_connect.call_count == 1
-    assert mock_automower_client.start_listening.call_count == 1
-    assert mock_config_entry.state is ConfigEntryState.LOADED
-    freezer.tick(timedelta(seconds=2))
-    async_fire_time_changed(hass)
+    await mock_called.wait()
+    mock_called.clear()
+    # Allow the exception to be raised
+    mock_stall.set()
+    assert mock.call_count == 1
     await hass.async_block_till_done()
-    assert mock_automower_client.auth.websocket_connect.call_count == 2
-    assert mock_automower_client.start_listening.call_count == 2
-    assert mock_config_entry.state is ConfigEntryState.LOADED
+    assert f"{error_msg} Trying to reconnect: Boom" in caplog.text
+
+    # Simulate a successful connection
+    caplog.clear()
+    await mock_called.wait()
+    mock_called.clear()
+    await hass.async_block_till_done()
+    assert mock.call_count == 2
+    assert "Trying to reconnect: Boom" not in caplog.text
+
+    # Simulate hass shutting down
+    await hass.async_stop()
+    assert mock.call_count == 2
 
 
 async def test_device_info(

--- a/tests/components/hvv_departures/test_config_flow.py
+++ b/tests/components/hvv_departures/test_config_flow.py
@@ -4,7 +4,6 @@ import json
 from unittest.mock import patch
 
 from pygti.exceptions import CannotConnect, InvalidAuth
-import pytest
 
 from homeassistant.components.hvv_departures.const import (
     CONF_FILTER,
@@ -313,10 +312,6 @@ async def test_options_flow(hass: HomeAssistant) -> None:
         }
 
 
-@pytest.mark.parametrize(  # Remove when translations fixed
-    "ignore_translations",
-    ["component.hvv_departures.options.error.invalid_auth"],
-)
 async def test_options_flow_invalid_auth(hass: HomeAssistant) -> None:
     """Test that options flow works."""
 
@@ -360,10 +355,6 @@ async def test_options_flow_invalid_auth(hass: HomeAssistant) -> None:
         assert result["errors"] == {"base": "invalid_auth"}
 
 
-@pytest.mark.parametrize(  # Remove when translations fixed
-    "ignore_translations",
-    ["component.hvv_departures.options.error.cannot_connect"],
-)
 async def test_options_flow_cannot_connect(hass: HomeAssistant) -> None:
     """Test that options flow works."""
 

--- a/tests/components/hydrawise/test_binary_sensor.py
+++ b/tests/components/hydrawise/test_binary_sensor.py
@@ -9,7 +9,7 @@ from freezegun.api import FrozenDateTimeFactory
 from pydrawise.schema import Controller
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.components.hydrawise.const import SCAN_INTERVAL
+from homeassistant.components.hydrawise.const import MAIN_SCAN_INTERVAL
 from homeassistant.const import STATE_OFF, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -42,7 +42,8 @@ async def test_update_data_fails(
     # Make the coordinator refresh data.
     mock_pydrawise.get_user.reset_mock(return_value=True)
     mock_pydrawise.get_user.side_effect = ClientError
-    freezer.tick(SCAN_INTERVAL + timedelta(seconds=30))
+    mock_pydrawise.get_water_use_summary.side_effect = ClientError
+    freezer.tick(MAIN_SCAN_INTERVAL + timedelta(seconds=30))
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
@@ -61,7 +62,7 @@ async def test_controller_offline(
     """Test the binary_sensor for the controller being online."""
     # Make the coordinator refresh data.
     controller.online = False
-    freezer.tick(SCAN_INTERVAL + timedelta(seconds=30))
+    freezer.tick(MAIN_SCAN_INTERVAL + timedelta(seconds=30))
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 

--- a/tests/components/hydrawise/test_entity_availability.py
+++ b/tests/components/hydrawise/test_entity_availability.py
@@ -8,7 +8,7 @@ from aiohttp import ClientError
 from freezegun.api import FrozenDateTimeFactory
 from pydrawise.schema import Controller
 
-from homeassistant.components.hydrawise.const import SCAN_INTERVAL
+from homeassistant.components.hydrawise.const import WATER_USE_SCAN_INTERVAL
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_OFF, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
@@ -42,7 +42,8 @@ async def test_api_offline(
     config_entry = await mock_add_config_entry()
     mock_pydrawise.get_user.reset_mock(return_value=True)
     mock_pydrawise.get_user.side_effect = ClientError
-    freezer.tick(SCAN_INTERVAL + timedelta(seconds=30))
+    mock_pydrawise.get_water_use_summary.side_effect = ClientError
+    freezer.tick(WATER_USE_SCAN_INTERVAL + timedelta(seconds=30))
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
     _test_availability(hass, config_entry, entity_registry)

--- a/tests/components/hydrawise/test_sensor.py
+++ b/tests/components/hydrawise/test_sensor.py
@@ -1,12 +1,18 @@
 """Test Hydrawise sensor."""
 
 from collections.abc import Awaitable, Callable
-from unittest.mock import patch
+from datetime import timedelta
+from unittest.mock import AsyncMock, patch
 
+from freezegun.api import FrozenDateTimeFactory
 from pydrawise.schema import Controller, ControllerWaterUseSummary, User, Zone
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
+from homeassistant.components.hydrawise.const import (
+    MAIN_SCAN_INTERVAL,
+    WATER_USE_SCAN_INTERVAL,
+)
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -16,7 +22,7 @@ from homeassistant.util.unit_system import (
     UnitSystem,
 )
 
-from tests.common import MockConfigEntry, snapshot_platform
+from tests.common import MockConfigEntry, async_fire_time_changed, snapshot_platform
 
 
 @pytest.mark.freeze_time("2023-10-01 00:00:00+00:00")
@@ -48,6 +54,34 @@ async def test_suspended_state(
     next_cycle = hass.states.get("sensor.zone_one_next_cycle")
     assert next_cycle is not None
     assert next_cycle.state == "unknown"
+
+
+@pytest.mark.freeze_time("2024-11-01 00:00:00+00:00")
+async def test_usage_refresh(
+    hass: HomeAssistant,
+    mock_added_config_entry: MockConfigEntry,
+    mock_pydrawise: AsyncMock,
+    controller_water_use_summary: ControllerWaterUseSummary,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test that water usage summaries refresh less frequently than other data."""
+    assert hass.states.get("sensor.zone_one_daily_active_water_use") is not None
+    mock_pydrawise.get_water_use_summary.assert_called_once()
+
+    # Make the coordinator refresh data.
+    mock_pydrawise.get_water_use_summary.reset_mock()
+    freezer.tick(MAIN_SCAN_INTERVAL + timedelta(seconds=30))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    # Make sure we didn't fetch water use summary again.
+    mock_pydrawise.get_water_use_summary.assert_not_called()
+
+    # Wait for enough time to pass for a water use summary fetch.
+    mock_pydrawise.get_water_use_summary.return_value = controller_water_use_summary
+    freezer.tick(WATER_USE_SCAN_INTERVAL + timedelta(seconds=30))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    mock_pydrawise.get_water_use_summary.assert_called_once()
 
 
 async def test_no_sensor_and_water_state(

--- a/tests/components/lg_netcast/test_config_flow.py
+++ b/tests/components/lg_netcast/test_config_flow.py
@@ -3,8 +3,6 @@
 from datetime import timedelta
 from unittest.mock import DEFAULT, patch
 
-import pytest
-
 from homeassistant import data_entry_flow
 from homeassistant.components.lg_netcast.const import DOMAIN
 from homeassistant.config_entries import SOURCE_USER
@@ -114,10 +112,6 @@ async def test_manual_host_unsuccessful_details_response(hass: HomeAssistant) ->
         assert result["reason"] == "cannot_connect"
 
 
-@pytest.mark.parametrize(  # Remove when translations fixed
-    "ignore_translations",
-    ["component.lg_netcast.config.abort.invalid_host"],
-)
 async def test_manual_host_no_unique_id_response(hass: HomeAssistant) -> None:
     """Test manual host configuration."""
     with _patch_lg_netcast(no_unique_id=True):

--- a/tests/components/madvr/test_config_flow.py
+++ b/tests/components/madvr/test_config_flow.py
@@ -165,10 +165,6 @@ async def test_reconfigure_flow(
     mock_madvr_client.async_cancel_tasks.assert_called()
 
 
-@pytest.mark.parametrize(  # Remove when translations fixed
-    "ignore_translations",
-    ["component.madvr.config.abort.set_up_new_device"],
-)
 async def test_reconfigure_new_device(
     hass: HomeAssistant,
     mock_madvr_client: AsyncMock,

--- a/tests/components/nest/test_camera.py
+++ b/tests/components/nest/test_camera.py
@@ -483,6 +483,50 @@ async def test_stream_response_already_expired(
     assert stream_source == "rtsp://some/url?auth=g.2.streamingToken"
 
 
+async def test_extending_stream_already_expired(
+    hass: HomeAssistant,
+    auth: FakeAuth,
+    setup_platform: PlatformSetup,
+    camera_device: None,
+) -> None:
+    """Test a API response when extending the stream returns an expired stream url."""
+    now = utcnow()
+    stream_1_expiration = now + datetime.timedelta(seconds=180)
+    stream_2_expiration = now + datetime.timedelta(seconds=30)  # Will be in the past
+    stream_3_expiration = now + datetime.timedelta(seconds=600)
+    auth.responses = [
+        make_stream_url_response(stream_1_expiration, token_num=1),
+        make_stream_url_response(stream_2_expiration, token_num=2),
+        make_stream_url_response(stream_3_expiration, token_num=3),
+    ]
+    await setup_platform()
+
+    assert len(hass.states.async_all()) == 1
+    cam = hass.states.get("camera.my_camera")
+    assert cam is not None
+    assert cam.state == CameraState.STREAMING
+
+    # The stream is expired, but we return it anyway
+    stream_source = await camera.async_get_stream_source(hass, "camera.my_camera")
+    assert stream_source == "rtsp://some/url?auth=g.1.streamingToken"
+
+    # Jump to when the stream will be refreshed
+    await fire_alarm(hass, now + datetime.timedelta(seconds=160))
+    stream_source = await camera.async_get_stream_source(hass, "camera.my_camera")
+    assert stream_source == "rtsp://some/url?auth=g.2.streamingToken"
+
+    # The stream will have expired in the past, but 1 minute min refresh interval is applied.
+    # The stream token is not updated.
+    await fire_alarm(hass, now + datetime.timedelta(seconds=170))
+    stream_source = await camera.async_get_stream_source(hass, "camera.my_camera")
+    assert stream_source == "rtsp://some/url?auth=g.2.streamingToken"
+
+    # Now go past the min update interval and the stream is refreshed
+    await fire_alarm(hass, now + datetime.timedelta(seconds=225))
+    stream_source = await camera.async_get_stream_source(hass, "camera.my_camera")
+    assert stream_source == "rtsp://some/url?auth=g.3.streamingToken"
+
+
 async def test_camera_removed(
     hass: HomeAssistant,
     auth: FakeAuth,

--- a/tests/components/ollama/test_config_flow.py
+++ b/tests/components/ollama/test_config_flow.py
@@ -204,10 +204,6 @@ async def test_form_errors(hass: HomeAssistant, side_effect, error) -> None:
     assert result2["errors"] == {"base": error}
 
 
-@pytest.mark.parametrize(  # Remove when translations fixed
-    "ignore_translations",
-    ["component.ollama.config.abort.download_failed"],
-)
 async def test_download_error(hass: HomeAssistant) -> None:
     """Test we handle errors while downloading a model."""
     result = await hass.config_entries.flow.async_init(

--- a/tests/components/onewire/test_config_flow.py
+++ b/tests/components/onewire/test_config_flow.py
@@ -253,10 +253,6 @@ async def test_user_options_set_multiple(
     )
 
 
-@pytest.mark.parametrize(  # Remove when translations fixed
-    "ignore_translations",
-    ["component.onewire.options.abort.No configurable devices found."],
-)
 async def test_user_options_no_devices(
     hass: HomeAssistant, config_entry: ConfigEntry
 ) -> None:
@@ -267,4 +263,4 @@ async def test_user_options_no_devices(
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
     await hass.async_block_till_done()
     assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "No configurable devices found."
+    assert result["reason"] == "no_configurable_devices"

--- a/tests/components/philips_js/test_config_flow.py
+++ b/tests/components/philips_js/test_config_flow.py
@@ -161,10 +161,6 @@ async def test_pairing(hass: HomeAssistant, mock_tv_pairable, mock_setup_entry) 
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-@pytest.mark.parametrize(  # Remove when translations fixed
-    "ignore_translations",
-    ["component.philips_js.config.abort.pairing_failure"],
-)
 async def test_pair_request_failed(
     hass: HomeAssistant, mock_tv_pairable, mock_setup_entry
 ) -> None:
@@ -192,10 +188,6 @@ async def test_pair_request_failed(
     }
 
 
-@pytest.mark.parametrize(  # Remove when translations fixed
-    "ignore_translations",
-    ["component.philips_js.config.abort.pairing_failure"],
-)
 async def test_pair_grant_failed(
     hass: HomeAssistant, mock_tv_pairable, mock_setup_entry
 ) -> None:

--- a/tests/components/powerwall/test_config_flow.py
+++ b/tests/components/powerwall/test_config_flow.py
@@ -339,6 +339,11 @@ async def test_form_reauth(hass: HomeAssistant) -> None:
     result = await entry.start_reauth_flow(hass)
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {}
+    flow = hass.config_entries.flow.async_get(result["flow_id"])
+    assert flow["context"]["title_placeholders"] == {
+        "ip_address": VALID_CONFIG[CONF_IP_ADDRESS],
+        "name": entry.title,
+    }
 
     mock_powerwall = await _mock_powerwall_site_name(hass, "My site")
 

--- a/tests/components/srp_energy/test_config_flow.py
+++ b/tests/components/srp_energy/test_config_flow.py
@@ -100,10 +100,6 @@ async def test_form_invalid_auth(
     assert result["errors"] == {"base": "invalid_auth"}
 
 
-@pytest.mark.parametrize(  # Remove when translations fixed
-    "ignore_translations",
-    ["component.srp_energy.config.abort.unknown"],
-)
 async def test_form_unknown_error(
     hass: HomeAssistant,
     mock_srp_energy_config_flow: MagicMock,

--- a/tests/components/subaru/test_config_flow.py
+++ b/tests/components/subaru/test_config_flow.py
@@ -192,10 +192,6 @@ async def test_two_factor_request_success(
     assert len(mock_two_factor_request.mock_calls) == 1
 
 
-@pytest.mark.parametrize(  # Remove when translations fixed
-    "ignore_translations",
-    ["component.subaru.config.abort.two_factor_request_failed"],
-)
 async def test_two_factor_request_fail(
     hass: HomeAssistant, two_factor_start_form
 ) -> None:

--- a/tests/components/toon/test_config_flow.py
+++ b/tests/components/toon/test_config_flow.py
@@ -249,10 +249,6 @@ async def test_agreement_already_set_up(
         assert result3["reason"] == "already_configured"
 
 
-@pytest.mark.parametrize(  # Remove when translations fixed
-    "ignore_translations",
-    ["component.toon.config.abort.connection_error"],
-)
 @pytest.mark.usefixtures("current_request_with_host")
 async def test_toon_abort(
     hass: HomeAssistant,

--- a/tests/components/tradfri/test_config_flow.py
+++ b/tests/components/tradfri/test_config_flow.py
@@ -86,10 +86,6 @@ async def test_user_connection_timeout(
     assert result["errors"] == {"base": "timeout"}
 
 
-@pytest.mark.parametrize(  # Remove when translations fixed
-    "ignore_translations",
-    ["component.tradfri.config.error.invalid_security_code"],
-)
 async def test_user_connection_bad_key(
     hass: HomeAssistant, mock_auth, mock_entry_setup
 ) -> None:
@@ -107,7 +103,7 @@ async def test_user_connection_bad_key(
     assert len(mock_entry_setup.mock_calls) == 0
 
     assert result["type"] is FlowResultType.FORM
-    assert result["errors"] == {"security_code": "invalid_security_code"}
+    assert result["errors"] == {"base": "invalid_security_code"}
 
 
 async def test_discovery_connection(

--- a/tests/components/utility_meter/test_config_flow.py
+++ b/tests/components/utility_meter/test_config_flow.py
@@ -72,10 +72,6 @@ async def test_config_flow(hass: HomeAssistant, platform) -> None:
     assert config_entry.title == "Electricity meter"
 
 
-@pytest.mark.parametrize(  # Remove when translations fixed
-    "ignore_translations",
-    ["component.utility_meter.config.error.tariffs_not_unique"],
-)
 async def test_tariffs(hass: HomeAssistant) -> None:
     """Test tariffs."""
     input_sensor_entity_id = "sensor.input"

--- a/tests/components/vilfo/test_config_flow.py
+++ b/tests/components/vilfo/test_config_flow.py
@@ -150,10 +150,6 @@ async def test_form_exceptions(
     assert result["type"] is FlowResultType.CREATE_ENTRY
 
 
-@pytest.mark.parametrize(  # Remove when translations fixed
-    "ignore_translations",
-    ["component.vilfo.config.error.wrong_host"],
-)
 async def test_form_wrong_host(
     hass: HomeAssistant,
     mock_is_valid_host: AsyncMock,
@@ -169,7 +165,7 @@ async def test_form_wrong_host(
         },
     )
 
-    assert result["errors"] == {"host": "wrong_host"}
+    assert result["errors"] == {"base": "invalid_host"}
 
 
 async def test_form_already_configured(

--- a/tests/components/zha/test_config_flow.py
+++ b/tests/components/zha/test_config_flow.py
@@ -21,7 +21,7 @@ import zigpy.types
 
 from homeassistant import config_entries
 from homeassistant.components import ssdp, usb, zeroconf
-from homeassistant.components.hassio import AddonState
+from homeassistant.components.hassio import AddonError, AddonState
 from homeassistant.components.ssdp import ATTR_UPNP_MANUFACTURER_URL, ATTR_UPNP_SERIAL
 from homeassistant.components.zha import config_flow, radio_manager
 from homeassistant.components.zha.const import (
@@ -1878,10 +1878,23 @@ async def test_config_flow_port_yellow_port_name(hass: HomeAssistant) -> None:
     )
 
 
+async def test_config_flow_ports_no_hassio(hass: HomeAssistant) -> None:
+    """Test config flow serial port name when this is not a hassio install."""
+
+    with (
+        patch("homeassistant.components.zha.config_flow.is_hassio", return_value=False),
+        patch("serial.tools.list_ports.comports", MagicMock(return_value=[])),
+    ):
+        ports = await config_flow.list_serial_ports(hass)
+
+    assert ports == []
+
+
 async def test_config_flow_port_multiprotocol_port_name(hass: HomeAssistant) -> None:
     """Test config flow serial port name for multiprotocol add-on."""
 
     with (
+        patch("homeassistant.components.zha.config_flow.is_hassio", return_value=True),
         patch(
             "homeassistant.components.hassio.addon_manager.AddonManager.async_get_addon_info"
         ) as async_get_addon_info,
@@ -1889,16 +1902,28 @@ async def test_config_flow_port_multiprotocol_port_name(hass: HomeAssistant) -> 
     ):
         async_get_addon_info.return_value.state = AddonState.RUNNING
         async_get_addon_info.return_value.hostname = "core-silabs-multiprotocol"
+        ports = await config_flow.list_serial_ports(hass)
 
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={CONF_SOURCE: SOURCE_USER},
-        )
+    assert len(ports) == 1
+    assert ports[0].description == "Multiprotocol add-on"
+    assert ports[0].manufacturer == "Nabu Casa"
+    assert ports[0].device == "socket://core-silabs-multiprotocol:9999"
 
-    assert (
-        result["data_schema"].schema["path"].container[0]
-        == "socket://core-silabs-multiprotocol:9999 - Multiprotocol add-on - Nabu Casa"
-    )
+
+async def test_config_flow_port_no_multiprotocol(hass: HomeAssistant) -> None:
+    """Test config flow serial port listing when addon info fails to load."""
+
+    with (
+        patch("homeassistant.components.zha.config_flow.is_hassio", return_value=True),
+        patch(
+            "homeassistant.components.hassio.addon_manager.AddonManager.async_get_addon_info",
+            side_effect=AddonError,
+        ),
+        patch("serial.tools.list_ports.comports", MagicMock(return_value=[])),
+    ):
+        ports = await config_flow.list_serial_ports(hass)
+
+    assert ports == []
 
 
 @patch("serial.tools.list_ports.comports", MagicMock(return_value=[com_port()]))

--- a/tests/components/zha/test_update.py
+++ b/tests/components/zha/test_update.py
@@ -394,7 +394,7 @@ async def test_firmware_update_success(
                         attrs[ATTR_INSTALLED_VERSION] == f"0x{installed_fw_version:08x}"
                     )
                     assert attrs[ATTR_IN_PROGRESS] is True
-                    assert attrs[ATTR_UPDATE_PERCENTAGE] == 58
+                    assert attrs[ATTR_UPDATE_PERCENTAGE] == pytest.approx(100 * 40 / 70)
                     assert (
                         attrs[ATTR_LATEST_VERSION]
                         == f"0x{fw_image.firmware.header.file_version:08x}"


### PR DESCRIPTION
- Bump aiohttp to 3.10.11 ([@bdraco] - [#130483]) (dependency)
- Fix RecursionError in Husqvarna Automower coordinator ([@Thomas55555] - [#123085]) ([husqvarna_automower docs])
- Bump python-linkplay to v0.0.18 ([@silamon] - [#130159]) ([linkplay docs]) (dependency)
- Allow dynamic max preset in linkplay play preset ([@silamon] - [#130160]) ([linkplay docs])
- No longer thrown an error when device is offline in linkplay ([@silamon] - [#130161]) ([linkplay docs])
- Fix translations in ollama ([@sheldonip] - [#130164]) ([ollama docs])
- Bump nice-go to 0.3.10 ([@IceBotYT] - [#130173]) ([nice_go docs]) (dependency)
- Fix wording in Google Calendar create_event strings for consistency ([@maxshcherbina] - [#130183]) ([google docs])
- Fix uptime sensor for Vodafone Station ([@chemelli74] - [#130215]) ([vodafone_station docs])
- Bump pyTibber ([@Danielhiversen] - [#130216]) ([tibber docs]) (dependency)
- Bump SoCo to 0.30.6 ([@jjlawren] - [#130223]) ([sonos docs]) (dependency)
- Bump google-nest-sdm to 6.1.5 ([@allenporter] - [#130229]) ([nest docs]) (dependency)
- Rename "CO2 Signal" display name to Electricity Maps for consistency ([@corradio] - [#130242]) ([co2signal docs])
- Update generic thermostat strings for clarity and accuracy ([@maxshcherbina] - [#130243]) ([generic_thermostat docs])
- Fix translation key for `done` response in conversation ([@mib1185] - [#130247]) ([conversation docs])
- Improve nest camera stream expiration to be defensive against errors ([@allenporter] - [#130265]) ([nest docs])
- Add more f-series models to myuplink ([@astrandb] - [#130283]) ([myuplink docs])
- Make Hydrawise poll non-critical data less frequently ([@dknowles2] - [#130289]) ([hydrawise docs])
- Ignore WebRTC candidates for nest cameras ([@allenporter] - [#130294]) ([nest docs])
- Avoid Shelly data update during shutdown ([@chemelli74] - [#130301]) ([shelly docs])
- Fix Homekit error handling alarm state unknown or unavailable ([@gjohansson-ST] - [#130311]) ([homekit docs])
- Fix fan's warning TURN_ON, TURN_OFF ([@LG-ThinQ-Integration] - [#130327]) ([lg_thinq docs])
- Bump python-linkplay to 0.0.20 ([@silamon] - [#130348]) ([linkplay docs])
- Add seek support to LinkPlay ([@silamon] - [#130349]) ([linkplay docs])
- Add Spotify and Tidal to playingmode mapping ([@silamon] - [#130351]) ([linkplay docs])
- Disable brightness from devices with no display in Cambridge Audio ([@noahhusby] - [#130369]) ([cambridge_audio docs]) (dependency)
- Use f-strings in go2rtc code and test and do not use abbreviation ([@jbouwh] - [#130158]) ([go2rtc docs])
- Fix typo in go2rtc ([@jbouwh] - [#130165]) ([go2rtc docs])
- Go2rtc bump and set ffmpeg logs to debug ([@edenhaus] - [#130371]) ([go2rtc docs]) (dependency)
- Bump spotifyaio to 0.8.8 ([@joostlek] - [#130372]) ([spotify docs])
- Bump Tibber 0.30.8 ([@Danielhiversen] - [#130388]) ([tibber docs]) (dependency)
- Fix missing title placeholders in powerwall reauth ([@bdraco] - [#130389]) ([powerwall docs])
- Bump ring library ring-doorbell to 0.9.9 ([@sdb9696] - [#129966]) ([ring docs]) (dependency)
- Bump ring-doorbell to 0.9.12 ([@sdb9696] - [#130419]) ([ring docs]) (dependency)
- Do not trigger events for updated ring events ([@sdb9696] - [#130430]) ([ring docs])
- Add title to water heater component ([@joostlek] - [#130446]) ([water_heater docs])
- Fix translation in statistics ([@gjohansson-ST] - [#130455]) ([statistics docs])
- Fix typo in file strings ([@KelvinDekker] - [#130465]) ([file docs])
- Bump aiowithings to 3.1.2 ([@joostlek] - [#130469]) ([withings docs])
- Ensure ZHA setup works with container installs ([@puddly] - [#130470]) ([zha docs])
- Fix legacy _attr_state handling in AlarmControlPanel ([@gjohansson-ST] - [#130479]) ([alarm_control_panel docs])
- Bump reolink_aio to 0.11.0 ([@starkillerOG] - [#130481]) ([reolink docs]) (dependency)
- Fix translations in subaru ([@sheldonip] - [#130486]) ([subaru docs])
- Bump aioruckus to 0.42 ([@ms264556] - [#130487]) ([ruckus_unleashed docs]) (dependency)
- Bump go2rtc-client to 0.1.1 ([@edenhaus] - [#130498]) ([go2rtc docs]) (dependency)
- Bump aiowithings to 3.1.3 ([@joostlek] - [#130504]) ([withings docs])
- Add go2rtc recommended version ([@edenhaus] - [#130508]) ([go2rtc docs])
- fix translation in srp_energy ([@briglx] - [#130540]) ([srp_energy docs])
- Fix non-thread-safe operation in powerview number ([@bdraco] - [#130557]) ([hunterdouglas_powerview docs])
- Bump ZHA dependencies ([@puddly] - [#130563]) ([zha docs])
- Update uptime deviation for Vodafone Station ([@chemelli74] - [#130571]) ([vodafone_station docs])
- Fixes webhook schema for different temp and volume units ([@JohNan] - [#130578]) ([plaato docs]) (dependency)
- Bump reolink-aio to 0.11.1 ([@starkillerOG] - [#130600]) ([reolink docs]) (dependency)
- Fix hassfest by adding go2rtc reqs ([@edenhaus] - [#130602])
- Add missing translation string to smarty ([@epenet] - [#130624]) ([smarty docs])
- Bump sense-energy to 0.13.4 ([@kbickar] - [#130625]) ([sense docs]) ([emulated_kasa docs]) (dependency)
- Fix scene loading issue ([@alistairg] - [#130627]) ([hue docs])
- Add missing translation string to hvv_departures ([@epenet] - [#130634]) ([hvv_departures docs])
- Add missing translation string to lg_netcast ([@epenet] - [#130635]) ([lg_netcast docs])
- Add missing translation string to philips_js ([@epenet] - [#130637]) ([philips_js docs])
- Bump pyplaato to 0.0.19 ([@JohNan] - [#130641]) ([plaato docs]) (dependency)
- Remove dumping config entry to log in setup of roborock ([@jpbede] - [#130648]) ([roborock docs])
- Fix missing translations in vilfo ([@epenet] - [#130650]) ([vilfo docs])
- Fix missing translations in utility_meter ([@epenet] - [#130652]) ([utility_meter docs])
- Fix missing translations in tradfri ([@epenet] - [#130654]) ([tradfri docs])
- Fix missing translations in toon ([@epenet] - [#130655]) ([toon docs])
- Fix missing translations in madvr ([@epenet] - [#130656]) ([madvr docs])
- Fix missing translations in generic ([@epenet] - [#130672]) ([generic docs])
- Fix missing translations in onewire ([@epenet] - [#130673]) ([onewire docs])
- Bump python-smarttub to 0.0.38 ([@mdz] - [#130679]) ([smarttub docs]) (dependency)

[#123085]: https://github.com/home-assistant/core/pull/123085
[#129966]: https://github.com/home-assistant/core/pull/129966
[#129970]: https://github.com/home-assistant/core/pull/129970
[#130156]: https://github.com/home-assistant/core/pull/130156
[#130158]: https://github.com/home-assistant/core/pull/130158
[#130159]: https://github.com/home-assistant/core/pull/130159
[#130160]: https://github.com/home-assistant/core/pull/130160
[#130161]: https://github.com/home-assistant/core/pull/130161
[#130164]: https://github.com/home-assistant/core/pull/130164
[#130165]: https://github.com/home-assistant/core/pull/130165
[#130173]: https://github.com/home-assistant/core/pull/130173
[#130183]: https://github.com/home-assistant/core/pull/130183
[#130215]: https://github.com/home-assistant/core/pull/130215
[#130216]: https://github.com/home-assistant/core/pull/130216
[#130223]: https://github.com/home-assistant/core/pull/130223
[#130229]: https://github.com/home-assistant/core/pull/130229
[#130242]: https://github.com/home-assistant/core/pull/130242
[#130243]: https://github.com/home-assistant/core/pull/130243
[#130247]: https://github.com/home-assistant/core/pull/130247
[#130265]: https://github.com/home-assistant/core/pull/130265
[#130283]: https://github.com/home-assistant/core/pull/130283
[#130289]: https://github.com/home-assistant/core/pull/130289
[#130294]: https://github.com/home-assistant/core/pull/130294
[#130301]: https://github.com/home-assistant/core/pull/130301
[#130311]: https://github.com/home-assistant/core/pull/130311
[#130327]: https://github.com/home-assistant/core/pull/130327
[#130348]: https://github.com/home-assistant/core/pull/130348
[#130349]: https://github.com/home-assistant/core/pull/130349
[#130351]: https://github.com/home-assistant/core/pull/130351
[#130369]: https://github.com/home-assistant/core/pull/130369
[#130371]: https://github.com/home-assistant/core/pull/130371
[#130372]: https://github.com/home-assistant/core/pull/130372
[#130388]: https://github.com/home-assistant/core/pull/130388
[#130389]: https://github.com/home-assistant/core/pull/130389
[#130419]: https://github.com/home-assistant/core/pull/130419
[#130430]: https://github.com/home-assistant/core/pull/130430
[#130446]: https://github.com/home-assistant/core/pull/130446
[#130455]: https://github.com/home-assistant/core/pull/130455
[#130465]: https://github.com/home-assistant/core/pull/130465
[#130469]: https://github.com/home-assistant/core/pull/130469
[#130470]: https://github.com/home-assistant/core/pull/130470
[#130479]: https://github.com/home-assistant/core/pull/130479
[#130481]: https://github.com/home-assistant/core/pull/130481
[#130483]: https://github.com/home-assistant/core/pull/130483
[#130486]: https://github.com/home-assistant/core/pull/130486
[#130487]: https://github.com/home-assistant/core/pull/130487
[#130498]: https://github.com/home-assistant/core/pull/130498
[#130504]: https://github.com/home-assistant/core/pull/130504
[#130508]: https://github.com/home-assistant/core/pull/130508
[#130540]: https://github.com/home-assistant/core/pull/130540
[#130557]: https://github.com/home-assistant/core/pull/130557
[#130563]: https://github.com/home-assistant/core/pull/130563
[#130571]: https://github.com/home-assistant/core/pull/130571
[#130578]: https://github.com/home-assistant/core/pull/130578
[#130600]: https://github.com/home-assistant/core/pull/130600
[#130602]: https://github.com/home-assistant/core/pull/130602
[#130624]: https://github.com/home-assistant/core/pull/130624
[#130625]: https://github.com/home-assistant/core/pull/130625
[#130627]: https://github.com/home-assistant/core/pull/130627
[#130634]: https://github.com/home-assistant/core/pull/130634
[#130635]: https://github.com/home-assistant/core/pull/130635
[#130637]: https://github.com/home-assistant/core/pull/130637
[#130641]: https://github.com/home-assistant/core/pull/130641
[#130648]: https://github.com/home-assistant/core/pull/130648
[#130650]: https://github.com/home-assistant/core/pull/130650
[#130652]: https://github.com/home-assistant/core/pull/130652
[#130654]: https://github.com/home-assistant/core/pull/130654
[#130655]: https://github.com/home-assistant/core/pull/130655
[#130656]: https://github.com/home-assistant/core/pull/130656
[#130672]: https://github.com/home-assistant/core/pull/130672
[#130673]: https://github.com/home-assistant/core/pull/130673
[#130679]: https://github.com/home-assistant/core/pull/130679
[@Danielhiversen]: https://github.com/Danielhiversen
[@IceBotYT]: https://github.com/IceBotYT
[@JohNan]: https://github.com/JohNan
[@KelvinDekker]: https://github.com/KelvinDekker
[@LG-ThinQ-Integration]: https://github.com/LG-ThinQ-Integration
[@Thomas55555]: https://github.com/Thomas55555
[@alistairg]: https://github.com/alistairg
[@allenporter]: https://github.com/allenporter
[@astrandb]: https://github.com/astrandb
[@bdraco]: https://github.com/bdraco
[@briglx]: https://github.com/briglx
[@chemelli74]: https://github.com/chemelli74
[@corradio]: https://github.com/corradio
[@dknowles2]: https://github.com/dknowles2
[@edenhaus]: https://github.com/edenhaus
[@epenet]: https://github.com/epenet
[@frenck]: https://github.com/frenck
[@gjohansson-ST]: https://github.com/gjohansson-ST
[@jbouwh]: https://github.com/jbouwh
[@jjlawren]: https://github.com/jjlawren
[@joostlek]: https://github.com/joostlek
[@jpbede]: https://github.com/jpbede
[@kbickar]: https://github.com/kbickar
[@maxshcherbina]: https://github.com/maxshcherbina
[@mdz]: https://github.com/mdz
[@mib1185]: https://github.com/mib1185
[@ms264556]: https://github.com/ms264556
[@noahhusby]: https://github.com/noahhusby
[@puddly]: https://github.com/puddly
[@sdb9696]: https://github.com/sdb9696
[@sheldonip]: https://github.com/sheldonip
[@silamon]: https://github.com/silamon
[@starkillerOG]: https://github.com/starkillerOG
[alarm_control_panel docs]: https://www.home-assistant.io/integrations/alarm_control_panel/
[cambridge_audio docs]: https://www.home-assistant.io/integrations/cambridge_audio/
[co2signal docs]: https://www.home-assistant.io/integrations/co2signal/
[conversation docs]: https://www.home-assistant.io/integrations/conversation/
[emulated_kasa docs]: https://www.home-assistant.io/integrations/emulated_kasa/
[file docs]: https://www.home-assistant.io/integrations/file/
[generic docs]: https://www.home-assistant.io/integrations/generic/
[generic_thermostat docs]: https://www.home-assistant.io/integrations/generic_thermostat/
[go2rtc docs]: https://www.home-assistant.io/integrations/go2rtc/
[google docs]: https://www.home-assistant.io/integrations/google/
[homekit docs]: https://www.home-assistant.io/integrations/homekit/
[hue docs]: https://www.home-assistant.io/integrations/hue/
[hunterdouglas_powerview docs]: https://www.home-assistant.io/integrations/hunterdouglas_powerview/
[husqvarna_automower docs]: https://www.home-assistant.io/integrations/husqvarna_automower/
[hvv_departures docs]: https://www.home-assistant.io/integrations/hvv_departures/
[hydrawise docs]: https://www.home-assistant.io/integrations/hydrawise/
[lg_netcast docs]: https://www.home-assistant.io/integrations/lg_netcast/
[lg_thinq docs]: https://www.home-assistant.io/integrations/lg_thinq/
[linkplay docs]: https://www.home-assistant.io/integrations/linkplay/
[madvr docs]: https://www.home-assistant.io/integrations/madvr/
[myuplink docs]: https://www.home-assistant.io/integrations/myuplink/
[nest docs]: https://www.home-assistant.io/integrations/nest/
[nice_go docs]: https://www.home-assistant.io/integrations/nice_go/
[ollama docs]: https://www.home-assistant.io/integrations/ollama/
[onewire docs]: https://www.home-assistant.io/integrations/onewire/
[philips_js docs]: https://www.home-assistant.io/integrations/philips_js/
[plaato docs]: https://www.home-assistant.io/integrations/plaato/
[powerwall docs]: https://www.home-assistant.io/integrations/powerwall/
[reolink docs]: https://www.home-assistant.io/integrations/reolink/
[ring docs]: https://www.home-assistant.io/integrations/ring/
[roborock docs]: https://www.home-assistant.io/integrations/roborock/
[ruckus_unleashed docs]: https://www.home-assistant.io/integrations/ruckus_unleashed/
[sense docs]: https://www.home-assistant.io/integrations/sense/
[shelly docs]: https://www.home-assistant.io/integrations/shelly/
[smarttub docs]: https://www.home-assistant.io/integrations/smarttub/
[smarty docs]: https://www.home-assistant.io/integrations/smarty/
[sonos docs]: https://www.home-assistant.io/integrations/sonos/
[spotify docs]: https://www.home-assistant.io/integrations/spotify/
[srp_energy docs]: https://www.home-assistant.io/integrations/srp_energy/
[statistics docs]: https://www.home-assistant.io/integrations/statistics/
[subaru docs]: https://www.home-assistant.io/integrations/subaru/
[tibber docs]: https://www.home-assistant.io/integrations/tibber/
[toon docs]: https://www.home-assistant.io/integrations/toon/
[tradfri docs]: https://www.home-assistant.io/integrations/tradfri/
[utility_meter docs]: https://www.home-assistant.io/integrations/utility_meter/
[vilfo docs]: https://www.home-assistant.io/integrations/vilfo/
[vodafone_station docs]: https://www.home-assistant.io/integrations/vodafone_station/
[water_heater docs]: https://www.home-assistant.io/integrations/water_heater/
[withings docs]: https://www.home-assistant.io/integrations/withings/
[zha docs]: https://www.home-assistant.io/integrations/zha/

Documentation release PR: <https://github.com/home-assistant/home-assistant.io/pull/35777>