### PR TITLE
Cache intent recognition results

### DIFF
--- a/tests/components/conversation/test_default_agent.py
+++ b/tests/components/conversation/test_default_agent.py
@@ -2833,3 +2833,110 @@ async def test_query_same_name_different_areas(
     assert result.response.response_type == intent.IntentResponseType.QUERY_ANSWER
     assert len(result.response.matched_states) == 1
     assert result.response.matched_states[0].entity_id == kitchen_light.entity_id
+
+
+@pytest.mark.usefixtures("init_components")
+async def test_intent_cache_exposed(hass: HomeAssistant) -> None:
+    """Test that intent recognition results are cached for exposed entities."""
+    agent = hass.data[DATA_DEFAULT_ENTITY]
+    assert isinstance(agent, default_agent.DefaultAgent)
+
+    entity_id = "light.test_light"
+    hass.states.async_set(entity_id, "off")
+    expose_entity(hass, entity_id, True)
+    await hass.async_block_till_done()
+
+    user_input = ConversationInput(
+        text="turn on test light",
+        context=Context(),
+        conversation_id=None,
+        device_id=None,
+        language=hass.config.language,
+        agent_id=None,
+    )
+    result = await agent.async_recognize_intent(user_input)
+    assert result is not None
+    assert result.entities["name"].text == "test light"
+
+    # Mark this result so we know it is from cache next time
+    mark = "_from_cache"
+    setattr(result, mark, True)
+
+    # Should be from cache this time
+    result = await agent.async_recognize_intent(user_input)
+    assert result is not None
+    assert getattr(result, mark, None) is True
+
+    # Unexposing clears the cache
+    expose_entity(hass, entity_id, False)
+    result = await agent.async_recognize_intent(user_input)
+    assert result is not None
+    assert getattr(result, mark, None) is None
+
+
+@pytest.mark.usefixtures("init_components")
+async def test_intent_cache_all_entities(hass: HomeAssistant) -> None:
+    """Test that intent recognition results are cached for all entities."""
+    agent = hass.data[DATA_DEFAULT_ENTITY]
+    assert isinstance(agent, default_agent.DefaultAgent)
+
+    entity_id = "light.test_light"
+    hass.states.async_set(entity_id, "off")
+    expose_entity(hass, entity_id, False)  # not exposed
+    await hass.async_block_till_done()
+
+    user_input = ConversationInput(
+        text="turn on test light",
+        context=Context(),
+        conversation_id=None,
+        device_id=None,
+        language=hass.config.language,
+        agent_id=None,
+    )
+    result = await agent.async_recognize_intent(user_input)
+    assert result is not None
+    assert result.entities["name"].text == "test light"
+
+    # Mark this result so we know it is from cache next time
+    mark = "_from_cache"
+    setattr(result, mark, True)
+
+    # Should be from cache this time
+    result = await agent.async_recognize_intent(user_input)
+    assert result is not None
+    assert getattr(result, mark, None) is True
+
+    # Adding a new entity clears the cache
+    hass.states.async_set("light.new_light", "off")
+    result = await agent.async_recognize_intent(user_input)
+    assert result is not None
+    assert getattr(result, mark, None) is None
+
+
+@pytest.mark.usefixtures("init_components")
+async def test_intent_cache_fuzzy(hass: HomeAssistant) -> None:
+    """Test that intent recognition results are cached for fuzzy matches."""
+    agent = hass.data[DATA_DEFAULT_ENTITY]
+    assert isinstance(agent, default_agent.DefaultAgent)
+
+    # There is no entity named test light
+    user_input = ConversationInput(
+        text="turn on test light",
+        context=Context(),
+        conversation_id=None,
+        device_id=None,
+        language=hass.config.language,
+        agent_id=None,
+    )
+    result = await agent.async_recognize_intent(user_input)
+    assert result is not None
+    assert result.unmatched_entities["name"].text == "test light"
+
+    # Mark this result so we know it is from cache next time
+    mark = "_from_cache"
+    setattr(result, mark, True)
+
+    # Should be from cache this time
+    result = await agent.async_recognize_intent(user_input)
+    assert result is not None
+    assert getattr(result, mark, None) is True


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Intent recognition can take a long time under specific circumstances: https://github.com/home-assistant/core/issues/130969

There are 3 stages to intent recognition:
1. Strict recognition with only exposed entities
2. Strict recognition with all entities in HA (slow)
3. Fuzzy recognition with all entities in HA (slowest)

As part of a series of performance enhancements for intent recognition, this PR:

1. Uses only exposed entities for fuzzy recognition. This no effect on the default error messages since we don't support naming multiple entities in a single command.
2. Intent results are cached, both when a result is found and when one is not.

Caching intent results is tricky to get right, so here is what is done in the PR:
* An LRU cache with a max size of 128 is used (similar to `functools.lru_cache`)
* The cache key contains the text input, the language, and the device id (for area context)
* The cache is cleared when slot lists are cleared and when intents are reloaded

As mentioned above, negative results are also cached. This allows us to skip matching stages under different conditions. For example, if the text "turn on unexposed light" fails stage 1 (exposed entities) but succeeds in stage 2 (all entities), the stage 1 failure is cached. Then, if only stage 1 is run in the future (such as when LLMs check intents), matching is skipped entirely.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/issues/130969
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
