### PR TITLE
Internalize backup tasks

### DIFF
--- a/homeassistant/components/backup/__init__.py
+++ b/homeassistant/components/backup/__init__.py
@@ -82,8 +82,6 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             name=None,
             password=call.data.get(CONF_PASSWORD),
         )
-        if backup_task := backup_manager.backup_task:
-            await backup_task
 
     hass.services.async_register(
         DOMAIN,

--- a/homeassistant/components/backup/websocket.py
+++ b/homeassistant/components/backup/websocket.py
@@ -165,7 +165,7 @@ async def handle_create(
 ) -> None:
     """Generate a backup."""
 
-    backup = await hass.data[DATA_MANAGER].async_create_backup(
+    backup = await hass.data[DATA_MANAGER].async_initiate_backup(
         agent_ids=msg["agent_ids"],
         include_addons=msg.get("include_addons"),
         include_all_addons=msg["include_all_addons"],

--- a/tests/components/backup/test_manager.py
+++ b/tests/components/backup/test_manager.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-from pathlib import Path
 from typing import Any
 from unittest.mock import ANY, AsyncMock, MagicMock, Mock, call, mock_open, patch
 
@@ -29,6 +28,7 @@ from homeassistant.components.backup.manager import (
     CreateBackupState,
     ManagerStateEvent,
     NewBackup,
+    WrittenBackup,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -303,9 +303,10 @@ async def test_async_create_backup(
 
     new_backup = NewBackup(backup_job_id="time-123")
     backup_task = AsyncMock(
-        return_value=(
-            TEST_BACKUP_ABC123,
-            Path(hass.config.path("backups"), TEST_BACKUP_PATH_ABC123),
+        return_value=WrittenBackup(
+            backup=TEST_BACKUP_ABC123,
+            open_stream=AsyncMock(),
+            release_stream=AsyncMock(),
         ),
     )()  # call it so that it can be awaited
 

--- a/tests/components/backup/test_manager.py
+++ b/tests/components/backup/test_manager.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import asyncio
 import json
+from pathlib import Path
 from typing import Any
 from unittest.mock import ANY, AsyncMock, MagicMock, Mock, call, mock_open, patch
 
@@ -28,6 +28,7 @@ from homeassistant.components.backup.manager import (
     CreateBackupStage,
     CreateBackupState,
     ManagerStateEvent,
+    NewBackup,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -77,9 +78,9 @@ async def _mock_backup_generation(
         """Mock progress callback."""
         progress.append(_progress)
 
-    assert manager.backup_task is None
+    assert manager._backup_task is None
     manager.async_subscribe_events(on_progress)
-    await manager.async_create_backup(
+    await manager.async_initiate_backup(
         agent_ids=agent_ids,
         include_addons=[],
         include_all_addons=False,
@@ -89,13 +90,13 @@ async def _mock_backup_generation(
         name=name,
         password=password,
     )
-    assert manager.backup_task is not None
+    assert manager._backup_task is not None
     assert progress == [
         CreateBackupEvent(stage=None, state=CreateBackupState.IN_PROGRESS)
     ]
 
-    finished_backup = await manager.backup_task
-    await manager.backup_finish_task
+    finished_backup = await manager._backup_task
+    await manager._backup_finish_task
     assert progress == [
         CreateBackupEvent(stage=None, state=CreateBackupState.IN_PROGRESS),
         CreateBackupEvent(
@@ -289,9 +290,51 @@ async def test_getting_backup_that_does_not_exist(
         ) in caplog.text
 
 
+@pytest.mark.usefixtures("mock_backup_generation")
+async def test_async_create_backup(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    mocked_json_bytes: Mock,
+    mocked_tarfile: Mock,
+) -> None:
+    """Test create backup."""
+    assert await async_setup_component(hass, DOMAIN, {})
+    await hass.async_block_till_done()
+
+    new_backup = NewBackup(backup_job_id="time-123")
+    backup_task = AsyncMock(
+        return_value=(
+            TEST_BACKUP_ABC123,
+            Path(hass.config.path("backups"), TEST_BACKUP_PATH_ABC123),
+        ),
+    )()  # call it so that it can be awaited
+
+    with patch(
+        "homeassistant.components.backup.manager.CoreBackupReaderWriter.async_create_backup",
+        return_value=(new_backup, backup_task),
+    ) as create_backup:
+        await hass.services.async_call(
+            DOMAIN,
+            "create",
+            blocking=True,
+        )
+
+    assert create_backup.called
+    assert create_backup.call_args == call(
+        agent_ids=["backup.local"],
+        backup_name="Core 2025.1.0",
+        include_addons=None,
+        include_all_addons=False,
+        include_database=True,
+        include_folders=None,
+        include_homeassistant=True,
+        on_progress=ANY,
+        password=None,
+    )
+
+
 async def test_async_create_backup_when_backing_up(hass: HomeAssistant) -> None:
     """Test generate backup."""
-    event = asyncio.Event()
     manager = BackupManager(hass, CoreBackupReaderWriter(hass))
     manager.last_event = CreateBackupEvent(
         stage=None, state=CreateBackupState.IN_PROGRESS
@@ -307,7 +350,6 @@ async def test_async_create_backup_when_backing_up(hass: HomeAssistant) -> None:
             name=None,
             password=None,
         )
-    event.set()
 
 
 @pytest.mark.parametrize(
@@ -364,7 +406,7 @@ async def test_async_create_backup_wrong_parameters(
         {"password": "abc123"},
     ],
 )
-async def test_async_create_backup(
+async def test_async_initiate_backup(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
     mocked_json_bytes: Mock,

--- a/tests/components/backup/test_websocket.py
+++ b/tests/components/backup/test_websocket.py
@@ -9,7 +9,7 @@ from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy import SnapshotAssertion
 
-from homeassistant.components.backup import AgentBackup, BackupAgentError, Folder
+from homeassistant.components.backup import AgentBackup, BackupAgentError
 from homeassistant.components.backup.agent import BackupAgentUnreachableError
 from homeassistant.components.backup.const import DATA_MANAGER, DOMAIN
 from homeassistant.components.backup.manager import (
@@ -380,16 +380,14 @@ async def test_generate_wrong_parameters(
         (
             {
                 "agent_ids": ["backup.local"],
-                "include_addons": ["ssl"],
                 "include_database": False,
-                "include_folders": ["media"],
                 "name": "abc123",
             },
             {
                 "agent_ids": ["backup.local"],
-                "include_addons": ["ssl"],
+                "include_addons": None,
                 "include_database": False,
-                "include_folders": [Folder.MEDIA],
+                "include_folders": None,
                 "name": "abc123",
             },
         ),
@@ -411,7 +409,7 @@ async def test_generate_calls_create(
     await hass.async_block_till_done()
 
     with patch(
-        "homeassistant.components.backup.manager.BackupManager.async_create_backup",
+        "homeassistant.components.backup.manager.BackupManager.async_initiate_backup",
         return_value=NewBackup(backup_job_id="abc123"),
     ) as generate_backup:
         await client.send_json_auto_id({"type": "backup/generate"} | params)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Make the backup manager tasks protected. The backup tasks are details of the BackupManager. Forcing callers, that want to wait until the backup is complete, to await these tasks isn't appropriate and makes the code and testing more complicated.
- Await the tasks in `BackupManager.async_create_backup`.
- Add a new method `BackupManager.async_initiate_backup` for callers that don't want to wait until the backup is complete.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
