### PR TITLE
Bump deebot-client to 9.0.0

### DIFF
--- a/homeassistant/components/ecovacs/controller.py
+++ b/homeassistant/components/ecovacs/controller.py
@@ -13,7 +13,6 @@ from deebot_client.authentication import Authenticator, create_rest_config
 from deebot_client.const import UNDEFINED, UndefinedType
 from deebot_client.device import Device
 from deebot_client.exceptions import DeebotError, InvalidAuthenticationError
-from deebot_client.models import DeviceInfo
 from deebot_client.mqtt_client import MqttClient, create_mqtt_config
 from deebot_client.util import md5
 from deebot_client.util.continents import get_continent
@@ -81,25 +80,32 @@ class EcovacsController:
         try:
             devices = await self._api_client.get_devices()
             credentials = await self._authenticator.authenticate()
-            for device_config in devices:
-                if isinstance(device_config, DeviceInfo):
-                    # MQTT device
-                    device = Device(device_config, self._authenticator)
-                    mqtt = await self._get_mqtt_client()
-                    await device.initialize(mqtt)
-                    self._devices.append(device)
-                else:
-                    # Legacy device
-                    bot = VacBot(
-                        credentials.user_id,
-                        EcoVacsAPI.REALM,
-                        self._device_id[0:8],
-                        credentials.token,
-                        device_config,
-                        self._continent,
-                        monitor=True,
-                    )
-                    self._legacy_devices.append(bot)
+            for device_info in devices.mqtt:
+                device = Device(device_info, self._authenticator)
+                mqtt = await self._get_mqtt_client()
+                await device.initialize(mqtt)
+                self._devices.append(device)
+            for device_config in devices.xmpp:
+                bot = VacBot(
+                    credentials.user_id,
+                    EcoVacsAPI.REALM,
+                    self._device_id[0:8],
+                    credentials.token,
+                    device_config,
+                    self._continent,
+                    monitor=True,
+                )
+                self._legacy_devices.append(bot)
+            for device_config in devices.not_supported:
+                _LOGGER.warning(
+                    (
+                        'Device "%s" not supported. Please add support for it to '
+                        "https://github.com/DeebotUniverse/client.py: %s"
+                    ),
+                    device_config["deviceName"],
+                    device_config,
+                )
+
         except InvalidAuthenticationError as ex:
             raise ConfigEntryError("Invalid credentials") from ex
         except DeebotError as ex:

--- a/homeassistant/components/ecovacs/manifest.json
+++ b/homeassistant/components/ecovacs/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/ecovacs",
   "iot_class": "cloud_push",
   "loggers": ["sleekxmppfs", "sucks", "deebot_client"],
-  "requirements": ["py-sucks==0.9.10", "deebot-client==8.4.1"]
+  "requirements": ["py-sucks==0.9.10", "deebot-client==9.0.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -738,7 +738,7 @@ debugpy==1.8.6
 # decora==0.6
 
 # homeassistant.components.ecovacs
-deebot-client==8.4.1
+deebot-client==9.0.0
 
 # homeassistant.components.ihc
 # homeassistant.components.namecheapdns

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -628,7 +628,7 @@ dbus-fast==2.24.3
 debugpy==1.8.6
 
 # homeassistant.components.ecovacs
-deebot-client==8.4.1
+deebot-client==9.0.0
 
 # homeassistant.components.ihc
 # homeassistant.components.namecheapdns


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Ecovacs devices not recognized by the library will no longer use the fallback vacuum. Instead, the device will not be added to Home Assistant, and a warning log will created.


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Release: https://github.com/DeebotUniverse/client.py/releases/tag/9.0.0
The reason for the breaking change is that the fallback created more issues than it solved.
Examples:
- Mower/Win bot mapped as vacuum
- Due to incorrect mapping used the wrong command -> a lot of errors in the logs
- Continuously bug reports on not working features
....

By adding the model to the library we can use the correct commands and provide the correct entities


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
