### PR TITLE
Remove workaround for flaky translation tests

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -1815,3 +1815,20 @@ async def snapshot_platform(
         state = hass.states.get(entity_entry.entity_id)
         assert state, f"State not found for {entity_entry.entity_id}"
         assert state == snapshot(name=f"{entity_entry.entity_id}-state")
+
+
+def reset_translation_cache(hass: HomeAssistant, components: list[str]) -> None:
+    """Reset translation cache for specified components.
+
+    Use this if you are mocking a core component (for example via
+    mock_integration), to ensure that the mocked translations are not
+    persisted in the shared session cache.
+    """
+    translations_cache = translation._async_get_translations_cache(hass)
+    for loaded_components in translations_cache.cache_data.loaded.values():
+        for component_to_unload in components:
+            loaded_components.discard(component_to_unload)
+    for loaded_categories in translations_cache.cache_data.cache.values():
+        for loaded_components in loaded_categories.values():
+            for component_to_unload in components:
+                loaded_components.pop(component_to_unload, None)

--- a/tests/components/conftest.py
+++ b/tests/components/conftest.py
@@ -777,9 +777,6 @@ async def check_translations(
             f"Unused ignore translations: {', '.join(unused_ignore)}. "
             "Please remove them from the ignore_translations fixture."
         )
-    for key, description in translation_errors.items():
-        if key.startswith("component.cloud.issues."):
-            # cloud tests are flaky
-            continue
+    for description in translation_errors.values():
         if description not in {"used", "unused"}:
             pytest.fail(description)

--- a/tests/components/tts/test_init.py
+++ b/tests/components/tts/test_init.py
@@ -22,6 +22,7 @@ from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import ATTR_ENTITY_ID, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant, State
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import translation
 from homeassistant.helpers.typing import UNDEFINED
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
@@ -1988,3 +1989,9 @@ async def test_default_engine_prefer_cloud_entity(
     provider_engine = tts.async_resolve_engine(hass, "test")
     assert provider_engine == "test"
     assert tts.async_default_engine(hass) == "tts.cloud_tts_entity"
+
+    # Reset the `cloud` translations cache
+    translations_cache = translation._async_get_translations_cache(hass)
+    loaded_translations = translations_cache.cache_data.loaded
+    for language in loaded_translations:
+        loaded_translations[language].discard("cloud")

--- a/tests/components/tts/test_init.py
+++ b/tests/components/tts/test_init.py
@@ -22,7 +22,6 @@ from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import ATTR_ENTITY_ID, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant, State
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import translation
 from homeassistant.helpers.typing import UNDEFINED
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
@@ -46,6 +45,7 @@ from tests.common import (
     mock_integration,
     mock_platform,
     mock_restore_cache,
+    reset_translation_cache,
 )
 from tests.typing import ClientSessionGenerator, WebSocketGenerator
 
@@ -1991,7 +1991,4 @@ async def test_default_engine_prefer_cloud_entity(
     assert tts.async_default_engine(hass) == "tts.cloud_tts_entity"
 
     # Reset the `cloud` translations cache
-    translations_cache = translation._async_get_translations_cache(hass)
-    loaded_translations = translations_cache.cache_data.loaded
-    for language in loaded_translations:
-        loaded_translations[language].discard("cloud")
+    reset_translation_cache(hass, ["cloud"])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1190,13 +1190,13 @@ def mock_get_source_ip() -> Generator[_patch]:
         patcher.stop()
 
 
-@pytest.fixture(autouse=True, scope="module")
+@pytest.fixture(autouse=True, scope="session")
 def translations_once() -> Generator[_patch]:
-    """Only load translations once per module.
+    """Only load translations once per session.
 
-    Having this as a session fixture would cause issues with tests that create
-    mock integrations, overriding the real integration translations
-    with empty ones (see #131628)
+    Warning: having this as a session fixture can cause issues with tests that
+    create mock integrations, overriding the real integration translations
+    with empty ones. Translations should be reset after such tests (see #131628)
     """
     cache = _TranslationsCacheData({}, {})
     patcher = patch(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1194,9 +1194,9 @@ def mock_get_source_ip() -> Generator[_patch]:
 def translations_once() -> Generator[_patch]:
     """Only load translations once per module.
 
-    Having this as a session fixture causes issues with tests that create
+    Having this as a session fixture would cause issues with tests that create
     mock integrations, overriding the real integration translations
-    with empty ones
+    with empty ones (see #131628)
     """
     cache = _TranslationsCacheData({}, {})
     patcher = patch(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1190,9 +1190,14 @@ def mock_get_source_ip() -> Generator[_patch]:
         patcher.stop()
 
 
-@pytest.fixture(autouse=True, scope="session")
+@pytest.fixture(autouse=True, scope="module")
 def translations_once() -> Generator[_patch]:
-    """Only load translations once per session."""
+    """Only load translations once per module.
+
+    Having this as a session fixture causes issues with tests that create
+    mock integrations, overriding the real integration translations
+    with empty ones
+    """
     cache = _TranslationsCacheData({}, {})
     patcher = patch(
         "homeassistant.helpers.translation._TranslationsCacheData",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I was finally able to find the root cause of the issue, which could be reproduced with:
`pytest tests/components/tts/test_init.py::test_default_engine_prefer_cloud_entity tests/components/cloud/test_tts.py::test_deprecated_voice`

The gist of the issue is that:
- we have a `session` scope fixture that caches the translations for the test run
- `tests/components/tts/test_init.py::test_default_engine_prefer_cloud_entity` creates a mock `cloud` integration, which causes the cache to be loaded with a "title-only" translation file
- when `tests/components/cloud/test_tts.py::test_deprecated_voice` retrieves the `cloud` translations, the cached (empty) entry from the previous test gets retrieved, cause the check to report the required translations as missing

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
