### PR TITLE
Add number platform to sabnzbd and deprecate custom action

### DIFF
--- a/homeassistant/components/sabnzbd/__init__.py
+++ b/homeassistant/components/sabnzbd/__init__.py
@@ -42,7 +42,7 @@ from .coordinator import SabnzbdUpdateCoordinator
 from .sab import get_client
 from .sensor import OLD_SENSOR_KEYS
 
-PLATFORMS = [Platform.BUTTON, Platform.SENSOR]
+PLATFORMS = [Platform.BUTTON, Platform.NUMBER, Platform.SENSOR]
 _LOGGER = logging.getLogger(__name__)
 
 SERVICES = (
@@ -235,6 +235,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     async def async_set_queue_speed(
         call: ServiceCall, coordinator: SabnzbdUpdateCoordinator
     ) -> None:
+        ir.async_create_issue(
+            hass,
+            DOMAIN,
+            "set_speed_action_deprecated",
+            is_fixable=False,
+            severity=ir.IssueSeverity.WARNING,
+            breaks_in_ha_version="2025.6",
+            translation_key="set_speed_action_deprecated",
+        )
         speed = call.data.get(ATTR_SPEED)
         await coordinator.sab_api.set_speed_limit(speed)
 

--- a/homeassistant/components/sabnzbd/icons.json
+++ b/homeassistant/components/sabnzbd/icons.json
@@ -6,6 +6,9 @@
       },
       "resume": {
         "default": "mdi:play"
+      },
+      "speedlimit": {
+        "default": "mdi:speedometer"
       }
     }
   },

--- a/homeassistant/components/sabnzbd/number.py
+++ b/homeassistant/components/sabnzbd/number.py
@@ -34,7 +34,6 @@ NUMBER_DESCRIPTIONS: tuple[SabnzbdNumberEntityDescription, ...] = (
     SabnzbdNumberEntityDescription(
         key="speedlimit",
         translation_key="speedlimit",
-        icon="mdi:speedometer",
         mode=NumberMode.BOX,
         native_max_value=100,
         native_min_value=0,

--- a/homeassistant/components/sabnzbd/number.py
+++ b/homeassistant/components/sabnzbd/number.py
@@ -1,0 +1,83 @@
+"""Number entities for the SABnzbd integration."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+
+from pysabnzbd import SabnzbdApiException
+
+from homeassistant.components.number import (
+    NumberEntity,
+    NumberEntityDescription,
+    NumberMode,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import PERCENTAGE
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .coordinator import SabnzbdUpdateCoordinator
+from .entity import SabnzbdEntity
+
+
+@dataclass(frozen=True, kw_only=True)
+class SabnzbdNumberEntityDescription(NumberEntityDescription):
+    """Class describing a SABnzbd number entities."""
+
+    set_fn: Callable[[SabnzbdUpdateCoordinator, float], Awaitable]
+
+
+NUMBER_DESCRIPTIONS: tuple[SabnzbdNumberEntityDescription, ...] = (
+    SabnzbdNumberEntityDescription(
+        key="speedlimit",
+        translation_key="speedlimit",
+        icon="mdi:speedometer",
+        mode=NumberMode.BOX,
+        native_max_value=100,
+        native_min_value=0,
+        native_step=1,
+        native_unit_of_measurement=PERCENTAGE,
+        set_fn=lambda coordinator, speed: (
+            coordinator.sab_api.set_speed_limit(int(speed))
+        ),
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the SABnzbd number entity."""
+    coordinator = hass.data[DOMAIN][config_entry.entry_id]
+
+    async_add_entities(
+        SabnzbdNumber(coordinator, description) for description in NUMBER_DESCRIPTIONS
+    )
+
+
+class SabnzbdNumber(SabnzbdEntity, NumberEntity):
+    """Representation of a SABnzbd number."""
+
+    entity_description: SabnzbdNumberEntityDescription
+
+    @property
+    def native_value(self) -> float:
+        """Return latest value for number."""
+        return self.coordinator.data[self.entity_description.key]
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set the new number value."""
+        try:
+            await self.entity_description.set_fn(self.coordinator, value)
+        except SabnzbdApiException as e:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="service_call_exception",
+            ) from e
+        else:
+            await self.coordinator.async_request_refresh()

--- a/homeassistant/components/sabnzbd/strings.json
+++ b/homeassistant/components/sabnzbd/strings.json
@@ -26,6 +26,11 @@
         "name": "[%key:component::sabnzbd::services::resume::name%]"
       }
     },
+    "number": {
+      "speedlimit": {
+        "name": "Speedlimit"
+      }
+    },
     "sensor": {
       "status": {
         "name": "Status"
@@ -106,6 +111,10 @@
     "resume_action_deprecated": {
       "title": "SABnzbd resume action deprecated",
       "description": "The 'Resume' action is deprecated and will be removed in a future version. Please use the 'Resume' button instead. To remove this issue, please adjust automations accordingly and restart Home Assistant."
+    },
+    "set_speed_action_deprecated": {
+      "title": "SABnzbd set_speed action deprecated",
+      "description": "The 'Set speed' action is deprecated and will be removed in a future version. Please use the 'Speedlimit' number entity instead. To remove this issue, please adjust automations accordingly and restart Home Assistant."
     }
   },
   "exceptions": {

--- a/tests/components/sabnzbd/snapshots/test_number.ambr
+++ b/tests/components/sabnzbd/snapshots/test_number.ambr
@@ -1,0 +1,58 @@
+# serializer version: 1
+# name: test_number_setup[number.sabnzbd_speedlimit-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'max': 100,
+      'min': 0,
+      'mode': <NumberMode.BOX: 'box'>,
+      'step': 1,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': None,
+    'entity_id': 'number.sabnzbd_speedlimit',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:speedometer',
+    'original_name': 'Speedlimit',
+    'platform': 'sabnzbd',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'speedlimit',
+    'unique_id': '01JD2YVVPBC62D620DGYNG2R8H_speedlimit',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_number_setup[number.sabnzbd_speedlimit-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Sabnzbd Speedlimit',
+      'icon': 'mdi:speedometer',
+      'max': 100,
+      'min': 0,
+      'mode': <NumberMode.BOX: 'box'>,
+      'step': 1,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.sabnzbd_speedlimit',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '85',
+  })
+# ---

--- a/tests/components/sabnzbd/snapshots/test_number.ambr
+++ b/tests/components/sabnzbd/snapshots/test_number.ambr
@@ -27,7 +27,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:speedometer',
+    'original_icon': None,
     'original_name': 'Speedlimit',
     'platform': 'sabnzbd',
     'previous_unique_id': None,
@@ -41,7 +41,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Sabnzbd Speedlimit',
-      'icon': 'mdi:speedometer',
       'max': 100,
       'min': 0,
       'mode': <NumberMode.BOX: 'box'>,

--- a/tests/components/sabnzbd/test_init.py
+++ b/tests/components/sabnzbd/test_init.py
@@ -11,6 +11,7 @@ from homeassistant.components.sabnzbd import (
     OLD_SENSOR_KEYS,
     SERVICE_PAUSE,
     SERVICE_RESUME,
+    SERVICE_SET_SPEED,
 )
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.const import CONF_API_KEY, CONF_NAME, CONF_URL
@@ -95,6 +96,7 @@ async def test_unique_id_migrate(
     [
         (SERVICE_RESUME, "resume_action_deprecated"),
         (SERVICE_PAUSE, "pause_action_deprecated"),
+        (SERVICE_SET_SPEED, "set_speed_action_deprecated"),
     ],
 )
 @pytest.mark.usefixtures("setup_integration")

--- a/tests/components/sabnzbd/test_number.py
+++ b/tests/components/sabnzbd/test_number.py
@@ -48,7 +48,7 @@ async def test_number_set(
     called_function: str,
     expected_state: str,
 ) -> None:
-    """Test the sabnzbd button presses."""
+    """Test the sabnzbd number set."""
     await hass.services.async_call(
         NUMBER_DOMAIN,
         SERVICE_SET_VALUE,
@@ -75,7 +75,7 @@ async def test_number_exception(
     input_number: float,
     called_function: str,
 ) -> None:
-    """Test the button handles errors."""
+    """Test the number entity handles errors."""
     function = getattr(sabnzbd, called_function)
     function.side_effect = SabnzbdApiException("Boom")
 

--- a/tests/components/sabnzbd/test_number.py
+++ b/tests/components/sabnzbd/test_number.py
@@ -1,0 +1,123 @@
+"""Number tests for the SABnzbd component."""
+
+from datetime import timedelta
+from unittest.mock import AsyncMock, patch
+
+from freezegun.api import FrozenDateTimeFactory
+from pysabnzbd import SabnzbdApiException
+import pytest
+from syrupy import SnapshotAssertion
+
+from homeassistant.components.number import (
+    ATTR_VALUE,
+    DOMAIN as NUMBER_DOMAIN,
+    SERVICE_SET_VALUE,
+)
+from homeassistant.const import ATTR_ENTITY_ID, STATE_UNAVAILABLE, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry as er
+
+from tests.common import MockConfigEntry, async_fire_time_changed, snapshot_platform
+
+
+@patch("homeassistant.components.sabnzbd.PLATFORMS", [Platform.NUMBER])
+async def test_number_setup(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    config_entry: MockConfigEntry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test number setup."""
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await snapshot_platform(hass, entity_registry, snapshot, config_entry.entry_id)
+
+
+@pytest.mark.parametrize(
+    ("number", "input_number", "called_function", "expected_state"),
+    [
+        ("speedlimit", 50.0, "set_speed_limit", 50),
+    ],
+)
+@pytest.mark.usefixtures("setup_integration")
+async def test_number_set(
+    hass: HomeAssistant,
+    sabnzbd: AsyncMock,
+    number: str,
+    input_number: float,
+    called_function: str,
+    expected_state: str,
+) -> None:
+    """Test the sabnzbd button presses."""
+    await hass.services.async_call(
+        NUMBER_DOMAIN,
+        SERVICE_SET_VALUE,
+        {
+            ATTR_VALUE: input_number,
+            ATTR_ENTITY_ID: f"number.sabnzbd_{number}",
+        },
+        blocking=True,
+    )
+
+    function = getattr(sabnzbd, called_function)
+    function.assert_called_with(int(input_number))
+
+
+@pytest.mark.parametrize(
+    ("number", "input_number", "called_function"),
+    [("speedlimit", 55.0, "set_speed_limit")],
+)
+@pytest.mark.usefixtures("setup_integration")
+async def test_number_exception(
+    hass: HomeAssistant,
+    sabnzbd: AsyncMock,
+    number: str,
+    input_number: float,
+    called_function: str,
+) -> None:
+    """Test the button handles errors."""
+    function = getattr(sabnzbd, called_function)
+    function.side_effect = SabnzbdApiException("Boom")
+
+    with pytest.raises(
+        HomeAssistantError,
+        match="Unable to send command to SABnzbd due to a connection error, try again later",
+    ):
+        await hass.services.async_call(
+            NUMBER_DOMAIN,
+            SERVICE_SET_VALUE,
+            {
+                ATTR_VALUE: input_number,
+                ATTR_ENTITY_ID: f"number.sabnzbd_{number}",
+            },
+            blocking=True,
+        )
+
+    function.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    ("number", "initial_state"),
+    [("speedlimit", "85")],
+)
+@pytest.mark.usefixtures("setup_integration")
+async def test_number_unavailable(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    sabnzbd: AsyncMock,
+    number: str,
+    initial_state: str,
+) -> None:
+    """Test the number is unavailable when coordinator can't update data."""
+    state = hass.states.get(f"number.sabnzbd_{number}")
+    assert state
+    assert state.state == initial_state
+
+    sabnzbd.refresh_data.side_effect = Exception("Boom")
+    freezer.tick(timedelta(minutes=10))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(f"number.sabnzbd_{number}")
+    assert state
+    assert state.state == STATE_UNAVAILABLE


### PR DESCRIPTION
## Proposed change
Add number platform to sabnzbd, which adds a entity for setting the download speedlimit in percentage. Also deprecate the custom action for that.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/35846

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
