### PR TITLE
Use ConfigEntry runtime_data in P1 Monitor

### DIFF
--- a/homeassistant/components/p1_monitor/__init__.py
+++ b/homeassistant/components/p1_monitor/__init__.py
@@ -7,10 +7,12 @@ from homeassistant.const import CONF_HOST, CONF_PORT, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 
-from .const import DOMAIN, LOGGER
+from .const import LOGGER
 from .coordinator import P1MonitorDataUpdateCoordinator
 
-PLATFORMS = [Platform.SENSOR]
+PLATFORMS: list[Platform] = [Platform.SENSOR]
+
+type P1MonitorConfigEntry = ConfigEntry[P1MonitorDataUpdateCoordinator]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -23,8 +25,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         await coordinator.p1monitor.close()
         raise
 
-    hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN][entry.entry_id] = coordinator
+    entry.runtime_data = coordinator
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
@@ -55,7 +56,4 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload P1 Monitor config entry."""
-    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-    if unload_ok:
-        del hass.data[DOMAIN][entry.entry_id]
-    return unload_ok
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/p1_monitor/diagnostics.py
+++ b/homeassistant/components/p1_monitor/diagnostics.py
@@ -11,13 +11,11 @@ from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import HomeAssistant
 
 from .const import (
-    DOMAIN,
     SERVICE_PHASES,
     SERVICE_SETTINGS,
     SERVICE_SMARTMETER,
     SERVICE_WATERMETER,
 )
-from .coordinator import P1MonitorDataUpdateCoordinator
 
 if TYPE_CHECKING:
     from _typeshed import DataclassInstance
@@ -29,23 +27,21 @@ async def async_get_config_entry_diagnostics(
     hass: HomeAssistant, entry: ConfigEntry
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
-    coordinator: P1MonitorDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
-
     data = {
         "entry": {
             "title": entry.title,
             "data": async_redact_data(entry.data, TO_REDACT),
         },
         "data": {
-            "smartmeter": asdict(coordinator.data[SERVICE_SMARTMETER]),
-            "phases": asdict(coordinator.data[SERVICE_PHASES]),
-            "settings": asdict(coordinator.data[SERVICE_SETTINGS]),
+            "smartmeter": asdict(entry.runtime_data.data[SERVICE_SMARTMETER]),
+            "phases": asdict(entry.runtime_data.data[SERVICE_PHASES]),
+            "settings": asdict(entry.runtime_data.data[SERVICE_SETTINGS]),
         },
     }
 
-    if coordinator.has_water_meter:
+    if entry.runtime_data.has_water_meter:
         data["data"]["watermeter"] = asdict(
-            cast("DataclassInstance", coordinator.data[SERVICE_WATERMETER])
+            cast("DataclassInstance", entry.runtime_data.data[SERVICE_WATERMETER])
         )
 
     return data

--- a/homeassistant/components/p1_monitor/sensor.py
+++ b/homeassistant/components/p1_monitor/sensor.py
@@ -239,11 +239,10 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up P1 Monitor Sensors based on a config entry."""
-    coordinator: P1MonitorDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
     entities: list[P1MonitorSensorEntity] = []
     entities.extend(
         P1MonitorSensorEntity(
-            coordinator=coordinator,
+            entry=entry,
             description=description,
             name="SmartMeter",
             service=SERVICE_SMARTMETER,
@@ -252,7 +251,7 @@ async def async_setup_entry(
     )
     entities.extend(
         P1MonitorSensorEntity(
-            coordinator=coordinator,
+            entry=entry,
             description=description,
             name="Phases",
             service=SERVICE_PHASES,
@@ -261,17 +260,17 @@ async def async_setup_entry(
     )
     entities.extend(
         P1MonitorSensorEntity(
-            coordinator=coordinator,
+            entry=entry,
             description=description,
             name="Settings",
             service=SERVICE_SETTINGS,
         )
         for description in SENSORS_SETTINGS
     )
-    if coordinator.has_water_meter:
+    if entry.runtime_data.has_water_meter:
         entities.extend(
             P1MonitorSensorEntity(
-                coordinator=coordinator,
+                entry=entry,
                 description=description,
                 name="WaterMeter",
                 service=SERVICE_WATERMETER,
@@ -291,24 +290,26 @@ class P1MonitorSensorEntity(
     def __init__(
         self,
         *,
-        coordinator: P1MonitorDataUpdateCoordinator,
+        entry: ConfigEntry,
         description: SensorEntityDescription,
         name: str,
         service: Literal["smartmeter", "watermeter", "phases", "settings"],
     ) -> None:
         """Initialize P1 Monitor sensor."""
-        super().__init__(coordinator=coordinator)
+        super().__init__(coordinator=entry.runtime_data)
         self._service_key = service
 
         self.entity_description = description
         self._attr_unique_id = (
-            f"{coordinator.config_entry.entry_id}_{service}_{description.key}"
+            f"{entry.runtime_data.config_entry.entry_id}_{service}_{description.key}"
         )
 
         self._attr_device_info = DeviceInfo(
             entry_type=DeviceEntryType.SERVICE,
-            identifiers={(DOMAIN, f"{coordinator.config_entry.entry_id}_{service}")},
-            configuration_url=f"http://{coordinator.config_entry.data[CONF_HOST]}",
+            identifiers={
+                (DOMAIN, f"{entry.runtime_data.config_entry.entry_id}_{service}")
+            },
+            configuration_url=f"http://{entry.runtime_data.config_entry.data[CONF_HOST]}",
             manufacturer="P1 Monitor",
             name=name,
         )

--- a/tests/components/p1_monitor/test_init.py
+++ b/tests/components/p1_monitor/test_init.py
@@ -26,7 +26,6 @@ async def test_load_unload_config_entry(
     await hass.config_entries.async_unload(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert not hass.data.get(DOMAIN)
     assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Moves the P1 Monitor integration to use the `runtime_data` attribute of the `ConfigEntry` instead of `hass.data`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
