### PR TITLE
Update climate strings for consistent names and descriptions

### DIFF
--- a/homeassistant/components/climate/strings.json
+++ b/homeassistant/components/climate/strings.json
@@ -151,29 +151,29 @@
     },
     "set_preset_mode": {
       "name": "Set preset mode",
-      "description": "Sets preset mode.",
+      "description": "Sets preset operation mode.",
       "fields": {
         "preset_mode": {
           "name": "Preset mode",
-          "description": "Preset mode."
+          "description": "Preset operation mode."
         }
       }
     },
     "set_temperature": {
       "name": "Set target temperature",
-      "description": "Sets target temperature.",
+      "description": "Sets the target temperature for a climate device.",
       "fields": {
         "temperature": {
-          "name": "Temperature",
-          "description": "Target temperature."
+          "name": "Target temperature",
+          "description": "The setpoint for the climate device."
         },
         "target_temp_high": {
-          "name": "Target temperature high",
-          "description": "High target temperature."
+          "name": "Upper target temperature",
+          "description": "The highest temperature that the climate device will allow."
         },
         "target_temp_low": {
-          "name": "Target temperature low",
-          "description": "Low target temperature."
+          "name": "Lower target temperature",
+          "description": "The lowest temperature that the climate device will allow."
         },
         "hvac_mode": {
           "name": "HVAC mode",

--- a/homeassistant/components/climate/strings.json
+++ b/homeassistant/components/climate/strings.json
@@ -161,19 +161,19 @@
     },
     "set_temperature": {
       "name": "Set target temperature",
-      "description": "Sets the target temperature for a climate device.",
+      "description": "Sets the temperature setpoint.",
       "fields": {
         "temperature": {
           "name": "Target temperature",
-          "description": "The setpoint for the climate device."
+          "description": "The temperature setpoint."
         },
         "target_temp_high": {
           "name": "Upper target temperature",
-          "description": "The highest temperature that the climate device will allow."
+          "description": "The highest temperature allowed."
         },
         "target_temp_low": {
           "name": "Lower target temperature",
-          "description": "The lowest temperature that the climate device will allow."
+          "description": "The lowest temperature allowed."
         },
         "hvac_mode": {
           "name": "HVAC mode",

--- a/homeassistant/components/climate/strings.json
+++ b/homeassistant/components/climate/strings.json
@@ -151,11 +151,11 @@
     },
     "set_preset_mode": {
       "name": "Set preset mode",
-      "description": "Sets preset operation mode.",
+      "description": "Sets preset mode.",
       "fields": {
         "preset_mode": {
           "name": "Preset mode",
-          "description": "Preset operation mode."
+          "description": "Preset mode."
         }
       }
     },

--- a/homeassistant/components/climate/strings.json
+++ b/homeassistant/components/climate/strings.json
@@ -169,11 +169,11 @@
         },
         "target_temp_high": {
           "name": "Upper target temperature",
-          "description": "The highest temperature allowed."
+          "description": "The max temperature setpoint."
         },
         "target_temp_low": {
           "name": "Lower target temperature",
-          "description": "The lowest temperature allowed."
+          "description": "The min temperature setpoint."
         },
         "hvac_mode": {
           "name": "HVAC mode",


### PR DESCRIPTION
Fix the current naming and description of the `set_temperature` action and its different data attributes.

Currently the names are inconsistent with the defined attributes of a climate device and the descriptions don't add any information as they just repeat the names in a different word order.

In addition it adds "operation" to the preset mode explanations to make them consistent with all other mode actions.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Bring the descriptions of the `set_temperature` action and its data attributes to the usual level.
Better align them with the online documentation.
Remove several inconsistencies. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #130762 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
