### PR TITLE
USB device add/remove callbacks

### DIFF
--- a/homeassistant/components/usb/__init__.py
+++ b/homeassistant/components/usb/__init__.py
@@ -258,7 +258,7 @@ class USBDiscovery:
         self._request_callbacks: list[CALLBACK_TYPE] = []
         self.initial_scan_done = False
         self._initial_scan_callbacks: list[CALLBACK_TYPE] = []
-        self._port_event_callbacks: list[PORT_EVENT_CALLBACK_TYPE] = []
+        self._port_event_callbacks: set[PORT_EVENT_CALLBACK_TYPE] = set()
         self._last_processed_devices: set[USBDevice] = set()
 
     async def async_setup(self) -> None:
@@ -414,13 +414,11 @@ class USBDiscovery:
         callback: PORT_EVENT_CALLBACK_TYPE,
     ) -> CALLBACK_TYPE:
         """Register a port event callback."""
-        self._port_event_callbacks.append(callback)
+        self._port_event_callbacks.add(callback)
 
         @hass_callback
         def _async_remove_callback() -> None:
-            if callback not in self._port_event_callbacks:
-                return
-            self._port_event_callbacks.remove(callback)
+            self._port_event_callbacks.discard(callback)
 
         return _async_remove_callback
 
@@ -468,11 +466,11 @@ class USBDiscovery:
 
     async def _async_process_ports(self, ports: Sequence[ListPortInfo]) -> None:
         """Process each discovered port."""
-        usb_devices = [
+        usb_devices = {
             usb_device_from_port(port)
             for port in ports
             if port.vid is not None or port.pid is not None
-        ]
+        }
 
         # CP2102N chips create *two* serial ports on macOS: `/dev/cu.usbserial-` and
         # `/dev/cu.SLAB_USBtoUART*`. The former does not work and we should ignore them.
@@ -483,7 +481,7 @@ class USBDiscovery:
                 if dev.device.startswith("/dev/cu.SLAB_USBtoUART")
             }
 
-            usb_devices = [
+            usb_devices = {
                 dev
                 for dev in usb_devices
                 if dev.serial_number not in silabs_serials
@@ -491,19 +489,18 @@ class USBDiscovery:
                     dev.serial_number in silabs_serials
                     and dev.device.startswith("/dev/cu.SLAB_USBtoUART")
                 )
-            ]
+            }
 
-        unique_devices = set(usb_devices)
-        added_devices = unique_devices - self._last_processed_devices
-        removed_devices = self._last_processed_devices - unique_devices
-        self._last_processed_devices = unique_devices
+        added_devices = usb_devices - self._last_processed_devices
+        removed_devices = self._last_processed_devices - usb_devices
+        self._last_processed_devices = usb_devices
 
         _LOGGER.debug(
             "Added devices: %r, removed devices: %r", added_devices, removed_devices
         )
 
         if added_devices or removed_devices:
-            for callback in self._port_event_callbacks:
+            for callback in self._port_event_callbacks.copy():
                 callback(added_devices, removed_devices)
 
         for usb_device in usb_devices:

--- a/homeassistant/components/usb/__init__.py
+++ b/homeassistant/components/usb/__init__.py
@@ -56,8 +56,8 @@ REQUEST_SCAN_COOLDOWN = 10  # 10 second cooldown
 __all__ = [
     "USBCallbackMatcher",
     "async_is_plugged_in",
-    "async_register_scan_request_callback",
     "async_register_port_event_callback",
+    "async_register_scan_request_callback",
 ]
 
 CONFIG_SCHEMA = cv.empty_config_schema(DOMAIN)

--- a/homeassistant/components/usb/__init__.py
+++ b/homeassistant/components/usb/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Coroutine, Sequence
+from collections.abc import Callable, Coroutine, Sequence
 import dataclasses
 from datetime import datetime, timedelta
 import fnmatch

--- a/homeassistant/components/usb/__init__.py
+++ b/homeassistant/components/usb/__init__.py
@@ -501,7 +501,10 @@ class USBDiscovery:
 
         if added_devices or removed_devices:
             for callback in self._port_event_callbacks.copy():
-                callback(added_devices, removed_devices)
+                try:
+                    callback(added_devices, removed_devices)
+                except Exception:
+                    _LOGGER.exception("Error in USB port event callback")
 
         for usb_device in usb_devices:
             await self._async_process_discovered_usb_device(usb_device)

--- a/homeassistant/components/usb/__init__.py
+++ b/homeassistant/components/usb/__init__.py
@@ -363,19 +363,16 @@ class USBDiscovery:
 
     def _device_event(self, device: Device) -> None:
         """Call when the observer receives a USB device event."""
-        if device.action == "add":
-            _LOGGER.debug(
-                "Discovered Device at path: %s, triggering scan serial",
-                device.device_path,
-            )
-            self.hass.create_task(self._async_scan())
+        if device.action not in ("add", "remove"):
+            return
 
-        if device.action == "remove":
-            _LOGGER.debug(
-                "Device removed %s, triggering scan serial",
-                device,
-            )
-            self.hass.create_task(self._async_scan())
+        _LOGGER.info(
+            "Received a udev device event %r for %s, triggering scan",
+            device.action,
+            device.device_node,
+        )
+
+        self.hass.create_task(self._async_scan())
 
     @hass_callback
     def async_register_scan_request_callback(

--- a/homeassistant/components/usb/__init__.py
+++ b/homeassistant/components/usb/__init__.py
@@ -498,6 +498,10 @@ class USBDiscovery:
         removed_devices = self._last_processed_devices - unique_devices
         self._last_processed_devices = unique_devices
 
+        _LOGGER.debug(
+            "Added devices: %r, removed devices: %r", added_devices, removed_devices
+        )
+
         if added_devices or removed_devices:
             for callback in self._port_event_callbacks:
                 callback(added_devices, removed_devices)

--- a/homeassistant/components/usb/__init__.py
+++ b/homeassistant/components/usb/__init__.py
@@ -48,6 +48,8 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
+PORT_EVENT_CALLBACK_TYPE = Callable[[set[USBDevice], set[USBDevice]], None]
+
 POLLING_MONITOR_SCAN_PERIOD = timedelta(seconds=5)
 REQUEST_SCAN_COOLDOWN = 10  # 10 second cooldown
 
@@ -55,6 +57,7 @@ __all__ = [
     "USBCallbackMatcher",
     "async_is_plugged_in",
     "async_register_scan_request_callback",
+    "async_register_port_event_callback",
 ]
 
 CONFIG_SCHEMA = cv.empty_config_schema(DOMAIN)
@@ -86,6 +89,15 @@ def async_register_initial_scan_callback(
 
 
 @hass_callback
+def async_register_port_event_callback(
+    hass: HomeAssistant, callback: PORT_EVENT_CALLBACK_TYPE
+) -> CALLBACK_TYPE:
+    """Register to receive a callback when a USB device is connected or disconnected."""
+    discovery: USBDiscovery = hass.data[DOMAIN]
+    return discovery.async_register_port_event_callback(callback)
+
+
+@hass_callback
 def async_is_plugged_in(hass: HomeAssistant, matcher: USBCallbackMatcher) -> bool:
     """Return True is a USB device is present."""
 
@@ -108,8 +120,25 @@ def async_is_plugged_in(hass: HomeAssistant, matcher: USBCallbackMatcher) -> boo
 
     usb_discovery: USBDiscovery = hass.data[DOMAIN]
     return any(
-        _is_matching(USBDevice(*device_tuple), matcher)
-        for device_tuple in usb_discovery.seen
+        _is_matching(
+            USBDevice(
+                device=device,
+                vid=vid,
+                pid=pid,
+                serial_number=serial_number,
+                manufacturer=manufacturer,
+                description=description,
+            ),
+            matcher,
+        )
+        for (
+            device,
+            vid,
+            pid,
+            serial_number,
+            manufacturer,
+            description,
+        ) in usb_discovery.seen
     )
 
 
@@ -229,6 +258,8 @@ class USBDiscovery:
         self._request_callbacks: list[CALLBACK_TYPE] = []
         self.initial_scan_done = False
         self._initial_scan_callbacks: list[CALLBACK_TYPE] = []
+        self._port_event_callbacks: list[PORT_EVENT_CALLBACK_TYPE] = []
+        self._last_processed_devices: set[USBDevice] = set()
 
     async def async_setup(self) -> None:
         """Set up USB Discovery."""
@@ -324,21 +355,27 @@ class USBDiscovery:
             return None
 
         observer = MonitorObserver(
-            monitor, callback=self._device_discovered, name="usb-observer"
+            monitor, callback=self._device_event, name="usb-observer"
         )
 
         observer.start()
         return observer
 
-    def _device_discovered(self, device: Device) -> None:
-        """Call when the observer discovers a new usb tty device."""
-        if device.action != "add":
-            return
-        _LOGGER.debug(
-            "Discovered Device at path: %s, triggering scan serial",
-            device.device_path,
-        )
-        self.hass.create_task(self._async_scan())
+    def _device_event(self, device: Device) -> None:
+        """Call when the observer receives a USB device event."""
+        if device.action == "add":
+            _LOGGER.debug(
+                "Discovered Device at path: %s, triggering scan serial",
+                device.device_path,
+            )
+            self.hass.create_task(self._async_scan())
+
+        if device.action == "remove":
+            _LOGGER.debug(
+                "Device removed %s, triggering scan serial",
+                device,
+            )
+            self.hass.create_task(self._async_scan())
 
     @hass_callback
     def async_register_scan_request_callback(
@@ -371,6 +408,22 @@ class USBDiscovery:
             if callback not in self._initial_scan_callbacks:
                 return
             self._initial_scan_callbacks.remove(callback)
+
+        return _async_remove_callback
+
+    @hass_callback
+    def async_register_port_event_callback(
+        self,
+        callback: PORT_EVENT_CALLBACK_TYPE,
+    ) -> CALLBACK_TYPE:
+        """Register a port event callback."""
+        self._port_event_callbacks.append(callback)
+
+        @hass_callback
+        def _async_remove_callback() -> None:
+            if callback not in self._port_event_callbacks:
+                return
+            self._port_event_callbacks.remove(callback)
 
         return _async_remove_callback
 
@@ -442,6 +495,15 @@ class USBDiscovery:
                     and dev.device.startswith("/dev/cu.SLAB_USBtoUART")
                 )
             ]
+
+        unique_devices = set(usb_devices)
+        added_devices = unique_devices - self._last_processed_devices
+        removed_devices = self._last_processed_devices - unique_devices
+        self._last_processed_devices = unique_devices
+
+        if added_devices or removed_devices:
+            for callback in self._port_event_callbacks:
+                callback(added_devices, removed_devices)
 
         for usb_device in usb_devices:
             await self._async_process_discovered_usb_device(usb_device)

--- a/homeassistant/components/usb/models.py
+++ b/homeassistant/components/usb/models.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 
-@dataclass
+@dataclass(slots=True, frozen=True, kw_only=True)
 class USBDevice:
     """A usb device."""
 

--- a/tests/components/usb/test_init.py
+++ b/tests/components/usb/test_init.py
@@ -1301,6 +1301,7 @@ async def test_register_port_event_callback(
         await ws_client.send_json({"id": 2, "type": "usb/scan"})
         response = await ws_client.receive_json()
         assert response["success"]
+        await hass.async_block_till_done()
 
     assert mock_callback1.mock_calls == [call(set(), {port2_usb})]
     assert mock_callback2.mock_calls == []  # The second callback was unregistered
@@ -1313,6 +1314,7 @@ async def test_register_port_event_callback(
         await ws_client.send_json({"id": 3, "type": "usb/scan"})
         response = await ws_client.receive_json()
         assert response["success"]
+        await hass.async_block_till_done()
 
     # Nothing changed so no callback is called
     assert mock_callback1.mock_calls == []
@@ -1323,6 +1325,7 @@ async def test_register_port_event_callback(
         await ws_client.send_json({"id": 4, "type": "usb/scan"})
         response = await ws_client.receive_json()
         assert response["success"]
+        await hass.async_block_till_done()
 
     assert mock_callback1.mock_calls == [call({port2_usb}, {port1_usb})]
     assert mock_callback2.mock_calls == []

--- a/tests/components/usb/test_init.py
+++ b/tests/components/usb/test_init.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, Mock, call, patch, sentinel
 import pytest
 
 from homeassistant.components import usb
+from homeassistant.components.usb.utils import usb_device_from_port
 from homeassistant.const import EVENT_HOMEASSISTANT_STARTED, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.service_info.usb import UsbServiceInfo
@@ -1235,3 +1236,93 @@ def test_deprecated_constants(
         replacement,
         "2026.2",
     )
+
+
+@patch("homeassistant.components.usb.REQUEST_SCAN_COOLDOWN", 0)
+async def test_register_port_event_callback(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
+    """Test the registration of a port event callback."""
+
+    port1 = Mock(
+        device=slae_sh_device.device,
+        vid=12345,
+        pid=12345,
+        serial_number=slae_sh_device.serial_number,
+        manufacturer=slae_sh_device.manufacturer,
+        description=slae_sh_device.description,
+    )
+
+    port2 = Mock(
+        device=conbee_device.device,
+        vid=12346,
+        pid=12346,
+        serial_number=conbee_device.serial_number,
+        manufacturer=conbee_device.manufacturer,
+        description=conbee_device.description,
+    )
+
+    port1_usb = usb_device_from_port(port1)
+    port2_usb = usb_device_from_port(port2)
+
+    ws_client = await hass_ws_client(hass)
+
+    mock_callback1 = Mock()
+    mock_callback2 = Mock()
+
+    # Start off with no ports
+    with patch("homeassistant.components.usb.comports", return_value=[]):
+        assert await async_setup_component(hass, "usb", {"usb": {}})
+
+        _cancel1 = usb.async_register_port_event_callback(hass, mock_callback1)
+        cancel2 = usb.async_register_port_event_callback(hass, mock_callback2)
+
+    assert mock_callback1.mock_calls == []
+    assert mock_callback2.mock_calls == []
+
+    # Add two new ports
+    with patch("homeassistant.components.usb.comports", return_value=[port1, port2]):
+        await ws_client.send_json({"id": 1, "type": "usb/scan"})
+        response = await ws_client.receive_json()
+        assert response["success"]
+
+    assert mock_callback1.mock_calls == [call({port1_usb, port2_usb}, set())]
+    assert mock_callback2.mock_calls == [call({port1_usb, port2_usb}, set())]
+
+    # Cancel the second callback
+    cancel2()
+    cancel2()
+
+    mock_callback1.reset_mock()
+    mock_callback2.reset_mock()
+
+    # Remove port 2
+    with patch("homeassistant.components.usb.comports", return_value=[port1]):
+        await ws_client.send_json({"id": 2, "type": "usb/scan"})
+        response = await ws_client.receive_json()
+        assert response["success"]
+
+    assert mock_callback1.mock_calls == [call(set(), {port2_usb})]
+    assert mock_callback2.mock_calls == []  # The second callback was unregistered
+
+    mock_callback1.reset_mock()
+    mock_callback2.reset_mock()
+
+    # Keep port 2 removed
+    with patch("homeassistant.components.usb.comports", return_value=[port1]):
+        await ws_client.send_json({"id": 3, "type": "usb/scan"})
+        response = await ws_client.receive_json()
+        assert response["success"]
+
+    # Nothing changed so no callback is called
+    assert mock_callback1.mock_calls == []
+    assert mock_callback2.mock_calls == []
+
+    # Unplug one and plug in the other
+    with patch("homeassistant.components.usb.comports", return_value=[port2]):
+        await ws_client.send_json({"id": 4, "type": "usb/scan"})
+        response = await ws_client.receive_json()
+        assert response["success"]
+
+    assert mock_callback1.mock_calls == [call({port2_usb}, {port1_usb})]
+    assert mock_callback2.mock_calls == []

--- a/tests/components/usb/test_init.py
+++ b/tests/components/usb/test_init.py
@@ -1271,7 +1271,10 @@ async def test_register_port_event_callback(
     mock_callback2 = Mock()
 
     # Start off with no ports
-    with patch("homeassistant.components.usb.comports", return_value=[]):
+    with (
+        patch("pyudev.Context", side_effect=ImportError),
+        patch("homeassistant.components.usb.comports", return_value=[]),
+    ):
         assert await async_setup_component(hass, "usb", {"usb": {}})
 
         _cancel1 = usb.async_register_port_event_callback(hass, mock_callback1)

--- a/tests/components/usb/test_init.py
+++ b/tests/components/usb/test_init.py
@@ -81,7 +81,7 @@ async def test_observer_discovery(
 
     async def _mock_monitor_observer_callback(callback):
         await hass.async_add_executor_job(
-            callback, MagicMock(action="create", device_path="/dev/new")
+            callback, MagicMock(action="add", device_path="/dev/new")
         )
 
     def _create_mock_monitor_observer(monitor, callback, name):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
#130918 is required to test this on macOS.

Background: I would like the SkyConnect integration to unload itself when the SkyConnect becomes unplugged. Current integrations take control of the serial port and react to the disconnect but the SkyConnect integration cannot do this, as it only passively monitors the state of the device.

To implement this, we keep track of the results of the previous device scan and compare it to the new one, reacting now to the `remove` udev event in addition to the `add` event. Registered callbacks are called with two sets as arguments: added devices and removed devices.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
