### PR TITLE
Use ConfigEntry runtime_data in Garages Amsterdam

### DIFF
--- a/homeassistant/components/garages_amsterdam/__init__.py
+++ b/homeassistant/components/garages_amsterdam/__init__.py
@@ -16,7 +16,9 @@ PLATFORMS: list[Platform] = [Platform.BINARY_SENSOR, Platform.SENSOR]
 type GaragesAmsterdamConfigEntry = ConfigEntry[GaragesAmsterdamDataUpdateCoordinator]
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(
+    hass: HomeAssistant, entry: GaragesAmsterdamConfigEntry
+) -> bool:
     """Set up Garages Amsterdam from a config entry."""
     client = ODPAmsterdam(session=async_get_clientsession(hass))
     coordinator = GaragesAmsterdamDataUpdateCoordinator(hass, client)
@@ -29,6 +31,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(
+    hass: HomeAssistant, entry: GaragesAmsterdamConfigEntry
+) -> bool:
     """Unload Garages Amsterdam config entry."""
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/garages_amsterdam/__init__.py
+++ b/homeassistant/components/garages_amsterdam/__init__.py
@@ -9,7 +9,6 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import DOMAIN
 from .coordinator import GaragesAmsterdamDataUpdateCoordinator
 
 PLATFORMS: list[Platform] = [Platform.BINARY_SENSOR, Platform.SENSOR]
@@ -24,8 +23,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     await coordinator.async_config_entry_first_refresh()
 
-    hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN][entry.entry_id] = coordinator
+    entry.runtime_data = coordinator
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
@@ -33,8 +31,4 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload Garages Amsterdam config entry."""
-    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-    if len(hass.config_entries.async_entries(DOMAIN)) == 1:
-        hass.data.pop(DOMAIN)
-
-    return unload_ok
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/garages_amsterdam/binary_sensor.py
+++ b/homeassistant/components/garages_amsterdam/binary_sensor.py
@@ -6,10 +6,10 @@ from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from . import GaragesAmsterdamConfigEntry
 from .entity import GaragesAmsterdamEntity
 
 BINARY_SENSORS = {
@@ -19,7 +19,7 @@ BINARY_SENSORS = {
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: GaragesAmsterdamConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Defer sensor setup to the shared sensor module."""

--- a/homeassistant/components/garages_amsterdam/binary_sensor.py
+++ b/homeassistant/components/garages_amsterdam/binary_sensor.py
@@ -10,6 +10,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import GaragesAmsterdamConfigEntry
+from .coordinator import GaragesAmsterdamDataUpdateCoordinator
 from .entity import GaragesAmsterdamEntity
 
 BINARY_SENSORS = {
@@ -23,9 +24,10 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Defer sensor setup to the shared sensor module."""
+    coordinator: GaragesAmsterdamDataUpdateCoordinator = entry.runtime_data
 
     async_add_entities(
-        GaragesAmsterdamBinarySensor(entry, entry.data["garage_name"], info_type)
+        GaragesAmsterdamBinarySensor(coordinator, entry.data["garage_name"], info_type)
         for info_type in BINARY_SENSORS
     )
 

--- a/homeassistant/components/garages_amsterdam/binary_sensor.py
+++ b/homeassistant/components/garages_amsterdam/binary_sensor.py
@@ -10,8 +10,6 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN
-from .coordinator import GaragesAmsterdamDataUpdateCoordinator
 from .entity import GaragesAmsterdamEntity
 
 BINARY_SENSORS = {
@@ -25,12 +23,9 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Defer sensor setup to the shared sensor module."""
-    coordinator: GaragesAmsterdamDataUpdateCoordinator = hass.data[DOMAIN][
-        entry.entry_id
-    ]
 
     async_add_entities(
-        GaragesAmsterdamBinarySensor(coordinator, entry.data["garage_name"], info_type)
+        GaragesAmsterdamBinarySensor(entry, entry.data["garage_name"], info_type)
         for info_type in BINARY_SENSORS
     )
 

--- a/homeassistant/components/garages_amsterdam/binary_sensor.py
+++ b/homeassistant/components/garages_amsterdam/binary_sensor.py
@@ -10,7 +10,6 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import GaragesAmsterdamConfigEntry
-from .coordinator import GaragesAmsterdamDataUpdateCoordinator
 from .entity import GaragesAmsterdamEntity
 
 BINARY_SENSORS = {
@@ -24,7 +23,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Defer sensor setup to the shared sensor module."""
-    coordinator: GaragesAmsterdamDataUpdateCoordinator = entry.runtime_data
+    coordinator = entry.runtime_data
 
     async_add_entities(
         GaragesAmsterdamBinarySensor(coordinator, entry.data["garage_name"], info_type)

--- a/homeassistant/components/garages_amsterdam/entity.py
+++ b/homeassistant/components/garages_amsterdam/entity.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -17,12 +18,12 @@ class GaragesAmsterdamEntity(CoordinatorEntity[GaragesAmsterdamDataUpdateCoordin
 
     def __init__(
         self,
-        coordinator: GaragesAmsterdamDataUpdateCoordinator,
+        entry: ConfigEntry,
         garage_name: str,
         info_type: str,
     ) -> None:
         """Initialize garages amsterdam entity."""
-        super().__init__(coordinator)
+        super().__init__(coordinator=entry.runtime_data)
         self._attr_unique_id = f"{garage_name}-{info_type}"
         self._garage_name = garage_name
         self._info_type = info_type

--- a/homeassistant/components/garages_amsterdam/entity.py
+++ b/homeassistant/components/garages_amsterdam/entity.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -18,12 +17,12 @@ class GaragesAmsterdamEntity(CoordinatorEntity[GaragesAmsterdamDataUpdateCoordin
 
     def __init__(
         self,
-        entry: ConfigEntry,
+        coordinator: GaragesAmsterdamDataUpdateCoordinator,
         garage_name: str,
         info_type: str,
     ) -> None:
         """Initialize garages amsterdam entity."""
-        super().__init__(coordinator=entry.runtime_data)
+        super().__init__(coordinator)
         self._attr_unique_id = f"{garage_name}-{info_type}"
         self._garage_name = garage_name
         self._info_type = info_type

--- a/homeassistant/components/garages_amsterdam/sensor.py
+++ b/homeassistant/components/garages_amsterdam/sensor.py
@@ -27,7 +27,7 @@ async def async_setup_entry(
     async_add_entities(
         GaragesAmsterdamSensor(entry, entry.data["garage_name"], info_type)
         for info_type in SENSORS
-        if getattr(entry.data[entry.data["garage_name"]], info_type) != ""
+        if getattr(entry.runtime_data.data[entry.data["garage_name"]], info_type) != ""
     )
 
 

--- a/homeassistant/components/garages_amsterdam/sensor.py
+++ b/homeassistant/components/garages_amsterdam/sensor.py
@@ -29,7 +29,7 @@ async def async_setup_entry(
     async_add_entities(
         GaragesAmsterdamSensor(coordinator, entry.data["garage_name"], info_type)
         for info_type in SENSORS
-        if getattr(entry.runtime_data.data[entry.data["garage_name"]], info_type) != ""
+        if getattr(coordinator.data[entry.data["garage_name"]], info_type) != ""
     )
 
 

--- a/homeassistant/components/garages_amsterdam/sensor.py
+++ b/homeassistant/components/garages_amsterdam/sensor.py
@@ -24,7 +24,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Defer sensor setup to the shared sensor module."""
-    coordinator: GaragesAmsterdamDataUpdateCoordinator = entry.runtime_data
+    coordinator = entry.runtime_data
 
     async_add_entities(
         GaragesAmsterdamSensor(coordinator, entry.data["garage_name"], info_type)

--- a/homeassistant/components/garages_amsterdam/sensor.py
+++ b/homeassistant/components/garages_amsterdam/sensor.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 from homeassistant.components.sensor import SensorEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from . import GaragesAmsterdamConfigEntry
+from .coordinator import GaragesAmsterdamDataUpdateCoordinator
 from .entity import GaragesAmsterdamEntity
 
 SENSORS = {
@@ -19,13 +20,14 @@ SENSORS = {
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: GaragesAmsterdamConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Defer sensor setup to the shared sensor module."""
+    coordinator: GaragesAmsterdamDataUpdateCoordinator = entry.runtime_data
 
     async_add_entities(
-        GaragesAmsterdamSensor(entry, entry.data["garage_name"], info_type)
+        GaragesAmsterdamSensor(coordinator, entry.data["garage_name"], info_type)
         for info_type in SENSORS
         if getattr(entry.runtime_data.data[entry.data["garage_name"]], info_type) != ""
     )
@@ -38,12 +40,12 @@ class GaragesAmsterdamSensor(GaragesAmsterdamEntity, SensorEntity):
 
     def __init__(
         self,
-        entry: ConfigEntry,
+        coordinator: GaragesAmsterdamDataUpdateCoordinator,
         garage_name: str,
         info_type: str,
     ) -> None:
         """Initialize garages amsterdam sensor."""
-        super().__init__(entry, garage_name, info_type)
+        super().__init__(coordinator, garage_name, info_type)
         self._attr_translation_key = info_type
 
     @property

--- a/homeassistant/components/garages_amsterdam/sensor.py
+++ b/homeassistant/components/garages_amsterdam/sensor.py
@@ -7,8 +7,6 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN
-from .coordinator import GaragesAmsterdamDataUpdateCoordinator
 from .entity import GaragesAmsterdamEntity
 
 SENSORS = {
@@ -25,14 +23,11 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Defer sensor setup to the shared sensor module."""
-    coordinator: GaragesAmsterdamDataUpdateCoordinator = hass.data[DOMAIN][
-        entry.entry_id
-    ]
 
     async_add_entities(
-        GaragesAmsterdamSensor(coordinator, entry.data["garage_name"], info_type)
+        GaragesAmsterdamSensor(entry, entry.data["garage_name"], info_type)
         for info_type in SENSORS
-        if getattr(coordinator.data[entry.data["garage_name"]], info_type) != ""
+        if getattr(entry.data[entry.data["garage_name"]], info_type) != ""
     )
 
 
@@ -43,12 +38,12 @@ class GaragesAmsterdamSensor(GaragesAmsterdamEntity, SensorEntity):
 
     def __init__(
         self,
-        coordinator: GaragesAmsterdamDataUpdateCoordinator,
+        entry: ConfigEntry,
         garage_name: str,
         info_type: str,
     ) -> None:
         """Initialize garages amsterdam sensor."""
-        super().__init__(coordinator, garage_name, info_type)
+        super().__init__(entry, garage_name, info_type)
         self._attr_translation_key = info_type
 
     @property

--- a/tests/components/garages_amsterdam/test_init.py
+++ b/tests/components/garages_amsterdam/test_init.py
@@ -2,7 +2,6 @@
 
 from unittest.mock import AsyncMock
 
-from homeassistant.components.garages_amsterdam.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 
@@ -24,5 +23,4 @@ async def test_load_unload_config_entry(
     await hass.config_entries.async_unload(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert not hass.data.get(DOMAIN)
     assert mock_config_entry.state is ConfigEntryState.NOT_LOADED


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Moves the Garages Amsterdam integration to use the `runtime_data` attribute of the ConfigEntry instead of `hass.data`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
