### PR TITLE
Bump reolink_aio to 0.11.2

### DIFF
--- a/homeassistant/components/reolink/manifest.json
+++ b/homeassistant/components/reolink/manifest.json
@@ -18,5 +18,5 @@
   "documentation": "https://www.home-assistant.io/integrations/reolink",
   "iot_class": "local_push",
   "loggers": ["reolink_aio"],
-  "requirements": ["reolink-aio==0.11.1"]
+  "requirements": ["reolink-aio==0.11.2"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2556,7 +2556,7 @@ renault-api==0.2.7
 renson-endura-delta==1.7.1
 
 # homeassistant.components.reolink
-reolink-aio==0.11.1
+reolink-aio==0.11.2
 
 # homeassistant.components.idteck_prox
 rfk101py==0.0.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2047,7 +2047,7 @@ renault-api==0.2.7
 renson-endura-delta==1.7.1
 
 # homeassistant.components.reolink
-reolink-aio==0.11.1
+reolink-aio==0.11.2
 
 # homeassistant.components.rflink
 rflink==0.0.66


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump reolink_aio to 0.11.2:
**Additions:**
- [Add python 3.13 support (testing)](https://github.com/starkillerOG/reolink_aio/commit/5fe8250dee11c2484db4020bda9fca8b78cb02b5)
- [Add Baichuan fallback mechanism for redundancy](https://github.com/starkillerOG/reolink_aio/commit/8927fa41237f7ed1c316ea7a114508f9bd80b788)
- [Use Baichuan fallback for send_setting](https://github.com/starkillerOG/reolink_aio/commit/a2afe08cc0ad02b3f8c5bb345c3e3871f57837ca)
- [Add Baichuan fallbacks for GetDingDongList, DingDongOpt, and GetDingDongCfg](https://github.com/starkillerOG/reolink_aio/commit/e60d8e09cce6a989854ef4dd28a98073c257f2b4)
- [Add set chime fallbacks](https://github.com/starkillerOG/reolink_aio/commit/c55b97a1a5edf7d605fffae9313bf7d68743c6dc)
- [Add Sleep status push](https://github.com/starkillerOG/reolink_aio/commit/e03028ed5bf88a6319c1823c06b601ffe2cfe677)
- [Add BatteryInfo push](https://github.com/starkillerOG/reolink_aio/commit/557e7aea0bb2ae65392bae8dd9ab9a8fe2aec9b1)

**Bug fixes:**
- [Fix battery cam motion push](https://github.com/starkillerOG/reolink_aio/commit/b646676671ef7b8b3d6b726de8e71e35945e0f0a)
- [Add DingDong commands as waking](https://github.com/starkillerOG/reolink_aio/commit/18f3dfb5b3dc7778f46459d0a8f5d6d62ce4489f)
- [Encrypt extension and body XML separately](https://github.com/starkillerOG/reolink_aio/commit/b361995c65454fb0eeca3246c522c31e3c43dde6)
- [Fix chimes beeing set unavailable by other channels](https://github.com/starkillerOG/reolink_aio/commit/674d186d6b1cd957df6672a1a5c87cad3a8ba58a)
- [Fix KeyError when baichuan has connection error](https://github.com/starkillerOG/reolink_aio/commit/33b3103749874db4cffbaf6719395c4bb350dce6)
- [Solve ringName keyerror](https://github.com/starkillerOG/reolink_aio/commit/c913382a873ab744d0c93fcf1813525a018b5211)
- [Catch errors while removing chime](https://github.com/starkillerOG/reolink_aio/commit/b15677b9b2043650e6a6b5c90899af4108a2df41)
- [prevent warning about "other" push](https://github.com/starkillerOG/reolink_aio/commit/e129a9f59c86e1f0ce413212d550f4c34c794e83)

**Optimizations:**
- [Use cmd_id 93 (LinkType) for keepalive to let battery cams sleep](https://github.com/starkillerOG/reolink_aio/commit/94a4de7e7c30df7f423624b42636c4793d1e668d)
- [Skip checking RTSP url for battery cameras to not wake them](https://github.com/starkillerOG/reolink_aio/commit/f34a9573cc984429dafaa3abf990f283df0c016b)
- [Timeout API firmware check after 15s and continue with online firmware check](https://github.com/starkillerOG/reolink_aio/commit/39065c4cb7b378f2e8c24a29b608636632fe945e)
- [Bump minimum version of RLN8-410 N7MB01 to v3.5.1.356_24110154](https://github.com/starkillerOG/reolink_aio/commit/701553ea52ddc9564cc319dc5db0c61d78d2c1dd)
- [Improve lost event subscription logging](https://github.com/starkillerOG/reolink_aio/commit/306d44ae82fe6f7473d07f72d2bbea11ac1c2065)
- [Immediately reestablish connection when subscribed](https://github.com/starkillerOG/reolink_aio/commit/ec45aa2e5a3ecdc8897e4272d2a6d667b8888c0b)
- [Add more typing](https://github.com/starkillerOG/reolink_aio/commit/0f925d1cc132f3fbc976c843327f4c9d40684f04)
- [Bump down decrypt push error to debug](https://github.com/starkillerOG/reolink_aio/commit/29b68c7c778a1f9645456fc169f3c1ae81fe64f6)

**Full Changelog**: https://github.com/starkillerOG/reolink_aio/compare/0.11.1...0.11.2

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/130525 https://github.com/home-assistant/core/issues/130741 https://github.com/home-assistant/core/issues/129868
- This PR is related to issue: #130730
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
