### PR TITLE
Add config flow rules to quality_scale hassfest validation

### DIFF
--- a/homeassistant/components/mqtt/quality_scale.yaml
+++ b/homeassistant/components/mqtt/quality_scale.yaml
@@ -86,7 +86,10 @@ rules:
     comment: >
       This is not possible because the integrations generates entities
       based on a user supplied config or discovery.
-  reconfiguration-flow: done
+  reconfiguration-flow:
+    status: exempt
+    comment: >
+      This integration is reconfigured via options flow.
   dynamic-devices:
     status: done
     comment: |

--- a/script/hassfest/quality_scale.py
+++ b/script/hassfest/quality_scale.py
@@ -12,7 +12,13 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.util.yaml import load_yaml_dict
 
 from .model import Config, Integration, ScaledQualityScaleTiers
-from .quality_scale_validation import RuleValidationProtocol, config_entry_unloading
+from .quality_scale_validation import (
+    RuleValidationProtocol,
+    config_entry_unloading,
+    config_flow,
+    reauthentication_flow,
+    reconfiguration_flow,
+)
 
 QUALITY_SCALE_TIERS = {value.name.lower(): value for value in ScaledQualityScaleTiers}
 
@@ -32,7 +38,7 @@ ALL_RULES = [
     Rule("appropriate-polling", ScaledQualityScaleTiers.BRONZE),
     Rule("brands", ScaledQualityScaleTiers.BRONZE),
     Rule("common-modules", ScaledQualityScaleTiers.BRONZE),
-    Rule("config-flow", ScaledQualityScaleTiers.BRONZE),
+    Rule("config-flow", ScaledQualityScaleTiers.BRONZE, config_flow),
     Rule("config-flow-test-coverage", ScaledQualityScaleTiers.BRONZE),
     Rule("dependency-transparency", ScaledQualityScaleTiers.BRONZE),
     Rule("docs-actions", ScaledQualityScaleTiers.BRONZE),
@@ -57,7 +63,9 @@ ALL_RULES = [
     Rule("integration-owner", ScaledQualityScaleTiers.SILVER),
     Rule("log-when-unavailable", ScaledQualityScaleTiers.SILVER),
     Rule("parallel-updates", ScaledQualityScaleTiers.SILVER),
-    Rule("reauthentication-flow", ScaledQualityScaleTiers.SILVER),
+    Rule(
+        "reauthentication-flow", ScaledQualityScaleTiers.SILVER, reauthentication_flow
+    ),
     Rule("test-coverage", ScaledQualityScaleTiers.SILVER),
     # GOLD: [
     Rule("devices", ScaledQualityScaleTiers.GOLD),
@@ -78,7 +86,7 @@ ALL_RULES = [
     Rule("entity-translations", ScaledQualityScaleTiers.GOLD),
     Rule("exception-translations", ScaledQualityScaleTiers.GOLD),
     Rule("icon-translations", ScaledQualityScaleTiers.GOLD),
-    Rule("reconfiguration-flow", ScaledQualityScaleTiers.GOLD),
+    Rule("reconfiguration-flow", ScaledQualityScaleTiers.GOLD, reconfiguration_flow),
     Rule("repair-issues", ScaledQualityScaleTiers.GOLD),
     Rule("stale-devices", ScaledQualityScaleTiers.GOLD),
     # PLATINUM

--- a/script/hassfest/quality_scale_validation/config_entry_unloading.py
+++ b/script/hassfest/quality_scale_validation/config_entry_unloading.py
@@ -1,4 +1,7 @@
-"""Enforce that the integration implements entry unloading."""
+"""Enforce that the integration implements entry unloading.
+
+https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/config-entry-unloading/
+"""
 
 import ast
 

--- a/script/hassfest/quality_scale_validation/config_flow.py
+++ b/script/hassfest/quality_scale_validation/config_flow.py
@@ -1,0 +1,25 @@
+"""Enforce that the integration implements config flow.
+
+https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/config-flow/
+"""
+
+from homeassistant.generated import config_flows
+from script.hassfest.model import Integration
+
+
+def validate(integration: Integration) -> list[str] | None:
+    """Validate that the integration implements config flow."""
+
+    config_flow_file = integration.path / "config_flow.py"
+    if not config_flow_file.exists():
+        return [
+            "Integration does not implement config flow (is missing config_flow.py)",
+        ]
+
+    if integration.domain not in config_flows.FLOWS["integration"]:
+        return [
+            "Integration is missing from homeassistant/generator/config_flow.py "
+            f"(or homeassistant/components/{integration.domain}/manifest.json)",
+        ]
+
+    return None

--- a/script/hassfest/quality_scale_validation/config_flow.py
+++ b/script/hassfest/quality_scale_validation/config_flow.py
@@ -3,23 +3,22 @@
 https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/config-flow/
 """
 
-from homeassistant.generated import config_flows
 from script.hassfest.model import Integration
 
 
 def validate(integration: Integration) -> list[str] | None:
     """Validate that the integration implements config flow."""
 
+    if not integration.config_flow:
+        return [
+            "Integration does not set config_flow in its manifest "
+            f"homeassistant/components/{integration.domain}/manifest.json",
+        ]
+
     config_flow_file = integration.path / "config_flow.py"
     if not config_flow_file.exists():
         return [
             "Integration does not implement config flow (is missing config_flow.py)",
-        ]
-
-    if integration.domain not in config_flows.FLOWS["integration"]:
-        return [
-            "Integration is missing from homeassistant/generator/config_flow.py "
-            f"(or homeassistant/components/{integration.domain}/manifest.json)",
         ]
 
     return None

--- a/script/hassfest/quality_scale_validation/reauthentication_flow.py
+++ b/script/hassfest/quality_scale_validation/reauthentication_flow.py
@@ -1,0 +1,30 @@
+"""Enforce that the integration implements reauthentication flow.
+
+https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/reauthentication-flow/
+"""
+
+import ast
+
+from script.hassfest.model import Integration
+
+
+def _has_async_function(module: ast.Module, name: str) -> bool:
+    """Test if the module defines a function."""
+    return any(
+        type(item) is ast.AsyncFunctionDef and item.name == name
+        for item in ast.walk(module)
+    )
+
+
+def validate(integration: Integration) -> list[str] | None:
+    """Validate that the integration has a reauthentication flow."""
+
+    config_flow_file = integration.path / "config_flow.py"
+    config_flow = ast.parse(config_flow_file.read_text())
+
+    if not _has_async_function(config_flow, "async_step_reauth"):
+        return [
+            "Integration does not support a reauthentication flow "
+            f"(is missing `async_step_reauth` in {config_flow_file})"
+        ]
+    return None

--- a/script/hassfest/quality_scale_validation/reconfiguration_flow.py
+++ b/script/hassfest/quality_scale_validation/reconfiguration_flow.py
@@ -1,0 +1,30 @@
+"""Enforce that the integration implements reconfiguration flow.
+
+https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/reconfiguration-flow/
+"""
+
+import ast
+
+from script.hassfest.model import Integration
+
+
+def _has_async_function(module: ast.Module, name: str) -> bool:
+    """Test if the module defines a function."""
+    return any(
+        type(item) is ast.AsyncFunctionDef and item.name == name
+        for item in ast.walk(module)
+    )
+
+
+def validate(integration: Integration) -> list[str] | None:
+    """Validate that the integration has a reconfiguration flow."""
+
+    config_flow_file = integration.path / "config_flow.py"
+    config_flow = ast.parse(config_flow_file.read_text())
+
+    if not _has_async_function(config_flow, "async_step_reconfigure"):
+        return [
+            "Integration does not support a reconfiguration flow "
+            f"(is missing `async_step_reconfigure` in {config_flow_file})"
+        ]
+    return None


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add config flow rules to quality_scale hassfest validation:

- `config-flow`
  - ensure file exists
  - ensure manifest key is set (via `homeassistant/generator/config_flow.py`)
- `reauthentication-flow`
  - ensure step exists
- `reconfiguration-flow`
  - ensure step exists

Based on #131413 (thanks @allenporter)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
