### PR TITLE
Fix Reolink dispatcher ID for onvif fallback

### DIFF
--- a/homeassistant/components/reolink/binary_sensor.py
+++ b/homeassistant/components/reolink/binary_sensor.py
@@ -176,14 +176,14 @@ class ReolinkPushBinarySensorEntity(ReolinkBinarySensorEntity):
         self.async_on_remove(
             async_dispatcher_connect(
                 self.hass,
-                f"{self._host.webhook_id}_{self._channel}",
+                f"{self._host.unique_id}_{self._channel}",
                 self._async_handle_event,
             )
         )
         self.async_on_remove(
             async_dispatcher_connect(
                 self.hass,
-                f"{self._host.webhook_id}_all",
+                f"{self._host.unique_id}_all",
                 self._async_handle_event,
             )
         )

--- a/homeassistant/components/reolink/host.py
+++ b/homeassistant/components/reolink/host.py
@@ -721,7 +721,7 @@ class ReolinkHost:
                     self._hass, POLL_INTERVAL_NO_PUSH, self._poll_job
                 )
 
-        self._signal_write_ha_state(None)
+        self._signal_write_ha_state()
 
     async def handle_webhook(
         self, hass: HomeAssistant, webhook_id: str, request: Request
@@ -780,7 +780,7 @@ class ReolinkHost:
                         "Could not poll motion state after losing connection during receiving ONVIF event"
                     )
                     return
-                async_dispatcher_send(hass, f"{webhook_id}_all", {})
+                self._signal_write_ha_state()
                 return
 
             message = data.decode("utf-8")
@@ -793,14 +793,14 @@ class ReolinkHost:
 
         self._signal_write_ha_state(channels)
 
-    def _signal_write_ha_state(self, channels: list[int] | None) -> None:
+    def _signal_write_ha_state(self, channels: list[int] | None = None) -> None:
         """Update the binary sensors with async_write_ha_state."""
         if channels is None:
-            async_dispatcher_send(self._hass, f"{self.webhook_id}_all", {})
+            async_dispatcher_send(self._hass, f"{self.unique_id}_all", {})
             return
 
         for channel in channels:
-            async_dispatcher_send(self._hass, f"{self.webhook_id}_{channel}", {})
+            async_dispatcher_send(self._hass, f"{self.unique_id}_{channel}", {})
 
     @property
     def event_connection(self) -> str:

--- a/tests/components/reolink/test_host.py
+++ b/tests/components/reolink/test_host.py
@@ -21,12 +21,14 @@ from homeassistant.components.reolink.host import (
 )
 from homeassistant.components.webhook import async_handle_webhook
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import Platform
+from homeassistant.const import STATE_OFF, STATE_ON, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.network import NoURLAvailableError
 from homeassistant.util.aiohttp import MockRequest
+
+from .conftest import TEST_NVR_NAME
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 from tests.components.diagnostics import get_diagnostics_for_config_entry
@@ -92,10 +94,14 @@ async def test_webhook_callback(
     entity_registry: er.EntityRegistry,
 ) -> None:
     """Test webhook callback with motion sensor."""
-    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    reolink_connect.motion_detected.return_value = False
+
+    with patch("homeassistant.components.reolink.PLATFORMS", [Platform.BINARY_SENSOR]):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
     assert config_entry.state is ConfigEntryState.LOADED
 
+    entity_id = f"{Platform.BINARY_SENSOR}.{TEST_NVR_NAME}_motion"
     webhook_id = config_entry.runtime_data.host.webhook_id
     unique_id = config_entry.runtime_data.host.unique_id
 
@@ -106,10 +112,14 @@ async def test_webhook_callback(
 
     client = await hass_client_no_auth()
 
+    assert hass.states.get(entity_id).state == STATE_OFF
+
     # test webhook callback success all channels
+    reolink_connect.motion_detected.return_value = True
     reolink_connect.ONVIF_event_callback.return_value = None
     await client.post(f"/api/webhook/{webhook_id}")
     signal_all.assert_called_once()
+    assert hass.states.get(entity_id).state == STATE_ON
 
     freezer.tick(timedelta(seconds=FIRST_ONVIF_TIMEOUT))
     async_fire_time_changed(hass)
@@ -121,10 +131,14 @@ async def test_webhook_callback(
     await client.post(f"/api/webhook/{webhook_id}")
     signal_all.assert_not_called()
 
+    assert hass.states.get(entity_id).state == STATE_ON
+
     # test webhook callback success single channel
+    reolink_connect.motion_detected.return_value = False
     reolink_connect.ONVIF_event_callback.return_value = [0]
     await client.post(f"/api/webhook/{webhook_id}", data="test_data")
     signal_ch.assert_called_once()
+    assert hass.states.get(entity_id).state == STATE_OFF
 
     # test webhook callback single channel with error in event callback
     signal_ch.reset_mock()

--- a/tests/components/reolink/test_host.py
+++ b/tests/components/reolink/test_host.py
@@ -97,11 +97,12 @@ async def test_webhook_callback(
     assert config_entry.state is ConfigEntryState.LOADED
 
     webhook_id = config_entry.runtime_data.host.webhook_id
+    unique_id = config_entry.runtime_data.host.unique_id
 
     signal_all = MagicMock()
     signal_ch = MagicMock()
-    async_dispatcher_connect(hass, f"{webhook_id}_all", signal_all)
-    async_dispatcher_connect(hass, f"{webhook_id}_0", signal_ch)
+    async_dispatcher_connect(hass, f"{unique_id}_all", signal_all)
+    async_dispatcher_connect(hass, f"{unique_id}_0", signal_ch)
 
     client = await hass_client_no_auth()
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When TCP initialy works, the webhook for ONVIF push will not be subscribed and the webhook_id will be None.
The entties then subscibe to the dispatcher with a wrong ID.
This fixes that such that when the ONVIF push is later used as fallback, the dispatcher will have a correct and unique ID such that the signaling gets to the entities.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/issues/130960 https://github.com/home-assistant/core/issues/131851 https://github.com/home-assistant/core/issues/130237
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
