### PR TITLE
Bump nibe to 2.13.0

### DIFF
--- a/homeassistant/components/nibe_heatpump/manifest.json
+++ b/homeassistant/components/nibe_heatpump/manifest.json
@@ -5,5 +5,5 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/nibe_heatpump",
   "iot_class": "local_polling",
-  "requirements": ["nibe==2.11.0"]
+  "requirements": ["nibe==2.13.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1457,7 +1457,7 @@ nextcord==2.6.0
 nextdns==4.0.0
 
 # homeassistant.components.nibe_heatpump
-nibe==2.11.0
+nibe==2.13.0
 
 # homeassistant.components.nice_go
 nice-go==0.3.10

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1217,7 +1217,7 @@ nextcord==2.6.0
 nextdns==4.0.0
 
 # homeassistant.components.nibe_heatpump
-nibe==2.11.0
+nibe==2.13.0
 
 # homeassistant.components.nice_go
 nice-go==0.3.10


### PR DESCRIPTION
## Proposed change
Bump nibe dependency to 2.13.0 to fix #127832
See https://github.com/yozik04/nibe/releases
2.13.0:
- JSON File conversion validation in PRs (https://github.com/yozik04/nibe/pull/184) @yozik04
- Update S1155PC registers (https://github.com/yozik04/nibe/pull/182) @juniormajor
- Fix unit of current power consumption for S320 (https://github.com/yozik04/nibe/pull/181) @cedeherd
- Add holiday extensions to F1155, F1255 (https://github.com/yozik04/nibe/pull/178) @elupus
- Clean up construct configuration for nibe gw (https://github.com/yozik04/nibe/pull/179) @elupus
- Remove duplicate logging of coil value (https://github.com/yozik04/nibe/pull/177) @elupus
- Handle out of range values on rmu data (https://github.com/yozik04/nibe/pull/173) @elupus
2.12.0:
- Allow read of CoilData with missing mappings by @yozik04 in https://github.com/yozik04/nibe/pull/172

## Type of change
- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #127832
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
