### PR TITLE
Add "cancel room setpoint override" button to opentherm_gw

### DIFF
--- a/homeassistant/components/opentherm_gw/button.py
+++ b/homeassistant/components/opentherm_gw/button.py
@@ -16,7 +16,12 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import OpenThermGatewayHub
-from .const import DATA_GATEWAYS, DATA_OPENTHERM_GW, GATEWAY_DEVICE_DESCRIPTION
+from .const import (
+    DATA_GATEWAYS,
+    DATA_OPENTHERM_GW,
+    GATEWAY_DEVICE_DESCRIPTION,
+    THERMOSTAT_DEVICE_DESCRIPTION,
+)
 from .entity import OpenThermEntity, OpenThermEntityDescription
 
 
@@ -30,6 +35,12 @@ class OpenThermButtonEntityDescription(
 
 
 BUTTON_DESCRIPTIONS: tuple[OpenThermButtonEntityDescription, ...] = (
+    OpenThermButtonEntityDescription(
+        key="cancel_room_setpoint_override",
+        translation_key="cancel_room_setpoint_override",
+        device_description=THERMOSTAT_DEVICE_DESCRIPTION,
+        action=lambda hub: hub.set_room_setpoint(0),
+    ),
     OpenThermButtonEntityDescription(
         key="restart_button",
         device_class=ButtonDeviceClass.RESTART,

--- a/homeassistant/components/opentherm_gw/strings.json
+++ b/homeassistant/components/opentherm_gw/strings.json
@@ -158,6 +158,11 @@
         "name": "Programmed change has priority over override"
       }
     },
+    "button": {
+      "cancel_room_setpoint_override": {
+        "name": "Cancel room setpoint override"
+      }
+    },
     "select": {
       "gpio_mode_n": {
         "name": "GPIO {gpio_id} mode",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add a `cancel room setpoint override` button to the `Thermostat` device of the `opentherm_gw` integration. This button sends a target temperature of `0` to the OpenTherm Gateway, which cancels an active room setpoint override.

Since 2024.8 Home Assistant enforces the `min_temp` and `max_temp` values on the `climate` platform. Before this change, users could cancel an active room setpoint override by calling the `set_temperature` service action with an out-of-range temperature of `0`. This functionality was undocumented within Home Assistant but supported by the OpenTherm Gateway and documented there.

With this PR, we add support for this functionality. Sending a target temperature of `0` does not change the actual target temperature, so rather than lowering the `min_temp` of the climate entity we are adding a button which sends the value to the OpenTherm Gateway.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #131376 
- This PR is related to issue: 
- Link to documentation pull request: home-assistant/home-assistant.io#36121

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
