### PR TITLE
Bump elmax-api to 0.0.6.3

### DIFF
--- a/homeassistant/components/elmax/common.py
+++ b/homeassistant/components/elmax/common.py
@@ -35,7 +35,7 @@ def check_local_version_supported(api_version: str | None) -> bool:
 class DirectPanel(PanelEntry):
     """Helper class for wrapping a directly accessed Elmax Panel."""
 
-    def __init__(self, panel_uri):
+    def __init__(self, panel_uri) -> None:
         """Construct the object."""
         super().__init__(panel_uri, True, {})
 

--- a/homeassistant/components/elmax/config_flow.py
+++ b/homeassistant/components/elmax/config_flow.py
@@ -203,7 +203,7 @@ class ElmaxConfigFlow(ConfigFlow, domain=DOMAIN):
 
     async def async_step_direct(self, user_input: dict[str, Any]) -> ConfigFlowResult:
         """Handle the direct setup step."""
-        self._selected_mode = CONF_ELMAX_MODE_CLOUD
+        self._selected_mode = CONF_ELMAX_MODE_DIRECT
         if user_input is None:
             return self.async_show_form(
                 step_id=CONF_ELMAX_MODE_DIRECT,

--- a/homeassistant/components/elmax/cover.py
+++ b/homeassistant/components/elmax/cover.py
@@ -121,13 +121,13 @@ class ElmaxCover(ElmaxEntity, CoverEntity):
         else:
             _LOGGER.debug("Ignoring stop request as the cover is IDLE")
 
-    async def async_open_cover(self, **kwargs):
+    async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""
         await self.coordinator.http_client.execute_command(
             endpoint_id=self._device.endpoint_id, command=CoverCommand.UP
         )
 
-    async def async_close_cover(self, **kwargs):
+    async def async_close_cover(self, **kwargs: Any) -> None:
         """Close the cover."""
         await self.coordinator.http_client.execute_command(
             endpoint_id=self._device.endpoint_id, command=CoverCommand.DOWN

--- a/homeassistant/components/elmax/manifest.json
+++ b/homeassistant/components/elmax/manifest.json
@@ -6,7 +6,7 @@
   "documentation": "https://www.home-assistant.io/integrations/elmax",
   "iot_class": "cloud_polling",
   "loggers": ["elmax_api"],
-  "requirements": ["elmax-api==0.0.6.3rc2"],
+  "requirements": ["elmax-api==0.0.6.3"],
   "zeroconf": [
     {
       "type": "_elmax-ssl._tcp.local."

--- a/homeassistant/components/elmax/manifest.json
+++ b/homeassistant/components/elmax/manifest.json
@@ -6,7 +6,7 @@
   "documentation": "https://www.home-assistant.io/integrations/elmax",
   "iot_class": "cloud_polling",
   "loggers": ["elmax_api"],
-  "requirements": ["elmax-api==0.0.6.3"],
+  "requirements": ["elmax-api==0.0.6.1"],
   "zeroconf": [
     {
       "type": "_elmax-ssl._tcp.local."

--- a/homeassistant/components/elmax/manifest.json
+++ b/homeassistant/components/elmax/manifest.json
@@ -6,7 +6,7 @@
   "documentation": "https://www.home-assistant.io/integrations/elmax",
   "iot_class": "cloud_polling",
   "loggers": ["elmax_api"],
-  "requirements": ["elmax-api==0.0.6.2"],
+  "requirements": ["elmax-api==0.0.6.3rc2"],
   "zeroconf": [
     {
       "type": "_elmax-ssl._tcp.local."

--- a/homeassistant/components/elmax/manifest.json
+++ b/homeassistant/components/elmax/manifest.json
@@ -6,7 +6,7 @@
   "documentation": "https://www.home-assistant.io/integrations/elmax",
   "iot_class": "cloud_polling",
   "loggers": ["elmax_api"],
-  "requirements": ["elmax-api==0.0.6.2"],
+  "requirements": ["elmax-api==0.0.6.3"],
   "zeroconf": [
     {
       "type": "_elmax-ssl._tcp.local."

--- a/homeassistant/components/elmax/manifest.json
+++ b/homeassistant/components/elmax/manifest.json
@@ -6,7 +6,7 @@
   "documentation": "https://www.home-assistant.io/integrations/elmax",
   "iot_class": "cloud_polling",
   "loggers": ["elmax_api"],
-  "requirements": ["elmax-api==0.0.6.1"],
+  "requirements": ["elmax-api==0.0.6.2"],
   "zeroconf": [
     {
       "type": "_elmax-ssl._tcp.local."

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -821,7 +821,7 @@ eliqonline==1.2.2
 elkm1-lib==2.2.10
 
 # homeassistant.components.elmax
-elmax-api==0.0.6.3rc2
+elmax-api==0.0.6.3
 
 # homeassistant.components.elvia
 elvia==0.1.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -821,7 +821,7 @@ eliqonline==1.2.2
 elkm1-lib==2.2.10
 
 # homeassistant.components.elmax
-elmax-api==0.0.6.1
+elmax-api==0.0.6.2
 
 # homeassistant.components.elvia
 elvia==0.1.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -821,7 +821,7 @@ eliqonline==1.2.2
 elkm1-lib==2.2.10
 
 # homeassistant.components.elmax
-elmax-api==0.0.6.2
+elmax-api==0.0.6.3rc2
 
 # homeassistant.components.elvia
 elvia==0.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -696,7 +696,7 @@ elgato==5.1.2
 elkm1-lib==2.2.10
 
 # homeassistant.components.elmax
-elmax-api==0.0.6.1
+elmax-api==0.0.6.2
 
 # homeassistant.components.elvia
 elvia==0.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -696,7 +696,7 @@ elgato==5.1.2
 elkm1-lib==2.2.10
 
 # homeassistant.components.elmax
-elmax-api==0.0.6.2
+elmax-api==0.0.6.3rc2
 
 # homeassistant.components.elvia
 elvia==0.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -696,7 +696,7 @@ elgato==5.1.2
 elkm1-lib==2.2.10
 
 # homeassistant.components.elmax
-elmax-api==0.0.6.3rc2
+elmax-api==0.0.6.3
 
 # homeassistant.components.elvia
 elvia==0.1.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
None.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Fix the integration setup issue when targeting a local-panel (username key error).
- Upgrade low-level library dependency from v0.0.6.1 to v0.0.6.3rc2. Changelog [here](https://github.com/albertogeniola/elmax-api/blob/main/CHANGELOG.md#0063rc2).
What changed:
```md
# 0.0.6.3rc2
- Implement refresh token api
- Improve websocket connection handling
- Reduce wait time before reconnecting to websocket in case of connection drop

# v0.0.6.2
- Fix wrong protocol check to better handle https/wss endpoints with SSL
- Handle pipy dependency to explicitly point to the new asyncio implementation
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #131872
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
