### PR TITLE
Reolink fix dev/entity id migration

### DIFF
--- a/homeassistant/components/reolink/__init__.py
+++ b/homeassistant/components/reolink/__init__.py
@@ -328,9 +328,16 @@ def migrate_entity_ids(
             new_identifiers = {(DOMAIN, new_device_id)}
             existing_device = device_reg.async_get_device(identifiers=new_identifiers)
             if existing_device is None:
-                device_reg.async_update_device(device.id, new_identifiers=new_identifiers)
+                device_reg.async_update_device(
+                    device.id, new_identifiers=new_identifiers
+                )
             else:
-                _LOGGER.error("Reolink device with uid %s already exists, removing device with uid %s", new_device_id, device_uid)
+                _LOGGER.error(
+                    "Reolink device with uid %s already exists, "
+                    "removing device with uid %s",
+                    new_device_id,
+                    device_uid,
+                )
                 device_reg.async_remove_device(device.id)
 
     entity_reg = er.async_get(hass)
@@ -357,4 +364,18 @@ def migrate_entity_ids(
             id_parts = entity.unique_id.split("_", 2)
             if host.api.supported(ch, "UID") and id_parts[1] != host.api.camera_uid(ch):
                 new_id = f"{host.unique_id}_{host.api.camera_uid(ch)}_{id_parts[2]}"
-                entity_reg.async_update_entity(entity.entity_id, new_unique_id=new_id)
+                existing_entity = entity_reg.async_get_entity_id(
+                    entity.domain, entity.platform, new_id
+                )
+                if existing_entity is None:
+                    entity_reg.async_update_entity(
+                        entity.entity_id, new_unique_id=new_id
+                    )
+                else:
+                    _LOGGER.error(
+                        "Reolink entity with unique_id %s already exists, "
+                        "removing device with unique_id %s",
+                        new_id,
+                        entity.unique_id,
+                    )
+                    entity_reg.async_remove(entity.entity_id)

--- a/homeassistant/components/reolink/__init__.py
+++ b/homeassistant/components/reolink/__init__.py
@@ -330,6 +330,7 @@ def migrate_entity_ids(
             if existing_device is None:
                 device_reg.async_update_device(device.id, new_identifiers=new_identifiers)
             else:
+                _LOGGER.error("Reolink device with uid %s already exists, removing device with uid %s", new_device_id, device_uid)
                 device_reg.async_remove_device(device.id)
 
     entity_reg = er.async_get(hass)

--- a/homeassistant/components/reolink/__init__.py
+++ b/homeassistant/components/reolink/__init__.py
@@ -332,7 +332,7 @@ def migrate_entity_ids(
                     device.id, new_identifiers=new_identifiers
                 )
             else:
-                _LOGGER.error(
+                _LOGGER.warning(
                     "Reolink device with uid %s already exists, "
                     "removing device with uid %s",
                     new_device_id,
@@ -372,7 +372,7 @@ def migrate_entity_ids(
                         entity.entity_id, new_unique_id=new_id
                     )
                 else:
-                    _LOGGER.error(
+                    _LOGGER.warning(
                         "Reolink entity with unique_id %s already exists, "
                         "removing device with unique_id %s",
                         new_id,

--- a/homeassistant/components/reolink/__init__.py
+++ b/homeassistant/components/reolink/__init__.py
@@ -326,7 +326,11 @@ def migrate_entity_ids(
             else:
                 new_device_id = f"{device_uid[0]}_{host.api.camera_uid(ch)}"
             new_identifiers = {(DOMAIN, new_device_id)}
-            device_reg.async_update_device(device.id, new_identifiers=new_identifiers)
+            existing_device = device_reg.async_get_device(identifiers=new_identifiers)
+            if existing_device is None:
+                device_reg.async_update_device(device.id, new_identifiers=new_identifiers)
+            else:
+                device_reg.async_remove_device(device.id)
 
     entity_reg = er.async_get(hass)
     entities = er.async_entries_for_config_entry(entity_reg, config_entry_id)

--- a/tests/components/reolink/test_init.py
+++ b/tests/components/reolink/test_init.py
@@ -469,6 +469,116 @@ async def test_migrate_entity_ids(
     assert device_registry.async_get_device(identifiers={(DOMAIN, new_dev_id)})
 
 
+async def test_migrate_with_already_existing_device(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    reolink_connect: MagicMock,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test device ids that need to be migrated while the new ids already exist."""
+    original_dev_id = f"{TEST_MAC}_ch0"
+    new_dev_id = f"{TEST_UID}_{TEST_UID_CAM}"
+    domain = Platform.SWITCH
+
+    def mock_supported(ch, capability):
+        if capability == "UID" and ch is None:
+            return True
+        if capability == "UID":
+            return True
+        return True
+
+    reolink_connect.channels = [0]
+    reolink_connect.supported = mock_supported
+
+    device_registry.async_get_or_create(
+        identifiers={(DOMAIN, new_dev_id)},
+        config_entry_id=config_entry.entry_id,
+        disabled_by=None,
+    )
+
+    device_registry.async_get_or_create(
+        identifiers={(DOMAIN, original_dev_id)},
+        config_entry_id=config_entry.entry_id,
+        disabled_by=None,
+    )
+
+    assert device_registry.async_get_device(identifiers={(DOMAIN, original_dev_id)})
+    assert device_registry.async_get_device(identifiers={(DOMAIN, new_dev_id)})
+
+    # setup CH 0 and host entities/device
+    with patch("homeassistant.components.reolink.PLATFORMS", [domain]):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert (
+        device_registry.async_get_device(identifiers={(DOMAIN, original_dev_id)})
+        is None
+    )
+    assert device_registry.async_get_device(identifiers={(DOMAIN, new_dev_id)})
+
+
+async def test_migrate_with_already_existing_entity(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    reolink_connect: MagicMock,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test entity ids that need to be migrated while the new ids already exist."""
+    original_id = f"{TEST_UID}_0_record_audio"
+    new_id = f"{TEST_UID}_{TEST_UID_CAM}_record_audio"
+    dev_id = f"{TEST_UID}_{TEST_UID_CAM}"
+    domain = Platform.SWITCH
+
+    def mock_supported(ch, capability):
+        if capability == "UID" and ch is None:
+            return True
+        if capability == "UID":
+            return True
+        return True
+
+    reolink_connect.channels = [0]
+    reolink_connect.supported = mock_supported
+
+    dev_entry = device_registry.async_get_or_create(
+        identifiers={(DOMAIN, dev_id)},
+        config_entry_id=config_entry.entry_id,
+        disabled_by=None,
+    )
+
+    entity_registry.async_get_or_create(
+        domain=domain,
+        platform=DOMAIN,
+        unique_id=new_id,
+        config_entry=config_entry,
+        suggested_object_id=new_id,
+        disabled_by=None,
+        device_id=dev_entry.id,
+    )
+
+    entity_registry.async_get_or_create(
+        domain=domain,
+        platform=DOMAIN,
+        unique_id=original_id,
+        config_entry=config_entry,
+        suggested_object_id=original_id,
+        disabled_by=None,
+        device_id=dev_entry.id,
+    )
+
+    assert entity_registry.async_get_entity_id(domain, DOMAIN, original_id)
+    assert entity_registry.async_get_entity_id(domain, DOMAIN, new_id)
+
+    # setup CH 0 and host entities/device
+    with patch("homeassistant.components.reolink.PLATFORMS", [domain]):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entity_registry.async_get_entity_id(domain, DOMAIN, original_id) is None
+    assert entity_registry.async_get_entity_id(domain, DOMAIN, new_id)
+
+
 async def test_no_repair_issue(
     hass: HomeAssistant, config_entry: MockConfigEntry, issue_registry: ir.IssueRegistry
 ) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
With the latest Reolink NVR firmware, unique_ids for the IPC cams connected to the NVR are now supported instead of relaying on the channel number.
The following situation leads to issues:
1) User updates from firmware v3.5.0.321_24060733 -> v3.5.1.356_24110154 --> device/entity ids are migrated
2) User downgrades fimrware  again v3.5.1.356_24110154 -> v3.5.0.321_24060733 --> integration goes back to old channel ids and you know have duplicate devices/entities (not much I can do about this, users should not be downgrading firmware)
3) Now the actual issue, user updates again from firmware v3.5.0.321_24060733 -> v3.5.1.356_24110154  --> now we are stuck: the device/entity ids are beeing migrated, but there already is a device with that ID giving a exception blocking the integration from starting :(

This PR fixes this by detecting situation 3) and then not migrating, but rather deleting/cleaning up the old devices and then just using the already existing devices with the new IDs.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/130730
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
