### PR TITLE
Add tests for media player support_* properties

### DIFF
--- a/tests/components/media_player/test_init.py
+++ b/tests/components/media_player/test_init.py
@@ -117,10 +117,7 @@ def test_deprecated_constants_const(
     ],
 )
 def test_support_properties(property_suffix: str) -> None:
-    """Test support_*** properties.
-
-    These seem unused in the codebase, but might be used by custom components.
-    """
+    """Test support_*** properties explicitely."""
 
     all_features = media_player.MediaPlayerEntityFeature(653887)
     feature = media_player.MediaPlayerEntityFeature[property_suffix.upper()]

--- a/tests/components/media_player/test_init.py
+++ b/tests/components/media_player/test_init.py
@@ -97,6 +97,49 @@ def test_deprecated_constants_const(
     )
 
 
+@pytest.mark.parametrize(
+    "property_suffix",
+    [
+        "play",
+        "pause",
+        "stop",
+        "seek",
+        "volume_set",
+        "volume_mute",
+        "previous_track",
+        "next_track",
+        "play_media",
+        "select_source",
+        "select_sound_mode",
+        "clear_playlist",
+        "shuffle_set",
+        "grouping",
+    ],
+)
+def test_support_properties(property_suffix: str) -> None:
+    """Test support_*** properties.
+
+    These seem unused in the codebase, but might be used by custom components.
+    """
+
+    all_features = media_player.MediaPlayerEntityFeature(653887)
+    feature = media_player.MediaPlayerEntityFeature[property_suffix.upper()]
+
+    entity1 = MediaPlayerEntity()
+    entity1._attr_supported_features = media_player.MediaPlayerEntityFeature(0)
+    entity2 = MediaPlayerEntity()
+    entity2._attr_supported_features = all_features
+    entity3 = MediaPlayerEntity()
+    entity3._attr_supported_features = feature
+    entity4 = MediaPlayerEntity()
+    entity4._attr_supported_features = all_features - feature
+
+    assert getattr(entity1, f"support_{property_suffix}") is False
+    assert getattr(entity2, f"support_{property_suffix}") is True
+    assert getattr(entity3, f"support_{property_suffix}") is True
+    assert getattr(entity4, f"support_{property_suffix}") is False
+
+
 async def test_get_image_http(
     hass: HomeAssistant, hass_client_no_auth: ClientSessionGenerator
 ) -> None:

--- a/tests/components/media_player/test_init.py
+++ b/tests/components/media_player/test_init.py
@@ -117,7 +117,7 @@ def test_deprecated_constants_const(
     ],
 )
 def test_support_properties(property_suffix: str) -> None:
-    """Test support_*** properties explicitely."""
+    """Test support_*** properties explicitly."""
 
     all_features = media_player.MediaPlayerEntityFeature(653887)
     feature = media_player.MediaPlayerEntityFeature[property_suffix.upper()]


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, spotted in https://github.com/home-assistant/core/pull/132365

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
