### PR TITLE
Add consistent descriptions to turn on / off and toggle commands

### DIFF
--- a/homeassistant/components/remote/strings.json
+++ b/homeassistant/components/remote/strings.json
@@ -28,7 +28,7 @@
   "services": {
     "turn_on": {
       "name": "[%key:common::action::turn_on%]",
-      "description": "Sends the turn on command to a device.",
+      "description": "Sends the turn on command.",
       "fields": {
         "activity": {
           "name": "Activity",
@@ -38,11 +38,11 @@
     },
     "toggle": {
       "name": "[%key:common::action::toggle%]",
-      "description": "Sends the turn on or turn off command to toggle a device."
+      "description": "Sends the toggle command."
     },
     "turn_off": {
       "name": "[%key:common::action::turn_off%]",
-      "description": "Sends the turn off command to a device."
+      "description": "Sends the turn off command."
     },
     "send_command": {
       "name": "Send command",

--- a/homeassistant/components/remote/strings.json
+++ b/homeassistant/components/remote/strings.json
@@ -28,7 +28,7 @@
   "services": {
     "turn_on": {
       "name": "[%key:common::action::turn_on%]",
-      "description": "Sends the power on command.",
+      "description": "Sends the turn on command to a device.",
       "fields": {
         "activity": {
           "name": "Activity",
@@ -38,11 +38,11 @@
     },
     "toggle": {
       "name": "[%key:common::action::toggle%]",
-      "description": "Toggles a device on/off."
+      "description": "Sends the toggle command to a device to turn it on or off."
     },
     "turn_off": {
       "name": "[%key:common::action::turn_off%]",
-      "description": "Turns the device off."
+      "description": "Sends the turn off command to a device."
     },
     "send_command": {
       "name": "Send command",

--- a/homeassistant/components/remote/strings.json
+++ b/homeassistant/components/remote/strings.json
@@ -38,7 +38,7 @@
     },
     "toggle": {
       "name": "[%key:common::action::toggle%]",
-      "description": "Sends the toggle command to a device to turn it on or off."
+      "description": "Sends the turn on or turn off command to toggle a device."
     },
     "turn_off": {
       "name": "[%key:common::action::turn_off%]",


### PR DESCRIPTION
Currently these three commands have very inconsistent descriptions that make it hard to translate them without creating even more inconsistencies:

- Sends the power on command.
- Turns the device off.
- Toggles a device on/off.

These don't all match the actual action names and the documentation, too.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Make all three descriptions use a consistent wording that matches that of other device types:

- Sends the turn on command to a device.
- Sends the turn off command to a device.
- Sends the toggle command to a device to turn it on or off.

This makes it much easier to create consistent translations, too.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #130943 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
