### PR TITLE
Add set hold duration action to HomeKit for Ecobee thermostat

### DIFF
--- a/homeassistant/components/homekit_controller/connection.py
+++ b/homeassistant/components/homekit_controller/connection.py
@@ -46,6 +46,7 @@ from .const import (
     STARTUP_EXCEPTIONS,
     SUBSCRIBE_COOLDOWN,
 )
+from .device_action import async_setup_actions_for_entry
 from .device_trigger import async_fire_triggers, async_setup_triggers_for_entry
 from .utils import IidTuple, unique_id_to_iids
 
@@ -696,6 +697,9 @@ class HKDevice:
 
         # Load any triggers for this config entry
         await async_setup_triggers_for_entry(self.hass, self.config_entry)
+
+        # Load device actions for this config entry
+        await async_setup_actions_for_entry(self.hass, self.config_entry)
 
     async def async_unload(self) -> None:
         """Stop interacting with device and prepare for removal from hass."""

--- a/homeassistant/components/homekit_controller/const.py
+++ b/homeassistant/components/homekit_controller/const.py
@@ -14,6 +14,7 @@ KNOWN_DEVICES = f"{DOMAIN}-devices"
 CONTROLLER = f"{DOMAIN}-controller"
 ENTITY_MAP = f"{DOMAIN}-entity-map"
 TRIGGERS = f"{DOMAIN}-triggers"
+ACTIONS = f"{DOMAIN}-actions"
 
 HOMEKIT_DIR = ".homekit"
 PAIRING_FILE = "pairing.json"

--- a/homeassistant/components/homekit_controller/device_action.py
+++ b/homeassistant/components/homekit_controller/device_action.py
@@ -1,0 +1,169 @@
+"""Provides device actions for HomeKit devices."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import TYPE_CHECKING
+
+from aiohomekit.model import Characteristic
+from aiohomekit.model.characteristics import CharacteristicsTypes
+import voluptuous as vol
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_DEVICE_ID, CONF_DOMAIN, CONF_TYPE
+from homeassistant.core import Context, HomeAssistant, callback
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.typing import ConfigType, TemplateVarsType
+import homeassistant.util.dt as dt_util
+
+from .const import ACTIONS, DOMAIN, KNOWN_DEVICES
+
+if TYPE_CHECKING:
+    from .connection import HKDevice
+
+CONF_HOLD_DURATION = "hold_duration"
+CONF_ECOBEE_TIMEZONE = "ecobee_timezone"
+ECOBEE_SET_HOLD_DURATION = "ecobee_set_hold_duration"
+SET_HOLD_DURATION_SCHEMA = cv.DEVICE_ACTION_BASE_SCHEMA.extend(
+    {
+        vol.Required(CONF_TYPE): ECOBEE_SET_HOLD_DURATION,
+        vol.Required(CONF_HOLD_DURATION): cv.time_period,
+        vol.Required(CONF_ECOBEE_TIMEZONE): cv.time_zone,
+    }
+)
+
+ACTIONS_BY_CHARACTERISTIC: dict[str, str] = {
+    CharacteristicsTypes.VENDOR_ECOBEE_NEXT_SCHEDULED_CHANGE_TIME: ECOBEE_SET_HOLD_DURATION
+}
+
+ACTION_SCHEMA = vol.Any(SET_HOLD_DURATION_SCHEMA)
+
+
+class ActionDevice:
+    """Tracks the actions for a specific device id."""
+
+    def __init__(self, hkid: str) -> None:
+        """Initialize tracking a device for actions."""
+        self.hkid = hkid
+        self.actions: dict[str, tuple[int, int]] = {}
+
+    def add_action(self, aid: int, iid: int, action_type: str) -> None:
+        """Add an action that's available for a particular accessory/service."""
+        self.actions[action_type] = (aid, iid)
+
+
+async def async_setup_actions_for_entry(
+    hass: HomeAssistant, config_entry: ConfigEntry
+) -> None:
+    """Actions aren't entities so have no state, but need to keep track of the available actions for a device id."""
+    hkid = config_entry.data["AccessoryPairingID"]
+    conn: HKDevice = hass.data[KNOWN_DEVICES][hkid]
+
+    @callback
+    def async_add_characteristic(char: Characteristic) -> bool:
+        if not (action_type := ACTIONS_BY_CHARACTERISTIC.get(char.type)):
+            return False
+
+        device_id = conn.devices[char.service.accessory.aid]
+
+        action_device: ActionDevice = async_get_or_create_action_device(
+            hass, device_id, hkid
+        )
+
+        if action_type in action_device.actions:
+            # Action is already registered
+            return False
+
+        action_device.add_action(
+            char.service.accessory.aid, char.service.iid, action_type
+        )
+        return False
+
+    conn.add_char_factory(async_add_characteristic)
+
+
+@callback
+def async_get_or_create_action_device(
+    hass: HomeAssistant, device_id: str, hkid: str
+) -> ActionDevice:
+    """Get or create an action device reference for a given device id."""
+
+    action_devices: dict[str, ActionDevice] = hass.data.setdefault(ACTIONS, {})
+    if not (actionDevice := action_devices.get(device_id)):
+        actionDevice = ActionDevice(hkid)
+        action_devices[device_id] = actionDevice
+
+    return actionDevice
+
+
+async def async_get_actions(
+    hass: HomeAssistant, device_id: str
+) -> list[dict[str, str]]:
+    """List device actions."""
+
+    if device_id not in hass.data.get(ACTIONS, {}):
+        return []
+
+    actionDevice: ActionDevice = hass.data[ACTIONS][device_id]
+
+    actions = []
+
+    global_type = {
+        CONF_DEVICE_ID: device_id,
+        CONF_DOMAIN: DOMAIN,
+    }
+
+    for action_type in actionDevice.actions:
+        actions.append({**global_type, CONF_TYPE: action_type})
+        break
+
+    return actions
+
+
+async def async_call_action_from_config(
+    hass: HomeAssistant,
+    config: ConfigType,
+    variables: TemplateVarsType,
+    context: Context | None,
+) -> None:
+    """Execute a device action."""
+    action_type = config[CONF_TYPE]
+    device_id = config[CONF_DEVICE_ID]
+
+    actionDevice: ActionDevice = hass.data[ACTIONS][device_id]
+    conn: HKDevice = hass.data[KNOWN_DEVICES][actionDevice.hkid]
+
+    aid, iid = actionDevice.actions[action_type]
+
+    if action_type == ECOBEE_SET_HOLD_DURATION:
+        # New hold end time will need to be a time local to the ecobee device, so use the specified time zone
+        delta: timedelta = config[CONF_HOLD_DURATION]
+        timezone = await dt_util.async_get_time_zone(config[CONF_ECOBEE_TIMEZONE])
+        now = datetime.now(timezone)
+        holdEnd = now + delta
+        holdEndString = holdEnd.strftime("%Y-%m-%dT%H:%M:%S")
+
+        service = conn.entity_map.aid(aid).services.iid(iid)
+
+        if service.has(CharacteristicsTypes.VENDOR_ECOBEE_NEXT_SCHEDULED_CHANGE_TIME):
+            payload = service.build_update(
+                {
+                    CharacteristicsTypes.VENDOR_ECOBEE_NEXT_SCHEDULED_CHANGE_TIME: holdEndString,
+                }
+            )
+            await conn.put_characteristics(payload)
+
+
+async def async_get_action_capabilities(
+    hass: HomeAssistant, config: ConfigType
+) -> dict[str, vol.Schema]:
+    """List action capabilities."""
+    action_type = config[CONF_TYPE]
+
+    fields = {}
+
+    if action_type == ECOBEE_SET_HOLD_DURATION:
+        fields[vol.Required(CONF_HOLD_DURATION)] = cv.string
+        fields[vol.Required(CONF_ECOBEE_TIMEZONE)] = cv.string
+
+    return {"extra_fields": vol.Schema(fields)}

--- a/homeassistant/components/homekit_controller/strings.json
+++ b/homeassistant/components/homekit_controller/strings.json
@@ -68,6 +68,13 @@
       "button8": "Button 8",
       "button9": "Button 9",
       "button10": "Button 10"
+    },
+    "action_type": {
+      "ecobee_set_hold_duration": "Set Climate Hold Duration"
+    },
+    "extra_fields": {
+      "hold_duration": "Hold Duration",
+      "ecobee_timezone": "Time Zone of Ecobee device"
     }
   },
   "entity": {

--- a/tests/components/homekit_controller/test_device_action.py
+++ b/tests/components/homekit_controller/test_device_action.py
@@ -1,0 +1,183 @@
+"""The tests for HomeKit Device device actions."""
+
+from collections.abc import Callable
+from datetime import timedelta
+
+from aiohomekit.model import Accessory, Service
+from aiohomekit.model.characteristics import CharacteristicsTypes
+from aiohomekit.model.services import ServicesTypes
+
+from homeassistant.components import automation
+from homeassistant.components.device_automation import DeviceAutomationType
+from homeassistant.components.homekit_controller import DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.setup import async_setup_component
+
+from .common import setup_test_component
+
+from tests.common import (
+    async_get_device_automation_capabilities,
+    async_get_device_automations,
+)
+
+DEFAULT_HOLD_TIME = "2040-01-01T13:35:00"
+
+
+def create_ecobee_thermostat(accessory: Accessory):
+    """Create Ecobee thermostat with the NEXT_SCHEDULED_CHANGE_TIME characteristic."""
+    service = accessory.add_service(ServicesTypes.THERMOSTAT)
+
+    char = service.add_char(CharacteristicsTypes.HEATING_COOLING_TARGET)
+    char.value = 0
+    char.minValue = 0
+    char.maxValue = 1
+
+    char = service.add_char(
+        CharacteristicsTypes.VENDOR_ECOBEE_NEXT_SCHEDULED_CHANGE_TIME
+    )
+    char.value = DEFAULT_HOLD_TIME
+
+
+def create_generic_thermostat(accessory: Accessory) -> None:
+    """Create generic thermostat with no characteristics."""
+    service = accessory.add_service(ServicesTypes.THERMOSTAT)
+
+    char = service.add_char(CharacteristicsTypes.HEATING_COOLING_TARGET)
+    char.value = 0
+    char.minValue = 0
+    char.maxValue = 1
+
+
+async def test_get_ecobee_hold_action(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    get_next_aid: Callable[[], int],
+) -> None:
+    """Test we get the expected Ecobee hold action."""
+    await setup_test_component(hass, get_next_aid(), create_ecobee_thermostat)
+
+    ecobee_thermostat_entry = entity_registry.async_get("button.testdevice_identify")
+
+    actions = await async_get_device_automations(
+        hass, DeviceAutomationType.ACTION, ecobee_thermostat_entry.device_id
+    )
+
+    expected_action = {
+        "domain": DOMAIN,
+        "type": "ecobee_set_hold_duration",
+        "device_id": ecobee_thermostat_entry.device_id,
+        "metadata": {},
+    }
+
+    assert expected_action in actions
+
+
+async def test_hold_action_not_on_device_without_characteristic(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    get_next_aid: Callable[[], int],
+) -> None:
+    """Test we do not get the device action on a device without the matching characteristic."""
+    await setup_test_component(hass, get_next_aid(), create_generic_thermostat)
+
+    thermostat_entry = entity_registry.async_get("button.testdevice_identify")
+
+    actions = await async_get_device_automations(
+        hass, DeviceAutomationType.ACTION, thermostat_entry.device_id
+    )
+
+    expected_action = {
+        "domain": DOMAIN,
+        "type": "ecobee_set_hold_duration",
+        "device_id": thermostat_entry.device_id,
+        "metadata": {},
+    }
+
+    assert expected_action not in actions
+
+
+async def test_ecobee_hold_action(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    get_next_aid: Callable[[], int],
+) -> None:
+    """Test firing the hold action changes the next scheduled change time."""
+
+    helper = await setup_test_component(hass, get_next_aid(), create_ecobee_thermostat)
+    service: Service = helper.accessory.services.first(
+        characteristics={
+            CharacteristicsTypes.VENDOR_ECOBEE_NEXT_SCHEDULED_CHANGE_TIME: DEFAULT_HOLD_TIME
+        }
+    )
+
+    thermostat_entry = entity_registry.async_get(helper.entity_id)
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {
+                        "platform": "event",
+                        "event_type": "test_hold_duration_set",
+                    },
+                    "action": {
+                        "domain": DOMAIN,
+                        "device_id": thermostat_entry.device_id,
+                        "type": "ecobee_set_hold_duration",
+                        "ecobee_timezone": "America/New_York",
+                        "hold_duration": timedelta(minutes=30),
+                    },
+                },
+            ]
+        },
+    )
+
+    assert (
+        service.value(CharacteristicsTypes.VENDOR_ECOBEE_NEXT_SCHEDULED_CHANGE_TIME)
+        == DEFAULT_HOLD_TIME
+    )
+
+    hass.bus.async_fire("test_hold_duration_set")
+    await hass.async_block_till_done()
+    assert (
+        service.value(CharacteristicsTypes.VENDOR_ECOBEE_NEXT_SCHEDULED_CHANGE_TIME)
+        != DEFAULT_HOLD_TIME
+    )
+
+
+async def test_ecobee_hold_action_capabilities(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    get_next_aid: Callable[[], int],
+) -> None:
+    """Verify hold duration capabilities."""
+    helper = await setup_test_component(hass, get_next_aid(), create_ecobee_thermostat)
+
+    thermostat_entry = entity_registry.async_get(helper.entity_id)
+
+    capabilities = await async_get_device_automation_capabilities(
+        hass,
+        DeviceAutomationType.ACTION,
+        {
+            "platform": "device",
+            "domain": DOMAIN,
+            "device_id": thermostat_entry.device_id,
+            "type": "ecobee_set_hold_duration",
+        },
+    )
+
+    expected_capabilities = {
+        "extra_fields": [
+            {"name": "hold_duration", "required": True, "type": "string"},
+            {"name": "ecobee_timezone", "required": True, "type": "string"},
+        ]
+    }
+
+    assert capabilities == expected_capabilities


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
<!--## Breaking change-->
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Ecobee thermostats have the ability to set a climate hold duration for any change, the default for which is generally to hold until the next scheduled activity (such as sleep/home).

This change adds a device action to the thermostat to allow setting the hold duration to an arbitrary time span, provided by the user when configuring the action.

![image](https://github.com/user-attachments/assets/a35cee21-fb14-4dfb-94b0-64c7629aa95f)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
