### PR TITLE
Remove support for live recorder data migration of entity IDs

### DIFF
--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -2564,15 +2564,11 @@ class EventTypeIDMigration(BaseMigrationWithQuery, BaseRunTimeMigration):
         return has_event_type_to_migrate()
 
 
-class EntityIDMigration(BaseMigrationWithQuery, BaseRunTimeMigration):
+class EntityIDMigration(BaseMigrationWithQuery, BaseOffLineMigration):
     """Migration to migrate entity_ids to states_meta."""
 
     required_schema_version = STATES_META_SCHEMA_VERSION
     migration_id = "entity_id_migration"
-    task = CommitBeforeMigrationTask
-    # We have to commit before to make sure there are
-    # no new pending states_meta about to be added to
-    # the db since this happens live
 
     def migrate_data_impl(self, instance: Recorder) -> DataMigrationStatus:
         """Migrate entity_ids to states_meta, return True if completed.
@@ -2641,18 +2637,6 @@ class EntityIDMigration(BaseMigrationWithQuery, BaseRunTimeMigration):
 
         _LOGGER.debug("Migrating entity_ids done=%s", is_done)
         return DataMigrationStatus(needs_migrate=not is_done, migration_done=is_done)
-
-    def migration_done(self, instance: Recorder, session: Session) -> None:
-        """Will be called after migrate returns True."""
-        # The migration has finished, now we start the post migration
-        # to remove the old entity_id data from the states table
-        # at this point we can also start using the StatesMeta table
-        # so we set active to True
-        _LOGGER.debug("Activating states_meta manager as all data is migrated")
-        instance.states_meta_manager.active = True
-        with contextlib.suppress(SQLAlchemyError):
-            migrate = EntityIDPostMigration(self.schema_version, self.migration_changes)
-            migrate.queue_migration(instance, session)
 
     def needs_migrate_query(self) -> StatementLambdaElement:
         """Check if the data is migrated."""
@@ -2764,12 +2748,13 @@ class EntityIDPostMigration(BaseMigrationWithQuery, BaseRunTimeMigration):
 NON_LIVE_DATA_MIGRATORS = (
     StatesContextIDMigration,  # Introduced in HA Core 2023.4
     EventsContextIDMigration,  # Introduced in HA Core 2023.4
+    EntityIDMigration,  # Introduced in HA Core 2023.4 by PR #89557
 )
 
 LIVE_DATA_MIGRATORS = (
     EventTypeIDMigration,  # Introduced in HA Core 2023.4 by PR #89465
-    EntityIDMigration,  # Introduced in HA Core 2023.4 by PR #89557
     EventIDPostMigration,  # Introduced in HA Core 2023.4 by PR #89901
+    EntityIDPostMigration,  # Introduced in HA Core 2023.4 by PR #89557
 )
 
 

--- a/homeassistant/components/recorder/table_managers/states_meta.py
+++ b/homeassistant/components/recorder/table_managers/states_meta.py
@@ -24,7 +24,7 @@ CACHE_SIZE = 8192
 class StatesMetaManager(BaseLRUTableManager[StatesMeta]):
     """Manage the StatesMeta table."""
 
-    active = False
+    active = True
 
     def __init__(self, recorder: Recorder) -> None:
         """Initialize the states meta manager."""

--- a/tests/components/recorder/common.py
+++ b/tests/components/recorder/common.py
@@ -428,14 +428,6 @@ def get_schema_module_path(schema_version_postfix: str) -> str:
     return f"tests.components.recorder.db_schema_{schema_version_postfix}"
 
 
-@dataclass(slots=True)
-class MockMigrationTask(migration.MigrationTask):
-    """Mock migration task which does nothing."""
-
-    def run(self, instance: Recorder) -> None:
-        """Run migration task."""
-
-
 @contextmanager
 def old_db_schema(schema_version_postfix: str) -> Iterator[None]:
     """Fixture to initialize the db with the old schema."""
@@ -453,7 +445,6 @@ def old_db_schema(schema_version_postfix: str) -> Iterator[None]:
         patch.object(core, "States", old_db_schema.States),
         patch.object(core, "Events", old_db_schema.Events),
         patch.object(core, "StateAttributes", old_db_schema.StateAttributes),
-        patch.object(migration.EntityIDMigration, "task", MockMigrationTask),
         patch(
             CREATE_ENGINE_TARGET,
             new=partial(

--- a/tests/components/recorder/test_history_db_schema_32.py
+++ b/tests/components/recorder/test_history_db_schema_32.py
@@ -38,6 +38,17 @@ async def mock_recorder_before_hass(
     """Set up recorder."""
 
 
+@pytest.fixture
+def disable_states_meta_manager():
+    """Disable the states meta manager."""
+    with patch.object(
+        recorder.table_managers.states_meta.StatesMetaManager,
+        "active",
+        False,
+    ):
+        yield
+
+
 @pytest.fixture(autouse=True)
 def db_schema_32():
     """Fixture to initialize the db with the old schema 32."""
@@ -46,7 +57,9 @@ def db_schema_32():
 
 
 @pytest.fixture(autouse=True)
-def setup_recorder(db_schema_32, recorder_mock: Recorder) -> recorder.Recorder:
+def setup_recorder(
+    db_schema_32, disable_states_meta_manager, recorder_mock: Recorder
+) -> recorder.Recorder:
     """Set up recorder."""
 
 

--- a/tests/components/recorder/test_migration_run_time_migrations_remember.py
+++ b/tests/components/recorder/test_migration_run_time_migrations_remember.py
@@ -19,11 +19,7 @@ from homeassistant.components.recorder.util import (
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import HomeAssistant
 
-from .common import (
-    MockMigrationTask,
-    async_recorder_block_till_done,
-    async_wait_recording_done,
-)
+from .common import async_recorder_block_till_done, async_wait_recording_done
 
 from tests.common import async_test_home_assistant
 from tests.typing import RecorderInstanceGenerator
@@ -102,7 +98,6 @@ async def test_migration_changes_prevent_trying_to_migrate_again(
         patch.object(core, "States", old_db_schema.States),
         patch.object(core, "Events", old_db_schema.Events),
         patch.object(core, "StateAttributes", old_db_schema.StateAttributes),
-        patch.object(migration.EntityIDMigration, "task", MockMigrationTask),
         patch(CREATE_ENGINE_TARGET, new=_create_engine_test),
     ):
         async with (


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove support for live recorder data migration of entity IDs

This is a follow-up to PR https://github.com/home-assistant/core/pull/122399 which removed support for live schema migration of old databases

In this PR, the entity id data migrator, which was introduced in Home Assistant Core 2023.4, will run to completion before Home Assistant starts.

Note:
With this PR we can remove the "legacy" history queries which are used when the history API is called while data migration is ongoing and the associated tests. After a discussion with @bdraco, we think it's better to remove the dead code in a separate PR.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
