### PR TITLE
Refactor Onkyo tests to patch underlying pyeiscp library

### DIFF
--- a/tests/components/onkyo/__init__.py
+++ b/tests/components/onkyo/__init__.py
@@ -19,6 +19,16 @@ def create_receiver_info(id: int) -> ReceiverInfo:
     )
 
 
+def create_connection(id: int) -> Mock:
+    """Create an mock connection object for testing."""
+    connection = Mock()
+    connection.host = f"host {id}"
+    connection.port = 0
+    connection.name = f"type {id}"
+    connection.identifier = f"id{id}"
+    return connection
+
+
 def create_config_entry_from_info(info: ReceiverInfo) -> MockConfigEntry:
     """Create a config entry from receiver info."""
     data = {CONF_HOST: info.host}

--- a/tests/components/onkyo/conftest.py
+++ b/tests/components/onkyo/conftest.py
@@ -1,23 +1,14 @@
 """Configure tests for the Onkyo integration."""
 
-from collections.abc import Generator
-from unittest.mock import AsyncMock, patch
+from unittest.mock import patch
 
 import pytest
 
 from homeassistant.components.onkyo.const import DOMAIN
 
+from . import create_connection
+
 from tests.common import MockConfigEntry
-
-
-@pytest.fixture
-def mock_setup_entry() -> Generator[AsyncMock]:
-    """Override async_setup_entry."""
-    with patch(
-        "homeassistant.components.onkyo.async_setup_entry",
-        return_value=True,
-    ) as mock_setup_entry:
-        yield mock_setup_entry
 
 
 @pytest.fixture(name="config_entry")
@@ -28,3 +19,59 @@ def mock_config_entry() -> MockConfigEntry:
         title="Onkyo",
         data={},
     )
+
+
+@pytest.fixture(autouse=True)
+def patch_timeouts():
+    """Patch timeouts to avoid tests waiting."""
+    with (
+        patch(
+            "homeassistant.components.onkyo.receiver.DEVICE_INTERVIEW_TIMEOUT", new=0
+        ),
+        patch(
+            "homeassistant.components.onkyo.receiver.DEVICE_DISCOVERY_TIMEOUT", new=0
+        ),
+    ):
+        yield
+
+
+@pytest.fixture
+async def default_mock_discovery():
+    """Mock discovery with a single device."""
+
+    async def mock_discover(host=None, discovery_callback=None, timeout=0):
+        await discovery_callback(create_connection(1))
+
+    with patch(
+        "homeassistant.components.onkyo.receiver.pyeiscp.Connection.discover",
+        new=mock_discover,
+    ):
+        yield
+
+
+@pytest.fixture
+async def stub_mock_discovery():
+    """Mock discovery with no devices."""
+
+    async def mock_discover(host=None, discovery_callback=None, timeout=0):
+        pass
+
+    with patch(
+        "homeassistant.components.onkyo.receiver.pyeiscp.Connection.discover",
+        new=mock_discover,
+    ):
+        yield
+
+
+@pytest.fixture
+async def empty_mock_discovery():
+    """Mock discovery with an empty connection."""
+
+    async def mock_discover(host=None, discovery_callback=None, timeout=0):
+        await discovery_callback(None)
+
+    with patch(
+        "homeassistant.components.onkyo.receiver.pyeiscp.Connection.discover",
+        new=mock_discover,
+    ):
+        yield

--- a/tests/components/onkyo/conftest.py
+++ b/tests/components/onkyo/conftest.py
@@ -24,13 +24,10 @@ def mock_config_entry() -> MockConfigEntry:
 @pytest.fixture(autouse=True)
 def patch_timeouts():
     """Patch timeouts to avoid tests waiting."""
-    with (
-        patch(
-            "homeassistant.components.onkyo.receiver.DEVICE_INTERVIEW_TIMEOUT", new=0
-        ),
-        patch(
-            "homeassistant.components.onkyo.receiver.DEVICE_DISCOVERY_TIMEOUT", new=0
-        ),
+    with patch.multiple(
+        "homeassistant.components.onkyo.receiver",
+        DEVICE_INTERVIEW_TIMEOUT=0,
+        DEVICE_DISCOVERY_TIMEOUT=0,
     ):
         yield
 

--- a/tests/components/onkyo/test_config_flow.py
+++ b/tests/components/onkyo/test_config_flow.py
@@ -29,53 +29,6 @@ from . import (
 from tests.common import MockConfigEntry
 
 
-@pytest.fixture(autouse=True)
-def patch_timeouts():
-    """Patch timeouts to avoid tests waiting."""
-    with (
-        patch(
-            "homeassistant.components.onkyo.receiver.DEVICE_INTERVIEW_TIMEOUT", new=0
-        ),
-        patch(
-            "homeassistant.components.onkyo.receiver.DEVICE_DISCOVERY_TIMEOUT", new=0
-        ),
-    ):
-        yield
-
-
-@pytest.fixture
-async def default_mock_discovery():
-    """Mock discovery with a single device."""
-
-    async def mock_discover(host=None, discovery_callback=None, timeout=0):
-        await discovery_callback(create_connection(1))
-
-    with patch("pyeiscp.Connection.discover", new=mock_discover):
-        yield
-
-
-@pytest.fixture
-async def stub_mock_discovery():
-    """Mock discovery with no devices."""
-
-    async def mock_discover(host=None, discovery_callback=None, timeout=0):
-        pass
-
-    with patch("pyeiscp.Connection.discover", new=mock_discover):
-        yield
-
-
-@pytest.fixture
-async def empty_mock_discovery():
-    """Mock discovery with an empty connection."""
-
-    async def mock_discover(host=None, discovery_callback=None, timeout=0):
-        await discovery_callback(None)
-
-    with patch("pyeiscp.Connection.discover", new=mock_discover):
-        yield
-
-
 async def test_user_initial_menu(hass: HomeAssistant) -> None:
     """Test initial menu."""
     init_result = await hass.config_entries.flow.async_init(

--- a/tests/components/onkyo/test_config_flow.py
+++ b/tests/components/onkyo/test_config_flow.py
@@ -360,7 +360,10 @@ async def test_reconfigure_new_device(hass: HomeAssistant) -> None:
     async def mock_discover(host, discovery_callback, timeout):
         await discovery_callback(mock_connection)
 
-    with patch("pyeiscp.Connection.discover", new=mock_discover):
+    with patch(
+        "homeassistant.components.onkyo.receiver.pyeiscp.Connection.discover",
+        new=mock_discover,
+    ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={"host": mock_connection.host}
         )
@@ -411,7 +414,10 @@ async def test_import_fail(
     async def mock_discover(host, discovery_callback, timeout):
         raise exception
 
-    with patch("pyeiscp.Connection.discover", new=mock_discover):
+    with patch(
+        "homeassistant.components.onkyo.receiver.pyeiscp.Connection.discover",
+        new=mock_discover,
+    ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_IMPORT}, data=user_input
         )

--- a/tests/components/onkyo/test_config_flow.py
+++ b/tests/components/onkyo/test_config_flow.py
@@ -411,12 +411,9 @@ async def test_import_fail(
 ) -> None:
     """Test import flow failed."""
 
-    async def mock_discover(host, discovery_callback, timeout):
-        raise exception
-
     with patch(
         "homeassistant.components.onkyo.receiver.pyeiscp.Connection.discover",
-        new=mock_discover,
+        side_effect=exception,
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_IMPORT}, data=user_input

--- a/tests/components/onkyo/test_config_flow.py
+++ b/tests/components/onkyo/test_config_flow.py
@@ -20,12 +20,60 @@ from homeassistant.data_entry_flow import FlowResultType, InvalidData
 
 from . import (
     create_config_entry_from_info,
+    create_connection,
     create_empty_config_entry,
     create_receiver_info,
     setup_integration,
 )
 
-from tests.common import Mock, MockConfigEntry
+from tests.common import MockConfigEntry
+
+
+@pytest.fixture(autouse=True)
+def patch_timeouts():
+    """Patch timeouts to avoid tests waiting."""
+    with (
+        patch(
+            "homeassistant.components.onkyo.receiver.DEVICE_INTERVIEW_TIMEOUT", new=0
+        ),
+        patch(
+            "homeassistant.components.onkyo.receiver.DEVICE_DISCOVERY_TIMEOUT", new=0
+        ),
+    ):
+        yield
+
+
+@pytest.fixture
+async def default_mock_discovery():
+    """Mock discovery with a single device."""
+
+    async def mock_discover(host=None, discovery_callback=None, timeout=0):
+        await discovery_callback(create_connection(1))
+
+    with patch("pyeiscp.Connection.discover", new=mock_discover):
+        yield
+
+
+@pytest.fixture
+async def stub_mock_discovery():
+    """Mock discovery with no devices."""
+
+    async def mock_discover(host=None, discovery_callback=None, timeout=0):
+        pass
+
+    with patch("pyeiscp.Connection.discover", new=mock_discover):
+        yield
+
+
+@pytest.fixture
+async def empty_mock_discovery():
+    """Mock discovery with an empty connection."""
+
+    async def mock_discover(host=None, discovery_callback=None, timeout=0):
+        await discovery_callback(None)
+
+    with patch("pyeiscp.Connection.discover", new=mock_discover):
+        yield
 
 
 async def test_user_initial_menu(hass: HomeAssistant) -> None:
@@ -40,9 +88,8 @@ async def test_user_initial_menu(hass: HomeAssistant) -> None:
     assert not set(init_result["menu_options"]) ^ {"manual", "eiscp_discovery"}
 
 
-async def test_manual_valid_host(hass: HomeAssistant) -> None:
+async def test_manual_valid_host(hass: HomeAssistant, default_mock_discovery) -> None:
     """Test valid host entered."""
-
     init_result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_USER},
@@ -53,30 +100,17 @@ async def test_manual_valid_host(hass: HomeAssistant) -> None:
         {"next_step_id": "manual"},
     )
 
-    mock_info = Mock()
-    mock_info.identifier = "mock_id"
-    mock_info.host = "mock_host"
-    mock_info.model_name = "mock_model"
+    select_result = await hass.config_entries.flow.async_configure(
+        form_result["flow_id"],
+        user_input={CONF_HOST: "host 1"},
+    )
 
-    with patch(
-        "homeassistant.components.onkyo.config_flow.async_interview",
-        return_value=mock_info,
-    ):
-        select_result = await hass.config_entries.flow.async_configure(
-            form_result["flow_id"],
-            user_input={CONF_HOST: "sample-host-name"},
-        )
-
-        assert select_result["step_id"] == "configure_receiver"
-        assert (
-            select_result["description_placeholders"]["name"]
-            == "mock_model (mock_host)"
-        )
+    assert select_result["step_id"] == "configure_receiver"
+    assert select_result["description_placeholders"]["name"] == "type 1 (host 1)"
 
 
-async def test_manual_invalid_host(hass: HomeAssistant) -> None:
+async def test_manual_invalid_host(hass: HomeAssistant, stub_mock_discovery) -> None:
     """Test invalid host entered."""
-
     init_result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_USER},
@@ -87,19 +121,18 @@ async def test_manual_invalid_host(hass: HomeAssistant) -> None:
         {"next_step_id": "manual"},
     )
 
-    with patch(
-        "homeassistant.components.onkyo.config_flow.async_interview", return_value=None
-    ):
-        host_result = await hass.config_entries.flow.async_configure(
-            form_result["flow_id"],
-            user_input={CONF_HOST: "sample-host-name"},
-        )
+    host_result = await hass.config_entries.flow.async_configure(
+        form_result["flow_id"],
+        user_input={CONF_HOST: "sample-host-name"},
+    )
 
     assert host_result["step_id"] == "manual"
     assert host_result["errors"]["base"] == "cannot_connect"
 
 
-async def test_manual_valid_host_unexpected_error(hass: HomeAssistant) -> None:
+async def test_manual_valid_host_unexpected_error(
+    hass: HomeAssistant, empty_mock_discovery
+) -> None:
     """Test valid host entered."""
 
     init_result = await hass.config_entries.flow.async_init(
@@ -112,55 +145,49 @@ async def test_manual_valid_host_unexpected_error(hass: HomeAssistant) -> None:
         {"next_step_id": "manual"},
     )
 
-    with patch(
-        "homeassistant.components.onkyo.config_flow.async_interview",
-        side_effect=Exception(),
-    ):
-        host_result = await hass.config_entries.flow.async_configure(
-            form_result["flow_id"],
-            user_input={CONF_HOST: "sample-host-name"},
-        )
+    host_result = await hass.config_entries.flow.async_configure(
+        form_result["flow_id"],
+        user_input={CONF_HOST: "sample-host-name"},
+    )
 
     assert host_result["step_id"] == "manual"
     assert host_result["errors"]["base"] == "unknown"
 
 
-async def test_discovery_and_no_devices_discovered(hass: HomeAssistant) -> None:
+async def test_discovery_and_no_devices_discovered(
+    hass: HomeAssistant, stub_mock_discovery
+) -> None:
     """Test initial menu."""
     init_result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_USER},
     )
 
-    with patch(
-        "homeassistant.components.onkyo.config_flow.async_discover", return_value=[]
-    ):
-        form_result = await hass.config_entries.flow.async_configure(
-            init_result["flow_id"],
-            {"next_step_id": "eiscp_discovery"},
-        )
+    form_result = await hass.config_entries.flow.async_configure(
+        init_result["flow_id"],
+        {"next_step_id": "eiscp_discovery"},
+    )
 
-        assert form_result["type"] is FlowResultType.ABORT
-        assert form_result["reason"] == "no_devices_found"
+    assert form_result["type"] is FlowResultType.ABORT
+    assert form_result["reason"] == "no_devices_found"
 
 
-async def test_discovery_with_exception(hass: HomeAssistant) -> None:
+async def test_discovery_with_exception(
+    hass: HomeAssistant, empty_mock_discovery
+) -> None:
     """Test discovery which throws an unexpected exception."""
     init_result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_USER},
     )
-    with patch(
-        "homeassistant.components.onkyo.config_flow.async_discover",
-        side_effect=Exception(),
-    ):
-        form_result = await hass.config_entries.flow.async_configure(
-            init_result["flow_id"],
-            {"next_step_id": "eiscp_discovery"},
-        )
 
-        assert form_result["type"] is FlowResultType.ABORT
-        assert form_result["reason"] == "unknown"
+    form_result = await hass.config_entries.flow.async_configure(
+        init_result["flow_id"],
+        {"next_step_id": "eiscp_discovery"},
+    )
+
+    assert form_result["type"] is FlowResultType.ABORT
+    assert form_result["reason"] == "unknown"
 
 
 async def test_discovery_with_new_and_existing_found(hass: HomeAssistant) -> None:
@@ -170,13 +197,12 @@ async def test_discovery_with_new_and_existing_found(hass: HomeAssistant) -> Non
         context={"source": SOURCE_USER},
     )
 
-    infos = [create_receiver_info(1), create_receiver_info(2)]
+    async def mock_discover(discovery_callback, timeout):
+        await discovery_callback(create_connection(1))
+        await discovery_callback(create_connection(2))
 
     with (
-        patch(
-            "homeassistant.components.onkyo.config_flow.async_discover",
-            return_value=infos,
-        ),
+        patch("pyeiscp.Connection.discover", new=mock_discover),
         # Fake it like the first entry was already added
         patch.object(OnkyoConfigFlow, "_async_current_ids", return_value=["id1"]),
     ):
@@ -185,12 +211,12 @@ async def test_discovery_with_new_and_existing_found(hass: HomeAssistant) -> Non
             {"next_step_id": "eiscp_discovery"},
         )
 
-        assert form_result["type"] is FlowResultType.FORM
+    assert form_result["type"] is FlowResultType.FORM
 
-        assert form_result["data_schema"] is not None
-        schema = form_result["data_schema"].schema
-        container = schema["device"].container
-        assert container == {"id2": "type 2 (host 2)"}
+    assert form_result["data_schema"] is not None
+    schema = form_result["data_schema"].schema
+    container = schema["device"].container
+    assert container == {"id2": "type 2 (host 2)"}
 
 
 async def test_discovery_with_one_selected(hass: HomeAssistant) -> None:
@@ -200,14 +226,11 @@ async def test_discovery_with_one_selected(hass: HomeAssistant) -> None:
         context={"source": SOURCE_USER},
     )
 
-    infos = [create_receiver_info(42), create_receiver_info(0)]
+    async def mock_discover(discovery_callback, timeout):
+        await discovery_callback(create_connection(42))
+        await discovery_callback(create_connection(0))
 
-    with (
-        patch(
-            "homeassistant.components.onkyo.config_flow.async_discover",
-            return_value=infos,
-        ),
-    ):
+    with patch("pyeiscp.Connection.discover", new=mock_discover):
         form_result = await hass.config_entries.flow.async_configure(
             init_result["flow_id"],
             {"next_step_id": "eiscp_discovery"},
@@ -218,11 +241,13 @@ async def test_discovery_with_one_selected(hass: HomeAssistant) -> None:
             user_input={"device": "id42"},
         )
 
-        assert select_result["step_id"] == "configure_receiver"
-        assert select_result["description_placeholders"]["name"] == "type 42 (host 42)"
+    assert select_result["step_id"] == "configure_receiver"
+    assert select_result["description_placeholders"]["name"] == "type 42 (host 42)"
 
 
-async def test_configure_empty_source_list(hass: HomeAssistant) -> None:
+async def test_configure_empty_source_list(
+    hass: HomeAssistant, default_mock_discovery
+) -> None:
     """Test receiver configuration with no sources set."""
 
     init_result = await hass.config_entries.flow.async_init(
@@ -235,29 +260,22 @@ async def test_configure_empty_source_list(hass: HomeAssistant) -> None:
         {"next_step_id": "manual"},
     )
 
-    mock_info = Mock()
-    mock_info.identifier = "mock_id"
+    select_result = await hass.config_entries.flow.async_configure(
+        form_result["flow_id"],
+        user_input={CONF_HOST: "sample-host-name"},
+    )
 
-    with patch(
-        "homeassistant.components.onkyo.config_flow.async_interview",
-        return_value=mock_info,
-    ):
-        select_result = await hass.config_entries.flow.async_configure(
-            form_result["flow_id"],
-            user_input={CONF_HOST: "sample-host-name"},
-        )
+    configure_result = await hass.config_entries.flow.async_configure(
+        select_result["flow_id"],
+        user_input={"volume_resolution": 200, "input_sources": []},
+    )
 
-        configure_result = await hass.config_entries.flow.async_configure(
-            select_result["flow_id"],
-            user_input={"volume_resolution": 200, "input_sources": []},
-        )
-
-        assert configure_result["errors"] == {
-            "input_sources": "empty_input_source_list"
-        }
+    assert configure_result["errors"] == {"input_sources": "empty_input_source_list"}
 
 
-async def test_configure_no_resolution(hass: HomeAssistant) -> None:
+async def test_configure_no_resolution(
+    hass: HomeAssistant, default_mock_discovery
+) -> None:
     """Test receiver configure with no resolution set."""
 
     init_result = await hass.config_entries.flow.async_init(
@@ -270,26 +288,21 @@ async def test_configure_no_resolution(hass: HomeAssistant) -> None:
         {"next_step_id": "manual"},
     )
 
-    mock_info = Mock()
-    mock_info.identifier = "mock_id"
+    select_result = await hass.config_entries.flow.async_configure(
+        form_result["flow_id"],
+        user_input={CONF_HOST: "sample-host-name"},
+    )
 
-    with patch(
-        "homeassistant.components.onkyo.config_flow.async_interview",
-        return_value=mock_info,
-    ):
-        select_result = await hass.config_entries.flow.async_configure(
-            form_result["flow_id"],
-            user_input={CONF_HOST: "sample-host-name"},
+    with pytest.raises(InvalidData):
+        await hass.config_entries.flow.async_configure(
+            select_result["flow_id"],
+            user_input={"input_sources": ["TV"]},
         )
 
-        with pytest.raises(InvalidData):
-            await hass.config_entries.flow.async_configure(
-                select_result["flow_id"],
-                user_input={"input_sources": ["TV"]},
-            )
 
-
-async def test_configure_resolution_set(hass: HomeAssistant) -> None:
+async def test_configure_resolution_set(
+    hass: HomeAssistant, default_mock_discovery
+) -> None:
     """Test receiver configure with specified resolution."""
 
     init_result = await hass.config_entries.flow.async_init(
@@ -302,16 +315,10 @@ async def test_configure_resolution_set(hass: HomeAssistant) -> None:
         {"next_step_id": "manual"},
     )
 
-    receiver_info = create_receiver_info(1)
-
-    with patch(
-        "homeassistant.components.onkyo.config_flow.async_interview",
-        return_value=receiver_info,
-    ):
-        select_result = await hass.config_entries.flow.async_configure(
-            form_result["flow_id"],
-            user_input={CONF_HOST: "sample-host-name"},
-        )
+    select_result = await hass.config_entries.flow.async_configure(
+        form_result["flow_id"],
+        user_input={CONF_HOST: "sample-host-name"},
+    )
 
     configure_result = await hass.config_entries.flow.async_configure(
         select_result["flow_id"],
@@ -322,7 +329,9 @@ async def test_configure_resolution_set(hass: HomeAssistant) -> None:
     assert configure_result["options"]["volume_resolution"] == 200
 
 
-async def test_configure_invalid_resolution_set(hass: HomeAssistant) -> None:
+async def test_configure_invalid_resolution_set(
+    hass: HomeAssistant, default_mock_discovery
+) -> None:
     """Test receiver configure with invalid resolution."""
 
     init_result = await hass.config_entries.flow.async_init(
@@ -335,26 +344,19 @@ async def test_configure_invalid_resolution_set(hass: HomeAssistant) -> None:
         {"next_step_id": "manual"},
     )
 
-    mock_info = Mock()
-    mock_info.identifier = "mock_id"
+    select_result = await hass.config_entries.flow.async_configure(
+        form_result["flow_id"],
+        user_input={CONF_HOST: "sample-host-name"},
+    )
 
-    with patch(
-        "homeassistant.components.onkyo.config_flow.async_interview",
-        return_value=mock_info,
-    ):
-        select_result = await hass.config_entries.flow.async_configure(
-            form_result["flow_id"],
-            user_input={CONF_HOST: "sample-host-name"},
+    with pytest.raises(InvalidData):
+        await hass.config_entries.flow.async_configure(
+            select_result["flow_id"],
+            user_input={"volume_resolution": 42, "input_sources": ["TV"]},
         )
 
-        with pytest.raises(InvalidData):
-            await hass.config_entries.flow.async_configure(
-                select_result["flow_id"],
-                user_input={"volume_resolution": 42, "input_sources": ["TV"]},
-            )
 
-
-async def test_reconfigure(hass: HomeAssistant) -> None:
+async def test_reconfigure(hass: HomeAssistant, default_mock_discovery) -> None:
     """Test the reconfigure config flow."""
     receiver_info = create_receiver_info(1)
     config_entry = create_config_entry_from_info(receiver_info)
@@ -368,14 +370,10 @@ async def test_reconfigure(hass: HomeAssistant) -> None:
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "manual"
 
-    with patch(
-        "homeassistant.components.onkyo.config_flow.async_interview",
-        return_value=receiver_info,
-    ):
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={"host": receiver_info.host}
-        )
-        await hass.async_block_till_done()
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={"host": receiver_info.host}
+    )
+    await hass.async_block_till_done()
 
     assert result2["type"] is FlowResultType.FORM
     assert result2["step_id"] == "configure_receiver"
@@ -403,14 +401,15 @@ async def test_reconfigure_new_device(hass: HomeAssistant) -> None:
 
     result = await config_entry.start_reconfigure_flow(hass)
 
-    receiver_info_2 = create_receiver_info(2)
+    mock_connection = create_connection(2)
 
-    with patch(
-        "homeassistant.components.onkyo.config_flow.async_interview",
-        return_value=receiver_info_2,
-    ):
+    # Create mock discover that calls callback immediately
+    async def mock_discover(host, discovery_callback, timeout):
+        await discovery_callback(mock_connection)
+
+    with patch("pyeiscp.Connection.discover", new=mock_discover):
         result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={"host": receiver_info_2.host}
+            result["flow_id"], user_input={"host": mock_connection.host}
         )
         await hass.async_block_till_done()
 
@@ -455,13 +454,11 @@ async def test_import_fail(
     error: str,
 ) -> None:
     """Test import flow failed."""
-    with (
-        patch(
-            "homeassistant.components.onkyo.config_flow.async_interview",
-            return_value=None,
-            side_effect=exception,
-        ),
-    ):
+
+    async def mock_discover(host, discovery_callback, timeout):
+        raise exception
+
+    with patch("pyeiscp.Connection.discover", new=mock_discover):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_IMPORT}, data=user_input
         )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR is related to this conversation
https://github.com/home-assistant/core/pull/131066#discussion_r1852819997
 
Refactoring the config tests in the onkyo component, so instead of patching methods within home assistant, they patch the underlying pyeiscp library instead.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue: 
https://github.com/home-assistant/core/pull/131066#discussion_r1852819997

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
