### PR TITLE
Support KNX lights with multiple color modes

### DIFF
--- a/tests/components/knx/test_light.py
+++ b/tests/components/knx/test_light.py
@@ -41,7 +41,11 @@ async def test_light_simple(hass: HomeAssistant, knx: KNXTestKit) -> None:
         }
     )
 
-    knx.assert_state("light.test", STATE_OFF)
+    knx.assert_state(
+        "light.test",
+        STATE_OFF,
+        supported_color_modes=[ColorMode.ONOFF],
+    )
     # turn on light
     await hass.services.async_call(
         "light",
@@ -110,6 +114,7 @@ async def test_light_brightness(hass: HomeAssistant, knx: KNXTestKit) -> None:
         "light.test",
         STATE_ON,
         brightness=80,
+        supported_color_modes=[ColorMode.BRIGHTNESS],
         color_mode=ColorMode.BRIGHTNESS,
     )
     # receive brightness changes from KNX
@@ -165,6 +170,7 @@ async def test_light_color_temp_absolute(hass: HomeAssistant, knx: KNXTestKit) -
         "light.test",
         STATE_ON,
         brightness=255,
+        supported_color_modes=[ColorMode.COLOR_TEMP],
         color_mode=ColorMode.COLOR_TEMP,
         color_temp=370,
         color_temp_kelvin=2700,
@@ -227,6 +233,7 @@ async def test_light_color_temp_relative(hass: HomeAssistant, knx: KNXTestKit) -
         "light.test",
         STATE_ON,
         brightness=255,
+        supported_color_modes=[ColorMode.COLOR_TEMP],
         color_mode=ColorMode.COLOR_TEMP,
         color_temp=250,
         color_temp_kelvin=4000,
@@ -300,6 +307,7 @@ async def test_light_hs_color(hass: HomeAssistant, knx: KNXTestKit) -> None:
         "light.test",
         STATE_ON,
         brightness=255,
+        supported_color_modes=[ColorMode.HS],
         color_mode=ColorMode.HS,
         hs_color=(360, 100),
     )
@@ -375,6 +383,7 @@ async def test_light_xyy_color(hass: HomeAssistant, knx: KNXTestKit) -> None:
         "light.test",
         STATE_ON,
         brightness=204,
+        supported_color_modes=[ColorMode.XY],
         color_mode=ColorMode.XY,
         xy_color=(0.8, 0.8),
     )
@@ -457,6 +466,7 @@ async def test_light_xyy_color_with_brightness(
         "light.test",
         STATE_ON,
         brightness=255,  # brightness form xyy_color ignored when extra brightness GA is used
+        supported_color_modes=[ColorMode.XY],
         color_mode=ColorMode.XY,
         xy_color=(0.8, 0.8),
     )
@@ -543,6 +553,7 @@ async def test_light_rgb_individual(hass: HomeAssistant, knx: KNXTestKit) -> Non
         "light.test",
         STATE_ON,
         brightness=255,
+        supported_color_modes=[ColorMode.RGB],
         color_mode=ColorMode.RGB,
         rgb_color=(255, 255, 255),
     )
@@ -699,6 +710,7 @@ async def test_light_rgbw_individual(
         "light.test",
         STATE_ON,
         brightness=255,
+        supported_color_modes=[ColorMode.RGBW],
         color_mode=ColorMode.RGBW,
         rgbw_color=(0, 0, 0, 255),
     )
@@ -853,6 +865,7 @@ async def test_light_rgb(hass: HomeAssistant, knx: KNXTestKit) -> None:
         "light.test",
         STATE_ON,
         brightness=255,
+        supported_color_modes=[ColorMode.RGB],
         color_mode=ColorMode.RGB,
         rgb_color=(255, 255, 255),
     )
@@ -961,6 +974,7 @@ async def test_light_rgbw(hass: HomeAssistant, knx: KNXTestKit) -> None:
         "light.test",
         STATE_ON,
         brightness=255,
+        supported_color_modes=[ColorMode.RGBW],
         color_mode=ColorMode.RGBW,
         rgbw_color=(255, 101, 102, 103),
     )
@@ -1078,6 +1092,7 @@ async def test_light_rgbw_brightness(hass: HomeAssistant, knx: KNXTestKit) -> No
         "light.test",
         STATE_ON,
         brightness=255,
+        supported_color_modes=[ColorMode.RGBW],
         color_mode=ColorMode.RGBW,
         rgbw_color=(255, 101, 102, 103),
     )
@@ -1174,8 +1189,12 @@ async def test_light_ui_create(
     # created entity sends read-request to KNX bus
     await knx.assert_read("2/2/2")
     await knx.receive_response("2/2/2", True)
-    state = hass.states.get("light.test")
-    assert state.state is STATE_ON
+    knx.assert_state(
+        "light.test",
+        STATE_ON,
+        supported_color_modes=[ColorMode.ONOFF],
+        color_mode=ColorMode.ONOFF,
+    )
 
 
 @pytest.mark.parametrize(
@@ -1216,9 +1235,13 @@ async def test_light_ui_color_temp(
         blocking=True,
     )
     await knx.assert_write("3/3/3", raw_ct)
-    state = hass.states.get("light.test")
-    assert state.state is STATE_ON
-    assert state.attributes[ATTR_COLOR_TEMP_KELVIN] == pytest.approx(4200, abs=1)
+    knx.assert_state(
+        "light.test",
+        STATE_ON,
+        supported_color_modes=[ColorMode.COLOR_TEMP],
+        color_mode=ColorMode.COLOR_TEMP,
+        color_temp_kelvin=pytest.approx(4200, abs=1),
+    )
 
 
 async def test_light_ui_load(
@@ -1234,8 +1257,12 @@ async def test_light_ui_load(
     # unrelated switch in config store
     await knx.assert_read("1/0/45", response=True, ignore_order=True)
 
-    state = hass.states.get("light.test")
-    assert state.state is STATE_ON
+    knx.assert_state(
+        "light.test",
+        STATE_ON,
+        supported_color_modes=[ColorMode.ONOFF],
+        color_mode=ColorMode.ONOFF,
+    )
 
     entity = entity_registry.async_get("light.test")
     assert entity.entity_category is EntityCategory.CONFIG


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Previously it was possible to configure color and color_temp GAs, but a light did only support a single color mode. Now these configurations support color + color_temp modes.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
