### PR TITLE
Refactor template lock to only return LockState or None

### DIFF
--- a/homeassistant/components/template/lock.py
+++ b/homeassistant/components/template/lock.py
@@ -89,7 +89,7 @@ class TemplateLock(TemplateEntity, LockEntity):
         super().__init__(
             hass, config=config, fallback_name=DEFAULT_NAME, unique_id=unique_id
         )
-        self._state: str | bool | LockState | None = None
+        self._state: LockState | None = None
         name = self._attr_name
         assert name
         self._state_template = config.get(CONF_VALUE_TEMPLATE)
@@ -107,7 +107,7 @@ class TemplateLock(TemplateEntity, LockEntity):
     @property
     def is_locked(self) -> bool:
         """Return true if lock is locked."""
-        return self._state in ("true", STATE_ON, LockState.LOCKED)
+        return self._state == LockState.LOCKED
 
     @property
     def is_jammed(self) -> bool:
@@ -130,7 +130,7 @@ class TemplateLock(TemplateEntity, LockEntity):
         return self._state == LockState.OPEN
 
     @callback
-    def _update_state(self, result):
+    def _update_state(self, result: str | TemplateError) -> None:
         """Update the state from the template."""
         super()._update_state(result)
         if isinstance(result, TemplateError):
@@ -142,7 +142,13 @@ class TemplateLock(TemplateEntity, LockEntity):
             return
 
         if isinstance(result, str):
-            self._state = result.lower()
+            if result.lower() in ("true", STATE_ON, LockState.LOCKED):
+                self._state = LockState.LOCKED
+            else:
+                try:
+                    self._state = LockState(result.lower())
+                except ValueError:
+                    self._state = None
             return
 
         self._state = None
@@ -189,7 +195,7 @@ class TemplateLock(TemplateEntity, LockEntity):
         self._raise_template_error_if_available()
 
         if self._optimistic:
-            self._state = True
+            self._state = LockState.LOCKED
             self.async_write_ha_state()
 
         tpl_vars = {ATTR_CODE: kwargs.get(ATTR_CODE) if kwargs else None}
@@ -205,7 +211,7 @@ class TemplateLock(TemplateEntity, LockEntity):
         self._raise_template_error_if_available()
 
         if self._optimistic:
-            self._state = False
+            self._state = LockState.UNLOCKED
             self.async_write_ha_state()
 
         tpl_vars = {ATTR_CODE: kwargs.get(ATTR_CODE) if kwargs else None}

--- a/homeassistant/components/template/lock.py
+++ b/homeassistant/components/template/lock.py
@@ -18,8 +18,6 @@ from homeassistant.const import (
     CONF_OPTIMISTIC,
     CONF_UNIQUE_ID,
     CONF_VALUE_TEMPLATE,
-    STATE_OFF,
-    STATE_ON,
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ServiceValidationError, TemplateError
@@ -145,14 +143,14 @@ class TemplateLock(TemplateEntity, LockEntity):
         if isinstance(result, str):
             if result.lower() in (
                 "true",
-                STATE_ON,
-                LockState.LOCKED,
+                "on",
+                "locked",
             ):
                 self._state = LockState.LOCKED
             elif result.lower() in (
                 "false",
-                STATE_OFF,
-                LockState.UNLOCKED,
+                "off",
+                "unlocked",
             ):
                 self._state = LockState.UNLOCKED
             else:

--- a/homeassistant/components/template/lock.py
+++ b/homeassistant/components/template/lock.py
@@ -18,6 +18,7 @@ from homeassistant.const import (
     CONF_OPTIMISTIC,
     CONF_UNIQUE_ID,
     CONF_VALUE_TEMPLATE,
+    STATE_OFF,
     STATE_ON,
 )
 from homeassistant.core import HomeAssistant, callback
@@ -142,8 +143,18 @@ class TemplateLock(TemplateEntity, LockEntity):
             return
 
         if isinstance(result, str):
-            if result.lower() in ("true", STATE_ON, LockState.LOCKED):
+            if result.lower() in (
+                "true",
+                STATE_ON,
+                LockState.LOCKED,
+            ):
                 self._state = LockState.LOCKED
+            elif result.lower() in (
+                "false",
+                STATE_OFF,
+                LockState.UNLOCKED,
+            ):
+                self._state = LockState.UNLOCKED
             else:
                 try:
                     self._state = LockState(result.lower())


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 