### PR TITLE
Use ConfigEntry runtime_data in Pure Energie

### DIFF
--- a/homeassistant/components/pure_energie/__init__.py
+++ b/homeassistant/components/pure_energie/__init__.py
@@ -7,13 +7,14 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 
-from .const import DOMAIN
 from .coordinator import PureEnergieDataUpdateCoordinator
 
-PLATFORMS = [Platform.SENSOR]
+PLATFORMS: list[Platform] = [Platform.SENSOR]
+
+type PureEnergieConfigEntry = ConfigEntry[PureEnergieDataUpdateCoordinator]
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: PureEnergieConfigEntry) -> bool:
     """Set up Pure Energie from a config entry."""
 
     coordinator = PureEnergieDataUpdateCoordinator(hass)
@@ -23,14 +24,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         await coordinator.gridnet.close()
         raise
 
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
+    entry.runtime_data = coordinator
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(
+    hass: HomeAssistant, entry: PureEnergieConfigEntry
+) -> bool:
     """Unload Pure Energie config entry."""
-    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        del hass.data[DOMAIN][entry.entry_id]
-    return unload_ok
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/pure_energie/diagnostics.py
+++ b/homeassistant/components/pure_energie/diagnostics.py
@@ -6,12 +6,10 @@ from dataclasses import asdict
 from typing import Any
 
 from homeassistant.components.diagnostics import async_redact_data
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 
-from .const import DOMAIN
-from .coordinator import PureEnergieDataUpdateCoordinator
+from . import PureEnergieConfigEntry
 
 TO_REDACT = {
     CONF_HOST,
@@ -20,18 +18,18 @@ TO_REDACT = {
 
 
 async def async_get_config_entry_diagnostics(
-    hass: HomeAssistant, entry: ConfigEntry
+    hass: HomeAssistant, entry: PureEnergieConfigEntry
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
-    coordinator: PureEnergieDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
-
     return {
         "entry": {
             "title": entry.title,
             "data": async_redact_data(entry.data, TO_REDACT),
         },
         "data": {
-            "device": async_redact_data(asdict(coordinator.data.device), TO_REDACT),
-            "smartbridge": asdict(coordinator.data.smartbridge),
+            "device": async_redact_data(
+                asdict(entry.runtime_data.data.device), TO_REDACT
+            ),
+            "smartbridge": asdict(entry.runtime_data.data.smartbridge),
         },
     }

--- a/homeassistant/components/pure_energie/sensor.py
+++ b/homeassistant/components/pure_energie/sensor.py
@@ -12,13 +12,13 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, UnitOfEnergy, UnitOfPower
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from . import PureEnergieConfigEntry
 from .const import DOMAIN
 from .coordinator import PureEnergieData, PureEnergieDataUpdateCoordinator
 
@@ -59,12 +59,13 @@ SENSORS: tuple[PureEnergieSensorEntityDescription, ...] = (
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+    hass: HomeAssistant,
+    entry: PureEnergieConfigEntry,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Pure Energie Sensors based on a config entry."""
     async_add_entities(
         PureEnergieSensorEntity(
-            coordinator=hass.data[DOMAIN][entry.entry_id],
             description=description,
             entry=entry,
         )
@@ -83,21 +84,22 @@ class PureEnergieSensorEntity(
     def __init__(
         self,
         *,
-        coordinator: PureEnergieDataUpdateCoordinator,
         description: PureEnergieSensorEntityDescription,
-        entry: ConfigEntry,
+        entry: PureEnergieConfigEntry,
     ) -> None:
         """Initialize Pure Energie sensor."""
-        super().__init__(coordinator=coordinator)
+        super().__init__(coordinator=entry.runtime_data)
         self.entity_id = f"{SENSOR_DOMAIN}.pem_{description.key}"
         self.entity_description = description
-        self._attr_unique_id = f"{coordinator.data.device.n2g_id}_{description.key}"
+        self._attr_unique_id = (
+            f"{entry.runtime_data.data.device.n2g_id}_{description.key}"
+        )
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, coordinator.data.device.n2g_id)},
-            configuration_url=f"http://{coordinator.config_entry.data[CONF_HOST]}",
-            sw_version=coordinator.data.device.firmware,
-            manufacturer=coordinator.data.device.manufacturer,
-            model=coordinator.data.device.model,
+            identifiers={(DOMAIN, entry.runtime_data.data.device.n2g_id)},
+            configuration_url=f"http://{entry.runtime_data.config_entry.data[CONF_HOST]}",
+            sw_version=entry.runtime_data.data.device.firmware,
+            manufacturer=entry.runtime_data.data.device.manufacturer,
+            model=entry.runtime_data.data.device.model,
             name=entry.title,
         )
 

--- a/tests/components/pure_energie/test_init.py
+++ b/tests/components/pure_energie/test_init.py
@@ -5,7 +5,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from gridnet import GridNetConnectionError
 import pytest
 
-from homeassistant.components.pure_energie.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 
@@ -32,7 +31,6 @@ async def test_load_unload_config_entry(
     await hass.config_entries.async_unload(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert not hass.data.get(DOMAIN)
     assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Moves the Pure Energie integration to use the `runtime_data` attribute of the `ConfigEntry` instead of `hass.data`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
