### PR TITLE
Add reauthentication flow for Powerfox integration

### DIFF
--- a/homeassistant/components/powerfox/config_flow.py
+++ b/homeassistant/components/powerfox/config_flow.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import Any
 
 from powerfox import Powerfox, PowerfoxAuthenticationError, PowerfoxConnectionError
@@ -20,6 +21,12 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
     }
 )
 
+STEP_REAUTH_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_PASSWORD): str,
+    }
+)
+
 
 class PowerfoxConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Powerfox."""
@@ -28,7 +35,8 @@ class PowerfoxConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle the initial step."""
-        errors: dict[str, str] = {}
+        errors = {}
+
         if user_input is not None:
             self._async_abort_entries_match({CONF_EMAIL: user_input[CONF_EMAIL]})
             client = Powerfox(
@@ -54,4 +62,41 @@ class PowerfoxConfigFlow(ConfigFlow, domain=DOMAIN):
             step_id="user",
             errors=errors,
             data_schema=STEP_USER_DATA_SCHEMA,
+        )
+
+    async def async_step_reauth(
+        self, entry_data: Mapping[str, Any]
+    ) -> ConfigFlowResult:
+        """Handle re-authentication flow for Powerfox."""
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle re-authentication flow for Powerfox."""
+        errors = {}
+
+        reauth_entry = self._get_reauth_entry()
+        if user_input is not None:
+            client = Powerfox(
+                username=reauth_entry.data[CONF_EMAIL],
+                password=user_input[CONF_PASSWORD],
+                session=async_get_clientsession(self.hass),
+            )
+            try:
+                await client.all_devices()
+            except PowerfoxAuthenticationError:
+                errors["base"] = "invalid_auth"
+            except PowerfoxConnectionError:
+                errors["base"] = "cannot_connect"
+            else:
+                return self.async_update_reload_and_abort(
+                    reauth_entry,
+                    data_updates=user_input,
+                )
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            description_placeholders={"email": reauth_entry.data[CONF_EMAIL]},
+            data_schema=STEP_REAUTH_SCHEMA,
+            errors=errors,
         )

--- a/homeassistant/components/powerfox/coordinator.py
+++ b/homeassistant/components/powerfox/coordinator.py
@@ -2,10 +2,17 @@
 
 from __future__ import annotations
 
-from powerfox import Device, Powerfox, PowerfoxConnectionError, Poweropti
+from powerfox import (
+    Device,
+    Powerfox,
+    PowerfoxAuthenticationError,
+    PowerfoxConnectionError,
+    Poweropti,
+)
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import DOMAIN, LOGGER, SCAN_INTERVAL
@@ -36,5 +43,7 @@ class PowerfoxDataUpdateCoordinator(DataUpdateCoordinator[Poweropti]):
         """Fetch data from Powerfox API."""
         try:
             return await self.client.device(device_id=self.device.id)
-        except PowerfoxConnectionError as error:
-            raise UpdateFailed(error) from error
+        except PowerfoxAuthenticationError as err:
+            raise ConfigEntryAuthFailed(err) from err
+        except PowerfoxConnectionError as err:
+            raise UpdateFailed(err) from err

--- a/homeassistant/components/powerfox/quality_scale.yaml
+++ b/homeassistant/components/powerfox/quality_scale.yaml
@@ -46,7 +46,7 @@ rules:
     status: exempt
     comment: |
       This integration uses a coordinator to handle updates.
-  reauthentication-flow: todo
+  reauthentication-flow: done
   test-coverage: done
 
   # Gold

--- a/homeassistant/components/powerfox/strings.json
+++ b/homeassistant/components/powerfox/strings.json
@@ -11,6 +11,16 @@
           "email": "The email address of your Powerfox account.",
           "password": "The password of your Powerfox account."
         }
+      },
+      "reauth_confirm": {
+        "title": "[%key:common::config_flow::title::reauth%]",
+        "description": "The password for {email} is no longer valid.",
+        "data": {
+          "password": "[%key:common::config_flow::data::password%]"
+        },
+        "data_description": {
+          "password": "[%key:component::powerfox::config::step::user::data_description::password%]"
+        }
       }
     },
     "error": {
@@ -18,7 +28,8 @@
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]"
     },
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_account%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     }
   },
   "entity": {

--- a/tests/components/powerfox/test_init.py
+++ b/tests/components/powerfox/test_init.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock
 
-from powerfox import PowerfoxConnectionError
+from powerfox import PowerfoxAuthenticationError, PowerfoxConnectionError
 
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
@@ -43,3 +43,20 @@ async def test_config_entry_not_ready(
     await hass.async_block_till_done()
 
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_setup_entry_exception(
+    hass: HomeAssistant,
+    mock_powerfox_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test ConfigEntryNotReady when API raises an exception during entry setup."""
+    mock_config_entry.add_to_hass(hass)
+    mock_powerfox_client.device.side_effect = PowerfoxAuthenticationError
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
+
+    flows = hass.config_entries.flow.async_progress()
+    assert len(flows) == 1
+    assert flows[0]["step_id"] == "reauth_confirm"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adding a reauthentication flow for when a user has changed their login credentials at Powerfox.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
