### PR TITLE
Update strings.json to fix typo in "Husqavarna"

### DIFF
--- a/homeassistant/components/husqvarna_automower/strings.json
+++ b/homeassistant/components/husqvarna_automower/strings.json
@@ -314,7 +314,7 @@
   "issues": {
     "deprecated_entity": {
       "title": "The Husqvarna Automower {entity_name} sensor is deprecated",
-      "description": "The Husqavarna Automower entity `{entity}` is deprecated and will be removed in a future release.\nYou can use the new returning state of the lawn mower entity instead.\nPlease update your automations and scripts to replace the sensor entity with the newly added todo entity.\nWhen you are done migrating you can disable `{entity}`."
+      "description": "The Husqvarna Automower entity `{entity}` is deprecated and will be removed in a future release.\nYou can use the new returning state of the lawn mower entity instead.\nPlease update your automations and scripts to replace the sensor entity with the newly added todo entity.\nWhen you are done migrating you can disable `{entity}`."
     }
   },
   "services": {


### PR DESCRIPTION
## Proposed change

Fix for typo in [core/homeassistant/components/husqvarna_automower/strings.json](https://github.com/home-assistant/core/blob/efa86293aa47f8f7b5395cd0b48f72ea8002b674/homeassistant/components/husqvarna_automower/strings.json#L317)

Removes an extra "a" in "Husqavarna" 

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #130878
