### PR TITLE
Remove configurable name in config flow from SABnzbd

### DIFF
--- a/homeassistant/components/sabnzbd/config_flow.py
+++ b/homeassistant/components/sabnzbd/config_flow.py
@@ -8,9 +8,9 @@ from typing import Any
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
-from homeassistant.const import CONF_API_KEY, CONF_NAME, CONF_URL
+from homeassistant.const import CONF_API_KEY, CONF_URL
 
-from .const import DEFAULT_NAME, DOMAIN
+from .const import DOMAIN
 from .sab import get_client
 
 _LOGGER = logging.getLogger(__name__)
@@ -18,7 +18,6 @@ _LOGGER = logging.getLogger(__name__)
 USER_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_API_KEY): str,
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): str,
         vol.Required(CONF_URL): str,
     }
 )

--- a/homeassistant/components/sabnzbd/const.py
+++ b/homeassistant/components/sabnzbd/const.py
@@ -7,7 +7,6 @@ ATTR_SPEED = "speed"
 ATTR_API_KEY = "api_key"
 
 DEFAULT_HOST = "localhost"
-DEFAULT_NAME = "SABnzbd"
 DEFAULT_PORT = 8080
 DEFAULT_SPEED_LIMIT = "100"
 DEFAULT_SSL = False

--- a/homeassistant/components/sabnzbd/strings.json
+++ b/homeassistant/components/sabnzbd/strings.json
@@ -4,7 +4,6 @@
       "user": {
         "data": {
           "api_key": "[%key:common::config_flow::data::api_key%]",
-          "name": "[%key:common::config_flow::data::name%]",
           "url": "[%key:common::config_flow::data::url%]"
         },
         "data_description": {

--- a/tests/components/sabnzbd/conftest.py
+++ b/tests/components/sabnzbd/conftest.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from homeassistant.components.sabnzbd import DOMAIN
-from homeassistant.const import CONF_API_KEY, CONF_NAME, CONF_URL
+from homeassistant.const import CONF_API_KEY, CONF_URL
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
@@ -42,7 +42,6 @@ async def mock_config_entry(hass: HomeAssistant, sabnzbd: AsyncMock) -> MockConf
         title="Sabnzbd",
         entry_id="01JD2YVVPBC62D620DGYNG2R8H",
         data={
-            CONF_NAME: "Sabnzbd",
             CONF_API_KEY: "edc3eee7330e4fdda04489e3fbc283d0",
             CONF_URL: "http://localhost:8080",
         },

--- a/tests/components/sabnzbd/test_config_flow.py
+++ b/tests/components/sabnzbd/test_config_flow.py
@@ -8,12 +8,11 @@ import pytest
 from homeassistant import config_entries
 from homeassistant.components.sabnzbd import DOMAIN
 from homeassistant.config_entries import SOURCE_USER
-from homeassistant.const import CONF_API_KEY, CONF_NAME, CONF_URL
+from homeassistant.const import CONF_API_KEY, CONF_URL
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 VALID_CONFIG = {
-    CONF_NAME: "Sabnzbd",
     CONF_API_KEY: "edc3eee7330e4fdda04489e3fbc283d0",
     CONF_URL: "http://localhost:8080",
 }
@@ -43,7 +42,6 @@ async def test_create_entry(hass: HomeAssistant, mock_setup_entry: AsyncMock) ->
         assert result2["title"] == "edc3eee7330e"
         assert result2["data"] == {
             CONF_API_KEY: "edc3eee7330e4fdda04489e3fbc283d0",
-            CONF_NAME: "Sabnzbd",
             CONF_URL: "http://localhost:8080",
         }
         assert len(mock_setup_entry.mock_calls) == 1


### PR DESCRIPTION
## Proposed change
Remove the configurable name in config flow from SABnzbd, a) we don't want to have configurable names in config flows and b) this field was no longer used

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
