### PR TITLE
Bump cryptography to 44.0.0 and pyOpenSSL to 24.3.0

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -25,7 +25,7 @@ bluetooth-data-tools==1.20.0
 cached-ipaddress==0.8.0
 certifi>=2021.5.30
 ciso8601==2.3.1
-cryptography==43.0.1
+cryptography==44.0.0
 dbus-fast==2.24.3
 fnv-hash-fast==1.0.2
 go2rtc-client==0.1.1
@@ -50,7 +50,7 @@ psutil-home-assistant==0.0.1
 PyJWT==2.10.0
 pymicro-vad==1.0.1
 PyNaCl==1.5.0
-pyOpenSSL==24.2.1
+pyOpenSSL==24.3.0
 pyserial==3.5
 pyspeex-noise==1.0.2
 python-slugify==8.0.4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,10 +55,10 @@ dependencies    = [
     "lru-dict==1.3.0",
     "PyJWT==2.10.0",
     # PyJWT has loose dependency. We want the latest one.
-    "cryptography==43.0.1",
+    "cryptography==44.0.0",
     "Pillow==11.0.0",
     "propcache==0.2.1",
-    "pyOpenSSL==24.2.1",
+    "pyOpenSSL==24.3.0",
     "orjson==3.10.12",
     "packaging>=23.1",
     "psutil-home-assistant==0.0.1",

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,10 +26,10 @@ ifaddr==0.2.0
 Jinja2==3.1.4
 lru-dict==1.3.0
 PyJWT==2.10.0
-cryptography==43.0.1
+cryptography==44.0.0
 Pillow==11.0.0
 propcache==0.2.1
-pyOpenSSL==24.2.1
+pyOpenSSL==24.3.0
 orjson==3.10.12
 packaging>=23.1
 psutil-home-assistant==0.0.1


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

These should be bumped together to make sure we do not have any incompatibility issues.

> Note: The Python Cryptographic Authority strongly suggests the use of pyca/cryptography where possible. If you are using pyOpenSSL for anything other than making a TLS connection you should move to cryptography and drop your pyOpenSSL dependency.

changelogs:
https://github.com/pyca/pyopenssl/compare/24.2.1...24.3.0
https://github.com/pyca/cryptography/compare/43.0.1...44.0.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
