### PR TITLE
Support units and filters in async_get_travel_times_service for waze_travel_time

### DIFF
--- a/homeassistant/components/waze_travel_time/sensor.py
+++ b/homeassistant/components/waze_travel_time/sensor.py
@@ -20,7 +20,6 @@ from homeassistant.const import (
     CONF_NAME,
     CONF_REGION,
     EVENT_HOMEASSISTANT_STARTED,
-    UnitOfLength,
     UnitOfTime,
 )
 from homeassistant.core import CoreState, HomeAssistant
@@ -28,7 +27,6 @@ from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.httpx_client import get_async_client
 from homeassistant.helpers.location import find_coordinates
-from homeassistant.util.unit_conversion import DistanceConverter
 
 from . import async_get_travel_times
 from .const import (
@@ -44,7 +42,6 @@ from .const import (
     CONF_VEHICLE_TYPE,
     DEFAULT_NAME,
     DOMAIN,
-    IMPERIAL_UNITS,
     SEMAPHORE,
 )
 
@@ -201,6 +198,7 @@ class WazeTravelTimeData:
                 avoid_subscription_roads,
                 avoid_ferries,
                 realtime,
+                self.config_entry.options[CONF_UNITS],
                 incl_filter,
                 excl_filter,
             )
@@ -211,14 +209,5 @@ class WazeTravelTimeData:
                 return
 
             self.duration = route.duration
-            distance = route.distance
-
-            if self.config_entry.options[CONF_UNITS] == IMPERIAL_UNITS:
-                # Convert to miles.
-                self.distance = DistanceConverter.convert(
-                    distance, UnitOfLength.KILOMETERS, UnitOfLength.MILES
-                )
-            else:
-                self.distance = distance
-
+            self.distance = route.distance
             self.route = route.name

--- a/homeassistant/components/waze_travel_time/services.yaml
+++ b/homeassistant/components/waze_travel_time/services.yaml
@@ -55,3 +55,13 @@ get_travel_times:
       required: false
       selector:
         boolean:
+    incl_filter:
+      required: false
+      selector:
+        text:
+          multiple: true
+    excl_filter:
+      required: false
+      selector:
+        text:
+          multiple: true

--- a/homeassistant/components/waze_travel_time/strings.json
+++ b/homeassistant/components/waze_travel_time/strings.json
@@ -101,6 +101,14 @@
         "avoid_subscription_roads": {
           "name": "[%key:component::waze_travel_time::options::step::init::data::avoid_subscription_roads%]",
           "description": "Whether to avoid subscription roads."
+        },
+        "incl_filter": {
+          "name": "[%key:component::waze_travel_time::options::step::init::data::incl_filter%]",
+          "description": "Exact streetname which must be part of the selected route."
+        },
+        "excl_filter": {
+          "name": "[%key:component::waze_travel_time::options::step::init::data::excl_filter%]",
+          "description": "Exact streetname which must NOT be part of the selected route."
         }
       }
     }

--- a/tests/components/waze_travel_time/test_init.py
+++ b/tests/components/waze_travel_time/test_init.py
@@ -44,6 +44,8 @@ async def test_service_get_travel_times(hass: HomeAssistant) -> None:
             "destination": "location2",
             "vehicle_type": "car",
             "region": "us",
+            "units": "imperial",
+            "incl_filter": ["IncludeThis"],
         },
         blocking=True,
         return_response=True,
@@ -51,16 +53,10 @@ async def test_service_get_travel_times(hass: HomeAssistant) -> None:
     assert response_data == {
         "routes": [
             {
-                "distance": 300,
+                "distance": pytest.approx(186.4113),
                 "duration": 150,
                 "name": "E1337 - Teststreet",
                 "street_names": ["E1337", "IncludeThis", "Teststreet"],
-            },
-            {
-                "distance": 500,
-                "duration": 600,
-                "name": "E0815 - Otherstreet",
-                "street_names": ["E0815", "ExcludeThis", "Otherstreet"],
             },
         ]
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Support units and filters in action `Get Travel Times`

The documentation already claims that this is supported.
Moreover this change brings the service on par with what the configuration of the config entry supports.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #130703
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
