### PR TITLE
Fix Xiaomi Miio translation strings

### DIFF
--- a/homeassistant/components/xiaomi_miio/strings.json
+++ b/homeassistant/components/xiaomi_miio/strings.json
@@ -216,22 +216,22 @@
         "name": "Air quality index"
       },
       "filter_life_remaining": {
-        "name": "Filter lifetime remaining"
+        "name": "Filter life remaining"
       },
       "filter_hours_used": {
         "name": "Filter use"
       },
       "filter_left_time": {
-        "name": "Filter lifetime left"
+        "name": "Filter lifetime remaining"
       },
       "dust_filter_life_remaining": {
-        "name": "Dust filter lifetime remaining"
+        "name": "Dust filter life remaining"
       },
       "dust_filter_life_remaining_days": {
         "name": "Dust filter lifetime remaining days"
       },
       "upper_filter_life_remaining": {
-        "name": "Upper filter lifetime remaining"
+        "name": "Upper filter life remaining"
       },
       "upper_filter_life_remaining_days": {
         "name": "Upper filter lifetime remaining days"
@@ -276,16 +276,16 @@
         "name": "Total dust collection count"
       },
       "main_brush_left": {
-        "name": "Main brush left"
+        "name": "Main brush remaining"
       },
       "side_brush_left": {
-        "name": "Side brush left"
+        "name": "Side brush remaining"
       },
       "filter_left": {
-        "name": "Filter left"
+        "name": "Filter remaining"
       },
       "sensor_dirty_left": {
-        "name": "Sensor dirty left"
+        "name": "Sensor dirty remaining"
       }
     },
     "switch": {


### PR DESCRIPTION
Currently the "remaining" or "left" sensor names in the Xiaomi Miio integration are easy to misunderstand, especially by translators who might create even more confusion for users.

For sensors that report a percentage remaining the name should use "life" instead of "lifetime" as there are separate sensors for that which report a timespan.

And instead of "left" which can easily be misunderstood by translators as the opposite of "right" use "remaining" as well, making them all consistent.

As agreed with @starkillerOG in the discussion for https://github.com/home-assistant/core/issues/128367

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Replaces three occurrences of "lifetime" with "life" making them consistent with their key names, too.

Replaces five occurrences of "left" with "remaining" to avoid the ambiguity.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #128367 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
