### PR TITLE
Switcher runner child lock support

### DIFF
--- a/homeassistant/components/switcher_kis/cover.py
+++ b/homeassistant/components/switcher_kis/cover.py
@@ -22,8 +22,6 @@ from .const import SIGNAL_DEVICE_ADD
 from .coordinator import SwitcherDataUpdateCoordinator
 from .entity import SwitcherEntity
 
-_LOGGER = logging.getLogger(__name__)
-
 API_SET_POSITON = "set_position"
 API_STOP = "stop_shutter"
 

--- a/homeassistant/components/switcher_kis/cover.py
+++ b/homeassistant/components/switcher_kis/cover.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 from typing import Any, cast
 
 from aioswitcher.device import DeviceCategory, ShutterDirection, SwitcherShutter

--- a/homeassistant/components/switcher_kis/cover.py
+++ b/homeassistant/components/switcher_kis/cover.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import logging
 from typing import Any, cast
 
-from aioswitcher.api import SwitcherApi, SwitcherBaseResponse
 from aioswitcher.device import DeviceCategory, ShutterDirection, SwitcherShutter
 
 from homeassistant.components.cover import (
@@ -16,7 +15,6 @@ from homeassistant.components.cover import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -92,49 +90,23 @@ class SwitcherBaseCoverEntity(SwitcherEntity, CoverEntity):
             data.direction[self._cover_id] == ShutterDirection.SHUTTER_UP
         )
 
-    async def _async_call_api(self, api: str, *args: Any) -> None:
-        """Call Switcher API."""
-        _LOGGER.debug("Calling api for %s, api: '%s', args: %s", self.name, api, args)
-        response: SwitcherBaseResponse | None = None
-        error = None
-
-        try:
-            async with SwitcherApi(
-                self.coordinator.data.device_type,
-                self.coordinator.data.ip_address,
-                self.coordinator.data.device_id,
-                self.coordinator.data.device_key,
-                self.coordinator.token,
-            ) as swapi:
-                response = await getattr(swapi, api)(*args)
-        except (TimeoutError, OSError, RuntimeError) as err:
-            error = repr(err)
-
-        if error or not response or not response.successful:
-            self.coordinator.last_update_success = False
-            self.async_write_ha_state()
-            raise HomeAssistantError(
-                f"Call api for {self.name} failed, api: '{api}', "
-                f"args: {args}, response/error: {response or error}"
-            )
-
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close cover."""
-        await self._async_call_api(API_SET_POSITON, 0, self._cover_id)
+        await self._async_call_api2(API_SET_POSITON, 0, self._cover_id)
 
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open cover."""
-        await self._async_call_api(API_SET_POSITON, 100, self._cover_id)
+        await self._async_call_api2(API_SET_POSITON, 100, self._cover_id)
 
     async def async_set_cover_position(self, **kwargs: Any) -> None:
         """Move the cover to a specific position."""
-        await self._async_call_api(
+        await self._async_call_api2(
             API_SET_POSITON, kwargs[ATTR_POSITION], self._cover_id
         )
 
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Stop the cover."""
-        await self._async_call_api(API_STOP, self._cover_id)
+        await self._async_call_api2(API_STOP, self._cover_id)
 
 
 class SwitcherSingleCoverEntity(SwitcherBaseCoverEntity):

--- a/homeassistant/components/switcher_kis/cover.py
+++ b/homeassistant/components/switcher_kis/cover.py
@@ -92,21 +92,21 @@ class SwitcherBaseCoverEntity(SwitcherEntity, CoverEntity):
 
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close cover."""
-        await self._async_call_api2(API_SET_POSITON, 0, self._cover_id)
+        await self._async_call_api(API_SET_POSITON, 0, self._cover_id)
 
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open cover."""
-        await self._async_call_api2(API_SET_POSITON, 100, self._cover_id)
+        await self._async_call_api(API_SET_POSITON, 100, self._cover_id)
 
     async def async_set_cover_position(self, **kwargs: Any) -> None:
         """Move the cover to a specific position."""
-        await self._async_call_api2(
+        await self._async_call_api(
             API_SET_POSITON, kwargs[ATTR_POSITION], self._cover_id
         )
 
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Stop the cover."""
-        await self._async_call_api2(API_STOP, self._cover_id)
+        await self._async_call_api(API_STOP, self._cover_id)
 
 
 class SwitcherSingleCoverEntity(SwitcherBaseCoverEntity):

--- a/homeassistant/components/switcher_kis/entity.py
+++ b/homeassistant/components/switcher_kis/entity.py
@@ -46,34 +46,6 @@ class SwitcherEntity(CoordinatorEntity[SwitcherDataUpdateCoordinator]):
             error = repr(err)
 
         if error or not response or not response.successful:
-            _LOGGER.error(
-                "Call api for %s failed, api: '%s', args: %s, response/error: %s",
-                self.coordinator.name,
-                api,
-                args,
-                response or error,
-            )
-            self.coordinator.last_update_success = False
-
-    async def _async_call_api2(self, api: str, *args: Any) -> None:
-        """Call Switcher API."""
-        _LOGGER.debug("Calling api for %s, api: '%s', args: %s", self.name, api, args)
-        response: SwitcherBaseResponse | None = None
-        error = None
-
-        try:
-            async with SwitcherApi(
-                self.coordinator.data.device_type,
-                self.coordinator.data.ip_address,
-                self.coordinator.data.device_id,
-                self.coordinator.data.device_key,
-                self.coordinator.token,
-            ) as swapi:
-                response = await getattr(swapi, api)(*args)
-        except (TimeoutError, OSError, RuntimeError) as err:
-            error = repr(err)
-
-        if error or not response or not response.successful:
             self.coordinator.last_update_success = False
             self.async_write_ha_state()
             raise HomeAssistantError(

--- a/homeassistant/components/switcher_kis/entity.py
+++ b/homeassistant/components/switcher_kis/entity.py
@@ -1,10 +1,18 @@
 """Base class for Switcher entities."""
 
+import logging
+from typing import Any
+
+from aioswitcher.api import SwitcherApi, SwitcherBaseResponse
+
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .coordinator import SwitcherDataUpdateCoordinator
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class SwitcherEntity(CoordinatorEntity[SwitcherDataUpdateCoordinator]):
@@ -18,3 +26,57 @@ class SwitcherEntity(CoordinatorEntity[SwitcherDataUpdateCoordinator]):
         self._attr_device_info = DeviceInfo(
             connections={(dr.CONNECTION_NETWORK_MAC, coordinator.mac_address)}
         )
+
+    async def _async_call_api(self, api: str, *args: Any) -> None:
+        """Call Switcher API."""
+        _LOGGER.debug("Calling api for %s, api: '%s', args: %s", self.name, api, args)
+        response: SwitcherBaseResponse | None = None
+        error = None
+
+        try:
+            async with SwitcherApi(
+                self.coordinator.data.device_type,
+                self.coordinator.data.ip_address,
+                self.coordinator.data.device_id,
+                self.coordinator.data.device_key,
+                self.coordinator.token,
+            ) as swapi:
+                response = await getattr(swapi, api)(*args)
+        except (TimeoutError, OSError, RuntimeError) as err:
+            error = repr(err)
+
+        if error or not response or not response.successful:
+            _LOGGER.error(
+                "Call api for %s failed, api: '%s', args: %s, response/error: %s",
+                self.coordinator.name,
+                api,
+                args,
+                response or error,
+            )
+            self.coordinator.last_update_success = False
+
+    async def _async_call_api2(self, api: str, *args: Any) -> None:
+        """Call Switcher API."""
+        _LOGGER.debug("Calling api for %s, api: '%s', args: %s", self.name, api, args)
+        response: SwitcherBaseResponse | None = None
+        error = None
+
+        try:
+            async with SwitcherApi(
+                self.coordinator.data.device_type,
+                self.coordinator.data.ip_address,
+                self.coordinator.data.device_id,
+                self.coordinator.data.device_key,
+                self.coordinator.token,
+            ) as swapi:
+                response = await getattr(swapi, api)(*args)
+        except (TimeoutError, OSError, RuntimeError) as err:
+            error = repr(err)
+
+        if error or not response or not response.successful:
+            self.coordinator.last_update_success = False
+            self.async_write_ha_state()
+            raise HomeAssistantError(
+                f"Call api for {self.name} failed, api: '{api}', "
+                f"args: {args}, response/error: {response or error}"
+            )

--- a/homeassistant/components/switcher_kis/light.py
+++ b/homeassistant/components/switcher_kis/light.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 from typing import Any, cast
 
 from aioswitcher.device import DeviceCategory, DeviceState, SwitcherLight

--- a/homeassistant/components/switcher_kis/light.py
+++ b/homeassistant/components/switcher_kis/light.py
@@ -79,13 +79,13 @@ class SwitcherBaseLightEntity(SwitcherEntity, LightEntity):
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the light on."""
-        await self._async_call_api2(API_SET_LIGHT, DeviceState.ON, self._light_id)
+        await self._async_call_api(API_SET_LIGHT, DeviceState.ON, self._light_id)
         self.control_result = True
         self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the light off."""
-        await self._async_call_api2(API_SET_LIGHT, DeviceState.OFF, self._light_id)
+        await self._async_call_api(API_SET_LIGHT, DeviceState.OFF, self._light_id)
         self.control_result = False
         self.async_write_ha_state()
 

--- a/homeassistant/components/switcher_kis/light.py
+++ b/homeassistant/components/switcher_kis/light.py
@@ -17,8 +17,6 @@ from .const import SIGNAL_DEVICE_ADD
 from .coordinator import SwitcherDataUpdateCoordinator
 from .entity import SwitcherEntity
 
-_LOGGER = logging.getLogger(__name__)
-
 API_SET_LIGHT = "set_light"
 
 

--- a/homeassistant/components/switcher_kis/manifest.json
+++ b/homeassistant/components/switcher_kis/manifest.json
@@ -6,6 +6,6 @@
   "documentation": "https://www.home-assistant.io/integrations/switcher_kis",
   "iot_class": "local_push",
   "loggers": ["aioswitcher"],
-  "requirements": ["aioswitcher==5.0.0"],
+  "requirements": ["aioswitcher==5.1.0"],
   "single_config_entry": true
 }

--- a/homeassistant/components/switcher_kis/strings.json
+++ b/homeassistant/components/switcher_kis/strings.json
@@ -63,6 +63,14 @@
       "temperature": {
         "name": "Current temperature"
       }
+    },
+    "switch": {
+      "child_lock": {
+        "name": "Lock physical controls"
+      },
+      "multi_child_lock": {
+        "name": "Lock physical controls {cover_id}"
+      }
     }
   },
   "services": {

--- a/homeassistant/components/switcher_kis/switch.py
+++ b/homeassistant/components/switcher_kis/switch.py
@@ -4,14 +4,15 @@ from __future__ import annotations
 
 from datetime import timedelta
 import logging
-from typing import Any
+from typing import Any, cast
 
-from aioswitcher.api import Command, SwitcherApi, SwitcherBaseResponse
-from aioswitcher.device import DeviceCategory, DeviceState
+from aioswitcher.api import Command, ShutterChildLock, SwitcherApi, SwitcherBaseResponse
+from aioswitcher.device import DeviceCategory, DeviceState, SwitcherShutter
 import voluptuous as vol
 
 from homeassistant.components.switch import SwitchDeviceClass, SwitchEntity
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -32,6 +33,7 @@ _LOGGER = logging.getLogger(__name__)
 
 API_CONTROL_DEVICE = "control_device"
 API_SET_AUTO_SHUTDOWN = "set_auto_shutdown"
+API_SET_CHILD_LOCK = "set_shutter_child_lock"
 
 SERVICE_SET_AUTO_OFF_SCHEMA: VolDictType = {
     vol.Required(CONF_AUTO_OFF): cv.time_period_str,
@@ -67,10 +69,29 @@ async def async_setup_entry(
     @callback
     def async_add_switch(coordinator: SwitcherDataUpdateCoordinator) -> None:
         """Add switch from Switcher device."""
+        entities: list[SwitchEntity] = []
+
         if coordinator.data.device_type.category == DeviceCategory.POWER_PLUG:
             async_add_entities([SwitcherPowerPlugSwitchEntity(coordinator)])
         elif coordinator.data.device_type.category == DeviceCategory.WATER_HEATER:
             async_add_entities([SwitcherWaterHeaterSwitchEntity(coordinator)])
+
+        if coordinator.data.device_type.category in (
+            DeviceCategory.SHUTTER,
+            DeviceCategory.SINGLE_SHUTTER_DUAL_LIGHT,
+            DeviceCategory.DUAL_SHUTTER_SINGLE_LIGHT,
+        ):
+            number_of_covers = len(cast(SwitcherShutter, coordinator.data).position)
+            if number_of_covers == 1:
+                entities.append(
+                    SwitchereShutterChildLockSingleSwitchEntity(coordinator, 0)
+                )
+            else:
+                entities.extend(
+                    SwitchereShutterChildLockMultiSwitchEntity(coordinator, i)
+                    for i in range(number_of_covers)
+                )
+        async_add_entities(entities)
 
     config_entry.async_on_unload(
         async_dispatcher_connect(hass, SIGNAL_DEVICE_ADD, async_add_switch)
@@ -183,3 +204,117 @@ class SwitcherWaterHeaterSwitchEntity(SwitcherBaseSwitchEntity):
         await self._async_call_api(API_CONTROL_DEVICE, Command.ON, timer_minutes)
         self.control_result = True
         self.async_write_ha_state()
+
+
+class SwitchereShutterChildLockBaseSwitchEntity(SwitcherEntity, SwitchEntity):
+    """Representation of a Switcher shutter base switch entity."""
+
+    _attr_device_class = SwitchDeviceClass.SWITCH
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_icon = "mdi:lock-open"
+    _cover_id: int
+
+    def __init__(self, coordinator: SwitcherDataUpdateCoordinator) -> None:
+        """Initialize the entity."""
+        super().__init__(coordinator)
+        self.control_result: bool | None = None
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """When device updates, clear control result that overrides state."""
+        self.control_result = None
+        self.async_write_ha_state()
+
+    async def _async_call_api(self, api: str, *args: Any) -> None:
+        """Call Switcher API."""
+        _LOGGER.debug("Calling api for %s, api: '%s', args: %s", self.name, api, args)
+        response: SwitcherBaseResponse | None = None
+        error = None
+
+        try:
+            async with SwitcherApi(
+                self.coordinator.data.device_type,
+                self.coordinator.data.ip_address,
+                self.coordinator.data.device_id,
+                self.coordinator.data.device_key,
+                self.coordinator.token,
+            ) as swapi:
+                response = await getattr(swapi, api)(*args)
+        except (TimeoutError, OSError, RuntimeError) as err:
+            error = repr(err)
+
+        if error or not response or not response.successful:
+            _LOGGER.error(
+                "Call api for %s failed, api: '%s', args: %s, response/error: %s",
+                self.coordinator.name,
+                api,
+                args,
+                response or error,
+            )
+            self.coordinator.last_update_success = False
+
+    @property
+    def is_on(self) -> bool:
+        """Return True if entity is on."""
+        if self.control_result is not None:
+            return self.control_result
+
+        data = cast(SwitcherShutter, self.coordinator.data)
+        return bool(data.child_lock[self._cover_id] == ShutterChildLock.ON)
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the entity on."""
+        await self._async_call_api(
+            API_SET_CHILD_LOCK, ShutterChildLock.ON, self._cover_id
+        )
+        self.control_result = True
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the entity off."""
+        await self._async_call_api(
+            API_SET_CHILD_LOCK, ShutterChildLock.OFF, self._cover_id
+        )
+        self.control_result = False
+        self.async_write_ha_state()
+
+
+class SwitchereShutterChildLockSingleSwitchEntity(
+    SwitchereShutterChildLockBaseSwitchEntity
+):
+    """Representation of a Switcher runner child lock single switch entity."""
+
+    _attr_translation_key = "child_lock"
+
+    def __init__(
+        self,
+        coordinator: SwitcherDataUpdateCoordinator,
+        cover_id: int,
+    ) -> None:
+        """Initialize the entity."""
+        super().__init__(coordinator)
+        self._cover_id = cover_id
+
+        self._attr_unique_id = f"{coordinator.device_id}-{coordinator.mac_address}"
+
+
+class SwitchereShutterChildLockMultiSwitchEntity(
+    SwitchereShutterChildLockBaseSwitchEntity
+):
+    """Representation of a Switcher runner child lock multiple switch entity."""
+
+    _attr_translation_key = "multi_child_lock"
+
+    def __init__(
+        self,
+        coordinator: SwitcherDataUpdateCoordinator,
+        cover_id: int,
+    ) -> None:
+        """Initialize the entity."""
+        super().__init__(coordinator)
+        self._cover_id = cover_id
+
+        self._attr_translation_placeholders = {"cover_id": str(cover_id + 1)}
+        self._attr_unique_id = (
+            f"{coordinator.device_id}-{coordinator.mac_address}-{cover_id}"
+        )

--- a/homeassistant/components/switcher_kis/switch.py
+++ b/homeassistant/components/switcher_kis/switch.py
@@ -72,11 +72,10 @@ async def async_setup_entry(
         entities: list[SwitchEntity] = []
 
         if coordinator.data.device_type.category == DeviceCategory.POWER_PLUG:
-            async_add_entities([SwitcherPowerPlugSwitchEntity(coordinator)])
+            entities.append(SwitcherPowerPlugSwitchEntity(coordinator))
         elif coordinator.data.device_type.category == DeviceCategory.WATER_HEATER:
-            async_add_entities([SwitcherWaterHeaterSwitchEntity(coordinator)])
-
-        if coordinator.data.device_type.category in (
+            entities.append(SwitcherWaterHeaterSwitchEntity(coordinator))
+        elif coordinator.data.device_type.category in (
             DeviceCategory.SHUTTER,
             DeviceCategory.SINGLE_SHUTTER_DUAL_LIGHT,
             DeviceCategory.DUAL_SHUTTER_SINGLE_LIGHT,

--- a/homeassistant/components/switcher_kis/switch.py
+++ b/homeassistant/components/switcher_kis/switch.py
@@ -6,7 +6,7 @@ from datetime import timedelta
 import logging
 from typing import Any, cast
 
-from aioswitcher.api import Command, ShutterChildLock, SwitcherApi, SwitcherBaseResponse
+from aioswitcher.api import Command, ShutterChildLock
 from aioswitcher.device import DeviceCategory, DeviceState, SwitcherShutter
 import voluptuous as vol
 
@@ -117,35 +117,6 @@ class SwitcherBaseSwitchEntity(SwitcherEntity, SwitchEntity):
         self.control_result = None
         self.async_write_ha_state()
 
-    async def _async_call_api(self, api: str, *args: Any) -> None:
-        """Call Switcher API."""
-        _LOGGER.debug(
-            "Calling api for %s, api: '%s', args: %s", self.coordinator.name, api, args
-        )
-        response: SwitcherBaseResponse | None = None
-        error = None
-
-        try:
-            async with SwitcherApi(
-                self.coordinator.data.device_type,
-                self.coordinator.data.ip_address,
-                self.coordinator.data.device_id,
-                self.coordinator.data.device_key,
-            ) as swapi:
-                response = await getattr(swapi, api)(*args)
-        except (TimeoutError, OSError, RuntimeError) as err:
-            error = repr(err)
-
-        if error or not response or not response.successful:
-            _LOGGER.error(
-                "Call api for %s failed, api: '%s', args: %s, response/error: %s",
-                self.coordinator.name,
-                api,
-                args,
-                response or error,
-            )
-            self.coordinator.last_update_success = False
-
     @property
     def is_on(self) -> bool:
         """Return True if entity is on."""
@@ -224,34 +195,6 @@ class SwitchereShutterChildLockBaseSwitchEntity(SwitcherEntity, SwitchEntity):
         """When device updates, clear control result that overrides state."""
         self.control_result = None
         self.async_write_ha_state()
-
-    async def _async_call_api(self, api: str, *args: Any) -> None:
-        """Call Switcher API."""
-        _LOGGER.debug("Calling api for %s, api: '%s', args: %s", self.name, api, args)
-        response: SwitcherBaseResponse | None = None
-        error = None
-
-        try:
-            async with SwitcherApi(
-                self.coordinator.data.device_type,
-                self.coordinator.data.ip_address,
-                self.coordinator.data.device_id,
-                self.coordinator.data.device_key,
-                self.coordinator.token,
-            ) as swapi:
-                response = await getattr(swapi, api)(*args)
-        except (TimeoutError, OSError, RuntimeError) as err:
-            error = repr(err)
-
-        if error or not response or not response.successful:
-            _LOGGER.error(
-                "Call api for %s failed, api: '%s', args: %s, response/error: %s",
-                self.coordinator.name,
-                api,
-                args,
-                response or error,
-            )
-            self.coordinator.last_update_success = False
 
     @property
     def is_on(self) -> bool:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -384,7 +384,7 @@ aiosteamist==1.0.0
 aiostreammagic==2.10.0
 
 # homeassistant.components.switcher_kis
-aioswitcher==5.0.0
+aioswitcher==5.1.0
 
 # homeassistant.components.syncthing
 aiosyncthing==0.5.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -366,7 +366,7 @@ aiosteamist==1.0.0
 aiostreammagic==2.10.0
 
 # homeassistant.components.switcher_kis
-aioswitcher==5.0.0
+aioswitcher==5.1.0
 
 # homeassistant.components.syncthing
 aiosyncthing==0.5.1

--- a/tests/components/switcher_kis/conftest.py
+++ b/tests/components/switcher_kis/conftest.py
@@ -60,11 +60,11 @@ def mock_api():
 
     patchers = [
         patch(
-            "homeassistant.components.switcher_kis.switch.SwitcherApi.connect",
+            "homeassistant.components.switcher_kis.entity.SwitcherApi.connect",
             new=api_mock,
         ),
         patch(
-            "homeassistant.components.switcher_kis.switch.SwitcherApi.disconnect",
+            "homeassistant.components.switcher_kis.entity.SwitcherApi.disconnect",
             new=api_mock,
         ),
         patch(

--- a/tests/components/switcher_kis/consts.py
+++ b/tests/components/switcher_kis/consts.py
@@ -3,6 +3,7 @@
 from aioswitcher.device import (
     DeviceState,
     DeviceType,
+    ShutterChildLock,
     ShutterDirection,
     SwitcherDualShutterSingleLight,
     SwitcherLight,
@@ -90,6 +91,8 @@ DUMMY_POSITION = [54]
 DUMMY_POSITION_2 = [54, 54]
 DUMMY_DIRECTION = [ShutterDirection.SHUTTER_STOP]
 DUMMY_DIRECTION_2 = [ShutterDirection.SHUTTER_STOP, ShutterDirection.SHUTTER_STOP]
+DUMMY_CHILD_LOCK = [ShutterChildLock.ON]
+DUMMY_CHILD_LOCK_2 = [ShutterChildLock.ON, ShutterChildLock.ON]
 DUMMY_USERNAME = "email"
 DUMMY_TOKEN = "zvVvd7JxtN7CgvkD1Psujw=="
 DUMMY_LIGHT = [DeviceState.ON]
@@ -135,6 +138,7 @@ DUMMY_SHUTTER_DEVICE = SwitcherShutter(
     DUMMY_TOKEN_NEEDED4,
     DUMMY_POSITION,
     DUMMY_DIRECTION,
+    DUMMY_CHILD_LOCK,
 )
 
 DUMMY_SINGLE_SHUTTER_DUAL_LIGHT_DEVICE = SwitcherSingleShutterDualLight(
@@ -148,6 +152,7 @@ DUMMY_SINGLE_SHUTTER_DUAL_LIGHT_DEVICE = SwitcherSingleShutterDualLight(
     DUMMY_TOKEN_NEEDED5,
     DUMMY_POSITION,
     DUMMY_DIRECTION,
+    DUMMY_CHILD_LOCK,
     DUMMY_LIGHT_2,
 )
 
@@ -162,6 +167,7 @@ DUMMY_DUAL_SHUTTER_SINGLE_LIGHT_DEVICE = SwitcherDualShutterSingleLight(
     DUMMY_TOKEN_NEEDED6,
     DUMMY_POSITION_2,
     DUMMY_DIRECTION_2,
+    DUMMY_CHILD_LOCK_2,
     DUMMY_LIGHT,
 )
 

--- a/tests/components/switcher_kis/test_cover.py
+++ b/tests/components/switcher_kis/test_cover.py
@@ -115,7 +115,7 @@ async def test_cover(
 
     # Test set position
     with patch(
-        "homeassistant.components.switcher_kis.cover.SwitcherApi.set_position"
+        "homeassistant.components.switcher_kis.entity.SwitcherApi.set_position"
     ) as mock_control_device:
         await hass.services.async_call(
             COVER_DOMAIN,
@@ -136,7 +136,7 @@ async def test_cover(
 
     # Test open
     with patch(
-        "homeassistant.components.switcher_kis.cover.SwitcherApi.set_position"
+        "homeassistant.components.switcher_kis.entity.SwitcherApi.set_position"
     ) as mock_control_device:
         await hass.services.async_call(
             COVER_DOMAIN,
@@ -156,7 +156,7 @@ async def test_cover(
 
     # Test close
     with patch(
-        "homeassistant.components.switcher_kis.cover.SwitcherApi.set_position"
+        "homeassistant.components.switcher_kis.entity.SwitcherApi.set_position"
     ) as mock_control_device:
         await hass.services.async_call(
             COVER_DOMAIN,
@@ -176,7 +176,7 @@ async def test_cover(
 
     # Test stop
     with patch(
-        "homeassistant.components.switcher_kis.cover.SwitcherApi.stop_shutter"
+        "homeassistant.components.switcher_kis.entity.SwitcherApi.stop_shutter"
     ) as mock_control_device:
         await hass.services.async_call(
             COVER_DOMAIN,
@@ -232,7 +232,7 @@ async def test_cover_control_fail(
 
     # Test exception during set position
     with patch(
-        "homeassistant.components.switcher_kis.cover.SwitcherApi.set_position",
+        "homeassistant.components.switcher_kis.entity.SwitcherApi.set_position",
         side_effect=RuntimeError("fake error"),
     ) as mock_control_device:
         with pytest.raises(HomeAssistantError):
@@ -257,7 +257,7 @@ async def test_cover_control_fail(
 
     # Test error response during set position
     with patch(
-        "homeassistant.components.switcher_kis.cover.SwitcherApi.set_position",
+        "homeassistant.components.switcher_kis.entity.SwitcherApi.set_position",
         return_value=SwitcherBaseResponse(None),
     ) as mock_control_device:
         with pytest.raises(HomeAssistantError):

--- a/tests/components/switcher_kis/test_light.py
+++ b/tests/components/switcher_kis/test_light.py
@@ -86,7 +86,7 @@ async def test_light(
 
     # Test turning on light
     with patch(
-        "homeassistant.components.switcher_kis.light.SwitcherApi.set_light",
+        "homeassistant.components.switcher_kis.entity.SwitcherApi.set_light",
     ) as mock_set_light:
         await hass.services.async_call(
             LIGHT_DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: entity_id}, blocking=True
@@ -99,7 +99,7 @@ async def test_light(
 
     # Test turning off light
     with patch(
-        "homeassistant.components.switcher_kis.light.SwitcherApi.set_light"
+        "homeassistant.components.switcher_kis.entity.SwitcherApi.set_light"
     ) as mock_set_light:
         await hass.services.async_call(
             LIGHT_DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: entity_id}, blocking=True
@@ -153,7 +153,7 @@ async def test_light_control_fail(
 
     # Test exception during turn on
     with patch(
-        "homeassistant.components.switcher_kis.cover.SwitcherApi.set_light",
+        "homeassistant.components.switcher_kis.entity.SwitcherApi.set_light",
         side_effect=RuntimeError("fake error"),
     ) as mock_control_device:
         with pytest.raises(HomeAssistantError):
@@ -178,7 +178,7 @@ async def test_light_control_fail(
 
     # Test error response during turn on
     with patch(
-        "homeassistant.components.switcher_kis.cover.SwitcherApi.set_light",
+        "homeassistant.components.switcher_kis.entity.SwitcherApi.set_light",
         return_value=SwitcherBaseResponse(None),
     ) as mock_control_device:
         with pytest.raises(HomeAssistantError):

--- a/tests/components/switcher_kis/test_services.py
+++ b/tests/components/switcher_kis/test_services.py
@@ -16,6 +16,7 @@ from homeassistant.components.switcher_kis.const import (
 )
 from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.config_validation import time_period_str
 from homeassistant.util import slugify
 
@@ -48,7 +49,7 @@ async def test_turn_on_with_timer_service(
     assert state.state == STATE_OFF
 
     with patch(
-        "homeassistant.components.switcher_kis.switch.SwitcherApi.control_device"
+        "homeassistant.components.switcher_kis.entity.SwitcherApi.control_device"
     ) as mock_control_device:
         await hass.services.async_call(
             DOMAIN,
@@ -78,7 +79,7 @@ async def test_set_auto_off_service(hass: HomeAssistant, mock_bridge, mock_api) 
     entity_id = f"{SWITCH_DOMAIN}.{slugify(device.name)}"
 
     with patch(
-        "homeassistant.components.switcher_kis.switch.SwitcherApi.set_auto_shutdown"
+        "homeassistant.components.switcher_kis.entity.SwitcherApi.set_auto_shutdown"
     ) as mock_set_auto_shutdown:
         await hass.services.async_call(
             DOMAIN,
@@ -105,23 +106,20 @@ async def test_set_auto_off_service_fail(
     entity_id = f"{SWITCH_DOMAIN}.{slugify(device.name)}"
 
     with patch(
-        "homeassistant.components.switcher_kis.switch.SwitcherApi.set_auto_shutdown",
+        "homeassistant.components.switcher_kis.entity.SwitcherApi.set_auto_shutdown",
         return_value=None,
     ) as mock_set_auto_shutdown:
-        await hass.services.async_call(
-            DOMAIN,
-            SERVICE_SET_AUTO_OFF_NAME,
-            {ATTR_ENTITY_ID: entity_id, CONF_AUTO_OFF: DUMMY_AUTO_OFF_SET},
-            blocking=True,
-        )
+        with pytest.raises(HomeAssistantError):
+            await hass.services.async_call(
+                DOMAIN,
+                SERVICE_SET_AUTO_OFF_NAME,
+                {ATTR_ENTITY_ID: entity_id, CONF_AUTO_OFF: DUMMY_AUTO_OFF_SET},
+                blocking=True,
+            )
 
         assert mock_api.call_count == 2
         mock_set_auto_shutdown.assert_called_once_with(
             time_period_str(DUMMY_AUTO_OFF_SET)
-        )
-        assert (
-            f"Call api for {device.name} failed, api: 'set_auto_shutdown'"
-            in caplog.text
         )
         state = hass.states.get(entity_id)
         assert state.state == STATE_UNAVAILABLE

--- a/tests/components/switcher_kis/test_switch.py
+++ b/tests/components/switcher_kis/test_switch.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import patch
 
-from aioswitcher.api import Command, SwitcherBaseResponse
+from aioswitcher.api import Command, ShutterChildLock, SwitcherBaseResponse
 from aioswitcher.device import DeviceState
 import pytest
 
@@ -19,7 +19,20 @@ from homeassistant.core import HomeAssistant
 from homeassistant.util import slugify
 
 from . import init_integration
-from .consts import DUMMY_PLUG_DEVICE, DUMMY_WATER_HEATER_DEVICE
+from .consts import (
+    DUMMY_DUAL_SHUTTER_SINGLE_LIGHT_DEVICE as DEVICE3,
+    DUMMY_PLUG_DEVICE,
+    DUMMY_SHUTTER_DEVICE as DEVICE,
+    DUMMY_SINGLE_SHUTTER_DUAL_LIGHT_DEVICE as DEVICE2,
+    DUMMY_TOKEN as TOKEN,
+    DUMMY_USERNAME as USERNAME,
+    DUMMY_WATER_HEATER_DEVICE,
+)
+
+ENTITY_ID = f"{SWITCH_DOMAIN}.{slugify(DEVICE.name)}_lock_physical_controls"
+ENTITY_ID2 = f"{SWITCH_DOMAIN}.{slugify(DEVICE2.name)}_lock_physical_controls"
+ENTITY_ID3 = f"{SWITCH_DOMAIN}.{slugify(DEVICE3.name)}_lock_physical_controls_1"
+ENTITY_ID3_2 = f"{SWITCH_DOMAIN}.{slugify(DEVICE3.name)}_lock_physical_controls_2"
 
 
 @pytest.mark.parametrize("mock_bridge", [[DUMMY_WATER_HEATER_DEVICE]], indirect=True)
@@ -132,6 +145,196 @@ async def test_switch_control_fail(
         mock_control_device.assert_called_once_with(Command.ON)
         assert (
             f"Call api for {device.name} failed, api: 'control_device'" in caplog.text
+        )
+        state = hass.states.get(entity_id)
+        assert state.state == STATE_UNAVAILABLE
+
+
+@pytest.mark.parametrize(
+    (
+        "device",
+        "entity_id",
+        "cover_id",
+        "child_lock_state",
+    ),
+    [
+        (
+            DEVICE,
+            ENTITY_ID,
+            0,
+            [ShutterChildLock.OFF],
+        ),
+        (
+            DEVICE2,
+            ENTITY_ID2,
+            0,
+            [ShutterChildLock.OFF],
+        ),
+        (
+            DEVICE3,
+            ENTITY_ID3,
+            0,
+            [ShutterChildLock.OFF, ShutterChildLock.ON],
+        ),
+        (
+            DEVICE3,
+            ENTITY_ID3_2,
+            1,
+            [ShutterChildLock.ON, ShutterChildLock.OFF],
+        ),
+    ],
+)
+@pytest.mark.parametrize("mock_bridge", [[DEVICE, DEVICE2, DEVICE3]], indirect=True)
+async def test_child_lock_switch(
+    hass: HomeAssistant,
+    mock_bridge,
+    mock_api,
+    monkeypatch: pytest.MonkeyPatch,
+    device,
+    entity_id: str,
+    cover_id: int,
+    child_lock_state: list[ShutterChildLock],
+) -> None:
+    """Test the switch."""
+    await init_integration(hass, USERNAME, TOKEN)
+    assert mock_bridge
+
+    # Test initial state - on
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_ON
+
+    # Test state change on --> off
+    monkeypatch.setattr(device, "child_lock", child_lock_state)
+    mock_bridge.mock_callbacks([device])
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_OFF
+
+    # Test turning on child lock
+    with patch(
+        "homeassistant.components.switcher_kis.switch.SwitcherApi.set_shutter_child_lock",
+    ) as mock_control_device:
+        await hass.services.async_call(
+            SWITCH_DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: entity_id}, blocking=True
+        )
+
+        assert mock_api.call_count == 2
+        mock_control_device.assert_called_once_with(ShutterChildLock.ON, cover_id)
+        state = hass.states.get(entity_id)
+        assert state.state == STATE_ON
+
+    # Test turning off
+    with patch(
+        "homeassistant.components.switcher_kis.switch.SwitcherApi.set_shutter_child_lock"
+    ) as mock_control_device:
+        await hass.services.async_call(
+            SWITCH_DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: entity_id}, blocking=True
+        )
+
+        assert mock_api.call_count == 4
+        mock_control_device.assert_called_once_with(ShutterChildLock.OFF, cover_id)
+        state = hass.states.get(entity_id)
+        assert state.state == STATE_OFF
+
+
+@pytest.mark.parametrize(
+    (
+        "device",
+        "entity_id",
+        "cover_id",
+        "child_lock_state",
+    ),
+    [
+        (
+            DEVICE,
+            ENTITY_ID,
+            0,
+            [ShutterChildLock.OFF],
+        ),
+        (
+            DEVICE2,
+            ENTITY_ID2,
+            0,
+            [ShutterChildLock.OFF],
+        ),
+        (
+            DEVICE3,
+            ENTITY_ID3,
+            0,
+            [ShutterChildLock.OFF, ShutterChildLock.ON],
+        ),
+        (
+            DEVICE3,
+            ENTITY_ID3_2,
+            1,
+            [ShutterChildLock.ON, ShutterChildLock.OFF],
+        ),
+    ],
+)
+@pytest.mark.parametrize("mock_bridge", [[DEVICE, DEVICE2, DEVICE3]], indirect=True)
+async def test_child_lock_control_fail(
+    hass: HomeAssistant,
+    mock_bridge,
+    mock_api,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    device,
+    entity_id: str,
+    cover_id: int,
+    child_lock_state: list[ShutterChildLock],
+) -> None:
+    """Test switch control fail."""
+    await init_integration(hass, USERNAME, TOKEN)
+    assert mock_bridge
+
+    # Test initial state - off
+    monkeypatch.setattr(device, "child_lock", child_lock_state)
+    mock_bridge.mock_callbacks([device])
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_OFF
+
+    # Test exception during turn on
+    with patch(
+        "homeassistant.components.switcher_kis.switch.SwitcherApi.set_shutter_child_lock",
+        side_effect=RuntimeError("fake error"),
+    ) as mock_control_device:
+        await hass.services.async_call(
+            SWITCH_DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: entity_id}, blocking=True
+        )
+
+        assert mock_api.call_count == 2
+        mock_control_device.assert_called_once_with(ShutterChildLock.ON, cover_id)
+        assert (
+            f"Call api for {device.name} failed, api: 'set_shutter_child_lock'"
+            in caplog.text
+        )
+        state = hass.states.get(entity_id)
+        assert state.state == STATE_UNAVAILABLE
+
+    # Make device available again
+    mock_bridge.mock_callbacks([device])
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_OFF
+
+    # Test error response during turn on
+    with patch(
+        "homeassistant.components.switcher_kis.switch.SwitcherApi.set_shutter_child_lock",
+        return_value=SwitcherBaseResponse(None),
+    ) as mock_control_device:
+        await hass.services.async_call(
+            SWITCH_DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: entity_id}, blocking=True
+        )
+
+        assert mock_api.call_count == 4
+        mock_control_device.assert_called_once_with(ShutterChildLock.ON, cover_id)
+        assert (
+            f"Call api for {device.name} failed, api: 'set_shutter_child_lock'"
+            in caplog.text
         )
         state = hass.states.get(entity_id)
         assert state.state == STATE_UNAVAILABLE

--- a/tests/components/switcher_kis/test_switch.py
+++ b/tests/components/switcher_kis/test_switch.py
@@ -16,6 +16,7 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.util import slugify
 
 from . import init_integration
@@ -60,7 +61,7 @@ async def test_switch(
 
     # Test turning on
     with patch(
-        "homeassistant.components.switcher_kis.switch.SwitcherApi.control_device",
+        "homeassistant.components.switcher_kis.entity.SwitcherApi.control_device",
     ) as mock_control_device:
         await hass.services.async_call(
             SWITCH_DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: entity_id}, blocking=True
@@ -73,7 +74,7 @@ async def test_switch(
 
     # Test turning off
     with patch(
-        "homeassistant.components.switcher_kis.switch.SwitcherApi.control_device"
+        "homeassistant.components.switcher_kis.entity.SwitcherApi.control_device"
     ) as mock_control_device:
         await hass.services.async_call(
             SWITCH_DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: entity_id}, blocking=True
@@ -110,18 +111,19 @@ async def test_switch_control_fail(
 
     # Test exception during turn on
     with patch(
-        "homeassistant.components.switcher_kis.switch.SwitcherApi.control_device",
+        "homeassistant.components.switcher_kis.entity.SwitcherApi.control_device",
         side_effect=RuntimeError("fake error"),
     ) as mock_control_device:
-        await hass.services.async_call(
-            SWITCH_DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: entity_id}, blocking=True
-        )
+        with pytest.raises(HomeAssistantError):
+            await hass.services.async_call(
+                SWITCH_DOMAIN,
+                SERVICE_TURN_ON,
+                {ATTR_ENTITY_ID: entity_id},
+                blocking=True,
+            )
 
         assert mock_api.call_count == 2
         mock_control_device.assert_called_once_with(Command.ON)
-        assert (
-            f"Call api for {device.name} failed, api: 'control_device'" in caplog.text
-        )
         state = hass.states.get(entity_id)
         assert state.state == STATE_UNAVAILABLE
 
@@ -134,18 +136,19 @@ async def test_switch_control_fail(
 
     # Test error response during turn on
     with patch(
-        "homeassistant.components.switcher_kis.switch.SwitcherApi.control_device",
+        "homeassistant.components.switcher_kis.entity.SwitcherApi.control_device",
         return_value=SwitcherBaseResponse(None),
     ) as mock_control_device:
-        await hass.services.async_call(
-            SWITCH_DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: entity_id}, blocking=True
-        )
+        with pytest.raises(HomeAssistantError):
+            await hass.services.async_call(
+                SWITCH_DOMAIN,
+                SERVICE_TURN_ON,
+                {ATTR_ENTITY_ID: entity_id},
+                blocking=True,
+            )
 
         assert mock_api.call_count == 4
         mock_control_device.assert_called_once_with(Command.ON)
-        assert (
-            f"Call api for {device.name} failed, api: 'control_device'" in caplog.text
-        )
         state = hass.states.get(entity_id)
         assert state.state == STATE_UNAVAILABLE
 
@@ -213,7 +216,7 @@ async def test_child_lock_switch(
 
     # Test turning on child lock
     with patch(
-        "homeassistant.components.switcher_kis.switch.SwitcherApi.set_shutter_child_lock",
+        "homeassistant.components.switcher_kis.entity.SwitcherApi.set_shutter_child_lock",
     ) as mock_control_device:
         await hass.services.async_call(
             SWITCH_DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: entity_id}, blocking=True
@@ -226,7 +229,7 @@ async def test_child_lock_switch(
 
     # Test turning off
     with patch(
-        "homeassistant.components.switcher_kis.switch.SwitcherApi.set_shutter_child_lock"
+        "homeassistant.components.switcher_kis.entity.SwitcherApi.set_shutter_child_lock"
     ) as mock_control_device:
         await hass.services.async_call(
             SWITCH_DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: entity_id}, blocking=True
@@ -298,19 +301,19 @@ async def test_child_lock_control_fail(
 
     # Test exception during turn on
     with patch(
-        "homeassistant.components.switcher_kis.switch.SwitcherApi.set_shutter_child_lock",
+        "homeassistant.components.switcher_kis.entity.SwitcherApi.set_shutter_child_lock",
         side_effect=RuntimeError("fake error"),
     ) as mock_control_device:
-        await hass.services.async_call(
-            SWITCH_DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: entity_id}, blocking=True
-        )
+        with pytest.raises(HomeAssistantError):
+            await hass.services.async_call(
+                SWITCH_DOMAIN,
+                SERVICE_TURN_ON,
+                {ATTR_ENTITY_ID: entity_id},
+                blocking=True,
+            )
 
         assert mock_api.call_count == 2
         mock_control_device.assert_called_once_with(ShutterChildLock.ON, cover_id)
-        assert (
-            f"Call api for {device.name} failed, api: 'set_shutter_child_lock'"
-            in caplog.text
-        )
         state = hass.states.get(entity_id)
         assert state.state == STATE_UNAVAILABLE
 
@@ -323,18 +326,18 @@ async def test_child_lock_control_fail(
 
     # Test error response during turn on
     with patch(
-        "homeassistant.components.switcher_kis.switch.SwitcherApi.set_shutter_child_lock",
+        "homeassistant.components.switcher_kis.entity.SwitcherApi.set_shutter_child_lock",
         return_value=SwitcherBaseResponse(None),
     ) as mock_control_device:
-        await hass.services.async_call(
-            SWITCH_DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: entity_id}, blocking=True
-        )
+        with pytest.raises(HomeAssistantError):
+            await hass.services.async_call(
+                SWITCH_DOMAIN,
+                SERVICE_TURN_ON,
+                {ATTR_ENTITY_ID: entity_id},
+                blocking=True,
+            )
 
         assert mock_api.call_count == 4
         mock_control_device.assert_called_once_with(ShutterChildLock.ON, cover_id)
-        assert (
-            f"Call api for {device.name} failed, api: 'set_shutter_child_lock'"
-            in caplog.text
-        )
         state = hass.states.get(entity_id)
         assert state.state == STATE_UNAVAILABLE


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump aioswitcher to 5.1.0

GitHub diff: https://github.com/TomerFi/aioswitcher/compare/5.0.0...5.1.0
Release notes: https://github.com/TomerFi/aioswitcher/releases/tag/5.1.0

Add controlling child lock support for all Switcher Runners

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/36188

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
