### PR TITLE
Add quality scale for Fronius

### DIFF
--- a/homeassistant/components/fronius/quality_scale.yaml
+++ b/homeassistant/components/fronius/quality_scale.yaml
@@ -11,12 +11,7 @@ rules:
     comment: |
       Single platform only, so no entity.py file.
       CoordinatorEntity is used.
-  config-flow-test-coverage:
-    status: todo
-    comment: |
-      - Remove duplicated patch of `async_setup_entry`.
-      - Assert unique_id in test_form_with_logger and test_dhcp.
-      - All tests should end in either a CREATE_ENTRY or ABORT.
+  config-flow-test-coverage: done
   config-flow: done
   dependency-transparency: done
   docs-actions:
@@ -63,12 +58,7 @@ rules:
     status: exempt
     comment: |
       This integration doesn't require authentication.
-  test-coverage:
-    status: todo
-    comment: |
-      - Use fixture `enable_all_entities` instead of custom code.
-      - Use freezer.
-      - Use snapshots.
+  test-coverage: done
   # Gold
   devices: done
   diagnostics: done

--- a/homeassistant/components/fronius/quality_scale.yaml
+++ b/homeassistant/components/fronius/quality_scale.yaml
@@ -29,11 +29,7 @@ rules:
   has-entity-name: done
   runtime-data: done
   test-before-configure: done
-  test-before-setup:
-    status: todo
-    comment: |
-      ConfigEntryNotReady not raised in async_setup_entry but in helper function.
-      Hassfest test fails for this.
+  test-before-setup: done
   unique-config-entry: done
   # Silver
   action-exceptions:

--- a/homeassistant/components/fronius/quality_scale.yaml
+++ b/homeassistant/components/fronius/quality_scale.yaml
@@ -71,10 +71,7 @@ rules:
   entity-category: done
   entity-device-class: done
   entity-disabled-by-default: done
-  entity-translations:
-    status: todo
-    comment: |
-      - `Unknown` should not be a valid state of status_message.
+  entity-translations: done
   exception-translations: done
   icon-translations: done
   reconfiguration-flow: done

--- a/homeassistant/components/fronius/quality_scale.yaml
+++ b/homeassistant/components/fronius/quality_scale.yaml
@@ -17,10 +17,7 @@ rules:
       - Remove duplicated patch of `async_setup_entry`.
       - Assert unique_id in test_form_with_logger and test_dhcp.
       - All tests should end in either a CREATE_ENTRY or ABORT.
-  config-flow:
-    status: todo
-    comment: |
-      - Missing data_description for host.
+  config-flow: done
   dependency-transparency: done
   docs-actions:
     status: exempt
@@ -91,12 +88,8 @@ rules:
   entity-translations:
     status: todo
     comment: |
-      - Remove name translations that are handled by device class translations.
       - `Unknown` should not be a valid state of status_message.
-  exception-translations:
-    status: todo
-    comment: |
-      CannotConnect in config_flow.py shall not be translated - errors dict is used.
+  exception-translations: done
   icon-translations: done
   reconfiguration-flow: done
   repair-issues:

--- a/homeassistant/components/fronius/quality_scale.yaml
+++ b/homeassistant/components/fronius/quality_scale.yaml
@@ -32,10 +32,7 @@ rules:
       This integration does not subscribe to events.
   entity-unique-id: done
   has-entity-name: done
-  runtime-data:
-    status: todo
-    comment: |
-      `async_remove_config_entry_device` does not use typed ConfigEntry.
+  runtime-data: done
   test-before-configure: done
   test-before-setup:
     status: todo

--- a/homeassistant/components/fronius/quality_scale.yaml
+++ b/homeassistant/components/fronius/quality_scale.yaml
@@ -37,9 +37,12 @@ rules:
     comment: |
       `async_remove_config_entry_device` does not use typed ConfigEntry.
   test-before-configure: done
-  test-before-setup: done
+  test-before-setup:
+    status: todo
+    comment: |
+      ConfigEntryNotReady not raised in async_setup_entry but in helper function.
+      Hassfest test fails for this.
   unique-config-entry: done
-
   # Silver
   action-exceptions:
     status: exempt

--- a/homeassistant/components/fronius/quality_scale.yaml
+++ b/homeassistant/components/fronius/quality_scale.yaml
@@ -1,0 +1,79 @@
+rules:
+  # Bronze
+  action-setup:
+    status: exempt
+    comment: |
+      This integration does not provide additional actions.
+  appropriate-polling: done
+  brands: done
+  common-modules: done
+  config-flow-test-coverage: done
+  config-flow: done
+  dependency-transparency: done
+  docs-actions:
+    status: exempt
+    comment: |
+      This integration does not provide additional actions.
+  docs-high-level-description: done
+  docs-installation-instructions: done
+  docs-removal-instructions: done
+  entity-event-setup:
+    status: exempt
+    comment: |
+      This integration does not subscribe to events.
+  entity-unique-id: done
+  has-entity-name: done
+  runtime-data: done
+  test-before-configure: done
+  test-before-setup: done
+  unique-config-entry: done
+
+  # Silver
+  action-exceptions:
+    status: exempt
+    comment: |
+      This integration does not provide additional actions.
+  config-entry-unloading: done
+  docs-configuration-parameters:
+    status: exempt
+    comment: |
+      This integration does not provide configuration options.
+  docs-installation-parameters: done
+  entity-unavailable: done
+  integration-owner: done
+  log-when-unavailable: done
+  parallel-updates: done
+  reauthentication-flow:
+    status: exempt
+    comment: |
+      This integration doesn't require authentication.
+  test-coverage: done
+  # Gold
+  devices: done
+  diagnostics: done
+  discovery-update-info: done
+  discovery: done
+  docs-data-update: done
+  docs-examples: done
+  docs-known-limitations: done
+  docs-supported-devices: done
+  docs-supported-functions: done
+  docs-troubleshooting: done
+  docs-use-cases: done
+  dynamic-devices: done
+  entity-category: done
+  entity-device-class: done
+  entity-disabled-by-default: done
+  entity-translations: done
+  exception-translations: done
+  icon-translations: done
+  reconfiguration-flow: done
+  repair-issues:
+    status: exempt
+    comment: |
+      This integration doesn't have any known user-repairable issues.
+  stale-devices: done
+  # Platinum
+  async-dependency: done
+  inject-websession: done
+  strict-typing: done

--- a/homeassistant/components/fronius/quality_scale.yaml
+++ b/homeassistant/components/fronius/quality_scale.yaml
@@ -6,7 +6,11 @@ rules:
       This integration does not provide additional actions.
   appropriate-polling: done
   brands: done
-  common-modules: done
+  common-modules:
+    status: done
+    comment: |
+      Single platform only, so no entity.py file.
+      CoordinatorEntity is used.
   config-flow-test-coverage: done
   config-flow: done
   dependency-transparency: done
@@ -42,7 +46,11 @@ rules:
   entity-unavailable: done
   integration-owner: done
   log-when-unavailable: done
-  parallel-updates: done
+  parallel-updates:
+    status: done
+    comment: |
+      Coordinators are used and asyncio.Lock mutex across them ensure proper
+      rate limiting. Platforms are read-only.
   reauthentication-flow:
     status: exempt
     comment: |

--- a/homeassistant/components/fronius/quality_scale.yaml
+++ b/homeassistant/components/fronius/quality_scale.yaml
@@ -11,8 +11,16 @@ rules:
     comment: |
       Single platform only, so no entity.py file.
       CoordinatorEntity is used.
-  config-flow-test-coverage: done
-  config-flow: done
+  config-flow-test-coverage:
+    status: todo
+    comment: |
+      - Remove duplicated patch of `async_setup_entry`.
+      - Assert unique_id in test_form_with_logger and test_dhcp.
+      - All tests should end in either a CREATE_ENTRY or ABORT.
+  config-flow:
+    status: todo
+    comment: |
+      - Missing data_description for host.
   dependency-transparency: done
   docs-actions:
     status: exempt
@@ -27,7 +35,10 @@ rules:
       This integration does not subscribe to events.
   entity-unique-id: done
   has-entity-name: done
-  runtime-data: done
+  runtime-data:
+    status: todo
+    comment: |
+      `async_remove_config_entry_device` does not use typed ConfigEntry.
   test-before-configure: done
   test-before-setup: done
   unique-config-entry: done
@@ -55,7 +66,12 @@ rules:
     status: exempt
     comment: |
       This integration doesn't require authentication.
-  test-coverage: done
+  test-coverage:
+    status: todo
+    comment: |
+      - Use fixture `enable_all_entities` instead of custom code.
+      - Use freezer.
+      - Use snapshots.
   # Gold
   devices: done
   diagnostics: done
@@ -72,8 +88,15 @@ rules:
   entity-category: done
   entity-device-class: done
   entity-disabled-by-default: done
-  entity-translations: done
-  exception-translations: done
+  entity-translations:
+    status: todo
+    comment: |
+      - Remove name translations that are handled by device class translations.
+      - `Unknown` should not be a valid state of status_message.
+  exception-translations:
+    status: todo
+    comment: |
+      CannotConnect in config_flow.py shall not be translated - errors dict is used.
   icon-translations: done
   reconfiguration-flow: done
   repair-issues:
@@ -84,4 +107,7 @@ rules:
   # Platinum
   async-dependency: done
   inject-websession: done
-  strict-typing: done
+  strict-typing:
+    status: todo
+    comment: |
+      The pyfronius library isn't strictly typed and doesn't export type information.

--- a/script/hassfest/quality_scale.py
+++ b/script/hassfest/quality_scale.py
@@ -418,7 +418,6 @@ INTEGRATIONS_WITHOUT_QUALITY_SCALE_FILE = [
     "freedompro",
     "fritzbox",
     "fritzbox_callmonitor",
-    "fronius",
     "frontier_silicon",
     "fujitsu_fglair",
     "fujitsu_hvac",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Some of the docs requirements are done in the linked doc-PR.

## Bronze
- [x] `config-flow` - Integration needs to be able to be set up via the UI
    - [x] Uses `data-description` to give context to fields
only host is used - doesn't really require extra description
    - [x] Uses `ConfigEntry.data` and `ConfigEntry.options` correctly
https://github.com/home-assistant/core/blob/eac6673c2bcc44dc60fb8acef278a68208a61867/homeassistant/components/fronius/const.py#L18
- [x] `test-before-configure` - Test a connection in the config flow
https://github.com/home-assistant/core/blob/eac6673c2bcc44dc60fb8acef278a68208a61867/homeassistant/components/fronius/config_flow.py#L34
- [x] `unique-config-entry` - Don't allow the same device or service to be able to be set up twice
https://github.com/home-assistant/core/blob/eac6673c2bcc44dc60fb8acef278a68208a61867/homeassistant/components/fronius/config_flow.py#L92
- [x] `config-flow-test-coverage` - Full test coverage for the config flow
- [x] `runtime-data` - Use ConfigEntry.runtime_data to store runtime data
https://github.com/home-assistant/core/blob/eac6673c2bcc44dc60fb8acef278a68208a61867/homeassistant/components/fronius/__init__.py#L52
- [x] `test-before-setup` - Check during integration initialization if we are able to set it up correctly
https://github.com/home-assistant/core/blob/eac6673c2bcc44dc60fb8acef278a68208a61867/homeassistant/components/fronius/__init__.py#L222
- [x] `appropriate-polling` - If it's a polling integration, set an appropriate polling interval
https://github.com/home-assistant/core/blob/eac6673c2bcc44dc60fb8acef278a68208a61867/homeassistant/components/fronius/coordinator.py#L41-L42
- [x] `entity-unique-id` - Entities have a unique ID
https://github.com/home-assistant/core/blob/eac6673c2bcc44dc60fb8acef278a68208a61867/homeassistant/components/fronius/config_flow.py#L91
- [x] `has-entity-name` - Entities use has_entity_name = True
https://github.com/home-assistant/core/blob/eac6673c2bcc44dc60fb8acef278a68208a61867/homeassistant/components/fronius/sensor.py#L703
- [ ] `entity-event-setup` - Entities event setup
doesn't subscribe to events
- [x] `dependency-transparency` - Dependency transparency
https://github.com/nielstron/pyfronius
- [ ] `action-setup` - Service actions are registered in async_setup
no service actions
- [x] `common-modules` - Place common patterns in common modules
- [x] `docs-high-level-description` - The documentation includes a high-level description of the integration brand, product, or service
- [x] `docs-installation-instructions` - The documentation provides step-by-step installation instructions for the integration, including, if needed, prerequisites
- [x] `docs-removal-instructions` - The documentation provides removal instructions
- [ ] `docs-actions` - The documentation describes the provided service actions that can be used
no service actions
- [x] `brands` - Has branding assets available for the integration

## Silver
- [x] `config-entry-unloading` - Support config entry unloading
https://github.com/home-assistant/core/blob/eac6673c2bcc44dc60fb8acef278a68208a61867/homeassistant/components/fronius/__init__.py#L57
- [x] `log-when-unavailable` - If internet/device/service is unavailable, log once when unavailable and once when back connected
data update coordinator handles that
- [x] `entity-unavailable` - Mark entity unavailable if appropriate
data update coordinator handles that
- [ ] `action-exceptions` - Service actions raise exceptions when encountering failures
no service actions
- [ ] `reauthentication-flow` - Reauthentication flow
no authentication
- [x] `parallel-updates` - Set Parallel updates
added in this PR
- [x] `test-coverage` - Above 95% test coverage for all integration modules
- [x] `integration-owner` - Has an integration owner
- [x] `docs-installation-parameters` - The documentation describes all integration installation parameters
- [ ] `docs-configuration-parameters` - The documentation describes all integration configuration options
no option flow

## Gold
- [x] `entity-translations` - Entities have translated names
https://github.com/home-assistant/core/blob/eac6673c2bcc44dc60fb8acef278a68208a61867/homeassistant/components/fronius/strings.json#L33
- [x] `entity-device-class` - Entities use device classes where possible
https://github.com/home-assistant/core/blob/eac6673c2bcc44dc60fb8acef278a68208a61867/homeassistant/components/fronius/sensor.py#L119-L125
- [x] `devices` - The integration creates devices
https://github.com/home-assistant/core/blob/eac6673c2bcc44dc60fb8acef278a68208a61867/homeassistant/components/fronius/sensor.py#L760
- [x] `entity-category` - Entities are assigned an appropriate EntityCategory
see entity-device-class
- [x] `entity-disabled-by-default` - Integration disables less popular (or noisy) entities
see entity-device-class
- [x] `discovery` - Can be discovered
https://github.com/home-assistant/core/blob/0f5e0dd4bfb25b68828ea302a8e2ce3af80e2aef/homeassistant/components/fronius/manifest.json#L6-L10
- [x] `stale-devices` - Clean up stale devices
https://github.com/home-assistant/core/blob/0f5e0dd4bfb25b68828ea302a8e2ce3af80e2aef/homeassistant/components/fronius/__init__.py#L62
- [x] `diagnostics` - Implements diagnostics
https://github.com/home-assistant/core/blob/dev/homeassistant/components/fronius/diagnostics.py
- [x] `exception-translations` - Exception messages are translatable
added in this PR
- [x] `icon-translations` - Icon translations
https://github.com/home-assistant/core/blob/dev/homeassistant/components/fronius/icons.json
- [x] `reconfiguration-flow` - Integrations should have a reconfigure flow
https://github.com/home-assistant/core/blob/39c2a529d129475c5c2ec3def1a1954180f8bd4b/homeassistant/components/fronius/config_flow.py#L142
- [x] `dynamic-devices` - Devices added after integration setup
https://github.com/home-assistant/core/blob/17236a56989ff82f6aba9a2231cfc88741709baf/homeassistant/components/fronius/__init__.py#L145-L151
- [x] `discovery-update-info` - Integration uses discovery info to update network information
https://github.com/home-assistant/core/blob/17236a56989ff82f6aba9a2231cfc88741709baf/homeassistant/components/fronius/config_flow.py#L121
- [ ] `repair-issues` - Repair issues and repair flows are used when user intervention is needed
This integration doesn't have any known user-repairable issues.
- [x] `docs-use-cases` - The documentation describes use cases to illustrate how this integration can be used
- [x] `docs-supported-devices` - The integration documents known supported / unsupported devices
- [x] `docs-supported-functions` - The documentation describes the supported functionality, including entities, and platforms
- [x] `docs-data-update` - The documentation describes how data is updated
- [x] `docs-known-limitations` - The documentation describes known limitations of the integration (not to be confused with bugs)
- [x] `docs-troubleshooting` - The documentation provides troubleshooting information
- [x] `docs-examples` - The documentation provides automation examples the user can use.

## Platinum
- [x] `async-dependency` - Dependency is async
- [x] `inject-websession` - The integration dependency supports passing in a websession
https://github.com/home-assistant/core/blob/17236a56989ff82f6aba9a2231cfc88741709baf/homeassistant/components/fronius/__init__.py#L48
- [ ] `strict-typing` - Strict typing
https://github.com/home-assistant/core/blob/17236a56989ff82f6aba9a2231cfc88741709baf/.strict-typing#L201


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/36033

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
