### PR TITLE
Remove deprecated yaml import from sabnzbd

### DIFF
--- a/homeassistant/components/sabnzbd/__init__.py
+++ b/homeassistant/components/sabnzbd/__init__.py
@@ -8,31 +8,18 @@ from typing import Any
 
 import voluptuous as vol
 
-from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry, ConfigEntryState
-from homeassistant.const import (
-    CONF_API_KEY,
-    CONF_HOST,
-    CONF_NAME,
-    CONF_PORT,
-    CONF_SENSORS,
-    CONF_SSL,
-    Platform,
-)
+from homeassistant.config_entries import ConfigEntry, ConfigEntryState
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
 from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.helpers.entity_registry import RegistryEntry, async_migrate_entries
 import homeassistant.helpers.issue_registry as ir
-from homeassistant.helpers.typing import ConfigType
 
 from .const import (
     ATTR_API_KEY,
     ATTR_SPEED,
-    DEFAULT_HOST,
-    DEFAULT_NAME,
-    DEFAULT_PORT,
     DEFAULT_SPEED_LIMIT,
-    DEFAULT_SSL,
     DOMAIN,
     SERVICE_PAUSE,
     SERVICE_RESUME,
@@ -40,7 +27,6 @@ from .const import (
 )
 from .coordinator import SabnzbdUpdateCoordinator
 from .sab import get_client
-from .sensor import OLD_SENSOR_KEYS
 
 PLATFORMS = [Platform.BUTTON, Platform.SENSOR]
 _LOGGER = logging.getLogger(__name__)
@@ -62,49 +48,6 @@ SERVICE_SPEED_SCHEMA = SERVICE_BASE_SCHEMA.extend(
         vol.Optional(ATTR_SPEED, default=DEFAULT_SPEED_LIMIT): cv.string,
     }
 )
-
-CONFIG_SCHEMA = vol.Schema(
-    {
-        DOMAIN: vol.Schema(
-            vol.All(
-                cv.deprecated(CONF_HOST),
-                cv.deprecated(CONF_PORT),
-                cv.deprecated(CONF_SENSORS),
-                cv.deprecated(CONF_SSL),
-                {
-                    vol.Required(CONF_API_KEY): str,
-                    vol.Optional(CONF_NAME, default=DEFAULT_NAME): str,
-                    vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string,
-                    vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
-                    vol.Optional(CONF_SENSORS): vol.All(
-                        cv.ensure_list, [vol.In(OLD_SENSOR_KEYS)]
-                    ),
-                    vol.Optional(CONF_SSL, default=DEFAULT_SSL): cv.boolean,
-                },
-            )
-        )
-    },
-    extra=vol.ALLOW_EXTRA,
-)
-
-
-async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
-    """Set up the SABnzbd component."""
-    hass.data.setdefault(DOMAIN, {})
-
-    if hass.config_entries.async_entries(DOMAIN):
-        return True
-
-    if DOMAIN in config:
-        hass.async_create_task(
-            hass.config_entries.flow.async_init(
-                DOMAIN,
-                context={"source": SOURCE_IMPORT},
-                data=config[DOMAIN],
-            )
-        )
-
-    return True
 
 
 @callback

--- a/tests/components/sabnzbd/test_config_flow.py
+++ b/tests/components/sabnzbd/test_config_flow.py
@@ -7,15 +7,8 @@ import pytest
 
 from homeassistant import config_entries
 from homeassistant.components.sabnzbd import DOMAIN
-from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
-from homeassistant.const import (
-    CONF_API_KEY,
-    CONF_HOST,
-    CONF_NAME,
-    CONF_PORT,
-    CONF_SSL,
-    CONF_URL,
-)
+from homeassistant.config_entries import SOURCE_USER
+from homeassistant.const import CONF_API_KEY, CONF_NAME, CONF_URL
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
@@ -23,14 +16,6 @@ VALID_CONFIG = {
     CONF_NAME: "Sabnzbd",
     CONF_API_KEY: "edc3eee7330e4fdda04489e3fbc283d0",
     CONF_URL: "http://localhost:8080",
-}
-
-VALID_CONFIG_OLD = {
-    CONF_NAME: "Sabnzbd",
-    CONF_API_KEY: "edc3eee7330e4fdda04489e3fbc283d0",
-    CONF_HOST: "localhost",
-    CONF_PORT: 8080,
-    CONF_SSL: False,
 }
 
 pytestmark = pytest.mark.usefixtures("mock_setup_entry")
@@ -77,24 +62,3 @@ async def test_auth_error(hass: HomeAssistant) -> None:
         )
 
         assert result["errors"] == {"base": "cannot_connect"}
-
-
-async def test_import_flow(hass: HomeAssistant) -> None:
-    """Test the import configuration flow."""
-    with patch(
-        "homeassistant.components.sabnzbd.sab.SabnzbdApi.check_available",
-        return_value=True,
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": SOURCE_IMPORT},
-            data=VALID_CONFIG_OLD,
-        )
-
-        assert result["type"] is FlowResultType.CREATE_ENTRY
-        assert result["title"] == "edc3eee7330e"
-        assert result["data"][CONF_NAME] == "Sabnzbd"
-        assert result["data"][CONF_API_KEY] == "edc3eee7330e4fdda04489e3fbc283d0"
-        assert result["data"][CONF_HOST] == "localhost"
-        assert result["data"][CONF_PORT] == 8080
-        assert result["data"][CONF_SSL] is False

--- a/tests/components/sabnzbd/test_init.py
+++ b/tests/components/sabnzbd/test_init.py
@@ -4,14 +4,14 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant.components.sabnzbd import (
+from homeassistant.components.sabnzbd.const import (
     ATTR_API_KEY,
     DEFAULT_NAME,
     DOMAIN,
-    OLD_SENSOR_KEYS,
     SERVICE_PAUSE,
     SERVICE_RESUME,
 )
+from homeassistant.components.sabnzbd.sensor import OLD_SENSOR_KEYS
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.const import CONF_API_KEY, CONF_NAME, CONF_URL
 from homeassistant.core import HomeAssistant


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
The yaml import has existed since version 2022.4 and the configuration via YAML has been deprecated since then, the import and YAML support has now been completely removed.

## Proposed change
See breaking change

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
