### PR TITLE
Add Habitica quality scale record

### DIFF
--- a/homeassistant/components/bring/quality_scale.yaml
+++ b/homeassistant/components/bring/quality_scale.yaml
@@ -37,7 +37,7 @@ rules:
     comment: handled by coordinator
   parallel-updates: todo
   reauthentication-flow: done
-  test-coverage: todo
+  test-coverage: done
 
   # Gold
   devices: done

--- a/homeassistant/components/bring/quality_scale.yaml
+++ b/homeassistant/components/bring/quality_scale.yaml
@@ -37,7 +37,7 @@ rules:
     comment: handled by coordinator
   parallel-updates: todo
   reauthentication-flow: done
-  test-coverage: done
+  test-coverage: todo
 
   # Gold
   devices: done

--- a/homeassistant/components/habitica/quality_scale.yaml
+++ b/homeassistant/components/habitica/quality_scale.yaml
@@ -66,7 +66,9 @@ rules:
   entity-device-class: done
   entity-disabled-by-default: done
   entity-translations: done
-  exception-translations: done
+  exception-translations:
+    status: todo
+    comment: translations for UpdateFailed missing
   icon-translations: done
   reconfiguration-flow: todo
   repair-issues:

--- a/homeassistant/components/habitica/quality_scale.yaml
+++ b/homeassistant/components/habitica/quality_scale.yaml
@@ -33,7 +33,7 @@ rules:
   entity-unavailable: done
   integration-owner: done
   log-when-unavailable: done
-  parallel-updates: done
+  parallel-updates: todo
   reauthentication-flow: todo
   test-coverage: todo
 

--- a/homeassistant/components/habitica/quality_scale.yaml
+++ b/homeassistant/components/habitica/quality_scale.yaml
@@ -4,9 +4,11 @@ rules:
   appropriate-polling: done
   brands: done
   common-modules: done
-  config-flow-test-coverage: done
+  config-flow-test-coverage:
+    status: todo
+    comment: test already_configured, tests should finish with create_entry or abort, assert unique_id
   config-flow: done
-  dependency-transparency: done
+  dependency-transparency: todo
   docs-actions: done
   docs-high-level-description: done
   docs-installation-instructions: done
@@ -75,6 +77,6 @@ rules:
     comment: Not applicable. Only one device per config entry. Removed together with the config entry.
 
   # Platinum
-  async-dependency: done
+  async-dependency: todo
   inject-websession: done
   strict-typing: todo

--- a/homeassistant/components/habitica/quality_scale.yaml
+++ b/homeassistant/components/habitica/quality_scale.yaml
@@ -1,0 +1,80 @@
+rules:
+  # Bronze
+  action-setup: done
+  appropriate-polling: done
+  brands: done
+  common-modules: done
+  config-flow-test-coverage: done
+  config-flow: done
+  dependency-transparency: done
+  docs-actions: done
+  docs-high-level-description: todo
+  docs-installation-instructions: done
+  docs-removal-instructions: todo
+  entity-event-setup:
+    status: exempt
+    comment: No events are registered by the integration.
+  entity-unique-id: done
+  has-entity-name: done
+  runtime-data: done
+  test-before-configure: done
+  test-before-setup: done
+  unique-config-entry: done
+
+  # Silver
+  action-exceptions: done
+  config-entry-unloading: done
+  docs-configuration-parameters:
+    status: exempt
+    comment: There is no options flow.
+  docs-installation-parameters: todo
+  entity-unavailable: done
+  integration-owner: done
+  log-when-unavailable: done
+  parallel-updates: todo
+  reauthentication-flow: todo
+  test-coverage: done
+
+  # Gold
+  devices: done
+  diagnostics: todo
+  discovery-update-info:
+    status: exempt
+    comment: Integration represents a service
+  discovery:
+    status: exempt
+    comment: Integration represents a service
+  docs-data-update: todo
+  docs-examples: done
+  docs-known-limitations: todo
+  docs-supported-devices:
+    status: exempt
+    comment: No supportable devices.
+  docs-supported-functions: done
+  docs-troubleshooting: todo
+  docs-use-cases: todo
+  dynamic-devices:
+    status: exempt
+    comment: |
+      Integration is a service, no devices that could be added at runtime.
+      Button entities for casting skills are created/removed dynamically if unlocked or on class change
+  entity-category:
+    status: done
+    comment: Default categories are appropriate for currently available entities.
+  entity-device-class: done
+  entity-disabled-by-default: done
+  entity-translations: done
+  exception-translations: done
+  icon-translations: done
+  reconfiguration-flow: todo
+  repair-issues:
+    status: done
+    comment: Used to inform of deprecated entities and actions.
+  stale-devices:
+    status: done
+    comment: Not applicable. Only one device per config entry. Removed together with the config entry.
+
+  # Platinum
+  async-dependency: done
+  inject-websession: done
+  strict-typing: todo

--- a/homeassistant/components/habitica/quality_scale.yaml
+++ b/homeassistant/components/habitica/quality_scale.yaml
@@ -5,7 +5,7 @@ rules:
   brands: done
   common-modules: done
   config-flow-test-coverage: done
-  config-flow: done
+  config-flow: todo
   dependency-transparency: done
   docs-actions: done
   docs-high-level-description: todo

--- a/homeassistant/components/habitica/quality_scale.yaml
+++ b/homeassistant/components/habitica/quality_scale.yaml
@@ -44,7 +44,7 @@ rules:
   discovery:
     status: exempt
     comment: Integration represents a service
-  docs-data-update: todo
+  docs-data-update: done
   docs-examples: done
   docs-known-limitations: done
   docs-supported-devices:

--- a/homeassistant/components/habitica/quality_scale.yaml
+++ b/homeassistant/components/habitica/quality_scale.yaml
@@ -31,7 +31,7 @@ rules:
   entity-unavailable: done
   integration-owner: done
   log-when-unavailable: done
-  parallel-updates: todo
+  parallel-updates: done
   reauthentication-flow: todo
   test-coverage: done
 

--- a/homeassistant/components/habitica/quality_scale.yaml
+++ b/homeassistant/components/habitica/quality_scale.yaml
@@ -5,12 +5,12 @@ rules:
   brands: done
   common-modules: done
   config-flow-test-coverage: done
-  config-flow: todo
+  config-flow: done
   dependency-transparency: done
   docs-actions: done
-  docs-high-level-description: todo
+  docs-high-level-description: done
   docs-installation-instructions: done
-  docs-removal-instructions: todo
+  docs-removal-instructions: done
   entity-event-setup:
     status: exempt
     comment: No events are registered by the integration.
@@ -27,7 +27,7 @@ rules:
   docs-configuration-parameters:
     status: exempt
     comment: There is no options flow.
-  docs-installation-parameters: todo
+  docs-installation-parameters: done
   entity-unavailable: done
   integration-owner: done
   log-when-unavailable: done
@@ -46,13 +46,13 @@ rules:
     comment: Integration represents a service
   docs-data-update: todo
   docs-examples: done
-  docs-known-limitations: todo
+  docs-known-limitations: done
   docs-supported-devices:
     status: exempt
     comment: No supportable devices.
   docs-supported-functions: done
   docs-troubleshooting: todo
-  docs-use-cases: todo
+  docs-use-cases: done
   dynamic-devices:
     status: exempt
     comment: |

--- a/homeassistant/components/habitica/quality_scale.yaml
+++ b/homeassistant/components/habitica/quality_scale.yaml
@@ -37,7 +37,7 @@ rules:
 
   # Gold
   devices: done
-  diagnostics: todo
+  diagnostics: done
   discovery-update-info:
     status: exempt
     comment: Integration represents a service

--- a/homeassistant/components/habitica/quality_scale.yaml
+++ b/homeassistant/components/habitica/quality_scale.yaml
@@ -33,7 +33,7 @@ rules:
   log-when-unavailable: done
   parallel-updates: done
   reauthentication-flow: todo
-  test-coverage: done
+  test-coverage: todo
 
   # Gold
   devices: done

--- a/script/hassfest/quality_scale.py
+++ b/script/hassfest/quality_scale.py
@@ -474,7 +474,6 @@ INTEGRATIONS_WITHOUT_QUALITY_SCALE_FILE = [
     "gstreamer",
     "gtfs",
     "guardian",
-    "habitica",
     "harman_kardon_avr",
     "harmony",
     "hassio",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Bronze
- [x] `config-flow` - Integration needs to be able to be set up via the UI
    - [x] Uses `data-description` to give context to fields
    - [x] Uses `ConfigEntry.data` and `ConfigEntry.options` correctly
- [x] `test-before-configure` - Test a connection in the config flow
- [x] `unique-config-entry` - Don't allow the same device or service to be able to be set up twice
- [ ] `config-flow-test-coverage` - Full test coverage for the config flow
- [x] `runtime-data` - Use ConfigEntry.runtime_data to store runtime data
- [x] `test-before-setup` - Check during integration initialization if we are able to set it up correctly
- [x] `appropriate-polling` - If it's a polling integration, set an appropriate polling interval
- [x] `entity-unique-id` - Entities have a unique ID
- [x] `has-entity-name` - Entities use has_entity_name = True
- [ ] `entity-event-setup` - Entities event setup
    - exempt: No events are registered by the integration.
- [ ] `dependency-transparency` - Dependency transparency
- [x] `action-setup` - Service actions are registered in async_setup
- [x] `common-modules` - Place common patterns in common modules
- [x] `docs-high-level-description` - The documentation includes a high-level description of the integration brand, product, or service
- [x] `docs-installation-instructions` - The documentation provides step-by-step installation instructions for the integration, including, if needed, prerequisites
- [x] `docs-removal-instructions` - The documentation provides removal instructions
- [x] `docs-actions` - The documentation describes the provided service actions that can be used
- [x] `brands` - Has branding assets available for the integration

## Silver
- [x] `config-entry-unloading` - Support config entry unloading
- [x] `log-when-unavailable` - If internet/device/service is unavailable, log once when unavailable and once when back connected
- [x] `entity-unavailable` - Mark entity unavailable if appropriate
- [x] `action-exceptions` - Service actions raise exceptions when encountering failures
- [ ] `reauthentication-flow` - Reauthentication flow
    - https://github.com/home-assistant/core/pull/131676
- [ ] `parallel-updates` - Set Parallel updates
- [ ] `test-coverage` - Above 95% test coverage for all integration modules
    - https://github.com/home-assistant/core/pull/131778
    - https://github.com/home-assistant/core/pull/131780
- [x] `integration-owner` - Has an integration owner
- [x] `docs-installation-parameters` - The documentation describes all integration installation parameters
- [ ] `docs-configuration-parameters` - The documentation describes all integration configuration options
    - exempt: There is no options flow.

## Gold
- [x] `entity-translations` - Entities have translated names
- [x] `entity-device-class` - Entities use device classes where possible
- [x] `devices` - The integration creates devices
- [x] `entity-category` - Entities are assigned an appropriate EntityCategory
    - Default categories are appropriate for currently available entities.
- [x] `entity-disabled-by-default` - Integration disables less popular (or noisy) entities
- [ ] `discovery` - Can be discovered
    - exempt: Integration represents a service
- [x] `stale-devices` - Clean up stale devices
    - Only one device per config entry. Removed together with the config entry.
- [x] `diagnostics` - Implements diagnostics
- [ ] `exception-translations` - Exception messages are translatable
- [x] `icon-translations` - Icon translations
- [ ] `reconfiguration-flow` - Integrations should have a reconfigure flow
- [ ] `dynamic-devices` - Devices added after integration setup
    - exempt: Integration is a service, no devices that could be added at runtime.
      Button entities for casting skills are created/removed dynamically
- [ ] `discovery-update-info` - Integration uses discovery info to update network information
    - Integration represents a service
- [x] `repair-issues` - Repair issues and repair flows are used when user intervention is needed
- [x] `docs-use-cases` - The documentation describes use cases to illustrate how this integration can be used
- [ ] `docs-supported-devices` - The integration documents known supported / unsupported devices
     - exempt: Integration represents a service, there are no devices.
- [x] `docs-supported-functions` - The documentation describes the supported functionality, including entities, and platforms
- [x] `docs-data-update` - The documentation describes how data is updated
- [x] `docs-known-limitations` - The documentation describes known limitations of the integration (not to be confused with bugs)
- [ ] `docs-troubleshooting` - The documentation provides troubleshooting information
- [x] `docs-examples` - The documentation provides automation examples the user can use.

## Platinum
- [ ] `async-dependency` - Dependency is async
- [x] `inject-websession` - The integration dependency supports passing in a websession
- [ ] `strict-typing` - Strict typing
    - https://github.com/home-assistant/core/pull/131032

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
