### PR TITLE
Use _attr_is_on in fibaro light

### DIFF
--- a/homeassistant/components/fibaro/light.py
+++ b/homeassistant/components/fibaro/light.py
@@ -132,32 +132,25 @@ class FibaroLight(FibaroEntity, LightEntity):
         """Turn the light off."""
         self.call_turn_off()
 
-    @property
-    def is_on(self) -> bool | None:
-        """Return true if device is on.
-
-        Dimmable and RGB lights can be on based on different
-        properties, so we need to check here several values.
-
-        JSON for HC2 uses always string, HC3 uses int for integers.
-        """
-        if self.current_binary_state:
-            return True
-        with suppress(TypeError):
-            if self.fibaro_device.brightness != 0:
-                return True
-        with suppress(TypeError):
-            if self.fibaro_device.current_program != 0:
-                return True
-        with suppress(TypeError):
-            if self.fibaro_device.current_program_id != 0:
-                return True
-
-        return False
-
     def update(self) -> None:
         """Update the state."""
         super().update()
+
+        # Dimmable and RGB lights can be on based on different
+        # properties, so we need to check here several values
+        # to see if the light is on.
+        light_is_on = self.current_binary_state
+        with suppress(TypeError):
+            if self.fibaro_device.brightness != 0:
+                light_is_on = True
+        with suppress(TypeError):
+            if self.fibaro_device.current_program != 0:
+                light_is_on = True
+        with suppress(TypeError):
+            if self.fibaro_device.current_program_id != 0:
+                light_is_on = True
+        self._attr_is_on = light_is_on
+
         # Brightness handling
         if brightness_supported(self.supported_color_modes):
             self._attr_brightness = scaleto255(self.fibaro_device.value.int_value())
@@ -172,7 +165,7 @@ class FibaroLight(FibaroEntity, LightEntity):
             if rgbw == (0, 0, 0, 0) and self.fibaro_device.last_color_set.has_color:
                 rgbw = self.fibaro_device.last_color_set.rgbw_color
 
-            if self._attr_color_mode == ColorMode.RGB:
+            if self.color_mode == ColorMode.RGB:
                 self._attr_rgb_color = rgbw[:3]
             else:
                 self._attr_rgbw_color = rgbw

--- a/tests/components/fibaro/conftest.py
+++ b/tests/components/fibaro/conftest.py
@@ -107,6 +107,29 @@ def mock_cover() -> Mock:
 
 
 @pytest.fixture
+def mock_light() -> Mock:
+    """Fixture for a dimmmable light."""
+    light = Mock()
+    light.fibaro_id = 3
+    light.parent_fibaro_id = 0
+    light.name = "Test light"
+    light.room_id = 1
+    light.dead = False
+    light.visible = True
+    light.enabled = True
+    light.type = "com.fibaro.FGD212"
+    light.base_type = "com.fibaro.device"
+    light.properties = {"manufacturer": ""}
+    light.actions = {"setValue": 1, "on": 0, "off": 0}
+    light.supported_features = {}
+    value_mock = Mock()
+    value_mock.has_value = True
+    value_mock.int_value.return_value = 20
+    light.value = value_mock
+    return light
+
+
+@pytest.fixture
 def mock_config_entry(hass: HomeAssistant) -> MockConfigEntry:
     """Return the default mocked config entry."""
     mock_config_entry = MockConfigEntry(

--- a/tests/components/fibaro/test_light.py
+++ b/tests/components/fibaro/test_light.py
@@ -1,4 +1,4 @@
-"""Test the Fibaro cover platform."""
+"""Test the Fibaro light platform."""
 
 from unittest.mock import Mock, patch
 
@@ -42,7 +42,7 @@ async def test_light_brightness(
     mock_light: Mock,
     mock_room: Mock,
 ) -> None:
-    """Test that the cover dimm value is reported."""
+    """Test that the light brightness value is translated."""
 
     # Arrange
     mock_fibaro_client.read_rooms.return_value = [mock_room]

--- a/tests/components/fibaro/test_light.py
+++ b/tests/components/fibaro/test_light.py
@@ -1,0 +1,57 @@
+"""Test the Fibaro cover platform."""
+
+from unittest.mock import Mock, patch
+
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from .conftest import init_integration
+
+from tests.common import MockConfigEntry
+
+
+async def test_light_setup(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_fibaro_client: Mock,
+    mock_config_entry: MockConfigEntry,
+    mock_light: Mock,
+    mock_room: Mock,
+) -> None:
+    """Test that the light creates an entity."""
+
+    # Arrange
+    mock_fibaro_client.read_rooms.return_value = [mock_room]
+    mock_fibaro_client.read_devices.return_value = [mock_light]
+
+    with patch("homeassistant.components.fibaro.PLATFORMS", [Platform.LIGHT]):
+        # Act
+        await init_integration(hass, mock_config_entry)
+        # Assert
+        entry = entity_registry.async_get("light.room_1_test_light_3")
+        assert entry
+        assert entry.unique_id == "hc2_111111.3"
+        assert entry.original_name == "Room 1 Test light"
+
+
+async def test_light_brightness(
+    hass: HomeAssistant,
+    mock_fibaro_client: Mock,
+    mock_config_entry: MockConfigEntry,
+    mock_light: Mock,
+    mock_room: Mock,
+) -> None:
+    """Test that the cover dimm value is reported."""
+
+    # Arrange
+    mock_fibaro_client.read_rooms.return_value = [mock_room]
+    mock_fibaro_client.read_devices.return_value = [mock_light]
+
+    with patch("homeassistant.components.fibaro.PLATFORMS", [Platform.LIGHT]):
+        # Act
+        await init_integration(hass, mock_config_entry)
+        # Assert
+        state = hass.states.get("light.room_1_test_light_3")
+        assert state.attributes["brightness"] == 51
+        assert state.state == "on"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use `_attr_is_on` in fibaro light entity as otherwise cached_property sometimes could be in wrong state.
Anyway using the `_attr_*` fields is the preferred way.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
