### PR TITLE
Add Reolink quality scale yaml

### DIFF
--- a/homeassistant/components/reolink/quality_scale.yaml
+++ b/homeassistant/components/reolink/quality_scale.yaml
@@ -43,7 +43,7 @@ rules:
   discovery-update-info: done
   discovery: done
   docs-data-update: done
-  docs-examples: todo
+  docs-examples: done
   docs-known-limitations: done
   docs-supported-devices: done
   docs-supported-functions: done

--- a/homeassistant/components/reolink/quality_scale.yaml
+++ b/homeassistant/components/reolink/quality_scale.yaml
@@ -14,7 +14,7 @@ rules:
   docs-actions: done
   docs-high-level-description: done
   docs-installation-instructions: done
-  docs-removal-instructions: todo
+  docs-removal-instructions: done
   entity-event-setup: done
   entity-unique-id: done
   has-entity-name: done

--- a/homeassistant/components/reolink/quality_scale.yaml
+++ b/homeassistant/components/reolink/quality_scale.yaml
@@ -63,7 +63,7 @@ rules:
       For standalone cameras this does not apply: the integration should be removed.
       For cameras connected to a NVR/Hub: the entities of a device are marked unavailable when power is unplugged. They can be removed using async_remove_config_entry_device.
       Chimes can be uncoupled from the doorbell and removed from HA using async_remove_config_entry_device
-      Automatic removal lead to many user issues when a device was temporarly out of wifi range or disconnected from power, so not implemented anymore
+      Automatic removal lead to many user issues when a device was temporarily out of wifi range or disconnected from power, so not implemented anymore
   # Platinumasync_remove_config_entry_device.
   async-dependency: done
   inject-websession: done

--- a/homeassistant/components/reolink/quality_scale.yaml
+++ b/homeassistant/components/reolink/quality_scale.yaml
@@ -67,4 +67,4 @@ rules:
   # Platinumasync_remove_config_entry_device.
   async-dependency: done
   inject-websession: done
-  strict-typing: done
+  strict-typing: todo

--- a/homeassistant/components/reolink/quality_scale.yaml
+++ b/homeassistant/components/reolink/quality_scale.yaml
@@ -1,0 +1,70 @@
+rules:
+  # Bronze
+  action-setup:
+    status: done
+    comment: |
+      play_chime service is setup in async_setup
+      ptz_move service is setup in async_setup_entry since it is a entity_service
+  appropriate-polling: done
+  brands: done
+  common-modules: done
+  config-flow-test-coverage: done
+  config-flow: done
+  dependency-transparency: done
+  docs-actions: done
+  docs-high-level-description: done
+  docs-installation-instructions: todo
+  docs-removal-instructions: todo
+  entity-event-setup: done
+  entity-unique-id: done
+  has-entity-name: done
+  runtime-data: done
+  test-before-configure: done
+  test-before-setup: done
+  unique-config-entry: done
+  # Silver
+  action-exceptions: done
+  config-entry-unloading: done
+  docs-configuration-parameters: done
+  docs-installation-parameters: todo
+  entity-unavailable: done
+  integration-owner: done
+  log-when-unavailable: done
+  parallel-updates:
+    status: done
+    comment: |
+      Coordinators are used and asyncio mutex locks ensure safe operation in the upstream lib
+  reauthentication-flow: done
+  test-coverage: done
+  # Gold
+  devices: done
+  diagnostics: done
+  discovery-update-info: done
+  discovery: done
+  docs-data-update: todo
+  docs-examples: todo
+  docs-known-limitations: todo
+  docs-supported-devices: done
+  docs-supported-functions: done
+  docs-troubleshooting: done
+  docs-use-cases: todo
+  dynamic-devices: done
+  entity-category: done
+  entity-device-class: done
+  entity-disabled-by-default: done
+  entity-translations: done
+  exception-translations: done
+  icon-translations: done
+  reconfiguration-flow: done
+  repair-issues: done
+  stale-devices:
+    status: done
+    comment: |
+      For standalone cameras this does not apply: the integration should be removed.
+      For cameras connected to a NVR/Hub: the entities of a device are marked unavailable when power is unplugged. They can be removed using async_remove_config_entry_device.
+      Chimes can be uncoupled from the doorbell and removed from HA using async_remove_config_entry_device
+      Automatic removal lead to many user issues when a device was temporarly out of wifi range or disconnected from power, so not implemented anymore
+  # Platinumasync_remove_config_entry_device.
+  async-dependency: done
+  inject-websession: done
+  strict-typing: done

--- a/homeassistant/components/reolink/quality_scale.yaml
+++ b/homeassistant/components/reolink/quality_scale.yaml
@@ -31,9 +31,10 @@ rules:
   integration-owner: done
   log-when-unavailable: done
   parallel-updates:
-    status: todo
+    status: done
     comment: |
       Coordinators are used and asyncio mutex locks ensure safe operation in the upstream lib
+      Parallel_update=0 set on all platforms
   reauthentication-flow: done
   test-coverage: done
   # Gold

--- a/homeassistant/components/reolink/quality_scale.yaml
+++ b/homeassistant/components/reolink/quality_scale.yaml
@@ -54,7 +54,7 @@ rules:
   entity-device-class: done
   entity-disabled-by-default: done
   entity-translations: done
-  exception-translations: done
+  exception-translations: todo
   icon-translations: done
   reconfiguration-flow: done
   repair-issues: done

--- a/homeassistant/components/reolink/quality_scale.yaml
+++ b/homeassistant/components/reolink/quality_scale.yaml
@@ -13,7 +13,7 @@ rules:
   dependency-transparency: done
   docs-actions: done
   docs-high-level-description: done
-  docs-installation-instructions: todo
+  docs-installation-instructions: done
   docs-removal-instructions: todo
   entity-event-setup: done
   entity-unique-id: done
@@ -26,12 +26,12 @@ rules:
   action-exceptions: done
   config-entry-unloading: done
   docs-configuration-parameters: done
-  docs-installation-parameters: todo
+  docs-installation-parameters: done
   entity-unavailable: done
   integration-owner: done
   log-when-unavailable: done
   parallel-updates:
-    status: done
+    status: todo
     comment: |
       Coordinators are used and asyncio mutex locks ensure safe operation in the upstream lib
   reauthentication-flow: done

--- a/homeassistant/components/reolink/quality_scale.yaml
+++ b/homeassistant/components/reolink/quality_scale.yaml
@@ -44,11 +44,11 @@ rules:
   discovery: done
   docs-data-update: done
   docs-examples: todo
-  docs-known-limitations: todo
+  docs-known-limitations: done
   docs-supported-devices: done
   docs-supported-functions: done
   docs-troubleshooting: done
-  docs-use-cases: todo
+  docs-use-cases: done
   dynamic-devices: done
   entity-category: done
   entity-device-class: done

--- a/homeassistant/components/reolink/quality_scale.yaml
+++ b/homeassistant/components/reolink/quality_scale.yaml
@@ -42,7 +42,7 @@ rules:
   diagnostics: done
   discovery-update-info: done
   discovery: done
-  docs-data-update: todo
+  docs-data-update: done
   docs-examples: todo
   docs-known-limitations: todo
   docs-supported-devices: done
@@ -68,4 +68,4 @@ rules:
   # Platinum
   async-dependency: done
   inject-websession: done
-  strict-typing: todo
+  strict-typing: done

--- a/homeassistant/components/reolink/quality_scale.yaml
+++ b/homeassistant/components/reolink/quality_scale.yaml
@@ -63,8 +63,8 @@ rules:
       For standalone cameras this does not apply: the integration should be removed.
       For cameras connected to a NVR/Hub: the entities of a device are marked unavailable when power is unplugged. They can be removed using async_remove_config_entry_device.
       Chimes can be uncoupled from the doorbell and removed from HA using async_remove_config_entry_device
-      Automatic removal lead to many user issues when a device was temporarily out of wifi range or disconnected from power, so not implemented anymore
-  # Platinumasync_remove_config_entry_device.
+      Automatic removal lead to many user issues when a device was temporarily out of wifi range or disconnected from power, so not implemented anymore.
+  # Platinum
   async-dependency: done
   inject-websession: done
   strict-typing: todo

--- a/script/hassfest/quality_scale.py
+++ b/script/hassfest/quality_scale.py
@@ -850,7 +850,6 @@ INTEGRATIONS_WITHOUT_QUALITY_SCALE_FILE = [
     "remote_rpi_gpio",
     "renault",
     "renson",
-    "reolink",
     "repetier",
     "rest",
     "rest_command",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add Reolink quality scale yaml to track progress

Checklist (checked the 'done' and 'exempt' rules):
## Bronze
- [x] `config-flow` - Integration needs to be able to be set up via the UI
    - [x] Uses `data-description` to give context to fields
    - [x] Uses `ConfigEntry.data` and `ConfigEntry.options` correctly
- [x] `test-before-configure` - Test a connection in the config flow
- [x] `unique-config-entry` - Don't allow the same device or service to be able to be set up twice
- [x] `config-flow-test-coverage` - Full test coverage for the config flow
- [x] `runtime-data` - Use ConfigEntry.runtime_data to store runtime data
- [x] `test-before-setup` - Check during integration initialization if we are able to set it up correctly
- [x] `appropriate-polling` - If it's a polling integration, set an appropriate polling interval
- [x] `entity-unique-id` - Entities have a unique ID
- [x] `has-entity-name` - Entities use has_entity_name = True
- [x] `entity-event-setup` - Entities event setup
- [x] `dependency-transparency` - Dependency transparency
- [x] `action-setup` - Service actions are registered in async_setup
- [x] `common-modules` - Place common patterns in common modules
- [x] `docs-high-level-description` - The documentation includes a high-level description of the integration brand, product, or service
- [x] `docs-installation-instructions` - The documentation provides step-by-step installation instructions for the integration, including, if needed, prerequisites
- [x] `docs-removal-instructions` - The documentation provides removal instructions
- [x] `docs-actions` - The documentation describes the provided service actions that can be used
- [x] `brands` - Has branding assets available for the integration

## Silver
- [x] `config-entry-unloading` - Support config entry unloading
- [x] `log-when-unavailable` - If internet/device/service is unavailable, log once when unavailable and once when back connected
- [x] `entity-unavailable` - Mark entity unavailable if appropriate
- [x] `action-exceptions` - Service actions raise exceptions when encountering failures
- [x] `reauthentication-flow` - Reauthentication flow
- [x] `parallel-updates` - Set Parallel updates
- [x] `test-coverage` - Above 95% test coverage for all integration modules
- [x] `integration-owner` - Has an integration owner
- [x] `docs-installation-parameters` - The documentation describes all integration installation parameters
- [x] `docs-configuration-parameters` - The documentation describes all integration configuration options

## Gold
- [x] `entity-translations` - Entities have translated names
- [x] `entity-device-class` - Entities use device classes where possible
- [x] `devices` - The integration creates devices
- [x] `entity-category` - Entities are assigned an appropriate EntityCategory
- [x] `entity-disabled-by-default` - Integration disables less popular (or noisy) entities
- [x] `discovery` - Can be discovered
- [x] `stale-devices` - Clean up stale devices
- [x] `diagnostics` - Implements diagnostics
- [x] `exception-translations` - Exception messages are translatable
- [x] `icon-translations` - Icon translations
- [x] `reconfiguration-flow` - Integrations should have a reconfigure flow
- [x] `dynamic-devices` - Devices added after integration setup
- [x] `discovery-update-info` - Integration uses discovery info to update network information
- [x] `repair-issues` - Repair issues and repair flows are used when user intervention is needed
- [x] `docs-use-cases` - The documentation describes use cases to illustrate how this integration can be used
- [x] `docs-supported-devices` - The integration documents known supported / unsupported devices
- [x] `docs-supported-functions` - The documentation describes the supported functionality, including entities, and platforms
- [x] `docs-data-update` - The documentation describes how data is updated
- [x] `docs-known-limitations` - The documentation describes known limitations of the integration (not to be confused with bugs)
- [x] `docs-troubleshooting` - The documentation provides troubleshooting information
- [x] `docs-examples` - The documentation provides automation examples the user can use.

## Platinum
- [x] `async-dependency` - Dependency is async
- [x] `inject-websession` - The integration dependency supports passing in a websession
- [x] `strict-typing` - Strict typing


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
