### PR TITLE
Log warning if via_device reference not exists when creating or updating a device registry entry

### DIFF
--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -821,7 +821,14 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
             name = default_name
 
         if via_device is not None and via_device is not UNDEFINED:
-            via = self.async_get_device(identifiers={via_device})
+            if (via := self.async_get_device(identifiers={via_device})) is None:
+                _LOGGER.warning(
+                    "Unable to create reference for non existing "
+                    "`via_device` %s in device info %s",
+                    via_device,
+                    device_info,
+                )
+
             via_device_id: str | UndefinedType = via.id if via else UNDEFINED
         else:
             via_device_id = UNDEFINED

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -38,6 +38,7 @@ from .deprecation import (
     check_if_deprecated_constant,
     dir_with_deprecated_constants,
 )
+from .frame import ReportBehavior, report_usage
 from .json import JSON_DUMP, find_paths_unserializable_data, json_bytes, json_fragment
 from .registry import BaseRegistry, BaseRegistryItems, RegistryIndexType
 from .singleton import singleton
@@ -822,11 +823,12 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
 
         if via_device is not None and via_device is not UNDEFINED:
             if (via := self.async_get_device(identifiers={via_device})) is None:
-                _LOGGER.warning(
-                    "Unable to create reference for non existing "
-                    "`via_device` %s in device info %s",
-                    via_device,
-                    device_info,
+                report_usage(
+                    "calls `device_registry.async_get_or_create` referencing a "
+                    f"non existing `via_device` {via_device}, "
+                    f"with device info: {device_info}",
+                    core_behavior=ReportBehavior.LOG,
+                    breaks_in_ha_version="2025.12.0",
                 )
 
             via_device_id: str | UndefinedType = via.id if via else UNDEFINED

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -1525,7 +1525,8 @@ async def test_specifying_via_device_create(
         via_device=("hue", "non_existing_123"),
     )
     assert {
-        "Unable to create reference for non existing `via_device` "
+        "calls `device_registry.async_get_or_create` "
+        "referencing a non existing `via_device` "
         '("hue","non_existing_123")' in caplog.text
     }
     assert light_via_nonexisting_parent_device is not None
@@ -1590,7 +1591,8 @@ async def test_specifying_via_device_update(
         via_device=("hue", "non_existing_abc"),
     )
     assert {
-        "Unable to create reference for non existing `via_device` "
+        "calls `device_registry.async_get_or_create` "
+        "referencing a non existing `via_device` "
         '("hue","non_existing_123")' in caplog.text
     }
     # Assert the name was updated correctly

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -1482,7 +1482,9 @@ async def test_removing_area_id(
 
 
 async def test_specifying_via_device_create(
-    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test specifying a via_device and removal of the hub device."""
     config_entry_1 = MockConfigEntry()
@@ -1513,9 +1515,31 @@ async def test_specifying_via_device_create(
     light = device_registry.async_get_device(identifiers={("hue", "456")})
     assert light.via_device_id is None
 
+    # A device with a non existing via_device reference should create
+    light_via_nonexisting_parent_device = device_registry.async_get_or_create(
+        config_entry_id=config_entry_2.entry_id,
+        connections=set(),
+        identifiers={("hue", "789")},
+        manufacturer="manufacturer",
+        model="light",
+        via_device=("hue", "non_existing_123"),
+    )
+    assert {
+        "Unable to create reference for non existing `via_device` "
+        '("hue","non_existing_123")' in caplog.text
+    }
+    assert light_via_nonexisting_parent_device is not None
+    assert light_via_nonexisting_parent_device.via_device_id is None
+    nonexisting_parent_device = device_registry.async_get_device(
+        identifiers={("hue", "non_existing_123")}
+    )
+    assert nonexisting_parent_device is None
+
 
 async def test_specifying_via_device_update(
-    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test specifying a via_device and updating."""
     config_entry_1 = MockConfigEntry()
@@ -1529,6 +1553,7 @@ async def test_specifying_via_device_update(
         identifiers={("hue", "456")},
         manufacturer="manufacturer",
         model="light",
+        name="Light",
         via_device=("hue", "0123"),
     )
 
@@ -1552,6 +1577,25 @@ async def test_specifying_via_device_update(
     )
 
     assert light.via_device_id == via.id
+    assert light.name == "Light"
+
+    # Try updating with a non existing via device
+    light = device_registry.async_get_or_create(
+        config_entry_id=config_entry_2.entry_id,
+        connections=set(),
+        identifiers={("hue", "456")},
+        manufacturer="manufacturer",
+        model="light",
+        name="New light",
+        via_device=("hue", "non_existing_abc"),
+    )
+    assert {
+        "Unable to create reference for non existing `via_device` "
+        '("hue","non_existing_123")' in caplog.text
+    }
+    # Assert the name was updated correctly
+    assert light.via_device_id == via.id
+    assert light.name == "New light"
 
 
 async def test_loading_saving_data(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When `device_registry.async_get_or_create` is used to create or update a device registry entry and the `via_device` reference is not revering to an exiting device, the device reference is not updated. But no warning is logged to inform users the `via_device` reference could not be resolved.

This PR adds a warning log when the `via_device` reference can not be resolved.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
