### PR TITLE
Add µV as UnitOfElectricPotential

### DIFF
--- a/homeassistant/components/number/const.py
+++ b/homeassistant/components/number/const.py
@@ -369,7 +369,7 @@ class NumberDeviceClass(StrEnum):
     VOLTAGE = "voltage"
     """Voltage.
 
-    Unit of measurement: `V`, `mV`
+    Unit of measurement: `V`, `mV`, `µV`
     """
 
     VOLUME = "volume"

--- a/homeassistant/components/sensor/const.py
+++ b/homeassistant/components/sensor/const.py
@@ -391,7 +391,7 @@ class SensorDeviceClass(StrEnum):
     VOLTAGE = "voltage"
     """Voltage.
 
-    Unit of measurement: `V`, `mV`
+    Unit of measurement: `V`, `mV`, `µV`
     """
 
     VOLUME = "volume"

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -827,6 +827,11 @@ class UnitOfElectricPotential(StrEnum):
     VOLT = "V"
 
 
+_DEPRECATED_ELECTRIC_POTENTIAL_MICROVOLT: Final = DeprecatedConstantEnum(
+    UnitOfElectricPotential.MICROVOLT,
+    "2025.1",
+)
+"""Deprecated: please use UnitOfElectricPotential.MICROVOLT."""
 _DEPRECATED_ELECTRIC_POTENTIAL_MILLIVOLT: Final = DeprecatedConstantEnum(
     UnitOfElectricPotential.MILLIVOLT,
     "2025.1",

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -822,6 +822,7 @@ _DEPRECATED_ELECTRIC_CURRENT_AMPERE: Final = DeprecatedConstantEnum(
 class UnitOfElectricPotential(StrEnum):
     """Electric potential units."""
 
+    MICROVOLT = "µV"
     MILLIVOLT = "mV"
     VOLT = "V"
 

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -827,11 +827,6 @@ class UnitOfElectricPotential(StrEnum):
     VOLT = "V"
 
 
-_DEPRECATED_ELECTRIC_POTENTIAL_MICROVOLT: Final = DeprecatedConstantEnum(
-    UnitOfElectricPotential.MICROVOLT,
-    "2025.1",
-)
-"""Deprecated: please use UnitOfElectricPotential.MICROVOLT."""
 _DEPRECATED_ELECTRIC_POTENTIAL_MILLIVOLT: Final = DeprecatedConstantEnum(
     UnitOfElectricPotential.MILLIVOLT,
     "2025.1",

--- a/homeassistant/util/unit_conversion.py
+++ b/homeassistant/util/unit_conversion.py
@@ -215,10 +215,12 @@ class ElectricPotentialConverter(BaseUnitConverter):
     _UNIT_CONVERSION: dict[str | None, float] = {
         UnitOfElectricPotential.VOLT: 1,
         UnitOfElectricPotential.MILLIVOLT: 1e3,
+        UnitOfElectricPotential.MICROVOLT: 1e6,
     }
     VALID_UNITS = {
         UnitOfElectricPotential.VOLT,
         UnitOfElectricPotential.MILLIVOLT,
+        UnitOfElectricPotential.MICROVOLT,
     }
 
 

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -83,7 +83,13 @@ def test_all() -> None:
         "ENERGY_",
     )
     + _create_tuples(const.UnitOfElectricCurrent, "ELECTRIC_CURRENT_")
-    + _create_tuples(const.UnitOfElectricPotential, "ELECTRIC_POTENTIAL_")
+    + _create_tuples(
+        [
+            const.UnitOfElectricPotential.MILLIVOLT,
+            const.UnitOfElectricPotential.VOLT,
+        ],
+        "ELECTRIC_POTENTIAL_",
+    )
     + _create_tuples(const.UnitOfTemperature, "TEMP_")
     + _create_tuples(const.UnitOfTime, "TIME_")
     + _create_tuples(

--- a/tests/util/test_unit_conversion.py
+++ b/tests/util/test_unit_conversion.py
@@ -374,7 +374,11 @@ _CONVERTED_VALUE: dict[
     ],
     ElectricPotentialConverter: [
         (5, UnitOfElectricPotential.VOLT, 5000, UnitOfElectricPotential.MILLIVOLT),
+        (5, UnitOfElectricPotential.VOLT, 5e6, UnitOfElectricPotential.MICROVOLT),
         (5, UnitOfElectricPotential.MILLIVOLT, 0.005, UnitOfElectricPotential.VOLT),
+        (5, UnitOfElectricPotential.MILLIVOLT, 5e3, UnitOfElectricPotential.MICROVOLT),
+        (5, UnitOfElectricPotential.MICROVOLT, 5e-3, UnitOfElectricPotential.MILLIVOLT),
+        (5, UnitOfElectricPotential.MICROVOLT, 5e-6, UnitOfElectricPotential.VOLT),
     ],
     EnergyConverter: [
         (10, UnitOfEnergy.WATT_HOUR, 0.01, UnitOfEnergy.KILO_WATT_HOUR),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


Add µV (microvolts) as unit to `UnitOfElectricPotential`


Most temperature sensors use thermocouples to measure temperature. The measured voltage at the junction of [thermocouples ](https://en.wikipedia.org/wiki/Thermocouple) is converted to an offset calibrated temperature. Generally this voltage is in the microvolt range. IronOS devices expose those raw measurements and also offer an offset calibration, which is in a range of 100 to 2500µV with a step resolution of 1 µV.


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/35811, https://github.com/home-assistant/developers.home-assistant/pull/2456

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
