### PR TITLE
Add tests for already_configured erros in IronOS integration

### DIFF
--- a/homeassistant/components/iron_os/quality_scale.yaml
+++ b/homeassistant/components/iron_os/quality_scale.yaml
@@ -6,7 +6,7 @@ rules:
   appropriate-polling: done
   brands: done
   common-modules: done
-  config-flow-test-coverage: todo
+  config-flow-test-coverage: done
   config-flow: done
   dependency-transparency: done
   docs-actions:

--- a/tests/components/iron_os/test_config_flow.py
+++ b/tests/components/iron_os/test_config_flow.py
@@ -38,10 +38,10 @@ async def test_async_step_user(
 
 
 @pytest.mark.usefixtures("discovery")
-async def test_async_step_user_devices_already_setup(
+async def test_async_step_user_device_added_between_steps(
     hass: HomeAssistant, config_entry: MockConfigEntry
 ) -> None:
-    """Test we can't start a flow if there is already a config entry."""
+    """Test the device gets added via another flow between steps."""
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}

--- a/tests/components/iron_os/test_config_flow.py
+++ b/tests/components/iron_os/test_config_flow.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
+
 from homeassistant.components.iron_os import DOMAIN
 from homeassistant.config_entries import SOURCE_BLUETOOTH, SOURCE_USER
 from homeassistant.core import HomeAssistant
@@ -11,9 +13,12 @@ from homeassistant.data_entry_flow import FlowResultType
 
 from .conftest import DEFAULT_NAME, PINECIL_SERVICE_INFO, USER_INPUT
 
+from tests.common import MockConfigEntry
 
-async def test_form(
-    hass: HomeAssistant, mock_setup_entry: AsyncMock, discovery: MagicMock
+
+@pytest.mark.usefixtures("discovery")
+async def test_async_step_user(
+    hass: HomeAssistant, mock_setup_entry: AsyncMock
 ) -> None:
     """Test the user config flow."""
     result = await hass.config_entries.flow.async_init(
@@ -32,10 +37,31 @@ async def test_form(
     assert len(mock_setup_entry.mock_calls) == 1
 
 
+@pytest.mark.usefixtures("discovery")
+async def test_async_step_user_devices_already_setup(
+    hass: HomeAssistant, config_entry: MockConfigEntry
+) -> None:
+    """Test we can't start a flow if there is already a config entry."""
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    assert result["type"] is FlowResultType.FORM
+
+    config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        USER_INPUT,
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+@pytest.mark.usefixtures("mock_setup_entry")
 async def test_form_no_device_discovered(
-    hass: HomeAssistant,
-    mock_setup_entry: AsyncMock,
-    discovery: MagicMock,
+    hass: HomeAssistant, discovery: MagicMock
 ) -> None:
     """Test setup with no device discoveries."""
     discovery.return_value = []
@@ -48,7 +74,7 @@ async def test_form_no_device_discovered(
 
 
 async def test_async_step_bluetooth(hass: HomeAssistant) -> None:
-    """Test discovery via bluetooth.."""
+    """Test discovery via bluetooth."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_BLUETOOTH},
@@ -64,3 +90,19 @@ async def test_async_step_bluetooth(hass: HomeAssistant) -> None:
     assert result["title"] == DEFAULT_NAME
     assert result["data"] == {}
     assert result["result"].unique_id == "c0:ff:ee:c0:ff:ee"
+
+
+async def test_async_step_bluetooth_devices_already_setup(
+    hass: HomeAssistant, config_entry: AsyncMock
+) -> None:
+    """Test we can't start a flow if there is already a config entry."""
+
+    config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_BLUETOOTH},
+        data=PINECIL_SERVICE_INFO,
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
