### PR TITLE
Add unit translations for Brother integration

### DIFF
--- a/homeassistant/components/brother/sensor.py
+++ b/homeassistant/components/brother/sensor.py
@@ -30,8 +30,6 @@ from .const import DOMAIN
 ATTR_COUNTER = "counter"
 ATTR_REMAINING_PAGES = "remaining_pages"
 
-UNIT_PAGES = "p"
-
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -52,7 +50,6 @@ SENSOR_TYPES: tuple[BrotherSensorEntityDescription, ...] = (
     BrotherSensorEntityDescription(
         key="page_counter",
         translation_key="page_counter",
-        native_unit_of_measurement=UNIT_PAGES,
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
         value=lambda data: data.page_counter,
@@ -60,7 +57,6 @@ SENSOR_TYPES: tuple[BrotherSensorEntityDescription, ...] = (
     BrotherSensorEntityDescription(
         key="bw_counter",
         translation_key="bw_pages",
-        native_unit_of_measurement=UNIT_PAGES,
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
         value=lambda data: data.bw_counter,
@@ -68,7 +64,6 @@ SENSOR_TYPES: tuple[BrotherSensorEntityDescription, ...] = (
     BrotherSensorEntityDescription(
         key="color_counter",
         translation_key="color_pages",
-        native_unit_of_measurement=UNIT_PAGES,
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
         value=lambda data: data.color_counter,
@@ -76,7 +71,6 @@ SENSOR_TYPES: tuple[BrotherSensorEntityDescription, ...] = (
     BrotherSensorEntityDescription(
         key="duplex_unit_pages_counter",
         translation_key="duplex_unit_page_counter",
-        native_unit_of_measurement=UNIT_PAGES,
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
         value=lambda data: data.duplex_unit_pages_counter,
@@ -92,7 +86,6 @@ SENSOR_TYPES: tuple[BrotherSensorEntityDescription, ...] = (
     BrotherSensorEntityDescription(
         key="drum_remaining_pages",
         translation_key="drum_remaining_pages",
-        native_unit_of_measurement=UNIT_PAGES,
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
         value=lambda data: data.drum_remaining_pages,
@@ -100,7 +93,6 @@ SENSOR_TYPES: tuple[BrotherSensorEntityDescription, ...] = (
     BrotherSensorEntityDescription(
         key="drum_counter",
         translation_key="drum_page_counter",
-        native_unit_of_measurement=UNIT_PAGES,
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
         value=lambda data: data.drum_counter,
@@ -116,7 +108,6 @@ SENSOR_TYPES: tuple[BrotherSensorEntityDescription, ...] = (
     BrotherSensorEntityDescription(
         key="black_drum_remaining_pages",
         translation_key="black_drum_remaining_pages",
-        native_unit_of_measurement=UNIT_PAGES,
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
         value=lambda data: data.black_drum_remaining_pages,
@@ -124,7 +115,6 @@ SENSOR_TYPES: tuple[BrotherSensorEntityDescription, ...] = (
     BrotherSensorEntityDescription(
         key="black_drum_counter",
         translation_key="black_drum_page_counter",
-        native_unit_of_measurement=UNIT_PAGES,
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
         value=lambda data: data.black_drum_counter,
@@ -140,7 +130,6 @@ SENSOR_TYPES: tuple[BrotherSensorEntityDescription, ...] = (
     BrotherSensorEntityDescription(
         key="cyan_drum_remaining_pages",
         translation_key="cyan_drum_remaining_pages",
-        native_unit_of_measurement=UNIT_PAGES,
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
         value=lambda data: data.cyan_drum_remaining_pages,
@@ -148,7 +137,6 @@ SENSOR_TYPES: tuple[BrotherSensorEntityDescription, ...] = (
     BrotherSensorEntityDescription(
         key="cyan_drum_counter",
         translation_key="cyan_drum_page_counter",
-        native_unit_of_measurement=UNIT_PAGES,
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
         value=lambda data: data.cyan_drum_counter,
@@ -164,7 +152,6 @@ SENSOR_TYPES: tuple[BrotherSensorEntityDescription, ...] = (
     BrotherSensorEntityDescription(
         key="magenta_drum_remaining_pages",
         translation_key="magenta_drum_remaining_pages",
-        native_unit_of_measurement=UNIT_PAGES,
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
         value=lambda data: data.magenta_drum_remaining_pages,
@@ -172,7 +159,6 @@ SENSOR_TYPES: tuple[BrotherSensorEntityDescription, ...] = (
     BrotherSensorEntityDescription(
         key="magenta_drum_counter",
         translation_key="magenta_drum_page_counter",
-        native_unit_of_measurement=UNIT_PAGES,
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
         value=lambda data: data.magenta_drum_counter,
@@ -188,7 +174,6 @@ SENSOR_TYPES: tuple[BrotherSensorEntityDescription, ...] = (
     BrotherSensorEntityDescription(
         key="yellow_drum_remaining_pages",
         translation_key="yellow_drum_remaining_pages",
-        native_unit_of_measurement=UNIT_PAGES,
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
         value=lambda data: data.yellow_drum_remaining_pages,
@@ -196,7 +181,6 @@ SENSOR_TYPES: tuple[BrotherSensorEntityDescription, ...] = (
     BrotherSensorEntityDescription(
         key="yellow_drum_counter",
         translation_key="yellow_drum_page_counter",
-        native_unit_of_measurement=UNIT_PAGES,
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
         value=lambda data: data.yellow_drum_counter,

--- a/homeassistant/components/brother/strings.json
+++ b/homeassistant/components/brother/strings.json
@@ -46,61 +46,75 @@
         "name": "Status"
       },
       "page_counter": {
-        "name": "Page counter"
+        "name": "Page counter",
+        "unit_of_measurement": "pages"
       },
       "bw_pages": {
-        "name": "B/W pages"
+        "name": "B/W pages",
+        "unit_of_measurement": "[%key:component::brother::entity::sensor::page_counter::unit_of_measurement%]"
       },
       "color_pages": {
-        "name": "Color pages"
+        "name": "Color pages",
+        "unit_of_measurement": "[%key:component::brother::entity::sensor::page_counter::unit_of_measurement%]"
       },
       "duplex_unit_page_counter": {
-        "name": "Duplex unit page counter"
+        "name": "Duplex unit page counter",
+        "unit_of_measurement": "[%key:component::brother::entity::sensor::page_counter::unit_of_measurement%]"
       },
       "drum_remaining_life": {
         "name": "Drum remaining lifetime"
       },
       "drum_remaining_pages": {
-        "name": "Drum remaining pages"
+        "name": "Drum remaining pages",
+        "unit_of_measurement": "[%key:component::brother::entity::sensor::page_counter::unit_of_measurement%]"
       },
       "drum_page_counter": {
-        "name": "Drum page counter"
+        "name": "Drum page counter",
+        "unit_of_measurement": "[%key:component::brother::entity::sensor::page_counter::unit_of_measurement%]"
       },
       "black_drum_remaining_life": {
         "name": "Black drum remaining lifetime"
       },
       "black_drum_remaining_pages": {
-        "name": "Black drum remaining pages"
+        "name": "Black drum remaining pages",
+        "unit_of_measurement": "[%key:component::brother::entity::sensor::page_counter::unit_of_measurement%]"
       },
       "black_drum_page_counter": {
-        "name": "Black drum page counter"
+        "name": "Black drum page counter",
+        "unit_of_measurement": "[%key:component::brother::entity::sensor::page_counter::unit_of_measurement%]"
       },
       "cyan_drum_remaining_life": {
         "name": "Cyan drum remaining lifetime"
       },
       "cyan_drum_remaining_pages": {
-        "name": "Cyan drum remaining pages"
+        "name": "Cyan drum remaining pages",
+        "unit_of_measurement": "[%key:component::brother::entity::sensor::page_counter::unit_of_measurement%]"
       },
       "cyan_drum_page_counter": {
-        "name": "Cyan drum page counter"
+        "name": "Cyan drum page counter",
+        "unit_of_measurement": "[%key:component::brother::entity::sensor::page_counter::unit_of_measurement%]"
       },
       "magenta_drum_remaining_life": {
         "name": "Magenta drum remaining lifetime"
       },
       "magenta_drum_remaining_pages": {
-        "name": "Magenta drum remaining pages"
+        "name": "Magenta drum remaining pages",
+        "unit_of_measurement": "[%key:component::brother::entity::sensor::page_counter::unit_of_measurement%]"
       },
       "magenta_drum_page_counter": {
-        "name": "Magenta drum page counter"
+        "name": "Magenta drum page counter",
+        "unit_of_measurement": "[%key:component::brother::entity::sensor::page_counter::unit_of_measurement%]"
       },
       "yellow_drum_remaining_life": {
         "name": "Yellow drum remaining lifetime"
       },
       "yellow_drum_remaining_pages": {
-        "name": "Yellow drum remaining pages"
+        "name": "Yellow drum remaining pages",
+        "unit_of_measurement": "[%key:component::brother::entity::sensor::page_counter::unit_of_measurement%]"
       },
       "yellow_drum_page_counter": {
-        "name": "Yellow drum page counter"
+        "name": "Yellow drum page counter",
+        "unit_of_measurement": "[%key:component::brother::entity::sensor::page_counter::unit_of_measurement%]"
       },
       "belt_unit_remaining_life": {
         "name": "Belt unit remaining lifetime"

--- a/tests/components/brother/snapshots/test_sensor.ambr
+++ b/tests/components/brother/snapshots/test_sensor.ambr
@@ -31,7 +31,7 @@
     'supported_features': 0,
     'translation_key': 'bw_pages',
     'unique_id': '0123456789_bw_counter',
-    'unit_of_measurement': 'p',
+    'unit_of_measurement': None,
   })
 # ---
 # name: test_sensors[sensor.hl_l2340dw_b_w_pages-state]
@@ -39,7 +39,6 @@
     'attributes': ReadOnlyDict({
       'friendly_name': 'HL-L2340DW B/W pages',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': 'p',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.hl_l2340dw_b_w_pages',
@@ -131,7 +130,7 @@
     'supported_features': 0,
     'translation_key': 'black_drum_page_counter',
     'unique_id': '0123456789_black_drum_counter',
-    'unit_of_measurement': 'p',
+    'unit_of_measurement': None,
   })
 # ---
 # name: test_sensors[sensor.hl_l2340dw_black_drum_page_counter-state]
@@ -139,7 +138,6 @@
     'attributes': ReadOnlyDict({
       'friendly_name': 'HL-L2340DW Black drum page counter',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': 'p',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.hl_l2340dw_black_drum_page_counter',
@@ -231,7 +229,7 @@
     'supported_features': 0,
     'translation_key': 'black_drum_remaining_pages',
     'unique_id': '0123456789_black_drum_remaining_pages',
-    'unit_of_measurement': 'p',
+    'unit_of_measurement': None,
   })
 # ---
 # name: test_sensors[sensor.hl_l2340dw_black_drum_remaining_pages-state]
@@ -239,7 +237,6 @@
     'attributes': ReadOnlyDict({
       'friendly_name': 'HL-L2340DW Black drum remaining pages',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': 'p',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.hl_l2340dw_black_drum_remaining_pages',
@@ -331,7 +328,7 @@
     'supported_features': 0,
     'translation_key': 'color_pages',
     'unique_id': '0123456789_color_counter',
-    'unit_of_measurement': 'p',
+    'unit_of_measurement': None,
   })
 # ---
 # name: test_sensors[sensor.hl_l2340dw_color_pages-state]
@@ -339,7 +336,6 @@
     'attributes': ReadOnlyDict({
       'friendly_name': 'HL-L2340DW Color pages',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': 'p',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.hl_l2340dw_color_pages',
@@ -381,7 +377,7 @@
     'supported_features': 0,
     'translation_key': 'cyan_drum_page_counter',
     'unique_id': '0123456789_cyan_drum_counter',
-    'unit_of_measurement': 'p',
+    'unit_of_measurement': None,
   })
 # ---
 # name: test_sensors[sensor.hl_l2340dw_cyan_drum_page_counter-state]
@@ -389,7 +385,6 @@
     'attributes': ReadOnlyDict({
       'friendly_name': 'HL-L2340DW Cyan drum page counter',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': 'p',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.hl_l2340dw_cyan_drum_page_counter',
@@ -481,7 +476,7 @@
     'supported_features': 0,
     'translation_key': 'cyan_drum_remaining_pages',
     'unique_id': '0123456789_cyan_drum_remaining_pages',
-    'unit_of_measurement': 'p',
+    'unit_of_measurement': None,
   })
 # ---
 # name: test_sensors[sensor.hl_l2340dw_cyan_drum_remaining_pages-state]
@@ -489,7 +484,6 @@
     'attributes': ReadOnlyDict({
       'friendly_name': 'HL-L2340DW Cyan drum remaining pages',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': 'p',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.hl_l2340dw_cyan_drum_remaining_pages',
@@ -581,7 +575,7 @@
     'supported_features': 0,
     'translation_key': 'drum_page_counter',
     'unique_id': '0123456789_drum_counter',
-    'unit_of_measurement': 'p',
+    'unit_of_measurement': None,
   })
 # ---
 # name: test_sensors[sensor.hl_l2340dw_drum_page_counter-state]
@@ -589,7 +583,6 @@
     'attributes': ReadOnlyDict({
       'friendly_name': 'HL-L2340DW Drum page counter',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': 'p',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.hl_l2340dw_drum_page_counter',
@@ -681,7 +674,7 @@
     'supported_features': 0,
     'translation_key': 'drum_remaining_pages',
     'unique_id': '0123456789_drum_remaining_pages',
-    'unit_of_measurement': 'p',
+    'unit_of_measurement': None,
   })
 # ---
 # name: test_sensors[sensor.hl_l2340dw_drum_remaining_pages-state]
@@ -689,7 +682,6 @@
     'attributes': ReadOnlyDict({
       'friendly_name': 'HL-L2340DW Drum remaining pages',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': 'p',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.hl_l2340dw_drum_remaining_pages',
@@ -731,7 +723,7 @@
     'supported_features': 0,
     'translation_key': 'duplex_unit_page_counter',
     'unique_id': '0123456789_duplex_unit_pages_counter',
-    'unit_of_measurement': 'p',
+    'unit_of_measurement': None,
   })
 # ---
 # name: test_sensors[sensor.hl_l2340dw_duplex_unit_page_counter-state]
@@ -739,7 +731,6 @@
     'attributes': ReadOnlyDict({
       'friendly_name': 'HL-L2340DW Duplex unit page counter',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': 'p',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.hl_l2340dw_duplex_unit_page_counter',
@@ -878,7 +869,7 @@
     'supported_features': 0,
     'translation_key': 'magenta_drum_page_counter',
     'unique_id': '0123456789_magenta_drum_counter',
-    'unit_of_measurement': 'p',
+    'unit_of_measurement': None,
   })
 # ---
 # name: test_sensors[sensor.hl_l2340dw_magenta_drum_page_counter-state]
@@ -886,7 +877,6 @@
     'attributes': ReadOnlyDict({
       'friendly_name': 'HL-L2340DW Magenta drum page counter',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': 'p',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.hl_l2340dw_magenta_drum_page_counter',
@@ -978,7 +968,7 @@
     'supported_features': 0,
     'translation_key': 'magenta_drum_remaining_pages',
     'unique_id': '0123456789_magenta_drum_remaining_pages',
-    'unit_of_measurement': 'p',
+    'unit_of_measurement': None,
   })
 # ---
 # name: test_sensors[sensor.hl_l2340dw_magenta_drum_remaining_pages-state]
@@ -986,7 +976,6 @@
     'attributes': ReadOnlyDict({
       'friendly_name': 'HL-L2340DW Magenta drum remaining pages',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': 'p',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.hl_l2340dw_magenta_drum_remaining_pages',
@@ -1078,7 +1067,7 @@
     'supported_features': 0,
     'translation_key': 'page_counter',
     'unique_id': '0123456789_page_counter',
-    'unit_of_measurement': 'p',
+    'unit_of_measurement': None,
   })
 # ---
 # name: test_sensors[sensor.hl_l2340dw_page_counter-state]
@@ -1086,7 +1075,6 @@
     'attributes': ReadOnlyDict({
       'friendly_name': 'HL-L2340DW Page counter',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': 'p',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.hl_l2340dw_page_counter',
@@ -1224,7 +1212,7 @@
     'supported_features': 0,
     'translation_key': 'yellow_drum_page_counter',
     'unique_id': '0123456789_yellow_drum_counter',
-    'unit_of_measurement': 'p',
+    'unit_of_measurement': None,
   })
 # ---
 # name: test_sensors[sensor.hl_l2340dw_yellow_drum_page_counter-state]
@@ -1232,7 +1220,6 @@
     'attributes': ReadOnlyDict({
       'friendly_name': 'HL-L2340DW Yellow drum page counter',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': 'p',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.hl_l2340dw_yellow_drum_page_counter',
@@ -1324,7 +1311,7 @@
     'supported_features': 0,
     'translation_key': 'yellow_drum_remaining_pages',
     'unique_id': '0123456789_yellow_drum_remaining_pages',
-    'unit_of_measurement': 'p',
+    'unit_of_measurement': None,
   })
 # ---
 # name: test_sensors[sensor.hl_l2340dw_yellow_drum_remaining_pages-state]
@@ -1332,7 +1319,6 @@
     'attributes': ReadOnlyDict({
       'friendly_name': 'HL-L2340DW Yellow drum remaining pages',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': 'p',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.hl_l2340dw_yellow_drum_remaining_pages',


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The unit changes from `p` to `pages`. This can break templates where state with unit is used, such as `states('sensor.pages', with_unit=True)`.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds unit translations for Brother integration.

To make it easier to translate the unit, I changed the `p` to `pages`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
