### PR TITLE
Add runtime_data rule to quality_scale hassfest validation

### DIFF
--- a/script/hassfest/quality_scale.py
+++ b/script/hassfest/quality_scale.py
@@ -18,6 +18,8 @@ from .quality_scale_validation import (
     config_flow,
     reauthentication_flow,
     reconfiguration_flow,
+    runtime_data,
+
 )
 
 QUALITY_SCALE_TIERS = {value.name.lower(): value for value in ScaledQualityScaleTiers}
@@ -48,7 +50,7 @@ ALL_RULES = [
     Rule("entity-event-setup", ScaledQualityScaleTiers.BRONZE),
     Rule("entity-unique-id", ScaledQualityScaleTiers.BRONZE),
     Rule("has-entity-name", ScaledQualityScaleTiers.BRONZE),
-    Rule("runtime-data", ScaledQualityScaleTiers.BRONZE),
+    Rule("runtime-data", ScaledQualityScaleTiers.BRONZE, runtime_data),
     Rule("test-before-configure", ScaledQualityScaleTiers.BRONZE),
     Rule("test-before-setup", ScaledQualityScaleTiers.BRONZE),
     Rule("unique-config-entry", ScaledQualityScaleTiers.BRONZE),

--- a/script/hassfest/quality_scale.py
+++ b/script/hassfest/quality_scale.py
@@ -19,7 +19,6 @@ from .quality_scale_validation import (
     reauthentication_flow,
     reconfiguration_flow,
     runtime_data,
-
 )
 
 QUALITY_SCALE_TIERS = {value.name.lower(): value for value in ScaledQualityScaleTiers}

--- a/script/hassfest/quality_scale_validation/runtime_data.py
+++ b/script/hassfest/quality_scale_validation/runtime_data.py
@@ -1,4 +1,7 @@
-"""Enforce that the integration only uses ConfigEntry.runtime_data."""
+"""Enforce that the integration only uses ConfigEntry.runtime_data.
+
+https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/runtime-data
+"""
 
 import ast
 from collections.abc import Generator

--- a/script/hassfest/quality_scale_validation/runtime_data.py
+++ b/script/hassfest/quality_scale_validation/runtime_data.py
@@ -8,16 +8,33 @@ import ast
 from script.hassfest.model import Integration
 
 
-def _has_attribute_access(tree: ast.AST, node_name: str, attribute_name: str) -> bool:
-    """Check if a node with the specified attribute is accessed."""
+def _sets_attribute(tree: ast.AST, node_name: str, attribute_name: str) -> bool:
+    """Check that an attribute is set on a node within the tree."""
     for node in ast.walk(tree):
         if (
             isinstance(node, ast.Attribute)
             and isinstance(node.value, ast.Name)
             and node.value.id == node_name
             and node.attr == attribute_name
+            and isinstance(node.ctx, ast.Store)
         ):
             return True
+    return False
+
+
+def _sets_runtime_data_on_setup(init: ast.AST, filename: str) -> bool:
+    """Check if the integration sets entry.runtime_data in async_setup_entry."""
+    for item in init.body:
+        if not (
+            isinstance(item, ast.AsyncFunctionDef) and item.name == "async_setup_entry"
+        ):
+            continue
+        if len(item.args.args) != 2:
+            raise ValueError(
+                f"async_setup_entry in {filename} has incorrect signature (expected 2 arguments)"
+            )
+        config_entry_arg = item.args.args[1].arg
+        return _sets_attribute(item, config_entry_arg, "runtime_data")
     return False
 
 
@@ -26,9 +43,9 @@ def validate(integration: Integration) -> list[str] | None:
     init_file = integration.path / "__init__.py"
     init = ast.parse(init_file.read_text())
 
-    if not _defines_runtime_data_on_setup(init):
+    if not _sets_runtime_data_on_setup(init, init_file):
         return [
-            "Integration does not define entry.runtime_data in async_setup_entry",
+            "Integration does not set entry.runtime_data in async_setup_entry",
         ]
 
     return None

--- a/script/hassfest/quality_scale_validation/runtime_data.py
+++ b/script/hassfest/quality_scale_validation/runtime_data.py
@@ -1,13 +1,15 @@
 """Enforce that the integration only uses ConfigEntry.runtime_data."""
 
 import ast
-import pathlib
 from collections.abc import Generator
+import pathlib
 
 from script.hassfest.model import Integration
 
 
-def _integration_python_files(integration: Integration) -> Generator[pathlib.Path, None, None]:
+def _integration_python_files(
+    integration: Integration,
+) -> Generator[pathlib.Path, None, None]:
     """Return all python files in the integration."""
     for root, _dirs, files in integration.path.walk():
         for file in files:
@@ -26,6 +28,7 @@ def _has_hass_data(tree: ast.Module) -> bool:
         ):
             return True
     return False
+
 
 def validate(integration: Integration) -> list[str] | None:
     """Validate that the integration does not use hass.data."""

--- a/script/hassfest/quality_scale_validation/runtime_data.py
+++ b/script/hassfest/quality_scale_validation/runtime_data.py
@@ -26,16 +26,9 @@ def validate(integration: Integration) -> list[str] | None:
     init_file = integration.path / "__init__.py"
     init = ast.parse(init_file.read_text())
 
-    for item in init.body:
-        if isinstance(item, ast.AsyncFunctionDef) and item.name == "async_setup_entry":
-            if len(item.args.args) != 2:
-                raise ValueError(
-                    f"async_setup_entry in {init_file} has incorrect signature (expected 2 arguments)"
-                )
-            config_entry_arg = item.args.args[1].arg
-            if not _has_attribute_access(item, config_entry_arg, "runtime_data"):
-                return [
-                    "Integration does not use ConfigEntry.runtime_data in async_setup_entry.",
-                ]
+    if not _defines_runtime_data_on_setup(init):
+        return [
+            "Integration does not define entry.runtime_data in async_setup_entry",
+        ]
 
     return None

--- a/script/hassfest/quality_scale_validation/runtime_data.py
+++ b/script/hassfest/quality_scale_validation/runtime_data.py
@@ -1,0 +1,41 @@
+"""Enforce that the integration only uses ConfigEntry.runtime_data."""
+
+import ast
+import pathlib
+from collections.abc import Generator
+
+from script.hassfest.model import Integration
+
+
+def _integration_python_files(integration: Integration) -> Generator[pathlib.Path, None, None]:
+    """Return all python files in the integration."""
+    for root, _dirs, files in integration.path.walk():
+        for file in files:
+            if file.endswith(".py"):
+                yield root / file
+
+
+def _has_hass_data(tree: ast.Module) -> bool:
+    """Test if the module uses hass.data."""
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Attribute)
+            and isinstance(node.value, ast.Name)
+            and node.value.id == "hass"
+            and node.attr == "data"
+        ):
+            return True
+    return False
+
+def validate(integration: Integration) -> list[str] | None:
+    """Validate that the integration does not use hass.data."""
+    rules = []
+    for file_path in _integration_python_files(integration):
+        module = ast.parse(file_path.read_text())
+        if _has_hass_data(module):
+            rules.append(
+                "Integration is not exclusively using ConfigEntry.runtime_data "
+                f"(found use of hass.data in {file_path}). You may add an exemption "
+                "to this using hass.data for global storage not specific to a config entry.)",
+            )
+    return rules

--- a/script/hassfest/quality_scale_validation/runtime_data.py
+++ b/script/hassfest/quality_scale_validation/runtime_data.py
@@ -8,44 +8,46 @@ import ast
 from script.hassfest.model import Integration
 
 
-def _sets_attribute(tree: ast.AST, node_name: str, attribute_name: str) -> bool:
-    """Check that an attribute is set on a node within the tree."""
-    for node in ast.walk(tree):
+def _sets_runtime_data(
+    async_setup_entry_function: ast.AsyncFunctionDef, config_entry_argument: ast.arg
+) -> bool:
+    """Check that `entry.runtime` gets set within `async_setup_entry`."""
+    for node in ast.walk(async_setup_entry_function):
         if (
             isinstance(node, ast.Attribute)
             and isinstance(node.value, ast.Name)
-            and node.value.id == node_name
-            and node.attr == attribute_name
+            and node.value.id == config_entry_argument.arg
+            and node.attr == "runtime_data"
             and isinstance(node.ctx, ast.Store)
         ):
             return True
     return False
 
 
-def _sets_runtime_data_on_setup(init: ast.AST, filename: str) -> bool:
-    """Check if the integration sets entry.runtime_data in async_setup_entry."""
-    for item in init.body:
-        if not (
-            isinstance(item, ast.AsyncFunctionDef) and item.name == "async_setup_entry"
-        ):
-            continue
-        if len(item.args.args) != 2:
-            raise ValueError(
-                f"async_setup_entry in {filename} has incorrect signature (expected 2 arguments)"
-            )
-        config_entry_arg = item.args.args[1].arg
-        return _sets_attribute(item, config_entry_arg, "runtime_data")
-    return False
+def _get_setup_entry_function(module: ast.Module) -> ast.AsyncFunctionDef | None:
+    """Get async_setup_entry function."""
+    for item in module.body:
+        if isinstance(item, ast.AsyncFunctionDef) and item.name == "async_setup_entry":
+            return item
+    return None
 
 
 def validate(integration: Integration) -> list[str] | None:
-    """Validate that the integration uses ConfigEntry.runtime_data to store runtime data."""
+    """Validate correct use of ConfigEntry.runtime_data."""
     init_file = integration.path / "__init__.py"
     init = ast.parse(init_file.read_text())
 
-    if not _sets_runtime_data_on_setup(init, init_file):
+    # Should not happen, but better to be safe
+    if not (async_setup_entry := _get_setup_entry_function(init)):
+        return [f"Could not find `async_setup_entry` in {init_file}"]
+    if len(async_setup_entry.args.args) != 2:
+        return [f"async_setup_entry has incorrect signature in {init_file}"]
+    config_entry_argument = async_setup_entry.args.args[1]
+
+    if not _sets_runtime_data(async_setup_entry, config_entry_argument):
         return [
-            "Integration does not set entry.runtime_data in async_setup_entry",
+            "Integration does not set entry.runtime_data in async_setup_entry"
+            f"({init_file})"
         ]
 
     return None

--- a/script/hassfest/quality_scale_validation/runtime_data.py
+++ b/script/hassfest/quality_scale_validation/runtime_data.py
@@ -35,13 +35,13 @@ def _has_hass_data(tree: ast.Module) -> bool:
 
 def validate(integration: Integration) -> list[str] | None:
     """Validate that the integration does not use hass.data."""
-    rules = []
+    errors = []
     for file_path in _integration_python_files(integration):
         module = ast.parse(file_path.read_text())
         if _has_hass_data(module):
-            rules.append(
+            errors.append(
                 "Integration is not exclusively using ConfigEntry.runtime_data "
                 f"(found use of hass.data in {file_path}). You may add an exemption "
                 "to this using hass.data for global storage not specific to a config entry.)",
             )
-    return rules
+    return errors


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add hassfest quality scale check for runtime_data pulled from #131413

```
Integration rainbird:
* [ERROR] [QUALITY_SCALE] [runtime-data] Integration is not exclusively using ConfigEntry.runtime_data (found use of hass.data in homeassistant/components/rainbird/__init__.py). You may add an exemption to this using hass.data for global storage not specific to a config entry.)
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
