### PR TITLE
Change friendly names of all photovoltaic entities to "PV …"

### DIFF
--- a/homeassistant/components/vicare/strings.json
+++ b/homeassistant/components/vicare/strings.json
@@ -31,7 +31,7 @@
   "entity": {
     "binary_sensor": {
       "circulation_pump": {
-        "name": "Circulation pump"
+        "name": "Heating circulation pump"
       },
       "frost_protection": {
         "name": "Frost protection"
@@ -365,25 +365,25 @@
         "name": "Energy export to grid"
       },
       "photovoltaic_power_production_current": {
-        "name": "Solar power"
+        "name": "PV power"
       },
       "photovoltaic_energy_production_today": {
-        "name": "Solar energy production today"
+        "name": "PV energy production today"
       },
       "photovoltaic_energy_production_this_week": {
-        "name": "Solar energy production this week"
+        "name": "PV energy production this week"
       },
       "photovoltaic_energy_production_this_month": {
-        "name": "Solar energy production this month"
+        "name": "PV energy production this month"
       },
       "photovoltaic_energy_production_this_year": {
-        "name": "Solar energy production this year"
+        "name": "PV energy production this year"
       },
       "photovoltaic_energy_production_total": {
-        "name": "Solar energy production total"
+        "name": "PV energy production total"
       },
       "photovoltaic_status": {
-        "name": "Solar state",
+        "name": "PV state",
         "state": {
           "ready": "Standby",
           "production": "Producing"


### PR DESCRIPTION
There are two groups of "solar" production entities, one for photovotaic and one for thermal solar production, in the vicare integration.

Currently they both have completely identical friendly names labeling them both as "Solar …".
This leads to confusion and makes it impossible to keep them apart.

This PR fixes this by giving all photovoltaic entities friendly names that begin with "PV …".

In addition the 'circulation_pump' entity  is renamed as "Heating circulation pump" to clearly differentiate it from the "DHW circulation pump".

Otherwise many will misunderstand these, in German for example a "Zirkulationspumpe" is always for DHW, while the "Heating circulation pump" is called "Heizkreisumwälzpumpe" or just "Heizkreispumpe".

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Change "Solar …" to "PV …" on all 'photovoltaic' keys.
Add "Heating …" to the 'circulation_pump' entity.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #128859 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
