### PR TITLE
Filter entity names before intent matching

### DIFF
--- a/homeassistant/components/conversation/manifest.json
+++ b/homeassistant/components/conversation/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/conversation",
   "integration_type": "system",
   "quality_scale": "internal",
-  "requirements": ["hassil==2.0.2", "home-assistant-intents==2024.11.13"]
+  "requirements": ["hassil==2.0.3", "home-assistant-intents==2024.11.13"]
 }

--- a/homeassistant/components/conversation/manifest.json
+++ b/homeassistant/components/conversation/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/conversation",
   "integration_type": "system",
   "quality_scale": "internal",
-  "requirements": ["hassil==2.0.3", "home-assistant-intents==2024.11.13"]
+  "requirements": ["hassil==2.0.4", "home-assistant-intents==2024.11.13"]
 }

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -32,7 +32,7 @@ go2rtc-client==0.1.1
 ha-ffmpeg==3.2.2
 habluetooth==3.6.0
 hass-nabucasa==0.85.0
-hassil==2.0.2
+hassil==2.0.3
 home-assistant-bluetooth==1.13.0
 home-assistant-frontend==20241106.2
 home-assistant-intents==2024.11.13

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -32,7 +32,7 @@ go2rtc-client==0.1.1
 ha-ffmpeg==3.2.2
 habluetooth==3.6.0
 hass-nabucasa==0.85.0
-hassil==2.0.3
+hassil==2.0.4
 home-assistant-bluetooth==1.13.0
 home-assistant-frontend==20241106.2
 home-assistant-intents==2024.11.13

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1096,7 +1096,7 @@ hass-nabucasa==0.85.0
 hass-splunk==0.1.1
 
 # homeassistant.components.conversation
-hassil==2.0.2
+hassil==2.0.3
 
 # homeassistant.components.jewish_calendar
 hdate==0.11.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1096,7 +1096,7 @@ hass-nabucasa==0.85.0
 hass-splunk==0.1.1
 
 # homeassistant.components.conversation
-hassil==2.0.3
+hassil==2.0.4
 
 # homeassistant.components.jewish_calendar
 hdate==0.11.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -931,7 +931,7 @@ habluetooth==3.6.0
 hass-nabucasa==0.85.0
 
 # homeassistant.components.conversation
-hassil==2.0.2
+hassil==2.0.3
 
 # homeassistant.components.jewish_calendar
 hdate==0.11.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -931,7 +931,7 @@ habluetooth==3.6.0
 hass-nabucasa==0.85.0
 
 # homeassistant.components.conversation
-hassil==2.0.3
+hassil==2.0.4
 
 # homeassistant.components.jewish_calendar
 hdate==0.11.1

--- a/script/hassfest/docker/Dockerfile
+++ b/script/hassfest/docker/Dockerfile
@@ -23,7 +23,7 @@ RUN --mount=from=ghcr.io/astral-sh/uv:0.5.4,source=/uv,target=/bin/uv \
         -c /usr/src/homeassistant/homeassistant/package_constraints.txt \
         -r /usr/src/homeassistant/requirements.txt \
         stdlib-list==0.10.0 pipdeptree==2.23.4 tqdm==4.66.5 ruff==0.8.0 \
-        PyTurboJPEG==1.7.5 go2rtc-client==0.1.1 ha-ffmpeg==3.2.2 hassil==2.0.2 home-assistant-intents==2024.11.13 mutagen==1.47.0 pymicro-vad==1.0.1 pyspeex-noise==1.0.2
+        PyTurboJPEG==1.7.5 go2rtc-client==0.1.1 ha-ffmpeg==3.2.2 hassil==2.0.3 home-assistant-intents==2024.11.13 mutagen==1.47.0 pymicro-vad==1.0.1 pyspeex-noise==1.0.2
 
 LABEL "name"="hassfest"
 LABEL "maintainer"="Home Assistant <hello@home-assistant.io>"

--- a/script/hassfest/docker/Dockerfile
+++ b/script/hassfest/docker/Dockerfile
@@ -23,7 +23,7 @@ RUN --mount=from=ghcr.io/astral-sh/uv:0.5.4,source=/uv,target=/bin/uv \
         -c /usr/src/homeassistant/homeassistant/package_constraints.txt \
         -r /usr/src/homeassistant/requirements.txt \
         stdlib-list==0.10.0 pipdeptree==2.23.4 tqdm==4.66.5 ruff==0.8.0 \
-        PyTurboJPEG==1.7.5 go2rtc-client==0.1.1 ha-ffmpeg==3.2.2 hassil==2.0.3 home-assistant-intents==2024.11.13 mutagen==1.47.0 pymicro-vad==1.0.1 pyspeex-noise==1.0.2
+        PyTurboJPEG==1.7.5 go2rtc-client==0.1.1 ha-ffmpeg==3.2.2 hassil==2.0.4 home-assistant-intents==2024.11.13 mutagen==1.47.0 pymicro-vad==1.0.1 pyspeex-noise==1.0.2
 
 LABEL "name"="hassfest"
 LABEL "maintainer"="Home Assistant <hello@home-assistant.io>"

--- a/tests/components/conversation/test_default_agent.py
+++ b/tests/components/conversation/test_default_agent.py
@@ -2950,38 +2950,42 @@ async def test_entities_filtered_by_input(hass: HomeAssistant) -> None:
 
     # Only the switch is exposed
     hass.states.async_set("light.test_light", "off")
+    hass.states.async_set(
+        "light.test_light_2", "off", attributes={ATTR_FRIENDLY_NAME: "test light"}
+    )
     hass.states.async_set("cover.garage_door", "closed")
     hass.states.async_set("switch.test_switch", "off")
     expose_entity(hass, "light.test_light", False)
+    expose_entity(hass, "light.test_light_2", False)
     expose_entity(hass, "cover.garage_door", False)
     expose_entity(hass, "switch.test_switch", True)
     await hass.async_block_till_done()
 
     # test switch is exposed
-    user_input = ConversationInput(
-        text="turn on test switch",
-        context=Context(),
-        conversation_id=None,
-        device_id=None,
-        language=hass.config.language,
-        agent_id=None,
-    )
+    # user_input = ConversationInput(
+    #     text="turn on test switch",
+    #     context=Context(),
+    #     conversation_id=None,
+    #     device_id=None,
+    #     language=hass.config.language,
+    #     agent_id=None,
+    # )
 
-    with patch(
-        "homeassistant.components.conversation.default_agent.recognize_best",
-        return_value=None,
-    ) as recognize_best:
-        await agent.async_recognize_intent(user_input)
+    # with patch(
+    #     "homeassistant.components.conversation.default_agent.recognize_best",
+    #     return_value=None,
+    # ) as recognize_best:
+    #     await agent.async_recognize_intent(user_input)
 
-        # (1) exposed, (2) all entities
-        assert len(recognize_best.call_args_list) == 2
+    #     # (1) exposed, (2) all entities
+    #     assert len(recognize_best.call_args_list) == 2
 
-        # Only the test light should have been considered because its name shows
-        # up in the input text.
-        slot_lists = recognize_best.call_args_list[0].kwargs["slot_lists"]
-        name_list = slot_lists["name"]
-        assert len(name_list.values) == 1
-        assert name_list.values[0].text_in.text == "test switch"
+    #     # Only the test light should have been considered because its name shows
+    #     # up in the input text.
+    #     slot_lists = recognize_best.call_args_list[0].kwargs["slot_lists"]
+    #     name_list = slot_lists["name"]
+    #     assert len(name_list.values) == 1
+    #     assert name_list.values[0].text_in.text == "test switch"
 
     # test light is not exposed
     user_input = ConversationInput(
@@ -3002,9 +3006,10 @@ async def test_entities_filtered_by_input(hass: HomeAssistant) -> None:
         # (1) exposed, (2) all entities
         assert len(recognize_best.call_args_list) == 2
 
-        # Only the test light should have been considered because its name shows
+        # Both test lights should have been considered because their name shows
         # up in the input text.
         slot_lists = recognize_best.call_args_list[1].kwargs["slot_lists"]
         name_list = slot_lists["name"]
-        assert len(name_list.values) == 1
+        assert len(name_list.values) == 2
         assert name_list.values[0].text_in.text == "test light"
+        assert name_list.values[1].text_in.text == "test light"

--- a/tests/components/conversation/test_default_agent.py
+++ b/tests/components/conversation/test_default_agent.py
@@ -2962,30 +2962,30 @@ async def test_entities_filtered_by_input(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
     # test switch is exposed
-    # user_input = ConversationInput(
-    #     text="turn on test switch",
-    #     context=Context(),
-    #     conversation_id=None,
-    #     device_id=None,
-    #     language=hass.config.language,
-    #     agent_id=None,
-    # )
+    user_input = ConversationInput(
+        text="turn on test switch",
+        context=Context(),
+        conversation_id=None,
+        device_id=None,
+        language=hass.config.language,
+        agent_id=None,
+    )
 
-    # with patch(
-    #     "homeassistant.components.conversation.default_agent.recognize_best",
-    #     return_value=None,
-    # ) as recognize_best:
-    #     await agent.async_recognize_intent(user_input)
+    with patch(
+        "homeassistant.components.conversation.default_agent.recognize_best",
+        return_value=None,
+    ) as recognize_best:
+        await agent.async_recognize_intent(user_input)
 
-    #     # (1) exposed, (2) all entities
-    #     assert len(recognize_best.call_args_list) == 2
+        # (1) exposed, (2) all entities
+        assert len(recognize_best.call_args_list) == 2
 
-    #     # Only the test light should have been considered because its name shows
-    #     # up in the input text.
-    #     slot_lists = recognize_best.call_args_list[0].kwargs["slot_lists"]
-    #     name_list = slot_lists["name"]
-    #     assert len(name_list.values) == 1
-    #     assert name_list.values[0].text_in.text == "test switch"
+        # Only the test light should have been considered because its name shows
+        # up in the input text.
+        slot_lists = recognize_best.call_args_list[0].kwargs["slot_lists"]
+        name_list = slot_lists["name"]
+        assert len(name_list.values) == 1
+        assert name_list.values[0].text_in.text == "test switch"
 
     # test light is not exposed
     user_input = ConversationInput(

--- a/tests/components/conversation/test_default_agent.py
+++ b/tests/components/conversation/test_default_agent.py
@@ -1735,7 +1735,7 @@ async def test_empty_aliases(
         return_value=None,
     ) as mock_recognize_all:
         await conversation.async_converse(
-            hass, "turn on lights in the kitchen", None, Context(), None
+            hass, "turn on kitchen light", None, Context(), None
         )
 
         assert mock_recognize_all.call_count > 0
@@ -2940,3 +2940,71 @@ async def test_intent_cache_fuzzy(hass: HomeAssistant) -> None:
     result = await agent.async_recognize_intent(user_input)
     assert result is not None
     assert getattr(result, mark, None) is True
+
+
+@pytest.mark.usefixtures("init_components")
+async def test_entities_filtered_by_input(hass: HomeAssistant) -> None:
+    """Test that entities are filtered by the input text before intent matching."""
+    agent = hass.data[DATA_DEFAULT_ENTITY]
+    assert isinstance(agent, default_agent.DefaultAgent)
+
+    # Only the switch is exposed
+    hass.states.async_set("light.test_light", "off")
+    hass.states.async_set("cover.garage_door", "closed")
+    hass.states.async_set("switch.test_switch", "off")
+    expose_entity(hass, "light.test_light", False)
+    expose_entity(hass, "cover.garage_door", False)
+    expose_entity(hass, "switch.test_switch", True)
+    await hass.async_block_till_done()
+
+    # test switch is exposed
+    user_input = ConversationInput(
+        text="turn on test switch",
+        context=Context(),
+        conversation_id=None,
+        device_id=None,
+        language=hass.config.language,
+        agent_id=None,
+    )
+
+    with patch(
+        "homeassistant.components.conversation.default_agent.recognize_best",
+        return_value=None,
+    ) as recognize_best:
+        await agent.async_recognize_intent(user_input)
+
+        # (1) exposed, (2) all entities
+        assert len(recognize_best.call_args_list) == 2
+
+        # Only the test light should have been considered because its name shows
+        # up in the input text.
+        slot_lists = recognize_best.call_args_list[0].kwargs["slot_lists"]
+        name_list = slot_lists["name"]
+        assert len(name_list.values) == 1
+        assert name_list.values[0].text_in.text == "test switch"
+
+    # test light is not exposed
+    user_input = ConversationInput(
+        text="turn on Test Light",  # different casing for name
+        context=Context(),
+        conversation_id=None,
+        device_id=None,
+        language=hass.config.language,
+        agent_id=None,
+    )
+
+    with patch(
+        "homeassistant.components.conversation.default_agent.recognize_best",
+        return_value=None,
+    ) as recognize_best:
+        await agent.async_recognize_intent(user_input)
+
+        # (1) exposed, (2) all entities
+        assert len(recognize_best.call_args_list) == 2
+
+        # Only the test light should have been considered because its name shows
+        # up in the input text.
+        slot_lists = recognize_best.call_args_list[1].kwargs["slot_lists"]
+        name_list = slot_lists["name"]
+        assert len(name_list.values) == 1
+        assert name_list.values[0].text_in.text == "test light"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Filter the `{name}` slot list used by the intent matcher before matching begins. Filtering is based on the input string, and done using a [trie](https://github.com/home-assistant/hassil/blob/main/hassil/trie.py). For users with many entities (exposed or otherwise), this significantly speeds up intent recognition.

This PR also bumps `hassil` to 2.0.4: https://github.com/home-assistant/hassil/compare/v2.0.3...v2.0.4
The new version of hassil includes a required fix to the trie data structure (multiple values for the same input string).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
