### PR TITLE
Fix fibaro cover state is not always correct

### DIFF
--- a/homeassistant/components/fibaro/cover.py
+++ b/homeassistant/components/fibaro/cover.py
@@ -69,37 +69,29 @@ class FibaroCover(FibaroEntity, CoverEntity):
         # so if it is missing we have a device which supports open / close only
         return not self.fibaro_device.value.has_value
 
-    @property
-    def current_cover_position(self) -> int | None:
-        """Return current position of cover. 0 is closed, 100 is open."""
-        return self.bound(self.level)
+    def update(self) -> None:
+        """Update the state."""
+        super().update()
 
-    @property
-    def current_cover_tilt_position(self) -> int | None:
-        """Return the current tilt position for venetian blinds."""
-        return self.bound(self.level2)
+        self._attr_current_cover_position = self.bound(self.level)
+        self._attr_current_cover_tilt_position = self.bound(self.level2)
 
-    @property
-    def is_opening(self) -> bool | None:
-        """Return if the cover is opening or not.
+        device_state = self.fibaro_device.state
 
-        Be aware that this property is only available for some modern devices.
-        For example the Fibaro Roller Shutter 4 reports this correctly.
-        """
-        if self.fibaro_device.state.has_value:
-            return self.fibaro_device.state.str_value().lower() == "opening"
-        return None
+        # Be aware that opening and closing is only available for some modern
+        # devices.
+        # For example the Fibaro Roller Shutter 4 reports this correctly.
+        if device_state.has_value:
+            self._attr_is_opening = device_state.str_value().lower() == "opening"
+            self._attr_is_closing = device_state.str_value().lower() == "closing"
 
-    @property
-    def is_closing(self) -> bool | None:
-        """Return if the cover is closing or not.
-
-        Be aware that this property is only available for some modern devices.
-        For example the Fibaro Roller Shutter 4 reports this correctly.
-        """
-        if self.fibaro_device.state.has_value:
-            return self.fibaro_device.state.str_value().lower() == "closing"
-        return None
+        closed: bool | None = None
+        if self._is_open_close_only():
+            if device_state.has_value and device_state.str_value().lower() != "unknown":
+                closed = device_state.str_value().lower() == "closed"
+        elif self.current_cover_position is not None:
+            closed = self.current_cover_position == 0
+        self._attr_is_closed = closed
 
     def set_cover_position(self, **kwargs: Any) -> None:
         """Move the cover to a specific position."""
@@ -108,19 +100,6 @@ class FibaroCover(FibaroEntity, CoverEntity):
     def set_cover_tilt_position(self, **kwargs: Any) -> None:
         """Move the cover to a specific position."""
         self.set_level2(cast(int, kwargs.get(ATTR_TILT_POSITION)))
-
-    @property
-    def is_closed(self) -> bool | None:
-        """Return if the cover is closed."""
-        if self._is_open_close_only():
-            state = self.fibaro_device.state
-            if not state.has_value or state.str_value().lower() == "unknown":
-                return None
-            return state.str_value().lower() == "closed"
-
-        if self.current_cover_position is None:
-            return None
-        return self.current_cover_position == 0
 
     def open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As some properties of the cover are cached, it seems that just calculating the values within the property getters does not work always.
Therefore I changed the logic to assign the `_attr_*` fields which should correctly reassign the cached property values.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #130818
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
