### PR TITLE
Fix Home Connect service validation error placeholders

### DIFF
--- a/homeassistant/components/home_connect/__init__.py
+++ b/homeassistant/components/home_connect/__init__.py
@@ -329,10 +329,10 @@ async def async_migrate_entry(
 
 def get_dict_from_home_connect_error(err: api.HomeConnectError) -> dict[str, Any]:
     """Return a dict from a Home Connect error."""
-    return (
-        err.args[0]
+    return {
+        "description": cast(dict[str, Any], err.args[0]).get("description", "?")
         if len(err.args) > 0 and isinstance(err.args[0], dict)
-        else {"description": err.args[0]}
+        else err.args[0]
         if len(err.args) > 0 and isinstance(err.args[0], str)
-        else {}
-    )
+        else "?",
+    }

--- a/homeassistant/components/home_connect/strings.json
+++ b/homeassistant/components/home_connect/strings.json
@@ -38,13 +38,13 @@
       "message": "Error while trying to set color of {entity_id}: {description}"
     },
     "set_setting": {
-      "message": "Error while trying to assign the value \"{value}\" to the setting \"{key}\" for {entity_id}: {description}"
+      "message": "Error while trying to assign the value \"{value}\" to the setting \"{setting_key}\" for {entity_id}: {description}"
     },
     "turn_on": {
-      "message": "Error while trying to turn on {entity_id} ({key}): {description}"
+      "message": "Error while trying to turn on {entity_id} ({setting_key}): {description}"
     },
     "turn_off": {
-      "message": "Error while trying to turn off {entity_id} ({key}): {description}"
+      "message": "Error while trying to turn off {entity_id} ({setting_key}): {description}"
     },
     "start_program": {
       "message": "Error while trying to start program {program}: {description}"

--- a/tests/components/home_connect/test_switch.py
+++ b/tests/components/home_connect/test_switch.py
@@ -162,7 +162,7 @@ async def test_switch_functionality(
             SERVICE_TURN_OFF,
             "set_setting",
             "Dishwasher",
-            r"Error.*turn.*off.*appliance.*value",
+            r"Error.*turn.*off.*",
         ),
         (
             "switch.dishwasher_power",
@@ -170,7 +170,7 @@ async def test_switch_functionality(
             SERVICE_TURN_ON,
             "set_setting",
             "Dishwasher",
-            r"Error.*turn.*on.*appliance.*",
+            r"Error.*turn.*on.*",
         ),
         (
             "switch.dishwasher_child_lock",
@@ -178,7 +178,7 @@ async def test_switch_functionality(
             SERVICE_TURN_ON,
             "set_setting",
             "Dishwasher",
-            r"Error.*turn.*on.*key.*",
+            r"Error.*turn.*on.*",
         ),
         (
             "switch.dishwasher_child_lock",
@@ -186,7 +186,7 @@ async def test_switch_functionality(
             SERVICE_TURN_OFF,
             "set_setting",
             "Dishwasher",
-            r"Error.*turn.*off.*key.*",
+            r"Error.*turn.*off.*",
         ),
     ],
     indirect=["problematic_appliance"],
@@ -297,7 +297,7 @@ async def test_ent_desc_switch_functionality(
             SERVICE_TURN_ON,
             "set_setting",
             "FridgeFreezer",
-            r"Error.*turn.*on.*key.*",
+            r"Error.*turn.*on.*",
         ),
         (
             "switch.fridgefreezer_freezer_super_mode",
@@ -305,7 +305,7 @@ async def test_ent_desc_switch_functionality(
             SERVICE_TURN_OFF,
             "set_setting",
             "FridgeFreezer",
-            r"Error.*turn.*off.*key.*",
+            r"Error.*turn.*off.*",
         ),
     ],
     indirect=["problematic_appliance"],


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

As spotted at #131266, there was some place holder errors at Home Connect. This pr fixes them.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
