### PR TITLE
Remove deprecated alarm control panel constants

### DIFF
--- a/homeassistant/components/alarm_control_panel/__init__.py
+++ b/homeassistant/components/alarm_control_panel/__init__.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 from datetime import timedelta
-from functools import partial
 import logging
 from typing import TYPE_CHECKING, Any, Final, final
 
@@ -27,11 +26,6 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ServiceValidationError
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.config_validation import make_entity_service_schema
-from homeassistant.helpers.deprecation import (
-    all_with_deprecated_constants,
-    check_if_deprecated_constant,
-    dir_with_deprecated_constants,
-)
 from homeassistant.helpers.entity import Entity, EntityDescription
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.entity_platform import EntityPlatform
@@ -39,15 +33,7 @@ from homeassistant.helpers.frame import ReportBehavior, report_usage
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.util.hass_dict import HassKey
 
-from .const import (  # noqa: F401
-    _DEPRECATED_FORMAT_NUMBER,
-    _DEPRECATED_FORMAT_TEXT,
-    _DEPRECATED_SUPPORT_ALARM_ARM_AWAY,
-    _DEPRECATED_SUPPORT_ALARM_ARM_CUSTOM_BYPASS,
-    _DEPRECATED_SUPPORT_ALARM_ARM_HOME,
-    _DEPRECATED_SUPPORT_ALARM_ARM_NIGHT,
-    _DEPRECATED_SUPPORT_ALARM_ARM_VACATION,
-    _DEPRECATED_SUPPORT_ALARM_TRIGGER,
+from .const import (
     ATTR_CHANGED_BY,
     ATTR_CODE_ARM_REQUIRED,
     DOMAIN,
@@ -412,13 +398,3 @@ class AlarmControlPanelEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_A
             self._alarm_control_panel_option_default_code = default_code
             return
         self._alarm_control_panel_option_default_code = None
-
-
-# As we import constants of the const module here, we need to add the following
-# functions to check for deprecated constants again
-# These can be removed if no deprecated constant are in this module anymore
-__getattr__ = partial(check_if_deprecated_constant, module_globals=globals())
-__dir__ = partial(
-    dir_with_deprecated_constants, module_globals_keys=[*globals().keys()]
-)
-__all__ = all_with_deprecated_constants(globals())

--- a/homeassistant/components/alarm_control_panel/const.py
+++ b/homeassistant/components/alarm_control_panel/const.py
@@ -1,15 +1,7 @@
 """Provides the constants needed for component."""
 
 from enum import IntFlag, StrEnum
-from functools import partial
 from typing import Final
-
-from homeassistant.helpers.deprecation import (
-    DeprecatedConstantEnum,
-    all_with_deprecated_constants,
-    check_if_deprecated_constant,
-    dir_with_deprecated_constants,
-)
 
 DOMAIN: Final = "alarm_control_panel"
 
@@ -39,12 +31,6 @@ class CodeFormat(StrEnum):
     NUMBER = "number"
 
 
-# These constants are deprecated as of Home Assistant 2022.5, can be removed in 2025.1
-# Please use the CodeFormat enum instead.
-_DEPRECATED_FORMAT_TEXT: Final = DeprecatedConstantEnum(CodeFormat.TEXT, "2025.1")
-_DEPRECATED_FORMAT_NUMBER: Final = DeprecatedConstantEnum(CodeFormat.NUMBER, "2025.1")
-
-
 class AlarmControlPanelEntityFeature(IntFlag):
     """Supported features of the alarm control panel entity."""
 
@@ -56,27 +42,6 @@ class AlarmControlPanelEntityFeature(IntFlag):
     ARM_VACATION = 32
 
 
-# These constants are deprecated as of Home Assistant 2022.5
-# Please use the AlarmControlPanelEntityFeature enum instead.
-_DEPRECATED_SUPPORT_ALARM_ARM_HOME: Final = DeprecatedConstantEnum(
-    AlarmControlPanelEntityFeature.ARM_HOME, "2025.1"
-)
-_DEPRECATED_SUPPORT_ALARM_ARM_AWAY: Final = DeprecatedConstantEnum(
-    AlarmControlPanelEntityFeature.ARM_AWAY, "2025.1"
-)
-_DEPRECATED_SUPPORT_ALARM_ARM_NIGHT: Final = DeprecatedConstantEnum(
-    AlarmControlPanelEntityFeature.ARM_NIGHT, "2025.1"
-)
-_DEPRECATED_SUPPORT_ALARM_TRIGGER: Final = DeprecatedConstantEnum(
-    AlarmControlPanelEntityFeature.TRIGGER, "2025.1"
-)
-_DEPRECATED_SUPPORT_ALARM_ARM_CUSTOM_BYPASS: Final = DeprecatedConstantEnum(
-    AlarmControlPanelEntityFeature.ARM_CUSTOM_BYPASS, "2025.1"
-)
-_DEPRECATED_SUPPORT_ALARM_ARM_VACATION: Final = DeprecatedConstantEnum(
-    AlarmControlPanelEntityFeature.ARM_VACATION, "2025.1"
-)
-
 CONDITION_TRIGGERED: Final = "is_triggered"
 CONDITION_DISARMED: Final = "is_disarmed"
 CONDITION_ARMED_HOME: Final = "is_armed_home"
@@ -84,10 +49,3 @@ CONDITION_ARMED_AWAY: Final = "is_armed_away"
 CONDITION_ARMED_NIGHT: Final = "is_armed_night"
 CONDITION_ARMED_VACATION: Final = "is_armed_vacation"
 CONDITION_ARMED_CUSTOM_BYPASS: Final = "is_armed_custom_bypass"
-
-# These can be removed if no deprecated constant are in this module anymore
-__getattr__ = partial(check_if_deprecated_constant, module_globals=globals())
-__dir__ = partial(
-    dir_with_deprecated_constants, module_globals_keys=[*globals().keys()]
-)
-__all__ = all_with_deprecated_constants(globals())

--- a/tests/components/alarm_control_panel/test_init.py
+++ b/tests/components/alarm_control_panel/test_init.py
@@ -1,6 +1,5 @@
 """Test for the alarm control panel const module."""
 
-from types import ModuleType
 from typing import Any
 from unittest.mock import patch
 
@@ -33,7 +32,6 @@ from .conftest import MockAlarmControlPanel
 from tests.common import (
     MockConfigEntry,
     MockModule,
-    help_test_all,
     mock_integration,
     setup_test_component_platform,
 )
@@ -54,15 +52,6 @@ async def help_test_async_alarm_control_panel_service(
         alarm_control_panel.DOMAIN, service, data, blocking=True
     )
     await hass.async_block_till_done()
-
-
-@pytest.mark.parametrize(
-    "module",
-    [alarm_control_panel, alarm_control_panel.const],
-)
-def test_all(module: ModuleType) -> None:
-    """Test module.__all__ is correctly set."""
-    help_test_all(module)
 
 
 def test_deprecated_supported_features_ints(caplog: pytest.LogCaptureFixture) -> None:

--- a/tests/components/alarm_control_panel/test_init.py
+++ b/tests/components/alarm_control_panel/test_init.py
@@ -34,7 +34,6 @@ from tests.common import (
     MockConfigEntry,
     MockModule,
     help_test_all,
-    import_and_test_deprecated_constant_enum,
     mock_integration,
     setup_test_component_platform,
 )
@@ -64,44 +63,6 @@ async def help_test_async_alarm_control_panel_service(
 def test_all(module: ModuleType) -> None:
     """Test module.__all__ is correctly set."""
     help_test_all(module)
-
-
-@pytest.mark.parametrize(
-    "code_format",
-    list(alarm_control_panel.CodeFormat),
-)
-@pytest.mark.parametrize(
-    "module",
-    [alarm_control_panel, alarm_control_panel.const],
-)
-def test_deprecated_constant_code_format(
-    caplog: pytest.LogCaptureFixture,
-    code_format: alarm_control_panel.CodeFormat,
-    module: ModuleType,
-) -> None:
-    """Test deprecated format constants."""
-    import_and_test_deprecated_constant_enum(
-        caplog, module, code_format, "FORMAT_", "2025.1"
-    )
-
-
-@pytest.mark.parametrize(
-    "entity_feature",
-    list(alarm_control_panel.AlarmControlPanelEntityFeature),
-)
-@pytest.mark.parametrize(
-    "module",
-    [alarm_control_panel, alarm_control_panel.const],
-)
-def test_deprecated_support_alarm_constants(
-    caplog: pytest.LogCaptureFixture,
-    entity_feature: alarm_control_panel.AlarmControlPanelEntityFeature,
-    module: ModuleType,
-) -> None:
-    """Test deprecated support alarm constants."""
-    import_and_test_deprecated_constant_enum(
-        caplog, module, entity_feature, "SUPPORT_ALARM_", "2025.1"
-    )
 
 
 def test_deprecated_supported_features_ints(caplog: pytest.LogCaptureFixture) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Deprecated alarm control panel constants have been removed

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove deprecated alarm control panel constants

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
