### PR TITLE
spaceapi: fix sensor values

### DIFF
--- a/homeassistant/components/spaceapi/__init__.py
+++ b/homeassistant/components/spaceapi/__init__.py
@@ -1,6 +1,7 @@
 """Support for the SpaceAPI."""
 
 from contextlib import suppress
+import math
 
 import voluptuous as vol
 
@@ -254,7 +255,17 @@ class APISpaceApiView(HomeAssistantView):
         """Get data from a sensor."""
         if not (sensor_state := hass.states.get(sensor)):
             return None
-        sensor_data = {ATTR_NAME: sensor_state.name, ATTR_VALUE: sensor_state.state}
+
+        # SpaceAPI sensor values must be numbers
+        try:
+            state = float(sensor_state.state)
+        except ValueError:
+            state = math.nan
+        sensor_data = {
+            ATTR_NAME: sensor_state.name,
+            ATTR_VALUE: state,
+        }
+
         if ATTR_SENSOR_LOCATION in sensor_state.attributes:
             sensor_data[ATTR_LOCATION] = sensor_state.attributes[ATTR_SENSOR_LOCATION]
         else:

--- a/tests/components/spaceapi/test_init.py
+++ b/tests/components/spaceapi/test_init.py
@@ -6,7 +6,12 @@ from unittest.mock import patch
 from aiohttp.test_utils import TestClient
 import pytest
 
-from homeassistant.components.spaceapi import DOMAIN, SPACEAPI_VERSION, URL_API_SPACEAPI
+from homeassistant.components.spaceapi import (
+    ATTR_SENSOR_LOCATION,
+    DOMAIN,
+    SPACEAPI_VERSION,
+    URL_API_SPACEAPI,
+)
 from homeassistant.const import ATTR_UNIT_OF_MEASUREMENT, PERCENTAGE, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
@@ -70,7 +75,7 @@ SENSOR_OUTPUT = {
             "value": 25.0,
         },
         {
-            "location": "Home",
+            "location": "outside",
             "name": "temp2",
             "unit": UnitOfTemperature.CELSIUS,
             "value": 23.0,
@@ -102,6 +107,14 @@ def mock_client(hass: HomeAssistant, hass_client: ClientSessionGenerator) -> Tes
     hass.states.async_set(
         "test.temp2",
         23,
+        attributes={
+            ATTR_UNIT_OF_MEASUREMENT: UnitOfTemperature.CELSIUS,
+            ATTR_SENSOR_LOCATION: "outside",
+        },
+    )
+    hass.states.async_set(
+        "test.temp3",
+        "foo",
         attributes={ATTR_UNIT_OF_MEASUREMENT: UnitOfTemperature.CELSIUS},
     )
     hass.states.async_set(

--- a/tests/components/spaceapi/test_init.py
+++ b/tests/components/spaceapi/test_init.py
@@ -27,7 +27,7 @@ CONFIG = {
             "icon_closed": "https://home-assistant.io/close.png",
         },
         "sensors": {
-            "temperature": ["test.temp1", "test.temp2"],
+            "temperature": ["test.temp1", "test.temp2", "test.temp3"],
             "humidity": ["test.hum1"],
         },
         "spacefed": {"spacenet": True, "spacesaml": False, "spacephone": True},
@@ -67,17 +67,23 @@ SENSOR_OUTPUT = {
             "location": "Home",
             "name": "temp1",
             "unit": UnitOfTemperature.CELSIUS,
-            "value": "25",
+            "value": 25.0,
         },
         {
             "location": "Home",
             "name": "temp2",
             "unit": UnitOfTemperature.CELSIUS,
-            "value": "23",
+            "value": 23.0,
+        },
+        {
+            "location": "Home",
+            "name": "temp3",
+            "unit": UnitOfTemperature.CELSIUS,
+            "value": None,
         },
     ],
     "humidity": [
-        {"location": "Home", "name": "hum1", "unit": PERCENTAGE, "value": "88"}
+        {"location": "Home", "name": "hum1", "unit": PERCENTAGE, "value": 88.0}
     ],
 }
 
@@ -96,6 +102,11 @@ def mock_client(hass: HomeAssistant, hass_client: ClientSessionGenerator) -> Tes
     hass.states.async_set(
         "test.temp2",
         23,
+        attributes={ATTR_UNIT_OF_MEASUREMENT: UnitOfTemperature.CELSIUS},
+    )
+    hass.states.async_set(
+        "test.temp3",
+        "foo",
         attributes={ATTR_UNIT_OF_MEASUREMENT: UnitOfTemperature.CELSIUS},
     )
     hass.states.async_set(


### PR DESCRIPTION
## Breaking change

Sensor values reported by the SpaceAPI extension now have the correct number type, rather than being strings. Non-conformant SpaceAPI consumers may need to be made conformant.

## Proposed change

The [SpaceAPI schema](https://github.com/SpaceApi/schema/blob/359b3a204800b0dd1efcbde51e52e240aed2f6a9/13.json#L289) specifies that sensor values must be `number`s, but homeassistant internally represents them as strings. This has caused installations using the spaceapi component to report sensor values to report invalid SpaceAPI responses, failing the [validator](https://validator.spaceapi.io/ui/).

## Type of change

- [ ] Dependency upgrade
- [] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #122252
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
