### PR TITLE
Add button platform to sabnzbd and deprecate custom actions

### DIFF
--- a/homeassistant/components/sabnzbd/__init__.py
+++ b/homeassistant/components/sabnzbd/__init__.py
@@ -22,6 +22,7 @@ from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
 from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.helpers.entity_registry import RegistryEntry, async_migrate_entries
+import homeassistant.helpers.issue_registry as ir
 from homeassistant.helpers.typing import ConfigType
 
 from .const import (
@@ -41,7 +42,7 @@ from .coordinator import SabnzbdUpdateCoordinator
 from .sab import get_client
 from .sensor import OLD_SENSOR_KEYS
 
-PLATFORMS = [Platform.SENSOR]
+PLATFORMS = [Platform.BUTTON, Platform.SENSOR]
 _LOGGER = logging.getLogger(__name__)
 
 SERVICES = (
@@ -204,12 +205,30 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     async def async_pause_queue(
         call: ServiceCall, coordinator: SabnzbdUpdateCoordinator
     ) -> None:
+        ir.async_create_issue(
+            hass,
+            DOMAIN,
+            "pause_action_deprecated",
+            is_fixable=False,
+            severity=ir.IssueSeverity.WARNING,
+            breaks_in_ha_version="2025.6",
+            translation_key="pause_action_deprecated",
+        )
         await coordinator.sab_api.pause_queue()
 
     @extract_api
     async def async_resume_queue(
         call: ServiceCall, coordinator: SabnzbdUpdateCoordinator
     ) -> None:
+        ir.async_create_issue(
+            hass,
+            DOMAIN,
+            "resume_action_deprecated",
+            is_fixable=False,
+            severity=ir.IssueSeverity.WARNING,
+            breaks_in_ha_version="2025.6",
+            translation_key="resume_action_deprecated",
+        )
         await coordinator.sab_api.resume_queue()
 
     @extract_api

--- a/homeassistant/components/sabnzbd/button.py
+++ b/homeassistant/components/sabnzbd/button.py
@@ -1,0 +1,69 @@
+"""Button platform for the SABnzbd component."""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from pysabnzbd import SabnzbdApiException
+
+from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import SabnzbdUpdateCoordinator
+from .const import DOMAIN
+from .entity import SabnzbdEntity
+
+
+@dataclass(kw_only=True, frozen=True)
+class SabnzbdButtonEntityDescription(ButtonEntityDescription):
+    """Describes SABnzbd button entity."""
+
+    press_fn: Callable[[SabnzbdUpdateCoordinator], Any]
+
+
+BUTTON_DESCRIPTIONS: tuple[SabnzbdButtonEntityDescription, ...] = (
+    SabnzbdButtonEntityDescription(
+        key="pause",
+        translation_key="pause",
+        press_fn=lambda coordinator: coordinator.sab_api.pause_queue(),
+    ),
+    SabnzbdButtonEntityDescription(
+        key="resume",
+        translation_key="resume",
+        press_fn=lambda coordinator: coordinator.sab_api.resume_queue(),
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up buttons from a config entry."""
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+
+    async_add_entities(
+        SabnzbdButton(coordinator, description) for description in BUTTON_DESCRIPTIONS
+    )
+
+
+class SabnzbdButton(SabnzbdEntity, ButtonEntity):
+    """Representation of a SABnzbd button."""
+
+    entity_description: SabnzbdButtonEntityDescription
+
+    async def async_press(self) -> None:
+        """Handle the button press."""
+        try:
+            await self.entity_description.press_fn(self.coordinator)
+        except SabnzbdApiException as e:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="service_call_exception",
+            ) from e
+        else:
+            await self.coordinator.async_request_refresh()

--- a/homeassistant/components/sabnzbd/icons.json
+++ b/homeassistant/components/sabnzbd/icons.json
@@ -1,4 +1,14 @@
 {
+  "entity": {
+    "button": {
+      "pause": {
+        "default": "mdi:pause"
+      },
+      "resume": {
+        "default": "mdi:play"
+      }
+    }
+  },
   "services": {
     "pause": {
       "service": "mdi:pause"

--- a/homeassistant/components/sabnzbd/strings.json
+++ b/homeassistant/components/sabnzbd/strings.json
@@ -18,6 +18,14 @@
     }
   },
   "entity": {
+    "button": {
+      "pause": {
+        "name": "[%key:common::action::pause%]"
+      },
+      "resume": {
+        "name": "[%key:component::sabnzbd::services::resume::name%]"
+      }
+    },
     "sensor": {
       "status": {
         "name": "Status"
@@ -88,6 +96,21 @@
           "description": "Speed limit. If specified as a number with no units, will be interpreted as a percent. If units are provided (e.g., 500K) will be interpreted absolutely."
         }
       }
+    }
+  },
+  "issues": {
+    "pause_action_deprecated": {
+      "title": "SABnzbd pause action deprecated",
+      "description": "The 'Pause' action is deprecated and will be removed in a future version. Please use the 'Pause' button instead. To remove this issue, please adjust automations accordingly and restart Home Assistant."
+    },
+    "resume_action_deprecated": {
+      "title": "SABnzbd resume action deprecated",
+      "description": "The 'Resume' action is deprecated and will be removed in a future version. Please use the 'Resume' button instead. To remove this issue, please adjust automations accordingly and restart Home Assistant."
+    }
+  },
+  "exceptions": {
+    "service_call_exception": {
+      "message": "Unable to send command to SABnzbd due to a connection error, try again later"
     }
   }
 }

--- a/tests/components/sabnzbd/conftest.py
+++ b/tests/components/sabnzbd/conftest.py
@@ -35,9 +35,9 @@ def mock_sabnzbd() -> Generator[AsyncMock]:
 
 
 @pytest.fixture(name="config_entry")
-async def mock_config_entry(hass: HomeAssistant) -> MockConfigEntry:
+async def mock_config_entry(hass: HomeAssistant, sabnzbd: AsyncMock) -> MockConfigEntry:
     """Return a MockConfigEntry for testing."""
-    return MockConfigEntry(
+    config_entry = MockConfigEntry(
         domain=DOMAIN,
         title="Sabnzbd",
         entry_id="01JD2YVVPBC62D620DGYNG2R8H",
@@ -47,6 +47,9 @@ async def mock_config_entry(hass: HomeAssistant) -> MockConfigEntry:
             CONF_URL: "http://localhost:8080",
         },
     )
+    config_entry.add_to_hass(hass)
+
+    return config_entry
 
 
 @pytest.fixture(name="setup_integration")
@@ -54,7 +57,5 @@ async def mock_setup_integration(
     hass: HomeAssistant, config_entry: MockConfigEntry, sabnzbd: AsyncMock
 ) -> None:
     """Fixture for setting up the component."""
-    config_entry.add_to_hass(hass)
-
     assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()

--- a/tests/components/sabnzbd/snapshots/test_button.ambr
+++ b/tests/components/sabnzbd/snapshots/test_button.ambr
@@ -1,0 +1,93 @@
+# serializer version: 1
+# name: test_button_setup[button.sabnzbd_pause-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': None,
+    'entity_id': 'button.sabnzbd_pause',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Pause',
+    'platform': 'sabnzbd',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'pause',
+    'unique_id': '01JD2YVVPBC62D620DGYNG2R8H_pause',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_button_setup[button.sabnzbd_pause-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Sabnzbd Pause',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.sabnzbd_pause',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_button_setup[button.sabnzbd_resume-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': None,
+    'entity_id': 'button.sabnzbd_resume',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Resume',
+    'platform': 'sabnzbd',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'resume',
+    'unique_id': '01JD2YVVPBC62D620DGYNG2R8H_resume',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_button_setup[button.sabnzbd_resume-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Sabnzbd Resume',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.sabnzbd_resume',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---

--- a/tests/components/sabnzbd/test_button.py
+++ b/tests/components/sabnzbd/test_button.py
@@ -1,0 +1,116 @@
+"""Button tests for the SABnzbd component."""
+
+from datetime import timedelta
+from unittest.mock import AsyncMock, patch
+
+from freezegun.api import FrozenDateTimeFactory
+from pysabnzbd import SabnzbdApiException
+import pytest
+from syrupy import SnapshotAssertion
+
+from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+    Platform,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry as er
+
+from tests.common import MockConfigEntry, async_fire_time_changed, snapshot_platform
+
+
+@patch("homeassistant.components.sabnzbd.PLATFORMS", [Platform.BUTTON])
+async def test_button_setup(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    config_entry: MockConfigEntry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test button setup."""
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await snapshot_platform(hass, entity_registry, snapshot, config_entry.entry_id)
+
+
+@pytest.mark.parametrize(
+    ("button", "called_function"),
+    [("resume", "resume_queue"), ("pause", "pause_queue")],
+)
+@pytest.mark.usefixtures("setup_integration")
+async def test_button_presses(
+    hass: HomeAssistant,
+    sabnzbd: AsyncMock,
+    button: str,
+    called_function: str,
+) -> None:
+    """Test the sabnzbd button presses."""
+    await hass.services.async_call(
+        BUTTON_DOMAIN,
+        SERVICE_PRESS,
+        {
+            ATTR_ENTITY_ID: f"button.sabnzbd_{button}",
+        },
+        blocking=True,
+    )
+
+    function = getattr(sabnzbd, called_function)
+    function.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    ("button", "called_function"),
+    [("resume", "resume_queue"), ("pause", "pause_queue")],
+)
+@pytest.mark.usefixtures("setup_integration")
+async def test_buttons_exception(
+    hass: HomeAssistant,
+    sabnzbd: AsyncMock,
+    button: str,
+    called_function: str,
+) -> None:
+    """Test the button handles errors."""
+    function = getattr(sabnzbd, called_function)
+    function.side_effect = SabnzbdApiException("Boom")
+
+    with pytest.raises(
+        HomeAssistantError,
+        match="Unable to send command to SABnzbd due to a connection error, try again later",
+    ):
+        await hass.services.async_call(
+            BUTTON_DOMAIN,
+            SERVICE_PRESS,
+            {
+                ATTR_ENTITY_ID: f"button.sabnzbd_{button}",
+            },
+            blocking=True,
+        )
+
+    function.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "button",
+    ["resume", "pause"],
+)
+@pytest.mark.usefixtures("setup_integration")
+async def test_buttons_unavailable(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    sabnzbd: AsyncMock,
+    button: str,
+) -> None:
+    """Test the button is unavailable when coordinator can't update data."""
+    state = hass.states.get(f"button.sabnzbd_{button}")
+    assert state
+    assert state.state == STATE_UNKNOWN
+
+    sabnzbd.refresh_data.side_effect = Exception("Boom")
+    freezer.tick(timedelta(minutes=10))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(f"button.sabnzbd_{button}")
+    assert state
+    assert state.state == STATE_UNAVAILABLE

--- a/tests/components/sabnzbd/test_sensor.py
+++ b/tests/components/sabnzbd/test_sensor.py
@@ -1,15 +1,19 @@
 """Sensor tests for the Sabnzbd component."""
 
+from unittest.mock import patch
+
 import pytest
 from syrupy import SnapshotAssertion
 
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from tests.common import MockConfigEntry, snapshot_platform
 
 
-@pytest.mark.usefixtures("entity_registry_enabled_by_default", "setup_integration")
+@patch("homeassistant.components.sabnzbd.PLATFORMS", [Platform.SENSOR])
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_sensor(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
@@ -17,4 +21,5 @@ async def test_sensor(
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test sensor setup."""
+    await hass.config_entries.async_setup(config_entry.entry_id)
     await snapshot_platform(hass, entity_registry, snapshot, config_entry.entry_id)


### PR DESCRIPTION
## Proposed change
Add the button platform to sabnzbd. This adds a "pause" and "resume" button entity that replaces the custom actions. 

The deprecated custom "pause" and "resume" actions now create a issue upon use and informs the user about the deprecation and the new button entities. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/35834

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
