### PR TITLE
add option to ibeacon component to disable adding newly detected devices

### DIFF
--- a/homeassistant/components/ibeacon/config_flow.py
+++ b/homeassistant/components/ibeacon/config_flow.py
@@ -18,7 +18,12 @@ from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.typing import VolDictType
 
-from .const import CONF_ALLOW_NAMELESS_UUIDS, CONF_ALLOW_NEW_DEVICES, DEFAULT_ALLOW_NEW_DEVICES, DOMAIN
+from .const import (
+    CONF_ALLOW_NAMELESS_UUIDS,
+    CONF_ALLOW_NEW_DEVICES,
+    DEFAULT_ALLOW_NEW_DEVICES,
+    DOMAIN,
+)
 
 
 class IBeaconConfigFlow(ConfigFlow, domain=DOMAIN):
@@ -44,9 +49,11 @@ class IBeaconConfigFlow(ConfigFlow, domain=DOMAIN):
     def async_get_options_flow(config_entry):
         return IBeaconOptionsFlow(config_entry)
 
+
 class IBeaconOptionsFlow(OptionsFlow):
     def __init__(self, config_entry):
         self.config_entry = config_entry
+
     """Handle options."""
 
     async def async_step_init(self, user_input: dict | None = None) -> ConfigFlowResult:
@@ -71,7 +78,10 @@ class IBeaconOptionsFlow(OptionsFlow):
                 if new_uuid and new_uuid not in updated_uuids:
                     updated_uuids.append(new_uuid)
 
-                data = {CONF_ALLOW_NAMELESS_UUIDS: list(updated_uuids), CONF_ALLOW_NEW_DEVICES: user_input[CONF_ALLOW_NEW_DEVICES]}
+                data = {
+                    CONF_ALLOW_NAMELESS_UUIDS: list(updated_uuids),
+                    CONF_ALLOW_NEW_DEVICES: user_input[CONF_ALLOW_NEW_DEVICES],
+                }
                 return self.async_create_entry(title="", data=data)
 
         schema: VolDictType = {
@@ -81,7 +91,9 @@ class IBeaconOptionsFlow(OptionsFlow):
             ): str,
             vol.Optional(
                 CONF_ALLOW_NEW_DEVICES,
-                default=self.config_entry.options.get(CONF_ALLOW_NEW_DEVICES, DEFAULT_ALLOW_NEW_DEVICES),
+                default=self.config_entry.options.get(
+                    CONF_ALLOW_NEW_DEVICES, DEFAULT_ALLOW_NEW_DEVICES
+                ),
             ): bool,
         }
         if current_uuids:

--- a/homeassistant/components/ibeacon/const.py
+++ b/homeassistant/components/ibeacon/const.py
@@ -47,3 +47,5 @@ MIN_SEEN_TRANSIENT_NEW = (
 CONF_IGNORE_ADDRESSES = "ignore_addresses"
 CONF_IGNORE_UUIDS = "ignore_uuids"
 CONF_ALLOW_NAMELESS_UUIDS = "allow_nameless_uuids"
+CONF_ALLOW_NEW_DEVICES = "allow_new_devices"
+DEFAULT_ALLOW_NEW_DEVICES = "True"

--- a/homeassistant/components/ibeacon/coordinator.py
+++ b/homeassistant/components/ibeacon/coordinator.py
@@ -155,7 +155,9 @@ class IBeaconCoordinator:
         self._ignored_nameless_by_uuid: dict[str, set[str]] = {}
 
         # Global option to allow creating new devices or not
-        self._allow_new_devices = entry.options.get(CONF_ALLOW_NEW_DEVICES, DEFAULT_ALLOW_NEW_DEVICES)
+        self._allow_new_devices = entry.options.get(
+            CONF_ALLOW_NEW_DEVICES, DEFAULT_ALLOW_NEW_DEVICES
+        )
 
         self._entry.async_on_unload(
             self._entry.add_update_listener(self.async_config_entry_updated)
@@ -337,15 +339,12 @@ class IBeaconCoordinator:
             return
 
         previously_tracked = address in self._unique_ids_by_address
-        
+
         # If we are not set to allow new devices and this device has not been registered yet stop processing
-        if (
-            not previously_tracked
-            and not self._allow_new_devices
-        ):
+        if not previously_tracked and not self._allow_new_devices:
             _LOGGER.debug("ignoring new beacon %s due to config", unique_id)
             return
-            
+
         self._last_ibeacon_advertisement_by_unique_id[unique_id] = ibeacon_advertisement
         self._async_track_ibeacon_with_unique_address(address, group_id, unique_id)
         if address not in self._unavailable_trackers:

--- a/homeassistant/components/ibeacon/coordinator.py
+++ b/homeassistant/components/ibeacon/coordinator.py
@@ -320,15 +320,6 @@ class IBeaconCoordinator:
         new = unique_id not in self._last_ibeacon_advertisement_by_unique_id
         uuid = str(ibeacon_advertisement.uuid)
 
-        # If we are not set to allow new devices don't bother with any other processing
-        # Do not store new devices for use later
-        if (
-            new
-            and not self._allow_new_devices
-        ):
-            _LOGGER.debug("ignoring new beacon %s due to config", unique_id)
-            return
-            
         # Reject creating new trackers if the name is not set (unless the uuid is allowlisted).
         if (
             new
@@ -346,6 +337,15 @@ class IBeaconCoordinator:
             return
 
         previously_tracked = address in self._unique_ids_by_address
+        
+        # If we are not set to allow new devices and this device has not been registered yet stop processing
+        if (
+            not previously_tracked
+            and not self._allow_new_devices
+        ):
+            _LOGGER.debug("ignoring new beacon %s due to config", unique_id)
+            return
+            
         self._last_ibeacon_advertisement_by_unique_id[unique_id] = ibeacon_advertisement
         self._async_track_ibeacon_with_unique_address(address, group_id, unique_id)
         if address not in self._unavailable_trackers:

--- a/homeassistant/components/ibeacon/manifest.json
+++ b/homeassistant/components/ibeacon/manifest.json
@@ -14,5 +14,6 @@
   "iot_class": "local_push",
   "loggers": ["bleak"],
   "requirements": ["ibeacon-ble==1.2.0"],
-  "single_config_entry": true
+  "single_config_entry": true,
+  "version": "0.0.1"
 }

--- a/homeassistant/components/ibeacon/strings.json
+++ b/homeassistant/components/ibeacon/strings.json
@@ -14,6 +14,7 @@
       "init": {
         "description": "iBeacons with an empty device name are ignored by default, unless their UUID is explicitly allowed in the list below.",
         "data": {
+          "allow_new_devices": "Allow this integration to automatically create new devices.",
           "new_uuid": "Enter a new allowed UUID",
           "allow_nameless_uuids": "Currently allowed UUIDs. Uncheck to remove"
         }


### PR DESCRIPTION

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This change adds a new option to the core 'ibeacon' component that prevents the integration from adding newly detected ibeacons when the option is turned off. It is turned on by default to retain the existing behaviour.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #88111
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
