### PR TITLE
Allow Alexa to stop a cover

### DIFF
--- a/homeassistant/components/alexa/capabilities.py
+++ b/homeassistant/components/alexa/capabilities.py
@@ -816,13 +816,19 @@ class AlexaPlaybackController(AlexaCapability):
         """
         supported_features = self.entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
 
-        operations = {
-            media_player.MediaPlayerEntityFeature.NEXT_TRACK: "Next",
-            media_player.MediaPlayerEntityFeature.PAUSE: "Pause",
-            media_player.MediaPlayerEntityFeature.PLAY: "Play",
-            media_player.MediaPlayerEntityFeature.PREVIOUS_TRACK: "Previous",
-            media_player.MediaPlayerEntityFeature.STOP: "Stop",
-        }
+        operations: dict[
+            cover.CoverEntityFeature | media_player.MediaPlayerEntityFeature, str
+        ]
+        if self.entity.domain == cover.DOMAIN:
+            operations = {cover.CoverEntityFeature.STOP: "Stop"}
+        else:
+            operations = {
+                media_player.MediaPlayerEntityFeature.NEXT_TRACK: "Next",
+                media_player.MediaPlayerEntityFeature.PAUSE: "Pause",
+                media_player.MediaPlayerEntityFeature.PLAY: "Play",
+                media_player.MediaPlayerEntityFeature.PREVIOUS_TRACK: "Previous",
+                media_player.MediaPlayerEntityFeature.STOP: "Stop",
+            }
 
         return [
             value

--- a/homeassistant/components/alexa/entities.py
+++ b/homeassistant/components/alexa/entities.py
@@ -559,6 +559,10 @@ class CoverCapabilities(AlexaEntity):
             )
         if supported & cover.CoverEntityFeature.SET_TILT_POSITION:
             yield AlexaRangeController(self.entity, instance=f"{cover.DOMAIN}.tilt")
+        if supported & (
+            cover.CoverEntityFeature.STOP | cover.CoverEntityFeature.STOP_TILT
+        ):
+            yield AlexaPlaybackController(self.entity, instance=f"{cover.DOMAIN}.stop")
         yield AlexaEndpointHealth(self.hass, self.entity)
         yield Alexa(self.entity)
 

--- a/homeassistant/components/alexa/handlers.py
+++ b/homeassistant/components/alexa/handlers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Callable, Coroutine
 import logging
 import math
@@ -764,9 +765,25 @@ async def async_api_stop(
     entity = directive.entity
     data: dict[str, Any] = {ATTR_ENTITY_ID: entity.entity_id}
 
-    await hass.services.async_call(
-        entity.domain, SERVICE_MEDIA_STOP, data, blocking=False, context=context
-    )
+    if entity.domain == cover.DOMAIN:
+        supported: int = entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
+        feature_services: dict[int, str] = {
+            cover.CoverEntityFeature.STOP.value: cover.SERVICE_STOP_COVER,
+            cover.CoverEntityFeature.STOP_TILT.value: cover.SERVICE_STOP_COVER_TILT,
+        }
+        await asyncio.gather(
+            *(
+                hass.services.async_call(
+                    entity.domain, service, data, blocking=False, context=context
+                )
+                for feature, service in feature_services.items()
+                if feature & supported
+            )
+        )
+    else:
+        await hass.services.async_call(
+            entity.domain, SERVICE_MEDIA_STOP, data, blocking=False, context=context
+        )
 
     return directive.response()
 

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -4546,6 +4546,7 @@ async def test_presence_sensor(hass: HomeAssistant) -> None:
         "tilt_position_attr_in_service_call",
         "supported_features",
         "service_call",
+        "stop_feature_enabled",
     ),
     [
         (
@@ -4556,6 +4557,7 @@ async def test_presence_sensor(hass: HomeAssistant) -> None:
             | CoverEntityFeature.CLOSE_TILT
             | CoverEntityFeature.STOP_TILT,
             "cover.set_cover_tilt_position",
+            True,
         ),
         (
             0,
@@ -4565,6 +4567,7 @@ async def test_presence_sensor(hass: HomeAssistant) -> None:
             | CoverEntityFeature.CLOSE_TILT
             | CoverEntityFeature.STOP_TILT,
             "cover.close_cover_tilt",
+            True,
         ),
         (
             99,
@@ -4574,6 +4577,7 @@ async def test_presence_sensor(hass: HomeAssistant) -> None:
             | CoverEntityFeature.CLOSE_TILT
             | CoverEntityFeature.STOP_TILT,
             "cover.set_cover_tilt_position",
+            True,
         ),
         (
             100,
@@ -4583,36 +4587,42 @@ async def test_presence_sensor(hass: HomeAssistant) -> None:
             | CoverEntityFeature.CLOSE_TILT
             | CoverEntityFeature.STOP_TILT,
             "cover.open_cover_tilt",
+            True,
         ),
         (
             0,
             0,
             CoverEntityFeature.SET_TILT_POSITION,
             "cover.set_cover_tilt_position",
+            False,
         ),
         (
             60,
             60,
             CoverEntityFeature.SET_TILT_POSITION,
             "cover.set_cover_tilt_position",
+            False,
         ),
         (
             100,
             100,
             CoverEntityFeature.SET_TILT_POSITION,
             "cover.set_cover_tilt_position",
+            False,
         ),
         (
             0,
             0,
             CoverEntityFeature.SET_TILT_POSITION | CoverEntityFeature.OPEN_TILT,
             "cover.set_cover_tilt_position",
+            False,
         ),
         (
             100,
             100,
             CoverEntityFeature.SET_TILT_POSITION | CoverEntityFeature.CLOSE_TILT,
             "cover.set_cover_tilt_position",
+            False,
         ),
     ],
     ids=[
@@ -4633,6 +4643,7 @@ async def test_cover_tilt_position(
     tilt_position_attr_in_service_call: int | None,
     supported_features: CoverEntityFeature,
     service_call: str,
+    stop_feature_enabled: bool,
 ) -> None:
     """Test cover discovery and tilt position using rangeController."""
     device = (
@@ -4651,12 +4662,24 @@ async def test_cover_tilt_position(
     assert appliance["displayCategories"][0] == "INTERIOR_BLIND"
     assert appliance["friendlyName"] == "Test cover tilt range"
 
+    expected_interfaces: dict[bool, list[str]] = {
+        False: [
+            "Alexa.PowerController",
+            "Alexa.RangeController",
+            "Alexa.EndpointHealth",
+            "Alexa",
+        ],
+        True: [
+            "Alexa.PowerController",
+            "Alexa.RangeController",
+            "Alexa.PlaybackController",
+            "Alexa.EndpointHealth",
+            "Alexa",
+        ],
+    }
+
     capabilities = assert_endpoint_capabilities(
-        appliance,
-        "Alexa.PowerController",
-        "Alexa.RangeController",
-        "Alexa.EndpointHealth",
-        "Alexa",
+        appliance, *expected_interfaces[stop_feature_enabled]
     )
 
     range_capability = get_capability(capabilities, "Alexa.RangeController")
@@ -4713,6 +4736,7 @@ async def test_cover_tilt_position_range(hass: HomeAssistant) -> None:
         appliance,
         "Alexa.PowerController",
         "Alexa.RangeController",
+        "Alexa.PlaybackController",
         "Alexa.EndpointHealth",
         "Alexa",
     )

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -4807,7 +4807,7 @@ async def test_cover_stop(
     cover_stop_calls: int,
     cover_stop_tilt_calls: int,
 ) -> None:
-    """Test cover an cover tilt can be stopped."""
+    """Test cover and cover tilt can be stopped."""
 
     base_features = (
         CoverEntityFeature.OPEN


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Alow a cover or cover tilt to stop with Alexa Samrt Home

From Alexa you can say:
"Okay Alexa, stop <name cover>"

If the cover supports the stop feature, it will call the `stop_cover` service
If the cover supports the stop tilt feature, it will call the `stop_cover_tilt` service
If both features are supported, both services are invoked when asink Alexa to stop.

Offers a non breaking alternative for PR #125851

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #125841
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/35807

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
