### PR TITLE
fix: unifiprotect prevent RTSP repair for third-party cameras

### DIFF
--- a/homeassistant/components/unifiprotect/camera.py
+++ b/homeassistant/components/unifiprotect/camera.py
@@ -90,9 +90,8 @@ def _get_camera_channels(
                 is_default = False
 
         # no RTSP enabled use first channel with no stream
-        if is_default:
-            if not camera.is_third_party_camera:
-                _create_rtsp_repair(hass, entry, data, camera)
+        if is_default and not camera.is_third_party_camera:
+            _create_rtsp_repair(hass, entry, data, camera)
             yield camera, camera.channels[0], True
         else:
             ir.async_delete_issue(hass, DOMAIN, f"rtsp_disabled_{camera.id}")

--- a/homeassistant/components/unifiprotect/camera.py
+++ b/homeassistant/components/unifiprotect/camera.py
@@ -38,8 +38,6 @@ _LOGGER = logging.getLogger(__name__)
 def _create_rtsp_repair(
     hass: HomeAssistant, entry: UFPConfigEntry, data: ProtectData, camera: UFPCamera
 ) -> None:
-    if camera.is_third_party_camera:
-        return
     edit_key = "readonly"
     if camera.can_write(data.api.bootstrap.auth_user):
         edit_key = "writable"
@@ -93,7 +91,8 @@ def _get_camera_channels(
 
         # no RTSP enabled use first channel with no stream
         if is_default:
-            _create_rtsp_repair(hass, entry, data, camera)
+            if not camera.is_third_party_camera:
+                _create_rtsp_repair(hass, entry, data, camera)
             yield camera, camera.channels[0], True
         else:
             ir.async_delete_issue(hass, DOMAIN, f"rtsp_disabled_{camera.id}")

--- a/homeassistant/components/unifiprotect/camera.py
+++ b/homeassistant/components/unifiprotect/camera.py
@@ -38,6 +38,8 @@ _LOGGER = logging.getLogger(__name__)
 def _create_rtsp_repair(
     hass: HomeAssistant, entry: UFPConfigEntry, data: ProtectData, camera: UFPCamera
 ) -> None:
+    if camera.is_third_party_camera:
+        return
     edit_key = "readonly"
     if camera.can_write(data.api.bootstrap.auth_user):
         edit_key = "writable"

--- a/tests/components/unifiprotect/test_repairs.py
+++ b/tests/components/unifiprotect/test_repairs.py
@@ -389,4 +389,4 @@ async def test_rtsp_no_fix_if_third_party(
     msg = await ws_client.receive_json()
 
     assert msg["success"]
-    assert len(msg["result"]["issues"]) == 0
+    assert not msg["result"]["issues"]

--- a/tests/components/unifiprotect/test_repairs.py
+++ b/tests/components/unifiprotect/test_repairs.py
@@ -363,3 +363,30 @@ async def test_rtsp_writable_fix_when_not_setup(
     ufp.api.update_device.assert_called_with(
         ModelType.CAMERA, doorbell.id, {"channels": channels}
     )
+
+
+async def test_rtsp_no_fix_if_third_party(
+    hass: HomeAssistant,
+    ufp: MockUFPFixture,
+    doorbell: Camera,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test no RTSP disabled warning if camera is third-party."""
+
+    for channel in doorbell.channels:
+        channel.is_rtsp_enabled = False
+    for user in ufp.api.bootstrap.users.values():
+        user.all_permissions = []
+
+    ufp.api.get_camera = AsyncMock(return_value=doorbell)
+    doorbell.is_third_party_camera = True
+
+    await init_entry(hass, ufp, [doorbell])
+    await async_process_repairs_platforms(hass)
+    ws_client = await hass_ws_client(hass)
+
+    await ws_client.send_json({"id": 1, "type": "repairs/list_issues"})
+    msg = await ws_client.receive_json()
+
+    assert msg["success"]
+    assert len(msg["result"]["issues"]) == 0


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
should fix #127610

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #127610
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
