### PR TITLE
Add test-before-setup rule to quality_scale validation

### DIFF
--- a/script/hassfest/quality_scale.py
+++ b/script/hassfest/quality_scale.py
@@ -23,6 +23,7 @@ from .quality_scale_validation import (
     reconfiguration_flow,
     runtime_data,
     strict_typing,
+    test_before_setup,
     unique_config_entry,
 )
 
@@ -56,7 +57,7 @@ ALL_RULES = [
     Rule("has-entity-name", ScaledQualityScaleTiers.BRONZE),
     Rule("runtime-data", ScaledQualityScaleTiers.BRONZE, runtime_data),
     Rule("test-before-configure", ScaledQualityScaleTiers.BRONZE),
-    Rule("test-before-setup", ScaledQualityScaleTiers.BRONZE),
+    Rule("test-before-setup", ScaledQualityScaleTiers.BRONZE, test_before_setup),
     Rule("unique-config-entry", ScaledQualityScaleTiers.BRONZE, unique_config_entry),
     # SILVER
     Rule("action-exceptions", ScaledQualityScaleTiers.SILVER),

--- a/script/hassfest/quality_scale_validation/test_before_setup.py
+++ b/script/hassfest/quality_scale_validation/test_before_setup.py
@@ -5,6 +5,7 @@ https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/t
 
 import ast
 
+from script.hassfest import ast_parse_module
 from script.hassfest.model import Integration
 
 _VALID_EXCEPTIONS = {
@@ -50,7 +51,7 @@ def _get_setup_entry_function(module: ast.Module) -> ast.AsyncFunctionDef | None
 def validate(integration: Integration) -> list[str] | None:
     """Validate correct use of ConfigEntry.runtime_data."""
     init_file = integration.path / "__init__.py"
-    init = ast.parse(init_file.read_text())
+    init = ast_parse_module(init_file)
 
     # Should not happen, but better to be safe
     if not (async_setup_entry := _get_setup_entry_function(init)):

--- a/script/hassfest/quality_scale_validation/test_before_setup.py
+++ b/script/hassfest/quality_scale_validation/test_before_setup.py
@@ -1,0 +1,66 @@
+"""Enforce that the integration raises correctly during initialisation.
+
+https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/test-before-setup/
+"""
+
+import ast
+
+from script.hassfest.model import Integration
+
+_VALID_EXCEPTIONS = {
+    "ConfigEntryNotReady",
+    "ConfigEntryAuthFailed",
+    "ConfigEntryError",
+}
+
+
+def _raises_exception(async_setup_entry_function: ast.AsyncFunctionDef) -> bool:
+    """Check that a valid exception is raised within `async_setup_entry`."""
+    for node in ast.walk(async_setup_entry_function):
+        if isinstance(node, ast.Raise):
+            if isinstance(node.exc, ast.Name) and node.exc.id in _VALID_EXCEPTIONS:
+                return True
+            if isinstance(node.exc, ast.Call) and node.exc.func.id in _VALID_EXCEPTIONS:
+                return True
+
+    return False
+
+
+def _calls_first_refresh(async_setup_entry_function: ast.AsyncFunctionDef) -> bool:
+    """Check that a async_config_entry_first_refresh within `async_setup_entry`."""
+    for node in ast.walk(async_setup_entry_function):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "async_config_entry_first_refresh"
+        ):
+            return True
+
+    return False
+
+
+def _get_setup_entry_function(module: ast.Module) -> ast.AsyncFunctionDef | None:
+    """Get async_setup_entry function."""
+    for item in module.body:
+        if isinstance(item, ast.AsyncFunctionDef) and item.name == "async_setup_entry":
+            return item
+    return None
+
+
+def validate(integration: Integration) -> list[str] | None:
+    """Validate correct use of ConfigEntry.runtime_data."""
+    init_file = integration.path / "__init__.py"
+    init = ast.parse(init_file.read_text())
+
+    # Should not happen, but better to be safe
+    if not (async_setup_entry := _get_setup_entry_function(init)):
+        return [f"Could not find `async_setup_entry` in {init_file}"]
+
+    if not (
+        _raises_exception(async_setup_entry) or _calls_first_refresh(async_setup_entry)
+    ):
+        return [
+            f"Integration does not raise one of {_VALID_EXCEPTIONS} "
+            f"in async_setup_entry ({init_file})"
+        ]
+    return None

--- a/script/hassfest/quality_scale_validation/test_before_setup.py
+++ b/script/hassfest/quality_scale_validation/test_before_setup.py
@@ -6,7 +6,7 @@ https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/t
 import ast
 
 from script.hassfest import ast_parse_module
-from script.hassfest.model import Integration
+from script.hassfest.model import Config, Integration
 
 _VALID_EXCEPTIONS = {
     "ConfigEntryNotReady",
@@ -48,7 +48,9 @@ def _get_setup_entry_function(module: ast.Module) -> ast.AsyncFunctionDef | None
     return None
 
 
-def validate(integration: Integration, *, rules_done: set[str]) -> list[str] | None:
+def validate(
+    config: Config, integration: Integration, *, rules_done: set[str]
+) -> list[str] | None:
     """Validate correct use of ConfigEntry.runtime_data."""
     init_file = integration.path / "__init__.py"
     init = ast_parse_module(init_file)

--- a/script/hassfest/quality_scale_validation/test_before_setup.py
+++ b/script/hassfest/quality_scale_validation/test_before_setup.py
@@ -48,7 +48,7 @@ def _get_setup_entry_function(module: ast.Module) -> ast.AsyncFunctionDef | None
     return None
 
 
-def validate(integration: Integration) -> list[str] | None:
+def validate(integration: Integration, *, rules_done: set[str]) -> list[str] | None:
     """Validate correct use of ConfigEntry.runtime_data."""
     init_file = integration.path / "__init__.py"
     init = ast_parse_module(init_file)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Spotted in https://github.com/home-assistant/core/pull/132227
Documented in https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/test-before-setup/

Needs:
 - [x] #132334

```
Integrations: 1304
Invalid integrations: 1

Found errors. Generating files canceled.

Integration mqtt:
* [ERROR] [QUALITY_SCALE] [test-before-setup] Integration does not raise one of {'ConfigEntryAuthFailed', 'ConfigEntryNotReady', 'ConfigEntryError'} in async_setup_entry (homeassistant/components/mqtt/__init__.py)
* [ERROR] [QUALITY_SCALE] Please check the documentation at https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/test-before-setup/
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
