### PR TITLE
Bump PyJWT to 2.10.0

### DIFF
--- a/homeassistant/auth/jwt_wrapper.py
+++ b/homeassistant/auth/jwt_wrapper.py
@@ -18,7 +18,7 @@ from homeassistant.util.json import json_loads
 JWT_TOKEN_CACHE_SIZE = 16
 MAX_TOKEN_SIZE = 8192
 
-_VERIFY_KEYS = ("signature", "exp", "nbf", "iat", "aud", "iss")
+_VERIFY_KEYS = ("signature", "exp", "nbf", "iat", "aud", "iss", "sub", "jti")
 
 _VERIFY_OPTIONS: dict[str, Any] = {f"verify_{key}": True for key in _VERIFY_KEYS} | {
     "require": []

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -47,7 +47,7 @@ paho-mqtt==1.6.1
 Pillow==11.0.0
 propcache==0.2.0
 psutil-home-assistant==0.0.1
-PyJWT==2.9.0
+PyJWT==2.10.0
 pymicro-vad==1.0.1
 PyNaCl==1.5.0
 pyOpenSSL==24.2.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dependencies    = [
     "ifaddr==0.2.0",
     "Jinja2==3.1.4",
     "lru-dict==1.3.0",
-    "PyJWT==2.9.0",
+    "PyJWT==2.10.0",
     # PyJWT has loose dependency. We want the latest one.
     "cryptography==43.0.1",
     "Pillow==11.0.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ home-assistant-bluetooth==1.13.0
 ifaddr==0.2.0
 Jinja2==3.1.4
 lru-dict==1.3.0
-PyJWT==2.9.0
+PyJWT==2.10.0
 cryptography==43.0.1
 Pillow==11.0.0
 propcache==0.2.0

--- a/tests/auth/test_jwt_wrapper.py
+++ b/tests/auth/test_jwt_wrapper.py
@@ -6,6 +6,12 @@ import pytest
 from homeassistant.auth import jwt_wrapper
 
 
+async def test_all_default_options_are_in_verify_options() -> None:
+    """Test that all default options in _VERIFY_OPTIONS."""
+    for option in jwt_wrapper._PyJWTWithVerify._get_default_options():
+        assert option in jwt_wrapper._VERIFY_OPTIONS
+
+
 async def test_reject_access_token_with_impossible_large_size() -> None:
     """Test rejecting access tokens with impossible sizes."""
     with pytest.raises(jwt.DecodeError):


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
changelog: https://github.com/jpadilla/pyjwt/compare/2.9.0...2.10.0


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
