### PR TITLE
Add ability to get config_entry as required

### DIFF
--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -22,7 +22,7 @@ from functools import cache
 import logging
 from random import randint
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any, Generic, Self, cast
+from typing import TYPE_CHECKING, Any, Generic, Literal, Self, cast, overload
 
 from async_interrupt import interrupt
 from propcache import cached_property
@@ -1823,10 +1823,30 @@ class ConfigEntries:
             }
         )
 
+    @overload
     @callback
-    def async_get_entry(self, entry_id: str) -> ConfigEntry | None:
-        """Return entry with matching entry_id."""
-        return self._entries.data.get(entry_id)
+    def async_get_entry(
+        self, entry_id: str, *, required: Literal[True]
+    ) -> ConfigEntry: ...
+
+    @overload
+    @callback
+    def async_get_entry(
+        self, entry_id: str, *, required: bool = False
+    ) -> ConfigEntry | None: ...
+
+    @callback
+    def async_get_entry(
+        self, entry_id: str, *, required: bool = False
+    ) -> ConfigEntry | None:
+        """Return entry with matching entry_id.
+
+        Raises UnknownEntry if entry is not found and required is True.
+        """
+        entry = self._entries.data.get(entry_id)
+        if required and entry is None:
+            raise UnknownEntry
+        return entry
 
     @callback
     def async_entry_ids(self) -> list[str]:
@@ -1917,8 +1937,7 @@ class ConfigEntries:
 
     async def _async_remove(self, entry_id: str) -> tuple[bool, ConfigEntry]:
         """Remove and unload an entry."""
-        if (entry := self.async_get_entry(entry_id)) is None:
-            raise UnknownEntry
+        entry = self.async_get_entry(entry_id, required=True)
 
         async with entry.setup_lock:
             if not entry.state.recoverable:
@@ -2011,8 +2030,7 @@ class ConfigEntries:
 
         Return True if entry has been successfully loaded.
         """
-        if (entry := self.async_get_entry(entry_id)) is None:
-            raise UnknownEntry
+        entry = self.async_get_entry(entry_id, required=True)
 
         if entry.state is not ConfigEntryState.NOT_LOADED:
             raise OperationNotAllowed(
@@ -2043,8 +2061,7 @@ class ConfigEntries:
 
     async def async_unload(self, entry_id: str, _lock: bool = True) -> bool:
         """Unload a config entry."""
-        if (entry := self.async_get_entry(entry_id)) is None:
-            raise UnknownEntry
+        entry = self.async_get_entry(entry_id, required=True)
 
         if not entry.state.recoverable:
             raise OperationNotAllowed(
@@ -2062,8 +2079,7 @@ class ConfigEntries:
     @callback
     def async_schedule_reload(self, entry_id: str) -> None:
         """Schedule a config entry to be reloaded."""
-        if (entry := self.async_get_entry(entry_id)) is None:
-            raise UnknownEntry
+        entry = self.async_get_entry(entry_id, required=True)
         entry.async_cancel_retry_setup()
         self.hass.async_create_task(
             self.async_reload(entry_id),
@@ -2081,8 +2097,7 @@ class ConfigEntries:
 
         If an entry was not loaded, will just load.
         """
-        if (entry := self.async_get_entry(entry_id)) is None:
-            raise UnknownEntry
+        entry = self.async_get_entry(entry_id, required=True)
 
         # Cancel the setup retry task before waiting for the
         # reload lock to reduce the chance of concurrent reload
@@ -2112,8 +2127,7 @@ class ConfigEntries:
 
         If disabled_by is changed, the config entry will be reloaded.
         """
-        if (entry := self.async_get_entry(entry_id)) is None:
-            raise UnknownEntry
+        entry = self.async_get_entry(entry_id, required=True)
 
         _validate_item(disabled_by=disabled_by)
         if entry.disabled_by is disabled_by:
@@ -3000,9 +3014,9 @@ class ConfigFlow(ConfigEntryBaseFlow):
     @callback
     def _get_reauth_entry(self) -> ConfigEntry:
         """Return the reauth config entry linked to the current context."""
-        if entry := self.hass.config_entries.async_get_entry(self._reauth_entry_id):
-            return entry
-        raise UnknownEntry
+        return self.hass.config_entries.async_get_entry(
+            self._reauth_entry_id, required=True
+        )
 
     @property
     def _reconfigure_entry_id(self) -> str:
@@ -3014,11 +3028,9 @@ class ConfigFlow(ConfigEntryBaseFlow):
     @callback
     def _get_reconfigure_entry(self) -> ConfigEntry:
         """Return the reconfigure config entry linked to the current context."""
-        if entry := self.hass.config_entries.async_get_entry(
-            self._reconfigure_entry_id
-        ):
-            return entry
-        raise UnknownEntry
+        return self.hass.config_entries.async_get_entry(
+            self._reconfigure_entry_id, required=True
+        )
 
 
 class OptionsFlowManager(
@@ -3030,11 +3042,7 @@ class OptionsFlowManager(
 
     def _async_get_config_entry(self, config_entry_id: str) -> ConfigEntry:
         """Return config entry or raise if not found."""
-        entry = self.hass.config_entries.async_get_entry(config_entry_id)
-        if entry is None:
-            raise UnknownEntry(config_entry_id)
-
-        return entry
+        return self.hass.config_entries.async_get_entry(config_entry_id, required=True)
 
     async def async_create_flow(
         self,
@@ -3068,9 +3076,8 @@ class OptionsFlowManager(
         if result["type"] != data_entry_flow.FlowResultType.CREATE_ENTRY:
             return result
 
-        entry = self.hass.config_entries.async_get_entry(flow.handler)
-        if entry is None:
-            raise UnknownEntry(flow.handler)
+        entry = self.hass.config_entries.async_get_entry(flow.handler, required=True)
+
         if result["data"] is not None:
             self.hass.config_entries.async_update_entry(entry, options=result["data"])
 
@@ -3142,9 +3149,9 @@ class OptionsFlow(ConfigEntryBaseFlow):
 
         if self.hass is None:
             raise ValueError("The config entry is not available during initialisation")
-        if entry := self.hass.config_entries.async_get_entry(self._config_entry_id):
-            return entry
-        raise UnknownEntry
+        return self.hass.config_entries.async_get_entry(
+            self._config_entry_id, required=True
+        )
 
     @config_entry.setter
     def config_entry(self, value: ConfigEntry) -> None:

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -22,7 +22,7 @@ from functools import cache
 import logging
 from random import randint
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any, Generic, Literal, Self, cast, overload
+from typing import TYPE_CHECKING, Any, Generic, Self, cast
 
 from async_interrupt import interrupt
 from propcache import cached_property
@@ -1823,28 +1823,18 @@ class ConfigEntries:
             }
         )
 
-    @overload
     @callback
-    def async_get_entry(
-        self, entry_id: str, *, required: Literal[True]
-    ) -> ConfigEntry: ...
-
-    @overload
-    @callback
-    def async_get_entry(
-        self, entry_id: str, *, required: bool = False
-    ) -> ConfigEntry | None: ...
+    def async_get_entry(self, entry_id: str) -> ConfigEntry | None:
+        """Return entry with matching entry_id."""
+        return self._entries.data.get(entry_id)
 
     @callback
-    def async_get_entry(
-        self, entry_id: str, *, required: bool = False
-    ) -> ConfigEntry | None:
+    def async_get_known_entry(self, entry_id: str) -> ConfigEntry:
         """Return entry with matching entry_id.
 
-        Raises UnknownEntry if entry is not found and required is True.
+        Raises UnknownEntry if entry is not found.
         """
-        entry = self._entries.data.get(entry_id)
-        if required and entry is None:
+        if (entry := self.async_get_entry(entry_id)) is None:
             raise UnknownEntry
         return entry
 
@@ -1937,7 +1927,7 @@ class ConfigEntries:
 
     async def _async_remove(self, entry_id: str) -> tuple[bool, ConfigEntry]:
         """Remove and unload an entry."""
-        entry = self.async_get_entry(entry_id, required=True)
+        entry = self.async_get_known_entry(entry_id)
 
         async with entry.setup_lock:
             if not entry.state.recoverable:
@@ -2030,7 +2020,7 @@ class ConfigEntries:
 
         Return True if entry has been successfully loaded.
         """
-        entry = self.async_get_entry(entry_id, required=True)
+        entry = self.async_get_known_entry(entry_id)
 
         if entry.state is not ConfigEntryState.NOT_LOADED:
             raise OperationNotAllowed(
@@ -2061,7 +2051,7 @@ class ConfigEntries:
 
     async def async_unload(self, entry_id: str, _lock: bool = True) -> bool:
         """Unload a config entry."""
-        entry = self.async_get_entry(entry_id, required=True)
+        entry = self.async_get_known_entry(entry_id)
 
         if not entry.state.recoverable:
             raise OperationNotAllowed(
@@ -2079,7 +2069,7 @@ class ConfigEntries:
     @callback
     def async_schedule_reload(self, entry_id: str) -> None:
         """Schedule a config entry to be reloaded."""
-        entry = self.async_get_entry(entry_id, required=True)
+        entry = self.async_get_known_entry(entry_id)
         entry.async_cancel_retry_setup()
         self.hass.async_create_task(
             self.async_reload(entry_id),
@@ -2097,7 +2087,7 @@ class ConfigEntries:
 
         If an entry was not loaded, will just load.
         """
-        entry = self.async_get_entry(entry_id, required=True)
+        entry = self.async_get_known_entry(entry_id)
 
         # Cancel the setup retry task before waiting for the
         # reload lock to reduce the chance of concurrent reload
@@ -2127,7 +2117,7 @@ class ConfigEntries:
 
         If disabled_by is changed, the config entry will be reloaded.
         """
-        entry = self.async_get_entry(entry_id, required=True)
+        entry = self.async_get_known_entry(entry_id)
 
         _validate_item(disabled_by=disabled_by)
         if entry.disabled_by is disabled_by:
@@ -3014,9 +3004,7 @@ class ConfigFlow(ConfigEntryBaseFlow):
     @callback
     def _get_reauth_entry(self) -> ConfigEntry:
         """Return the reauth config entry linked to the current context."""
-        return self.hass.config_entries.async_get_entry(
-            self._reauth_entry_id, required=True
-        )
+        return self.hass.config_entries.async_get_known_entry(self._reauth_entry_id)
 
     @property
     def _reconfigure_entry_id(self) -> str:
@@ -3028,8 +3016,8 @@ class ConfigFlow(ConfigEntryBaseFlow):
     @callback
     def _get_reconfigure_entry(self) -> ConfigEntry:
         """Return the reconfigure config entry linked to the current context."""
-        return self.hass.config_entries.async_get_entry(
-            self._reconfigure_entry_id, required=True
+        return self.hass.config_entries.async_get_known_entry(
+            self._reconfigure_entry_id
         )
 
 
@@ -3042,7 +3030,7 @@ class OptionsFlowManager(
 
     def _async_get_config_entry(self, config_entry_id: str) -> ConfigEntry:
         """Return config entry or raise if not found."""
-        return self.hass.config_entries.async_get_entry(config_entry_id, required=True)
+        return self.hass.config_entries.async_get_known_entry(config_entry_id)
 
     async def async_create_flow(
         self,
@@ -3076,7 +3064,7 @@ class OptionsFlowManager(
         if result["type"] != data_entry_flow.FlowResultType.CREATE_ENTRY:
             return result
 
-        entry = self.hass.config_entries.async_get_entry(flow.handler, required=True)
+        entry = self.hass.config_entries.async_get_known_entry(flow.handler)
 
         if result["data"] is not None:
             self.hass.config_entries.async_update_entry(entry, options=result["data"])
@@ -3149,9 +3137,7 @@ class OptionsFlow(ConfigEntryBaseFlow):
 
         if self.hass is None:
             raise ValueError("The config entry is not available during initialisation")
-        return self.hass.config_entries.async_get_entry(
-            self._config_entry_id, required=True
-        )
+        return self.hass.config_entries.async_get_known_entry(self._config_entry_id)
 
     @config_entry.setter
     def config_entry(self, value: ConfigEntry) -> None:
@@ -3230,8 +3216,8 @@ class EntityRegistryDisabledHandler:
         ):
             return
 
-        config_entry = self.hass.config_entries.async_get_entry(
-            entity_entry.config_entry_id, required=True
+        config_entry = self.hass.config_entries.async_get_known_entry(
+            entity_entry.config_entry_id
         )
 
         if config_entry.entry_id not in self.changed and config_entry.supports_unload:

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -3231,9 +3231,8 @@ class EntityRegistryDisabledHandler:
             return
 
         config_entry = self.hass.config_entries.async_get_entry(
-            entity_entry.config_entry_id
+            entity_entry.config_entry_id, required=True
         )
-        assert config_entry is not None
 
         if config_entry.entry_id not in self.changed and config_entry.supports_unload:
             self.changed.add(config_entry.entry_id)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This allows us to reduce duplicate code within config_entries right now.

In a follow-up PR, we will be able to drop `if TYPE_CHECKING` and corresponding `assert entry` in components

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
