### PR TITLE
Cache AST module parsing in hassfest

### DIFF
--- a/script/hassfest/__init__.py
+++ b/script/hassfest/__init__.py
@@ -1,1 +1,14 @@
 """Manifest validator."""
+
+import ast
+from functools import lru_cache
+from pathlib import Path
+
+
+@lru_cache
+def ast_parse_module(file_path: Path) -> ast.Module:
+    """Parse a module.
+
+    Cached to avoid parsing the same file for each plugin.
+    """
+    return ast.parse(file_path.read_text())

--- a/script/hassfest/config_schema.py
+++ b/script/hassfest/config_schema.py
@@ -6,6 +6,7 @@ import ast
 
 from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN
 
+from . import ast_parse_module
 from .model import Config, Integration
 
 CONFIG_SCHEMA_IGNORE = {
@@ -60,7 +61,7 @@ def _validate_integration(config: Config, integration: Integration) -> None:
         # Virtual integrations don't have any implementation
         return
 
-    init = ast.parse(init_file.read_text())
+    init = ast_parse_module(init_file)
 
     # No YAML Support
     if not _has_function(
@@ -81,7 +82,7 @@ def _validate_integration(config: Config, integration: Integration) -> None:
 
     config_file = integration.path / "config.py"
     if config_file.is_file():
-        config_module = ast.parse(config_file.read_text())
+        config_module = ast_parse_module(config_file)
         if _has_function(config_module, ast.AsyncFunctionDef, "async_validate_config"):
             return
 

--- a/script/hassfest/dependencies.py
+++ b/script/hassfest/dependencies.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from homeassistant.const import Platform
 from homeassistant.requirements import DISCOVERY_INTEGRATIONS
 
+from . import ast_parse_module
 from .model import Config, Integration
 
 
@@ -33,7 +34,7 @@ class ImportCollector(ast.NodeVisitor):
             self._cur_fil_dir = fil.relative_to(self.integration.path)
             self.referenced[self._cur_fil_dir] = set()
             try:
-                self.visit(ast.parse(fil.read_text()))
+                self.visit(ast_parse_module(fil))
             except SyntaxError as e:
                 e.add_note(f"File: {fil}")
                 raise

--- a/script/hassfest/quality_scale_validation/config_entry_unloading.py
+++ b/script/hassfest/quality_scale_validation/config_entry_unloading.py
@@ -5,6 +5,7 @@ https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/c
 
 import ast
 
+from script.hassfest import ast_parse_module
 from script.hassfest.model import Integration
 
 
@@ -20,7 +21,7 @@ def validate(integration: Integration) -> list[str] | None:
     """Validate that the integration has a config flow."""
 
     init_file = integration.path / "__init__.py"
-    init = ast.parse(init_file.read_text())
+    init = ast_parse_module(init_file)
 
     if not _has_unload_entry_function(init):
         return [

--- a/script/hassfest/quality_scale_validation/diagnostics.py
+++ b/script/hassfest/quality_scale_validation/diagnostics.py
@@ -5,6 +5,7 @@ https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/d
 
 import ast
 
+from script.hassfest import ast_parse_module
 from script.hassfest.model import Integration
 
 DIAGNOSTICS_FUNCTIONS = {
@@ -31,7 +32,7 @@ def validate(integration: Integration) -> list[str] | None:
             "(is missing diagnostics.py)",
         ]
 
-    diagnostics = ast.parse(diagnostics_file.read_text())
+    diagnostics = ast_parse_module(diagnostics_file)
 
     if not _has_diagnostics_function(diagnostics):
         return [

--- a/script/hassfest/quality_scale_validation/discovery.py
+++ b/script/hassfest/quality_scale_validation/discovery.py
@@ -5,6 +5,7 @@ https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/d
 
 import ast
 
+from script.hassfest import ast_parse_module
 from script.hassfest.model import Integration
 
 MANIFEST_KEYS = [
@@ -49,7 +50,7 @@ def validate(integration: Integration) -> list[str] | None:
         return None
 
     # Fallback => check config_flow step
-    config_flow = ast.parse(config_flow_file.read_text())
+    config_flow = ast_parse_module(config_flow_file)
     if not (_has_discovery_function(config_flow)):
         return [
             f"Integration is missing one of {CONFIG_FLOW_STEPS} "

--- a/script/hassfest/quality_scale_validation/reauthentication_flow.py
+++ b/script/hassfest/quality_scale_validation/reauthentication_flow.py
@@ -5,6 +5,7 @@ https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/r
 
 import ast
 
+from script.hassfest import ast_parse_module
 from script.hassfest.model import Integration
 
 
@@ -20,7 +21,7 @@ def validate(integration: Integration) -> list[str] | None:
     """Validate that the integration has a reauthentication flow."""
 
     config_flow_file = integration.path / "config_flow.py"
-    config_flow = ast.parse(config_flow_file.read_text())
+    config_flow = ast_parse_module(config_flow_file)
 
     if not _has_step_reauth_function(config_flow):
         return [

--- a/script/hassfest/quality_scale_validation/reconfiguration_flow.py
+++ b/script/hassfest/quality_scale_validation/reconfiguration_flow.py
@@ -5,6 +5,7 @@ https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/r
 
 import ast
 
+from script.hassfest import ast_parse_module
 from script.hassfest.model import Integration
 
 
@@ -20,7 +21,7 @@ def validate(integration: Integration) -> list[str] | None:
     """Validate that the integration has a reconfiguration flow."""
 
     config_flow_file = integration.path / "config_flow.py"
-    config_flow = ast.parse(config_flow_file.read_text())
+    config_flow = ast_parse_module(config_flow_file)
 
     if not _has_step_reconfigure_function(config_flow):
         return [

--- a/script/hassfest/quality_scale_validation/runtime_data.py
+++ b/script/hassfest/quality_scale_validation/runtime_data.py
@@ -5,6 +5,7 @@ https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/r
 
 import ast
 
+from script.hassfest import ast_parse_module
 from script.hassfest.model import Integration
 
 
@@ -35,7 +36,7 @@ def _get_setup_entry_function(module: ast.Module) -> ast.AsyncFunctionDef | None
 def validate(integration: Integration) -> list[str] | None:
     """Validate correct use of ConfigEntry.runtime_data."""
     init_file = integration.path / "__init__.py"
-    init = ast.parse(init_file.read_text())
+    init = ast_parse_module(init_file)
 
     # Should not happen, but better to be safe
     if not (async_setup_entry := _get_setup_entry_function(init)):

--- a/script/hassfest/quality_scale_validation/unique_config_entry.py
+++ b/script/hassfest/quality_scale_validation/unique_config_entry.py
@@ -5,6 +5,7 @@ https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/u
 
 import ast
 
+from script.hassfest import ast_parse_module
 from script.hassfest.model import Integration
 
 
@@ -36,7 +37,7 @@ def validate(integration: Integration) -> list[str] | None:
         return None
 
     config_flow_file = integration.path / "config_flow.py"
-    config_flow = ast.parse(config_flow_file.read_text())
+    config_flow = ast_parse_module(config_flow_file)
 
     if not (
         _has_abort_entries_match(config_flow)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Avoids reading file from disk and re-parsing on every hassfest check

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
