### PR TITLE
Add strict_typing rule to quality_scale hassfest validation

### DIFF
--- a/.strict-typing
+++ b/.strict-typing
@@ -41,6 +41,7 @@ homeassistant.util.unit_system
 # --- Add components below this line ---
 homeassistant.components
 homeassistant.components.abode.*
+homeassistant.components.acaia.*
 homeassistant.components.accuweather.*
 homeassistant.components.acer_projector.*
 homeassistant.components.acmeda.*

--- a/mypy.ini
+++ b/mypy.ini
@@ -165,6 +165,16 @@ disallow_untyped_defs = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.acaia.*]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-homeassistant.components.accuweather.*]
 check_untyped_defs = true
 disallow_incomplete_defs = true

--- a/script/hassfest/quality_scale.py
+++ b/script/hassfest/quality_scale.py
@@ -19,6 +19,7 @@ from .quality_scale_validation import (
     diagnostics,
     reauthentication_flow,
     reconfiguration_flow,
+    strict_typing,
 )
 
 QUALITY_SCALE_TIERS = {value.name.lower(): value for value in ScaledQualityScaleTiers}
@@ -93,7 +94,7 @@ ALL_RULES = [
     # PLATINUM
     Rule("async-dependency", ScaledQualityScaleTiers.PLATINUM),
     Rule("inject-websession", ScaledQualityScaleTiers.PLATINUM),
-    Rule("strict-typing", ScaledQualityScaleTiers.PLATINUM),
+    Rule("strict-typing", ScaledQualityScaleTiers.PLATINUM, strict_typing),
 ]
 
 SCALE_RULES = {

--- a/script/hassfest/quality_scale_validation/strict_typing.py
+++ b/script/hassfest/quality_scale_validation/strict_typing.py
@@ -1,0 +1,35 @@
+"""Enforce that the integration has strict typing enabled.
+
+https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/strict-typing/
+"""
+
+from functools import lru_cache
+from pathlib import Path
+import re
+
+from script.hassfest.model import Integration
+
+_STRICT_TYPING_FILE = Path(".strict-typing")
+_COMPONENT_REGEX = r"homeassistant.components.([^.]+).*"
+
+
+@lru_cache
+def _strict_typing_components() -> set[str]:
+    return set(
+        {
+            match.group(1)
+            for line in _STRICT_TYPING_FILE.read_text(encoding="utf-8").splitlines()
+            if (match := re.match(_COMPONENT_REGEX, line)) is not None
+        }
+    )
+
+
+def validate(integration: Integration) -> list[str] | None:
+    """Validate that the integration has strict typing enabled."""
+
+    if integration.domain not in _strict_typing_components():
+        return [
+            "Integration does not have strict typing enabled "
+            "(is missing from .strict-typing)"
+        ]
+    return None


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Pulled from https://github.com/home-assistant/core/pull/131413

cc @allenporter

```
Integration acaia:
* [ERROR] [QUALITY_SCALE] [strict-typing] Integration does not have strict typing enabled (is missing from .strict-typing)
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
