### PR TITLE
Fallback to config entry ID as unique ID when serialno is not available for APCUPSD

### DIFF
--- a/homeassistant/components/apcupsd/binary_sensor.py
+++ b/homeassistant/components/apcupsd/binary_sensor.py
@@ -53,10 +53,8 @@ class OnlineStatus(CoordinatorEntity[APCUPSdCoordinator], BinarySensorEntity):
         """Initialize the APCUPSd binary device."""
         super().__init__(coordinator, context=description.key.upper())
 
-        # Set up unique id and device info if serial number is available.
-        if (serial_no := coordinator.data.serial_no) is not None:
-            self._attr_unique_id = f"{serial_no}_{description.key}"
         self.entity_description = description
+        self._attr_unique_id = f"{coordinator.unique_device_id}_{description.key}"
         self._attr_device_info = coordinator.device_info
 
     @property

--- a/homeassistant/components/apcupsd/coordinator.py
+++ b/homeassistant/components/apcupsd/coordinator.py
@@ -86,10 +86,15 @@ class APCUPSdCoordinator(DataUpdateCoordinator[APCUPSdData]):
         self._port = port
 
     @property
+    def unique_device_id(self) -> str:
+        """Return a unique ID of the device, which is the serial number (if available) or the config entry ID."""
+        return self.data.serial_no or self.config_entry.entry_id
+
+    @property
     def device_info(self) -> DeviceInfo:
         """Return the DeviceInfo of this APC UPS, if serial number is available."""
         return DeviceInfo(
-            identifiers={(DOMAIN, self.data.serial_no or self.config_entry.entry_id)},
+            identifiers={(DOMAIN, self.unique_device_id)},
             model=self.data.model,
             manufacturer="APC",
             name=self.data.name or "APC UPS",

--- a/homeassistant/components/apcupsd/sensor.py
+++ b/homeassistant/components/apcupsd/sensor.py
@@ -458,11 +458,8 @@ class APCUPSdSensor(CoordinatorEntity[APCUPSdCoordinator], SensorEntity):
         """Initialize the sensor."""
         super().__init__(coordinator=coordinator, context=description.key.upper())
 
-        # Set up unique id and device info if serial number is available.
-        if (serial_no := coordinator.data.serial_no) is not None:
-            self._attr_unique_id = f"{serial_no}_{description.key}"
-
         self.entity_description = description
+        self._attr_unique_id = f"{coordinator.unique_device_id}_{description.key}"
         self._attr_device_info = coordinator.device_info
 
         # Initial update of attributes.

--- a/tests/components/apcupsd/__init__.py
+++ b/tests/components/apcupsd/__init__.py
@@ -1,10 +1,13 @@
 """Tests for the APCUPSd component."""
 
+from __future__ import annotations
+
 from collections import OrderedDict
 from typing import Final
 from unittest.mock import patch
 
 from homeassistant.components.apcupsd.const import DOMAIN
+from homeassistant.components.apcupsd.coordinator import APCUPSdData
 from homeassistant.config_entries import SOURCE_USER
 from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import HomeAssistant
@@ -79,7 +82,7 @@ MOCK_MINIMAL_STATUS: Final = OrderedDict(
 
 
 async def async_init_integration(
-    hass: HomeAssistant, host: str = "test", status=None
+    hass: HomeAssistant, host: str = "test", status: dict[str, str] | None = None
 ) -> MockConfigEntry:
     """Set up the APC UPS Daemon integration in HomeAssistant."""
     if status is None:
@@ -90,7 +93,7 @@ async def async_init_integration(
         domain=DOMAIN,
         title="APCUPSd",
         data=CONF_DATA | {CONF_HOST: host},
-        unique_id=status.get("SERIALNO", None),
+        unique_id=APCUPSdData(status).serial_no,
         source=SOURCE_USER,
     )
 

--- a/tests/components/apcupsd/test_sensor.py
+++ b/tests/components/apcupsd/test_sensor.py
@@ -244,11 +244,14 @@ async def test_sensor_unknown(hass: HomeAssistant) -> None:
     """Test if our integration can properly certain sensors as unknown when it becomes so."""
     await async_init_integration(hass, status=MOCK_MINIMAL_STATUS)
 
-    assert hass.states.get("sensor.mode").state == MOCK_MINIMAL_STATUS["UPSMODE"]
+    ups_mode_id = "sensor.apc_ups_mode"
+    last_self_test_id = "sensor.apc_ups_last_self_test"
+
+    assert hass.states.get(ups_mode_id).state == MOCK_MINIMAL_STATUS["UPSMODE"]
     # Last self test sensor should be added even if our status does not report it initially (it is
     # a sensor that appears only after a periodical or manual self test is performed).
-    assert hass.states.get("sensor.last_self_test") is not None
-    assert hass.states.get("sensor.last_self_test").state == STATE_UNKNOWN
+    assert hass.states.get(last_self_test_id) is not None
+    assert hass.states.get(last_self_test_id).state == STATE_UNKNOWN
 
     # Simulate an event (a self test) such that "LASTSTEST" field is being reported, the state of
     # the sensor should be properly updated with the corresponding value.
@@ -259,7 +262,7 @@ async def test_sensor_unknown(hass: HomeAssistant) -> None:
         future = utcnow() + timedelta(minutes=2)
         async_fire_time_changed(hass, future)
         await hass.async_block_till_done()
-    assert hass.states.get("sensor.last_self_test").state == "1970-01-01 00:00:00 0000"
+    assert hass.states.get(last_self_test_id).state == "1970-01-01 00:00:00 0000"
 
     # Simulate another event (e.g., daemon restart) such that "LASTSTEST" is no longer reported.
     with patch("aioapcaccess.request_status") as mock_request_status:
@@ -268,4 +271,4 @@ async def test_sensor_unknown(hass: HomeAssistant) -> None:
         async_fire_time_changed(hass, future)
         await hass.async_block_till_done()
     # The state should become unknown again.
-    assert hass.states.get("sensor.last_self_test").state == STATE_UNKNOWN
+    assert hass.states.get(last_self_test_id).state == STATE_UNKNOWN


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

For some dumb APC UPSes the daemon might not report `SERIALNO`, in which case we should fall back to use config entry ID as the unique ID per [dev docs](https://developers.home-assistant.io/docs/entity_registry_index?_highlight=unique#unique-id-of-last-resort).

This PR adds such handling such that APC UPS entities should always have an unique ID to be registered. Tests are also updated to reflect this change.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #139205
- This PR is related to issue: #139205
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
