### PR TITLE
Fix twoSet temp and fan_mode error in LG ThinQ integration

### DIFF
--- a/homeassistant/components/lg_thinq/climate.py
+++ b/homeassistant/components/lg_thinq/climate.py
@@ -12,7 +12,6 @@ from thinqconnect.integration import ExtendedProperty
 from homeassistant.components.climate import (
     ATTR_TARGET_TEMP_HIGH,
     ATTR_TARGET_TEMP_LOW,
-    FAN_OFF,
     ClimateEntity,
     ClimateEntityDescription,
     ClimateEntityFeature,
@@ -150,7 +149,7 @@ class ThinQClimateEntity(ThinQEntity, ClimateEntity):
 
         # Update fan, hvac and preset mode.
         if self.supported_features & ClimateEntityFeature.FAN_MODE:
-                self._attr_fan_mode = self.data.fan_mode
+            self._attr_fan_mode = self.data.fan_mode
         if self.data.is_on:
             hvac_mode = self._requested_hvac_mode or self.data.hvac_mode
             if hvac_mode in STR_TO_HVAC:

--- a/homeassistant/components/lg_thinq/climate.py
+++ b/homeassistant/components/lg_thinq/climate.py
@@ -37,7 +37,7 @@ class ThinQClimateEntityDescription(ClimateEntityDescription):
     step: float | None = None
 
 
-DEVIE_TYPE_CLIMATE_MAP: dict[DeviceType, tuple[ThinQClimateEntityDescription, ...]] = {
+DEVICE_TYPE_CLIMATE_MAP: dict[DeviceType, tuple[ThinQClimateEntityDescription, ...]] = {
     DeviceType.AIR_CONDITIONER: (
         ThinQClimateEntityDescription(
             key=ExtendedProperty.CLIMATE_AIR_CONDITIONER,
@@ -86,7 +86,7 @@ async def async_setup_entry(
     entities: list[ThinQClimateEntity] = []
     for coordinator in entry.runtime_data.coordinators.values():
         if (
-            descriptions := DEVIE_TYPE_CLIMATE_MAP.get(
+            descriptions := DEVICE_TYPE_CLIMATE_MAP.get(
                 coordinator.api.device.device_type
             )
         ) is not None:
@@ -149,10 +149,9 @@ class ThinQClimateEntity(ThinQEntity, ClimateEntity):
         super()._update_status()
 
         # Update fan, hvac and preset mode.
-        if self.data.is_on:
-            if self.supported_features & ClimateEntityFeature.FAN_MODE:
+        if self.supported_features & ClimateEntityFeature.FAN_MODE:
                 self._attr_fan_mode = self.data.fan_mode
-
+        if self.data.is_on:
             hvac_mode = self._requested_hvac_mode or self.data.hvac_mode
             if hvac_mode in STR_TO_HVAC:
                 self._attr_hvac_mode = STR_TO_HVAC.get(hvac_mode)
@@ -160,9 +159,6 @@ class ThinQClimateEntity(ThinQEntity, ClimateEntity):
             elif hvac_mode in THINQ_PRESET_MODE:
                 self._attr_preset_mode = hvac_mode
         else:
-            if self.supported_features & ClimateEntityFeature.FAN_MODE:
-                self._attr_fan_mode = FAN_OFF
-
             self._attr_hvac_mode = HVACMode.OFF
             self._attr_preset_mode = None
 
@@ -170,6 +166,7 @@ class ThinQClimateEntity(ThinQEntity, ClimateEntity):
         self._attr_current_humidity = self.data.humidity
         self._attr_current_temperature = self.data.current_temp
 
+        # Update min, max and step.
         if (max_temp := self.entity_description.max_temp) is not None or (
             max_temp := self.data.max
         ) is not None:
@@ -184,26 +181,18 @@ class ThinQClimateEntity(ThinQEntity, ClimateEntity):
             self._attr_target_temperature_step = step
 
         # Update target temperatures.
-        if (
-            self.supported_features & ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
-            and self.hvac_mode == HVACMode.AUTO
-        ):
-            self._attr_target_temperature = None
-            self._attr_target_temperature_high = self.data.target_temp_high
-            self._attr_target_temperature_low = self.data.target_temp_low
-        else:
-            self._attr_target_temperature = self.data.target_temp
-            self._attr_target_temperature_high = None
-            self._attr_target_temperature_low = None
+        self._attr_target_temperature = self.data.target_temp
+        self._attr_target_temperature_high = self.data.target_temp_high
+        self._attr_target_temperature_low = self.data.target_temp_low
 
         _LOGGER.debug(
-            "[%s:%s] update status: %s/%s -> %s/%s, hvac:%s, unit:%s, step:%s",
+            "[%s:%s] update status: c:%s, t:%s, l:%s, h:%s, hvac:%s, unit:%s, step:%s",
             self.coordinator.device_name,
             self.property_id,
-            self.data.current_temp,
-            self.data.target_temp,
             self.current_temperature,
             self.target_temperature,
+            self.target_temperature_low,
+            self.target_temperature_high,
             self.hvac_mode,
             self.temperature_unit,
             self.target_temperature_step,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Fix twoSet mode's targetTemperature error.

- Fix fan_mode error when turned-off.

- Fix minor spelling error.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #https://github.com/home-assistant/core/issues/130739
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
