### PR TITLE
Add BMW quality scale details

### DIFF
--- a/homeassistant/components/bmw_connected_drive/quality_scale.yaml
+++ b/homeassistant/components/bmw_connected_drive/quality_scale.yaml
@@ -1,0 +1,71 @@
+rules:
+  # Bronze
+  action-setup: done
+  appropriate-polling: done
+  brands: done
+  common-modules: done
+  config-flow-test-coverage: done
+  config-flow: done
+  dependency-transparency: done
+  docs-actions: done
+  docs-high-level-description: done
+  docs-installation-instructions: done
+  docs-removal-instructions: todo
+  entity-event-setup:
+    status: exempt
+    comment: |
+      This integration doesn't have any events.
+  entity-unique-id: done
+  has-entity-name: done
+  runtime-data: done
+  test-before-configure: done
+  test-before-setup: done
+  unique-config-entry: done
+
+  # Silver
+  action-exceptions: done
+  config-entry-unloading: done
+  docs-configuration-parameters: done
+  docs-installation-parameters: done
+  entity-unavailable: done
+  integration-owner: done
+  log-when-unavailable: done
+  parallel-updates: todo
+  reauthentication-flow: done
+  test-coverage: done
+
+  # Gold
+  devices: done
+  diagnostics: done
+  discovery-update-info:
+    status: exempt
+    comment: This integration doesn't use discovery.
+  discovery:
+    status: exempt
+    comment: This integration doesn't use discovery.
+  docs-data-update: todo
+  docs-examples: todo
+  docs-known-limitations: todo
+  docs-supported-devices: todo
+  docs-supported-functions: done
+  docs-troubleshooting: todo
+  docs-use-cases: todo
+  dynamic-devices: done
+  entity-category: done
+  entity-device-class: done
+  entity-disabled-by-default: done
+  entity-translations: done
+  exception-translations: todo
+  icon-translations: done
+  reconfiguration-flow: done
+  repair-issues:
+    status: exempt
+    comment: |
+      Other than reauthentication, this integration doesn't have any cases where raising an issue is needed.
+  stale-devices: done
+  # Platinum
+  async-dependency: done
+  inject-websession:
+    status: exempt
+    comment: The library requires a custom client for API authentication.
+  strict-typing: done

--- a/homeassistant/components/bmw_connected_drive/quality_scale.yaml
+++ b/homeassistant/components/bmw_connected_drive/quality_scale.yaml
@@ -1,3 +1,5 @@
+# + in comment indicates requirement for quality scale
+# - in comment indicates issue to be fixed, not impacting quality scale
 rules:
   # Bronze
   action-setup:
@@ -6,9 +8,24 @@ rules:
       Does not have custom services
   appropriate-polling: done
   brands: done
-  common-modules: done
-  config-flow-test-coverage: done
-  config-flow: done
+  common-modules:
+    status: done
+    comment: |
+      - 2 states writes in async_added_to_hass() required for platforms that redefine _handle_coordinator_update()
+  config-flow-test-coverage:
+    status: todo
+    comment: |
+      - test_show_form doesn't really add anything
+      - Patch bimmer_connected imports with homeassistant.components.bmw_connected_drive.bimmer_connected imports
+      + Ensure that configs flows end in CREATE_ENTRY or ABORT
+      - Parameterize test_authentication_error, test_api_error and test_connection_error
+      + test_full_user_flow_implementation doesn't assert unique id of created entry
+      + test that aborts when a mocked config entry already exists
+      + don't test on internals (e.g. `coordinator.last_update_success`) but rather on the resulting state (change)
+  config-flow:
+    status: done
+    comment: |
+      - Don't set `data` as class instance
   dependency-transparency: done
   docs-actions:
     status: exempt
@@ -41,7 +58,10 @@ rules:
   log-when-unavailable: done
   parallel-updates: done
   reauthentication-flow: done
-  test-coverage: done
+  test-coverage:
+    status: done
+    comment: |
+      - Use constants in tests where possible
 
   # Gold
   devices: done
@@ -61,7 +81,9 @@ rules:
   docs-use-cases: todo
   dynamic-devices:
     status: todo
-    comment: Ongoing discussion, we cannot regularly get new devices/vehicles due to API quota limitations.
+    comment: >
+      To be discussed.
+      We cannot regularly get new devices/vehicles due to API quota limitations.
   entity-category: done
   entity-device-class: done
   entity-disabled-by-default: done
@@ -75,10 +97,14 @@ rules:
       Other than reauthentication, this integration doesn't have any cases where raising an issue is needed.
   stale-devices:
     status: todo
-    comment: Ongoing discussion, we cannot regularly check for stale devices/vehicles due to API quota limitations.
+    comment: >
+      To be discussed.
+      We cannot regularly check for stale devices/vehicles due to API quota limitations.
   # Platinum
   async-dependency: done
   inject-websession:
     status: todo
-    comment: The library requires a custom client for API authentication, with custom auth lifecycle and user agents.
+    comment: >
+      To be discussed. The library requires a custom client for API authentication,
+      with custom auth lifecycle and user agents.
   strict-typing: done

--- a/homeassistant/components/bmw_connected_drive/quality_scale.yaml
+++ b/homeassistant/components/bmw_connected_drive/quality_scale.yaml
@@ -16,7 +16,9 @@ rules:
       Does not have custom services
   docs-high-level-description: done
   docs-installation-instructions: done
-  docs-removal-instructions: todo
+  docs-removal-instructions:
+    status: todo
+    comment: https://github.com/home-assistant/home-assistant.io/pull/36083
   entity-event-setup:
     status: exempt
     comment: |
@@ -34,8 +36,12 @@ rules:
     comment: |
       Does not have custom services
   config-entry-unloading: done
-  docs-configuration-parameters: done
-  docs-installation-parameters: done
+  docs-configuration-parameters:
+    status: todo
+    comment: https://github.com/home-assistant/home-assistant.io/pull/36083
+  docs-installation-parameters:
+    status: todo
+    comment: https://github.com/home-assistant/home-assistant.io/pull/36083
   entity-unavailable: done
   integration-owner: done
   log-when-unavailable: done
@@ -59,13 +65,19 @@ rules:
   docs-supported-functions: done
   docs-troubleshooting: todo
   docs-use-cases: todo
-  dynamic-devices: done
+  dynamic-devices:
+    status: todo
+    comment: Discussion going on if needed as cars are not added regularly.
   entity-category: done
   entity-device-class: done
   entity-disabled-by-default: done
-  entity-translations: done
+  entity-translations:
+    status: todo
+    comment: Issue in button
   exception-translations: todo
-  icon-translations: done
+  icon-translations:
+    status: todo
+    comment: Issue in device_tracker
   reconfiguration-flow: done
   repair-issues:
     status: exempt
@@ -75,6 +87,6 @@ rules:
   # Platinum
   async-dependency: done
   inject-websession:
-    status: exempt
-    comment: The library requires a custom client for API authentication.
+    status: todo
+    comment: The library requires a custom client for API authentication, with custom auth lifecycle and user agents.
   strict-typing: done

--- a/homeassistant/components/bmw_connected_drive/quality_scale.yaml
+++ b/homeassistant/components/bmw_connected_drive/quality_scale.yaml
@@ -61,7 +61,7 @@ rules:
   docs-use-cases: todo
   dynamic-devices:
     status: todo
-    comment: Discussion going on if needed as cars are not added regularly.
+    comment: Ongoing discussion, we cannot regularly get new devices/vehicles due to API quota limitations.
   entity-category: done
   entity-device-class: done
   entity-disabled-by-default: done
@@ -73,7 +73,9 @@ rules:
     status: exempt
     comment: |
       Other than reauthentication, this integration doesn't have any cases where raising an issue is needed.
-  stale-devices: done
+  stale-devices:
+    status: todo
+    comment: Ongoing discussion, we cannot regularly check for stale devices/vehicles due to API quota limitations.
   # Platinum
   async-dependency: done
   inject-websession:

--- a/homeassistant/components/bmw_connected_drive/quality_scale.yaml
+++ b/homeassistant/components/bmw_connected_drive/quality_scale.yaml
@@ -30,7 +30,7 @@ rules:
   entity-unavailable: done
   integration-owner: done
   log-when-unavailable: done
-  parallel-updates: todo
+  parallel-updates: done
   reauthentication-flow: done
   test-coverage: done
 

--- a/homeassistant/components/bmw_connected_drive/quality_scale.yaml
+++ b/homeassistant/components/bmw_connected_drive/quality_scale.yaml
@@ -22,10 +22,7 @@ rules:
       + test_full_user_flow_implementation doesn't assert unique id of created entry
       + test that aborts when a mocked config entry already exists
       + don't test on internals (e.g. `coordinator.last_update_success`) but rather on the resulting state (change)
-  config-flow:
-    status: done
-    comment: |
-      - Don't set `data` as class instance
+  config-flow: done
   dependency-transparency: done
   docs-actions:
     status: exempt
@@ -105,6 +102,6 @@ rules:
   inject-websession:
     status: todo
     comment: >
-      To be discussed. The library requires a custom client for API authentication,
-      with custom auth lifecycle and user agents.
+      To be discussed.
+      The library requires a custom client for API authentication, with custom auth lifecycle and user agents.
   strict-typing: done

--- a/homeassistant/components/bmw_connected_drive/quality_scale.yaml
+++ b/homeassistant/components/bmw_connected_drive/quality_scale.yaml
@@ -1,13 +1,19 @@
 rules:
   # Bronze
-  action-setup: done
+  action-setup:
+    status: exempt
+    comment: |
+      Does not have custom services
   appropriate-polling: done
   brands: done
   common-modules: done
   config-flow-test-coverage: done
   config-flow: done
   dependency-transparency: done
-  docs-actions: done
+  docs-actions:
+    status: exempt
+    comment: |
+      Does not have custom services
   docs-high-level-description: done
   docs-installation-instructions: done
   docs-removal-instructions: todo
@@ -23,7 +29,10 @@ rules:
   unique-config-entry: done
 
   # Silver
-  action-exceptions: done
+  action-exceptions:
+    status: exempt
+    comment: |
+      Does not have custom services
   config-entry-unloading: done
   docs-configuration-parameters: done
   docs-installation-parameters: done

--- a/homeassistant/components/bmw_connected_drive/quality_scale.yaml
+++ b/homeassistant/components/bmw_connected_drive/quality_scale.yaml
@@ -65,13 +65,9 @@ rules:
   entity-category: done
   entity-device-class: done
   entity-disabled-by-default: done
-  entity-translations:
-    status: todo
-    comment: Issue in button
-  exception-translations: todo
-  icon-translations:
-    status: todo
-    comment: Issue in device_tracker
+  entity-translations: done
+  exception-translations: done
+  icon-translations: done
   reconfiguration-flow: done
   repair-issues:
     status: exempt

--- a/homeassistant/components/bmw_connected_drive/quality_scale.yaml
+++ b/homeassistant/components/bmw_connected_drive/quality_scale.yaml
@@ -16,9 +16,7 @@ rules:
       Does not have custom services
   docs-high-level-description: done
   docs-installation-instructions: done
-  docs-removal-instructions:
-    status: todo
-    comment: https://github.com/home-assistant/home-assistant.io/pull/36083
+  docs-removal-instructions: done
   entity-event-setup:
     status: exempt
     comment: |
@@ -36,12 +34,8 @@ rules:
     comment: |
       Does not have custom services
   config-entry-unloading: done
-  docs-configuration-parameters:
-    status: todo
-    comment: https://github.com/home-assistant/home-assistant.io/pull/36083
-  docs-installation-parameters:
-    status: todo
-    comment: https://github.com/home-assistant/home-assistant.io/pull/36083
+  docs-configuration-parameters: done
+  docs-installation-parameters: done
   entity-unavailable: done
   integration-owner: done
   log-when-unavailable: done
@@ -58,12 +52,12 @@ rules:
   discovery:
     status: exempt
     comment: This integration doesn't use discovery.
-  docs-data-update: todo
+  docs-data-update: done
   docs-examples: todo
-  docs-known-limitations: todo
-  docs-supported-devices: todo
+  docs-known-limitations: done
+  docs-supported-devices: done
   docs-supported-functions: done
-  docs-troubleshooting: todo
+  docs-troubleshooting: done
   docs-use-cases: todo
   dynamic-devices:
     status: todo

--- a/script/hassfest/quality_scale.py
+++ b/script/hassfest/quality_scale.py
@@ -219,7 +219,6 @@ INTEGRATIONS_WITHOUT_QUALITY_SCALE_FILE = [
     "bluetooth_adapters",
     "bluetooth_le_tracker",
     "bluetooth_tracker",
-    "bmw_connected_drive",
     "bond",
     "bosch_shc",
     "braviatv",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update BMW to new quality scale details. As we were on `platinum` before, most of the rules have already been observed.

## Bronze
- [x] `config-flow` - Integration needs to be able to be set up via the UI
    - [x] Uses `data-description` to give context to fields
    - [x] Uses `ConfigEntry.data` and `ConfigEntry.options` correctly
- [x] `test-before-configure` - Test a connection in the config flow
- [x] `unique-config-entry` - Don't allow the same device or service to be able to be set up twice
- [x] `config-flow-test-coverage` - Full test coverage for the config flow
- [x] `runtime-data` - Use ConfigEntry.runtime_data to store runtime data https://github.com/home-assistant/core/pull/132087
- [x] `test-before-setup` - Check during integration initialization if we are able to set it up correctly
- [x] `appropriate-polling` - If it's a polling integration, set an appropriate polling interval
- [x] `entity-unique-id` - Entities have a unique ID
- [x] `has-entity-name` - Entities use has_entity_name = True
- [x] `entity-event-setup` - Entities event setup
- [x] `dependency-transparency` - Dependency transparency
- [x] `action-setup` - Service actions are registered in async_setup
- [x] `common-modules` - Place common patterns in common modules
- [x] `docs-high-level-description` - The documentation includes a high-level description of the integration brand, product, or service
- [x] `docs-installation-instructions` - The documentation provides step-by-step installation instructions for the integration, including, if needed, prerequisites
- [x] `docs-removal-instructions` - The documentation provides removal instructions https://github.com/home-assistant/home-assistant.io/pull/36083
- [x] `docs-actions` - The documentation describes the provided service actions that can be used
- [x] `brands` - Has branding assets available for the integration

## Silver
- [x] `config-entry-unloading` - Support config entry unloading
- [x] `log-when-unavailable` - If internet/device/service is unavailable, log once when unavailable and once when back connected
- [x] `entity-unavailable` - Mark entity unavailable if appropriate
- [x] `action-exceptions` - Service actions raise exceptions when encountering failures
- [x] `reauthentication-flow` - Reauthentication flow
- [x] `parallel-updates` - Set Parallel updates #132019 #132088
- [x] `test-coverage` - Above 95% test coverage for all integration modules
- [x] `integration-owner` - Has an integration owner
- [x] `docs-installation-parameters` - The documentation describes all integration installation parameters https://github.com/home-assistant/home-assistant.io/pull/36083
- [x] `docs-configuration-parameters` - The documentation describes all integration configuration options https://github.com/home-assistant/home-assistant.io/pull/36083

## Gold
- [x] `entity-translations` - Entities have translated names #133236
- [x] `entity-device-class` - Entities use device classes where possible
- [x] `devices` - The integration creates devices
- [x] `entity-category` - Entities are assigned an appropriate EntityCategory
- [x] `entity-disabled-by-default` - Integration disables less popular (or noisy) entities
- [x] `discovery` - Can be discovered
- [ ] `stale-devices` - Clean up stale devices
- [x] `diagnostics` - Implements diagnostics
- [x] `exception-translations` - Exception messages are translatable #133236
- [x] `icon-translations` - Icon translations #133236
- [x] `reconfiguration-flow` - Integrations should have a reconfigure flow
- [ ] `dynamic-devices` - Devices added after integration setup
- [x] `discovery-update-info` - Integration uses discovery info to update network information
- [x] `repair-issues` - Repair issues and repair flows are used when user intervention is needed
- [ ] `docs-use-cases` - The documentation describes use cases to illustrate how this integration can be used
- [x] `docs-supported-devices` - The documentation describes known supported / unsupported devices https://github.com/home-assistant/home-assistant.io/pull/36083
- [x] `docs-supported-functions` - The documentation describes the supported functionality, including entities, and platforms
- [x] `docs-data-update` - The documentation describes how data is updated https://github.com/home-assistant/home-assistant.io/pull/36083
- [x] `docs-known-limitations` - The documentation describes known limitations of the integration (not to be confused with bugs) https://github.com/home-assistant/home-assistant.io/pull/36083
- [x] `docs-troubleshooting` - The documentation provides troubleshooting information https://github.com/home-assistant/home-assistant.io/pull/36083
- [ ] `docs-examples` - The documentation provides automation examples the user can use.

## Platinum
- [x] `async-dependency` - Dependency is async
- [ ] `inject-websession` - The integration dependency supports passing in a websession
- [x] `strict-typing` - Strict typing


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
