### PR TITLE
Add backup config storage

### DIFF
--- a/homeassistant/components/backup/config.py
+++ b/homeassistant/components/backup/config.py
@@ -8,6 +8,7 @@ from typing import Self, TypedDict
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.storage import Store
+from homeassistant.helpers.typing import UNDEFINED, UndefinedType
 
 from .const import DOMAIN
 
@@ -51,7 +52,6 @@ class BackupConfig:
     def __init__(self, hass: HomeAssistant) -> None:
         """Initialize backup config."""
         self.data = BackupConfigData()
-        self._hass = hass
         self._store: Store[StoredBackupConfig] = Store(
             hass, STORAGE_VERSION, STORAGE_KEY
         )
@@ -65,3 +65,13 @@ class BackupConfig:
     async def save(self) -> None:
         """Save config."""
         await self._store.async_save(self.data.to_dict())
+
+    async def update(
+        self, *, max_copies: int | None | UndefinedType = UNDEFINED
+    ) -> None:
+        """Update config."""
+        for param_name, param_value in {"max_copies": max_copies}.items():
+            if param_value is not UNDEFINED:
+                setattr(self.data, param_name, param_value)
+
+        await self.save()

--- a/homeassistant/components/backup/config.py
+++ b/homeassistant/components/backup/config.py
@@ -19,6 +19,7 @@ class StoredBackupConfig(TypedDict):
     """Represent the stored backup config."""
 
     last_automatic_backup: datetime | None
+    max_copies: int | None
 
 
 @dataclass(kw_only=True)
@@ -26,18 +27,21 @@ class BackupConfigData:
     """Represent loaded backup config data."""
 
     last_automatic_backup: datetime | None = None
+    max_copies: int | None = None
 
     @classmethod
     def from_dict(cls, data: StoredBackupConfig) -> Self:
         """Initialize backup config data from a dict."""
         return cls(
             last_automatic_backup=data["last_automatic_backup"],
+            max_copies=data["max_copies"],
         )
 
     def to_dict(self) -> StoredBackupConfig:
         """Convert backup config data to a dict."""
         return StoredBackupConfig(
             last_automatic_backup=self.last_automatic_backup,
+            max_copies=self.max_copies,
         )
 
 

--- a/homeassistant/components/backup/config.py
+++ b/homeassistant/components/backup/config.py
@@ -1,0 +1,63 @@
+"""Provide persistent configuration for the backup integration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Self, TypedDict
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.storage import Store
+
+from .const import DOMAIN
+
+STORAGE_KEY = DOMAIN
+STORAGE_VERSION = 1
+
+
+class StoredBackupConfig(TypedDict):
+    """Represent the stored backup config."""
+
+    last_automatic_backup: datetime | None
+
+
+@dataclass(kw_only=True)
+class BackupConfigData:
+    """Represent loaded backup config data."""
+
+    last_automatic_backup: datetime | None = None
+
+    @classmethod
+    def from_dict(cls, data: StoredBackupConfig) -> Self:
+        """Initialize backup config data from a dict."""
+        return cls(
+            last_automatic_backup=data["last_automatic_backup"],
+        )
+
+    def to_dict(self) -> StoredBackupConfig:
+        """Convert backup config data to a dict."""
+        return StoredBackupConfig(
+            last_automatic_backup=self.last_automatic_backup,
+        )
+
+
+class BackupConfig:
+    """Handle backup config."""
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Initialize backup config."""
+        self.data = BackupConfigData()
+        self._hass = hass
+        self._store: Store[StoredBackupConfig] = Store(
+            hass, STORAGE_VERSION, STORAGE_KEY
+        )
+
+    async def load(self) -> None:
+        """Load config."""
+        stored = await self._store.async_load()
+        if stored:
+            self.data = BackupConfigData.from_dict(stored)
+
+    async def save(self) -> None:
+        """Save config."""
+        await self._store.async_save(self.data.to_dict())

--- a/homeassistant/components/backup/manager.py
+++ b/homeassistant/components/backup/manager.py
@@ -35,6 +35,7 @@ from .agent import (
     BackupAgentPlatformProtocol,
     LocalBackupAgent,
 )
+from .config import BackupConfig
 from .const import (
     BUF_SIZE,
     DOMAIN,
@@ -93,10 +94,12 @@ class BaseBackupManager(abc.ABC, Generic[_BackupT]):
         self.platforms: dict[str, BackupPlatformProtocol] = {}
         self.backup_agents: dict[str, BackupAgent] = {}
         self.local_backup_agents: dict[str, LocalBackupAgent] = {}
+        self.config = BackupConfig(hass)
         self.syncing = False
 
     async def async_setup(self) -> None:
         """Set up the backup manager."""
+        await self.config.load()
         await self.load_platforms()
 
     @callback

--- a/homeassistant/components/backup/websocket.py
+++ b/homeassistant/components/backup/websocket.py
@@ -302,6 +302,8 @@ async def handle_config_update(
 ) -> None:
     """Update the stored backup config."""
     manager = hass.data[DATA_MANAGER]
-    manager.config.data.max_copies = msg.get("max_copies")
-    await manager.config.save()
+    changes = dict(msg)
+    changes.pop("id")
+    changes.pop("type")
+    await manager.config.update(**changes)
     connection.send_result(msg["id"])

--- a/homeassistant/components/backup/websocket.py
+++ b/homeassistant/components/backup/websocket.py
@@ -30,6 +30,7 @@ def async_register_websocket_handlers(hass: HomeAssistant, with_hassio: bool) ->
     websocket_api.async_register_command(hass, handle_restore)
 
     websocket_api.async_register_command(hass, handle_config_info)
+    websocket_api.async_register_command(hass, handle_config_update)
 
 
 @websocket_api.require_admin
@@ -284,3 +285,23 @@ async def handle_config_info(
             "config": manager.config.data,
         },
     )
+
+
+@websocket_api.require_admin
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "backup/config/update",
+        vol.Optional("max_copies"): int,
+    }
+)
+@websocket_api.async_response
+async def handle_config_update(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """Update the stored backup config."""
+    manager = hass.data[DATA_MANAGER]
+    manager.config.data.max_copies = msg.get("max_copies")
+    await manager.config.save()
+    connection.send_result(msg["id"])

--- a/homeassistant/components/backup/websocket.py
+++ b/homeassistant/components/backup/websocket.py
@@ -29,6 +29,8 @@ def async_register_websocket_handlers(hass: HomeAssistant, with_hassio: bool) ->
     websocket_api.async_register_command(hass, handle_remove)
     websocket_api.async_register_command(hass, handle_restore)
 
+    websocket_api.async_register_command(hass, handle_config_info)
+
 
 @websocket_api.require_admin
 @websocket_api.websocket_command({vol.Required("type"): "backup/info"})
@@ -264,3 +266,21 @@ async def backup_agents_download(
         return
 
     connection.send_result(msg["id"])
+
+
+@websocket_api.require_admin
+@websocket_api.websocket_command({vol.Required("type"): "backup/config/info"})
+@websocket_api.async_response
+async def handle_config_info(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """Send the stored backup config."""
+    manager = hass.data[DATA_MANAGER]
+    connection.send_result(
+        msg["id"],
+        {
+            "config": manager.config.data,
+        },
+    )

--- a/tests/components/backup/snapshots/test_websocket.ambr
+++ b/tests/components/backup/snapshots/test_websocket.ambr
@@ -263,6 +263,33 @@
     'result': dict({
       'config': dict({
         'last_automatic_backup': None,
+        'max_copies': None,
+      }),
+    }),
+    'success': True,
+    'type': 'result',
+  })
+# ---
+# name: test_config_update
+  dict({
+    'id': 1,
+    'result': dict({
+      'config': dict({
+        'last_automatic_backup': None,
+        'max_copies': None,
+      }),
+    }),
+    'success': True,
+    'type': 'result',
+  })
+# ---
+# name: test_config_update.1
+  dict({
+    'id': 3,
+    'result': dict({
+      'config': dict({
+        'last_automatic_backup': None,
+        'max_copies': 5,
       }),
     }),
     'success': True,

--- a/tests/components/backup/snapshots/test_websocket.ambr
+++ b/tests/components/backup/snapshots/test_websocket.ambr
@@ -257,12 +257,51 @@
     'type': 'result',
   })
 # ---
-# name: test_config_info
+# name: test_config_info[storage_data0]
   dict({
     'id': 1,
     'result': dict({
       'config': dict({
         'last_automatic_backup': None,
+        'max_copies': None,
+      }),
+    }),
+    'success': True,
+    'type': 'result',
+  })
+# ---
+# name: test_config_info[storage_data1]
+  dict({
+    'id': 1,
+    'result': dict({
+      'config': dict({
+        'last_automatic_backup': '2024-10-26T02:00:00+00:00',
+        'max_copies': 3,
+      }),
+    }),
+    'success': True,
+    'type': 'result',
+  })
+# ---
+# name: test_config_info[storage_data2]
+  dict({
+    'id': 1,
+    'result': dict({
+      'config': dict({
+        'last_automatic_backup': None,
+        'max_copies': 3,
+      }),
+    }),
+    'success': True,
+    'type': 'result',
+  })
+# ---
+# name: test_config_info[storage_data3]
+  dict({
+    'id': 1,
+    'result': dict({
+      'config': dict({
+        'last_automatic_backup': '2024-10-26T02:00:00+00:00',
         'max_copies': None,
       }),
     }),

--- a/tests/components/backup/snapshots/test_websocket.ambr
+++ b/tests/components/backup/snapshots/test_websocket.ambr
@@ -257,6 +257,18 @@
     'type': 'result',
   })
 # ---
+# name: test_config_info
+  dict({
+    'id': 1,
+    'result': dict({
+      'config': dict({
+        'last_automatic_backup': None,
+      }),
+    }),
+    'success': True,
+    'type': 'result',
+  })
+# ---
 # name: test_details[with_hassio-with_backup_content]
   dict({
     'error': dict({

--- a/tests/components/backup/test_websocket.py
+++ b/tests/components/backup/test_websocket.py
@@ -530,3 +530,26 @@ async def test_config_info(
 
     await client.send_json_auto_id({"type": "backup/config/info"})
     assert await client.receive_json() == snapshot
+
+
+async def test_config_update(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test updating the backup config."""
+    await setup_backup_integration(hass)
+    await hass.async_block_till_done()
+
+    client = await hass_ws_client(hass)
+
+    await client.send_json_auto_id({"type": "backup/config/info"})
+    assert await client.receive_json() == snapshot
+
+    await client.send_json_auto_id({"type": "backup/config/update", "max_copies": 5})
+    result = await client.receive_json()
+
+    assert result["success"]
+
+    await client.send_json_auto_id({"type": "backup/config/info"})
+    assert await client.receive_json() == snapshot

--- a/tests/components/backup/test_websocket.py
+++ b/tests/components/backup/test_websocket.py
@@ -10,7 +10,7 @@ from syrupy import SnapshotAssertion
 
 from homeassistant.components.backup import BaseBackup
 from homeassistant.components.backup.agent import BackupAgentUnreachableError
-from homeassistant.components.backup.const import DATA_MANAGER
+from homeassistant.components.backup.const import DATA_MANAGER, DOMAIN
 from homeassistant.components.backup.manager import NewBackup
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -517,12 +517,29 @@ async def test_agents_download_unknown_agent(
     assert await client.receive_json() == snapshot
 
 
+@pytest.mark.parametrize(
+    "storage_data",
+    [
+        {},
+        {"last_automatic_backup": "2024-10-26T02:00:00+00:00", "max_copies": 3},
+        {"last_automatic_backup": None, "max_copies": 3},
+        {"last_automatic_backup": "2024-10-26T02:00:00+00:00", "max_copies": None},
+    ],
+)
 async def test_config_info(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     snapshot: SnapshotAssertion,
+    hass_storage: dict[str, Any],
+    storage_data: dict[str, Any],
 ) -> None:
     """Test getting backup config info."""
+    hass_storage[DOMAIN] = {
+        "data": storage_data,
+        "key": DOMAIN,
+        "version": 1,
+    }
+
     await setup_backup_integration(hass)
     await hass.async_block_till_done()
 

--- a/tests/components/backup/test_websocket.py
+++ b/tests/components/backup/test_websocket.py
@@ -515,3 +515,18 @@ async def test_agents_download_unknown_agent(
         }
     )
     assert await client.receive_json() == snapshot
+
+
+async def test_config_info(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test getting backup config info."""
+    await setup_backup_integration(hass)
+    await hass.async_block_till_done()
+
+    client = await hass_ws_client(hass)
+
+    await client.send_json_auto_id({"type": "backup/config/info"})
+    assert await client.receive_json() == snapshot


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Add backup config storage with websocket interface.
- This store should save the automatic backup settings and data.
  - datetime of last automatic backup done (included)
  - an integer for max copies to keep (included)
  - a cron schedule string (todo)
  - a timedelta for max copies to keep (todo)
  - included data directories that should be backed up (todo)
- The logic to handle an updated config, ie what the manager should do when the config changes, will be added separately later.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
