### PR TITLE
Use breaks_in_ha_version in report_usage

### DIFF
--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -509,10 +509,10 @@ class HomeAssistantHTTP:
             "calls hass.http.register_static_path which is deprecated because "
             "it does blocking I/O in the event loop, instead "
             "call `await hass.http.async_register_static_paths("
-            f'[StaticPathConfig("{url_path}", "{path}", {cache_headers})])`; '
-            "This function will be removed in 2025.7",
+            f'[StaticPathConfig("{url_path}", "{path}", {cache_headers})])`',
             exclude_integrations={"http"},
             core_behavior=frame.ReportBehavior.LOG,
+            breaks_in_ha_version="2025.7",
         )
         configs = [StaticPathConfig(url_path, path, cache_headers)]
         resources = self._make_static_resources(configs)

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -657,11 +657,11 @@ class HomeAssistant:
         from .helpers import frame  # pylint: disable=import-outside-toplevel
 
         frame.report_usage(
-            "calls `async_add_job`, which is deprecated and will be removed in Home "
-            "Assistant 2025.4; Please review "
+            "calls `async_add_job`, which should be reviewed against "
             "https://developers.home-assistant.io/blog/2024/03/13/deprecate_add_run_job"
             " for replacement options",
             core_behavior=frame.ReportBehavior.LOG,
+            breaks_in_ha_version="2025.4",
         )
 
         if target is None:
@@ -713,11 +713,11 @@ class HomeAssistant:
         from .helpers import frame  # pylint: disable=import-outside-toplevel
 
         frame.report_usage(
-            "calls `async_add_hass_job`, which is deprecated and will be removed in Home "
-            "Assistant 2025.5; Please review "
+            "calls `async_add_hass_job`, which should be reviewed against "
             "https://developers.home-assistant.io/blog/2024/04/07/deprecate_add_hass_job"
             " for replacement options",
             core_behavior=frame.ReportBehavior.LOG,
+            breaks_in_ha_version="2025.5",
         )
 
         return self._async_add_hass_job(hassjob, *args, background=background)
@@ -987,11 +987,11 @@ class HomeAssistant:
         from .helpers import frame  # pylint: disable=import-outside-toplevel
 
         frame.report_usage(
-            "calls `async_run_job`, which is deprecated and will be removed in Home "
-            "Assistant 2025.4; Please review "
+            "calls `async_run_job`, which should be reviewed against "
             "https://developers.home-assistant.io/blog/2024/03/13/deprecate_add_run_job"
             " for replacement options",
             core_behavior=frame.ReportBehavior.LOG,
+            breaks_in_ha_version="2025.4",
         )
 
         if asyncio.iscoroutine(target):
@@ -1636,9 +1636,9 @@ class EventBus:
             from .helpers import frame  # pylint: disable=import-outside-toplevel
 
             frame.report_usage(
-                "calls `async_listen` with run_immediately, which is"
-                " deprecated and will be removed in Home Assistant 2025.5",
+                "calls `async_listen` with run_immediately",
                 core_behavior=frame.ReportBehavior.LOG,
+                breaks_in_ha_version="2025.5",
             )
 
         if event_filter is not None and not is_callback_check_partial(event_filter):
@@ -1706,9 +1706,9 @@ class EventBus:
             from .helpers import frame  # pylint: disable=import-outside-toplevel
 
             frame.report_usage(
-                "calls `async_listen_once` with run_immediately, which is "
-                "deprecated and will be removed in Home Assistant 2025.5",
+                "calls `async_listen_once` with run_immediately",
                 core_behavior=frame.ReportBehavior.LOG,
+                breaks_in_ha_version="2025.5",
             )
 
         one_time_listener: _OneTimeListener[_DataT] = _OneTimeListener(

--- a/homeassistant/core_config.py
+++ b/homeassistant/core_config.py
@@ -696,10 +696,10 @@ class Config:
         It will be removed in Home Assistant 2025.6.
         """
         report_usage(
-            "set the time zone using set_time_zone instead of async_set_time_zone"
-            " which will stop working in Home Assistant 2025.6",
+            "sets the time zone using set_time_zone instead of async_set_time_zone",
             core_integration_behavior=ReportBehavior.ERROR,
-            custom_integration_behavior=ReportBehavior.ERROR,
+            custom_integration_behavior=ReportBehavior.LOG,
+            breaks_in_ha_version="2025.6",
         )
         if time_zone := dt_util.get_time_zone(time_zone_str):
             self.time_zone = time_zone_str

--- a/homeassistant/core_config.py
+++ b/homeassistant/core_config.py
@@ -698,7 +698,7 @@ class Config:
         report_usage(
             "sets the time zone using set_time_zone instead of async_set_time_zone",
             core_integration_behavior=ReportBehavior.ERROR,
-            custom_integration_behavior=ReportBehavior.LOG,
+            custom_integration_behavior=ReportBehavior.ERROR,
             breaks_in_ha_version="2025.6",
         )
         if time_zone := dt_util.get_time_zone(time_zone_str):

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -531,11 +531,9 @@ class FlowManager(abc.ABC, Generic[_FlowContextT, _FlowResultT, _HandlerT]):
         if not isinstance(result["type"], FlowResultType):
             result["type"] = FlowResultType(result["type"])  # type: ignore[unreachable]
             report_usage(
-                (
-                    "does not use FlowResultType enum for data entry flow result type. "
-                    "This is deprecated and will stop working in Home Assistant 2025.1"
-                ),
+                "does not use FlowResultType enum for data entry flow result type",
                 core_behavior=ReportBehavior.LOG,
+                breaks_in_ha_version="2025.1",
             )
 
         if (

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -996,15 +996,10 @@ class TrackTemplateResultInfo:
             if track_template_.template.hass:
                 continue
 
-            # pylint: disable-next=import-outside-toplevel
-            from .frame import ReportBehavior, report_usage
-
-            report_usage(
-                (
-                    "calls async_track_template_result with template without hass, "
-                    "which will stop working in HA Core 2025.10"
-                ),
-                core_behavior=ReportBehavior.LOG,
+            frame.report_usage(
+                "calls async_track_template_result with template without hass",
+                core_behavior=frame.ReportBehavior.LOG,
+                breaks_in_ha_version="2025.10",
             )
             track_template_.template.hass = hass
 

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -1280,11 +1280,9 @@ def async_register_entity_service(
         from .frame import ReportBehavior, report_usage
 
         report_usage(
-            (
-                "registers an entity service with a non entity service schema "
-                "which will stop working in HA Core 2025.9"
-            ),
+            "registers an entity service with a non entity service schema",
             core_behavior=ReportBehavior.LOG,
+            breaks_in_ha_version="2025.9",
         )
 
     service_func: str | HassJob[..., Any]

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -522,11 +522,9 @@ class Template:
 
         if not hass:
             report_usage(
-                (
-                    "creates a template object without passing hass, "
-                    "which will stop working in HA Core 2025.10"
-                ),
+                "creates a template object without passing hass",
                 core_behavior=ReportBehavior.LOG,
+                breaks_in_ha_version="2025.10",
             )
 
         self.template: str = template.strip()

--- a/homeassistant/helpers/update_coordinator.py
+++ b/homeassistant/helpers/update_coordinator.py
@@ -288,8 +288,8 @@ class DataUpdateCoordinator(BaseDataUpdateCoordinatorProtocol, Generic[_DataT]):
         if self.config_entry is None:
             report_usage(
                 "uses `async_config_entry_first_refresh`, which is only supported "
-                "for coordinators with a config entry and will stop working in "
-                "Home Assistant 2025.11"
+                "for coordinators with a config entry",
+                breaks_in_ha_version="2025.11",
             )
         elif (
             self.config_entry.state
@@ -298,8 +298,8 @@ class DataUpdateCoordinator(BaseDataUpdateCoordinatorProtocol, Generic[_DataT]):
             report_usage(
                 "uses `async_config_entry_first_refresh`, which is only supported "
                 f"when entry state is {config_entries.ConfigEntryState.SETUP_IN_PROGRESS}, "
-                f"but it is in state {self.config_entry.state}, "
-                "This will stop working in Home Assistant 2025.11",
+                f"but it is in state {self.config_entry.state}",
+                breaks_in_ha_version="2025.11",
             )
         if await self.__wrap_async_setup():
             await self._async_refresh(

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -1560,14 +1560,12 @@ class Components:
         from .helpers.frame import ReportBehavior, report_usage
 
         report_usage(
-            (
-                f"accesses hass.components.{comp_name}."
-                " This is deprecated and will stop working in Home Assistant 2025.3, it"
-                f" should be updated to import functions used from {comp_name} directly"
-            ),
+            f"accesses hass.components.{comp_name}, which"
+            f" should be updated to import functions used from {comp_name} directly",
             core_behavior=ReportBehavior.IGNORE,
             core_integration_behavior=ReportBehavior.IGNORE,
             custom_integration_behavior=ReportBehavior.LOG,
+            breaks_in_ha_version="2025.3",
         )
 
         wrapped = ModuleWrapper(self._hass, component)
@@ -1592,13 +1590,13 @@ class Helpers:
 
         report_usage(
             (
-                f"accesses hass.helpers.{helper_name}."
-                " This is deprecated and will stop working in Home Assistant 2025.5, it"
+                f"accesses hass.helpers.{helper_name}, which"
                 f" should be updated to import functions used from {helper_name} directly"
             ),
             core_behavior=ReportBehavior.IGNORE,
             core_integration_behavior=ReportBehavior.IGNORE,
             custom_integration_behavior=ReportBehavior.LOG,
+            breaks_in_ha_version="2025.5",
         )
 
         wrapped = ModuleWrapper(self._hass, helper)

--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -4946,7 +4946,8 @@ async def test_async_track_template_no_hass_deprecated(
     """Test async_track_template with a template without hass is deprecated."""
     message = (
         "Detected code that calls async_track_template_result with template without "
-        "hass, which will stop working in HA Core 2025.10. Please report this issue"
+        "hass. This will stop working in Home Assistant 2025.10, please "
+        "report this issue"
     )
 
     async_track_template(hass, Template("blah"), lambda x, y, z: None)
@@ -4964,7 +4965,8 @@ async def test_async_track_template_result_no_hass_deprecated(
     """Test async_track_template_result with a template without hass is deprecated."""
     message = (
         "Detected code that calls async_track_template_result with template without "
-        "hass, which will stop working in HA Core 2025.10. Please report this issue"
+        "hass. This will stop working in Home Assistant 2025.10, please "
+        "report this issue"
     )
 
     async_track_template_result(

--- a/tests/helpers/test_update_coordinator.py
+++ b/tests/helpers/test_update_coordinator.py
@@ -628,8 +628,7 @@ async def test_async_config_entry_first_refresh_invalid_state(
         RuntimeError,
         match="Detected code that uses `async_config_entry_first_refresh`, which "
         "is only supported when entry state is ConfigEntryState.SETUP_IN_PROGRESS, "
-        "but it is in state ConfigEntryState.NOT_LOADED. This will stop working "
-        "in Home Assistant 2025.11. Please report this issue",
+        "but it is in state ConfigEntryState.NOT_LOADED. Please report this issue",
     ):
         await crd.async_config_entry_first_refresh()
 
@@ -653,8 +652,9 @@ async def test_async_config_entry_first_refresh_invalid_state_in_integration(
     assert (
         "Detected that integration 'hue' uses `async_config_entry_first_refresh`, which "
         "is only supported when entry state is ConfigEntryState.SETUP_IN_PROGRESS, "
-        "but it is in state ConfigEntryState.NOT_LOADED, This will stop working "
-        "in Home Assistant 2025.11"
+        "but it is in state ConfigEntryState.NOT_LOADED at "
+        "homeassistant/components/hue/light.py, line 23: self.light.is_on. "
+        "This will stop working in Home Assistant 2025.11"
     ) in caplog.text
 
 
@@ -665,8 +665,8 @@ async def test_async_config_entry_first_refresh_no_entry(hass: HomeAssistant) ->
     with pytest.raises(
         RuntimeError,
         match="Detected code that uses `async_config_entry_first_refresh`, "
-        "which is only supported for coordinators with a config entry and will "
-        "stop working in Home Assistant 2025.11. Please report this issue",
+        "which is only supported for coordinators with a config entry. "
+        "Please report this issue",
     ):
         await crd.async_config_entry_first_refresh()
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3040,10 +3040,9 @@ async def test_async_run_job_deprecated(
 
     hass.async_run_job(_test)
     assert (
-        "Detected code that calls `async_run_job`, which is deprecated "
-        "and will be removed in Home Assistant 2025.4; Please review "
+        "Detected code that calls `async_run_job`, which should be reviewed against "
         "https://developers.home-assistant.io/blog/2024/03/13/deprecate_add_run_job"
-        " for replacement options"
+        " for replacement options. This will stop working in Home Assistant 2025.4"
     ) in caplog.text
 
 
@@ -3057,10 +3056,9 @@ async def test_async_add_job_deprecated(
 
     hass.async_add_job(_test)
     assert (
-        "Detected code that calls `async_add_job`, which is deprecated "
-        "and will be removed in Home Assistant 2025.4; Please review "
+        "Detected code that calls `async_add_job`, which should be reviewed against "
         "https://developers.home-assistant.io/blog/2024/03/13/deprecate_add_run_job"
-        " for replacement options"
+        " for replacement options. This will stop working in Home Assistant 2025.4"
     ) in caplog.text
 
 
@@ -3074,10 +3072,9 @@ async def test_async_add_hass_job_deprecated(
 
     hass.async_add_hass_job(HassJob(_test))
     assert (
-        "Detected code that calls `async_add_hass_job`, which is deprecated "
-        "and will be removed in Home Assistant 2025.5; Please review "
+        "Detected code that calls `async_add_hass_job`, which should be reviewed against "
         "https://developers.home-assistant.io/blog/2024/04/07/deprecate_add_hass_job"
-        " for replacement options"
+        " for replacement options. This will stop working in Home Assistant 2025.5"
     ) in caplog.text
 
 
@@ -3245,8 +3242,8 @@ async def test_async_listen_with_run_immediately_deprecated(
     func = getattr(hass.bus, method)
     func(EVENT_HOMEASSISTANT_START, _test, run_immediately=run_immediately)
     assert (
-        f"Detected code that calls `{method}` with run_immediately, which is "
-        "deprecated and will be removed in Home Assistant 2025.5."
+        f"Detected code that calls `{method}` with run_immediately. "
+        "This will stop working in Home Assistant 2025.5"
     ) in caplog.text
 
 

--- a/tests/test_core_config.py
+++ b/tests/test_core_config.py
@@ -1075,9 +1075,8 @@ async def test_set_time_zone_deprecated(hass: HomeAssistant) -> None:
     with pytest.raises(
         RuntimeError,
         match=re.escape(
-            "Detected code that set the time zone using set_time_zone instead of "
-            "async_set_time_zone which will stop working in Home Assistant 2025.6. "
-            "Please report this issue",
+            "Detected code that sets the time zone using set_time_zone instead of "
+            "async_set_time_zone. Please report this issue"
         ),
     ):
         await hass.config.set_time_zone("America/New_York")

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1327,7 +1327,7 @@ async def test_hass_components_use_reported(
 
         reported = (
             "Detected that custom integration 'test_integration_frame'"
-            " accesses hass.components.http. This is deprecated"
+            " accesses hass.components.http, which should be updated"
         ) in caplog.text
         assert reported == expected
 
@@ -2023,7 +2023,7 @@ async def test_hass_helpers_use_reported(
 
         reported = (
             "Detected that custom integration 'test_integration_frame' "
-            "accesses hass.helpers.aiohttp_client. This is deprecated"
+            "accesses hass.helpers.aiohttp_client, which should be updated"
         ) in caplog.text
         assert reported == expected
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, as follow-up to #130858

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
