### PR TITLE
Raise issue for deprecated imperial unit system

### DIFF
--- a/homeassistant/components/homeassistant/strings.json
+++ b/homeassistant/components/homeassistant/strings.json
@@ -10,6 +10,10 @@
       "title": "The country has not been configured",
       "description": "No country has been configured, please update the configuration by clicking on the \"learn more\" button below."
     },
+    "imperial_unit_system": {
+      "title": "The imperial unit system is deprecated",
+      "description": "The imperial unit system is deprecated and your system is currently using us customary. Please update your configuration to use the us customary unit system and reload the core configuration to fix this issue."
+    },
     "deprecated_yaml": {
       "title": "The {integration_title} YAML configuration is being removed",
       "description": "Configuring {integration_title} using YAML is being removed.\n\nYour existing YAML configuration has been imported into the UI automatically.\n\nRemove the `{domain}` configuration from your configuration.yaml file and restart Home Assistant to fix this issue."

--- a/homeassistant/core_config.py
+++ b/homeassistant/core_config.py
@@ -68,11 +68,11 @@ from .util.hass_dict import HassKey
 from .util.package import is_docker_env
 from .util.unit_system import (
     _CONF_UNIT_SYSTEM_IMPERIAL,
+    _CONF_UNIT_SYSTEM_METRIC,
     _CONF_UNIT_SYSTEM_US_CUSTOMARY,
     METRIC_SYSTEM,
     UnitSystem,
     get_unit_system,
-    validate_unit_system,
 )
 
 # Typing imports that create a circular dependency
@@ -188,6 +188,26 @@ _CUSTOMIZE_CONFIG_SCHEMA = vol.Schema(
 )
 
 
+def _raise_issue_if_imperial_unit_system(
+    hass: HomeAssistant, config: dict[str, Any]
+) -> dict[str, Any]:
+    if config.get(CONF_UNIT_SYSTEM) == _CONF_UNIT_SYSTEM_IMPERIAL:
+        ir.async_create_issue(
+            hass,
+            HOMEASSISTANT_DOMAIN,
+            "imperial_unit_system",
+            is_fixable=False,
+            learn_more_url="homeassistant://config/general",
+            severity=ir.IssueSeverity.WARNING,
+            translation_key="imperial_unit_system",
+        )
+        config[CONF_UNIT_SYSTEM] = _CONF_UNIT_SYSTEM_US_CUSTOMARY
+    else:
+        ir.async_delete_issue(hass, HOMEASSISTANT_DOMAIN, "imperial_unit_system")
+
+    return config
+
+
 def _raise_issue_if_historic_currency(hass: HomeAssistant, currency: str) -> None:
     if currency not in HISTORIC_CURRENCIES:
         ir.async_delete_issue(hass, HOMEASSISTANT_DOMAIN, "historic_currency")
@@ -249,7 +269,11 @@ CORE_CONFIG_SCHEMA = vol.All(
             CONF_ELEVATION: vol.Coerce(int),
             CONF_RADIUS: cv.positive_int,
             vol.Remove(CONF_TEMPERATURE_UNIT): cv.temperature_unit,
-            CONF_UNIT_SYSTEM: validate_unit_system,
+            CONF_UNIT_SYSTEM: vol.Any(
+                _CONF_UNIT_SYSTEM_METRIC,
+                _CONF_UNIT_SYSTEM_US_CUSTOMARY,
+                _CONF_UNIT_SYSTEM_IMPERIAL,
+            ),
             CONF_TIME_ZONE: cv.time_zone,
             vol.Optional(CONF_INTERNAL_URL): cv.url,
             vol.Optional(CONF_EXTERNAL_URL): cv.url,
@@ -332,6 +356,9 @@ async def async_process_ha_core_config(hass: HomeAssistant, config: dict) -> Non
     # CORE_CONFIG_SCHEMA is not async safe since it uses vol.IsDir
     # so we need to run it in an executor job.
     config = await hass.async_add_executor_job(CORE_CONFIG_SCHEMA, config)
+
+    # Check if we need to raise an issue for imperial unit system
+    config = _raise_issue_if_imperial_unit_system(hass, config)
 
     # Only load auth during startup.
     if not hasattr(hass, "auth"):

--- a/homeassistant/util/unit_system.py
+++ b/homeassistant/util/unit_system.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from numbers import Number
 from typing import TYPE_CHECKING, Final
 
@@ -73,6 +74,8 @@ _VALID_BY_TYPE: dict[str, set[str] | set[str | None]] = {
     PRESSURE: PRESSURE_UNITS,
     AREA: AREA_UNITS,
 }
+
+_LOGGER = logging.getLogger(__name__)
 
 
 def _is_valid_unit(unit: str, unit_type: str) -> bool:
@@ -233,7 +236,13 @@ def _deprecated_unit_system(value: str) -> str:
     """Convert deprecated unit system."""
 
     if value == _CONF_UNIT_SYSTEM_IMPERIAL:
-        # need to add warning in 2023.1
+        # Deprecated in 2024.12, to raise error in 2025.12
+        _LOGGER.warning(
+            "Your Home Assistant configuration is using the imperial unit system"
+            " which is deprecated, please replace imperial with us_customary"
+            " in your Home Assistant configuration and restart Home Assistant"
+        )
+
         return _CONF_UNIT_SYSTEM_US_CUSTOMARY
     return value
 

--- a/homeassistant/util/unit_system.py
+++ b/homeassistant/util/unit_system.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 from numbers import Number
 from typing import TYPE_CHECKING, Final
 
@@ -74,8 +73,6 @@ _VALID_BY_TYPE: dict[str, set[str] | set[str | None]] = {
     PRESSURE: PRESSURE_UNITS,
     AREA: AREA_UNITS,
 }
-
-_LOGGER = logging.getLogger(__name__)
 
 
 def _is_valid_unit(unit: str, unit_type: str) -> bool:

--- a/homeassistant/util/unit_system.py
+++ b/homeassistant/util/unit_system.py
@@ -236,13 +236,6 @@ def _deprecated_unit_system(value: str) -> str:
     """Convert deprecated unit system."""
 
     if value == _CONF_UNIT_SYSTEM_IMPERIAL:
-        # Deprecated in 2024.12, to raise error in 2025.12
-        _LOGGER.warning(
-            "Your Home Assistant configuration is using the imperial unit system"
-            " which is deprecated, please replace imperial with us_customary"
-            " in your Home Assistant configuration and restart Home Assistant"
-        )
-
         return _CONF_UNIT_SYSTEM_US_CUSTOMARY
     return value
 

--- a/tests/test_core_config.py
+++ b/tests/test_core_config.py
@@ -1080,3 +1080,27 @@ async def test_set_time_zone_deprecated(hass: HomeAssistant) -> None:
         ),
     ):
         await hass.config.set_time_zone("America/New_York")
+
+
+async def test_core_config_schema_imperial_unit(
+    hass: HomeAssistant, issue_registry: ir.IssueRegistry
+) -> None:
+    """Test core config schema."""
+    await async_process_ha_core_config(
+        hass,
+        {
+            "latitude": 60,
+            "longitude": 50,
+            "elevation": 25,
+            "name": "Home",
+            "unit_system": "imperial",
+            "time_zone": "America/New_York",
+            "currency": "USD",
+            "country": "US",
+            "language": "en",
+            "radius": 150,
+        },
+    )
+
+    issue = issue_registry.async_get_issue("homeassistant", "imperial_unit_system")
+    assert issue

--- a/tests/util/test_unit_system.py
+++ b/tests/util/test_unit_system.py
@@ -911,9 +911,3 @@ async def test_imperial_deprecated_log_warning(
     assert hass.config.country == "US"
     assert hass.config.language == "en"
     assert hass.config.radius == 150
-
-    assert (
-        "Your Home Assistant configuration is using the imperial unit system"
-        " which is deprecated, please replace imperial with us_customary"
-        " in your Home Assistant configuration and restart Home Assistant"
-    ) in caplog.text

--- a/tests/util/test_unit_system.py
+++ b/tests/util/test_unit_system.py
@@ -24,6 +24,8 @@ from homeassistant.const import (
     UnitOfVolume,
     UnitOfVolumetricFlux,
 )
+from homeassistant.core import HomeAssistant
+from homeassistant.core_config import async_process_ha_core_config
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.util.unit_system import (  # pylint: disable=hass-deprecated-import
     _CONF_UNIT_SYSTEM_IMPERIAL,
@@ -877,3 +879,41 @@ def test_imperial_converted_units(device_class: SensorDeviceClass) -> None:
             assert (device_class, unit) not in unit_system._conversions
             continue
         assert (device_class, unit) in unit_system._conversions
+
+
+async def test_imperial_deprecated_log_warning(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test deprecated imperial unit system logs warning."""
+    await async_process_ha_core_config(
+        hass,
+        {
+            "latitude": 60,
+            "longitude": 50,
+            "elevation": 25,
+            "name": "Home",
+            "unit_system": "imperial",
+            "time_zone": "America/New_York",
+            "currency": "USD",
+            "country": "US",
+            "language": "en",
+            "radius": 150,
+        },
+    )
+
+    assert hass.config.latitude == 60
+    assert hass.config.longitude == 50
+    assert hass.config.elevation == 25
+    assert hass.config.location_name == "Home"
+    assert hass.config.units is US_CUSTOMARY_SYSTEM
+    assert hass.config.time_zone == "America/New_York"
+    assert hass.config.currency == "USD"
+    assert hass.config.country == "US"
+    assert hass.config.language == "en"
+    assert hass.config.radius == 150
+
+    assert (
+        "Your Home Assistant configuration is using the imperial unit system"
+        " which is deprecated, please replace imperial with us_customary"
+        " in your Home Assistant configuration and restart Home Assistant"
+    ) in caplog.text


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds a deprecation warning if people has `imperial` as the unit system.
Deprecation was introduced in #80253

Alternatively as this is pushing 2 years, we could consider to just remove it and fail?

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 