### PR TITLE
Adjust scope of zha global quirks fixture

### DIFF
--- a/tests/components/zha/conftest.py
+++ b/tests/components/zha/conftest.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, create_autospec, patch
 import warnings
 
 import pytest
+import zhaquirks
 import zigpy
 from zigpy.application import ControllerApplication
 import zigpy.backups
@@ -38,7 +39,7 @@ FIXTURE_GRP_NAME = "fixture group"
 COUNTER_NAMES = ["counter_1", "counter_2", "counter_3"]
 
 
-@pytest.fixture(scope="module", autouse=True)
+@pytest.fixture(scope="package", autouse=True)
 def globally_load_quirks():
     """Load quirks automatically so that ZHA tests run deterministically in isolation.
 
@@ -46,8 +47,6 @@ def globally_load_quirks():
     independently, bugs can emerge that will show up only when more of the test suite is
     run.
     """
-
-    import zhaquirks  # pylint: disable=import-outside-toplevel
 
     zhaquirks.setup()
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
`zhaquirks.setup()` can fail in CI, see https://github.com/home-assistant/core/actions/runs/12186783155/job/33996485228

Although this does not solve the root cause, I am hoping that making this a `package` fixture instead of a `module` will reduce occurence

```
>       zhaquirks.setup()

tests/components/zha/conftest.py:52: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
venv/lib/python3.12/site-packages/zhaquirks/__init__.py:461: in setup
    importlib.import_module(modname)
/opt/hostedtoolcache/Python/3.12.8/x64/lib/python3.12/importlib/__init__.py:90: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
venv/lib/python3.12/site-packages/zhaquirks/tuya/ts0601_valve.py:489: in <module>
    TuyaQuirkBuilder("_TZE284_8zizsafo", "TS0601")  # Giex GX04
venv/lib/python3.12/site-packages/zhaquirks/tuya/builder/__init__.py:75: in __init__
    super().__init__(manufacturer, model, registry)
venv/lib/python3.12/site-packages/zigpy/quirks/v2/__init__.py:474: in __init__
    stack: list[inspect.FrameInfo] = inspect.stack()
/opt/hostedtoolcache/Python/3.12.8/x64/lib/python3.12/inspect.py:1781: in stack
    return getouterframes(sys._getframe(1), context)
/opt/hostedtoolcache/Python/3.12.8/x64/lib/python3.12/inspect.py:1756: in getouterframes
    traceback_info = getframeinfo(frame, context)
/opt/hostedtoolcache/Python/3.12.8/x64/lib/python3.12/inspect.py:1718: in getframeinfo
    lines, lnum = findsource(frame)
/opt/hostedtoolcache/Python/3.12.8/x64/lib/python3.12/inspect.py:1090: in findsource
    module = getmodule(object, file)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

object = <frame at 0x7f79754a7ac0, file '/home/runner/work/core/core/venv/lib/python3.12/site-packages/xdist/remote.py', line 393, code <module>>
_filename = '/home/runner/work/core/core/venv/lib/python3.12/site-packages/xdist/remote.py'

    def getmodule(object, _filename=None):
        """Return the module an object was defined in, or None if not found."""
        if ismodule(object):
            return object
        if hasattr(object, '__module__'):
            return sys.modules.get(object.__module__)
        # Try the filename to modulename cache
        if _filename is not None and _filename in modulesbyfile:
            return sys.modules.get(modulesbyfile[_filename])
        # Try the cache again with the absolute file name
        try:
            file = getabsfile(object, _filename)
        except (TypeError, FileNotFoundError):
            return None
        if file in modulesbyfile:
            return sys.modules.get(modulesbyfile[file])
        # Update the filename to module name cache and check yet again
        # Copy sys.modules in order to cope with changes while iterating
        for modname, module in sys.modules.copy().items():
            if ismodule(module) and hasattr(module, '__file__'):
                f = module.__file__
>               if f == _filesbymodname.get(modname, None):
E               Failed: Timeout >9.0s
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
