### PR TITLE
Add unique_config_entry rule to quality_scale hassfest validation

### DIFF
--- a/script/hassfest/quality_scale.py
+++ b/script/hassfest/quality_scale.py
@@ -20,6 +20,7 @@ from .quality_scale_validation import (
     reauthentication_flow,
     reconfiguration_flow,
     strict_typing,
+    unique_config_entry,
 )
 
 QUALITY_SCALE_TIERS = {value.name.lower(): value for value in ScaledQualityScaleTiers}
@@ -53,7 +54,7 @@ ALL_RULES = [
     Rule("runtime-data", ScaledQualityScaleTiers.BRONZE),
     Rule("test-before-configure", ScaledQualityScaleTiers.BRONZE),
     Rule("test-before-setup", ScaledQualityScaleTiers.BRONZE),
-    Rule("unique-config-entry", ScaledQualityScaleTiers.BRONZE),
+    Rule("unique-config-entry", ScaledQualityScaleTiers.BRONZE, unique_config_entry),
     # SILVER
     Rule("action-exceptions", ScaledQualityScaleTiers.SILVER),
     Rule(

--- a/script/hassfest/quality_scale_validation/unique_config_entry.py
+++ b/script/hassfest/quality_scale_validation/unique_config_entry.py
@@ -44,6 +44,6 @@ def validate(integration: Integration) -> list[str] | None:
     ):
         return [
             "Integration doesn't prevent the same device or service from being "
-            f"set up twice (please review {config_flow_file})"
+            f"set up twice in {config_flow_file}"
         ]
     return None

--- a/script/hassfest/quality_scale_validation/unique_config_entry.py
+++ b/script/hassfest/quality_scale_validation/unique_config_entry.py
@@ -1,0 +1,49 @@
+"""Enforce that the integration prevents duplicates from being configured.
+
+https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/unique-config-entry/
+"""
+
+import ast
+
+from script.hassfest.model import Integration
+
+
+def _has_method_call(module: ast.Module, name: str) -> bool:
+    """Test if the module calls a specific method."""
+    return any(
+        type(item.func) is ast.Attribute and item.func.attr == name
+        for item in ast.walk(module)
+        if isinstance(item, ast.Call)
+    )
+
+
+def _has_abort_entries_match(module: ast.Module) -> bool:
+    """Test if the module calls `_async_abort_entries_match`."""
+    return _has_method_call(module, "_async_abort_entries_match")
+
+
+def _has_abort_unique_id_configured(module: ast.Module) -> bool:
+    """Test if the module calls defines (and checks for) a unique_id."""
+    return _has_method_call(module, "async_set_unique_id") and _has_method_call(
+        module, "_abort_if_unique_id_configured"
+    )
+
+
+def validate(integration: Integration) -> list[str] | None:
+    """Validate that the integration prevents duplicate devices."""
+
+    if integration.manifest.get("single_config_entry"):
+        return None
+
+    config_flow_file = integration.path / "config_flow.py"
+    config_flow = ast.parse(config_flow_file.read_text())
+
+    if not (
+        _has_abort_entries_match(config_flow)
+        or _has_abort_unique_id_configured(config_flow)
+    ):
+        return [
+            "Integration doesn't prevent the same device or service from being "
+            f"set up twice (please review {config_flow_file})"
+        ]
+    return None


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Pulled from https://github.com/home-assistant/core/pull/131413

cc @allenporter

```
Integration twentemilieu:
* [ERROR] [QUALITY_SCALE] [unique-config-entry] Integration doesn't prevent the same device or service from being set up twice (please review homeassistant/components/twentemilieu/config_flow.py)
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
