### PR TITLE
Add clearer descriptions to all Timer actions

### DIFF
--- a/homeassistant/components/timer/strings.json
+++ b/homeassistant/components/timer/strings.json
@@ -38,7 +38,7 @@
       "fields": {
         "duration": {
           "name": "Duration",
-          "description": "Optional duration to restart the timer with."
+          "description": "Custom duration to restart the timer with."
         }
       }
     },

--- a/homeassistant/components/timer/strings.json
+++ b/homeassistant/components/timer/strings.json
@@ -48,7 +48,7 @@
     },
     "cancel": {
       "name": "Cancel",
-      "description": "Resets the timer's duration to the last known initial value without firing the timer finished event."
+      "description": "Resets a timer's duration to the last known initial value without firing the timer finished event."
     },
     "finish": {
       "name": "Finish",

--- a/homeassistant/components/timer/strings.json
+++ b/homeassistant/components/timer/strings.json
@@ -48,7 +48,7 @@
     },
     "cancel": {
       "name": "Cancel",
-      "description": "Resets the timer's duration to the last known initial value without firing the `timer.finished` event."
+      "description": "Resets the timer's duration to the last known initial value without firing the timer finished event."
     },
     "finish": {
       "name": "Finish",

--- a/homeassistant/components/timer/strings.json
+++ b/homeassistant/components/timer/strings.json
@@ -34,33 +34,33 @@
   "services": {
     "start": {
       "name": "[%key:common::action::start%]",
-      "description": "Starts a timer.",
+      "description": "Starts a timer or restarts it with a provided duration.",
       "fields": {
         "duration": {
           "name": "Duration",
-          "description": "Duration the timer requires to finish. [optional]."
+          "description": "Optional duration to restart the timer with."
         }
       }
     },
     "pause": {
       "name": "[%key:common::action::pause%]",
-      "description": "Pauses a timer."
+      "description": "Pauses a running timer, retaining the remaining duration for later continuation."
     },
     "cancel": {
       "name": "Cancel",
-      "description": "Cancels a timer."
+      "description": "Resets the timer's duration to the last known initial value without firing the `timer.finished` event."
     },
     "finish": {
       "name": "Finish",
-      "description": "Finishes a timer."
+      "description": "Finishes a running timer earlier than scheduled."
     },
     "change": {
       "name": "Change",
-      "description": "Changes a timer.",
+      "description": "Changes a timer by adding or subtracting a given duration.",
       "fields": {
         "duration": {
           "name": "Duration",
-          "description": "Duration to add or subtract to the running timer."
+          "description": "Duration to add to or subtract from the running timer."
         }
       }
     },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Currently the descriptions of all Timer actions just repeat the action name adding "a timer" to them:

![image](https://github.com/user-attachments/assets/f1776471-158d-4078-bea7-f365ed8c7bc3)

These changes add some useful information about each action's purpose by providing a condensed version of the online documentation's explanations.

In particular it points out the main difference between Cancel and Finish which look very similar at first as they both return a Timer back to the Idle state. But only Finish fires the "timer.finished" event just as if the Timer had run down to zero on its own while Cancel just stops it and resets it to the previous duration.

In addition this PR fixes the grammar or punctuation mistakes in the descriptions of the two Duration fields
 "add or subtract to" and "… . [optional]." by rewording those.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
