### PR TITLE
Refactor calendars in Habitica

### DIFF
--- a/homeassistant/components/habitica/calendar.py
+++ b/homeassistant/components/habitica/calendar.py
@@ -60,6 +60,43 @@ class HabiticaCalendarEntity(HabiticaBase, CalendarEntity):
         """Initialize calendar entity."""
         super().__init__(coordinator, self.entity_description)
 
+    def get_events(
+        self, start_date: datetime, end_date: datetime | None = None
+    ) -> list[CalendarEvent]:
+        """Implement in calendar entities."""
+        raise NotImplementedError
+
+    @property
+    def event(self) -> CalendarEvent | None:
+        """Return the current or next upcoming event."""
+
+        return next(iter(self.get_events(dt_util.now())), None)
+
+    async def async_get_events(
+        self, hass: HomeAssistant, start_date: datetime, end_date: datetime
+    ) -> list[CalendarEvent]:
+        """Return calendar events within a datetime range."""
+
+        return self.get_events(start_date, end_date)
+
+    @property
+    def today(self) -> datetime:
+        """Habitica daystart."""
+        return dt_util.start_of_local_day(
+            datetime.fromisoformat(self.coordinator.data.user["lastCron"])
+        )
+
+    def get_recurrence_dates(
+        self, recurrences: rrule, start_date: datetime, end_date: datetime | None = None
+    ) -> list[datetime]:
+        """Calculate recurrence dates based on start_date and end_date."""
+        if end_date:
+            return recurrences.between(
+                start_date, end_date - timedelta(days=1), inc=True
+            )
+        # if no end_date is given, return only the next recurrence
+        return [recurrences.after(self.today, inc=True)]
+
 
 class HabiticaTodosCalendarEntity(HabiticaCalendarEntity):
     """Habitica todos calendar entity."""
@@ -69,7 +106,7 @@ class HabiticaTodosCalendarEntity(HabiticaCalendarEntity):
         translation_key=HabiticaCalendar.TODOS,
     )
 
-    def dated_todos(
+    def get_events(
         self, start_date: datetime, end_date: datetime | None = None
     ) -> list[CalendarEvent]:
         """Get all dated todos."""
@@ -112,18 +149,6 @@ class HabiticaTodosCalendarEntity(HabiticaCalendarEntity):
             ),
         )
 
-    @property
-    def event(self) -> CalendarEvent | None:
-        """Return the current or next upcoming event."""
-
-        return next(iter(self.dated_todos(dt_util.now())), None)
-
-    async def async_get_events(
-        self, hass: HomeAssistant, start_date: datetime, end_date: datetime
-    ) -> list[CalendarEvent]:
-        """Return calendar events within a datetime range."""
-        return self.dated_todos(start_date, end_date)
-
 
 class HabiticaDailiesCalendarEntity(HabiticaCalendarEntity):
     """Habitica dailies calendar entity."""
@@ -132,13 +157,6 @@ class HabiticaDailiesCalendarEntity(HabiticaCalendarEntity):
         key=HabiticaCalendar.DAILIES,
         translation_key=HabiticaCalendar.DAILIES,
     )
-
-    @property
-    def today(self) -> datetime:
-        """Habitica daystart."""
-        return dt_util.start_of_local_day(
-            datetime.fromisoformat(self.coordinator.data.user["lastCron"])
-        )
 
     def end_date(self, recurrence: datetime, end: datetime | None = None) -> date:
         """Calculate the end date for a yesterdaily.
@@ -155,18 +173,7 @@ class HabiticaDailiesCalendarEntity(HabiticaCalendarEntity):
             dt_util.start_of_local_day() if recurrence == self.today else recurrence
         ).date() + timedelta(days=1)
 
-    def get_recurrence_dates(
-        self, recurrences: rrule, start_date: datetime, end_date: datetime | None = None
-    ) -> list[datetime]:
-        """Calculate recurrence dates based on start_date and end_date."""
-        if end_date:
-            return recurrences.between(
-                start_date, end_date - timedelta(days=1), inc=True
-            )
-        # if no end_date is given, return only the next recurrence
-        return [recurrences.after(self.today, inc=True)]
-
-    def due_dailies(
+    def get_events(
         self, start_date: datetime, end_date: datetime | None = None
     ) -> list[CalendarEvent]:
         """Get dailies and recurrences for a given period or the next upcoming."""
@@ -190,7 +197,7 @@ class HabiticaDailiesCalendarEntity(HabiticaCalendarEntity):
                 is_future_event = recurrence > self.today
                 is_current_event = recurrence <= self.today and not task["completed"]
 
-                if not (is_future_event or is_current_event):
+                if not is_future_event and not is_current_event:
                     continue
 
                 events.append(
@@ -214,14 +221,7 @@ class HabiticaDailiesCalendarEntity(HabiticaCalendarEntity):
     @property
     def event(self) -> CalendarEvent | None:
         """Return the next upcoming event."""
-        return next(iter(self.due_dailies(self.today)), None)
-
-    async def async_get_events(
-        self, hass: HomeAssistant, start_date: datetime, end_date: datetime
-    ) -> list[CalendarEvent]:
-        """Return calendar events within a datetime range."""
-
-        return self.due_dailies(start_date, end_date)
+        return next(iter(self.get_events(self.today)), None)
 
     @property
     def extra_state_attributes(self) -> dict[str, bool | None] | None:
@@ -239,7 +239,7 @@ class HabiticaTodoRemindersCalendarEntity(HabiticaCalendarEntity):
         translation_key=HabiticaCalendar.TODO_REMINDERS,
     )
 
-    def reminders(
+    def get_events(
         self, start_date: datetime, end_date: datetime | None = None
     ) -> list[CalendarEvent]:
         """Reminders for todos."""
@@ -282,18 +282,6 @@ class HabiticaTodoRemindersCalendarEntity(HabiticaCalendarEntity):
             key=lambda event: event.start,
         )
 
-    @property
-    def event(self) -> CalendarEvent | None:
-        """Return the next upcoming event."""
-        return next(iter(self.reminders(dt_util.now())), None)
-
-    async def async_get_events(
-        self, hass: HomeAssistant, start_date: datetime, end_date: datetime
-    ) -> list[CalendarEvent]:
-        """Return calendar events within a datetime range."""
-
-        return self.reminders(start_date, end_date)
-
 
 class HabiticaDailyRemindersCalendarEntity(HabiticaCalendarEntity):
     """Habitica daily reminders calendar entity."""
@@ -321,25 +309,7 @@ class HabiticaDailyRemindersCalendarEntity(HabiticaCalendarEntity):
             tzinfo=dt_util.DEFAULT_TIME_ZONE,
         )
 
-    @property
-    def today(self) -> datetime:
-        """Habitica daystart."""
-        return dt_util.start_of_local_day(
-            datetime.fromisoformat(self.coordinator.data.user["lastCron"])
-        )
-
-    def get_recurrence_dates(
-        self, recurrences: rrule, start_date: datetime, end_date: datetime | None = None
-    ) -> list[datetime]:
-        """Calculate recurrence dates based on start_date and end_date."""
-        if end_date:
-            return recurrences.between(
-                start_date, end_date - timedelta(days=1), inc=True
-            )
-        # if no end_date is given, return only the next recurrence
-        return [recurrences.after(self.today, inc=True)]
-
-    def reminders(
+    def get_events(
         self, start_date: datetime, end_date: datetime | None = None
     ) -> list[CalendarEvent]:
         """Reminders for dailies."""
@@ -388,15 +358,3 @@ class HabiticaDailyRemindersCalendarEntity(HabiticaCalendarEntity):
             events,
             key=lambda event: event.start,
         )
-
-    @property
-    def event(self) -> CalendarEvent | None:
-        """Return the next upcoming event."""
-        return next(iter(self.reminders(dt_util.now())), None)
-
-    async def async_get_events(
-        self, hass: HomeAssistant, start_date: datetime, end_date: datetime
-    ) -> list[CalendarEvent]:
-        """Return calendar events within a datetime range."""
-
-        return self.reminders(start_date, end_date)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Refactoring of calendars to reduce code repetition

- `event` property and  `async_get_events` method implemented in common parent class and removed in child classes.
- Renamed methods to retrieve events to `get_events` to allow use from `event` and `async_get_events` in parent class
- identical `today` properties in `HabiticaDailiesCalendarEntity` and `HabiticaDailyRemindersCalendarEntity` merged in parent class
- identical `get_recurrence_dates` methods in `HabiticaDailiesCalendarEntity` and `HabiticaDailyRemindersCalendarEntity` merged in parent class  

This is a follow-up PR to #130789

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #130789
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
