### PR TITLE
Fix bluesound_group attribute in bluesound integration

### DIFF
--- a/homeassistant/components/bluesound/media_player.py
+++ b/homeassistant/components/bluesound/media_player.py
@@ -292,14 +292,6 @@ class BluesoundPlayer(MediaPlayerEntity):
             self._last_status_update = dt_util.utcnow()
             self._status = status
 
-            group_name = status.group_name
-            if group_name != self._group_name:
-                _LOGGER.debug("Group name change detected on device: %s", self.id)
-                self._group_name = group_name
-
-                # rebuild ordered list of entity_ids that are in the group, master is first
-                self._group_list = self.rebuild_bluesound_group()
-
             self.async_write_ha_state()
         except PlayerUnreachableError:
             self._attr_available = False
@@ -322,6 +314,8 @@ class BluesoundPlayer(MediaPlayerEntity):
         )
 
         self._sync_status = sync_status
+
+        self._group_list = self.rebuild_bluesound_group()
 
         if sync_status.master is not None:
             self._is_master = False
@@ -619,21 +613,33 @@ class BluesoundPlayer(MediaPlayerEntity):
 
     def rebuild_bluesound_group(self) -> list[str]:
         """Rebuild the list of entities in speaker group."""
-        if self._group_name is None:
+        if self.sync_status.master is None and self.sync_status.slaves is None:
             return []
 
-        device_group = self._group_name.split("+")
+        player_entities: list[BluesoundPlayer] = self.hass.data[DATA_BLUESOUND]
 
-        sorted_entities: list[BluesoundPlayer] = sorted(
-            self.hass.data[DATA_BLUESOUND],
-            key=lambda entity: entity.is_master,
-            reverse=True,
-        )
-        return [
-            entity.sync_status.name
-            for entity in sorted_entities
-            if entity.bluesound_device_name in device_group
-        ]
+        match self.sync_status.master:
+            case None:
+                leader = [self.sync_status.name]
+            case paired_player:
+                leader = [
+                    x.sync_status.name
+                    for x in player_entities
+                    if x.sync_status.id == f"{paired_player.ip}:{paired_player.port}"
+                ]
+
+        match self.sync_status.slaves:
+            case None:
+                followers = []
+            case paired_players:
+                paired_player_ids = [f"{x.ip}:{x.port}" for x in paired_players]
+                followers = [
+                    x.sync_status.name
+                    for x in player_entities
+                    if x.sync_status.id in paired_player_ids
+                ]
+
+        return [*leader, *followers]
 
     async def async_unjoin(self) -> None:
         """Unjoin the player from a group."""

--- a/homeassistant/components/bluesound/media_player.py
+++ b/homeassistant/components/bluesound/media_player.py
@@ -622,11 +622,9 @@ class BluesoundPlayer(MediaPlayerEntity):
         if self.sync_status.master is None:
             leader_sync_status = self.sync_status
         else:
+            required_id = f"{self.sync_status.master.ip}:{self.sync_status.master.port}"
             for x in player_entities:
-                if (
-                    x.sync_status.id
-                    == f"{self.sync_status.master.ip}:{self.sync_status.master.port}"
-                ):
+                if x.sync_status.id == required_id:
                     leader_sync_status = x.sync_status
                     break
 

--- a/homeassistant/components/bluesound/media_player.py
+++ b/homeassistant/components/bluesound/media_player.py
@@ -632,12 +632,12 @@ class BluesoundPlayer(MediaPlayerEntity):
             return []
 
         follower_ids = [f"{x.ip}:{x.port}" for x in leader_sync_status.slaves]
-        names = [leader_sync_status.name]
-        for x in player_entities:
-            if x.sync_status.id in follower_ids:
-                names.extend([x.sync_status.name])
-
-        return names
+        follower_names = [
+            x.sync_status.name
+            for x in player_entities
+            if x.sync_status.id in follower_ids
+        ]
+        follower_names.insert(0, leader_sync_status.name)
 
     async def async_unjoin(self) -> None:
         """Unjoin the player from a group."""

--- a/homeassistant/components/bluesound/media_player.py
+++ b/homeassistant/components/bluesound/media_player.py
@@ -638,6 +638,7 @@ class BluesoundPlayer(MediaPlayerEntity):
             if x.sync_status.id in follower_ids
         ]
         follower_names.insert(0, leader_sync_status.name)
+        return follower_names
 
     async def async_unjoin(self) -> None:
         """Unjoin the player from a group."""

--- a/tests/components/bluesound/test_media_player.py
+++ b/tests/components/bluesound/test_media_player.py
@@ -331,11 +331,11 @@ async def test_attr_bluesound_group(
     ).attributes.get("bluesound_group")
     assert attr_bluesound_group is None
 
-    updated_status = dataclasses.replace(
-        player_mocks.player_data.status_long_polling_mock.get(),
-        group_name="player-name1111+player-name2222",
+    updated_sync_status = dataclasses.replace(
+        player_mocks.player_data.sync_status_long_polling_mock.get(),
+        slaves=[PairedPlayer("2.2.2.2", 11000)],
     )
-    player_mocks.player_data.status_long_polling_mock.set(updated_status)
+    player_mocks.player_data.sync_status_long_polling_mock.set(updated_sync_status)
 
     # give the long polling loop a chance to update the state; this could be any async call
     await hass.async_block_till_done()

--- a/tests/components/bluesound/test_media_player.py
+++ b/tests/components/bluesound/test_media_player.py
@@ -325,7 +325,7 @@ async def test_attr_bluesound_group(
     setup_config_entry_secondary: None,
     player_mocks: PlayerMocks,
 ) -> None:
-    """Test the media player grouping."""
+    """Test the media player grouping for leader."""
     attr_bluesound_group = hass.states.get(
         "media_player.player_name1111"
     ).attributes.get("bluesound_group")
@@ -342,6 +342,45 @@ async def test_attr_bluesound_group(
 
     attr_bluesound_group = hass.states.get(
         "media_player.player_name1111"
+    ).attributes.get("bluesound_group")
+
+    assert attr_bluesound_group == ["player-name1111", "player-name2222"]
+
+
+async def test_attr_bluesound_group_for_follower(
+    hass: HomeAssistant,
+    setup_config_entry: None,
+    setup_config_entry_secondary: None,
+    player_mocks: PlayerMocks,
+) -> None:
+    """Test the media player grouping for follower."""
+    attr_bluesound_group = hass.states.get(
+        "media_player.player_name2222"
+    ).attributes.get("bluesound_group")
+    assert attr_bluesound_group is None
+
+    updated_sync_status = dataclasses.replace(
+        player_mocks.player_data.sync_status_long_polling_mock.get(),
+        slaves=[PairedPlayer("2.2.2.2", 11000)],
+    )
+    player_mocks.player_data.sync_status_long_polling_mock.set(updated_sync_status)
+
+    # give the long polling loop a chance to update the state; this could be any async call
+    await hass.async_block_till_done()
+
+    updated_sync_status = dataclasses.replace(
+        player_mocks.player_data_secondary.sync_status_long_polling_mock.get(),
+        master=PairedPlayer("1.1.1.1", 11000),
+    )
+    player_mocks.player_data_secondary.sync_status_long_polling_mock.set(
+        updated_sync_status
+    )
+
+    # give the long polling loop a chance to update the state; this could be any async call
+    await hass.async_block_till_done()
+
+    attr_bluesound_group = hass.states.get(
+        "media_player.player_name2222"
     ).attributes.get("bluesound_group")
 
     assert attr_bluesound_group == ["player-name1111", "player-name2222"]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
<!-- ## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This should fix the `bluesound_group` attribute which seemed to not work in some cases(see issue).

I have added tests for the code change and tested it against a local mock, but I cannot test it against a real group of devices because I only have one.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #130415 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
