### PR TITLE
Remove deprecated supported features warning in LightEntity

### DIFF
--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -1285,24 +1285,7 @@ class LightEntity(ToggleEntity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
                 type(self),
                 report_issue,
             )
-        supported_features = self.supported_features
-        supported_features_value = supported_features.value
-        supported_color_modes: set[ColorMode] = set()
-
-        if supported_features_value & _DEPRECATED_SUPPORT_COLOR_TEMP.value:
-            supported_color_modes.add(ColorMode.COLOR_TEMP)
-        if supported_features_value & _DEPRECATED_SUPPORT_COLOR.value:
-            supported_color_modes.add(ColorMode.HS)
-        if (
-            not supported_color_modes
-            and supported_features_value & _DEPRECATED_SUPPORT_BRIGHTNESS.value
-        ):
-            supported_color_modes = {ColorMode.BRIGHTNESS}
-
-        if not supported_color_modes:
-            supported_color_modes = {ColorMode.ONOFF}
-
-        return supported_color_modes
+        return {ColorMode.ONOFF}
 
     @cached_property
     def supported_color_modes(self) -> set[ColorMode] | set[str] | None:

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -374,7 +374,7 @@ def filter_turn_off_params(
     if not params:
         return params
 
-    supported_features = light.supported_features_compat
+    supported_features = light.supported_features
 
     if LightEntityFeature.FLASH not in supported_features:
         params.pop(ATTR_FLASH, None)
@@ -386,7 +386,7 @@ def filter_turn_off_params(
 
 def filter_turn_on_params(light: LightEntity, params: dict[str, Any]) -> dict[str, Any]:
     """Filter out params not supported by the light."""
-    supported_features = light.supported_features_compat
+    supported_features = light.supported_features
 
     if LightEntityFeature.EFFECT not in supported_features:
         params.pop(ATTR_EFFECT, None)
@@ -1049,7 +1049,7 @@ class LightEntity(ToggleEntity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
     def capability_attributes(self) -> dict[str, Any]:
         """Return capability attributes."""
         data: dict[str, Any] = {}
-        supported_features = self.supported_features_compat
+        supported_features = self.supported_features
         supported_color_modes = self._light_internal_supported_color_modes
 
         if ColorMode.COLOR_TEMP in supported_color_modes:
@@ -1211,7 +1211,7 @@ class LightEntity(ToggleEntity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
     def state_attributes(self) -> dict[str, Any] | None:
         """Return state attributes."""
         data: dict[str, Any] = {}
-        supported_features = self.supported_features_compat
+        supported_features = self.supported_features
         supported_color_modes = self.supported_color_modes
         legacy_supported_color_modes = (
             supported_color_modes or self._light_internal_supported_color_modes
@@ -1308,7 +1308,7 @@ class LightEntity(ToggleEntity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
                 type(self),
                 report_issue,
             )
-        supported_features = self.supported_features_compat
+        supported_features = self.supported_features
         supported_features_value = supported_features.value
         supported_color_modes: set[ColorMode] = set()
 
@@ -1336,37 +1336,6 @@ class LightEntity(ToggleEntity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
     def supported_features(self) -> LightEntityFeature:
         """Flag supported features."""
         return self._attr_supported_features
-
-    @property
-    def supported_features_compat(self) -> LightEntityFeature:
-        """Return the supported features as LightEntityFeature.
-
-        Remove this compatibility shim in 2025.1 or later.
-        """
-        features = self.supported_features
-        if type(features) is not int:  # noqa: E721
-            return features
-        new_features = LightEntityFeature(features)
-        if self._deprecated_supported_features_reported is True:
-            return new_features
-        self._deprecated_supported_features_reported = True
-        report_issue = self._suggest_report_issue()
-        report_issue += (
-            " and reference "
-            "https://developers.home-assistant.io/blog/2023/12/28/support-feature-magic-numbers-deprecation"
-        )
-        _LOGGER.warning(
-            (
-                "Entity %s (%s) is using deprecated supported features"
-                " values which will be removed in HA Core 2025.1. Instead it should use"
-                " %s and color modes, please %s"
-            ),
-            self.entity_id,
-            type(self),
-            repr(new_features),
-            report_issue,
-        )
-        return new_features
 
     def __should_report_light_issue(self) -> bool:
         """Return if light color mode issues should be reported."""

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -1216,7 +1216,6 @@ class LightEntity(ToggleEntity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
         legacy_supported_color_modes = (
             supported_color_modes or self._light_internal_supported_color_modes
         )
-        supported_features_value = supported_features.value
         _is_on = self.is_on
         color_mode = self._light_internal_color_mode if _is_on else None
 
@@ -1235,31 +1234,9 @@ class LightEntity(ToggleEntity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
                 data[ATTR_BRIGHTNESS] = self.brightness
             else:
                 data[ATTR_BRIGHTNESS] = None
-        elif supported_features_value & _DEPRECATED_SUPPORT_BRIGHTNESS.value:
-            # Backwards compatibility for ambiguous / incomplete states
-            # Warning is printed by supported_features_compat, remove in 2025.1
-            if _is_on:
-                data[ATTR_BRIGHTNESS] = self.brightness
-            else:
-                data[ATTR_BRIGHTNESS] = None
 
         if color_temp_supported(supported_color_modes):
             if color_mode == ColorMode.COLOR_TEMP:
-                color_temp_kelvin = self.color_temp_kelvin
-                data[ATTR_COLOR_TEMP_KELVIN] = color_temp_kelvin
-                if color_temp_kelvin:
-                    data[ATTR_COLOR_TEMP] = (
-                        color_util.color_temperature_kelvin_to_mired(color_temp_kelvin)
-                    )
-                else:
-                    data[ATTR_COLOR_TEMP] = None
-            else:
-                data[ATTR_COLOR_TEMP_KELVIN] = None
-                data[ATTR_COLOR_TEMP] = None
-        elif supported_features_value & _DEPRECATED_SUPPORT_COLOR_TEMP.value:
-            # Backwards compatibility
-            # Warning is printed by supported_features_compat, remove in 2025.1
-            if _is_on:
                 color_temp_kelvin = self.color_temp_kelvin
                 data[ATTR_COLOR_TEMP_KELVIN] = color_temp_kelvin
                 if color_temp_kelvin:

--- a/tests/components/light/common.py
+++ b/tests/components/light/common.py
@@ -25,6 +25,7 @@ from homeassistant.components.light import (
     DOMAIN,
     ColorMode,
     LightEntity,
+    LightEntityFeature,
 )
 from homeassistant.const import (
     ATTR_ENTITY_ID,
@@ -251,7 +252,7 @@ class MockLight(MockToggleEntity, LightEntity):
 
     _attr_max_color_temp_kelvin = 6500
     _attr_min_color_temp_kelvin = 2000
-    supported_features = 0
+    supported_features = LightEntityFeature(0)
 
     brightness = None
     color_temp_kelvin = None

--- a/tests/components/light/test_init.py
+++ b/tests/components/light/test_init.py
@@ -1363,7 +1363,7 @@ async def test_light_state_off(hass: HomeAssistant) -> None:
         "color_mode": None,
         "friendly_name": "Test_onoff",
         "supported_color_modes": [light.ColorMode.ONOFF],
-        "supported_features": 0,
+        "supported_features": light.LightEntityFeature(0),
     }
 
     state = hass.states.get(entity1.entity_id)
@@ -1371,7 +1371,7 @@ async def test_light_state_off(hass: HomeAssistant) -> None:
         "color_mode": None,
         "friendly_name": "Test_brightness",
         "supported_color_modes": [light.ColorMode.BRIGHTNESS],
-        "supported_features": 0,
+        "supported_features": light.LightEntityFeature(0),
         "brightness": None,
     }
 
@@ -1380,7 +1380,7 @@ async def test_light_state_off(hass: HomeAssistant) -> None:
         "color_mode": None,
         "friendly_name": "Test_ct",
         "supported_color_modes": [light.ColorMode.COLOR_TEMP],
-        "supported_features": 0,
+        "supported_features": light.LightEntityFeature(0),
         "brightness": None,
         "color_temp": None,
         "color_temp_kelvin": None,
@@ -1398,7 +1398,7 @@ async def test_light_state_off(hass: HomeAssistant) -> None:
         "color_mode": None,
         "friendly_name": "Test_rgbw",
         "supported_color_modes": [light.ColorMode.RGBW],
-        "supported_features": 0,
+        "supported_features": light.LightEntityFeature(0),
         "brightness": None,
         "rgbw_color": None,
         "hs_color": None,
@@ -1429,7 +1429,7 @@ async def test_light_state_rgbw(hass: HomeAssistant) -> None:
         "color_mode": light.ColorMode.RGBW,
         "friendly_name": "Test_rgbw",
         "supported_color_modes": [light.ColorMode.RGBW],
-        "supported_features": 0,
+        "supported_features": light.LightEntityFeature(0),
         "hs_color": (240.0, 25.0),
         "rgb_color": (3, 3, 4),
         "rgbw_color": (1, 2, 3, 4),
@@ -1460,7 +1460,7 @@ async def test_light_state_rgbww(hass: HomeAssistant) -> None:
         "color_mode": light.ColorMode.RGBWW,
         "friendly_name": "Test_rgbww",
         "supported_color_modes": [light.ColorMode.RGBWW],
-        "supported_features": 0,
+        "supported_features": light.LightEntityFeature(0),
         "hs_color": (60.0, 20.0),
         "rgb_color": (5, 5, 4),
         "rgbww_color": (1, 2, 3, 4, 5),
@@ -2623,27 +2623,6 @@ def test_filter_supported_color_modes() -> None:
     # ColorMode.BRIGHTNESS has priority over ColorMode.ONOFF
     supported = {light.ColorMode.ONOFF, light.ColorMode.BRIGHTNESS}
     assert light.filter_supported_color_modes(supported) == {light.ColorMode.BRIGHTNESS}
-
-
-def test_deprecated_supported_features_ints(caplog: pytest.LogCaptureFixture) -> None:
-    """Test deprecated supported features ints."""
-
-    class MockLightEntityEntity(light.LightEntity):
-        @property
-        def supported_features(self) -> int:
-            """Return supported features."""
-            return 1
-
-    entity = MockLightEntityEntity()
-    assert entity.supported_features_compat is light.LightEntityFeature(1)
-    assert "MockLightEntityEntity" in caplog.text
-    assert "is using deprecated supported features values" in caplog.text
-    assert "Instead it should use" in caplog.text
-    assert "LightEntityFeature" in caplog.text
-    assert "and color modes" in caplog.text
-    caplog.clear()
-    assert entity.supported_features_compat is light.LightEntityFeature(1)
-    assert "is using deprecated supported features values" not in caplog.text
 
 
 @pytest.mark.parametrize(

--- a/tests/components/light/test_init.py
+++ b/tests/components/light/test_init.py
@@ -2357,13 +2357,6 @@ async def test_light_state_color_conversion(hass: HomeAssistant) -> None:
     entity2.rgb_color = "Invalid"  # Should be ignored
     entity2.xy_color = (0.1, 0.8)
 
-    entity3 = entities[3]
-    entity3.hs_color = (240, 100)
-    entity3.supported_features = light.SUPPORT_COLOR
-    # Set color modes to none to trigger backwards compatibility in LightEntity
-    entity3.supported_color_modes = None
-    entity3.color_mode = None
-
     assert await async_setup_component(hass, "light", {"light": {"platform": "test"}})
     await hass.async_block_till_done()
 
@@ -2384,12 +2377,6 @@ async def test_light_state_color_conversion(hass: HomeAssistant) -> None:
     assert state.attributes["hs_color"] == (125.176, 100.0)
     assert state.attributes["rgb_color"] == (0, 255, 22)
     assert state.attributes["xy_color"] == (0.1, 0.8)
-
-    state = hass.states.get(entity3.entity_id)
-    assert state.attributes["color_mode"] == light.ColorMode.HS
-    assert state.attributes["hs_color"] == (240, 100)
-    assert state.attributes["rgb_color"] == (0, 0, 255)
-    assert state.attributes["xy_color"] == (0.136, 0.04)
 
 
 async def test_services_filter_parameters(

--- a/tests/components/light/test_init.py
+++ b/tests/components/light/test_init.py
@@ -131,26 +131,17 @@ async def test_services(
     )
     await hass.async_block_till_done()
 
-    ent1, ent2, ent3 = mock_light_entities
+    ent1, ent2, _ = mock_light_entities
     ent1.supported_color_modes = [light.ColorMode.HS]
-    ent3.supported_color_modes = [light.ColorMode.HS]
+    ent2.supported_color_modes = [light.ColorMode.HS]
     ent1.supported_features = light.LightEntityFeature.TRANSITION
     ent2.supported_features = (
-        light.SUPPORT_COLOR
-        | light.LightEntityFeature.EFFECT
-        | light.LightEntityFeature.TRANSITION
-    )
-    # Set color modes to none to trigger backwards compatibility in LightEntity
-    ent2.supported_color_modes = None
-    ent2.color_mode = None
-    ent3.supported_features = (
         light.LightEntityFeature.FLASH | light.LightEntityFeature.TRANSITION
     )
 
     # Test init
     assert light.is_on(hass, ent1.entity_id)
     assert not light.is_on(hass, ent2.entity_id)
-    assert not light.is_on(hass, ent3.entity_id)
 
     # Test basic turn_on, turn_off, toggle services
     await hass.services.async_call(
@@ -170,7 +161,6 @@ async def test_services(
 
     assert light.is_on(hass, ent1.entity_id)
     assert light.is_on(hass, ent2.entity_id)
-    assert light.is_on(hass, ent3.entity_id)
 
     # turn off all lights
     await hass.services.async_call(
@@ -182,7 +172,6 @@ async def test_services(
 
     assert not light.is_on(hass, ent1.entity_id)
     assert not light.is_on(hass, ent2.entity_id)
-    assert not light.is_on(hass, ent3.entity_id)
 
     # turn off all lights by setting brightness to 0
     await hass.services.async_call(
@@ -197,7 +186,6 @@ async def test_services(
 
     assert not light.is_on(hass, ent1.entity_id)
     assert not light.is_on(hass, ent2.entity_id)
-    assert not light.is_on(hass, ent3.entity_id)
 
     # toggle all lights
     await hass.services.async_call(
@@ -206,7 +194,6 @@ async def test_services(
 
     assert light.is_on(hass, ent1.entity_id)
     assert light.is_on(hass, ent2.entity_id)
-    assert light.is_on(hass, ent3.entity_id)
 
     # toggle all lights
     await hass.services.async_call(
@@ -215,7 +202,6 @@ async def test_services(
 
     assert not light.is_on(hass, ent1.entity_id)
     assert not light.is_on(hass, ent2.entity_id)
-    assert not light.is_on(hass, ent3.entity_id)
 
     # Ensure all attributes process correctly
     await hass.services.async_call(
@@ -234,16 +220,6 @@ async def test_services(
         SERVICE_TURN_ON,
         {
             ATTR_ENTITY_ID: ent2.entity_id,
-            light.ATTR_EFFECT: "fun_effect",
-            light.ATTR_RGB_COLOR: (255, 255, 255),
-        },
-        blocking=True,
-    )
-    await hass.services.async_call(
-        light.DOMAIN,
-        SERVICE_TURN_ON,
-        {
-            ATTR_ENTITY_ID: ent3.entity_id,
             light.ATTR_FLASH: "short",
             light.ATTR_XY_COLOR: (0.4, 0.6),
         },
@@ -258,12 +234,6 @@ async def test_services(
     }
 
     _, data = ent2.last_call("turn_on")
-    assert data == {
-        light.ATTR_EFFECT: "fun_effect",
-        light.ATTR_HS_COLOR: (0, 0),
-    }
-
-    _, data = ent3.last_call("turn_on")
     assert data == {light.ATTR_FLASH: "short", light.ATTR_HS_COLOR: (71.059, 100)}
 
     # Ensure attributes are filtered when light is turned off
@@ -284,16 +254,6 @@ async def test_services(
         {
             ATTR_ENTITY_ID: ent2.entity_id,
             light.ATTR_BRIGHTNESS: 0,
-            light.ATTR_RGB_COLOR: (255, 255, 255),
-        },
-        blocking=True,
-    )
-    await hass.services.async_call(
-        light.DOMAIN,
-        SERVICE_TURN_ON,
-        {
-            ATTR_ENTITY_ID: ent3.entity_id,
-            light.ATTR_BRIGHTNESS: 0,
             light.ATTR_XY_COLOR: (0.4, 0.6),
         },
         blocking=True,
@@ -301,15 +261,11 @@ async def test_services(
 
     assert not light.is_on(hass, ent1.entity_id)
     assert not light.is_on(hass, ent2.entity_id)
-    assert not light.is_on(hass, ent3.entity_id)
 
     _, data = ent1.last_call("turn_off")
     assert data == {light.ATTR_TRANSITION: 10}
 
     _, data = ent2.last_call("turn_off")
-    assert data == {}
-
-    _, data = ent3.last_call("turn_off")
     assert data == {}
 
     # One of the light profiles
@@ -323,18 +279,6 @@ async def test_services(
         {ATTR_ENTITY_ID: ent1.entity_id, light.ATTR_PROFILE: profile.name},
         blocking=True,
     )
-    # Specify a profile and a brightness attribute to overwrite it
-    await hass.services.async_call(
-        light.DOMAIN,
-        SERVICE_TURN_ON,
-        {
-            ATTR_ENTITY_ID: ent2.entity_id,
-            light.ATTR_PROFILE: profile.name,
-            light.ATTR_BRIGHTNESS: 100,
-            light.ATTR_TRANSITION: 1,
-        },
-        blocking=True,
-    )
 
     _, data = ent1.last_call("turn_on")
     assert data == {
@@ -343,26 +287,19 @@ async def test_services(
         light.ATTR_TRANSITION: profile.transition,
     }
 
-    _, data = ent2.last_call("turn_on")
-    assert data == {
-        light.ATTR_BRIGHTNESS: 100,
-        light.ATTR_HS_COLOR: profile.hs_color,
-        light.ATTR_TRANSITION: 1,
-    }
-
     # Test toggle with parameters
     await hass.services.async_call(
         light.DOMAIN,
         SERVICE_TOGGLE,
         {
-            ATTR_ENTITY_ID: ent3.entity_id,
+            ATTR_ENTITY_ID: ent2.entity_id,
             light.ATTR_PROFILE: profile.name,
             light.ATTR_BRIGHTNESS_PCT: 100,
         },
         blocking=True,
     )
 
-    _, data = ent3.last_call("turn_on")
+    _, data = ent2.last_call("turn_on")
     assert data == {
         light.ATTR_BRIGHTNESS: 255,
         light.ATTR_HS_COLOR: profile.hs_color,
@@ -373,13 +310,13 @@ async def test_services(
         light.DOMAIN,
         SERVICE_TOGGLE,
         {
-            ATTR_ENTITY_ID: ent3.entity_id,
+            ATTR_ENTITY_ID: ent2.entity_id,
             light.ATTR_TRANSITION: 4,
         },
         blocking=True,
     )
 
-    _, data = ent3.last_call("turn_off")
+    _, data = ent2.last_call("turn_off")
     assert data == {
         light.ATTR_TRANSITION: 4,
     }
@@ -394,18 +331,12 @@ async def test_services(
         {ATTR_ENTITY_ID: ent1.entity_id, light.ATTR_PROFILE: -1},
         blocking=True,
     )
+
     with pytest.raises(vol.MultipleInvalid):
         await hass.services.async_call(
             light.DOMAIN,
             SERVICE_TURN_ON,
-            {ATTR_ENTITY_ID: ent2.entity_id, light.ATTR_XY_COLOR: ["bla-di-bla", 5]},
-            blocking=True,
-        )
-    with pytest.raises(vol.MultipleInvalid):
-        await hass.services.async_call(
-            light.DOMAIN,
-            SERVICE_TURN_ON,
-            {ATTR_ENTITY_ID: ent3.entity_id, light.ATTR_RGB_COLOR: [255, None, 2]},
+            {ATTR_ENTITY_ID: ent2.entity_id, light.ATTR_RGB_COLOR: [255, None, 2]},
             blocking=True,
         )
 
@@ -413,9 +344,6 @@ async def test_services(
     assert data == {}
 
     _, data = ent2.last_call("turn_on")
-    assert data == {}
-
-    _, data = ent3.last_call("turn_on")
     assert data == {}
 
     # faulty attributes will not trigger a service call


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
For developpers only: following deprecation period, the use of integers for supported_features is no longer supported.
Please use the corresponding `LightEntityFeature` enum.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
History:
- https://developers.home-assistant.io/blog/2022/04/02/support-constants-deprecation/
- https://developers.home-assistant.io/blog/2023/12/28/support-feature-magic-numbers-deprecation/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
