### PR TITLE
Remove deprecated v2 api from glances

### DIFF
--- a/homeassistant/components/glances/__init__.py
+++ b/homeassistant/components/glances/__init__.py
@@ -28,9 +28,7 @@ from homeassistant.exceptions import (
     HomeAssistantError,
 )
 from homeassistant.helpers.httpx_client import get_async_client
-from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 
-from .const import DOMAIN
 from .coordinator import GlancesDataUpdateCoordinator
 
 PLATFORMS = [Platform.SENSOR]
@@ -71,7 +69,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: GlancesConfigEntry) -> 
 async def get_api(hass: HomeAssistant, entry_data: dict[str, Any]) -> Glances:
     """Return the api from glances_api."""
     httpx_client = get_async_client(hass, verify_ssl=entry_data[CONF_VERIFY_SSL])
-    for version in (4, 3, 2):
+    for version in (4, 3):
         api = Glances(
             host=entry_data[CONF_HOST],
             port=entry_data[CONF_PORT],
@@ -86,16 +84,6 @@ async def get_api(hass: HomeAssistant, entry_data: dict[str, Any]) -> Glances:
         except GlancesApiNoDataAvailable as err:
             _LOGGER.debug("Failed to connect to Glances API v%s: %s", version, err)
             continue
-        if version == 2:
-            async_create_issue(
-                hass,
-                DOMAIN,
-                "deprecated_version",
-                breaks_in_ha_version="2024.8.0",
-                is_fixable=False,
-                severity=IssueSeverity.WARNING,
-                translation_key="deprecated_version",
-            )
         _LOGGER.debug("Connected to Glances API v%s", version)
         return api
     raise ServerVersionMismatch("Could not connect to Glances API version 2, 3 or 4")

--- a/homeassistant/components/glances/__init__.py
+++ b/homeassistant/components/glances/__init__.py
@@ -86,7 +86,7 @@ async def get_api(hass: HomeAssistant, entry_data: dict[str, Any]) -> Glances:
             continue
         _LOGGER.debug("Connected to Glances API v%s", version)
         return api
-    raise ServerVersionMismatch("Could not connect to Glances API version 2, 3 or 4")
+    raise ServerVersionMismatch("Could not connect to Glances API version 3 or 4")
 
 
 class ServerVersionMismatch(HomeAssistantError):

--- a/homeassistant/components/glances/strings.json
+++ b/homeassistant/components/glances/strings.json
@@ -123,11 +123,5 @@
         "name": "{sensor_label} TX"
       }
     }
-  },
-  "issues": {
-    "deprecated_version": {
-      "title": "Glances servers with version 2 is deprecated",
-      "description": "Glances servers with version 2 is deprecated and will not be supported in future versions of HA. It is recommended to update your server to Glances version 3 then reload the integration."
-    }
   }
 }

--- a/tests/components/glances/test_config_flow.py
+++ b/tests/components/glances/test_config_flow.py
@@ -10,7 +10,7 @@ from glances_api.exceptions import (
 import pytest
 
 from homeassistant import config_entries
-from homeassistant.components import glances
+from homeassistant.components.glances.const import DOMAIN
 from homeassistant.const import CONF_NAME, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -31,7 +31,7 @@ async def test_form(hass: HomeAssistant) -> None:
     """Test config entry configured successfully."""
 
     result = await hass.config_entries.flow.async_init(
-        glances.DOMAIN, context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
@@ -60,7 +60,7 @@ async def test_form_fails(
 
     mock_api.return_value.get_ha_sensor_data.side_effect = error
     result = await hass.config_entries.flow.async_init(
-        glances.DOMAIN, context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input=MOCK_USER_INPUT
@@ -72,11 +72,11 @@ async def test_form_fails(
 
 async def test_form_already_configured(hass: HomeAssistant) -> None:
     """Test host is already configured."""
-    entry = MockConfigEntry(domain=glances.DOMAIN, data=MOCK_USER_INPUT)
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_INPUT)
     entry.add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(
-        glances.DOMAIN, context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input=MOCK_USER_INPUT
@@ -87,7 +87,7 @@ async def test_form_already_configured(hass: HomeAssistant) -> None:
 
 async def test_reauth_success(hass: HomeAssistant) -> None:
     """Test we can reauth."""
-    entry = MockConfigEntry(domain=glances.DOMAIN, data=MOCK_USER_INPUT)
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_INPUT)
     entry.add_to_hass(hass)
 
     result = await entry.start_reauth_flow(hass)
@@ -120,7 +120,7 @@ async def test_reauth_fails(
     hass: HomeAssistant, error: Exception, message: str, mock_api: MagicMock
 ) -> None:
     """Test we can reauth."""
-    entry = MockConfigEntry(domain=glances.DOMAIN, data=MOCK_USER_INPUT)
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_INPUT)
     entry.add_to_hass(hass)
 
     mock_api.return_value.get_ha_sensor_data.side_effect = [error, HA_SENSOR_DATA]

--- a/tests/components/glances/test_config_flow.py
+++ b/tests/components/glances/test_config_flow.py
@@ -1,6 +1,6 @@
 """Tests for Glances config flow."""
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from glances_api.exceptions import (
     GlancesApiAuthorizationError,
@@ -17,7 +17,7 @@ from homeassistant.data_entry_flow import FlowResultType
 
 from . import HA_SENSOR_DATA, MOCK_USER_INPUT
 
-from tests.common import MockConfigEntry, patch
+from tests.common import MockConfigEntry
 
 
 @pytest.fixture(autouse=True)

--- a/tests/components/glances/test_init.py
+++ b/tests/components/glances/test_init.py
@@ -1,6 +1,6 @@
 """Tests for Glances integration."""
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 from glances_api.exceptions import (
     GlancesApiAuthorizationError,
@@ -12,9 +12,8 @@ import pytest
 from homeassistant.components.glances.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import issue_registry as ir
 
-from . import HA_SENSOR_DATA, MOCK_USER_INPUT
+from . import MOCK_USER_INPUT
 
 from tests.common import MockConfigEntry
 
@@ -28,29 +27,6 @@ async def test_successful_config_entry(hass: HomeAssistant) -> None:
     await hass.config_entries.async_setup(entry.entry_id)
 
     assert entry.state is ConfigEntryState.LOADED
-
-
-async def test_entry_deprecated_version(
-    hass: HomeAssistant, issue_registry: ir.IssueRegistry, mock_api: AsyncMock
-) -> None:
-    """Test creating an issue if glances server is version 2."""
-    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_INPUT)
-    entry.add_to_hass(hass)
-
-    mock_api.return_value.get_ha_sensor_data.side_effect = [
-        GlancesApiNoDataAvailable("endpoint: 'all' is not valid"),  # fail v4
-        GlancesApiNoDataAvailable("endpoint: 'all' is not valid"),  # fail v3
-        HA_SENSOR_DATA,  # success v2
-        HA_SENSOR_DATA,
-    ]
-
-    await hass.config_entries.async_setup(entry.entry_id)
-
-    assert entry.state is ConfigEntryState.LOADED
-
-    issue = issue_registry.async_get_issue(DOMAIN, "deprecated_version")
-    assert issue is not None
-    assert issue.severity == ir.IssueSeverity.WARNING
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Glances v2 api has been deprecated and has now been removed. Upgrade to v3 or higher to continue using the integration

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 