### PR TITLE
Add check for typed ConfigEntry in quality scale validation

### DIFF
--- a/script/hassfest/quality_scale.py
+++ b/script/hassfest/quality_scale.py
@@ -1350,16 +1350,19 @@ def validate_iqs_file(config: Config, integration: Integration) -> None:
             "quality_scale", f"Invalid {name}: {humanize_error(data, err)}"
         )
 
+    rules_done = set[str]()
     rules_met = set[str]()
     for rule_name, rule_value in data.get("rules", {}).items():
         status = rule_value["status"] if isinstance(rule_value, dict) else rule_value
         if status not in {"done", "exempt"}:
             continue
         rules_met.add(rule_name)
-        if (
-            status == "done"
-            and (validator := VALIDATORS.get(rule_name))
-            and (errors := validator.validate(integration))
+        if status == "done":
+            rules_done.add(rule_name)
+
+    for rule_name in rules_done:
+        if (validator := VALIDATORS.get(rule_name)) and (
+            errors := validator.validate(integration, rules_done=rules_done)
         ):
             for error in errors:
                 integration.add_error("quality_scale", f"[{rule_name}] {error}")

--- a/script/hassfest/quality_scale_validation/__init__.py
+++ b/script/hassfest/quality_scale_validation/__init__.py
@@ -8,7 +8,9 @@ from script.hassfest.model import Integration
 class RuleValidationProtocol(Protocol):
     """Protocol for rule validation."""
 
-    def validate(self, integration: Integration) -> list[str] | None:
+    def validate(
+        self, integration: Integration, *, rules_done: set[str]
+    ) -> list[str] | None:
         """Validate a quality scale rule.
 
         Returns error (if any).

--- a/script/hassfest/quality_scale_validation/config_entry_unloading.py
+++ b/script/hassfest/quality_scale_validation/config_entry_unloading.py
@@ -17,7 +17,7 @@ def _has_unload_entry_function(module: ast.Module) -> bool:
     )
 
 
-def validate(integration: Integration) -> list[str] | None:
+def validate(integration: Integration, *, rules_done: set[str]) -> list[str] | None:
     """Validate that the integration has a config flow."""
 
     init_file = integration.path / "__init__.py"

--- a/script/hassfest/quality_scale_validation/config_flow.py
+++ b/script/hassfest/quality_scale_validation/config_flow.py
@@ -6,7 +6,7 @@ https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/c
 from script.hassfest.model import Integration
 
 
-def validate(integration: Integration) -> list[str] | None:
+def validate(integration: Integration, *, rules_done: set[str]) -> list[str] | None:
     """Validate that the integration implements config flow."""
 
     if not integration.config_flow:

--- a/script/hassfest/quality_scale_validation/diagnostics.py
+++ b/script/hassfest/quality_scale_validation/diagnostics.py
@@ -22,7 +22,7 @@ def _has_diagnostics_function(module: ast.Module) -> bool:
     )
 
 
-def validate(integration: Integration) -> list[str] | None:
+def validate(integration: Integration, *, rules_done: set[str]) -> list[str] | None:
     """Validate that the integration implements diagnostics."""
 
     diagnostics_file = integration.path / "diagnostics.py"

--- a/script/hassfest/quality_scale_validation/discovery.py
+++ b/script/hassfest/quality_scale_validation/discovery.py
@@ -38,7 +38,7 @@ def _has_discovery_function(module: ast.Module) -> bool:
     )
 
 
-def validate(integration: Integration) -> list[str] | None:
+def validate(integration: Integration, *, rules_done: set[str]) -> list[str] | None:
     """Validate that the integration implements diagnostics."""
 
     config_flow_file = integration.path / "config_flow.py"

--- a/script/hassfest/quality_scale_validation/parallel_updates.py
+++ b/script/hassfest/quality_scale_validation/parallel_updates.py
@@ -17,7 +17,7 @@ def _has_parallel_updates_defined(module: ast.Module) -> bool:
     )
 
 
-def validate(integration: Integration) -> list[str] | None:
+def validate(integration: Integration, *, rules_done: set[str]) -> list[str] | None:
     """Validate that the integration sets PARALLEL_UPDATES constant."""
 
     errors = []

--- a/script/hassfest/quality_scale_validation/reauthentication_flow.py
+++ b/script/hassfest/quality_scale_validation/reauthentication_flow.py
@@ -17,7 +17,7 @@ def _has_step_reauth_function(module: ast.Module) -> bool:
     )
 
 
-def validate(integration: Integration) -> list[str] | None:
+def validate(integration: Integration, *, rules_done: set[str]) -> list[str] | None:
     """Validate that the integration has a reauthentication flow."""
 
     config_flow_file = integration.path / "config_flow.py"

--- a/script/hassfest/quality_scale_validation/reconfiguration_flow.py
+++ b/script/hassfest/quality_scale_validation/reconfiguration_flow.py
@@ -17,7 +17,7 @@ def _has_step_reconfigure_function(module: ast.Module) -> bool:
     )
 
 
-def validate(integration: Integration) -> list[str] | None:
+def validate(integration: Integration, *, rules_done: set[str]) -> list[str] | None:
     """Validate that the integration has a reconfiguration flow."""
 
     config_flow_file = integration.path / "config_flow.py"

--- a/script/hassfest/quality_scale_validation/runtime_data.py
+++ b/script/hassfest/quality_scale_validation/runtime_data.py
@@ -78,7 +78,7 @@ def _check_typed_config_entry(integration: Integration) -> list[str]:
         module_file = integration.path / f"{file}.py"
         if not module_file.exists():
             continue
-        module = ast.parse(module_file.read_text())
+        module = ast_parse_module(module_file.read_text())
         for function, position in functions.items():
             if not (async_function := _get_async_function(module, function)):
                 continue
@@ -87,7 +87,7 @@ def _check_typed_config_entry(integration: Integration) -> list[str]:
 
     # Check config_flow annotations
     config_flow_file = integration.path / "config_flow.py"
-    config_flow = ast.parse(config_flow_file.read_text())
+    config_flow = ast_parse_module(config_flow_file.read_text())
     for node in config_flow.body:
         if not isinstance(node, ast.ClassDef):
             continue
@@ -105,7 +105,7 @@ def _check_typed_config_entry(integration: Integration) -> list[str]:
 def validate(integration: Integration, *, rules_done: set[str]) -> list[str] | None:
     """Validate correct use of ConfigEntry.runtime_data."""
     init_file = integration.path / "__init__.py"
-    init = ast.parse(init_file.read_text())
+    init = ast_parse_module(init_file.read_text())
 
     # Should not happen, but better to be safe
     if not (async_setup_entry := _get_async_function(init, "async_setup_entry")):

--- a/script/hassfest/quality_scale_validation/runtime_data.py
+++ b/script/hassfest/quality_scale_validation/runtime_data.py
@@ -78,7 +78,7 @@ def _check_typed_config_entry(integration: Integration) -> list[str]:
         module_file = integration.path / f"{file}.py"
         if not module_file.exists():
             continue
-        module = ast_parse_module(module_file.read_text())
+        module = ast_parse_module(module_file)
         for function, position in functions.items():
             if not (async_function := _get_async_function(module, function)):
                 continue
@@ -87,7 +87,7 @@ def _check_typed_config_entry(integration: Integration) -> list[str]:
 
     # Check config_flow annotations
     config_flow_file = integration.path / "config_flow.py"
-    config_flow = ast_parse_module(config_flow_file.read_text())
+    config_flow = ast_parse_module(config_flow_file)
     for node in config_flow.body:
         if not isinstance(node, ast.ClassDef):
             continue
@@ -105,7 +105,7 @@ def _check_typed_config_entry(integration: Integration) -> list[str]:
 def validate(integration: Integration, *, rules_done: set[str]) -> list[str] | None:
     """Validate correct use of ConfigEntry.runtime_data."""
     init_file = integration.path / "__init__.py"
-    init = ast_parse_module(init_file.read_text())
+    init = ast_parse_module(init_file)
 
     # Should not happen, but better to be safe
     if not (async_setup_entry := _get_async_function(init, "async_setup_entry")):

--- a/script/hassfest/quality_scale_validation/runtime_data.py
+++ b/script/hassfest/quality_scale_validation/runtime_data.py
@@ -66,7 +66,7 @@ def _check_function_annotation(
         and isinstance(annotation, ast.Name)
         and _ANNOTATION_MATCH.match(annotation.id)
     ):
-        return f"{function.name} does not use typed ConfigEntry"
+        return f"+[strict-typing] {function.name} does not use typed ConfigEntry"
     return None
 
 

--- a/script/hassfest/quality_scale_validation/runtime_data.py
+++ b/script/hassfest/quality_scale_validation/runtime_data.py
@@ -66,7 +66,7 @@ def _check_function_annotation(
         and isinstance(annotation, ast.Name)
         and _ANNOTATION_MATCH.match(annotation.id)
     ):
-        return f"+[strict-typing] {function.name} does not use typed ConfigEntry"
+        return f"([+ strict-typing]) {function.name} does not use typed ConfigEntry"
     return None
 
 

--- a/script/hassfest/quality_scale_validation/strict_typing.py
+++ b/script/hassfest/quality_scale_validation/strict_typing.py
@@ -24,7 +24,7 @@ def _strict_typing_components() -> set[str]:
     )
 
 
-def validate(integration: Integration) -> list[str] | None:
+def validate(integration: Integration, *, rules_done: set[str]) -> list[str] | None:
     """Validate that the integration has strict typing enabled."""
 
     if integration.domain not in _strict_typing_components():

--- a/script/hassfest/quality_scale_validation/unique_config_entry.py
+++ b/script/hassfest/quality_scale_validation/unique_config_entry.py
@@ -30,7 +30,7 @@ def _has_abort_unique_id_configured(module: ast.Module) -> bool:
     )
 
 
-def validate(integration: Integration) -> list[str] | None:
+def validate(integration: Integration, *, rules_done: set[str]) -> list[str] | None:
     """Validate that the integration prevents duplicate devices."""
 
     if integration.manifest.get("single_config_entry"):


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As follow-up to #131857

Needs:
- [x] #132029 
- [x] #132031
- [x] #132248
- [x] #132249
- [x] #132346 

```
Invalid integrations: 2
Integration fyta:
Error: R] [QUALITY_SCALE] [runtime-data] [+ strict-typing] async_migrate_entry does not use typed ConfigEntry in homeassistant/components/fyta/__init__.py
Error: R] [QUALITY_SCALE] [runtime-data] [+ strict-typing] async_unload_entry does not use typed ConfigEntry in homeassistant/components/fyta/__init__.py
Error: R] [QUALITY_SCALE] Please check the documentation at https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/runtime-data/
Integration mastodon:
Error: R] [QUALITY_SCALE] [runtime-data] [+ strict-typing] async_migrate_entry does not use typed ConfigEntry in homeassistant/components/mastodon/__init__.py
Error: R] [QUALITY_SCALE] Please check the documentation at https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/runtime-data/
Error: Process completed with exit code 1.
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/2479

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
