### PR TITLE
Add ssdp discovery to Onkyo

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1066,8 +1066,8 @@ build.json @home-assistant/supervisor
 /tests/components/ondilo_ico/ @JeromeHXP
 /homeassistant/components/onewire/ @garbled1 @epenet
 /tests/components/onewire/ @garbled1 @epenet
-/homeassistant/components/onkyo/ @arturpragacz
-/tests/components/onkyo/ @arturpragacz
+/homeassistant/components/onkyo/ @arturpragacz @eclair4151
+/tests/components/onkyo/ @arturpragacz @eclair4151
 /homeassistant/components/onvif/ @hunterjm
 /tests/components/onvif/ @hunterjm
 /homeassistant/components/open_meteo/ @frenck

--- a/homeassistant/components/onkyo/config_flow.py
+++ b/homeassistant/components/onkyo/config_flow.py
@@ -2,9 +2,9 @@
 
 import logging
 from typing import Any
-from urllib.parse import urlparse
 
 import voluptuous as vol
+from yarl import URL
 
 from homeassistant.components import ssdp
 from homeassistant.config_entries import (
@@ -173,8 +173,7 @@ class OnkyoConfigFlow(ConfigFlow, domain=DOMAIN):
         """Handle flow initialized by SSDP discovery."""
         _LOGGER.debug("Config flow start ssdp: %s", discovery_info)
 
-        udn = discovery_info.ssdp_udn
-        if udn:
+        if udn := discovery_info.ssdp_udn:
             udn_parts = udn.split(":")
             if len(udn_parts) == 2:
                 uuid = udn_parts[1]
@@ -186,7 +185,7 @@ class OnkyoConfigFlow(ConfigFlow, domain=DOMAIN):
             _LOGGER.error("SSDP location is None")
             return self.async_abort(reason="unknown")
 
-        host = urlparse(discovery_info.ssdp_location).hostname
+        host = URL(discovery_info.ssdp_location).host
 
         if host is None:
             _LOGGER.error("SSDP host is None")

--- a/homeassistant/components/onkyo/config_flow.py
+++ b/homeassistant/components/onkyo/config_flow.py
@@ -182,13 +182,13 @@ class OnkyoConfigFlow(ConfigFlow, domain=DOMAIN):
                 await self.async_set_unique_id(last_uuid_section)
                 self._abort_if_unique_id_configured()
 
-        if not discovery_info.ssdp_location:
+        if discovery_info.ssdp_location is None:
             _LOGGER.error("SSDP location is None")
             return self.async_abort(reason="unknown")
 
         host = urlparse(discovery_info.ssdp_location).hostname
 
-        if not host:
+        if host is None:
             _LOGGER.error("SSDP host is None")
             return self.async_abort(reason="unknown")
 
@@ -207,9 +207,7 @@ class OnkyoConfigFlow(ConfigFlow, domain=DOMAIN):
 
         self._receiver_info = info
 
-        title_string = (
-            f"{discovery_info.upnp.get(ssdp.ATTR_UPNP_MODEL_NAME, "")} ({host})"
-        )
+        title_string = f"{info.model_name} ({info.host})"
         self.context.update({"title_placeholders": {"name": title_string}})
         return await self.async_step_configure_receiver()
 

--- a/homeassistant/components/onkyo/config_flow.py
+++ b/homeassistant/components/onkyo/config_flow.py
@@ -194,7 +194,7 @@ class OnkyoConfigFlow(ConfigFlow, domain=DOMAIN):
 
         try:
             info = await async_interview(host)
-        except Exception:
+        except OSError:
             _LOGGER.exception("Unexpected exception interviewing host %s", host)
             return self.async_abort(reason="unknown")
 

--- a/homeassistant/components/onkyo/config_flow.py
+++ b/homeassistant/components/onkyo/config_flow.py
@@ -202,12 +202,12 @@ class OnkyoConfigFlow(ConfigFlow, domain=DOMAIN):
             return self.async_abort(reason="cannot_connect")
 
         await self.async_set_unique_id(info.identifier)
-        self._abort_if_unique_id_configured()
+        self._abort_if_unique_id_configured(updates={CONF_HOST: info.host})
 
         self._receiver_info = info
 
         title_string = f"{info.model_name} ({info.host})"
-        self.context.update({"title_placeholders": {"name": title_string}})
+        self.context["title_placeholders"] = {"name": title_string}
         return await self.async_step_configure_receiver()
 
     async def async_step_configure_receiver(

--- a/homeassistant/components/onkyo/manifest.json
+++ b/homeassistant/components/onkyo/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "onkyo",
   "name": "Onkyo",
-  "codeowners": ["@arturpragacz"],
+  "codeowners": ["@arturpragacz", "@eclair4151"],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/onkyo",
   "integration_type": "device",

--- a/homeassistant/components/onkyo/manifest.json
+++ b/homeassistant/components/onkyo/manifest.json
@@ -34,15 +34,15 @@
       "deviceType": "urn:schemas-upnp-org:device:MediaRenderer:3"
     },
     {
-      "manufacturer": "PIONEER CORPORATION",
+      "manufacturer": "Pioneer",
       "deviceType": "urn:schemas-upnp-org:device:MediaRenderer:1"
     },
     {
-      "manufacturer": "PIONEER CORPORATION",
+      "manufacturer": "Pioneer",
       "deviceType": "urn:schemas-upnp-org:device:MediaRenderer:2"
     },
     {
-      "manufacturer": "PIONEER CORPORATION",
+      "manufacturer": "Pioneer",
       "deviceType": "urn:schemas-upnp-org:device:MediaRenderer:3"
     }
   ]

--- a/homeassistant/components/onkyo/manifest.json
+++ b/homeassistant/components/onkyo/manifest.json
@@ -7,5 +7,43 @@
   "integration_type": "device",
   "iot_class": "local_push",
   "loggers": ["pyeiscp"],
-  "requirements": ["pyeiscp==0.0.7"]
+  "requirements": ["pyeiscp==0.0.7"],
+  "ssdp": [
+    {
+      "manufacturer": "ONKYO",
+      "deviceType": "urn:schemas-upnp-org:device:MediaRenderer:1"
+    },
+    {
+      "manufacturer": "ONKYO",
+      "deviceType": "urn:schemas-upnp-org:device:MediaRenderer:2"
+    },
+    {
+      "manufacturer": "ONKYO",
+      "deviceType": "urn:schemas-upnp-org:device:MediaRenderer:3"
+    },
+    {
+      "manufacturer": "Onkyo & Pioneer Corporation",
+      "deviceType": "urn:schemas-upnp-org:device:MediaRenderer:1"
+    },
+    {
+      "manufacturer": "Onkyo & Pioneer Corporation",
+      "deviceType": "urn:schemas-upnp-org:device:MediaRenderer:2"
+    },
+    {
+      "manufacturer": "Onkyo & Pioneer Corporation",
+      "deviceType": "urn:schemas-upnp-org:device:MediaRenderer:3"
+    },
+    {
+      "manufacturer": "PIONEER CORPORATION",
+      "deviceType": "urn:schemas-upnp-org:device:MediaRenderer:1"
+    },
+    {
+      "manufacturer": "PIONEER CORPORATION",
+      "deviceType": "urn:schemas-upnp-org:device:MediaRenderer:2"
+    },
+    {
+      "manufacturer": "PIONEER CORPORATION",
+      "deviceType": "urn:schemas-upnp-org:device:MediaRenderer:3"
+    }
+  ]
 }

--- a/homeassistant/generated/ssdp.py
+++ b/homeassistant/generated/ssdp.py
@@ -251,15 +251,15 @@ SSDP = {
         },
         {
             "deviceType": "urn:schemas-upnp-org:device:MediaRenderer:1",
-            "manufacturer": "PIONEER CORPORATION",
+            "manufacturer": "Pioneer",
         },
         {
             "deviceType": "urn:schemas-upnp-org:device:MediaRenderer:2",
-            "manufacturer": "PIONEER CORPORATION",
+            "manufacturer": "Pioneer",
         },
         {
             "deviceType": "urn:schemas-upnp-org:device:MediaRenderer:3",
-            "manufacturer": "PIONEER CORPORATION",
+            "manufacturer": "Pioneer",
         },
     ],
     "openhome": [

--- a/homeassistant/generated/ssdp.py
+++ b/homeassistant/generated/ssdp.py
@@ -224,6 +224,44 @@ SSDP = {
             "manufacturer": "The OctoPrint Project",
         },
     ],
+    "onkyo": [
+        {
+            "deviceType": "urn:schemas-upnp-org:device:MediaRenderer:1",
+            "manufacturer": "ONKYO",
+        },
+        {
+            "deviceType": "urn:schemas-upnp-org:device:MediaRenderer:2",
+            "manufacturer": "ONKYO",
+        },
+        {
+            "deviceType": "urn:schemas-upnp-org:device:MediaRenderer:3",
+            "manufacturer": "ONKYO",
+        },
+        {
+            "deviceType": "urn:schemas-upnp-org:device:MediaRenderer:1",
+            "manufacturer": "Onkyo & Pioneer Corporation",
+        },
+        {
+            "deviceType": "urn:schemas-upnp-org:device:MediaRenderer:2",
+            "manufacturer": "Onkyo & Pioneer Corporation",
+        },
+        {
+            "deviceType": "urn:schemas-upnp-org:device:MediaRenderer:3",
+            "manufacturer": "Onkyo & Pioneer Corporation",
+        },
+        {
+            "deviceType": "urn:schemas-upnp-org:device:MediaRenderer:1",
+            "manufacturer": "PIONEER CORPORATION",
+        },
+        {
+            "deviceType": "urn:schemas-upnp-org:device:MediaRenderer:2",
+            "manufacturer": "PIONEER CORPORATION",
+        },
+        {
+            "deviceType": "urn:schemas-upnp-org:device:MediaRenderer:3",
+            "manufacturer": "PIONEER CORPORATION",
+        },
+    ],
     "openhome": [
         {
             "st": "urn:av-openhome-org:service:Product:1",

--- a/tests/components/onkyo/test_config_flow.py
+++ b/tests/components/onkyo/test_config_flow.py
@@ -209,10 +209,9 @@ async def test_ssdp_discovery_success(hass: HomeAssistant) -> None:
         ssdp_st="mock_st",
     )
 
-    mock_info = create_receiver_info(1)
     with patch(
         "homeassistant.components.onkyo.config_flow.async_interview",
-        return_value=mock_info,
+        return_value=create_receiver_info(1),
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,

--- a/tests/components/onkyo/test_config_flow.py
+++ b/tests/components/onkyo/test_config_flow.py
@@ -234,7 +234,7 @@ async def test_ssdp_discovery_host_info_error(hass: HomeAssistant) -> None:
 
     with patch(
         "homeassistant.components.onkyo.config_flow.async_interview",
-        side_effect=Exception(),
+        side_effect=OSError(),
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,

--- a/tests/components/onkyo/test_config_flow.py
+++ b/tests/components/onkyo/test_config_flow.py
@@ -315,7 +315,9 @@ async def test_ssdp_discovery_no_host(hass: HomeAssistant) -> None:
     assert result["reason"] == "unknown"
 
 
-async def test_configure_empty_source_list(hass: HomeAssistant) -> None:
+async def test_configure_empty_source_list(
+    hass: HomeAssistant, default_mock_discovery
+) -> None:
     """Test receiver configuration with no sources set."""
 
     init_result = await hass.config_entries.flow.async_init(

--- a/tests/components/onkyo/test_config_flow.py
+++ b/tests/components/onkyo/test_config_flow.py
@@ -199,9 +199,124 @@ async def test_discovery_with_one_selected(hass: HomeAssistant) -> None:
     assert select_result["description_placeholders"]["name"] == "type 42 (host 42)"
 
 
-async def test_configure_empty_source_list(
-    hass: HomeAssistant, default_mock_discovery
-) -> None:
+async def test_ssdp_discovery_success(hass: HomeAssistant) -> None:
+    """Test SSDP discovery with valid host."""
+    discovery_info = ssdp.SsdpServiceInfo(
+        ssdp_location="http://192.168.1.100:8080",
+        upnp={ssdp.ATTR_UPNP_FRIENDLY_NAME: "Onkyo Receiver"},
+        ssdp_usn="uuid:mock_usn",
+        ssdp_udn="uuid:00000000-0000-0000-0000-000000000000",
+        ssdp_st="mock_st",
+    )
+
+    mock_info = create_receiver_info(1)
+    with patch(
+        "homeassistant.components.onkyo.config_flow.async_interview",
+        return_value=mock_info,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_SSDP},
+            data=discovery_info,
+        )
+
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "configure_receiver"
+
+
+async def test_ssdp_discovery_host_info_error(hass: HomeAssistant) -> None:
+    """Test SSDP discovery with host info error."""
+    discovery_info = ssdp.SsdpServiceInfo(
+        ssdp_location="http://192.168.1.100:8080",
+        upnp={ssdp.ATTR_UPNP_FRIENDLY_NAME: "Onkyo Receiver"},
+        ssdp_usn="uuid:mock_usn",
+        ssdp_st="mock_st",
+    )
+
+    with patch(
+        "homeassistant.components.onkyo.config_flow.async_interview",
+        side_effect=Exception(),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_SSDP},
+            data=discovery_info,
+        )
+
+        assert result["type"] == FlowResultType.ABORT
+        assert result["reason"] == "unknown"
+
+
+async def test_ssdp_discovery_host_none_info(hass: HomeAssistant) -> None:
+    """Test SSDP discovery with host info error."""
+    discovery_info = ssdp.SsdpServiceInfo(
+        ssdp_location="http://192.168.1.100:8080",
+        upnp={ssdp.ATTR_UPNP_FRIENDLY_NAME: "Onkyo Receiver"},
+        ssdp_usn="uuid:mock_usn",
+        ssdp_st="mock_st",
+    )
+
+    with patch(
+        "homeassistant.components.onkyo.config_flow.async_interview",
+        return_value=None,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_SSDP},
+            data=discovery_info,
+        )
+
+        assert result["type"] == FlowResultType.ABORT
+        assert result["reason"] == "cannot_connect"
+
+
+async def test_ssdp_discovery_no_location(hass: HomeAssistant) -> None:
+    """Test SSDP discovery with no location."""
+    discovery_info = ssdp.SsdpServiceInfo(
+        ssdp_location=None,
+        upnp={ssdp.ATTR_UPNP_FRIENDLY_NAME: "Onkyo Receiver"},
+        ssdp_usn="uuid:mock_usn",
+        ssdp_st="mock_st",
+    )
+
+    with patch(
+        "homeassistant.components.onkyo.config_flow.async_interview",
+        return_value=create_receiver_info(1),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_SSDP},
+            data=discovery_info,
+        )
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "unknown"
+
+
+async def test_ssdp_discovery_no_host(hass: HomeAssistant) -> None:
+    """Test SSDP discovery with no host."""
+    discovery_info = ssdp.SsdpServiceInfo(
+        ssdp_location="http://",
+        upnp={ssdp.ATTR_UPNP_FRIENDLY_NAME: "Onkyo Receiver"},
+        ssdp_usn="uuid:mock_usn",
+        ssdp_st="mock_st",
+    )
+
+    with patch(
+        "homeassistant.components.onkyo.config_flow.async_interview",
+        return_value=create_receiver_info(1),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_SSDP},
+            data=discovery_info,
+        )
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "unknown"
+
+
+async def test_configure_empty_source_list(hass: HomeAssistant) -> None:
     """Test receiver configuration with no sources set."""
 
     init_result = await hass.config_entries.flow.async_init(
@@ -493,55 +608,3 @@ async def test_options_flow(hass: HomeAssistant, config_entry: MockConfigEntry) 
             "12": "television",
         },
     }
-
-
-async def test_ssdp_discovery_success(hass: HomeAssistant) -> None:
-    """Test SSDP discovery with valid host."""
-    discovery_info = ssdp.SsdpServiceInfo(
-        ssdp_location="http://192.168.1.100:8080",
-        upnp={ssdp.ATTR_UPNP_FRIENDLY_NAME: "Onkyo Receiver"},
-        ssdp_usn="uuid:mock_usn",
-        ssdp_udn="uuid:00000000-0000-0000-0000-000000000000",
-        ssdp_st="mock_st",
-    )
-
-    mock_info = Mock()
-    mock_info.identifier = "mock_id"
-    mock_info.host = "192.168.1.100"
-    mock_info.model_name = "mock_model"
-
-    with patch(
-        "homeassistant.components.onkyo.config_flow.async_interview",
-        return_value=mock_info,
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_SSDP},
-            data=discovery_info,
-        )
-
-    assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == "configure_receiver"
-
-
-async def test_ssdp_discovery_host_info_error(hass: HomeAssistant) -> None:
-    """Test SSDP discovery with host info error."""
-    discovery_info = ssdp.SsdpServiceInfo(
-        ssdp_location="http://192.168.1.100:8080",
-        upnp={ssdp.ATTR_UPNP_FRIENDLY_NAME: "Onkyo Receiver"},
-        ssdp_usn="uuid:mock_usn",
-        ssdp_st="mock_st",
-    )
-
-    with patch(
-        "homeassistant.components.onkyo.config_flow.async_interview",
-        side_effect=Exception(),
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_SSDP},
-            data=discovery_info,
-        )
-
-    assert result["type"] == FlowResultType.ABORT
-    assert result["reason"] == "cannot_connect"

--- a/tests/components/onkyo/test_config_flow.py
+++ b/tests/components/onkyo/test_config_flow.py
@@ -217,8 +217,15 @@ async def test_ssdp_discovery_success(
         data=discovery_info,
     )
 
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "configure_receiver"
+
+    select_result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={"volume_resolution": 200, "input_sources": ["TV"]},
+    )
+
+    assert select_result["type"] is FlowResultType.CREATE_ENTRY
 
 
 async def test_ssdp_discovery_host_info_error(hass: HomeAssistant) -> None:
@@ -240,7 +247,7 @@ async def test_ssdp_discovery_host_info_error(hass: HomeAssistant) -> None:
             data=discovery_info,
         )
 
-    assert result["type"] == FlowResultType.ABORT
+    assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "unknown"
 
 
@@ -261,7 +268,7 @@ async def test_ssdp_discovery_host_none_info(
         data=discovery_info,
     )
 
-    assert result["type"] == FlowResultType.ABORT
+    assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "cannot_connect"
 
 
@@ -282,7 +289,7 @@ async def test_ssdp_discovery_no_location(
         data=discovery_info,
     )
 
-    assert result["type"] == FlowResultType.ABORT
+    assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "unknown"
 
 
@@ -303,7 +310,7 @@ async def test_ssdp_discovery_no_host(
         data=discovery_info,
     )
 
-    assert result["type"] == FlowResultType.ABORT
+    assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "unknown"
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This change adds SSDP auto discovery for Onkyo receivers. The integration currently auto discovers once the user has manually added the integration, but this change allows receivers that are discovered on the network to show as suggested devices in the integrations page. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]
Once this pr is merged I will raise a PR to https://www.home-assistant.io/integrations/ssdp to add this integration.

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
