### PR TITLE
Support self-signed certificates in Certificate Expiry

### DIFF
--- a/homeassistant/components/cert_expiry/errors.py
+++ b/homeassistant/components/cert_expiry/errors.py
@@ -15,6 +15,10 @@ class ValidationFailure(CertExpiryException):
     """Certificate validation failure has occurred."""
 
 
+class CertificateExpiredFailure(CertExpiryException):
+    """Certificate is expired."""
+
+
 class ResolveFailed(TemporaryFailure):
     """Name resolution failed."""
 

--- a/tests/components/cert_expiry/helpers.py
+++ b/tests/components/cert_expiry/helpers.py
@@ -1,16 +1,20 @@
 """Helpers for Cert Expiry tests."""
 
-from datetime import datetime, timedelta
-
-from homeassistant.util import dt as dt_util
+from datetime import UTC, datetime, timedelta
 
 
-def static_datetime():
-    """Build a datetime object for testing in the correct timezone."""
-    return dt_util.as_utc(datetime(2020, 6, 12, 8, 0, 0))
+def datetime_today():
+    """Return the current day without time."""
+    return datetime.now(UTC).replace(hour=0, minute=0, second=0, microsecond=0)
+
+
+def past_timestamp(days):
+    """Create timestamp object for requested days in the past."""
+    delta = timedelta(days=days, minutes=1)
+    return datetime_today() - delta
 
 
 def future_timestamp(days):
     """Create timestamp object for requested days in future."""
     delta = timedelta(days=days, minutes=1)
-    return static_datetime() + delta
+    return datetime_today() + delta

--- a/tests/components/cert_expiry/helpers.py
+++ b/tests/components/cert_expiry/helpers.py
@@ -2,6 +2,11 @@
 
 from datetime import UTC, datetime, timedelta
 
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
+
 
 def datetime_today():
     """Return the current day without time."""
@@ -18,3 +23,23 @@ def future_timestamp(days):
     """Create timestamp object for requested days in future."""
     delta = timedelta(days=days, minutes=1)
     return datetime_today() + delta
+
+
+def expired_certificate():
+    """Create an expired certificate."""
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+    subject = issuer = x509.Name(
+        [x509.NameAttribute(NameOID.COMMON_NAME, "Test Expired Certificate")]
+    )
+
+    return (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(issuer)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(past_timestamp(100))
+        .not_valid_after(past_timestamp(10))
+        .sign(key, hashes.SHA256())
+    )

--- a/tests/components/cert_expiry/test_init.py
+++ b/tests/components/cert_expiry/test_init.py
@@ -16,7 +16,7 @@ from homeassistant.core import CoreState, HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from .const import HOST, PORT
-from .helpers import future_timestamp, static_datetime
+from .helpers import datetime_today, future_timestamp
 
 from tests.common import MockConfigEntry
 
@@ -44,7 +44,7 @@ async def test_update_unique_id(hass: HomeAssistant) -> None:
     assert entry.unique_id == f"{HOST}:{PORT}"
 
 
-@freeze_time(static_datetime())
+@freeze_time(datetime_today())
 async def test_unload_config_entry(hass: HomeAssistant) -> None:
     """Test unloading a config entry."""
     assert hass.state is CoreState.running

--- a/tests/components/cert_expiry/test_sensor.py
+++ b/tests/components/cert_expiry/test_sensor.py
@@ -13,7 +13,7 @@ from homeassistant.core import CoreState, HomeAssistant
 from homeassistant.util.dt import utcnow
 
 from .const import HOST, PORT
-from .helpers import datetime_today, future_timestamp, past_timestamp
+from .helpers import datetime_today, expired_certificate, future_timestamp
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
@@ -82,10 +82,9 @@ async def test_async_setup_entry_expired_cert(hass: HomeAssistant) -> None:
         unique_id=f"{HOST}:{PORT}",
     )
 
-    timestamp = past_timestamp(100)
     with patch(
-        "homeassistant.components.cert_expiry.coordinator.get_cert_expiry_timestamp",
-        return_value=timestamp,
+        "homeassistant.components.cert_expiry.helper.async_get_cert",
+        return_value=expired_certificate(),
     ):
         entry.add_to_hass(hass)
         assert await hass.config_entries.async_setup(entry.entry_id)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The current implementation only produces a certificate timestamp if the certificate is valid and signed by a trusted CA. This PR changes the behavior to permit the use of self-signed certificates. Additionally, instead of failing to return a timestamp if the certificate is expired, the integration will now return the timestamp and set `is_cert_valid` to `false`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #91170
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
