### PR TITLE
Bump Python Matter server to 7.0.0 (Matter 1.4)

### DIFF
--- a/homeassistant/components/matter/adapter.py
+++ b/homeassistant/components/matter/adapter.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, cast
 
 from chip.clusters import Objects as clusters
-from matter_server.client.models.device_types import BridgedDevice
+from matter_server.client.models.device_types import BridgedNode
 from matter_server.common.models import EventType, ServerInfoMessage
 
 from homeassistant.config_entries import ConfigEntry
@@ -162,7 +162,7 @@ class MatterAdapter:
             (
                 x
                 for x in endpoint.device_types
-                if x.device_type != BridgedDevice.device_type
+                if x.device_type != BridgedNode.device_type
             ),
             None,
         )

--- a/homeassistant/components/matter/light.py
+++ b/homeassistant/components/matter/light.py
@@ -37,9 +37,9 @@ from .util import (
 )
 
 COLOR_MODE_MAP = {
-    clusters.ColorControl.Enums.ColorMode.kCurrentHueAndCurrentSaturation: ColorMode.HS,
-    clusters.ColorControl.Enums.ColorMode.kCurrentXAndCurrentY: ColorMode.XY,
-    clusters.ColorControl.Enums.ColorMode.kColorTemperature: ColorMode.COLOR_TEMP,
+    clusters.ColorControl.Enums.ColorModeEnum.kCurrentHueAndCurrentSaturation: ColorMode.HS,
+    clusters.ColorControl.Enums.ColorModeEnum.kCurrentXAndCurrentY: ColorMode.XY,
+    clusters.ColorControl.Enums.ColorModeEnum.kColorTemperature: ColorMode.COLOR_TEMP,
 }
 
 # there's a bug in (at least) Espressif's implementation of light transitions
@@ -258,7 +258,7 @@ class MatterLight(MatterEntity, LightEntity):
         """Get color mode from matter."""
 
         color_mode = self.get_matter_attribute_value(
-            clusters.ColorControl.Attributes.ColorMode
+            clusters.ColorControl.Attributes.ColorModeEnum
         )
 
         assert color_mode is not None

--- a/homeassistant/components/matter/light.py
+++ b/homeassistant/components/matter/light.py
@@ -258,7 +258,7 @@ class MatterLight(MatterEntity, LightEntity):
         """Get color mode from matter."""
 
         color_mode = self.get_matter_attribute_value(
-            clusters.ColorControl.Attributes.ColorModeEnum
+            clusters.ColorControl.Attributes.ColorMode
         )
 
         assert color_mode is not None
@@ -346,21 +346,21 @@ class MatterLight(MatterEntity, LightEntity):
 
                 if (
                     capabilities
-                    & clusters.ColorControl.Bitmaps.ColorCapabilities.kHueSaturationSupported
+                    & clusters.ColorControl.Bitmaps.ColorCapabilitiesBitmap.kHueSaturation
                 ):
                     supported_color_modes.add(ColorMode.HS)
                     self._supports_color = True
 
                 if (
                     capabilities
-                    & clusters.ColorControl.Bitmaps.ColorCapabilities.kXYAttributesSupported
+                    & clusters.ColorControl.Bitmaps.ColorCapabilitiesBitmap.kXy
                 ):
                     supported_color_modes.add(ColorMode.XY)
                     self._supports_color = True
 
                 if (
                     capabilities
-                    & clusters.ColorControl.Bitmaps.ColorCapabilities.kColorTemperatureSupported
+                    & clusters.ColorControl.Bitmaps.ColorCapabilitiesBitmap.kColorTemperature
                 ):
                     supported_color_modes.add(ColorMode.COLOR_TEMP)
                     self._supports_color_temperature = True

--- a/homeassistant/components/matter/light.py
+++ b/homeassistant/components/matter/light.py
@@ -39,7 +39,7 @@ from .util import (
 COLOR_MODE_MAP = {
     clusters.ColorControl.Enums.ColorModeEnum.kCurrentHueAndCurrentSaturation: ColorMode.HS,
     clusters.ColorControl.Enums.ColorModeEnum.kCurrentXAndCurrentY: ColorMode.XY,
-    clusters.ColorControl.Enums.ColorModeEnum.kColorTemperature: ColorMode.COLOR_TEMP,
+    clusters.ColorControl.Enums.ColorModeEnum.kColorTemperatureMireds: ColorMode.COLOR_TEMP,
 }
 
 # there's a bug in (at least) Espressif's implementation of light transitions

--- a/homeassistant/components/matter/manifest.json
+++ b/homeassistant/components/matter/manifest.json
@@ -7,6 +7,6 @@
   "dependencies": ["websocket_api"],
   "documentation": "https://www.home-assistant.io/integrations/matter",
   "iot_class": "local_push",
-  "requirements": ["python-matter-server==6.6.0"],
+  "requirements": ["python-matter-server==7.0.0"],
   "zeroconf": ["_matter._tcp.local.", "_matterc._udp.local."]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2371,7 +2371,7 @@ python-linkplay==0.0.20
 # python-lirc==1.2.3
 
 # homeassistant.components.matter
-python-matter-server==6.6.0
+python-matter-server==7.0.0
 
 # homeassistant.components.xiaomi_miio
 python-miio==0.5.12

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1898,7 +1898,7 @@ python-kasa[speedups]==0.8.0
 python-linkplay==0.0.20
 
 # homeassistant.components.matter
-python-matter-server==6.6.0
+python-matter-server==7.0.0
 
 # homeassistant.components.xiaomi_miio
 python-miio==0.5.12


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump to [python-matter-server 7.0.0](https://github.com/home-assistant-libs/python-matter-server/releases/tag/7.0.0) for Matter 1.4

This PR contains the required changes for the breaking changes to the Matter clusters in Matter server library. This allow to integrate the new Matter 1.4 version:
- Device types
  - `BridgedDevice` device type is renamed to `BridgedNode`
- Clusters
  - `Color Control Cluster`
    - Features
      - `Hue/Saturation` feature bit 0 is renamed to `HueSaturation`
      - `Enhanced` feature bit 1 is renamed to `EnhancedHue`
      - `Color` feature bit 2 is renamed to `ColorLoop`
      - `Color` feature bit 4 is renamed to `ColorTemperature`
    - Attributes
      - `ColorMode` attribute type changed from `enum8` to `ColorModeEnum` with `Color Control Cluster` rev.7
      - `Options` attribute type changed from `map8` to `OptionsBitmap` with `Color Control Cluster` rev.7
      - `EnhancedColorMode` attribute type changed from `enum8` to `EnhancedColorModeEnum` with `Color Control Cluster` rev.7
      - `ColorCapabilities` attribute type changed from `map16` to `ColorCapabilitiesBitmap` with `Color Control Cluster` rev.7
    - Enums
      - `ColorMode` enum renamed to `ColorModeEnum`
      - Item `kColorTemperature` renamed to `kColorTemperatureMireds` with `Color Control Cluster` rev.7
    - Bitmaps
        - `ColorCapabilities` bitmap is renamed to `ColorCapabilitiesBitmap`
          - `ColorCapabilities.kHueSaturationSupported` bitfied is renamed to `ColorCapabilitiesBitmap.kHueSaturation`
          - `ColorCapabilities.kColorTemperatureSupported` bitfied is renamed to `ColorCapabilitiesBitmap.kColorTemperature`


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
