### PR TITLE
Use HomeAssistant error in the right cases

### DIFF
--- a/homeassistant/components/home_connect/light.py
+++ b/homeassistant/components/home_connect/light.py
@@ -16,7 +16,7 @@ from homeassistant.components.light import (
     LightEntityDescription,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ServiceValidationError
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 import homeassistant.util.color as color_util
 
@@ -150,7 +150,7 @@ class HomeConnectLight(HomeConnectEntity, LightEntity):
                 self.device.appliance.set_setting, self.bsh_key, True
             )
         except HomeConnectError as err:
-            raise ServiceValidationError(
+            raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="turn_on_light",
                 translation_placeholders={
@@ -169,7 +169,7 @@ class HomeConnectLight(HomeConnectEntity, LightEntity):
                         self._enable_custom_color_value_key,
                     )
                 except HomeConnectError as err:
-                    raise ServiceValidationError(
+                    raise HomeAssistantError(
                         translation_domain=DOMAIN,
                         translation_key="select_light_custom_color",
                         translation_placeholders={
@@ -187,7 +187,7 @@ class HomeConnectLight(HomeConnectEntity, LightEntity):
                         f"#{hex_val}",
                     )
                 except HomeConnectError as err:
-                    raise ServiceValidationError(
+                    raise HomeAssistantError(
                         translation_domain=DOMAIN,
                         translation_key="set_light_color",
                         translation_placeholders={
@@ -219,7 +219,7 @@ class HomeConnectLight(HomeConnectEntity, LightEntity):
                             f"#{hex_val}",
                         )
                     except HomeConnectError as err:
-                        raise ServiceValidationError(
+                        raise HomeAssistantError(
                             translation_domain=DOMAIN,
                             translation_key="set_light_color",
                             translation_placeholders={
@@ -244,7 +244,7 @@ class HomeConnectLight(HomeConnectEntity, LightEntity):
                     self.device.appliance.set_setting, self._brightness_key, brightness
                 )
             except HomeConnectError as err:
-                raise ServiceValidationError(
+                raise HomeAssistantError(
                     translation_domain=DOMAIN,
                     translation_key="set_light_brightness",
                     translation_placeholders={
@@ -263,7 +263,7 @@ class HomeConnectLight(HomeConnectEntity, LightEntity):
                 self.device.appliance.set_setting, self.bsh_key, False
             )
         except HomeConnectError as err:
-            raise ServiceValidationError(
+            raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="turn_off_light",
                 translation_placeholders={

--- a/homeassistant/components/home_connect/number.py
+++ b/homeassistant/components/home_connect/number.py
@@ -12,7 +12,7 @@ from homeassistant.components.number import (
     NumberEntityDescription,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ServiceValidationError
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import HomeConnectConfigEntry, get_dict_from_home_connect_error
@@ -117,7 +117,7 @@ class HomeConnectNumberEntity(HomeConnectEntity, NumberEntity):
                 value,
             )
         except HomeConnectError as err:
-            raise ServiceValidationError(
+            raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="set_setting",
                 translation_placeholders={

--- a/homeassistant/components/home_connect/select.py
+++ b/homeassistant/components/home_connect/select.py
@@ -7,7 +7,7 @@ from homeconnect.api import HomeConnectError
 
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ServiceValidationError
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import (
@@ -289,7 +289,7 @@ class HomeConnectProgramSelectEntity(HomeConnectEntity, SelectEntity):
                 translation_key = "start_program"
             else:
                 translation_key = "select_program"
-            raise ServiceValidationError(
+            raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key=translation_key,
                 translation_placeholders={

--- a/homeassistant/components/home_connect/strings.json
+++ b/homeassistant/components/home_connect/strings.json
@@ -23,43 +23,43 @@
   },
   "exceptions": {
     "turn_on_light": {
-      "message": "Error while trying to turn on {entity_id}: {description}"
+      "message": "Error turning on {entity_id}: {description}"
     },
     "turn_off_light": {
-      "message": "Error while trying to turn off {entity_id}: {description}"
+      "message": "Error turning off {entity_id}: {description}"
     },
     "set_light_brightness": {
-      "message": "Error while trying to set brightness of {entity_id}: {description}"
+      "message": "Error setting brightness of {entity_id}: {description}"
     },
     "select_light_custom_color": {
-      "message": "Error while trying to select custom color of {entity_id}: {description}"
+      "message": "Error selecting custom color of {entity_id}: {description}"
     },
     "set_light_color": {
-      "message": "Error while trying to set color of {entity_id}: {description}"
+      "message": "Error setting color of {entity_id}: {description}"
     },
     "set_setting": {
-      "message": "Error while trying to assign the value \"{value}\" to the setting \"{setting_key}\" for {entity_id}: {description}"
+      "message": "Error assigning the value \"{value}\" to the setting \"{setting_key}\" for {entity_id}: {description}"
     },
     "turn_on": {
-      "message": "Error while trying to turn on {entity_id} ({setting_key}): {description}"
+      "message": "Error turning on {entity_id} ({setting_key}): {description}"
     },
     "turn_off": {
-      "message": "Error while trying to turn off {entity_id} ({setting_key}): {description}"
+      "message": "Error turning off {entity_id} ({setting_key}): {description}"
     },
     "select_program": {
-      "message": "Error while trying to select program {program}: {description}"
+      "message": "Error selecting program {program}: {description}"
     },
     "start_program": {
-      "message": "Error while trying to start program {program}: {description}"
+      "message": "Error starting program {program}: {description}"
     },
     "stop_program": {
-      "message": "Error while trying to stop program {program}: {description}"
+      "message": "Error stopping program {program}: {description}"
     },
     "power_on": {
-      "message": "Error while trying to turn on {appliance_name}: {description}"
+      "message": "Error turning on {appliance_name}: {description}"
     },
     "power_off": {
-      "message": "Error while trying to turn off {appliance_name} with value \"{value}\": {description}"
+      "message": "Error turning off {appliance_name} with value \"{value}\": {description}"
     },
     "turn_off_not_supported": {
       "message": "{appliance_name} does not support turning off or entering standby mode."

--- a/homeassistant/components/home_connect/switch.py
+++ b/homeassistant/components/home_connect/switch.py
@@ -8,7 +8,7 @@ from homeconnect.api import HomeConnectError
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ServiceValidationError
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import HomeConnectConfigEntry, get_dict_from_home_connect_error
@@ -134,7 +134,7 @@ class HomeConnectSwitch(HomeConnectEntity, SwitchEntity):
             )
         except HomeConnectError as err:
             self._attr_available = False
-            raise ServiceValidationError(
+            raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="turn_on",
                 translation_placeholders={
@@ -158,7 +158,7 @@ class HomeConnectSwitch(HomeConnectEntity, SwitchEntity):
         except HomeConnectError as err:
             _LOGGER.error("Error while trying to turn off: %s", err)
             self._attr_available = False
-            raise ServiceValidationError(
+            raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="turn_off",
                 translation_placeholders={
@@ -209,7 +209,7 @@ class HomeConnectProgramSwitch(HomeConnectEntity, SwitchEntity):
                 self.device.appliance.start_program, self.program_name
             )
         except HomeConnectError as err:
-            raise ServiceValidationError(
+            raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="start_program",
                 translation_placeholders={
@@ -225,7 +225,7 @@ class HomeConnectProgramSwitch(HomeConnectEntity, SwitchEntity):
         try:
             await self.hass.async_add_executor_job(self.device.appliance.stop_program)
         except HomeConnectError as err:
-            raise ServiceValidationError(
+            raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="stop_program",
                 translation_placeholders={
@@ -278,7 +278,7 @@ class HomeConnectPowerSwitch(HomeConnectEntity, SwitchEntity):
             )
         except HomeConnectError as err:
             self._attr_is_on = False
-            raise ServiceValidationError(
+            raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="power_on",
                 translation_placeholders={
@@ -291,7 +291,7 @@ class HomeConnectPowerSwitch(HomeConnectEntity, SwitchEntity):
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Switch the device off."""
         if not hasattr(self, "power_off_state"):
-            raise ServiceValidationError(
+            raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="unable_to_retrieve_turn_off",
                 translation_placeholders={
@@ -300,7 +300,7 @@ class HomeConnectPowerSwitch(HomeConnectEntity, SwitchEntity):
             )
 
         if self.power_off_state is None:
-            raise ServiceValidationError(
+            raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="turn_off_not_supported",
                 translation_placeholders={
@@ -316,7 +316,7 @@ class HomeConnectPowerSwitch(HomeConnectEntity, SwitchEntity):
             )
         except HomeConnectError as err:
             self._attr_is_on = True
-            raise ServiceValidationError(
+            raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="power_off",
                 translation_placeholders={

--- a/homeassistant/components/home_connect/time.py
+++ b/homeassistant/components/home_connect/time.py
@@ -7,7 +7,7 @@ from homeconnect.api import HomeConnectError
 
 from homeassistant.components.time import TimeEntity, TimeEntityDescription
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ServiceValidationError
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import HomeConnectConfigEntry, get_dict_from_home_connect_error
@@ -80,7 +80,7 @@ class HomeConnectTimeEntity(HomeConnectEntity, TimeEntity):
                 time_to_seconds(value),
             )
         except HomeConnectError as err:
-            raise ServiceValidationError(
+            raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="set_setting",
                 translation_placeholders={

--- a/tests/components/home_connect/test_light.py
+++ b/tests/components/home_connect/test_light.py
@@ -27,7 +27,7 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ServiceValidationError
+from homeassistant.exceptions import HomeAssistantError
 
 from .conftest import get_all_appliances
 
@@ -341,7 +341,7 @@ async def test_switch_exception_handling(
 
     problematic_appliance.status.update(status)
     service_data["entity_id"] = entity_id
-    with pytest.raises(ServiceValidationError, match=exception_match):
+    with pytest.raises(HomeAssistantError, match=exception_match):
         await hass.services.async_call(
             LIGHT_DOMAIN, service, service_data, blocking=True
         )

--- a/tests/components/home_connect/test_number.py
+++ b/tests/components/home_connect/test_number.py
@@ -24,7 +24,7 @@ from homeassistant.components.number import (
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ServiceValidationError
+from homeassistant.exceptions import HomeAssistantError
 
 from .conftest import get_all_appliances
 
@@ -162,7 +162,7 @@ async def test_number_entity_error(
         getattr(problematic_appliance, mock_attr)()
 
     with pytest.raises(
-        ServiceValidationError, match=r"Error.*assign.*value.*to.*setting.*"
+        HomeAssistantError, match=r"Error.*assign.*value.*to.*setting.*"
     ):
         await hass.services.async_call(
             NUMBER_DOMAIN,

--- a/tests/components/home_connect/test_select.py
+++ b/tests/components/home_connect/test_select.py
@@ -14,7 +14,7 @@ from homeassistant.components.select import ATTR_OPTION, DOMAIN as SELECT_DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_SELECT_OPTION, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ServiceValidationError
+from homeassistant.exceptions import HomeAssistantError
 
 from .conftest import get_all_appliances
 
@@ -151,7 +151,7 @@ async def test_select_exception_handling(
         getattr(problematic_appliance, mock_attr)()
 
     problematic_appliance.status.update(status)
-    with pytest.raises(ServiceValidationError, match=exception_match):
+    with pytest.raises(HomeAssistantError, match=exception_match):
         await hass.services.async_call(
             SELECT_DOMAIN,
             SERVICE_SELECT_OPTION,

--- a/tests/components/home_connect/test_switch.py
+++ b/tests/components/home_connect/test_switch.py
@@ -29,7 +29,7 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ServiceValidationError
+from homeassistant.exceptions import HomeAssistantError
 
 from .conftest import get_all_appliances
 
@@ -219,7 +219,7 @@ async def test_switch_exception_handling(
     with pytest.raises(HomeConnectError):
         getattr(problematic_appliance, mock_attr)()
 
-    with pytest.raises(ServiceValidationError, match=exception_match):
+    with pytest.raises(HomeAssistantError, match=exception_match):
         await hass.services.async_call(
             SWITCH_DOMAIN, service, {"entity_id": entity_id}, blocking=True
         )
@@ -344,7 +344,7 @@ async def test_ent_desc_switch_exception_handling(
         getattr(problematic_appliance, mock_attr)()
 
     problematic_appliance.status.update(status)
-    with pytest.raises(ServiceValidationError, match=exception_match):
+    with pytest.raises(HomeAssistantError, match=exception_match):
         await hass.services.async_call(
             SWITCH_DOMAIN, service, {ATTR_ENTITY_ID: entity_id}, blocking=True
         )
@@ -502,7 +502,7 @@ async def test_power_switch_service_validation_errors(
 
     appliance.status.update({BSH_POWER_STATE: {"value": BSH_POWER_ON}})
 
-    with pytest.raises(ServiceValidationError, match=exception_match):
+    with pytest.raises(HomeAssistantError, match=exception_match):
         await hass.services.async_call(
             SWITCH_DOMAIN, service, {"entity_id": entity_id}, blocking=True
         )

--- a/tests/components/home_connect/test_time.py
+++ b/tests/components/home_connect/test_time.py
@@ -12,7 +12,7 @@ from homeassistant.components.time import DOMAIN as TIME_DOMAIN, SERVICE_SET_VAL
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_TIME, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ServiceValidationError
+from homeassistant.exceptions import HomeAssistantError
 
 from .conftest import get_all_appliances
 
@@ -136,7 +136,7 @@ async def test_time_entity_error(
         getattr(problematic_appliance, mock_attr)()
 
     with pytest.raises(
-        ServiceValidationError, match=r"Error.*assign.*value.*to.*setting.*"
+        HomeAssistantError, match=r"Error.*assign.*value.*to.*setting.*"
     ):
         await hass.services.async_call(
             TIME_DOMAIN,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

`ServiceValidationErrors` were used to inform about a problem reported by the API, but following the ["Service actions raise exceptions when encountering failures"](https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/action-exceptions) rule, `HomeAssistantError` should be used in those cases.

Additionally, some exception strings have been updated

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
