### PR TITLE
Add startup exception handling to nordpool

### DIFF
--- a/homeassistant/components/nordpool/__init__.py
+++ b/homeassistant/components/nordpool/__init__.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.util import dt as dt_util
 
-from .const import PLATFORMS
+from .const import DOMAIN, PLATFORMS
 from .coordinator import NordPoolDataUpdateCoordinator
 
 type NordPoolConfigEntry = ConfigEntry[NordPoolDataUpdateCoordinator]
@@ -17,6 +18,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: NordPoolConfigEntry) -> 
 
     coordinator = NordPoolDataUpdateCoordinator(hass, entry)
     await coordinator.fetch_data(dt_util.utcnow())
+    if not coordinator.last_update_success:
+        raise ConfigEntryNotReady(
+            translation_domain=DOMAIN,
+            translation_key="initial_update_failed",
+            translation_placeholders={"error": str(coordinator.last_exception)},
+        )
     entry.runtime_data = coordinator
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/homeassistant/components/nordpool/strings.json
+++ b/homeassistant/components/nordpool/strings.json
@@ -61,5 +61,10 @@
         "name": "Daily average"
       }
     }
+  },
+  "exceptions": {
+    "initial_update_failed": {
+      "message": "Initial update failed on startup with error {error}"
+    }
   }
 }

--- a/tests/components/nordpool/test_init.py
+++ b/tests/components/nordpool/test_init.py
@@ -4,7 +4,14 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-from pynordpool import DeliveryPeriodData
+from pynordpool import (
+    DeliveryPeriodData,
+    NordPoolConnectionError,
+    NordPoolEmptyResponseError,
+    NordPoolError,
+    NordPoolResponseError,
+)
+import pytest
 
 from homeassistant.components.nordpool.const import DOMAIN
 from homeassistant.config_entries import SOURCE_USER, ConfigEntryState
@@ -37,3 +44,35 @@ async def test_unload_entry(hass: HomeAssistant, get_data: DeliveryPeriodData) -
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
     assert entry.state is ConfigEntryState.NOT_LOADED
+
+
+@pytest.mark.parametrize(
+    ("error"),
+    [
+        (NordPoolConnectionError),
+        (NordPoolEmptyResponseError),
+        (NordPoolError),
+        (NordPoolResponseError),
+    ],
+)
+async def test_initial_startup_fails(
+    hass: HomeAssistant, get_data: DeliveryPeriodData, error: Exception
+) -> None:
+    """Test load and unload an entry."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        source=SOURCE_USER,
+        data=ENTRY_CONFIG,
+    )
+    entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "homeassistant.components.nordpool.coordinator.NordPoolClient.async_get_delivery_period",
+            side_effect=error,
+        ),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert entry.state is ConfigEntryState.SETUP_RETRY


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As `nordpool` isnt using the built in pooling functionality we need to check and raise errors.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 