### PR TITLE
Improve config flow of devolo Home Network

### DIFF
--- a/homeassistant/components/devolo_home_network/config_flow.py
+++ b/homeassistant/components/devolo_home_network/config_flow.py
@@ -22,7 +22,7 @@ from .const import DOMAIN, PRODUCT, SERIAL_NUMBER, TITLE
 _LOGGER = logging.getLogger(__name__)
 
 STEP_USER_DATA_SCHEMA = vol.Schema(
-    {vol.Required(CONF_IP_ADDRESS): str, vol.Optional(CONF_PASSWORD, default=""): str}
+    {vol.Required(CONF_IP_ADDRESS): str, vol.Optional(CONF_PASSWORD): str}
 )
 STEP_REAUTH_DATA_SCHEMA = vol.Schema({vol.Optional(CONF_PASSWORD): str})
 
@@ -69,24 +69,22 @@ class DevoloHomeNetworkConfigFlow(ConfigFlow, domain=DOMAIN):
         """Handle the initial step."""
         errors: dict = {}
 
-        if user_input is None:
-            return self.async_show_form(
-                step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
-            )
-
-        try:
-            info = await validate_input(self.hass, user_input)
-        except DeviceNotFound:
-            errors["base"] = "cannot_connect"
-        except DevicePasswordProtected:
-            errors["base"] = "invalid_auth"
-        except Exception:
-            _LOGGER.exception("Unexpected exception")
-            errors["base"] = "unknown"
-        else:
-            await self.async_set_unique_id(info[SERIAL_NUMBER], raise_on_progress=False)
-            self._abort_if_unique_id_configured()
-            return self.async_create_entry(title=info[TITLE], data=user_input)
+        if user_input is not None:
+            try:
+                info = await validate_input(self.hass, user_input)
+            except DeviceNotFound:
+                errors["base"] = "cannot_connect"
+            except DevicePasswordProtected:
+                errors["base"] = "invalid_auth"
+            except Exception:
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+            else:
+                await self.async_set_unique_id(
+                    info[SERIAL_NUMBER], raise_on_progress=False
+                )
+                self._abort_if_unique_id_configured()
+                return self.async_create_entry(title=info[TITLE], data=user_input)
 
         return self.async_show_form(
             step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
@@ -117,6 +115,9 @@ class DevoloHomeNetworkConfigFlow(ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Handle a flow initiated by zeroconf."""
         title = self.context["title_placeholders"][CONF_NAME]
+        errors: dict = {}
+        data_schema: vol.Schema | None = None
+
         if user_input is not None:
             data = {
                 CONF_IP_ADDRESS: self.host,
@@ -125,17 +126,16 @@ class DevoloHomeNetworkConfigFlow(ConfigFlow, domain=DOMAIN):
             try:
                 await validate_input(self.hass, data)
             except DevicePasswordProtected:
-                return self.async_show_form(
-                    step_id="zeroconf_confirm",
-                    data_schema=STEP_REAUTH_DATA_SCHEMA,
-                    description_placeholders={"host_name": title},
-                    errors={"base": "invalid_auth"},
-                )
+                errors = {"base": "invalid_auth"}
+                data_schema = STEP_REAUTH_DATA_SCHEMA
             else:
                 return self.async_create_entry(title=title, data=data)
+
         return self.async_show_form(
             step_id="zeroconf_confirm",
+            data_schema=data_schema,
             description_placeholders={"host_name": title},
+            errors=errors,
         )
 
     async def async_step_reauth(
@@ -155,14 +155,21 @@ class DevoloHomeNetworkConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle a flow initiated by reauthentication."""
-        if user_input is None:
-            return self.async_show_form(
-                step_id="reauth_confirm",
-                data_schema=STEP_REAUTH_DATA_SCHEMA,
-            )
+        errors: dict = {}
+        if user_input is not None:
+            data = {
+                CONF_IP_ADDRESS: self.host,
+                CONF_PASSWORD: user_input[CONF_PASSWORD],
+            }
+            try:
+                await validate_input(self.hass, data)
+            except DevicePasswordProtected:
+                errors = {"base": "invalid_auth"}
+            else:
+                return self.async_update_reload_and_abort(self._reauth_entry, data=data)
 
-        data = {
-            CONF_IP_ADDRESS: self.host,
-            CONF_PASSWORD: user_input[CONF_PASSWORD],
-        }
-        return self.async_update_reload_and_abort(self._reauth_entry, data=data)
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=STEP_REAUTH_DATA_SCHEMA,
+            errors=errors,
+        )

--- a/homeassistant/components/devolo_home_network/strings.json
+++ b/homeassistant/components/devolo_home_network/strings.json
@@ -18,7 +18,7 @@
           "password": "[%key:common::config_flow::data::password%]"
         },
         "data_description": {
-          "password": "Password you protected the device with."
+          "password": "[%key:component::devolo_home_network::config::step::user::data_description::password%]"
         }
       },
       "zeroconf_confirm": {
@@ -28,7 +28,7 @@
           "password": "[%key:common::config_flow::data::password%]"
         },
         "data_description": {
-          "password": "Password you protected the device with."
+          "password": "[%key:component::devolo_home_network::config::step::user::data_description::password%]"
         }
       }
     },

--- a/homeassistant/components/devolo_home_network/strings.json
+++ b/homeassistant/components/devolo_home_network/strings.json
@@ -5,10 +5,12 @@
       "user": {
         "description": "[%key:common::config_flow::description::confirm_setup%]",
         "data": {
-          "ip_address": "[%key:common::config_flow::data::ip%]"
+          "ip_address": "[%key:common::config_flow::data::ip%]",
+          "password": "[%key:common::config_flow::data::password%]"
         },
         "data_description": {
-          "ip_address": "IP address of your devolo Home Network device. This can be found in the devolo Home Network App on the device dashboard."
+          "ip_address": "IP address of your devolo Home Network device. This can be found in the devolo Home Network App on the device dashboard.",
+          "password": "Password you protected the device with."
         }
       },
       "reauth_confirm": {
@@ -21,11 +23,18 @@
       },
       "zeroconf_confirm": {
         "description": "Do you want to add the devolo home network device with the hostname `{host_name}` to Home Assistant?",
-        "title": "Discovered devolo home network device"
+        "title": "Discovered devolo home network device",
+        "data": {
+          "password": "[%key:common::config_flow::data::password%]"
+        },
+        "data_description": {
+          "password": "Password you protected the device with."
+        }
       }
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {

--- a/tests/components/devolo_home_network/mock.py
+++ b/tests/components/devolo_home_network/mock.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock
 
 from devolo_plc_api.device import Device
 from devolo_plc_api.device_api.deviceapi import DeviceApi
+from devolo_plc_api.exceptions.device import DevicePasswordProtected
 from devolo_plc_api.plcnet_api.plcnetapi import PlcNetApi
 import httpx
 from zeroconf import Zeroconf
@@ -79,3 +80,16 @@ class MockDevice(Device):
         self.plcnet.async_get_network_overview = AsyncMock(return_value=PLCNET)
         self.plcnet.async_identify_device_start = AsyncMock(return_value=True)
         self.plcnet.async_pair_device = AsyncMock(return_value=True)
+
+
+class MockDeviceWrongPassword(MockDevice):
+    """Mock of a devolo Home Network device, that always complains about a wrong password."""
+
+    def __init__(
+        self,
+        ip: str,
+        zeroconf_instance: AsyncZeroconf | Zeroconf | None = None,
+    ) -> None:
+        """Bring mock in a well defined state."""
+        super().__init__(ip, zeroconf_instance)
+        self.device.async_uptime = AsyncMock(side_effect=DevicePasswordProtected)

--- a/tests/components/devolo_home_network/test_config_flow.py
+++ b/tests/components/devolo_home_network/test_config_flow.py
@@ -5,11 +5,10 @@ from __future__ import annotations
 from typing import Any
 from unittest.mock import patch
 
-from devolo_plc_api.exceptions.device import DeviceNotFound
+from devolo_plc_api.exceptions.device import DeviceNotFound, DevicePasswordProtected
 import pytest
 
 from homeassistant import config_entries
-from homeassistant.components.devolo_home_network import config_flow
 from homeassistant.components.devolo_home_network.const import (
     DOMAIN,
     SERIAL_NUMBER,
@@ -27,7 +26,7 @@ from .const import (
     IP,
     IP_ALT,
 )
-from .mock import MockDevice
+from .mock import MockDevice, MockDeviceWrongPassword
 
 from tests.common import MockConfigEntry
 
@@ -53,8 +52,8 @@ async def test_form(hass: HomeAssistant, info: dict[str, Any]) -> None:
         await hass.async_block_till_done()
 
     assert result2["type"] is FlowResultType.CREATE_ENTRY
-    assert result2["result"].unique_id == info["serial_number"]
-    assert result2["title"] == info["title"]
+    assert result2["result"].unique_id == info[SERIAL_NUMBER]
+    assert result2["title"] == info[TITLE]
     assert result2["data"] == {
         CONF_IP_ADDRESS: IP,
         CONF_PASSWORD: "",
@@ -64,7 +63,11 @@ async def test_form(hass: HomeAssistant, info: dict[str, Any]) -> None:
 
 @pytest.mark.parametrize(
     ("exception_type", "expected_error"),
-    [(DeviceNotFound(IP), "cannot_connect"), (Exception, "unknown")],
+    [
+        (DeviceNotFound(IP), "cannot_connect"),
+        (DevicePasswordProtected, "invalid_auth"),
+        (Exception, "unknown"),
+    ],
 )
 async def test_form_error(hass: HomeAssistant, exception_type, expected_error) -> None:
     """Test we handle errors."""
@@ -110,9 +113,15 @@ async def test_zeroconf(hass: HomeAssistant) -> None:
         == DISCOVERY_INFO.hostname.split(".", maxsplit=1)[0]
     )
 
-    with patch(
-        "homeassistant.components.devolo_home_network.async_setup_entry",
-        return_value=True,
+    with (
+        patch(
+            "homeassistant.components.devolo_home_network.async_setup_entry",
+            return_value=True,
+        ),
+        patch(
+            "homeassistant.components.devolo_home_network.config_flow.Device",
+            new=MockDevice,
+        ),
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -125,6 +134,49 @@ async def test_zeroconf(hass: HomeAssistant) -> None:
         CONF_IP_ADDRESS: IP,
         CONF_PASSWORD: "",
     }
+
+
+async def test_zeroconf_wrong_auth(hass: HomeAssistant) -> None:
+    """Test that the zeroconf form asks for password if authorization fails."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_ZEROCONF},
+        data=DISCOVERY_INFO,
+    )
+
+    assert result["step_id"] == "zeroconf_confirm"
+    assert result["type"] is FlowResultType.FORM
+    assert result["description_placeholders"] == {"host_name": "test"}
+
+    context = next(
+        flow["context"]
+        for flow in hass.config_entries.flow.async_progress()
+        if flow["flow_id"] == result["flow_id"]
+    )
+
+    assert (
+        context["title_placeholders"][CONF_NAME]
+        == DISCOVERY_INFO.hostname.split(".", maxsplit=1)[0]
+    )
+
+    with (
+        patch(
+            "homeassistant.components.devolo_home_network.async_setup_entry",
+            return_value=True,
+        ),
+        patch(
+            "homeassistant.components.devolo_home_network.config_flow.Device",
+            new=MockDeviceWrongPassword,
+        ),
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {},
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] is FlowResultType.FORM
+    assert result2["errors"] == {CONF_BASE: "invalid_auth"}
 
 
 async def test_abort_zeroconf_wrong_device(hass: HomeAssistant) -> None:
@@ -198,16 +250,3 @@ async def test_form_reauth(hass: HomeAssistant) -> None:
     assert len(mock_setup_entry.mock_calls) == 1
 
     await hass.config_entries.async_unload(entry.entry_id)
-
-
-@pytest.mark.usefixtures("mock_device")
-@pytest.mark.usefixtures("mock_zeroconf")
-async def test_validate_input(hass: HomeAssistant) -> None:
-    """Test input validation."""
-    with patch(
-        "homeassistant.components.devolo_home_network.config_flow.Device",
-        new=MockDevice,
-    ):
-        info = await config_flow.validate_input(hass, {CONF_IP_ADDRESS: IP})
-        assert SERIAL_NUMBER in info
-        assert TITLE in info


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Up to now, I had trouble detecting if a Devolo device is password protected or not. The API allows reading values without a password (and even ignores a wrong password sent to it), but validates them on writing calls.

So I always configured it as if there was no password and relied on a reauth flow as soon as writing failed. This did not harm many users, as most devices are not password protected. But I discovered that the entity added in https://github.com/home-assistant/core/pull/122190 needs a password, although it is read-only. 

If the device is not password protected and the device is added via the zeroconf flow, I don't ask for the password. If the device is added via the user flow, the password can now be optionally given.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
