### PR TITLE
Add missing translations and icons for ZHA Sinope devices

### DIFF
--- a/homeassistant/components/zha/icons.json
+++ b/homeassistant/components/zha/icons.json
@@ -118,6 +118,12 @@
       },
       "exercise_day_of_week": {
         "default": "mdi:wrench-clock"
+      },
+      "off_led_color": {
+        "default": "mdi:palette-outline"
+      },
+      "on_led_color": {
+        "default": "mdi:palette"
       }
     },
     "sensor": {
@@ -206,6 +212,9 @@
       },
       "use_load_balancing": {
         "default": "mdi:scale-balance"
+      },
+      "double_up_full": {
+        "default": "mdi:gesture-double-tap"
       }
     }
   },

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -791,6 +791,12 @@
       },
       "valve_countdown_2": {
         "name": "Irrigation time 2"
+      },
+      "on_led_intensity": {
+        "name": "On LED Intesity"
+      },
+      "off_led_intensity": {
+        "name": "Off LED Intensity"
       }
     },
     "select": {
@@ -886,6 +892,12 @@
       },
       "weather_delay": {
         "name": "Weather delay"
+      },
+      "on_led_color": {
+        "name": "On LED Color"
+      },
+      "off_led_color": {
+        "name": "Off LED Color"
       }
     },
     "sensor": {
@@ -1193,6 +1205,9 @@
       },
       "valve_on_off_2": {
         "name": "Valve 2"
+      },
+      "double_up_full": {
+        "name": "Double Tap On - Full"
       }
     }
   }

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -796,7 +796,7 @@
         "name": "On LED intensity"
       },
       "off_led_intensity": {
-        "name": "Off LED Intensity"
+        "name": "Off LED intensity"
       }
     },
     "select": {
@@ -894,10 +894,10 @@
         "name": "Weather delay"
       },
       "on_led_color": {
-        "name": "On LED Color"
+        "name": "On LED color"
       },
       "off_led_color": {
-        "name": "Off LED Color"
+        "name": "Off LED color"
       }
     },
     "sensor": {
@@ -1207,7 +1207,7 @@
         "name": "Valve 2"
       },
       "double_up_full": {
-        "name": "Double Tap On - Full"
+        "name": "Double tap on - full"
       }
     }
   }

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -793,7 +793,7 @@
         "name": "Irrigation time 2"
       },
       "on_led_intensity": {
-        "name": "On LED Intesity"
+        "name": "On LED intensity"
       },
       "off_led_intensity": {
         "name": "Off LED Intensity"


### PR DESCRIPTION
## Proposed change
Adds a few missing translation and icon entries to the ZHA component for Sinope devices.
ZHA PR: https://github.com/zigpy/zha/pull/153/

## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
N/A

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.
