### PR TITLE
Fix Visual Studio Code tasks to use selected Python interpreter

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -16,7 +16,7 @@
     {
       "label": "Pytest",
       "type": "shell",
-      "command": "python3 -m pytest --timeout=10 tests",
+      "command": "${command:python.interpreterPath} -m pytest --timeout=10 tests",
       "dependsOn": ["Install all Test Requirements"],
       "group": {
         "kind": "test",
@@ -31,7 +31,7 @@
     {
       "label": "Pytest (changed tests only)",
       "type": "shell",
-      "command": "python3 -m pytest --timeout=10 --picked",
+      "command": "${command:python.interpreterPath} -m pytest --timeout=10 --picked",
       "group": {
         "kind": "test",
         "isDefault": true
@@ -89,7 +89,7 @@
       "label": "Code Coverage",
       "detail": "Generate code coverage report for a given integration.",
       "type": "shell",
-      "command": "python3 -m pytest ./tests/components/${input:integrationName}/ --cov=homeassistant.components.${input:integrationName} --cov-report term-missing --durations-min=1 --durations=0 --numprocesses=auto",
+      "command": "${command:python.interpreterPath} -m pytest ./tests/components/${input:integrationName}/ --cov=homeassistant.components.${input:integrationName} --cov-report term-missing --durations-min=1 --durations=0 --numprocesses=auto",
       "dependsOn": ["Compile English translations"],
       "group": {
         "kind": "test",
@@ -105,7 +105,7 @@
       "label": "Update syrupy snapshots",
       "detail": "Update syrupy snapshots for a given integration.",
       "type": "shell",
-      "command": "python3 -m pytest ./tests/components/${input:integrationName} --snapshot-update",
+      "command": "${command:python.interpreterPath} -m pytest ./tests/components/${input:integrationName} --snapshot-update",
       "dependsOn": ["Compile English translations"],
       "group": {
         "kind": "test",
@@ -163,7 +163,7 @@
       "label": "Compile English translations",
       "detail": "In order to test changes to translation files, the translation strings must be compiled into Home Assistant's translation directories.",
       "type": "shell",
-      "command": "python3 -m script.translations develop --all",
+      "command": "${command:python.interpreterPath} -m script.translations develop --all",
       "group": {
         "kind": "build",
         "isDefault": true
@@ -173,7 +173,7 @@
       "label": "Run scaffold",
       "detail": "Add new functionality to a integration using a scaffold.",
       "type": "shell",
-      "command": "python3 -m script.scaffold ${input:scaffoldName} --integration ${input:integrationName}",
+      "command": "${command:python.interpreterPath} -m script.scaffold ${input:scaffoldName} --integration ${input:integrationName}",
       "group": {
         "kind": "build",
         "isDefault": true
@@ -183,7 +183,7 @@
       "label": "Create new integration",
       "detail": "Use the scaffold to create a new integration.",
       "type": "shell",
-      "command": "python3 -m script.scaffold integration",
+      "command": "${command:python.interpreterPath} -m script.scaffold integration",
       "group": {
         "kind": "build",
         "isDefault": true


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
`python3` does not necessarily refer to the ha-venv Python, and at least for me, causes these tasks to fail to execute in a clean, remote, up to date dev container. This is a trivial change to replace the hard-coded `python3` with the appropriate variable substitution, per https://code.visualstudio.com/docs/editor/tasks#_variable-substitution.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue #118787.

I found this issue which describes the exact problem I was having, but unlike the resolution there, I was using the correct venv setting and it did not help. I'm surprised others aren't reporting this and I don't understand why it would work for some people, since I'd think the dev container creates an identical environment.

In any case, if I try to run the Pytest task, for example, this is what happens:

```
 *  Executing task: python3 -m pytest --timeout=10 tests 

source /home/vscode/.local/ha-venv/bin/activate
/usr/local/bin/python3: No module named pytest

 *  The terminal process "/usr/bin/zsh '-c', 'python3 -m pytest --timeout=10 tests'" failed to launch (exit code: 1). 
 *  Press any key to close the terminal. 
```

That `source` line is a bit of a red herring. As far as I can tell, vscode executes the command and then pipes the `source /home/vscode/.local/ha-venv/bin/activate` line into its stdin, which is useless here.

Anyway, there is a variable substitution for the current Python (which was already used correctly by one of the other tasks), so it seems like it might as well be used everywhere. This does fix the problem for me.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
