### PR TITLE
Add coordinator to eq3btsmart

### DIFF
--- a/homeassistant/components/eq3btsmart/__init__.py
+++ b/homeassistant/components/eq3btsmart/__init__.py
@@ -1,11 +1,9 @@
 """Support for EQ3 devices."""
 
-import asyncio
-import logging
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from eq3btsmart import Thermostat
-from eq3btsmart.exceptions import Eq3Exception
 from eq3btsmart.thermostat_config import ThermostatConfig
 
 from homeassistant.components import bluetooth
@@ -13,10 +11,9 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.helpers.dispatcher import async_dispatcher_send
 
-from .const import SIGNAL_THERMOSTAT_CONNECTED, SIGNAL_THERMOSTAT_DISCONNECTED
-from .models import Eq3Config, Eq3ConfigEntryData
+from .coordinator import Eq3Coordinator
+from .models import Eq3Config
 
 PLATFORMS = [
     Platform.BINARY_SENSOR,
@@ -26,7 +23,14 @@ PLATFORMS = [
     Platform.SWITCH,
 ]
 
-_LOGGER = logging.getLogger(__name__)
+
+@dataclass(slots=True)
+class Eq3ConfigEntryData:
+    """Config entry for a single eQ-3 device."""
+
+    eq3_config: Eq3Config
+    thermostat: Thermostat
+    coordinator: Eq3Coordinator
 
 
 type Eq3ConfigEntry = ConfigEntry[Eq3ConfigEntryData]
@@ -59,15 +63,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: Eq3ConfigEntry) -> bool:
         ),
         ble_device=device,
     )
+    coordinator = Eq3Coordinator(hass, thermostat, mac_address)
 
     entry.runtime_data = Eq3ConfigEntryData(
-        eq3_config=eq3_config, thermostat=thermostat
+        eq3_config=eq3_config, thermostat=thermostat, coordinator=coordinator
     )
     entry.async_on_unload(entry.add_update_listener(update_listener))
+
+    await coordinator.async_config_entry_first_refresh()
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-    entry.async_create_background_task(
-        hass, _async_run_thermostat(hass, entry), entry.entry_id
-    )
+    coordinator.async_update_listeners()
 
     return True
 
@@ -85,66 +90,3 @@ async def update_listener(hass: HomeAssistant, entry: Eq3ConfigEntry) -> None:
     """Handle config entry update."""
 
     await hass.config_entries.async_reload(entry.entry_id)
-
-
-async def _async_run_thermostat(hass: HomeAssistant, entry: Eq3ConfigEntry) -> None:
-    """Run the thermostat."""
-
-    thermostat = entry.runtime_data.thermostat
-    mac_address = entry.runtime_data.eq3_config.mac_address
-    scan_interval = entry.runtime_data.eq3_config.scan_interval
-
-    await _async_reconnect_thermostat(hass, entry)
-
-    while True:
-        try:
-            await thermostat.async_get_status()
-        except Eq3Exception as e:
-            if not thermostat.is_connected:
-                _LOGGER.error(
-                    "[%s] eQ-3 device disconnected",
-                    mac_address,
-                )
-                async_dispatcher_send(
-                    hass,
-                    f"{SIGNAL_THERMOSTAT_DISCONNECTED}_{mac_address}",
-                )
-                await _async_reconnect_thermostat(hass, entry)
-                continue
-
-            _LOGGER.error(
-                "[%s] Error updating eQ-3 device: %s",
-                mac_address,
-                e,
-            )
-
-        await asyncio.sleep(scan_interval)
-
-
-async def _async_reconnect_thermostat(
-    hass: HomeAssistant, entry: Eq3ConfigEntry
-) -> None:
-    """Reconnect the thermostat."""
-
-    thermostat = entry.runtime_data.thermostat
-    mac_address = entry.runtime_data.eq3_config.mac_address
-    scan_interval = entry.runtime_data.eq3_config.scan_interval
-
-    while True:
-        try:
-            await thermostat.async_connect()
-        except Eq3Exception:
-            await asyncio.sleep(scan_interval)
-            continue
-
-        _LOGGER.debug(
-            "[%s] eQ-3 device connected",
-            mac_address,
-        )
-
-        async_dispatcher_send(
-            hass,
-            f"{SIGNAL_THERMOSTAT_CONNECTED}_{mac_address}",
-        )
-
-        return

--- a/homeassistant/components/eq3btsmart/binary_sensor.py
+++ b/homeassistant/components/eq3btsmart/binary_sensor.py
@@ -2,7 +2,6 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
 
 from eq3btsmart.models import Status
 
@@ -12,7 +11,7 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntityDescription,
 )
 from homeassistant.const import EntityCategory
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import Eq3ConfigEntry
@@ -76,11 +75,9 @@ class Eq3BinarySensorEntity(Eq3Entity, BinarySensorEntity):
         super().__init__(entry, entity_description.key)
         self.entity_description = entity_description
 
-    @property
-    def is_on(self) -> bool:
-        """Return the state of the binary sensor."""
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
 
-        if TYPE_CHECKING:
-            assert self._thermostat.status is not None
-
-        return self.entity_description.value_func(self._thermostat.status)
+        self._attr_is_on = self.entity_description.value_func(self._status)
+        super()._handle_coordinator_update()

--- a/homeassistant/components/eq3btsmart/const.py
+++ b/homeassistant/components/eq3btsmart/const.py
@@ -80,7 +80,7 @@ class TargetTemperatureSelector(str, Enum):
 
 DEFAULT_CURRENT_TEMP_SELECTOR = CurrentTemperatureSelector.DEVICE
 DEFAULT_TARGET_TEMP_SELECTOR = TargetTemperatureSelector.TARGET
-DEFAULT_SCAN_INTERVAL = 10  # seconds
+SCAN_INTERVAL = 10  # seconds
 
 SIGNAL_THERMOSTAT_DISCONNECTED = f"{DOMAIN}.thermostat_disconnected"
 SIGNAL_THERMOSTAT_CONNECTED = f"{DOMAIN}.thermostat_connected"

--- a/homeassistant/components/eq3btsmart/coordinator.py
+++ b/homeassistant/components/eq3btsmart/coordinator.py
@@ -1,0 +1,208 @@
+"""Coordinator for the eq3btsmart integration."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import timedelta
+import logging
+from typing import TYPE_CHECKING
+
+from eq3btsmart import Thermostat
+from eq3btsmart.exceptions import Eq3Exception
+from eq3btsmart.models import DeviceData, Status
+
+from homeassistant.core import HomeAssistant
+import homeassistant.helpers.device_registry as dr
+from homeassistant.helpers.device_registry import CONNECTION_BLUETOOTH, format_mac
+from homeassistant.helpers.dispatcher import async_dispatcher_send
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import (
+    DEVICE_MODEL,
+    MANUFACTURER,
+    SCAN_INTERVAL,
+    SIGNAL_THERMOSTAT_DISCONNECTED,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class Eq3Coordinator(DataUpdateCoordinator[Status]):
+    """Coordinator for the eq3btsmart integration."""
+
+    def __init__(
+        self, hass: HomeAssistant, thermostat: Thermostat, mac_address: str
+    ) -> None:
+        """Initialize the coordinator."""
+
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=format_mac(mac_address),
+            update_interval=timedelta(seconds=SCAN_INTERVAL),
+            always_update=False,
+        )
+
+        self._thermostat = thermostat
+        self._mac_address = mac_address
+        self._status_future: asyncio.Future[Status] | None = None
+        self._device_data_future: asyncio.Future[DeviceData] | None = None
+
+    async def _async_setup(self) -> None:
+        """Connect to the thermostat."""
+
+        self._thermostat.register_update_callback(self._async_on_update_received)
+        self._thermostat.register_connection_callback(self._async_on_connection_changed)
+
+        await self._async_connect_thermostat()
+
+    async def async_shutdown(self) -> None:
+        """Disconnect from the thermostat."""
+
+        self._thermostat.unregister_update_callback(self._async_on_update_received)
+        self._thermostat.unregister_connection_callback(
+            self._async_on_connection_changed
+        )
+
+        await super().async_shutdown()
+
+    async def _async_update_data(self) -> Status:
+        """Request status update from thermostat."""
+
+        if not self._thermostat.is_connected:
+            await self._async_connect_thermostat()
+
+        self._status_future = self.hass.loop.create_future()
+
+        source_error: Eq3Exception | TimeoutError | None = None
+        error: UpdateFailed | None = None
+
+        _LOGGER.debug(
+            "[%s] Requesting status update",
+            self._mac_address,
+        )
+        try:
+            await self._thermostat.async_get_status()
+        except Eq3Exception as e:
+            source_error = e
+            error = UpdateFailed("Error updating eQ-3 device")
+        else:
+            try:
+                async with asyncio.timeout(SCAN_INTERVAL):
+                    status = await self._status_future
+            except TimeoutError as e:
+                source_error = e
+                error = UpdateFailed("Timeout updating eQ-3 device")
+
+        self._status_future.cancel()
+        self._status_future = None
+
+        if error is not None:
+            async_dispatcher_send(
+                self.hass,
+                f"{SIGNAL_THERMOSTAT_DISCONNECTED}_{self._mac_address}",
+            )
+            raise error from source_error
+
+        return status
+
+    async def _async_connect_thermostat(self) -> None:
+        """Connect to the thermostat."""
+
+        _LOGGER.debug(
+            "[%s] Connecting to eQ-3 device",
+            self._mac_address,
+        )
+        try:
+            await self._thermostat.async_connect()
+
+            self._device_data_future = self.hass.loop.create_future()
+            await self._thermostat.async_get_status()
+
+            try:
+                async with asyncio.timeout(SCAN_INTERVAL):
+                    device_data = await self._device_data_future
+            except TimeoutError as e:
+                self._device_data_future.cancel()
+                self._device_data_future = None
+                raise UpdateFailed("Timeout connecting to eQ-3 device") from e
+
+            if TYPE_CHECKING:
+                assert self.config_entry is not None
+
+            device_registry = dr.async_get(self.hass)
+            if device := device_registry.async_get_or_create(
+                config_entry_id=self.config_entry.entry_id,
+                default_name=format_mac(self._mac_address),
+                connections={(CONNECTION_BLUETOOTH, self._mac_address)},
+            ):
+                sw_version = str(device_data.firmware_version)
+                serial_number = device_data.device_serial.value
+
+                if (
+                    device.sw_version != sw_version
+                    or device.serial_number != serial_number
+                ):
+                    _LOGGER.debug(
+                        "[%s] Updating device registry",
+                        self._mac_address,
+                    )
+                    device_registry.async_update_device(
+                        device.id,
+                        sw_version=str(device_data.firmware_version),
+                        serial_number=device_data.device_serial.value,
+                        manufacturer=MANUFACTURER,
+                        model=DEVICE_MODEL,
+                    )
+        except Eq3Exception as e:
+            raise UpdateFailed("Error connecting to eQ-3 device") from e
+
+    def _async_on_connection_changed(self, is_connected: bool) -> None:
+        """Handle connection changes."""
+
+        if is_connected:
+            _LOGGER.debug(
+                "[%s] eQ-3 device connected",
+                self._mac_address,
+            )
+        else:
+            _LOGGER.error(
+                "[%s] eQ-3 device disconnected",
+                self._mac_address,
+            )
+            async_dispatcher_send(
+                self.hass,
+                f"{SIGNAL_THERMOSTAT_DISCONNECTED}_{self._mac_address}",
+            )
+
+    def _async_on_update_received(self) -> None:
+        """Handle updated data from the thermostat."""
+
+        _LOGGER.debug(
+            "[%s] Received status update: %s",
+            self._mac_address,
+            self._thermostat.status,
+        )
+
+        status = self._thermostat.status
+        device_data = self._thermostat.device_data
+
+        if (
+            device_data is not None
+            and self._device_data_future is not None
+            and not self._device_data_future.done()
+        ):
+            self._device_data_future.set_result(device_data)
+
+        if (
+            status is not None
+            and self._status_future is not None
+            and not self._status_future.done()
+        ):
+            self._status_future.set_result(status)
+        elif status is not None:
+            _LOGGER.debug(
+                "[%s] Updating coordinator data",
+                self._mac_address,
+            )
+            self.async_set_updated_data(status)

--- a/homeassistant/components/eq3btsmart/entity.py
+++ b/homeassistant/components/eq3btsmart/entity.py
@@ -1,5 +1,7 @@
 """Base class for all eQ-3 entities."""
 
+from eq3btsmart.models import Status
+
 from homeassistant.core import callback
 from homeassistant.helpers.device_registry import (
     CONNECTION_BLUETOOTH,
@@ -7,19 +9,15 @@ from homeassistant.helpers.device_registry import (
     format_mac,
 )
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import slugify
 
 from . import Eq3ConfigEntry
-from .const import (
-    DEVICE_MODEL,
-    MANUFACTURER,
-    SIGNAL_THERMOSTAT_CONNECTED,
-    SIGNAL_THERMOSTAT_DISCONNECTED,
-)
+from .const import DEVICE_MODEL, MANUFACTURER, SIGNAL_THERMOSTAT_DISCONNECTED
+from .coordinator import Eq3Coordinator
 
 
-class Eq3Entity(Entity):
+class Eq3Entity(CoordinatorEntity[Eq3Coordinator]):
     """Base class for all eQ-3 entities."""
 
     _attr_has_entity_name = True
@@ -30,6 +28,8 @@ class Eq3Entity(Entity):
         unique_id_key: str | None = None,
     ) -> None:
         """Initialize the eq3 entity."""
+
+        super().__init__(entry.runtime_data.coordinator)
 
         self._eq3_config = entry.runtime_data.eq3_config
         self._thermostat = entry.runtime_data.thermostat
@@ -42,10 +42,16 @@ class Eq3Entity(Entity):
         suffix = f"_{unique_id_key}" if unique_id_key else ""
         self._attr_unique_id = f"{format_mac(self._eq3_config.mac_address)}{suffix}"
 
+    @property
+    def _status(self) -> Status:
+        """Return the status of the thermostat."""
+
+        return self.coordinator.data
+
     async def async_added_to_hass(self) -> None:
         """Run when entity about to be added to hass."""
 
-        self._thermostat.register_update_callback(self._async_on_updated)
+        await super().async_added_to_hass()
 
         self.async_on_remove(
             async_dispatcher_connect(
@@ -54,23 +60,6 @@ class Eq3Entity(Entity):
                 self._async_on_disconnected,
             )
         )
-        self.async_on_remove(
-            async_dispatcher_connect(
-                self.hass,
-                f"{SIGNAL_THERMOSTAT_CONNECTED}_{self._eq3_config.mac_address}",
-                self._async_on_connected,
-            )
-        )
-
-    async def async_will_remove_from_hass(self) -> None:
-        """Run when entity will be removed from hass."""
-
-        self._thermostat.unregister_update_callback(self._async_on_updated)
-
-    def _async_on_updated(self) -> None:
-        """Handle updated data from the thermostat."""
-
-        self.async_write_ha_state()
 
     @callback
     def _async_on_disconnected(self) -> None:
@@ -78,16 +67,3 @@ class Eq3Entity(Entity):
 
         self._attr_available = False
         self.async_write_ha_state()
-
-    @callback
-    def _async_on_connected(self) -> None:
-        """Handle connection to the thermostat."""
-
-        self._attr_available = True
-        self.async_write_ha_state()
-
-    @property
-    def available(self) -> bool:
-        """Whether the entity is available."""
-
-        return self._thermostat.status is not None and self._attr_available

--- a/homeassistant/components/eq3btsmart/models.py
+++ b/homeassistant/components/eq3btsmart/models.py
@@ -2,11 +2,8 @@
 
 from dataclasses import dataclass
 
-from eq3btsmart.thermostat import Thermostat
-
 from .const import (
     DEFAULT_CURRENT_TEMP_SELECTOR,
-    DEFAULT_SCAN_INTERVAL,
     DEFAULT_TARGET_TEMP_SELECTOR,
     CurrentTemperatureSelector,
     TargetTemperatureSelector,
@@ -21,12 +18,3 @@ class Eq3Config:
     current_temp_selector: CurrentTemperatureSelector = DEFAULT_CURRENT_TEMP_SELECTOR
     target_temp_selector: TargetTemperatureSelector = DEFAULT_TARGET_TEMP_SELECTOR
     external_temp_sensor: str = ""
-    scan_interval: int = DEFAULT_SCAN_INTERVAL
-
-
-@dataclass(slots=True)
-class Eq3ConfigEntryData:
-    """Config entry for a single eQ-3 device."""
-
-    eq3_config: Eq3Config
-    thermostat: Thermostat

--- a/homeassistant/components/eq3btsmart/sensor.py
+++ b/homeassistant/components/eq3btsmart/sensor.py
@@ -3,7 +3,6 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
-from typing import TYPE_CHECKING
 
 from eq3btsmart.models import Status
 
@@ -14,7 +13,7 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.components.sensor.const import SensorStateClass
 from homeassistant.const import PERCENTAGE
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import Eq3ConfigEntry
@@ -74,11 +73,9 @@ class Eq3SensorEntity(Eq3Entity, SensorEntity):
         super().__init__(entry, entity_description.key)
         self.entity_description = entity_description
 
-    @property
-    def native_value(self) -> int | datetime | None:
-        """Return the value reported by the sensor."""
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
 
-        if TYPE_CHECKING:
-            assert self._thermostat.status is not None
-
-        return self.entity_description.value_func(self._thermostat.status)
+        self._attr_native_value = self.entity_description.value_func(self._status)
+        super()._handle_coordinator_update()

--- a/homeassistant/components/eq3btsmart/switch.py
+++ b/homeassistant/components/eq3btsmart/switch.py
@@ -2,13 +2,13 @@
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from eq3btsmart import Thermostat
 from eq3btsmart.models import Status
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import Eq3ConfigEntry
@@ -74,6 +74,13 @@ class Eq3SwitchEntity(Eq3Entity, SwitchEntity):
         super().__init__(entry, entity_description.key)
         self.entity_description = entity_description
 
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+
+        self._attr_is_on = self.entity_description.value_func(self._status)
+        super()._handle_coordinator_update()
+
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the switch."""
 
@@ -83,12 +90,3 @@ class Eq3SwitchEntity(Eq3Entity, SwitchEntity):
         """Turn off the switch."""
 
         await self.entity_description.toggle_func(self._thermostat)(False)
-
-    @property
-    def is_on(self) -> bool:
-        """Return the state of the switch."""
-
-        if TYPE_CHECKING:
-            assert self._thermostat.status is not None
-
-        return self.entity_description.value_func(self._thermostat.status)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR refactors the `eq3btsmart` integration to use a `DataUpdateCoordinator` instead of hardcoding the data update process. This way the user can disable automatic polling and use an automation to update the entities if needed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
