### PR TITLE
Fix and bump codecov-action to 5.0.2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1248,12 +1248,11 @@ jobs:
           pattern: coverage-*
       - name: Upload coverage to Codecov
         if: needs.info.outputs.test_full_suite == 'true'
-        uses: codecov/codecov-action@v5.0.0
+        uses: codecov/codecov-action@v5.0.2
         with:
           fail_ci_if_error: true
           flags: full-suite
           token: ${{ secrets.CODECOV_TOKEN }}
-          version: v0.6.0
 
   pytest-partial:
     runs-on: ubuntu-24.04
@@ -1387,8 +1386,7 @@ jobs:
           pattern: coverage-*
       - name: Upload coverage to Codecov
         if: needs.info.outputs.test_full_suite == 'false'
-        uses: codecov/codecov-action@v5.0.0
+        uses: codecov/codecov-action@v5.0.2
         with:
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
-          version: v0.6.0


### PR DESCRIPTION
## Proposed change
Unpin the Codecov CLI version used in the Codecov GitHub action to fix broken Codecov uploads.
The codecov-action is also updated to [5.0.2](https://github.com/codecov/codecov-action/releases/tag/v5.0.2) (full diff: https://github.com/codecov/codecov-action/compare/v5.0.0...v5.0.2).

### Explanation

We've been using an older Codecov CLI version, as the latest CLI version was broken for a few days. It's been fixed since a while now, so this PR unpins the CLI version to the latest compatible version again ([as used before](https://github.com/home-assistant/core/pull/120084) and recommended).

It's not always the case that the Codecov action requires a specific CLI version, but it's at least the case with v5.0.0.
With the rework done in v5 (Codecov wrapper), follow-up changes and fixes that require a new CLI version might be more frequent.
Unpinning the old Codecov CI version should also allow us to merge dependabot PRs for codecov-action updates again, without the risk of breaking Codecov.

### Codecov v5 fixes

A good thing is that Codecov action v5 supposedly fixes multiple flaky upload errors with invalid error messages we've seen in this repo. Issues like this where mostly seen on PRs from forks where a tokenless upload is used, yet the error message specified that a token was required, even though the "run from a fork" was detected.
Previously, a rerun of the Codecov step was required. Now, it should *just work*.


## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
