### PR TITLE
Strip whitespaces from host in ping config flow

### DIFF
--- a/homeassistant/components/ping/config_flow.py
+++ b/homeassistant/components/ping/config_flow.py
@@ -27,6 +27,12 @@ from .const import CONF_PING_COUNT, DEFAULT_PING_COUNT, DOMAIN
 _LOGGER = logging.getLogger(__name__)
 
 
+def _clean_user_input(user_input: dict[str, Any]) -> dict[str, Any]:
+    """Clean up the user input."""
+    user_input[CONF_HOST] = user_input[CONF_HOST].strip()
+    return user_input
+
+
 class PingConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Ping."""
 
@@ -46,6 +52,7 @@ class PingConfigFlow(ConfigFlow, domain=DOMAIN):
                 ),
             )
 
+        user_input = _clean_user_input(user_input)
         if not is_ip_address(user_input[CONF_HOST]):
             self.async_abort(reason="invalid_ip_address")
 
@@ -77,7 +84,7 @@ class OptionsFlowHandler(OptionsFlow):
     ) -> ConfigFlowResult:
         """Manage the options."""
         if user_input is not None:
-            return self.async_create_entry(title="", data=user_input)
+            return self.async_create_entry(title="", data=_clean_user_input(user_input))
 
         return self.async_show_form(
             step_id="init",

--- a/tests/components/ping/test_config_flow.py
+++ b/tests/components/ping/test_config_flow.py
@@ -13,11 +13,15 @@ from tests.common import MockConfigEntry
 
 
 @pytest.mark.parametrize(
-    ("host", "expected_title"),
-    [("192.618.178.1", "192.618.178.1")],
+    ("host", "expected"),
+    [
+        ("192.618.178.1", "192.618.178.1"),
+        (" 192.618.178.1 ", "192.618.178.1"),
+        (" demo.host ", "demo.host"),
+    ],
 )
 @pytest.mark.usefixtures("patch_setup")
-async def test_form(hass: HomeAssistant, host, expected_title) -> None:
+async def test_form(hass: HomeAssistant, host, expected) -> None:
     """Test we get the form."""
 
     result = await hass.config_entries.flow.async_init(
@@ -35,21 +39,25 @@ async def test_form(hass: HomeAssistant, host, expected_title) -> None:
     await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == expected_title
+    assert result["title"] == expected
     assert result["data"] == {}
     assert result["options"] == {
         "count": 5,
-        "host": host,
+        "host": expected,
         "consider_home": 180,
     }
 
 
 @pytest.mark.parametrize(
-    ("host", "count", "expected_title"),
-    [("192.618.178.1", 10, "192.618.178.1")],
+    ("host", "expected_host"),
+    [
+        ("192.618.178.1", "192.618.178.1"),
+        (" 192.618.178.1 ", "192.618.178.1"),
+        (" demo.host ", "demo.host"),
+    ],
 )
 @pytest.mark.usefixtures("patch_setup")
-async def test_options(hass: HomeAssistant, host, count, expected_title) -> None:
+async def test_options(hass: HomeAssistant, host: str, expected_host: str) -> None:
     """Test options flow."""
 
     config_entry = MockConfigEntry(
@@ -57,8 +65,8 @@ async def test_options(hass: HomeAssistant, host, count, expected_title) -> None
         source=config_entries.SOURCE_USER,
         data={},
         domain=DOMAIN,
-        options={"count": count, "host": host, "consider_home": 180},
-        title=expected_title,
+        options={"count": 1, "host": "192.168.1.1", "consider_home": 180},
+        title="192.168.1.1",
     )
     config_entry.add_to_hass(hass)
 
@@ -72,15 +80,15 @@ async def test_options(hass: HomeAssistant, host, count, expected_title) -> None
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         {
-            "host": "10.10.10.1",
-            "count": count,
+            "host": host,
+            "count": 10,
         },
     )
     await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["data"] == {
-        "count": count,
-        "host": "10.10.10.1",
+        "count": 10,
+        "host": expected_host,
         "consider_home": 180,
     }


### PR DESCRIPTION
## Proposed change
Strip leading and trailing whitespaces from `host` in ping config flow to avoid constantly "disconnected" entities.
Fixed the options flow test as well, it didn't made much sense how it was done.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #130952
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
