### PR TITLE
Limit unique_id migration to platform for BMW

### DIFF
--- a/homeassistant/components/bmw_connected_drive/__init__.py
+++ b/homeassistant/components/bmw_connected_drive/__init__.py
@@ -85,23 +85,29 @@ async def _async_migrate_entries(
     @callback
     def update_unique_id(entry: er.RegistryEntry) -> dict[str, str] | None:
         replacements = {
-            "charging_level_hv": "fuel_and_battery.remaining_battery_percent",
-            "fuel_percent": "fuel_and_battery.remaining_fuel_percent",
-            "ac_current_limit": "charging_profile.ac_current_limit",
-            "charging_start_time": "fuel_and_battery.charging_start_time",
-            "charging_end_time": "fuel_and_battery.charging_end_time",
-            "charging_status": "fuel_and_battery.charging_status",
-            "charging_target": "fuel_and_battery.charging_target",
-            "remaining_battery_percent": "fuel_and_battery.remaining_battery_percent",
-            "remaining_range_total": "fuel_and_battery.remaining_range_total",
-            "remaining_range_electric": "fuel_and_battery.remaining_range_electric",
-            "remaining_range_fuel": "fuel_and_battery.remaining_range_fuel",
-            "remaining_fuel": "fuel_and_battery.remaining_fuel",
-            "remaining_fuel_percent": "fuel_and_battery.remaining_fuel_percent",
-            "activity": "climate.activity",
+            Platform.SENSOR.value: {
+                "charging_level_hv": "fuel_and_battery.remaining_battery_percent",
+                "fuel_percent": "fuel_and_battery.remaining_fuel_percent",
+                "ac_current_limit": "charging_profile.ac_current_limit",
+                "charging_start_time": "fuel_and_battery.charging_start_time",
+                "charging_end_time": "fuel_and_battery.charging_end_time",
+                "charging_status": "fuel_and_battery.charging_status",
+                "charging_target": "fuel_and_battery.charging_target",
+                "remaining_battery_percent": "fuel_and_battery.remaining_battery_percent",
+                "remaining_range_total": "fuel_and_battery.remaining_range_total",
+                "remaining_range_electric": "fuel_and_battery.remaining_range_electric",
+                "remaining_range_fuel": "fuel_and_battery.remaining_range_fuel",
+                "remaining_fuel": "fuel_and_battery.remaining_fuel",
+                "remaining_fuel_percent": "fuel_and_battery.remaining_fuel_percent",
+                "activity": "climate.activity",
+            }
         }
-        if (key := entry.unique_id.split("-")[-1]) in replacements:
-            new_unique_id = entry.unique_id.replace(key, replacements[key])
+        if (key := entry.unique_id.split("-")[-1]) in replacements.get(
+            entry.domain, []
+        ):
+            new_unique_id = entry.unique_id.replace(
+                key, replacements[entry.domain][key]
+            )
             _LOGGER.debug(
                 "Migrating entity '%s' unique_id from '%s' to '%s'",
                 entry.entity_id,

--- a/tests/components/bmw_connected_drive/test_init.py
+++ b/tests/components/bmw_connected_drive/test_init.py
@@ -10,13 +10,16 @@ from homeassistant.components.bmw_connected_drive.const import (
     CONF_READ_ONLY,
     DOMAIN as BMW_DOMAIN,
 )
-from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from . import FIXTURE_CONFIG_ENTRY
 
 from tests.common import MockConfigEntry
+
+BINARY_SENSOR_DOMAIN = Platform.BINARY_SENSOR.value
+SENSOR_DOMAIN = Platform.SENSOR.value
 
 VIN = "WBYYYYYYYYYYYYYYY"
 VEHICLE_NAME = "i3 (+ REX)"
@@ -108,6 +111,28 @@ async def test_migrate_options_from_data(hass: HomeAssistant) -> None:
             },
             f"{VIN}-mileage",
             f"{VIN}-mileage",
+        ),
+        (
+            {
+                "domain": SENSOR_DOMAIN,
+                "platform": BMW_DOMAIN,
+                "unique_id": f"{VIN}-charging_status",
+                "suggested_object_id": f"{VEHICLE_NAME} Charging Status",
+                "disabled_by": None,
+            },
+            f"{VIN}-charging_status",
+            f"{VIN}-fuel_and_battery.charging_status",
+        ),
+        (
+            {
+                "domain": BINARY_SENSOR_DOMAIN,
+                "platform": BMW_DOMAIN,
+                "unique_id": f"{VIN}-charging_status",
+                "suggested_object_id": f"{VEHICLE_NAME} Charging Status",
+                "disabled_by": None,
+            },
+            f"{VIN}-charging_status",
+            f"{VIN}-charging_status",
         ),
     ],
 )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Limit `unique_id` migration to single platforms during BMW init.

While `unique_id` is unique inside a platform, the migration script introduced with #121380 is not.
Unfortunately, we have a `binary_sensor` and a `sensor` with the same unique_id (before migration), so everytime the component is initialized, the binary sensor gets (wrongly) migrated.

**Maybe open:**
Clean up entities with wrong unique_id on init. (would love some feedback if this should be done or not) 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #131556
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
