### PR TITLE
Allow time triggers with offsets to use input_datetimes

### DIFF
--- a/homeassistant/components/homeassistant/triggers/time.py
+++ b/homeassistant/components/homeassistant/triggers/time.py
@@ -42,7 +42,7 @@ _TIME_AT_SCHEMA = vol.Any(cv.time, _TIME_TRIGGER_ENTITY)
 
 _TIME_TRIGGER_ENTITY_WITH_OFFSET = vol.Schema(
     {
-        vol.Required(CONF_ENTITY_ID): cv.entity_domain(["sensor"]),
+        vol.Required(CONF_ENTITY_ID): cv.entity_domain(["input_datetime", "sensor"]),
         vol.Optional(CONF_OFFSET): cv.time_period,
     }
 )

--- a/tests/components/homeassistant/triggers/test_time.py
+++ b/tests/components/homeassistant/triggers/test_time.py
@@ -157,6 +157,83 @@ async def test_if_fires_using_at_input_datetime(
 
 
 @pytest.mark.parametrize(
+    ("has_date", "has_time"), [(True, True), (False, True), (True, False)]
+)
+@pytest.mark.parametrize(
+    ("offset", "delta"),
+    [
+        ("00:00:10", timedelta(seconds=10)),
+        ("-00:00:10", timedelta(seconds=-10)),
+        ({"minutes": 5}, timedelta(minutes=5)),
+    ],
+)
+async def test_if_fires_using_at_input_datetime_with_offset(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    service_calls: list[ServiceCall],
+    has_date: bool,
+    has_time: bool,
+    offset: str,
+    delta: timedelta,
+) -> None:
+    """Test for firing at input_datetime."""
+    await async_setup_component(
+        hass,
+        "input_datetime",
+        {"input_datetime": {"trigger": {"has_date": has_date, "has_time": has_time}}},
+    )
+    now = dt_util.now()
+
+    start_dt = now.replace(
+        hour=5 if has_time else 0, minute=0, second=0, microsecond=0
+    ) + timedelta(2)
+    trigger_dt = start_dt + delta
+
+    await hass.services.async_call(
+        "input_datetime",
+        "set_datetime",
+        {
+            ATTR_ENTITY_ID: "input_datetime.trigger",
+            "datetime": str(start_dt.replace(tzinfo=None)),
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    time_that_will_not_match_right_away = trigger_dt - timedelta(minutes=1)
+
+    some_data = "{{ trigger.platform }}-{{ trigger.now.day }}-{{ trigger.now.hour }}-{{trigger.entity_id}}"
+
+    freezer.move_to(dt_util.as_utc(time_that_will_not_match_right_away))
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "trigger": {
+                    "platform": "time",
+                    "at": {"entity_id": "input_datetime.trigger", "offset": offset},
+                },
+                "action": {
+                    "service": "test.automation",
+                    "data_template": {"some": some_data},
+                },
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    async_fire_time_changed(hass, trigger_dt + timedelta(seconds=1))
+    await hass.async_block_till_done()
+
+    assert len(service_calls) == 2
+    assert (
+        service_calls[1].data["some"]
+        == f"time-{trigger_dt.day}-{trigger_dt.hour}-input_datetime.trigger"
+    )
+
+
+@pytest.mark.parametrize(
     ("conf_at", "trigger_deltas"),
     [
         (

--- a/tests/components/homeassistant/triggers/test_time.py
+++ b/tests/components/homeassistant/triggers/test_time.py
@@ -156,7 +156,7 @@ async def test_if_fires_using_at_input_datetime(
     )
 
 
-@pytest.mark.parametrize(("hour"), [0, 5])
+@pytest.mark.parametrize(("hour"), [0, 5, 23])
 @pytest.mark.parametrize(
     ("has_date", "has_time"), [(True, True), (False, True), (True, False)]
 )
@@ -166,6 +166,7 @@ async def test_if_fires_using_at_input_datetime(
         ("00:00:10", timedelta(seconds=10)),
         ("-00:00:10", timedelta(seconds=-10)),
         ({"minutes": 5}, timedelta(minutes=5)),
+        ("01:00:10", timedelta(hours=1, seconds=10)),
     ],
 )
 async def test_if_fires_using_at_input_datetime_with_offset(

--- a/tests/components/homeassistant/triggers/test_time.py
+++ b/tests/components/homeassistant/triggers/test_time.py
@@ -156,6 +156,7 @@ async def test_if_fires_using_at_input_datetime(
     )
 
 
+@pytest.mark.parametrize(("hour"), [0, 5])
 @pytest.mark.parametrize(
     ("has_date", "has_time"), [(True, True), (False, True), (True, False)]
 )
@@ -175,6 +176,7 @@ async def test_if_fires_using_at_input_datetime_with_offset(
     has_time: bool,
     offset: str,
     delta: timedelta,
+    hour: int,
 ) -> None:
     """Test for firing at input_datetime."""
     await async_setup_component(
@@ -185,7 +187,7 @@ async def test_if_fires_using_at_input_datetime_with_offset(
     now = dt_util.now()
 
     start_dt = now.replace(
-        hour=5 if has_time else 0, minute=0, second=0, microsecond=0
+        hour=hour if has_time else 0, minute=0, second=0, microsecond=0
     ) + timedelta(2)
     trigger_dt = start_dt + delta
 

--- a/tests/components/homeassistant/triggers/test_time.py
+++ b/tests/components/homeassistant/triggers/test_time.py
@@ -654,10 +654,6 @@ def test_schema_valid(conf) -> None:
         {"platform": "time", "at": "binary_sensor.bla"},
         {"platform": "time", "at": 745},
         {"platform": "time", "at": "25:00"},
-        {
-            "platform": "time",
-            "at": {"entity_id": "input_datetime.bla", "offset": "0:10"},
-        },
         {"platform": "time", "at": {"entity_id": "13:00:00", "offset": "0:10"}},
     ],
 )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Time triggers with offsets are restricted to only allow sensors.  We have a user attempting to do an offset with an input datetime.  They have 2 automations, 1 automation that triggers off the input datetime, then a second automation that should trigger 20 minutes before the input_datetime.  Right now, the user would have to create 2 input datetimes because of this restriction.

This PR removes the restriction.

relevant thread: https://community.home-assistant.io/t/trigger-using-input-datetime-with-time-offset/799710

also it's a WTH too: https://community.home-assistant.io/t/wth-offset-input-datetime-automation-trigger-by-input-number/802293

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
