### PR TITLE
Prevent changing email address in inexogy reauth

### DIFF
--- a/homeassistant/components/discovergy/config_flow.py
+++ b/homeassistant/components/discovergy/config_flow.py
@@ -11,12 +11,7 @@ from pydiscovergy.authentication import BasicAuth
 import pydiscovergy.error as discovergyError
 import voluptuous as vol
 
-from homeassistant.config_entries import (
-    SOURCE_REAUTH,
-    ConfigEntry,
-    ConfigFlow,
-    ConfigFlowResult,
-)
+from homeassistant.config_entries import SOURCE_REAUTH, ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 from homeassistant.helpers.httpx_client import get_async_client
 from homeassistant.helpers.selector import (
@@ -57,35 +52,26 @@ class DiscovergyConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
-    _existing_entry: ConfigEntry
-
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle the initial step."""
-        if user_input is None:
-            return self.async_show_form(
-                step_id="user",
-                data_schema=CONFIG_SCHEMA,
-            )
-
         return await self._validate_and_save(user_input)
 
     async def async_step_reauth(
         self, entry_data: Mapping[str, Any]
     ) -> ConfigFlowResult:
         """Handle the initial step."""
-        self._existing_entry = self._get_reauth_entry()
         return await self.async_step_reauth_confirm()
 
     async def async_step_reauth_confirm(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle the reauth step."""
-        return await self._validate_and_save(user_input, step_id="reauth_confirm")
+        return await self._validate_and_save(user_input)
 
     async def _validate_and_save(
-        self, user_input: Mapping[str, Any] | None = None, step_id: str = "user"
+        self, user_input: Mapping[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Validate user input and create config entry."""
         errors = {}
@@ -106,17 +92,17 @@ class DiscovergyConfigFlow(ConfigFlow, domain=DOMAIN):
                 _LOGGER.exception("Unexpected error occurred while getting meters")
                 errors["base"] = "unknown"
             else:
+                await self.async_set_unique_id(user_input[CONF_EMAIL].lower())
+
                 if self.source == SOURCE_REAUTH:
+                    self._abort_if_unique_id_mismatch(reason="account_mismatch")
                     return self.async_update_reload_and_abort(
-                        entry=self._existing_entry,
-                        data={
-                            CONF_EMAIL: user_input[CONF_EMAIL],
+                        entry=self._get_reauth_entry(),
+                        data_updates={
                             CONF_PASSWORD: user_input[CONF_PASSWORD],
                         },
                     )
 
-                # set unique id to title which is the account email
-                await self.async_set_unique_id(user_input[CONF_EMAIL].lower())
                 self._abort_if_unique_id_configured()
 
                 return self.async_create_entry(
@@ -124,10 +110,10 @@ class DiscovergyConfigFlow(ConfigFlow, domain=DOMAIN):
                 )
 
         return self.async_show_form(
-            step_id=step_id,
+            step_id="user",
             data_schema=self.add_suggested_values_to_schema(
                 CONFIG_SCHEMA,
-                self._existing_entry.data
+                self._get_reauth_entry().data
                 if self.source == SOURCE_REAUTH
                 else user_input,
             ),

--- a/homeassistant/components/discovergy/config_flow.py
+++ b/homeassistant/components/discovergy/config_flow.py
@@ -56,7 +56,7 @@ class DiscovergyConfigFlow(ConfigFlow, domain=DOMAIN):
         self, entry_data: Mapping[str, Any]
     ) -> ConfigFlowResult:
         """Handle the initial step."""
-        return await self.async_step_reauth_confirm()
+        return await self.async_step_user()
 
     async def async_step_reauth_confirm(
         self, user_input: dict[str, Any] | None = None

--- a/homeassistant/components/discovergy/config_flow.py
+++ b/homeassistant/components/discovergy/config_flow.py
@@ -52,12 +52,6 @@ class DiscovergyConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
-    async def async_step_user(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
-        """Handle the initial step."""
-        return await self._validate_and_save(user_input)
-
     async def async_step_reauth(
         self, entry_data: Mapping[str, Any]
     ) -> ConfigFlowResult:
@@ -68,9 +62,9 @@ class DiscovergyConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle the reauth step."""
-        return await self._validate_and_save(user_input)
+        return await self.async_step_user()
 
-    async def _validate_and_save(
+    async def async_step_user(
         self, user_input: Mapping[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Validate user input and create config entry."""

--- a/homeassistant/components/discovergy/config_flow.py
+++ b/homeassistant/components/discovergy/config_flow.py
@@ -58,12 +58,6 @@ class DiscovergyConfigFlow(ConfigFlow, domain=DOMAIN):
         """Handle the initial step."""
         return await self.async_step_user()
 
-    async def async_step_reauth_confirm(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
-        """Handle the reauth step."""
-        return await self.async_step_user()
-
     async def async_step_user(
         self, user_input: Mapping[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/discovergy/strings.json
+++ b/homeassistant/components/discovergy/strings.json
@@ -21,6 +21,7 @@
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
+      "account_mismatch": "The inexogy account authenticated with, does not match the account needed re-authentication.",
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     }
   },

--- a/homeassistant/components/discovergy/strings.json
+++ b/homeassistant/components/discovergy/strings.json
@@ -6,12 +6,6 @@
           "email": "[%key:common::config_flow::data::email%]",
           "password": "[%key:common::config_flow::data::password%]"
         }
-      },
-      "reauth_confirm": {
-        "data": {
-          "email": "[%key:common::config_flow::data::email%]",
-          "password": "[%key:common::config_flow::data::password%]"
-        }
       }
     },
     "error": {


### PR DESCRIPTION
## Proposed change
Prevent changing the email address in inexogy reauth flow

/cc @epenet 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
