### PR TITLE
Bump ZHA to 0.0.40

### DIFF
--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -21,7 +21,7 @@
     "zha",
     "universal_silabs_flasher"
   ],
-  "requirements": ["universal-silabs-flasher==0.0.25", "zha==0.0.39"],
+  "requirements": ["universal-silabs-flasher==0.0.25", "zha==0.0.40"],
   "usb": [
     {
       "vid": "10C4",

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -600,6 +600,12 @@
       },
       "self_test": {
         "name": "Self-test"
+      },
+      "reset_summation_delivered": {
+        "name": "Reset summation delivered"
+      },
+      "restart_device": {
+        "name": "Restart device"
       }
     },
     "climate": {
@@ -798,6 +804,24 @@
       },
       "off_led_intensity": {
         "name": "Off LED intensity"
+      },
+      "frost_protection_temperature": {
+        "name": "Frost protection temperature"
+      },
+      "valve_opening_degree": {
+        "name": "Valve opening degree"
+      },
+      "valve_closing_degree": {
+        "name": "Valve closing degree"
+      },
+      "siren_time": {
+        "name": "Siren time"
+      },
+      "timer_time_left": {
+        "name": "Timer time left"
+      },
+      "approach_distance": {
+        "name": "Approach distance"
       }
     },
     "select": {
@@ -899,6 +923,9 @@
       },
       "off_led_color": {
         "name": "Off LED color"
+      },
+      "external_trigger_mode": {
+        "name": "External trigger mode"
       }
     },
     "sensor": {
@@ -1096,6 +1123,15 @@
       },
       "valve_status_2": {
         "name": "Status 2"
+      },
+      "timer_state": {
+        "name": "Timer state"
+      },
+      "last_valve_open_duration": {
+        "name": "Last valve open duration"
+      },
+      "motion_distance": {
+        "name": "Motion distance"
       }
     },
     "switch": {
@@ -1209,6 +1245,18 @@
       },
       "double_up_full": {
         "name": "Double tap on - full"
+      },
+      "open_window": {
+        "name": "Open window"
+      },
+      "turbo_mode": {
+        "name": "Turbo mode"
+      },
+      "detach_relay": {
+        "name": "Detach relay"
+      },
+      "enable_siren": {
+        "name": "Enable siren"
       }
     }
   }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3081,7 +3081,7 @@ zeroconf==0.136.0
 zeversolar==0.3.2
 
 # homeassistant.components.zha
-zha==0.0.39
+zha==0.0.40
 
 # homeassistant.components.zhong_hong
 zhong-hong-hvac==1.0.13

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2464,7 +2464,7 @@ zeroconf==0.136.0
 zeversolar==0.3.2
 
 # homeassistant.components.zha
-zha==0.0.39
+zha==0.0.40
 
 # homeassistant.components.zwave_js
 zwave-js-server-python==0.59.1


### PR DESCRIPTION
## Proposed change
This bumps ZHA to [0.0.40](https://github.com/zigpy/zha/releases/tag/0.0.40). These dependency upgrades are bundled with it: 
- `bellows` [0.42.1](https://github.com/zigpy/bellows/releases/tag/0.42.1)
- `zha-quirks` [0.0.125](https://github.com/zigpy/zha-device-handlers/releases/tag/0.0.125)
- `zigpy` [0.73.1](https://github.com/zigpy/zigpy/releases/tag/0.73.1) (including [0.73.0](https://github.com/zigpy/zigpy/releases/tag/0.73.0) changes)

This zha-quirks release also adds a few entities via the quirks v2 API. The entity names are added to `strings.json`.


## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #130218, fixes #130710
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
