### PR TITLE
Remove native_unit_of_measurement from Onewire counters

### DIFF
--- a/homeassistant/components/onewire/sensor.py
+++ b/homeassistant/components/onewire/sensor.py
@@ -233,7 +233,6 @@ DEVICE_SENSORS: dict[str, tuple[OneWireSensorEntityDescription, ...]] = {
     "1D": tuple(
         OneWireSensorEntityDescription(
             key=f"counter.{device_key}",
-            native_unit_of_measurement="count",
             read_mode=READ_MODE_INT,
             state_class=SensorStateClass.TOTAL_INCREASING,
             translation_key="counter_id",

--- a/homeassistant/components/onewire/sensor.py
+++ b/homeassistant/components/onewire/sensor.py
@@ -233,6 +233,7 @@ DEVICE_SENSORS: dict[str, tuple[OneWireSensorEntityDescription, ...]] = {
     "1D": tuple(
         OneWireSensorEntityDescription(
             key=f"counter.{device_key}",
+            native_unit_of_measurement="count",
             read_mode=READ_MODE_INT,
             state_class=SensorStateClass.TOTAL_INCREASING,
             translation_key="counter_id",

--- a/homeassistant/components/onewire/strings.json
+++ b/homeassistant/components/onewire/strings.json
@@ -30,8 +30,7 @@
     },
     "sensor": {
       "counter_id": {
-        "name": "Counter {id}",
-        "unit_of_measurement": "count"
+        "name": "Counter {id}"
       },
       "humidity_hih3600": {
         "name": "HIH3600 humidity"

--- a/homeassistant/components/onewire/strings.json
+++ b/homeassistant/components/onewire/strings.json
@@ -30,7 +30,8 @@
     },
     "sensor": {
       "counter_id": {
-        "name": "Counter {id}"
+        "name": "Counter {id}",
+        "unit_of_measurement": "count"
       },
       "humidity_hih3600": {
         "name": "HIH3600 humidity"

--- a/tests/components/onewire/snapshots/test_sensor.ambr
+++ b/tests/components/onewire/snapshots/test_sensor.ambr
@@ -363,7 +363,7 @@
       'supported_features': 0,
       'translation_key': 'counter_id',
       'unique_id': '/1D.111111111111/counter.A',
-      'unit_of_measurement': 'count',
+      'unit_of_measurement': None,
     }),
     EntityRegistryEntrySnapshot({
       'aliases': set({
@@ -396,7 +396,7 @@
       'supported_features': 0,
       'translation_key': 'counter_id',
       'unique_id': '/1D.111111111111/counter.B',
-      'unit_of_measurement': 'count',
+      'unit_of_measurement': None,
     }),
   ])
 # ---
@@ -408,7 +408,6 @@
         'friendly_name': '1D.111111111111 Counter A',
         'raw_value': 251123.0,
         'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
-        'unit_of_measurement': 'count',
       }),
       'context': <ANY>,
       'entity_id': 'sensor.1d_111111111111_counter_a',
@@ -423,7 +422,6 @@
         'friendly_name': '1D.111111111111 Counter B',
         'raw_value': 248125.0,
         'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
-        'unit_of_measurement': 'count',
       }),
       'context': <ANY>,
       'entity_id': 'sensor.1d_111111111111_counter_b',
@@ -531,7 +529,7 @@
       'supported_features': 0,
       'translation_key': 'counter_id',
       'unique_id': '/1D.111111111111/counter.A',
-      'unit_of_measurement': 'count',
+      'unit_of_measurement': None,
     }),
     EntityRegistryEntrySnapshot({
       'aliases': set({
@@ -564,7 +562,7 @@
       'supported_features': 0,
       'translation_key': 'counter_id',
       'unique_id': '/1D.111111111111/counter.B',
-      'unit_of_measurement': 'count',
+      'unit_of_measurement': None,
     }),
   ])
 # ---
@@ -576,7 +574,6 @@
         'friendly_name': '1D.111111111111 Counter A',
         'raw_value': 251123.0,
         'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
-        'unit_of_measurement': 'count',
       }),
       'context': <ANY>,
       'entity_id': 'sensor.1d_111111111111_counter_a',
@@ -591,7 +588,6 @@
         'friendly_name': '1D.111111111111 Counter B',
         'raw_value': 248125.0,
         'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
-        'unit_of_measurement': 'count',
       }),
       'context': <ANY>,
       'entity_id': 'sensor.1d_111111111111_counter_b',


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
The `native_unit_of_measurement` has been removed from 1-Wire counters because `count` is not a unit.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove `native_unit_of_measurement` from 1-Wire counters.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
