### PR TITLE
Remove class backup.BackupUploadMetadata

### DIFF
--- a/homeassistant/components/backup/__init__.py
+++ b/homeassistant/components/backup/__init__.py
@@ -17,7 +17,7 @@ from .manager import (
     BackupPlatformProtocol,
     CoreBackupReaderWriter,
 )
-from .models import BackupUploadMetadata, BaseBackup
+from .models import BaseBackup
 from .websocket import async_register_websocket_handlers
 
 __all__ = [
@@ -25,7 +25,6 @@ __all__ = [
     "BackupAgent",
     "BackupAgentPlatformProtocol",
     "BackupPlatformProtocol",
-    "BackupUploadMetadata",
     "BaseBackup",
 ]
 

--- a/homeassistant/components/backup/agent.py
+++ b/homeassistant/components/backup/agent.py
@@ -9,7 +9,7 @@ from typing import Any, Protocol
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 
-from .models import BackupUploadMetadata, BaseBackup
+from .models import BaseBackup
 
 
 class BackupAgentError(HomeAssistantError):
@@ -46,13 +46,15 @@ class BackupAgent(abc.ABC):
         self,
         *,
         path: Path,
-        metadata: BackupUploadMetadata,
+        homeassistant_version: str,
+        backup: BaseBackup,
         **kwargs: Any,
     ) -> None:
         """Upload a backup.
 
         :param path: The full file path to the backup that should be uploaded.
-        :param metadata: Metadata about the backup that should be uploaded.
+        :param backup: Metadata about the backup that should be uploaded.
+        :param homeassistant_version: The version of Home Assistant that created the backup
         """
 
     @abc.abstractmethod

--- a/homeassistant/components/backup/backup.py
+++ b/homeassistant/components/backup/backup.py
@@ -12,7 +12,7 @@ from homeassistant.helpers.hassio import is_hassio
 
 from .agent import BackupAgent, LocalBackupAgent
 from .const import LOGGER
-from .models import BackupUploadMetadata, BaseBackup
+from .models import BaseBackup
 from .util import read_backup
 
 
@@ -78,17 +78,11 @@ class CoreLocalBackupAgent(LocalBackupAgent):
         self,
         *,
         path: Path,
-        metadata: BackupUploadMetadata,
+        backup: BaseBackup,
         **kwargs: Any,
     ) -> None:
         """Upload a backup."""
-        self._backups[metadata.backup_id] = BaseBackup(
-            backup_id=metadata.backup_id,
-            date=metadata.date,
-            name=metadata.name,
-            protected=metadata.protected,
-            size=round(path.stat().st_size / 1_048_576, 2),
-        )
+        self._backups[backup.backup_id] = backup
 
     async def async_list_backups(self, **kwargs: Any) -> list[BaseBackup]:
         """List backups."""

--- a/homeassistant/components/backup/manager.py
+++ b/homeassistant/components/backup/manager.py
@@ -43,7 +43,7 @@ from .const import (
     EXCLUDE_FROM_BACKUP,
     LOGGER,
 )
-from .models import BackupUploadMetadata, BaseBackup
+from .models import BaseBackup
 from .util import read_backup
 
 
@@ -226,20 +226,15 @@ class BackupManager:
         path: Path,
     ) -> None:
         """Upload a backup to selected agents."""
+        LOGGER.warning("Uploading backup %s to agents %s", backup.backup_id, agent_ids)
         self.syncing = True
         try:
             sync_backup_results = await asyncio.gather(
                 *(
                     self.backup_agents[agent_id].async_upload_backup(
                         path=path,
-                        metadata=BackupUploadMetadata(
-                            backup_id=backup.backup_id,
-                            date=backup.date,
-                            homeassistant=HAVERSION,
-                            name=backup.name,
-                            protected=backup.protected,
-                            size=backup.size,
-                        ),
+                        backup=backup,
+                        homeassistant_version=HAVERSION,
                     )
                     for agent_id in agent_ids
                 ),

--- a/homeassistant/components/backup/models.py
+++ b/homeassistant/components/backup/models.py
@@ -16,15 +16,3 @@ class BaseBackup:
     def as_dict(self) -> dict:
         """Return a dict representation of this backup."""
         return asdict(self)
-
-
-@dataclass()
-class BackupUploadMetadata:
-    """Backup upload metadata."""
-
-    backup_id: str  # The ID of the backup
-    date: str  # The date the backup was created
-    homeassistant: str  # The version of Home Assistant that created the backup
-    name: str  # The name of the backup
-    protected: bool  # If the backup is protected
-    size: float  # The size of the backup (in bytes)

--- a/homeassistant/components/kitchen_sink/backup.py
+++ b/homeassistant/components/kitchen_sink/backup.py
@@ -6,11 +6,7 @@ import logging
 from pathlib import Path
 from typing import Any
 
-from homeassistant.components.backup import (
-    BackupAgent,
-    BackupUploadMetadata,
-    BaseBackup,
-)
+from homeassistant.components.backup import BackupAgent, BaseBackup
 from homeassistant.core import HomeAssistant
 
 LOGGER = logging.getLogger(__name__)
@@ -54,20 +50,13 @@ class KitchenSinkBackupAgent(BackupAgent):
         self,
         *,
         path: Path,
-        metadata: BackupUploadMetadata,
+        backup: BaseBackup,
+        homeassistant_version: str,
         **kwargs: Any,
     ) -> None:
         """Upload a backup."""
-        LOGGER.info("Uploading backup %s %s", path.name, metadata)
-        self._uploads.append(
-            BaseBackup(
-                backup_id=metadata.backup_id,
-                date=metadata.date,
-                name=metadata.name,
-                protected=metadata.protected,
-                size=metadata.size,
-            )
-        )
+        LOGGER.info("Uploading backup %s %s", path.name, backup)
+        self._uploads.append(backup)
 
     async def async_delete_backup(
         self,

--- a/tests/components/backup/common.py
+++ b/tests/components/backup/common.py
@@ -10,7 +10,6 @@ from homeassistant.components.backup import (
     DOMAIN,
     BackupAgent,
     BackupAgentPlatformProtocol,
-    BackupUploadMetadata,
     BaseBackup,
 )
 from homeassistant.components.backup.const import DATA_MANAGER
@@ -75,17 +74,12 @@ class BackupAgentTest(BackupAgent):
         self,
         *,
         path: Path,
-        metadata: BackupUploadMetadata,
+        backup: BaseBackup,
+        homeassistant_version: str,
         **kwargs: Any,
     ) -> None:
         """Upload a backup."""
-        self._backups[metadata.backup_id] = BaseBackup(
-            backup_id=metadata.backup_id,
-            date=metadata.date,
-            name=metadata.name,
-            protected=metadata.protected,
-            size=metadata.size,
-        )
+        self._backups[backup.backup_id] = backup
 
     async def async_list_backups(self, **kwargs: Any) -> list[BaseBackup]:
         """List backups."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove class `backup.BackupUploadMetadata` 

Rationale:
The `BackupUploadMetadata` class was used by `BackupManager` when calling `BackupAgent.async_upload_backup`. However, the `BackupManager` had an instance of `BaseBackup` which it packed in a `BackupUploadMetadata` instance, the `BackupAgent` would then create a `BaseBackup` from the `BackupUploadMetadata`.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
