### PR TITLE
Add a header auth provider

### DIFF
--- a/homeassistant/auth/models.py
+++ b/homeassistant/auth/models.py
@@ -5,12 +5,13 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from ipaddress import IPv4Address, IPv6Address
 import secrets
-from typing import Any, NamedTuple
+from typing import Any, NamedTuple, TypedDict
 import uuid
 
 import attr
 from attr import Attribute
 from attr.setters import validate
+from multidict import CIMultiDictProxy
 from propcache import cached_property
 
 from homeassistant.const import __version__
@@ -28,12 +29,20 @@ TOKEN_TYPE_LONG_LIVED_ACCESS_TOKEN = "long_lived_access_token"
 class AuthFlowContext(FlowContext, total=False):
     """Typed context dict for auth flow."""
 
+    headers: CIMultiDictProxy[str]
     credential_only: bool
     ip_address: IPv4Address | IPv6Address
     redirect_uri: str
 
 
 AuthFlowResult = FlowResult[AuthFlowContext, tuple[str, str]]
+
+
+class RefreshFlowContext(TypedDict, total=False):
+    """Typed context dict for refresh flow."""
+
+    headers: CIMultiDictProxy[str]
+    ip_address: IPv4Address | IPv6Address
 
 
 @attr.s(slots=True)

--- a/homeassistant/auth/providers/__init__.py
+++ b/homeassistant/auth/providers/__init__.py
@@ -26,6 +26,7 @@ from ..models import (
     AuthFlowContext,
     AuthFlowResult,
     Credentials,
+    RefreshFlowContext,
     RefreshToken,
     User,
     UserMeta,
@@ -132,7 +133,9 @@ class AuthProvider:
 
     @callback
     def async_validate_refresh_token(
-        self, refresh_token: RefreshToken, remote_ip: str | None = None
+        self,
+        refresh_token: RefreshToken,
+        context: RefreshFlowContext,
     ) -> None:
         """Verify a refresh token is still valid.
 

--- a/homeassistant/components/auth/login_flow.py
+++ b/homeassistant/components/auth/login_flow.py
@@ -323,6 +323,7 @@ class LoginFlowIndexView(LoginFlowBaseView):
             result = await self._flow_mgr.async_init(
                 handler,
                 context=AuthFlowContext(
+                    headers=request.headers,
                     ip_address=ip_address(request.remote),  # type: ignore[arg-type]
                     credential_only=data.get("type") == "link_user",
                     redirect_uri=redirect_uri,

--- a/homeassistant/components/websocket_api/auth.py
+++ b/homeassistant/components/websocket_api/auth.py
@@ -89,6 +89,7 @@ class AuthPhase:
                 self._send_message,
                 refresh_token.user,
                 refresh_token,
+                self._request,
             )
             conn.subscriptions["auth"] = (
                 self._hass.auth.async_register_revoke_token_callback(

--- a/homeassistant/components/websocket_api/connection.py
+++ b/homeassistant/components/websocket_api/connection.py
@@ -7,6 +7,7 @@ from contextvars import ContextVar
 from typing import TYPE_CHECKING, Any, Literal
 
 from aiohttp import web
+from aiohttp.web import Request
 import voluptuous as vol
 
 from homeassistant.auth.models import RefreshToken, User
@@ -51,6 +52,7 @@ class ActiveConnection:
         "supported_features",
         "handlers",
         "binary_handlers",
+        "request",
     )
 
     def __init__(
@@ -60,6 +62,7 @@ class ActiveConnection:
         send_message: Callable[[bytes | str | dict[str, Any]], None],
         user: User,
         refresh_token: RefreshToken,
+        request: Request,
     ) -> None:
         """Initialize an active connection."""
         self.logger = logger
@@ -75,6 +78,7 @@ class ActiveConnection:
             self.hass.data[const.DOMAIN]
         )
         self.binary_handlers: list[BinaryHandler | None] = []
+        self.request = request
         current_connection.set(self)
 
     def __repr__(self) -> str:

--- a/tests/auth/providers/test_header.py
+++ b/tests/auth/providers/test_header.py
@@ -1,0 +1,237 @@
+"""Test the Trusted Networks auth provider."""
+
+from ipaddress import ip_address
+from unittest.mock import Mock, patch
+
+from hass_nabucasa import remote
+import pytest
+import voluptuous as vol
+
+from homeassistant import auth
+from homeassistant.auth import auth_store
+from homeassistant.auth.models import RefreshFlowContext
+from homeassistant.auth.providers import header as header_auth
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+
+@pytest.fixture
+async def store(hass: HomeAssistant) -> auth_store.AuthStore:
+    """Mock store."""
+    store = auth_store.AuthStore(hass)
+    await store.async_load()
+    return store
+
+
+@pytest.fixture
+def provider(
+    hass: HomeAssistant, store: auth_store.AuthStore
+) -> header_auth.HeaderAuthProvider:
+    """Mock provider."""
+    return header_auth.HeaderAuthProvider(
+        hass,
+        store,
+        header_auth.CONFIG_SCHEMA(
+            {
+                "type": "header",
+                "token_sha256": "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+            },
+        ),
+    )
+
+
+@pytest.fixture
+def provider_bypass_login(
+    hass: HomeAssistant, store: auth_store.AuthStore
+) -> header_auth.HeaderAuthProvider:
+    """Mock provider."""
+    return header_auth.HeaderAuthProvider(
+        hass,
+        store,
+        header_auth.CONFIG_SCHEMA(
+            {
+                "type": "header",
+                "token_sha256": "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+                "allow_bypass_login": True,
+            },
+        ),
+    )
+
+
+@pytest.fixture
+def manager(
+    hass: HomeAssistant,
+    store: auth_store.AuthStore,
+    provider: header_auth.HeaderAuthProvider,
+) -> auth.AuthManager:
+    """Mock manager."""
+    return auth.AuthManager(hass, store, {(provider.type, provider.id): provider}, {})
+
+
+@pytest.fixture
+def manager_bypass_login(
+    hass: HomeAssistant,
+    store: auth_store.AuthStore,
+    provider_bypass_login: header_auth.HeaderAuthProvider,
+) -> auth.AuthManager:
+    """Mock manager with allow bypass login."""
+    return auth.AuthManager(
+        hass,
+        store,
+        {(provider_bypass_login.type, provider_bypass_login.id): provider_bypass_login},
+        {},
+    )
+
+
+async def test_config_schema() -> None:
+    """Test CONFIG_SCHEMA."""
+    # Valid configuration
+    header_auth.CONFIG_SCHEMA(
+        {
+            "type": "header",
+            "token_sha256": "abc123",
+            "allow_bypass_login": True,
+        }
+    )
+    # Wrong token format
+    with pytest.raises(vol.Invalid):
+        header_auth.CONFIG_SCHEMA(
+            {
+                "type": "trusted_networks",
+                "token_sha256": "abc123",
+                "allow_bypass_login": "hi",
+            }
+        )
+
+
+async def test_trusted_networks_credentials(
+    manager: auth.AuthManager, provider: header_auth.HeaderAuthProvider
+) -> None:
+    """Test header credentials related functions."""
+    owner = await manager.async_create_user("test-owner")
+    tn_owner_cred = await provider.async_get_or_create_credentials({"user": owner.id})
+    assert tn_owner_cred.is_new is False
+    assert any(cred.id == tn_owner_cred.id for cred in owner.credentials)
+
+    user = await manager.async_create_user("test-user")
+    tn_user_cred = await provider.async_get_or_create_credentials({"user": user.id})
+    assert tn_user_cred.id != tn_owner_cred.id
+    assert tn_user_cred.is_new is False
+    assert any(cred.id == tn_user_cred.id for cred in user.credentials)
+
+    with pytest.raises(header_auth.InvalidUserError):
+        await provider.async_get_or_create_credentials({"user": "invalid-user"})
+
+
+async def test_validate_access(provider: header_auth.HeaderAuthProvider) -> None:
+    """Test validate access from trusted networks."""
+    provider.async_validate_access("test")
+
+    with pytest.raises(auth.InvalidAuthError):
+        provider.async_validate_access("not test")
+
+
+async def test_validate_access_cloud(
+    hass: HomeAssistant,
+    provider: header_auth.HeaderAuthProvider,
+) -> None:
+    """Test validate access from trusted networks are blocked from cloud."""
+    hass.config.components.add("cloud")
+
+    provider.async_validate_access("test")
+
+    remote.is_cloud_request.set(True)
+    with pytest.raises(auth.InvalidAuthError):
+        provider.async_validate_access("test")
+
+
+async def test_validate_refresh_token(
+    provider: header_auth.HeaderAuthProvider,
+) -> None:
+    """Verify re-validation of refresh token."""
+    with patch.object(provider, "async_validate_access") as mock:
+        with pytest.raises(auth.InvalidAuthError):
+            provider.async_validate_refresh_token(Mock(), RefreshFlowContext())
+
+        provider.async_validate_refresh_token(
+            Mock(), RefreshFlowContext(headers={header_auth.HEADER_NAME: "test"})
+        )
+        mock.assert_called_once_with("test")
+
+
+async def test_login_flow(
+    manager: auth.AuthManager, provider: header_auth.HeaderAuthProvider
+) -> None:
+    """Test login flow."""
+    owner = await manager.async_create_user("test-owner")
+    user = await manager.async_create_user("test-user")
+
+    # missing header
+    flow = await provider.async_login_flow(
+        {"headers": {}, "ip_address": ip_address("127.0.0.1")}
+    )
+    step = await flow.async_step_init()
+    assert step["type"] == FlowResultType.ABORT
+    assert step["reason"] == "not_allowed"
+
+    # header present, list users
+    flow = await provider.async_login_flow(
+        {
+            "headers": {header_auth.HEADER_NAME: "test"},
+            "ip_address": ip_address("127.0.0.1"),
+        }
+    )
+    step = await flow.async_step_init()
+    assert step["step_id"] == "init"
+
+    schema = step["data_schema"]
+    assert schema({"user": owner.id})
+    with pytest.raises(vol.Invalid):
+        assert schema({"user": "invalid-user"})
+
+    # login with valid user
+    step = await flow.async_step_init({"user": user.id})
+    assert step["type"] == FlowResultType.CREATE_ENTRY
+    assert step["data"]["user"] == user.id
+
+
+async def test_bypass_login_flow(
+    manager_bypass_login: auth.AuthManager,
+    provider_bypass_login: header_auth.HeaderAuthProvider,
+) -> None:
+    """Test login flow can be bypass if only one user available."""
+    owner = await manager_bypass_login.async_create_user("test-owner")
+
+    # incorrect header
+    flow = await provider_bypass_login.async_login_flow(
+        {"headers": {header_auth.HEADER_NAME: "not test"}}
+    )
+    step = await flow.async_step_init()
+    assert step["type"] == FlowResultType.ABORT
+    assert step["reason"] == "not_allowed"
+
+    # correct header, only one available user, bypass the login flow
+    flow = await provider_bypass_login.async_login_flow(
+        {
+            "headers": {header_auth.HEADER_NAME: "test"},
+            "ip_address": ip_address("127.0.0.1"),
+        }
+    )
+    step = await flow.async_step_init()
+    assert step["type"] == FlowResultType.CREATE_ENTRY
+    assert step["data"]["user"] == owner.id
+
+    user = await manager_bypass_login.async_create_user("test-user")
+
+    # correct header, two available user, show up login form
+    flow = await provider_bypass_login.async_login_flow(
+        {
+            "headers": {header_auth.HEADER_NAME: "test"},
+            "ip_address": ip_address("127.0.0.1"),
+        }
+    )
+    step = await flow.async_step_init()
+    schema = step["data_schema"]
+    # both owner and user listed
+    assert schema({"user": owner.id})
+    assert schema({"user": user.id})

--- a/tests/auth/providers/test_trusted_networks.py
+++ b/tests/auth/providers/test_trusted_networks.py
@@ -9,6 +9,7 @@ import voluptuous as vol
 
 from homeassistant import auth
 from homeassistant.auth import auth_store
+from homeassistant.auth.models import RefreshFlowContext
 from homeassistant.auth.providers import trusted_networks as tn_auth
 from homeassistant.components.http import CONF_TRUSTED_PROXIES, CONF_USE_X_FORWARDED_FOR
 from homeassistant.core import HomeAssistant
@@ -251,9 +252,11 @@ async def test_validate_refresh_token(
     """Verify re-validation of refresh token."""
     with patch.object(provider, "async_validate_access") as mock:
         with pytest.raises(auth.InvalidAuthError):
-            provider.async_validate_refresh_token(Mock(), None)
+            provider.async_validate_refresh_token(Mock(), RefreshFlowContext())
 
-        provider.async_validate_refresh_token(Mock(), "127.0.0.1")
+        provider.async_validate_refresh_token(
+            Mock(), RefreshFlowContext(ip_address=ip_address("127.0.0.1"))
+        )
         mock.assert_called_once_with(ip_address("127.0.0.1"))
 
 

--- a/tests/components/auth/test_init_link_user.py
+++ b/tests/components/auth/test_init_link_user.py
@@ -4,6 +4,7 @@ from http import HTTPStatus
 from typing import Any
 from unittest.mock import patch
 
+from homeassistant.auth.models import RefreshFlowContext
 from homeassistant.core import HomeAssistant
 
 from . import async_setup_auth
@@ -36,7 +37,9 @@ async def async_get_code(
     client = await async_setup_auth(hass, aiohttp_client, config)
     user = await hass.auth.async_create_user(name="Hello")
     refresh_token = await hass.auth.async_create_refresh_token(user, CLIENT_ID)
-    access_token = hass.auth.async_create_access_token(refresh_token)
+    access_token = hass.auth.async_create_access_token(
+        refresh_token, RefreshFlowContext()
+    )
 
     # Now authenticate with the 2nd flow
     resp = await client.post(

--- a/tests/components/auth/test_mfa_setup_flow.py
+++ b/tests/components/auth/test_mfa_setup_flow.py
@@ -1,6 +1,7 @@
 """Tests for the mfa setup flow."""
 
 from homeassistant.auth import auth_manager_from_config
+from homeassistant.auth.models import RefreshFlowContext
 from homeassistant.components.auth import mfa_setup_flow
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -45,7 +46,9 @@ async def test_ws_setup_depose_mfa(
     )
     await hass.auth.async_link_user(user, cred)
     refresh_token = await hass.auth.async_create_refresh_token(user, CLIENT_ID)
-    access_token = hass.auth.async_create_access_token(refresh_token)
+    access_token = hass.auth.async_create_access_token(
+        refresh_token, RefreshFlowContext()
+    )
 
     client = await hass_ws_client(hass, access_token)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -708,7 +708,7 @@ async def hass_access_token(
     refresh_token = await hass.auth.async_create_refresh_token(
         hass_admin_user, CLIENT_ID, credential=hass_admin_credential
     )
-    return hass.auth.async_create_access_token(refresh_token)
+    return hass.auth.async_create_access_token(refresh_token, {})
 
 
 @pytest.fixture


### PR DESCRIPTION
Implement a "header" auth provider for helping home assistant play slightly nicer with external auth providers. This is pretty simple but should cover many setups with a reverse proxy. I considered adding a user selection header as well, but I think that should probably be left to a more robust provider (for example oauth2) in the future.

Config looks like this

```yaml
homeassistant:
  auth_providers:
    - type: header
      token_sha256: 9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08
      allow_bypass_login: true
    - type: homeassistant
```

And then a reverse proxy (for example caddy) can add the header after auth checks:

```caddyfile
hass.snek.dev {
  forward_auth http://127.0.0.1:4180
  reverse_proxy http://127.0.0.1:8123 {
    header_up x-homeassistant-token test
  }
}
```