### PR TITLE
Fix incorrect action descriptions of Nexia integration

### DIFF
--- a/homeassistant/components/nexia/strings.json
+++ b/homeassistant/components/nexia/strings.json
@@ -64,7 +64,7 @@
   "services": {
     "set_aircleaner_mode": {
       "name": "Set air cleaner mode",
-      "description": "The air cleaner mode.",
+      "description": "Sets the air cleaner mode of the thermostat.",
       "fields": {
         "aircleaner_mode": {
           "name": "Air cleaner mode",
@@ -74,7 +74,7 @@
     },
     "set_humidify_setpoint": {
       "name": "Set humidify set point",
-      "description": "The humidification set point.",
+      "description": "Sets the target humidity of the thermostat.",
       "fields": {
         "humidity": {
           "name": "Humidify",
@@ -84,7 +84,7 @@
     },
     "set_hvac_run_mode": {
       "name": "Set hvac run mode",
-      "description": "The HVAC run mode.",
+      "description": "Sets the HVAC operation mode of the thermostat.",
       "fields": {
         "run_mode": {
           "name": "Run mode",

--- a/homeassistant/components/nexia/strings.json
+++ b/homeassistant/components/nexia/strings.json
@@ -64,7 +64,7 @@
   "services": {
     "set_aircleaner_mode": {
       "name": "Set air cleaner mode",
-      "description": "Sets the air cleaner mode of the thermostat.",
+      "description": "Sets the air cleaner mode.",
       "fields": {
         "aircleaner_mode": {
           "name": "Air cleaner mode",
@@ -74,7 +74,7 @@
     },
     "set_humidify_setpoint": {
       "name": "Set humidify set point",
-      "description": "Sets the target humidity of the thermostat.",
+      "description": "Sets the target humidity.",
       "fields": {
         "humidity": {
           "name": "Humidify",
@@ -84,7 +84,7 @@
     },
     "set_hvac_run_mode": {
       "name": "Set hvac run mode",
-      "description": "Sets the HVAC operation mode of the thermostat.",
+      "description": "Sets the HVAC operation mode.",
       "fields": {
         "run_mode": {
           "name": "Run mode",


### PR DESCRIPTION
The description keys for all three services / actions of the Nexia thermostat integration are wrong.

They show up when calling up the action and should explain the purpose of each action. Instead they try to explain the data fields they supply, which is actually found in the other "description" keys below them in the "fields" section.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add correct descriptions for all three actions.
Use slightly different wording to provide better search coverage.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #130772 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
