### PR TITLE
Improve BMWDataUpdateCoordinator typing

### DIFF
--- a/homeassistant/components/bmw_connected_drive/__init__.py
+++ b/homeassistant/components/bmw_connected_drive/__init__.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 import logging
 
 import voluptuous as vol
@@ -18,7 +17,7 @@ from homeassistant.helpers import (
 import homeassistant.helpers.config_validation as cv
 
 from .const import ATTR_VIN, CONF_READ_ONLY, DOMAIN
-from .coordinator import BMWDataUpdateCoordinator
+from .coordinator import BMWConfigEntry, BMWData, BMWDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -47,16 +46,6 @@ PLATFORMS = [
 ]
 
 SERVICE_UPDATE_STATE = "update_state"
-
-
-type BMWConfigEntry = ConfigEntry[BMWData]
-
-
-@dataclass
-class BMWData:
-    """Class to store BMW runtime data."""
-
-    coordinator: BMWDataUpdateCoordinator
 
 
 @callback
@@ -137,7 +126,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Set up one data coordinator per account/config entry
     coordinator = BMWDataUpdateCoordinator(
         hass,
-        entry=entry,
+        config_entry=entry,
     )
     await coordinator.async_config_entry_first_refresh()
 

--- a/homeassistant/components/bmw_connected_drive/__init__.py
+++ b/homeassistant/components/bmw_connected_drive/__init__.py
@@ -17,7 +17,7 @@ from homeassistant.helpers import (
 import homeassistant.helpers.config_validation as cv
 
 from .const import ATTR_VIN, CONF_READ_ONLY, DOMAIN
-from .coordinator import BMWConfigEntry, BMWData, BMWDataUpdateCoordinator
+from .coordinator import BMWConfigEntry, BMWDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -130,7 +130,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
     await coordinator.async_config_entry_first_refresh()
 
-    entry.runtime_data = BMWData(coordinator)
+    entry.runtime_data = coordinator
 
     # Set up all platforms except notify
     await hass.config_entries.async_forward_entry_setups(

--- a/homeassistant/components/bmw_connected_drive/binary_sensor.py
+++ b/homeassistant/components/bmw_connected_drive/binary_sensor.py
@@ -201,7 +201,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the BMW binary sensors from config entry."""
-    coordinator = config_entry.runtime_data.coordinator
+    coordinator = config_entry.runtime_data
 
     entities = [
         BMWBinarySensor(coordinator, vehicle, description, hass.config.units)

--- a/homeassistant/components/bmw_connected_drive/button.py
+++ b/homeassistant/components/bmw_connected_drive/button.py
@@ -73,7 +73,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the BMW buttons from config entry."""
-    coordinator = config_entry.runtime_data.coordinator
+    coordinator = config_entry.runtime_data
 
     entities: list[BMWButton] = []
 

--- a/homeassistant/components/bmw_connected_drive/coordinator.py
+++ b/homeassistant/components/bmw_connected_drive/coordinator.py
@@ -32,7 +32,7 @@ class BMWDataUpdateCoordinator(DataUpdateCoordinator[None]):
 
     account: MyBMWAccount
     read_only: bool
-    _entry: ConfigEntry
+    config_entry: ConfigEntry
 
     def __init__(self, hass: HomeAssistant, *, entry: ConfigEntry) -> None:
         """Initialize account-wide BMW data updater."""
@@ -44,7 +44,6 @@ class BMWDataUpdateCoordinator(DataUpdateCoordinator[None]):
             verify=get_default_context(),
         )
         self.read_only = entry.options[CONF_READ_ONLY]
-        self._entry = entry
 
         if CONF_REFRESH_TOKEN in entry.data:
             self.account.set_refresh_token(
@@ -55,6 +54,7 @@ class BMWDataUpdateCoordinator(DataUpdateCoordinator[None]):
         super().__init__(
             hass,
             _LOGGER,
+            config_entry=entry,
             name=f"{DOMAIN}-{entry.data['username']}",
             update_interval=timedelta(seconds=SCAN_INTERVALS[entry.data[CONF_REGION]]),
         )
@@ -90,9 +90,9 @@ class BMWDataUpdateCoordinator(DataUpdateCoordinator[None]):
     def _update_config_entry_refresh_token(self, refresh_token: str | None) -> None:
         """Update or delete the refresh_token in the Config Entry."""
         data = {
-            **self._entry.data,
+            **self.config_entry.data,
             CONF_REFRESH_TOKEN: refresh_token,
         }
         if not refresh_token:
             data.pop(CONF_REFRESH_TOKEN)
-        self.hass.config_entries.async_update_entry(self._entry, data=data)
+        self.hass.config_entries.async_update_entry(self.config_entry, data=data)

--- a/homeassistant/components/bmw_connected_drive/coordinator.py
+++ b/homeassistant/components/bmw_connected_drive/coordinator.py
@@ -31,6 +31,8 @@ class BMWDataUpdateCoordinator(DataUpdateCoordinator[None]):
     """Class to manage fetching BMW data."""
 
     account: MyBMWAccount
+    read_only: bool = False
+    _entry: ConfigEntry
 
     def __init__(self, hass: HomeAssistant, *, entry: ConfigEntry) -> None:
         """Initialize account-wide BMW data updater."""

--- a/homeassistant/components/bmw_connected_drive/coordinator.py
+++ b/homeassistant/components/bmw_connected_drive/coordinator.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from datetime import timedelta
 import logging
 
@@ -28,14 +27,7 @@ from .const import CONF_GCID, CONF_READ_ONLY, CONF_REFRESH_TOKEN, DOMAIN, SCAN_I
 _LOGGER = logging.getLogger(__name__)
 
 
-type BMWConfigEntry = ConfigEntry[BMWData]
-
-
-@dataclass
-class BMWData:
-    """Class to store BMW runtime data."""
-
-    coordinator: BMWDataUpdateCoordinator
+type BMWConfigEntry = ConfigEntry[BMWDataUpdateCoordinator]
 
 
 class BMWDataUpdateCoordinator(DataUpdateCoordinator[None]):

--- a/homeassistant/components/bmw_connected_drive/coordinator.py
+++ b/homeassistant/components/bmw_connected_drive/coordinator.py
@@ -34,7 +34,6 @@ class BMWDataUpdateCoordinator(DataUpdateCoordinator[None]):
     """Class to manage fetching BMW data."""
 
     account: MyBMWAccount
-    read_only: bool
     config_entry: BMWConfigEntry
 
     def __init__(self, hass: HomeAssistant, *, config_entry: ConfigEntry) -> None:
@@ -46,7 +45,7 @@ class BMWDataUpdateCoordinator(DataUpdateCoordinator[None]):
             observer_position=GPSPosition(hass.config.latitude, hass.config.longitude),
             verify=get_default_context(),
         )
-        self.read_only = config_entry.options[CONF_READ_ONLY]
+        self.read_only: bool = config_entry.options[CONF_READ_ONLY]
 
         if CONF_REFRESH_TOKEN in config_entry.data:
             self.account.set_refresh_token(

--- a/homeassistant/components/bmw_connected_drive/coordinator.py
+++ b/homeassistant/components/bmw_connected_drive/coordinator.py
@@ -31,7 +31,7 @@ class BMWDataUpdateCoordinator(DataUpdateCoordinator[None]):
     """Class to manage fetching BMW data."""
 
     account: MyBMWAccount
-    read_only: bool = False
+    read_only: bool
     _entry: ConfigEntry
 
     def __init__(self, hass: HomeAssistant, *, entry: ConfigEntry) -> None:

--- a/homeassistant/components/bmw_connected_drive/device_tracker.py
+++ b/homeassistant/components/bmw_connected_drive/device_tracker.py
@@ -25,7 +25,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the MyBMW tracker from config entry."""
-    coordinator = config_entry.runtime_data.coordinator
+    coordinator = config_entry.runtime_data
     entities: list[BMWDeviceTracker] = []
 
     for vehicle in coordinator.account.vehicles:

--- a/homeassistant/components/bmw_connected_drive/diagnostics.py
+++ b/homeassistant/components/bmw_connected_drive/diagnostics.py
@@ -49,7 +49,7 @@ async def async_get_config_entry_diagnostics(
     hass: HomeAssistant, config_entry: BMWConfigEntry
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
-    coordinator = config_entry.runtime_data.coordinator
+    coordinator = config_entry.runtime_data
 
     coordinator.account.config.log_responses = True
     await coordinator.account.get_vehicles(force_init=True)
@@ -75,7 +75,7 @@ async def async_get_device_diagnostics(
     hass: HomeAssistant, config_entry: BMWConfigEntry, device: DeviceEntry
 ) -> dict[str, Any]:
     """Return diagnostics for a device."""
-    coordinator = config_entry.runtime_data.coordinator
+    coordinator = config_entry.runtime_data
 
     coordinator.account.config.log_responses = True
     await coordinator.account.get_vehicles(force_init=True)

--- a/homeassistant/components/bmw_connected_drive/lock.py
+++ b/homeassistant/components/bmw_connected_drive/lock.py
@@ -31,7 +31,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the MyBMW lock from config entry."""
-    coordinator = config_entry.runtime_data.coordinator
+    coordinator = config_entry.runtime_data
 
     if not coordinator.read_only:
         async_add_entities(

--- a/homeassistant/components/bmw_connected_drive/notify.py
+++ b/homeassistant/components/bmw_connected_drive/notify.py
@@ -53,7 +53,7 @@ def get_service(
     targets = {}
     if (
         config_entry
-        and (coordinator := config_entry.runtime_data.coordinator)
+        and (coordinator := config_entry.runtime_data)
         and not coordinator.read_only
     ):
         targets.update({v.name: v for v in coordinator.account.vehicles})

--- a/homeassistant/components/bmw_connected_drive/number.py
+++ b/homeassistant/components/bmw_connected_drive/number.py
@@ -61,7 +61,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the MyBMW number from config entry."""
-    coordinator = config_entry.runtime_data.coordinator
+    coordinator = config_entry.runtime_data
 
     entities: list[BMWNumber] = []
 

--- a/homeassistant/components/bmw_connected_drive/select.py
+++ b/homeassistant/components/bmw_connected_drive/select.py
@@ -68,7 +68,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the MyBMW lock from config entry."""
-    coordinator = config_entry.runtime_data.coordinator
+    coordinator = config_entry.runtime_data
 
     entities: list[BMWSelect] = []
 

--- a/homeassistant/components/bmw_connected_drive/sensor.py
+++ b/homeassistant/components/bmw_connected_drive/sensor.py
@@ -191,7 +191,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the MyBMW sensors from config entry."""
-    coordinator = config_entry.runtime_data.coordinator
+    coordinator = config_entry.runtime_data
 
     entities = [
         BMWSensor(coordinator, vehicle, description)

--- a/homeassistant/components/bmw_connected_drive/switch.py
+++ b/homeassistant/components/bmw_connected_drive/switch.py
@@ -69,7 +69,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the MyBMW switch from config entry."""
-    coordinator = config_entry.runtime_data.coordinator
+    coordinator = config_entry.runtime_data
 
     entities: list[BMWSwitch] = []
 

--- a/tests/components/bmw_connected_drive/test_coordinator.py
+++ b/tests/components/bmw_connected_drive/test_coordinator.py
@@ -33,7 +33,7 @@ async def test_update_success(hass: HomeAssistant) -> None:
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert config_entry.runtime_data.coordinator.last_update_success is True
+    assert config_entry.runtime_data.last_update_success is True
 
 
 @pytest.mark.usefixtures("bmw_fixture")
@@ -48,7 +48,7 @@ async def test_update_failed(
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    coordinator = config_entry.runtime_data.coordinator
+    coordinator = config_entry.runtime_data
 
     assert coordinator.last_update_success is True
 
@@ -77,7 +77,7 @@ async def test_update_reauth(
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    coordinator = config_entry.runtime_data.coordinator
+    coordinator = config_entry.runtime_data
 
     assert coordinator.last_update_success is True
 
@@ -146,7 +146,7 @@ async def test_captcha_reauth(
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    coordinator = config_entry.runtime_data.coordinator
+    coordinator = config_entry.runtime_data
 
     assert coordinator.last_update_success is True
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve typing so `entry.runtime_data.coordinator` is fully typed with all attributes.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
