### PR TITLE
Add reconfigure flow to Cambridge Audio

### DIFF
--- a/homeassistant/components/cambridge_audio/config_flow.py
+++ b/homeassistant/components/cambridge_audio/config_flow.py
@@ -17,6 +17,8 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import CONNECT_TIMEOUT, DOMAIN, STREAM_MAGIC_EXCEPTIONS
 
+DATA_SCHEMA = vol.Schema({vol.Required(CONF_HOST): str})
+
 
 class CambridgeAudioConfigFlow(ConfigFlow, domain=DOMAIN):
     """Cambridge Audio configuration flow."""
@@ -72,12 +74,10 @@ class CambridgeAudioConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle reconfiguration of the integration."""
-        errors: dict[str, str] = {}
         if not user_input:
             return self.async_show_form(
                 step_id="reconfigure",
-                data_schema=vol.Schema({vol.Required(CONF_HOST): str}),
-                errors=errors,
+                data_schema=DATA_SCHEMA,
             )
         return await self.async_step_user(user_input)
 
@@ -114,6 +114,6 @@ class CambridgeAudioConfigFlow(ConfigFlow, domain=DOMAIN):
                 await client.disconnect()
         return self.async_show_form(
             step_id="user",
-            data_schema=vol.Schema({vol.Required(CONF_HOST): str}),
+            data_schema=DATA_SCHEMA,
             errors=errors,
         )

--- a/homeassistant/components/cambridge_audio/config_flow.py
+++ b/homeassistant/components/cambridge_audio/config_flow.py
@@ -7,7 +7,11 @@ from aiostreammagic import StreamMagicClient
 import voluptuous as vol
 
 from homeassistant.components import zeroconf
-from homeassistant.config_entries import ConfigFlow, ConfigFlowResult, SOURCE_RECONFIGURE
+from homeassistant.config_entries import (
+    SOURCE_RECONFIGURE,
+    ConfigFlow,
+    ConfigFlowResult,
+)
 from homeassistant.const import CONF_HOST, CONF_NAME
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 

--- a/homeassistant/components/cambridge_audio/quality_scale.yaml
+++ b/homeassistant/components/cambridge_audio/quality_scale.yaml
@@ -56,7 +56,7 @@ rules:
   diagnostics: done
   exception-translations: done
   icon-translations: done
-  reconfiguration-flow: todo
+  reconfiguration-flow: done
   dynamic-devices:
     status: exempt
     comment: |

--- a/homeassistant/components/cambridge_audio/strings.json
+++ b/homeassistant/components/cambridge_audio/strings.json
@@ -13,13 +13,23 @@
       },
       "discovery_confirm": {
         "description": "Do you want to setup {name}?"
+      },
+      "reconfigure": {
+        "description": "Reconfigure your Cambridge Audio Streamer.",
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]"
+        },
+        "data_description": {
+          "host": "[%key:component::cambridge_audio::config::step::user::data_description::host%]"
+        }
       }
     },
     "error": {
-      "cannot_connect": "Failed to connect to Cambridge Audio device. Please make sure the device is powered up and connected to the network. Try power-cycling the device if it does not connect.",
-      "wrong_device": "This Cambridge Audio device does not match the existing device id. Please make sure you entered the correct IP address."
+      "cannot_connect": "Failed to connect to Cambridge Audio device. Please make sure the device is powered up and connected to the network. Try power-cycling the device if it does not connect."
     },
     "abort": {
+      "wrong_device": "This Cambridge Audio device does not match the existing device id. Please make sure you entered the correct IP address.",
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
     }

--- a/homeassistant/components/cambridge_audio/strings.json
+++ b/homeassistant/components/cambridge_audio/strings.json
@@ -16,7 +16,8 @@
       }
     },
     "error": {
-      "cannot_connect": "Failed to connect to Cambridge Audio device. Please make sure the device is powered up and connected to the network. Try power-cycling the device if it does not connect."
+      "cannot_connect": "Failed to connect to Cambridge Audio device. Please make sure the device is powered up and connected to the network. Try power-cycling the device if it does not connect.",
+      "wrong_device": "This Cambridge Audio device does not match the existing device id. Please make sure you entered the correct IP address."
     },
     "abort": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",

--- a/tests/components/cambridge_audio/test_config_flow.py
+++ b/tests/components/cambridge_audio/test_config_flow.py
@@ -7,7 +7,7 @@ from aiostreammagic import StreamMagicError
 
 from homeassistant.components.cambridge_audio.const import DOMAIN
 from homeassistant.components.zeroconf import ZeroconfServiceInfo
-from homeassistant.config_entries import SOURCE_USER, SOURCE_ZEROCONF
+from homeassistant.config_entries import SOURCE_USER, SOURCE_ZEROCONF, ConfigFlowResult
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -194,13 +194,10 @@ async def test_zeroconf_duplicate(
     assert result["reason"] == "already_configured"
 
 
-async def test_reconfigure_flow(
-    hass: HomeAssistant,
-    mock_stream_magic_client: AsyncMock,
-    mock_setup_entry: AsyncMock,
-    mock_config_entry: MockConfigEntry,
-) -> None:
-    """Test reconfigure flow."""
+async def _start_reconfigure_flow(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> ConfigFlowResult:
+    """Initialize a reconfigure flow."""
     mock_config_entry.add_to_hass(hass)
 
     reconfigure_result = await mock_config_entry.start_reconfigure_flow(hass)
@@ -208,10 +205,21 @@ async def test_reconfigure_flow(
     assert reconfigure_result["type"] is FlowResultType.FORM
     assert reconfigure_result["step_id"] == "reconfigure"
 
-    result = await hass.config_entries.flow.async_configure(
+    return await hass.config_entries.flow.async_configure(
         reconfigure_result["flow_id"],
         {CONF_HOST: "192.168.20.219"},
     )
+
+
+async def test_reconfigure_flow(
+    hass: HomeAssistant,
+    mock_stream_magic_client: AsyncMock,
+    mock_setup_entry: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test reconfigure flow."""
+
+    result = await _start_reconfigure_flow(hass, mock_config_entry)
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reconfigure_successful"
@@ -232,17 +240,7 @@ async def test_reconfigure_unique_id_mismatch(
     """Ensure reconfigure flow aborts when the bride changes."""
     mock_stream_magic_client.info.unit_id = "different_udn"
 
-    mock_config_entry.add_to_hass(hass)
-
-    reconfigure_result = await mock_config_entry.start_reconfigure_flow(hass)
-
-    assert reconfigure_result["type"] is FlowResultType.FORM
-    assert reconfigure_result["step_id"] == "reconfigure"
-
-    result = await hass.config_entries.flow.async_configure(
-        reconfigure_result["flow_id"],
-        {CONF_HOST: "192.168.20.219"},
-    )
+    result = await _start_reconfigure_flow(hass, mock_config_entry)
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "wrong_device"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
