### PR TITLE
Fix recorder "year" period in leap year

### DIFF
--- a/homeassistant/components/recorder/util.py
+++ b/homeassistant/components/recorder/util.py
@@ -902,7 +902,7 @@ def resolve_period(
             start_time = (start_time + timedelta(days=cal_offset * 366)).replace(
                 month=1, day=1
             )
-            end_time = (start_time + timedelta(days=365)).replace(day=1)
+            end_time = (start_time + timedelta(days=366)).replace(day=1)
 
         start_time = dt_util.as_utc(start_time)
         end_time = dt_util.as_utc(end_time)

--- a/homeassistant/components/recorder/util.py
+++ b/homeassistant/components/recorder/util.py
@@ -897,12 +897,8 @@ def resolve_period(
             start_time = (start_time + timedelta(days=cal_offset * 31)).replace(day=1)
             end_time = (start_time + timedelta(days=31)).replace(day=1)
         else:  # calendar_period = "year"
-            start_time = start_of_day.replace(month=12, day=31)
-            # This works for 100+ years of offset
-            start_time = (start_time + timedelta(days=cal_offset * 366)).replace(
-                month=1, day=1
-            )
-            end_time = (start_time + timedelta(days=366)).replace(day=1)
+            start_time = start_of_day.replace(month=1, day=1, year=start_of_day.year + cal_offset)
+            end_time = start_time.replace(month=12, day=31)
 
         start_time = dt_util.as_utc(start_time)
         end_time = dt_util.as_utc(end_time)

--- a/homeassistant/components/recorder/util.py
+++ b/homeassistant/components/recorder/util.py
@@ -897,8 +897,12 @@ def resolve_period(
             start_time = (start_time + timedelta(days=cal_offset * 31)).replace(day=1)
             end_time = (start_time + timedelta(days=31)).replace(day=1)
         else:  # calendar_period = "year"
-            start_time = start_of_day.replace(month=1, day=1, year=start_of_day.year + cal_offset)
-            end_time = start_time.replace(month=12, day=31)
+            start_time = start_of_day.replace(month=12, day=31)
+            # This works for 100+ years of offset
+            start_time = (start_time + timedelta(days=cal_offset * 366)).replace(
+                month=1, day=1
+            )
+            end_time = (start_time + timedelta(days=366)).replace(day=1)
 
         start_time = dt_util.as_utc(start_time)
         end_time = dt_util.as_utc(end_time)

--- a/tests/components/recorder/test_util.py
+++ b/tests/components/recorder/test_util.py
@@ -1058,7 +1058,7 @@ async def test_execute_stmt_lambda_element(
     [
         (
             # Test 00:25 local time, during DST
-            datetime(2022, 10, 21, 7, 25, tzinfo=UTC),
+            datetime(2022, 10, 21, 7, 25, 50, 123, tzinfo=UTC),
             {
                 "hour": ["2022-10-21T07:00:00+00:00", "2022-10-21T08:00:00+00:00"],
                 "hour-1": ["2022-10-21T06:00:00+00:00", "2022-10-21T07:00:00+00:00"],
@@ -1074,7 +1074,7 @@ async def test_execute_stmt_lambda_element(
         ),
         (
             # Test 00:25 local time, standard time, February 28th a leap year
-            datetime(2024, 2, 28, 8, 25, tzinfo=UTC),
+            datetime(2024, 2, 28, 8, 25, 50, 123, tzinfo=UTC),
             {
                 "hour": ["2024-02-28T08:00:00+00:00", "2024-02-28T09:00:00+00:00"],
                 "hour-1": ["2024-02-28T07:00:00+00:00", "2024-02-28T08:00:00+00:00"],

--- a/tests/components/recorder/test_util.py
+++ b/tests/components/recorder/test_util.py
@@ -9,6 +9,7 @@ import threading
 from typing import Any
 from unittest.mock import MagicMock, Mock, patch
 
+from freezegun.api import FrozenDateTimeFactory
 import pytest
 from sqlalchemy import lambda_stmt, text
 from sqlalchemy.engine.result import ChunkedIteratorResult
@@ -1052,55 +1053,94 @@ async def test_execute_stmt_lambda_element(
             assert rows == ["mock_row"]
 
 
-@pytest.mark.freeze_time(datetime(2022, 10, 21, 7, 25, tzinfo=UTC))
-async def test_resolve_period(hass: HomeAssistant) -> None:
+@pytest.mark.parametrize(
+    ("start_time", "periods"),
+    [
+        (
+            # Test 00:25 local time, during DST
+            datetime(2022, 10, 21, 7, 25, tzinfo=UTC),
+            {
+                "hour": ["2022-10-21T07:00:00+00:00", "2022-10-21T08:00:00+00:00"],
+                "hour-1": ["2022-10-21T06:00:00+00:00", "2022-10-21T07:00:00+00:00"],
+                "day": ["2022-10-21T07:00:00+00:00", "2022-10-22T07:00:00+00:00"],
+                "day-1": ["2022-10-20T07:00:00+00:00", "2022-10-21T07:00:00+00:00"],
+                "week": ["2022-10-17T07:00:00+00:00", "2022-10-24T07:00:00+00:00"],
+                "week-1": ["2022-10-10T07:00:00+00:00", "2022-10-17T07:00:00+00:00"],
+                "month": ["2022-10-01T07:00:00+00:00", "2022-11-01T07:00:00+00:00"],
+                "month-1": ["2022-09-01T07:00:00+00:00", "2022-10-01T07:00:00+00:00"],
+                "year": ["2022-01-01T08:00:00+00:00", "2023-01-01T08:00:00+00:00"],
+                "year-1": ["2021-01-01T08:00:00+00:00", "2022-01-01T08:00:00+00:00"],
+            },
+        ),
+        (
+            # Test 00:25 local time, standard time, February 28th a leap year
+            datetime(2024, 2, 28, 8, 25, tzinfo=UTC),
+            {
+                "hour": ["2024-02-28T08:00:00+00:00", "2024-02-28T09:00:00+00:00"],
+                "hour-1": ["2024-02-28T07:00:00+00:00", "2024-02-28T08:00:00+00:00"],
+                "day": ["2024-02-28T08:00:00+00:00", "2024-02-29T08:00:00+00:00"],
+                "day-1": ["2024-02-27T08:00:00+00:00", "2024-02-28T08:00:00+00:00"],
+                "week": ["2024-02-26T08:00:00+00:00", "2024-03-04T08:00:00+00:00"],
+                "week-1": ["2024-02-19T08:00:00+00:00", "2024-02-26T08:00:00+00:00"],
+                "month": ["2024-02-01T08:00:00+00:00", "2024-03-01T08:00:00+00:00"],
+                "month-1": ["2024-01-01T08:00:00+00:00", "2024-02-01T08:00:00+00:00"],
+                "year": ["2024-01-01T08:00:00+00:00", "2025-01-01T08:00:00+00:00"],
+                "year-1": ["2023-01-01T08:00:00+00:00", "2024-01-01T08:00:00+00:00"],
+            },
+        ),
+    ],
+)
+async def test_resolve_period(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    start_time: datetime,
+    periods: dict[str, tuple[str, str]],
+) -> None:
     """Test statistic_during_period."""
+    assert hass.config.time_zone == "US/Pacific"
+    freezer.move_to(start_time)
 
     now = dt_util.utcnow()
 
     start_t, end_t = resolve_period({"calendar": {"period": "hour"}})
-    assert start_t.isoformat() == "2022-10-21T07:00:00+00:00"
-    assert end_t.isoformat() == "2022-10-21T08:00:00+00:00"
-
-    start_t, end_t = resolve_period({"calendar": {"period": "hour"}})
-    assert start_t.isoformat() == "2022-10-21T07:00:00+00:00"
-    assert end_t.isoformat() == "2022-10-21T08:00:00+00:00"
+    assert start_t.isoformat() == periods["hour"][0]
+    assert end_t.isoformat() == periods["hour"][1]
 
     start_t, end_t = resolve_period({"calendar": {"period": "hour", "offset": -1}})
-    assert start_t.isoformat() == "2022-10-21T06:00:00+00:00"
-    assert end_t.isoformat() == "2022-10-21T07:00:00+00:00"
+    assert start_t.isoformat() == periods["hour-1"][0]
+    assert end_t.isoformat() == periods["hour-1"][1]
 
     start_t, end_t = resolve_period({"calendar": {"period": "day"}})
-    assert start_t.isoformat() == "2022-10-21T07:00:00+00:00"
-    assert end_t.isoformat() == "2022-10-22T07:00:00+00:00"
+    assert start_t.isoformat() == periods["day"][0]
+    assert end_t.isoformat() == periods["day"][1]
 
     start_t, end_t = resolve_period({"calendar": {"period": "day", "offset": -1}})
-    assert start_t.isoformat() == "2022-10-20T07:00:00+00:00"
-    assert end_t.isoformat() == "2022-10-21T07:00:00+00:00"
+    assert start_t.isoformat() == periods["day-1"][0]
+    assert end_t.isoformat() == periods["day-1"][1]
 
     start_t, end_t = resolve_period({"calendar": {"period": "week"}})
-    assert start_t.isoformat() == "2022-10-17T07:00:00+00:00"
-    assert end_t.isoformat() == "2022-10-24T07:00:00+00:00"
+    assert start_t.isoformat() == periods["week"][0]
+    assert end_t.isoformat() == periods["week"][1]
 
     start_t, end_t = resolve_period({"calendar": {"period": "week", "offset": -1}})
-    assert start_t.isoformat() == "2022-10-10T07:00:00+00:00"
-    assert end_t.isoformat() == "2022-10-17T07:00:00+00:00"
+    assert start_t.isoformat() == periods["week-1"][0]
+    assert end_t.isoformat() == periods["week-1"][1]
 
     start_t, end_t = resolve_period({"calendar": {"period": "month"}})
-    assert start_t.isoformat() == "2022-10-01T07:00:00+00:00"
-    assert end_t.isoformat() == "2022-11-01T07:00:00+00:00"
+    assert start_t.isoformat() == periods["month"][0]
+    assert end_t.isoformat() == periods["month"][1]
 
     start_t, end_t = resolve_period({"calendar": {"period": "month", "offset": -1}})
-    assert start_t.isoformat() == "2022-09-01T07:00:00+00:00"
-    assert end_t.isoformat() == "2022-10-01T07:00:00+00:00"
+    assert start_t.isoformat() == periods["month-1"][0]
+    assert end_t.isoformat() == periods["month-1"][1]
 
     start_t, end_t = resolve_period({"calendar": {"period": "year"}})
-    assert start_t.isoformat() == "2022-01-01T08:00:00+00:00"
-    assert end_t.isoformat() == "2023-01-01T08:00:00+00:00"
+    assert start_t.isoformat() == periods["year"][0]
+    assert end_t.isoformat() == periods["year"][1]
 
     start_t, end_t = resolve_period({"calendar": {"period": "year", "offset": -1}})
-    assert start_t.isoformat() == "2021-01-01T08:00:00+00:00"
-    assert end_t.isoformat() == "2022-01-01T08:00:00+00:00"
+    assert start_t.isoformat() == periods["year-1"][0]
+    assert end_t.isoformat() == periods["year-1"][1]
 
     # Fixed period
     assert resolve_period({}) == (None, None)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In leap years the statistic card is omitting December from the data. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
The calculation for the end data is wrong in leap years when using a statistic card with period set to "year". 
The algorithm gets the 01.01. of the year, then adds 365 days and replaces the day with the 1st again. 
Thus in a leap year we would add 365 days resulting in the 31st of December in the current year rather than the 1st of January of the next year. In leap years this always results in 01.12.CURRENT_YEAR instead of 01.01.NEXTYEAR. 
There might be better solutions to fix it, e.g. calculating current year and then just create an actual period by hard setting day, month and year as a period but I think this should work reliably too. 

**For 2024**

Before the fix: \
start: 2024-01-01\
end: 2024-12-01

After fix: \
start: 2024-01-01\
end: 2025-01-01

- This PR fixes or closes issue: fixes #132156
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
