### PR TITLE
Add entity_filter to scene.turn_on

### DIFF
--- a/homeassistant/components/homeassistant/scene.py
+++ b/homeassistant/components/homeassistant/scene.py
@@ -363,9 +363,14 @@ class HomeAssistantScene(Scene):
 
     async def async_activate(self, **kwargs: Any) -> None:
         """Activate scene. Try to get entities into requested state."""
+        entity_filter = None
+        if "entity_filter" in kwargs:
+            entity_filter = kwargs.pop("entity_filter")
+
         await async_reproduce_state(
             self.hass,
             self.scene_config.states.values(),
             context=self._context,
             reproduce_options=kwargs,
+            entity_filter=entity_filter,
         )

--- a/homeassistant/components/scene/__init__.py
+++ b/homeassistant/components/scene/__init__.py
@@ -13,6 +13,7 @@ from homeassistant.components.light import ATTR_TRANSITION
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PLATFORM, SERVICE_TURN_ON, STATE_UNAVAILABLE
 from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant
+from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.typing import ConfigType
@@ -76,7 +77,10 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     )
     component.async_register_entity_service(
         SERVICE_TURN_ON,
-        {ATTR_TRANSITION: vol.All(vol.Coerce(float), vol.Clamp(min=0, max=6553))},
+        {
+            ATTR_TRANSITION: vol.All(vol.Coerce(float), vol.Clamp(min=0, max=6553)),
+            "entity_filter": vol.Optional(cv.entity_ids),
+        },
         "_async_activate",
     )
 

--- a/homeassistant/components/scene/services.yaml
+++ b/homeassistant/components/scene/services.yaml
@@ -11,6 +11,13 @@ turn_on:
           min: 0
           max: 300
           unit_of_measurement: seconds
+    entity_filter:
+      selector:
+        entity:
+          multiple: true
+      example: |
+        - light.tv_back_light
+        - light.theatre
 
 reload:
 apply:

--- a/homeassistant/components/scene/strings.json
+++ b/homeassistant/components/scene/strings.json
@@ -8,6 +8,10 @@
         "transition": {
           "name": "Transition",
           "description": "Time it takes the devices to transition into the states defined in the scene."
+        },
+        "entity_filter": {
+          "name": "Entity Filter",
+          "description": "Apply the scene to only the entities listed."
         }
       }
     },

--- a/homeassistant/helpers/state.py
+++ b/homeassistant/helpers/state.py
@@ -33,6 +33,7 @@ async def async_reproduce_state(
     *,
     context: Context | None = None,
     reproduce_options: dict[str, Any] | None = None,
+    entity_filter: list[str] | None = None,
 ) -> None:
     """Reproduce a list of states on multiple domains."""
     if isinstance(states, State):
@@ -41,7 +42,8 @@ async def async_reproduce_state(
     to_call: dict[str, list[State]] = defaultdict(list)
 
     for state in states:
-        to_call[state.domain].append(state)
+        if entity_filter is None or state.entity_id in entity_filter:
+            to_call[state.domain].append(state)
 
     async def worker(domain: str, states_by_domain: list[State]) -> None:
         try:


### PR DESCRIPTION
This commit adds in the ability to activate defined scenes against a subset of specified entities, allowing for partial application of a single scene.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

When using scenes, I find that I create general themes which are applied at different times of the day or for different events/parties. I usually have to duplicate these scenes across multiple different rooms if I want independent control for each room. Doing this for each room or space leaves Home Assistant with an overwhelming number of scenes that I personally find overwhelming.

Enter the `entity_filter` attribute to `scene.turn_on` which allows users to define a generic scene which applies to many entities and then can be tailored to automations which allows for more granular control of scene application. For example, I have a smart switch with scene buttons in each room in my house and also have lights in the whole house as part of a schedule. Instead of defining a `scene.dawn` for the generic house schedule and then duplicating that scene for each room (`scene.dawn_bedroom`, `scene.dawn_kitchen`, etc.), I can partially apply the scene to entities which are defined by the filter. Drastically reducing the number of scenes I have to maintain and pushing the power into automations.

I also understand that this is a change to a core component which should involve more scrutiny than a non-internal integration as there are many different ways this could be implemented which may benefit additional use cases. I'm hoping to hear thoughts and opinions about this feature to see if we can't make scenes less rigid.

- This PR fixes or closes issue: fixes # N/A
- This PR is related to issue: N/A
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/36234

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
