### PR TITLE
Add quality scale to roku

### DIFF
--- a/homeassistant/components/roku/manifest.json
+++ b/homeassistant/components/roku/manifest.json
@@ -10,6 +10,7 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "loggers": ["rokuecp"],
+  "quality_scale": "silver",
   "requirements": ["rokuecp==0.19.3"],
   "ssdp": [
     {

--- a/homeassistant/components/roku/manifest.json
+++ b/homeassistant/components/roku/manifest.json
@@ -10,7 +10,7 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "loggers": ["rokuecp"],
-  "quality_scale": "silver",
+  "quality_scale": "bronze",
   "requirements": ["rokuecp==0.19.3"],
   "ssdp": [
     {

--- a/homeassistant/components/roku/quality_scale.yaml
+++ b/homeassistant/components/roku/quality_scale.yaml
@@ -7,7 +7,7 @@ rules:
   appropriate-polling:
     status: done
     comment: |
-      This integration uses 10 seconds as its default polling rate.
+      This integration uses 10 seconds as its default polling rate. Apps and Channels are fetched every 15 minutes.
   brands: done
   common-modules: done
   config-flow-test-coverage: done
@@ -16,7 +16,7 @@ rules:
   docs-actions: done
   docs-high-level-description: done
   docs-installation-instructions: done
-  docs-removal-instructions: todo
+  docs-removal-instructions: done
   entity-event-setup:
     status: exempt
     comment: |
@@ -75,10 +75,10 @@ rules:
     status: done
     comment: |
       This integration supports SSDP and HomeKit discovery protocols.
-  docs-data-update: todo
+  docs-data-update: done
   docs-examples: done
-  docs-known-limitations: todo
-  docs-supported-devices: todo
+  docs-known-limitations: done
+  docs-supported-devices: done
   docs-supported-functions: done
   docs-troubleshooting: done
   docs-use-cases: done

--- a/homeassistant/components/roku/quality_scale.yaml
+++ b/homeassistant/components/roku/quality_scale.yaml
@@ -26,10 +26,7 @@ rules:
     comment: |
       Entities of this integration have a unique id based on the device serial number and entity description key.
   has-entity-name: done
-  runtime-data:
-    status: exempt
-    comment: |
-      Entities of this integration have no data beyond what the coordinator retains.
+  runtime-data: done
   test-before-configure: done
   test-before-setup: done
   unique-config-entry:

--- a/homeassistant/components/roku/quality_scale.yaml
+++ b/homeassistant/components/roku/quality_scale.yaml
@@ -49,10 +49,8 @@ rules:
   log-when-unavailable:
     status: done
     comment: This integration uses a coordinator.
-  parallel-updates:
+  parallel-updates: done
     status: exempt
-    comment: |
-      This integration only polls data using a coordinator.
   reauthentication-flow:
     status: exempt
     comment: |

--- a/homeassistant/components/roku/quality_scale.yaml
+++ b/homeassistant/components/roku/quality_scale.yaml
@@ -36,9 +36,9 @@ rules:
 
   # Silver
   action-exceptions:
-    status: exempt
+    status: todo
     comment: |
-      The integration only has an entity service.
+      The integration only has an entity service but will look into it for mutable platforms.
   config-entry-unloading: done
   docs-configuration-parameters: done
   docs-installation-parameters: done
@@ -86,7 +86,7 @@ rules:
   entity-translations: done
   exception-translations: todo
   icon-translations: todo
-  reconfiguration-flow: todo
+  reconfiguration-flow: done
   repair-issues:
     status: exempt
     comment: |

--- a/homeassistant/components/roku/quality_scale.yaml
+++ b/homeassistant/components/roku/quality_scale.yaml
@@ -50,7 +50,6 @@ rules:
     status: done
     comment: This integration uses a coordinator.
   parallel-updates: done
-    status: exempt
   reauthentication-flow:
     status: exempt
     comment: |

--- a/homeassistant/components/roku/quality_scale.yaml
+++ b/homeassistant/components/roku/quality_scale.yaml
@@ -1,62 +1,95 @@
 rules:
   # Bronze
-  action-setup: todo
-  appropriate-polling: todo
+  action-setup:
+    status: exempt
+    comment: |
+      The integration only has an entity service, registered in the media_player platform.
+  appropriate-polling:
+    status: done
+    comment: |
+      This integration uses 10 seconds as its default polling rate.
   brands: done
-  common-modules: todo
-  config-flow-test-coverage: todo
-  config-flow: todo
-  dependency-transparency: todo
-  docs-actions: todo
-  docs-high-level-description: todo
-  docs-installation-instructions: todo
+  common-modules: done
+  config-flow-test-coverage: done
+  config-flow: done
+  dependency-transparency: done
+  docs-actions: done
+  docs-high-level-description: done
+  docs-installation-instructions: done
   docs-removal-instructions: todo
   entity-event-setup:
     status: exempt
     comment: |
-      Entities of this integration does not explicitly subscribe to events.
-  entity-unique-id: todo
-  has-entity-name: todo
-  runtime-data: todo
-  test-before-configure: todo
-  test-before-setup: todo
-  unique-config-entry: todo
+      Entities of this integration use coordinator and do not explicitly subscribe to events.
+  entity-unique-id:
+    status: done
+    comment: |
+      Entities of this integration have a unique id based on the device serial number and entity description key.
+  has-entity-name: done
+  runtime-data:
+    status: exempt
+    comment: |
+      Entities of this integration have no data beyond what the coordinator retains.
+  test-before-configure: done
+  test-before-setup: done
+  unique-config-entry:
+    status: done
+    comment: |
+      Config entries of this integration have an unique id based on the device serial number.
 
   # Silver
-  action-exceptions: todo
-  config-entry-unloading: todo
-  docs-configuration-parameters: todo
-  docs-installation-parameters: todo
-  entity-unavailable: todo
-  integration-owner: todo
-  log-when-unavailable: todo
-  parallel-updates: todo
+  action-exceptions:
+    status: exempt
+    comment: |
+      The integration only has an entity service.
+  config-entry-unloading: done
+  docs-configuration-parameters: done
+  docs-installation-parameters: done
+  entity-unavailable:
+    status: done
+    comment: This integration uses a coordinator.
+  integration-owner: done
+  log-when-unavailable:
+    status: done
+    comment: This integration uses a coordinator.
+  parallel-updates:
+    status: exempt
+    comment: |
+      This integration only polls data using a coordinator.
   reauthentication-flow:
     status: exempt
     comment: |
       This integration does not require authentication.
   test-coverage: done
-
   # Gold
-  devices: done
+  devices:
+    status: done
+    comment: |
+      This integration creates a single device that corresponds to the Roku device.
   diagnostics: done
-  discovery-update-info: todo
-  discovery: todo
+  discovery-update-info:
+    status: done
+    comment: |
+      This integration updates Host IP when SSDP discovery for same serial number arrives.
+  discovery:
+    status: done
+    comment: |
+      This integration supports SSDP and HomeKit discovery protocols.
   docs-data-update: todo
-  docs-examples: todo
+  docs-examples: done
   docs-known-limitations: todo
   docs-supported-devices: todo
-  docs-supported-functions: todo
-  docs-troubleshooting: todo
-  docs-use-cases: todo
+  docs-supported-functions: done
+  docs-troubleshooting: done
+  docs-use-cases: done
   dynamic-devices:
     status: exempt
     comment: |
       This integration connects to a single device.
-  entity-category: todo
-  entity-device-class: todo
-  entity-disabled-by-default: todo
-  entity-translations: todo
+  entity-category: done
+  entity-device-class: done
+  entity-disabled-by-default: done
+  entity-translations: done
   exception-translations: todo
   icon-translations: todo
   reconfiguration-flow: todo
@@ -70,6 +103,6 @@ rules:
       This integration connects to a single device.
 
   # Platinum
-  async-dependency: todo
-  inject-websession: todo
-  strict-typing: todo
+  async-dependency: done
+  inject-websession: done
+  strict-typing: done

--- a/homeassistant/components/roku/quality_scale.yaml
+++ b/homeassistant/components/roku/quality_scale.yaml
@@ -1,0 +1,75 @@
+rules:
+  # Bronze
+  action-setup: todo
+  appropriate-polling: todo
+  brands: done
+  common-modules: todo
+  config-flow-test-coverage: todo
+  config-flow: todo
+  dependency-transparency: todo
+  docs-actions: todo
+  docs-high-level-description: todo
+  docs-installation-instructions: todo
+  docs-removal-instructions: todo
+  entity-event-setup:
+    status: exempt
+    comment: |
+      Entities of this integration does not explicitly subscribe to events.
+  entity-unique-id: todo
+  has-entity-name: todo
+  runtime-data: todo
+  test-before-configure: todo
+  test-before-setup: todo
+  unique-config-entry: todo
+
+  # Silver
+  action-exceptions: todo
+  config-entry-unloading: todo
+  docs-configuration-parameters: todo
+  docs-installation-parameters: todo
+  entity-unavailable: todo
+  integration-owner: todo
+  log-when-unavailable: todo
+  parallel-updates: todo
+  reauthentication-flow:
+    status: exempt
+    comment: |
+      This integration does not require authentication.
+  test-coverage: done
+
+  # Gold
+  devices: done
+  diagnostics: done
+  discovery-update-info: todo
+  discovery: todo
+  docs-data-update: todo
+  docs-examples: todo
+  docs-known-limitations: todo
+  docs-supported-devices: todo
+  docs-supported-functions: todo
+  docs-troubleshooting: todo
+  docs-use-cases: todo
+  dynamic-devices:
+    status: exempt
+    comment: |
+      This integration connects to a single device.
+  entity-category: todo
+  entity-device-class: todo
+  entity-disabled-by-default: todo
+  entity-translations: todo
+  exception-translations: todo
+  icon-translations: todo
+  reconfiguration-flow: todo
+  repair-issues:
+    status: exempt
+    comment: |
+      This integration does not raise any repairable issues.
+  stale-devices:
+    status: exempt
+    comment: |
+      This integration connects to a single device.
+
+  # Platinum
+  async-dependency: todo
+  inject-websession: todo
+  strict-typing: todo

--- a/script/hassfest/quality_scale.py
+++ b/script/hassfest/quality_scale.py
@@ -870,7 +870,6 @@ INTEGRATIONS_WITHOUT_QUALITY_SCALE_FILE = [
     "rmvtransport",
     "roborock",
     "rocketchat",
-    "roku",
     "romy",
     "roomba",
     "roon",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

SSIA

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
## Bronze
- [x] `config-flow` - Integration needs to be able to be set up via the UI
    - [x] Uses `data-description` to give context to fields
    - [x] Uses `ConfigEntry.data` and `ConfigEntry.options` correctly
- [x] `test-before-configure` - Test a connection in the config flow
- [x] `unique-config-entry` - Don't allow the same device or service to be able to be set up twice
- [x] `config-flow-test-coverage` - Full test coverage for the config flow
- [x] `runtime-data` - Use ConfigEntry.runtime_data to store runtime data
- [x] `test-before-setup` - Check during integration initialization if we are able to set it up correctly
- [x] `appropriate-polling` - If it's a polling integration, set an appropriate polling interval
- [x] `entity-unique-id` - Entities have a unique ID
- [x] `has-entity-name` - Entities use has_entity_name = True
- [x] `entity-event-setup` - Entities event setup *EXEMPT*
- [x] `dependency-transparency` - Dependency transparency
- [ ] `action-setup` - Service actions are registered in async_setup *EXEMPT*
- [x] `common-modules` - Place common patterns in common modules
- [x] `docs-high-level-description` - The documentation includes a high-level description of the integration brand, product, or service
- [x] `docs-installation-instructions` - The documentation provides step-by-step installation instructions for the integration, including, if needed, prerequisites
- [x] `docs-removal-instructions` - The documentation provides removal instructions
- [x] `docs-actions` - The documentation describes the provided service actions that can be used
- [x] `brands` - Has branding assets available for the integration

## Silver
- [x] `config-entry-unloading` - Support config entry unloading
- [x] `log-when-unavailable` - If internet/device/service is unavailable, log once when unavailable and once when back connected
- [x] `entity-unavailable` - Mark entity unavailable if appropriate
- [ ] `action-exceptions` - Service actions raise exceptions when encountering failures
- [ ] `reauthentication-flow` - Reauthentication flow *EXEMPT*
- [x] `parallel-updates` - Set Parallel updates
- [x] `test-coverage` - Above 95% test coverage for all integration modules
- [x] `integration-owner` - Has an integration owner
- [x] `docs-installation-parameters` - The documentation describes all integration installation parameters
- [x] `docs-configuration-parameters` - The documentation describes all integration configuration options

## Gold
- [x] `entity-translations` - Entities have translated names
- [x] `entity-device-class` - Entities use device classes where possible
- [x] `devices` - The integration creates devices
- [x] `entity-category` - Entities are assigned an appropriate EntityCategory
- [x] `entity-disabled-by-default` - Integration disables less popular (or noisy) entities
- [x] `discovery` - Can be discovered
- [ ] `stale-devices` - Clean up stale devices. *EXEMPT*
- [x] `diagnostics` - Implements diagnostics
- [ ] `exception-translations` - Exception messages are translatable
- [ ] `icon-translations` - Icon translations
- [x] `reconfiguration-flow` - Integrations should have a reconfigure flow
- [ ] `dynamic-devices` - Devices added after integration setup *EXEMPT*
- [x] `discovery-update-info` - Integration uses discovery info to update network information
- [x] `repair-issues` - Repair issues and repair flows are used when user intervention is needed *EXEMPT*
- [x] `docs-use-cases` - The documentation describes use cases to illustrate how this integration can be used
- [x] `docs-supported-devices` - The documentation describes known supported / unsupported devices
- [x] `docs-supported-functions` - The documentation describes the supported functionality, including entities, and platforms
- [x] `docs-data-update` - The documentation describes how data is updated
- [x] `docs-known-limitations` - The documentation describes known limitations of the integration (not to be confused with bugs)
- [x] `docs-troubleshooting` - The documentation provides troubleshooting information
- [x] `docs-examples` - The documentation provides automation examples the user can use.

## Platinum
- [x] `async-dependency` - Dependency is async
- [x] `inject-websession` - The integration dependency supports passing in a websession
- [x] `strict-typing` - Strict typing

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
