### PR TITLE
Bump hassil and intents

### DIFF
--- a/homeassistant/components/conversation/manifest.json
+++ b/homeassistant/components/conversation/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/conversation",
   "integration_type": "system",
   "quality_scale": "internal",
-  "requirements": ["hassil==2.0.4", "home-assistant-intents==2024.11.27"]
+  "requirements": ["hassil==2.0.5", "home-assistant-intents==2024.12.2"]
 }

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -32,10 +32,10 @@ go2rtc-client==0.1.1
 ha-ffmpeg==3.2.2
 habluetooth==3.6.0
 hass-nabucasa==0.85.0
-hassil==2.0.4
+hassil==2.0.5
 home-assistant-bluetooth==1.13.0
 home-assistant-frontend==20241127.1
-home-assistant-intents==2024.11.27
+home-assistant-intents==2024.12.2
 httpx==0.27.2
 ifaddr==0.2.0
 Jinja2==3.1.4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1093,7 +1093,7 @@ hass-nabucasa==0.85.0
 hass-splunk==0.1.1
 
 # homeassistant.components.conversation
-hassil==2.0.4
+hassil==2.0.5
 
 # homeassistant.components.jewish_calendar
 hdate==0.11.1
@@ -1130,7 +1130,7 @@ holidays==0.61
 home-assistant-frontend==20241127.1
 
 # homeassistant.components.conversation
-home-assistant-intents==2024.11.27
+home-assistant-intents==2024.12.2
 
 # homeassistant.components.home_connect
 homeconnect==0.8.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -928,7 +928,7 @@ habluetooth==3.6.0
 hass-nabucasa==0.85.0
 
 # homeassistant.components.conversation
-hassil==2.0.4
+hassil==2.0.5
 
 # homeassistant.components.jewish_calendar
 hdate==0.11.1
@@ -956,7 +956,7 @@ holidays==0.61
 home-assistant-frontend==20241127.1
 
 # homeassistant.components.conversation
-home-assistant-intents==2024.11.27
+home-assistant-intents==2024.12.2
 
 # homeassistant.components.home_connect
 homeconnect==0.8.0

--- a/script/hassfest/docker/Dockerfile
+++ b/script/hassfest/docker/Dockerfile
@@ -23,7 +23,7 @@ RUN --mount=from=ghcr.io/astral-sh/uv:0.5.4,source=/uv,target=/bin/uv \
         -c /usr/src/homeassistant/homeassistant/package_constraints.txt \
         -r /usr/src/homeassistant/requirements.txt \
         stdlib-list==0.10.0 pipdeptree==2.23.4 tqdm==4.66.5 ruff==0.8.1 \
-        PyTurboJPEG==1.7.5 go2rtc-client==0.1.1 ha-ffmpeg==3.2.2 hassil==2.0.4 home-assistant-intents==2024.11.27 mutagen==1.47.0 pymicro-vad==1.0.1 pyspeex-noise==1.0.2
+        PyTurboJPEG==1.7.5 go2rtc-client==0.1.1 ha-ffmpeg==3.2.2 hassil==2.0.5 home-assistant-intents==2024.12.2 mutagen==1.47.0 pymicro-vad==1.0.1 pyspeex-noise==1.0.2
 
 LABEL "name"="hassfest"
 LABEL "maintainer"="Home Assistant <hello@home-assistant.io>"

--- a/tests/components/conversation/snapshots/test_http.ambr
+++ b/tests/components/conversation/snapshots/test_http.ambr
@@ -535,7 +535,7 @@
           'name': 'HassTurnOn',
         }),
         'match': True,
-        'sentence_template': '<turn> on [all] <light> in <area>',
+        'sentence_template': '<turn> on [<all>] <light> <in> <area>',
         'slots': dict({
           'area': 'kitchen',
           'domain': 'light',
@@ -606,7 +606,7 @@
           'name': 'OrderBeer',
         }),
         'match': True,
-        'sentence_template': "I'd like to order a {beer_style} [please]",
+        'sentence_template': "[I'd like to ]order a {beer_style} [please]",
         'slots': dict({
           'beer_style': 'lager',
         }),

--- a/tests/testing_config/custom_sentences/en/beer.yaml
+++ b/tests/testing_config/custom_sentences/en/beer.yaml
@@ -3,11 +3,11 @@ intents:
   OrderBeer:
     data:
       - sentences:
-          - "I'd like to order a {beer_style} [please]"
+          - "[I'd like to ]order a {beer_style} [please]"
   OrderFood:
     data:
       - sentences:
-          - "I'd like to order {food_name:name} [please]"
+          - "[I'd like to ]order {food_name:name} [please]"
 lists:
   beer_style:
     values:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump intents: https://github.com/home-assistant/intents/compare/2024.11.27...2024.12.2
Bump hassil: https://github.com/home-assistant/hassil/compare/v2.0.4...v2.0.5

The new intents exposed two bugs:
* New "skip words" were added to English, which were part of the test sentence templates ("I'd like to order {beer_style}"). This will ultimately need to be fixed in hassil, so for the beta the test template has simply been changed.
* New floor sentences unearthed a small bug regarding how literal matched text is counted when intent matching initially fails. This resulted in the wrong error message, and required a small change in hassil.



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
