### PR TITLE
Implement a polling fallback for USB monitor

### DIFF
--- a/homeassistant/components/usb/__init__.py
+++ b/homeassistant/components/usb/__init__.py
@@ -250,10 +250,7 @@ class USBDiscovery:
 
     async def _async_supports_monitoring(self) -> bool:
         info = await system_info.async_get_system_info(self.hass)
-        if info.get("docker"):
-            return False
-
-        return True
+        return not info.get("docker")
 
     async def _async_start_monitor(self) -> None:
         """Start monitoring hardware."""
@@ -262,9 +259,10 @@ class USBDiscovery:
                 "Falling back to periodic filesystem polling for development, libudev "
                 "is not present"
             )
-            await self._async_start_monitor_polling()
+            self._async_start_monitor_polling()
 
-    async def _async_start_monitor_polling(self) -> None:
+    @hass_callback
+    def _async_start_monitor_polling(self) -> None:
         """Start monitoring hardware with polling (for development only!)."""
 
         async def _scan(event_time: datetime) -> None:

--- a/homeassistant/components/usb/__init__.py
+++ b/homeassistant/components/usb/__init__.py
@@ -258,15 +258,14 @@ class USBDiscovery:
     async def _async_start_monitor(self) -> None:
         """Start monitoring hardware."""
         if not await self._async_start_monitor_udev():
-            # We fall back to polling to make development possible, this is not a proper
-            # way to run Home Assistant
+            _LOGGER.info(
+                "Falling back to periodic filesystem polling for development, libudev "
+                "is not present"
+            )
             await self._async_start_monitor_polling()
 
     async def _async_start_monitor_polling(self) -> None:
         """Start monitoring hardware with polling (for development only!)."""
-        _LOGGER.info(
-            "Falling back to USB port polling for development, libudev is not preset"
-        )
 
         async def _scan(event_time: datetime) -> None:
             await self._async_scan_serial()
@@ -275,6 +274,7 @@ class USBDiscovery:
             self.hass, _scan, POLLING_MONITOR_SCAN_PERIOD
         )
 
+        @hass_callback
         def _stop_polling(event: Event) -> None:
             stop_callback()
 

--- a/homeassistant/components/usb/__init__.py
+++ b/homeassistant/components/usb/__init__.py
@@ -247,6 +247,7 @@ class USBDiscovery:
             self._request_debouncer.async_shutdown()
 
     async def _async_start_monitor(self) -> None:
+        """Start monitoring hardware."""
         fallback_to_polling = await self._async_start_monitor_udev()
 
         if not fallback_to_polling:

--- a/homeassistant/components/usb/__init__.py
+++ b/homeassistant/components/usb/__init__.py
@@ -258,10 +258,15 @@ class USBDiscovery:
     async def _async_start_monitor(self) -> None:
         """Start monitoring hardware."""
         if not await self._async_start_monitor_udev():
+            # We fall back to polling to make development possible, this is not a proper
+            # way to run Home Assistant
             await self._async_start_monitor_polling()
 
     async def _async_start_monitor_polling(self) -> None:
-        """Start monitoring hardware with polling."""
+        """Start monitoring hardware with polling (for development only!)."""
+        _LOGGER.info(
+            "Falling back to USB port polling for development, libudev is not preset"
+        )
 
         async def _scan(event_time: datetime) -> None:
             await self._async_scan_serial()

--- a/tests/components/usb/test_init.py
+++ b/tests/components/usb/test_init.py
@@ -3,7 +3,6 @@
 import asyncio
 from datetime import timedelta
 import os
-import sys
 from typing import Any
 from unittest.mock import MagicMock, Mock, call, patch, sentinel
 
@@ -61,10 +60,6 @@ def mock_venv():
         yield
 
 
-@pytest.mark.skipif(
-    not sys.platform.startswith("linux"),
-    reason="Only works on linux",
-)
 async def test_observer_discovery(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator, venv
 ) -> None:
@@ -95,6 +90,7 @@ async def test_observer_discovery(
         return mock_observer
 
     with (
+        patch("sys.platform", "linux"),
         patch("pyudev.Context"),
         patch("pyudev.MonitorObserver", new=_create_mock_monitor_observer),
         patch("pyudev.Monitor.filter_by"),
@@ -144,6 +140,7 @@ async def test_polling_discovery(
         ]
 
     with (
+        patch("sys.platform", "linux"),
         patch(
             "homeassistant.components.usb.USBDiscovery._get_monitor_observer",
             return_value=None,
@@ -175,10 +172,6 @@ async def test_polling_discovery(
     await hass.async_block_till_done()
 
 
-@pytest.mark.skipif(
-    not sys.platform.startswith("linux"),
-    reason="Only works on linux",
-)
 async def test_removal_by_observer_before_started(
     hass: HomeAssistant, operating_system
 ) -> None:
@@ -731,10 +724,6 @@ async def test_non_matching_discovered_by_scanner_after_started(
     assert len(mock_config_flow.mock_calls) == 0
 
 
-@pytest.mark.skipif(
-    not sys.platform.startswith("linux"),
-    reason="Only works on linux",
-)
 async def test_observer_on_wsl_fallback_without_throwing_exception(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator, venv
 ) -> None:
@@ -773,10 +762,6 @@ async def test_observer_on_wsl_fallback_without_throwing_exception(
     assert mock_config_flow.mock_calls[0][1][0] == "test1"
 
 
-@pytest.mark.skipif(
-    not sys.platform.startswith("linux"),
-    reason="Only works on linux",
-)
 async def test_not_discovered_by_observer_before_started_on_docker(
     hass: HomeAssistant, docker
 ) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Background: I'm preparing to add a `usb.async_register_port_event_callback` callback that will allow for integrations to register themselves for USB events, namely USB device discovery and removal. This will allow the SkyConnect integration to unload itself when the SkyConnect becomes unplugged, without having to actually use the serial port.

The current USB monitor does not work on macOS because it uses udev, which only runs on Linux. We instead can periodically call `_async_scan_serial` as a generic fallback solution for platforms that do not support udev properly.

This is intended for development purposes so the 5s polling interval realistically could be reduced to 1s. The only real platform I can see affected by this is WSL, which I don't believe we support for running HA Core.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
