### PR TITLE
Add quality scale hassfest check for config-entry-unload

### DIFF
--- a/script/hassfest/quality_scale.py
+++ b/script/hassfest/quality_scale.py
@@ -1353,9 +1353,10 @@ def validate_iqs_file(config: Config, integration: Integration) -> None:
         if (
             status == "done"
             and (validator := VALIDATORS.get(rule_name))
-            and (error := validator.validate(integration))
+            and (errors := validator.validate(integration))
         ):
-            integration.add_error("quality_scale", f"[{rule_name}] {error}")
+            for error in errors:
+                integration.add_error("quality_scale", f"[{rule_name}] {error}")
 
     # An integration must have all the necessary rules for the declared
     # quality scale, and all the rules below.

--- a/script/hassfest/quality_scale.py
+++ b/script/hassfest/quality_scale.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 import voluptuous as vol
 from voluptuous.humanize import humanize_error
 
@@ -13,67 +15,77 @@ from .model import Config, Integration, ScaledQualityScaleTiers
 
 QUALITY_SCALE_TIERS = {value.name.lower(): value for value in ScaledQualityScaleTiers}
 
-RULES = {
-    ScaledQualityScaleTiers.BRONZE: [
-        "action-setup",
-        "appropriate-polling",
-        "brands",
-        "common-modules",
-        "config-flow",
-        "config-flow-test-coverage",
-        "dependency-transparency",
-        "docs-actions",
-        "docs-high-level-description",
-        "docs-installation-instructions",
-        "docs-removal-instructions",
-        "entity-event-setup",
-        "entity-unique-id",
-        "has-entity-name",
-        "runtime-data",
-        "test-before-configure",
-        "test-before-setup",
-        "unique-config-entry",
-    ],
-    ScaledQualityScaleTiers.SILVER: [
-        "action-exceptions",
-        "config-entry-unloading",
-        "docs-configuration-parameters",
-        "docs-installation-parameters",
-        "entity-unavailable",
-        "integration-owner",
-        "log-when-unavailable",
-        "parallel-updates",
-        "reauthentication-flow",
-        "test-coverage",
-    ],
-    ScaledQualityScaleTiers.GOLD: [
-        "devices",
-        "diagnostics",
-        "discovery",
-        "discovery-update-info",
-        "docs-data-update",
-        "docs-examples",
-        "docs-known-limitations",
-        "docs-supported-devices",
-        "docs-supported-functions",
-        "docs-troubleshooting",
-        "docs-use-cases",
-        "dynamic-devices",
-        "entity-category",
-        "entity-device-class",
-        "entity-disabled-by-default",
-        "entity-translations",
-        "exception-translations",
-        "icon-translations",
-        "reconfiguration-flow",
-        "repair-issues",
-        "stale-devices",
-    ],
-    ScaledQualityScaleTiers.PLATINUM: [
-        "async-dependency",
-        "inject-websession",
-        "strict-typing",
-    ],
+
+@dataclass
+class Rule:
+    """Quality scale rules."""
+
+    name: str
+    tier: ScaledQualityScaleTiers
+
+
+ALL_RULES = [
+    # BRONZE
+    Rule("action-setup", ScaledQualityScaleTiers.BRONZE),
+    Rule("appropriate-polling", ScaledQualityScaleTiers.BRONZE),
+    Rule("brands", ScaledQualityScaleTiers.BRONZE),
+    Rule("common-modules", ScaledQualityScaleTiers.BRONZE),
+    Rule("config-flow", ScaledQualityScaleTiers.BRONZE),
+    Rule("config-flow-test-coverage", ScaledQualityScaleTiers.BRONZE),
+    Rule("dependency-transparency", ScaledQualityScaleTiers.BRONZE),
+    Rule("docs-actions", ScaledQualityScaleTiers.BRONZE),
+    Rule("docs-high-level-description", ScaledQualityScaleTiers.BRONZE),
+    Rule("docs-installation-instructions", ScaledQualityScaleTiers.BRONZE),
+    Rule("docs-removal-instructions", ScaledQualityScaleTiers.BRONZE),
+    Rule("entity-event-setup", ScaledQualityScaleTiers.BRONZE),
+    Rule("entity-unique-id", ScaledQualityScaleTiers.BRONZE),
+    Rule("has-entity-name", ScaledQualityScaleTiers.BRONZE),
+    Rule("runtime-data", ScaledQualityScaleTiers.BRONZE),
+    Rule("test-before-configure", ScaledQualityScaleTiers.BRONZE),
+    Rule("test-before-setup", ScaledQualityScaleTiers.BRONZE),
+    Rule("unique-config-entry", ScaledQualityScaleTiers.BRONZE),
+    # SILVER
+    Rule("action-exceptions", ScaledQualityScaleTiers.SILVER),
+    Rule("config-entry-unloading", ScaledQualityScaleTiers.SILVER),
+    Rule("docs-configuration-parameters", ScaledQualityScaleTiers.SILVER),
+    Rule("docs-installation-parameters", ScaledQualityScaleTiers.SILVER),
+    Rule("entity-unavailable", ScaledQualityScaleTiers.SILVER),
+    Rule("integration-owner", ScaledQualityScaleTiers.SILVER),
+    Rule("log-when-unavailable", ScaledQualityScaleTiers.SILVER),
+    Rule("parallel-updates", ScaledQualityScaleTiers.SILVER),
+    Rule("reauthentication-flow", ScaledQualityScaleTiers.SILVER),
+    Rule("test-coverage", ScaledQualityScaleTiers.SILVER),
+    # GOLD: [
+    Rule("devices", ScaledQualityScaleTiers.GOLD),
+    Rule("diagnostics", ScaledQualityScaleTiers.GOLD),
+    Rule("discovery", ScaledQualityScaleTiers.GOLD),
+    Rule("discovery-update-info", ScaledQualityScaleTiers.GOLD),
+    Rule("docs-data-update", ScaledQualityScaleTiers.GOLD),
+    Rule("docs-examples", ScaledQualityScaleTiers.GOLD),
+    Rule("docs-known-limitations", ScaledQualityScaleTiers.GOLD),
+    Rule("docs-supported-devices", ScaledQualityScaleTiers.GOLD),
+    Rule("docs-supported-functions", ScaledQualityScaleTiers.GOLD),
+    Rule("docs-troubleshooting", ScaledQualityScaleTiers.GOLD),
+    Rule("docs-use-cases", ScaledQualityScaleTiers.GOLD),
+    Rule("dynamic-devices", ScaledQualityScaleTiers.GOLD),
+    Rule("entity-category", ScaledQualityScaleTiers.GOLD),
+    Rule("entity-device-class", ScaledQualityScaleTiers.GOLD),
+    Rule("entity-disabled-by-default", ScaledQualityScaleTiers.GOLD),
+    Rule("entity-translations", ScaledQualityScaleTiers.GOLD),
+    Rule("exception-translations", ScaledQualityScaleTiers.GOLD),
+    Rule("icon-translations", ScaledQualityScaleTiers.GOLD),
+    Rule("reconfiguration-flow", ScaledQualityScaleTiers.GOLD),
+    Rule("repair-issues", ScaledQualityScaleTiers.GOLD),
+    Rule("stale-devices", ScaledQualityScaleTiers.GOLD),
+    # PLATINUM
+    Rule("async-dependency", ScaledQualityScaleTiers.PLATINUM),
+    Rule("inject-websession", ScaledQualityScaleTiers.PLATINUM),
+    Rule("strict-typing", ScaledQualityScaleTiers.PLATINUM),
+]
+
+SCALE_RULES = {
+    tier: [rule.name for rule in ALL_RULES if rule.tier == tier]
+    for tier in ScaledQualityScaleTiers
 }
 
 INTEGRATIONS_WITHOUT_QUALITY_SCALE_FILE = [
@@ -1244,7 +1256,7 @@ SCHEMA = vol.Schema(
     {
         vol.Required("rules"): vol.Schema(
             {
-                vol.Optional(rule): vol.Any(
+                vol.Optional(rule.name): vol.Any(
                     vol.In(["todo", "done"]),
                     vol.Schema(
                         {
@@ -1259,8 +1271,7 @@ SCHEMA = vol.Schema(
                         }
                     ),
                 )
-                for tier_list in RULES.values()
-                for rule in tier_list
+                for rule in ALL_RULES
             }
         )
     }
@@ -1330,7 +1341,7 @@ def validate_iqs_file(config: Config, integration: Integration) -> None:
     if declared_quality_scale is None:
         return
 
-    rules_met = set()
+    rules_met = set[str]()
     for rule_name, rule_value in data.get("rules", {}).items():
         status = rule_value["status"] if isinstance(rule_value, dict) else rule_value
         if status in {"done", "exempt"}:
@@ -1341,7 +1352,7 @@ def validate_iqs_file(config: Config, integration: Integration) -> None:
     for scale in ScaledQualityScaleTiers:
         if scale > declared_quality_scale:
             break
-        required_rules = set(RULES[scale])
+        required_rules = set(SCALE_RULES[scale])
         if missing_rules := (required_rules - rules_met):
             friendly_rule_str = "\n".join(
                 f"  {rule}: todo" for rule in sorted(missing_rules)

--- a/script/hassfest/quality_scale_validation/__init__.py
+++ b/script/hassfest/quality_scale_validation/__init__.py
@@ -8,7 +8,7 @@ from script.hassfest.model import Integration
 class RuleValidationProtocol(Protocol):
     """Protocol for rule validation."""
 
-    def validate(self, integration: Integration) -> str | None:
+    def validate(self, integration: Integration) -> list[str] | None:
         """Validate a quality scale rule.
 
         Returns error (if any).

--- a/script/hassfest/quality_scale_validation/__init__.py
+++ b/script/hassfest/quality_scale_validation/__init__.py
@@ -1,0 +1,15 @@
+"""Integration quality scale rules."""
+
+from typing import Protocol
+
+from script.hassfest.model import Integration
+
+
+class RuleValidationProtocol(Protocol):
+    """Protocol for rule validation."""
+
+    def validate(self, integration: Integration) -> str | None:
+        """Validate a quality scale rule.
+
+        Returns error (if any).
+        """

--- a/script/hassfest/quality_scale_validation/config_entry_unloading.py
+++ b/script/hassfest/quality_scale_validation/config_entry_unloading.py
@@ -12,15 +12,15 @@ def _has_async_function(module: ast.Module, name: str) -> bool:
     )
 
 
-def validate(integration: Integration) -> str | None:
+def validate(integration: Integration) -> list[str] | None:
     """Validate that the integration has a config flow."""
 
     init_file = integration.path / "__init__.py"
     init = ast.parse(init_file.read_text())
 
     if not _has_async_function(init, "async_unload_entry"):
-        return (
+        return [
             "Integration does not support config entry unloading "
             "(is missing `async_unload_entry` in __init__.py)"
-        )
+        ]
     return None

--- a/script/hassfest/quality_scale_validation/config_entry_unloading.py
+++ b/script/hassfest/quality_scale_validation/config_entry_unloading.py
@@ -1,0 +1,26 @@
+"""Enforce that the integration implements entry unloading."""
+
+import ast
+
+from script.hassfest.model import Integration
+
+
+def _has_async_function(module: ast.Module, name: str) -> bool:
+    """Test if the module defines a function."""
+    return any(
+        type(item) is ast.AsyncFunctionDef and item.name == name for item in module.body
+    )
+
+
+def validate(integration: Integration) -> str | None:
+    """Validate that the integration has a config flow."""
+
+    init_file = integration.path / "__init__.py"
+    init = ast.parse(init_file.read_text())
+
+    if not _has_async_function(init, "async_unload_entry"):
+        return (
+            "Integration does not support config entry unloading "
+            "(is missing `async_unload_entry` in __init__.py)"
+        )
+    return None


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As a first step towards adding custom validation.
- make Rule a dataclass
- add a Protocol for rule validators
- implement first rule for `config-entry-unload`

Sample run (forced):
```
python -m script.hassfest -p quality_scale --action validate
Validating quality_scale... done in 0.25s

Integrations: 1303
Invalid integrations: 1

Integration acaia:
* [ERROR] [QUALITY_SCALE] [config-entry-unloading] Integration does not support config entry unloading (is missing `async_unload_entry` in __init__.py)
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
