### PR TITLE
Bump music assistant client 1.0.8

### DIFF
--- a/homeassistant/components/music_assistant/manifest.json
+++ b/homeassistant/components/music_assistant/manifest.json
@@ -7,6 +7,6 @@
   "documentation": "https://www.home-assistant.io/integrations/music_assistant",
   "iot_class": "local_push",
   "loggers": ["music_assistant"],
-  "requirements": ["music-assistant-client==1.0.5"],
+  "requirements": ["music-assistant-client==1.0.8"],
   "zeroconf": ["_mass._tcp.local."]
 }

--- a/homeassistant/components/music_assistant/media_player.py
+++ b/homeassistant/components/music_assistant/media_player.py
@@ -365,12 +365,12 @@ class MusicAssistantPlayer(MusicAssistantEntity, MediaPlayerEntity):
             if (mass_player_id := hass_state.attributes.get("mass_player_id")) is None:
                 continue
             player_ids.append(mass_player_id)
-        await self.mass.players.player_command_sync_many(self.player_id, player_ids)
+        await self.mass.players.player_command_group_many(self.player_id, player_ids)
 
     @catch_musicassistant_error
     async def async_unjoin_player(self) -> None:
         """Remove this player from any group."""
-        await self.mass.players.player_command_unsync(self.player_id)
+        await self.mass.players.player_command_ungroup(self.player_id)
 
     @catch_musicassistant_error
     async def _async_handle_play_media(

--- a/homeassistant/components/music_assistant/media_player.py
+++ b/homeassistant/components/music_assistant/media_player.py
@@ -151,7 +151,7 @@ class MusicAssistantPlayer(MusicAssistantEntity, MediaPlayerEntity):
         super().__init__(mass, player_id)
         self._attr_icon = self.player.icon.replace("mdi-", "mdi:")
         self._attr_supported_features = SUPPORTED_FEATURES
-        if PlayerFeature.SYNC in self.player.supported_features:
+        if PlayerFeature.SET_MEMBERS in self.player.supported_features:
             self._attr_supported_features |= MediaPlayerEntityFeature.GROUPING
         if PlayerFeature.VOLUME_MUTE in self.player.supported_features:
             self._attr_supported_features |= MediaPlayerEntityFeature.VOLUME_MUTE

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1409,7 +1409,7 @@ mozart-api==4.1.1.116.3
 mullvad-api==1.0.0
 
 # homeassistant.components.music_assistant
-music-assistant-client==1.0.5
+music-assistant-client==1.0.8
 
 # homeassistant.components.tts
 mutagen==1.47.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1178,7 +1178,7 @@ mozart-api==4.1.1.116.3
 mullvad-api==1.0.0
 
 # homeassistant.components.music_assistant
-music-assistant-client==1.0.5
+music-assistant-client==1.0.8
 
 # homeassistant.components.tts
 mutagen==1.47.0

--- a/tests/components/music_assistant/fixtures/players.json
+++ b/tests/components/music_assistant/fixtures/players.json
@@ -16,7 +16,7 @@
         "volume_set",
         "volume_mute",
         "pause",
-        "sync",
+        "set_members",
         "power",
         "enqueue"
       ],
@@ -57,7 +57,7 @@
         "volume_set",
         "volume_mute",
         "pause",
-        "sync",
+        "set_members",
         "power",
         "enqueue"
       ],
@@ -109,7 +109,7 @@
         "volume_set",
         "volume_mute",
         "pause",
-        "sync",
+        "set_members",
         "power",
         "enqueue"
       ],


### PR DESCRIPTION
## Proposed change

Bump music assistant client library to [version 1.0.8](https://github.com/music-assistant/client/releases/tag/1.0.8)
This ensures we have the latest version of the models (+ small name change where syncing is renamed to grouping).

## Type of change

- [X] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
