### PR TITLE
Update buienradar sensors only after being added to HA

### DIFF
--- a/homeassistant/components/buienradar/sensor.py
+++ b/homeassistant/components/buienradar/sensor.py
@@ -766,10 +766,6 @@ class BrSensor(SensorEntity):
     def _load_data(self, data):  # noqa: C901
         """Load the sensor with relevant data."""
         # Find sensor
-
-        if not self.enabled:
-            return False
-
         # Check if we have a new measurement,
         # otherwise we do not have to update the sensor
         if self._measured == data.get(MEASURED):

--- a/homeassistant/components/buienradar/sensor.py
+++ b/homeassistant/components/buienradar/sensor.py
@@ -722,12 +722,12 @@ async def async_setup_entry(
         for description in SENSOR_TYPES
     ]
 
-    async_add_entities(entities)
-
     # create weather data:
     data = BrData(hass, coordinates, timeframe, entities)
     entry.runtime_data[Platform.SENSOR] = data
     await data.async_update()
+
+    async_add_entities(entities)
 
 
 class BrSensor(SensorEntity):
@@ -742,6 +742,7 @@ class BrSensor(SensorEntity):
     ) -> None:
         """Initialize the sensor."""
         self.entity_description = description
+        self._data: BrData | None = None
         self._measured = None
         self._attr_unique_id = (
             f"{coordinates[CONF_LATITUDE]:2.6f}{coordinates[CONF_LONGITUDE]:2.6f}"
@@ -756,10 +757,24 @@ class BrSensor(SensorEntity):
         if description.key.startswith(PRECIPITATION_FORECAST):
             self._timeframe = None
 
+    async def async_added_to_hass(self) -> None:
+        """Handle entity being added to hass."""
+        if self._data is None:
+            return
+        self._update()
+
     @callback
     def data_updated(self, data: BrData):
-        """Update data."""
-        if self._load_data(data.data) and self.hass:
+        """Handle data update."""
+        self._data = data
+        if not self.hass:
+            return
+        self._update()
+
+    def _update(self):
+        """Update sensor data."""
+        _LOGGER.debug("Updating sensor %s", self.entity_id)
+        if self._load_data(self._data.data):
             self.async_write_ha_state()
 
     @callback

--- a/homeassistant/components/buienradar/sensor.py
+++ b/homeassistant/components/buienradar/sensor.py
@@ -722,12 +722,12 @@ async def async_setup_entry(
         for description in SENSOR_TYPES
     ]
 
+    async_add_entities(entities)
+
     # create weather data:
     data = BrData(hass, coordinates, timeframe, entities)
     entry.runtime_data[Platform.SENSOR] = data
     await data.async_update()
-
-    async_add_entities(entities)
 
 
 class BrSensor(SensorEntity):
@@ -766,6 +766,9 @@ class BrSensor(SensorEntity):
     def _load_data(self, data):  # noqa: C901
         """Load the sensor with relevant data."""
         # Find sensor
+
+        if not self.enabled:
+            return False
 
         # Check if we have a new measurement,
         # otherwise we do not have to update the sensor

--- a/homeassistant/components/buienradar/sensor.py
+++ b/homeassistant/components/buienradar/sensor.py
@@ -780,7 +780,6 @@ class BrSensor(SensorEntity):
     @callback
     def _load_data(self, data):  # noqa: C901
         """Load the sensor with relevant data."""
-        # Find sensor
         # Check if we have a new measurement,
         # otherwise we do not have to update the sensor
         if self._measured == data.get(MEASURED):

--- a/homeassistant/components/buienradar/util.py
+++ b/homeassistant/components/buienradar/util.py
@@ -75,7 +75,8 @@ class BrData:
 
         # Update all devices
         for dev in self.devices:
-            dev.data_updated(self)
+            if dev.enabled:
+                dev.data_updated(self)
 
     @callback
     def async_schedule_update(self, minute=1):

--- a/homeassistant/components/buienradar/util.py
+++ b/homeassistant/components/buienradar/util.py
@@ -75,8 +75,7 @@ class BrData:
 
         # Update all devices
         for dev in self.devices:
-            if dev.enabled:
-                dev.data_updated(self)
+            dev.data_updated(self)
 
     @callback
     def async_schedule_update(self, minute=1):

--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -30,7 +30,7 @@ from homeassistant.helpers.deprecation import (
     check_if_deprecated_constant,
     dir_with_deprecated_constants,
 )
-from homeassistant.helpers.entity import Entity, EntityDescription, EntityPlatformState
+from homeassistant.helpers.entity import Entity, EntityDescription
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.entity_platform import EntityPlatform
 from homeassistant.helpers.restore_state import ExtraStoredData, RestoreEntity
@@ -481,6 +481,11 @@ class SensorEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
         """Return translation key for unit of measurement."""
         if self.translation_key is None:
             return None
+        if self.platform is None:
+            raise ValueError(
+                f"Sensor {type(self)} cannot have a translation key for "
+                "unit of measurement before being added to the entity platform"
+            )
         platform = self.platform
         return (
             f"component.{platform.platform_name}.entity.{platform.domain}"
@@ -535,11 +540,6 @@ class SensorEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
     @override
     def state(self) -> Any:
         """Return the state of the sensor and perform unit conversions, if needed."""
-        if self._platform_state is not EntityPlatformState.ADDED:
-            raise ValueError(
-                f"Cannot access state of entity {self.entity_id} ({type(self)}) "
-                "because it was not added to the entity platform"
-            )
         native_unit_of_measurement = self.native_unit_of_measurement
         unit_of_measurement = self.unit_of_measurement
         value = self.native_value

--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -30,7 +30,7 @@ from homeassistant.helpers.deprecation import (
     check_if_deprecated_constant,
     dir_with_deprecated_constants,
 )
-from homeassistant.helpers.entity import Entity, EntityDescription
+from homeassistant.helpers.entity import Entity, EntityDescription, EntityPlatformState
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.entity_platform import EntityPlatform
 from homeassistant.helpers.restore_state import ExtraStoredData, RestoreEntity
@@ -535,6 +535,11 @@ class SensorEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
     @override
     def state(self) -> Any:
         """Return the state of the sensor and perform unit conversions, if needed."""
+        if self._platform_state is not EntityPlatformState.ADDED:
+            raise ValueError(
+                f"Cannot access state of entity {self.entity_id} ({type(self)}) "
+                "because it was not added to the entity platform"
+            )
         native_unit_of_measurement = self.native_unit_of_measurement
         unit_of_measurement = self.unit_of_measurement
         value = self.native_value

--- a/tests/components/sensor/test_init.py
+++ b/tests/components/sensor/test_init.py
@@ -548,6 +548,45 @@ async def test_translated_unit_with_native_unit_raises(
         assert entity0.entity_id is None
 
 
+async def test_unit_translation_key_without_platform_raises(
+    hass: HomeAssistant,
+) -> None:
+    """Test that unit translation key property raises if the entity has no platform yet."""
+
+    with patch(
+        "homeassistant.helpers.service.translation.async_get_translations",
+        return_value={
+            "component.test.entity.sensor.test_translation_key.unit_of_measurement": "Tests"
+        },
+    ):
+        entity0 = MockSensor(
+            name="Test",
+            native_value="123",
+            unique_id="very_unique",
+        )
+        entity0.entity_description = SensorEntityDescription(
+            "test",
+            translation_key="test_translation_key",
+        )
+        with pytest.raises(
+            ValueError,
+            match="cannot have a translation key for unit of measurement before "
+            "being added to the entity platform",
+        ):
+            unit = entity0.unit_of_measurement  # noqa: F841
+
+        setup_test_component_platform(hass, sensor.DOMAIN, [entity0])
+
+        assert await async_setup_component(
+            hass, "sensor", {"sensor": {"platform": "test"}}
+        )
+        await hass.async_block_till_done()
+
+        # Should not raise after being added to the platform
+        unit = entity0.unit_of_measurement  # noqa: F841
+        assert unit == "Tests"
+
+
 @pytest.mark.parametrize(
     (
         "device_class",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The state of the entities was being updated before they were added to HA. They were also updated even when they were disabled. Both conditions caused a failure since `platform` was not set for the entity, which is required for the translated unit of measurement.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #131777
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
