### PR TITLE
Move SiLabs firmware probing helper from ZHA into `homeassistant_hardware`

### DIFF
--- a/homeassistant/components/homeassistant_hardware/firmware_config_flow.py
+++ b/homeassistant/components/homeassistant_hardware/firmware_config_flow.py
@@ -7,16 +7,11 @@ import asyncio
 import logging
 from typing import Any
 
-from universal_silabs_flasher.const import ApplicationType
-
 from homeassistant.components.hassio import (
     AddonError,
     AddonInfo,
     AddonManager,
     AddonState,
-)
-from homeassistant.components.zha.repairs.wrong_silabs_firmware import (
-    probe_silabs_firmware_type,
 )
 from homeassistant.config_entries import (
     ConfigEntry,
@@ -32,9 +27,11 @@ from homeassistant.helpers.hassio import is_hassio
 from . import silabs_multiprotocol_addon
 from .const import ZHA_DOMAIN
 from .util import (
+    ApplicationType,
     get_otbr_addon_manager,
     get_zha_device_path,
     get_zigbee_flasher_addon_manager,
+    probe_silabs_firmware_type,
 )
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/homeassistant_hardware/manifest.json
+++ b/homeassistant/components/homeassistant_hardware/manifest.json
@@ -1,8 +1,9 @@
 {
   "domain": "homeassistant_hardware",
   "name": "Home Assistant Hardware",
-  "after_dependencies": ["hassio", "zha"],
+  "after_dependencies": ["hassio"],
   "codeowners": ["@home-assistant/core"],
   "documentation": "https://www.home-assistant.io/integrations/homeassistant_hardware",
-  "integration_type": "system"
+  "integration_type": "system",
+  "requirements": ["universal-silabs-flasher==0.0.25"]
 }

--- a/homeassistant/components/homeassistant_sky_connect/config_flow.py
+++ b/homeassistant/components/homeassistant_sky_connect/config_flow.py
@@ -5,13 +5,12 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any, Protocol
 
-from universal_silabs_flasher.const import ApplicationType
-
 from homeassistant.components import usb
 from homeassistant.components.homeassistant_hardware import (
     firmware_config_flow,
     silabs_multiprotocol_addon,
 )
+from homeassistant.components.homeassistant_hardware.util import ApplicationType
 from homeassistant.config_entries import (
     ConfigEntry,
     ConfigEntryBaseFlow,

--- a/homeassistant/components/homeassistant_yellow/config_flow.py
+++ b/homeassistant/components/homeassistant_yellow/config_flow.py
@@ -8,7 +8,6 @@ import logging
 from typing import Any, final
 
 import aiohttp
-from universal_silabs_flasher.const import ApplicationType
 import voluptuous as vol
 
 from homeassistant.components.hassio import (
@@ -25,6 +24,7 @@ from homeassistant.components.homeassistant_hardware.silabs_multiprotocol_addon 
     OptionsFlowHandler as MultiprotocolOptionsFlowHandler,
     SerialPortSettings as MultiprotocolSerialPortSettings,
 )
+from homeassistant.components.homeassistant_hardware.util import ApplicationType
 from homeassistant.config_entries import (
     SOURCE_HARDWARE,
     ConfigEntry,

--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -4,7 +4,7 @@
   "after_dependencies": ["hassio", "onboarding", "usb"],
   "codeowners": ["@dmulcahey", "@adminiuga", "@puddly", "@TheJulianJES"],
   "config_flow": true,
-  "dependencies": ["file_upload"],
+  "dependencies": ["file_upload", "homeassistant_hardware"],
   "documentation": "https://www.home-assistant.io/integrations/zha",
   "iot_class": "local_polling",
   "loggers": [
@@ -21,7 +21,7 @@
     "zha",
     "universal_silabs_flasher"
   ],
-  "requirements": ["universal-silabs-flasher==0.0.25", "zha==0.0.44"],
+  "requirements": ["zha==0.0.44"],
   "usb": [
     {
       "vid": "10C4",

--- a/homeassistant/components/zha/repairs/wrong_silabs_firmware.py
+++ b/homeassistant/components/zha/repairs/wrong_silabs_firmware.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 import enum
 import logging
 
-from universal_silabs_flasher.const import ApplicationType
-from universal_silabs_flasher.flasher import Flasher
-
+from homeassistant.components.homeassistant_hardware.util import (
+    ApplicationType,
+    probe_silabs_firmware_type,
+)
 from homeassistant.components.homeassistant_sky_connect import (
     hardware as skyconnect_hardware,
 )
@@ -72,23 +73,6 @@ def _detect_radio_hardware(hass: HomeAssistant, device: str) -> HardwareType:
                     return HardwareType.SKYCONNECT
 
     return HardwareType.OTHER
-
-
-async def probe_silabs_firmware_type(
-    device: str, *, probe_methods: ApplicationType | None = None
-) -> ApplicationType | None:
-    """Probe the running firmware on a Silabs device."""
-    flasher = Flasher(
-        device=device,
-        **({"probe_methods": probe_methods} if probe_methods else {}),
-    )
-
-    try:
-        await flasher.probe_app_type()
-    except Exception:  # noqa: BLE001
-        _LOGGER.debug("Failed to probe application type", exc_info=True)
-
-    return flasher.app_type
 
 
 async def warn_on_wrong_silabs_firmware(hass: HomeAssistant, device: str) -> bool:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2939,7 +2939,7 @@ unifi_ap==0.0.2
 # homeassistant.components.unifiled
 unifiled==0.11
 
-# homeassistant.components.zha
+# homeassistant.components.homeassistant_hardware
 universal-silabs-flasher==0.0.25
 
 # homeassistant.components.upb

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2355,9 +2355,6 @@ ultraheat-api==0.5.7
 # homeassistant.components.unifiprotect
 unifi-discovery==1.2.0
 
-# homeassistant.components.zha
-universal-silabs-flasher==0.0.25
-
 # homeassistant.components.upb
 upb-lib==0.5.9
 

--- a/script/hassfest/dependencies.py
+++ b/script/hassfest/dependencies.py
@@ -168,6 +168,7 @@ IGNORE_VIOLATIONS = {
     ("zha", "homeassistant_sky_connect"),
     ("zha", "homeassistant_yellow"),
     ("homeassistant_sky_connect", "zha"),
+    ("homeassistant_hardware", "zha"),
     # This should become a helper method that integrations can submit data to
     ("websocket_api", "lovelace"),
     ("websocket_api", "shopping_list"),

--- a/tests/components/homeassistant_hardware/test_config_flow.py
+++ b/tests/components/homeassistant_hardware/test_config_flow.py
@@ -7,7 +7,6 @@ from typing import Any
 from unittest.mock import AsyncMock, Mock, call, patch
 
 import pytest
-from universal_silabs_flasher.const import ApplicationType
 
 from homeassistant.components.hassio import AddonInfo, AddonState
 from homeassistant.components.homeassistant_hardware.firmware_config_flow import (
@@ -17,6 +16,7 @@ from homeassistant.components.homeassistant_hardware.firmware_config_flow import
     BaseFirmwareOptionsFlow,
 )
 from homeassistant.components.homeassistant_hardware.util import (
+    ApplicationType,
     get_otbr_addon_manager,
     get_zigbee_flasher_addon_manager,
 )

--- a/tests/components/homeassistant_hardware/test_config_flow_failures.py
+++ b/tests/components/homeassistant_hardware/test_config_flow_failures.py
@@ -3,13 +3,13 @@
 from unittest.mock import AsyncMock
 
 import pytest
-from universal_silabs_flasher.const import ApplicationType
 
 from homeassistant.components.hassio import AddonError, AddonInfo, AddonState
 from homeassistant.components.homeassistant_hardware.firmware_config_flow import (
     STEP_PICK_FIRMWARE_THREAD,
     STEP_PICK_FIRMWARE_ZIGBEE,
 )
+from homeassistant.components.homeassistant_hardware.util import ApplicationType
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 

--- a/tests/components/homeassistant_hardware/test_util.py
+++ b/tests/components/homeassistant_hardware/test_util.py
@@ -2,10 +2,9 @@
 
 from unittest.mock import AsyncMock, patch
 
-from universal_silabs_flasher.const import ApplicationType
-
 from homeassistant.components.hassio import AddonError, AddonInfo, AddonState
 from homeassistant.components.homeassistant_hardware.util import (
+    ApplicationType,
     FirmwareGuess,
     get_zha_device_path,
     guess_firmware_type,

--- a/tests/components/homeassistant_hardware/test_util.py
+++ b/tests/components/homeassistant_hardware/test_util.py
@@ -6,8 +6,10 @@ from homeassistant.components.hassio import AddonError, AddonInfo, AddonState
 from homeassistant.components.homeassistant_hardware.util import (
     ApplicationType,
     FirmwareGuess,
+    FlasherApplicationType,
     get_zha_device_path,
     guess_firmware_type,
+    probe_silabs_firmware_type,
 )
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
@@ -155,3 +157,27 @@ async def test_guess_firmware_type(hass: HomeAssistant) -> None:
         assert (await guess_firmware_type(hass, path)) == FirmwareGuess(
             is_running=True, firmware_type=ApplicationType.CPC, source="multiprotocol"
         )
+
+
+async def test_probe_silabs_firmware_type() -> None:
+    """Test probing Silabs firmware type."""
+
+    with patch(
+        "homeassistant.components.homeassistant_hardware.util.Flasher.probe_app_type",
+        side_effect=RuntimeError,
+    ):
+        assert (await probe_silabs_firmware_type("/dev/ttyUSB0")) is None
+
+    with patch(
+        "homeassistant.components.homeassistant_hardware.util.Flasher.probe_app_type",
+        side_effect=lambda self: setattr(self, "app_type", FlasherApplicationType.EZSP),
+        autospec=True,
+    ) as mock_probe_app_type:
+        # The application type constant is converted back and forth transparently
+        result = await probe_silabs_firmware_type(
+            "/dev/ttyUSB0", probe_methods=[ApplicationType.EZSP]
+        )
+        assert result is ApplicationType.EZSP
+
+        flasher = mock_probe_app_type.mock_calls[0].args[0]
+        assert flasher._probe_methods == [FlasherApplicationType.EZSP]

--- a/tests/components/homeassistant_sky_connect/test_init.py
+++ b/tests/components/homeassistant_sky_connect/test_init.py
@@ -2,9 +2,10 @@
 
 from unittest.mock import patch
 
-from universal_silabs_flasher.const import ApplicationType
-
-from homeassistant.components.homeassistant_hardware.util import FirmwareGuess
+from homeassistant.components.homeassistant_hardware.util import (
+    ApplicationType,
+    FirmwareGuess,
+)
 from homeassistant.components.homeassistant_sky_connect.const import DOMAIN
 from homeassistant.core import HomeAssistant
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently, ZHA provides a way to probe SiLabs firmware via a helper in a repair. The `homeassistant_hardware` firmware config flow actually uses this helper function to determine running firmware. This is a bit backwards, as the `homeassistant_hardware` integration should be providing this, not the other way around.

To isolate the `universal-silabs-flasher` dependency to just `homeassistant_hardware`, I've provided a "proxy" enum for `ApplicationType`. This allows all integrations requiring firmware info to directly import from `homeassistant_hardware` instead of the external package.

This is the first of many PRs to clean up the various integrations interacting with Zigbee/Thread firmwares.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
