### PR TITLE
Remove old entity unique id migration from sabnzbd

### DIFF
--- a/homeassistant/components/sabnzbd/__init__.py
+++ b/homeassistant/components/sabnzbd/__init__.py
@@ -12,8 +12,7 @@ from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
-from homeassistant.helpers import config_validation as cv, device_registry as dr
-from homeassistant.helpers.entity_registry import RegistryEntry, async_migrate_entries
+from homeassistant.helpers import config_validation as cv
 import homeassistant.helpers.issue_registry as ir
 
 from .const import (
@@ -62,61 +61,12 @@ def async_get_entry_id_for_service_call(hass: HomeAssistant, call: ServiceCall) 
     raise ValueError(f"No api for API key: {call_data_api_key}")
 
 
-def update_device_identifiers(hass: HomeAssistant, entry: ConfigEntry):
-    """Update device identifiers to new identifiers."""
-    device_registry = dr.async_get(hass)
-    device_entry = device_registry.async_get_device(identifiers={(DOMAIN, DOMAIN)})
-    if device_entry and entry.entry_id in device_entry.config_entries:
-        new_identifiers = {(DOMAIN, entry.entry_id)}
-        _LOGGER.debug(
-            "Updating device id <%s> with new identifiers <%s>",
-            device_entry.id,
-            new_identifiers,
-        )
-        device_registry.async_update_device(
-            device_entry.id, new_identifiers=new_identifiers
-        )
-
-
-async def migrate_unique_id(hass: HomeAssistant, entry: ConfigEntry):
-    """Migrate entities to new unique ids (with entry_id)."""
-
-    @callback
-    def async_migrate_callback(entity_entry: RegistryEntry) -> dict | None:
-        """Define a callback to migrate appropriate SabnzbdSensor entities to new unique IDs.
-
-        Old: description.key
-        New: {entry_id}_description.key
-        """
-        entry_id = entity_entry.config_entry_id
-        if entry_id is None:
-            return None
-        if entity_entry.unique_id.startswith(entry_id):
-            return None
-
-        new_unique_id = f"{entry_id}_{entity_entry.unique_id}"
-
-        _LOGGER.debug(
-            "Migrating entity %s from old unique ID '%s' to new unique ID '%s'",
-            entity_entry.entity_id,
-            entity_entry.unique_id,
-            new_unique_id,
-        )
-
-        return {"new_unique_id": new_unique_id}
-
-    await async_migrate_entries(hass, entry.entry_id, async_migrate_callback)
-
-
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up the SabNzbd Component."""
 
     sab_api = await get_client(hass, entry.data)
     if not sab_api:
         raise ConfigEntryNotReady
-
-    await migrate_unique_id(hass, entry)
-    update_device_identifiers(hass, entry)
 
     coordinator = SabnzbdUpdateCoordinator(hass, entry, sab_api)
     await coordinator.async_config_entry_first_refresh()

--- a/homeassistant/components/sabnzbd/sensor.py
+++ b/homeassistant/components/sabnzbd/sensor.py
@@ -113,20 +113,6 @@ SENSOR_TYPES: tuple[SabnzbdSensorEntityDescription, ...] = (
     ),
 )
 
-OLD_SENSOR_KEYS = [
-    "current_status",
-    "speed",
-    "queue_size",
-    "queue_remaining",
-    "disk_size",
-    "disk_free",
-    "queue_count",
-    "day_size",
-    "week_size",
-    "month_size",
-    "total_size",
-]
-
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/tests/components/sabnzbd/test_init.py
+++ b/tests/components/sabnzbd/test_init.py
@@ -1,93 +1,15 @@
 """Tests for the SABnzbd Integration."""
 
-from unittest.mock import patch
-
 import pytest
 
 from homeassistant.components.sabnzbd.const import (
     ATTR_API_KEY,
-    DEFAULT_NAME,
     DOMAIN,
     SERVICE_PAUSE,
     SERVICE_RESUME,
 )
-from homeassistant.components.sabnzbd.sensor import OLD_SENSOR_KEYS
-from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
-from homeassistant.const import CONF_API_KEY, CONF_NAME, CONF_URL
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import (
-    device_registry as dr,
-    entity_registry as er,
-    issue_registry as ir,
-)
-
-from tests.common import MockConfigEntry
-
-MOCK_ENTRY_ID = "mock_entry_id"
-
-MOCK_UNIQUE_ID = "someuniqueid"
-
-MOCK_DEVICE_ID = "somedeviceid"
-
-MOCK_DATA_VERSION_1 = {
-    CONF_API_KEY: "api_key",
-    CONF_URL: "http://127.0.0.1:8080",
-    CONF_NAME: "name",
-}
-
-MOCK_ENTRY_VERSION_1 = MockConfigEntry(
-    domain=DOMAIN, data=MOCK_DATA_VERSION_1, entry_id=MOCK_ENTRY_ID, version=1
-)
-
-
-async def test_unique_id_migrate(
-    hass: HomeAssistant,
-    device_registry: dr.DeviceRegistry,
-    entity_registry: er.EntityRegistry,
-) -> None:
-    """Test that config flow entry is migrated correctly."""
-    # Start with the config entry at Version 1.
-    mock_entry = MOCK_ENTRY_VERSION_1
-    mock_entry.add_to_hass(hass)
-
-    mock_d_entry = device_registry.async_get_or_create(
-        config_entry_id=mock_entry.entry_id,
-        identifiers={(DOMAIN, DOMAIN)},
-        name=DEFAULT_NAME,
-        entry_type=dr.DeviceEntryType.SERVICE,
-    )
-
-    entity_id_sensor_key = []
-
-    for sensor_key in OLD_SENSOR_KEYS:
-        mock_entity_id = f"{SENSOR_DOMAIN}.{DOMAIN}_{sensor_key}"
-        entity_registry.async_get_or_create(
-            SENSOR_DOMAIN,
-            DOMAIN,
-            unique_id=sensor_key,
-            config_entry=mock_entry,
-            device_id=mock_d_entry.id,
-        )
-        entity = entity_registry.async_get(mock_entity_id)
-        assert entity.entity_id == mock_entity_id
-        assert entity.unique_id == sensor_key
-        entity_id_sensor_key.append((mock_entity_id, sensor_key))
-
-    with patch(
-        "homeassistant.components.sabnzbd.sab.SabnzbdApi.check_available",
-        return_value=True,
-    ):
-        await hass.config_entries.async_setup(mock_entry.entry_id)
-
-        await hass.async_block_till_done()
-
-    for mock_entity_id, sensor_key in entity_id_sensor_key:
-        entity = entity_registry.async_get(mock_entity_id)
-        assert entity.unique_id == f"{MOCK_ENTRY_ID}_{sensor_key}"
-
-    assert device_registry.async_get(mock_d_entry.id).identifiers == {
-        (DOMAIN, MOCK_ENTRY_ID)
-    }
+from homeassistant.helpers import issue_registry as ir
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Proposed change
Remove the old entity unique ID migration that has existed since the 2022.4 release and the start of the YAML import

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
