### PR TITLE
Allow for separate Opower costs and consumption data

### DIFF
--- a/homeassistant/components/opower/coordinator.py
+++ b/homeassistant/components/opower/coordinator.py
@@ -1,6 +1,7 @@
 """Coordinator to handle Opower connections."""
 
 from datetime import datetime, timedelta
+from enum import Enum
 import logging
 from types import MappingProxyType
 from typing import Any, cast
@@ -33,6 +34,17 @@ from homeassistant.util import dt as dt_util
 from .const import CONF_TOTP_SECRET, CONF_UTILITY, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
+
+
+class StatisticType(Enum):
+    """Statistic types included."""
+
+    COST = "COST"
+    CONSUMPTION = "CONSUMPTION"
+
+    def __str__(self) -> str:
+        """Return the value of the enum."""
+        return self.value
 
 
 class OpowerCoordinator(DataUpdateCoordinator[dict[str, Forecast]]):
@@ -113,14 +125,15 @@ class OpowerCoordinator(DataUpdateCoordinator[dict[str, Forecast]]):
             )
             if not last_stat:
                 _LOGGER.debug("Updating statistic for the first time")
-                cost_reads = await self._async_get_cost_reads(
+                cost_reads, cost_reads_billing = await self._async_get_cost_reads(
                     account, self.api.utility.timezone()
                 )
                 cost_sum = 0.0
                 consumption_sum = 0.0
                 last_stats_time = None
+                last_stats_time_billing = None
             else:
-                cost_reads = await self._async_get_cost_reads(
+                cost_reads, cost_reads_billing = await self._async_get_cost_reads(
                     account,
                     self.api.utility.timezone(),
                     last_stat[consumption_statistic_id][0]["start"],
@@ -156,32 +169,100 @@ class OpowerCoordinator(DataUpdateCoordinator[dict[str, Forecast]]):
                 cost_sum = cast(float, stats[cost_statistic_id][0]["sum"])
                 consumption_sum = cast(float, stats[consumption_statistic_id][0]["sum"])
                 last_stats_time = stats[consumption_statistic_id][0]["start"]
+                if cost_reads_billing:
+                    start = cost_reads_billing[0].start_time
+                    _LOGGER.debug("Getting cost statistics at: %s", start)
+                    # In the common case there should be a previous statistic at start time
+                    # so we only need to fetch one statistic. If there isn't any, fetch all.
+                    for end in (start + timedelta(seconds=1), None):
+                        stats = await get_instance(self.hass).async_add_executor_job(
+                            statistics_during_period,
+                            self.hass,
+                            start,
+                            end,
+                            {cost_statistic_id},
+                            "hour",
+                            None,
+                            {"sum"},
+                        )
+                        if stats:
+                            break
+                        if end:
+                            _LOGGER.debug(
+                                "Not found. Trying to find the oldest statistic after %s",
+                                start,
+                            )
+                    # We are in this code path only if get_last_statistics found a stat
+                    # so statistics_during_period should also have found at least one.
+                    assert stats
+                    cost_sum = cast(float, stats[cost_statistic_id][0]["sum"])
+                    last_stats_time_billing = stats[cost_statistic_id][0]["start"]
 
-            cost_statistics = []
-            consumption_statistics = []
+            await self._insert_statistics_cost_read(
+                account,
+                cost_statistic_id,
+                consumption_statistic_id,
+                cost_sum,
+                consumption_sum,
+                last_stats_time,
+                cost_reads,
+                [StatisticType.COST, StatisticType.CONSUMPTION]
+                if not cost_reads_billing
+                else [StatisticType.CONSUMPTION],
+            )
 
-            for cost_read in cost_reads:
-                start = cost_read.start_time
-                if last_stats_time is not None and start.timestamp() <= last_stats_time:
-                    continue
-                cost_sum += cost_read.provided_cost
-                consumption_sum += cost_read.consumption
+            if cost_reads_billing:
+                await self._insert_statistics_cost_read(
+                    account,
+                    cost_statistic_id,
+                    consumption_statistic_id,
+                    cost_sum,
+                    consumption_sum,
+                    last_stats_time_billing,
+                    cost_reads_billing,
+                    [StatisticType.COST],
+                )
 
+    async def _insert_statistics_cost_read(
+        self,
+        account: Account,
+        cost_statistic_id: str,
+        consumption_statistic_id: str,
+        cost_sum: float,
+        consumption_sum: float,
+        last_stats_time: float | None,
+        cost_reads: list[CostRead],
+        statistic_types: list[StatisticType],
+    ) -> None:
+        """Insert Opower statistics for a single cost read list."""
+        cost_statistics = []
+        consumption_statistics = []
+
+        for cost_read in cost_reads:
+            start = cost_read.start_time
+            if last_stats_time is not None and start.timestamp() <= last_stats_time:
+                continue
+            cost_sum += cost_read.provided_cost
+            consumption_sum += cost_read.consumption
+
+            if StatisticType.COST in statistic_types:
                 cost_statistics.append(
                     StatisticData(
                         start=start, state=cost_read.provided_cost, sum=cost_sum
                     )
                 )
+            if StatisticType.CONSUMPTION in statistic_types:
                 consumption_statistics.append(
                     StatisticData(
                         start=start, state=cost_read.consumption, sum=consumption_sum
                     )
                 )
 
-            name_prefix = (
-                f"Opower {self.api.utility.subdomain()} "
-                f"{account.meter_type.name.lower()} {account.utility_account_id}"
-            )
+        name_prefix = (
+            f"Opower {self.api.utility.subdomain()} "
+            f"{account.meter_type.name.lower()} {account.utility_account_id}"
+        )
+        if StatisticType.COST in statistic_types:
             cost_metadata = StatisticMetaData(
                 has_mean=False,
                 has_sum=True,
@@ -190,6 +271,7 @@ class OpowerCoordinator(DataUpdateCoordinator[dict[str, Forecast]]):
                 statistic_id=cost_statistic_id,
                 unit_of_measurement=None,
             )
+        if StatisticType.CONSUMPTION in statistic_types:
             consumption_metadata = StatisticMetaData(
                 has_mean=False,
                 has_sum=True,
@@ -201,12 +283,14 @@ class OpowerCoordinator(DataUpdateCoordinator[dict[str, Forecast]]):
                 else UnitOfVolume.CENTUM_CUBIC_FEET,
             )
 
+        if StatisticType.COST in statistic_types:
             _LOGGER.debug(
                 "Adding %s statistics for %s",
                 len(cost_statistics),
                 cost_statistic_id,
             )
             async_add_external_statistics(self.hass, cost_metadata, cost_statistics)
+        if StatisticType.CONSUMPTION in statistic_types:
             _LOGGER.debug(
                 "Adding %s statistics for %s",
                 len(consumption_statistics),
@@ -218,7 +302,7 @@ class OpowerCoordinator(DataUpdateCoordinator[dict[str, Forecast]]):
 
     async def _async_get_cost_reads(
         self, account: Account, time_zone_str: str, start_time: float | None = None
-    ) -> list[CostRead]:
+    ) -> tuple[list[CostRead], list[CostRead] | None]:
         """Get cost reads.
 
         If start_time is None, get cost reads since account activation,
@@ -245,6 +329,31 @@ class OpowerCoordinator(DataUpdateCoordinator[dict[str, Forecast]]):
                         break
             cost_reads += finer_cost_reads
 
+        def _check_is_cost_missing(
+            cost_reads: list[CostRead], finer_cost_reads: list[CostRead]
+        ) -> bool:
+            if not cost_reads or not finer_cost_reads:
+                return False
+            sum_cost_reads = 0
+            sum_finer_cost_reads = 0
+            for _, cost_read in enumerate(cost_reads):
+                # Skip to first bill read fully represented in fine reads
+                if cost_read.start_time < finer_cost_reads[0].start_time:
+                    continue
+                sum_cost_reads += cost_read.provided_cost
+            for _, finer_cost_read in enumerate(finer_cost_reads):
+                # End if beyond rough cost read window
+                if cost_reads[-1].end_time < finer_cost_read.start_time:
+                    break
+                sum_finer_cost_reads += finer_cost_read.provided_cost
+            _LOGGER.debug(
+                "Calculated cost sums rough: %s fine: %s",
+                sum_cost_reads,
+                sum_finer_cost_reads,
+            )
+            return sum_cost_reads > 0 and sum_finer_cost_reads == 0
+
+        cost_reads_billing = None
         tz = await dt_util.async_get_time_zone(time_zone_str)
         if start_time is None:
             start = None
@@ -257,7 +366,7 @@ class OpowerCoordinator(DataUpdateCoordinator[dict[str, Forecast]]):
         )
         _LOGGER.debug("Got %s monthly cost reads", len(cost_reads))
         if account.read_resolution == ReadResolution.BILLING:
-            return cost_reads
+            return cost_reads, None
 
         if start_time is None:
             start = end - timedelta(days=3 * 365)
@@ -271,9 +380,14 @@ class OpowerCoordinator(DataUpdateCoordinator[dict[str, Forecast]]):
             account, AggregateType.DAY, start, end
         )
         _LOGGER.debug("Got %s daily cost reads", len(daily_cost_reads))
+        if _check_is_cost_missing(cost_reads, daily_cost_reads):
+            _LOGGER.debug(
+                "Daily data seems to be missing cost data, falling back to bill view for costs"
+            )
+            cost_reads_billing = cost_reads.copy()
         _update_with_finer_cost_reads(cost_reads, daily_cost_reads)
         if account.read_resolution == ReadResolution.DAY:
-            return cost_reads
+            return cost_reads, cost_reads_billing
 
         if start_time is None:
             start = end - timedelta(days=2 * 30)
@@ -285,6 +399,11 @@ class OpowerCoordinator(DataUpdateCoordinator[dict[str, Forecast]]):
             account, AggregateType.HOUR, start, end
         )
         _LOGGER.debug("Got %s hourly cost reads", len(hourly_cost_reads))
+        if _check_is_cost_missing(daily_cost_reads, hourly_cost_reads):
+            _LOGGER.debug(
+                "Hourly data seems to be missing cost data, falling back to daily view for costs"
+            )
+            cost_reads_billing = daily_cost_reads.copy()
         _update_with_finer_cost_reads(cost_reads, hourly_cost_reads)
         _LOGGER.debug("Got %s cost reads", len(cost_reads))
-        return cost_reads
+        return cost_reads, cost_reads_billing


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

I'm unsure about other utilities, but PSE only reports costs in the billing view, not in the daily or hourly views. Previously, the finer windows overrode the billing view windows, and costs were set back to 0. This PR attempts to check if the utility has this behavior (fine views have 0 cost), and then fetches and stores the cost data in a separate set of statistics.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

This PR fixes or closes issue: fixes https://github.com/tronikos/opower/issues/56
This PR is related to issue: https://github.com/home-assistant/core/issues/99674

Due to the way HomeAssistant handles cost/usage data with mismatched time windows, the energy dashboard will only show costs on the first day of the billing period. The cost shown is the full cost of the entire billing period, despite only showing on that day. All other days show a cost of $0.

Unlike #128964, the data here is presented exactly as returned by the Opower API, with no interpolation. However this may require additional work on the HomeAssistant energy dashboard side to present the data in a meaningful way to the user.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
