### PR TITLE
Update exception handling for python3.13 for getpass.getuser()

### DIFF
--- a/homeassistant/helpers/system_info.py
+++ b/homeassistant/helpers/system_info.py
@@ -71,7 +71,7 @@ async def async_get_system_info(hass: HomeAssistant) -> dict[str, Any]:
 
     try:
         info_object["user"] = cached_get_user()
-    except KeyError:
+    except (KeyError, OSError):  # KeyError only thrown on python <3.13
         info_object["user"] = None
 
     if platform.system() == "Darwin":

--- a/homeassistant/helpers/system_info.py
+++ b/homeassistant/helpers/system_info.py
@@ -71,7 +71,7 @@ async def async_get_system_info(hass: HomeAssistant) -> dict[str, Any]:
 
     try:
         info_object["user"] = cached_get_user()
-    except (KeyError, OSError): 
+    except (KeyError, OSError):
         # OSError on python >= 3.13, KeyError on python < 3.13
         # KeyError can be removed when 3.12 support is dropped
         # see https://docs.python.org/3/whatsnew/3.13.html

--- a/homeassistant/helpers/system_info.py
+++ b/homeassistant/helpers/system_info.py
@@ -71,7 +71,10 @@ async def async_get_system_info(hass: HomeAssistant) -> dict[str, Any]:
 
     try:
         info_object["user"] = cached_get_user()
-    except (KeyError, OSError):  # KeyError only thrown on python <3.13
+    except (KeyError, OSError): 
+        # OSError on python >= 3.13, KeyError on python < 3.13
+        # KeyError can be removed when 3.12 support is dropped
+        # see https://docs.python.org/3/whatsnew/3.13.html
         info_object["user"] = None
 
     if platform.system() == "Darwin":

--- a/tests/helpers/test_system_info.py
+++ b/tests/helpers/test_system_info.py
@@ -93,10 +93,9 @@ async def test_container_installationtype(hass: HomeAssistant) -> None:
         assert info["installation_type"] == "Unsupported Third Party Container"
 
 
-async def test_getuser_keyerror(hass: HomeAssistant) -> None:
-    """Test getuser keyerror."""
-    with patch(
-        "homeassistant.helpers.system_info.cached_get_user", side_effect=KeyError
-    ):
+@pytest.mark.parametrize("error", [KeyError, OSError])
+async def test_getuser_oserror(hass: HomeAssistant, error: Exception) -> None:
+    """Test getuser oserror."""
+    with patch("homeassistant.helpers.system_info.cached_get_user", side_effect=error):
         info = await async_get_system_info(hass)
         assert info["user"] is None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update exception handling for python3.13 for getpass.getuser().  As part of the [CHANGELOG](https://docs.python.org/3/whatsnew/3.13.html):
> An OSError is now raised by getpass.getuser() for any failure to retrieve a username, instead of ImportError on non-Unix platforms or KeyError on Unix platforms where the password database is empty. 

This updates the logic added in #59667 to handle both the python3.13 exceptions in addition to previously thrown exceptions from earlier versions. In python 3.13 and beyond, the only exception thrown is `OSError`.

This is currently observed as an issue on some unsupported container use cases, but also appears like it can happen in other scenarios also.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
