### PR TITLE
Plugwise improve exception translations

### DIFF
--- a/homeassistant/components/plugwise/coordinator.py
+++ b/homeassistant/components/plugwise/coordinator.py
@@ -73,17 +73,30 @@ class PlugwiseDataUpdateCoordinator(DataUpdateCoordinator[PlugwiseData]):
                 await self._connect()
             data = await self.api.async_update()
         except ConnectionFailedError as err:
-            raise UpdateFailed("Failed to connect") from err
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="failed_to_connect",
+            ) from err
         except InvalidAuthentication as err:
-            raise ConfigEntryError("Authentication failed") from err
+            raise ConfigEntryError(
+                translation_domain=DOMAIN,
+                translation_key="authentication_failed",
+            ) from err
         except (InvalidXMLError, ResponseError) as err:
             raise UpdateFailed(
-                "Invalid XML data, or error indication received from the Plugwise Adam/Smile/Stretch"
+                translation_domain=DOMAIN,
+                translation_key="invalid_xml_data",
             ) from err
         except PlugwiseError as err:
-            raise UpdateFailed("Data incomplete or missing") from err
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="data_incomplete_or_missing",
+            ) from err
         except UnsupportedDeviceError as err:
-            raise ConfigEntryError("Device with unsupported firmware") from err
+            raise ConfigEntryError(
+                translation_domain=DOMAIN,
+                translation_key="unsupported_firmware",
+            ) from err
 
         self._async_add_remove_devices(data, self.config_entry)
         return data

--- a/homeassistant/components/plugwise/quality_scale.yaml
+++ b/homeassistant/components/plugwise/quality_scale.yaml
@@ -23,7 +23,7 @@ rules:
     comment: Verify entity for async_added_to_hass usage (discard?)
   docs-high-level-description:
     status: todo
-    comment: Rewrite top section, docs PR prepared
+    comment: Rewrite top section, docs PR prepared waiting for 36087 merge
   docs-installation-instructions:
     status: todo
     comment: Docs PR 36087
@@ -60,9 +60,7 @@ rules:
   discovery: done
   stale-devices: done
   diagnostics: done
-  exception-translations:
-    status: todo
-    comment: Add coordinator, util exceptions (climate done in core 132175)
+  exception-translations: done
   icon-translations: done
   reconfiguration-flow:
     status: todo
@@ -74,23 +72,23 @@ rules:
     comment: This integration does not have repairs
   docs-use-cases:
     status: todo
-    comment: Check for completeness, PR prepared
+    comment: Check for completeness, PR prepared waiting for 36087 merge
   docs-supported-devices:
     status: todo
-    comment: The list is there but could be improved for readability, PR prepared
+    comment: The list is there but could be improved for readability, PR prepared waiting for 36087 merge
   docs-supported-functions:
     status: todo
-    comment: Check for completeness
+    comment: Check for completeness, PR prepared waiting for 36087 merge
   docs-data-update: done
   docs-known-limitations:
     status: todo
     comment: Partial in 36087 but could be more elaborate
   docs-troubleshooting:
     status: todo
-    comment: Check for completeness, PR prepared
+    comment: Check for completeness, PR prepared waiting for 36087 merge
   docs-examples:
     status: todo
-    comment: Check for completeness
+    comment: Check for completeness, PR prepared waiting for 36087 merge
   ## Platinum
   async-dependency: done
   inject-websession: done

--- a/homeassistant/components/plugwise/strings.json
+++ b/homeassistant/components/plugwise/strings.json
@@ -286,8 +286,23 @@
     }
   },
   "exceptions": {
-    "invalid_temperature_change_requested": {
-      "message": "Invalid temperature change requested."
+    "authentication_failed": {
+      "message": "[%key:common::config_flow::error::invalid_auth%]"
+    },
+    "data_incomplete_or_missing": {
+      "message": "Data incomplete or missing."
+    },
+    "error_communicating_with_api": {
+      "message": "Error communicating with API: {error}."
+    },
+    "failed_to_connect": {
+      "message": "[%key:common::config_flow::error::cannot_connect%]"
+    },
+    "invalid_xml_data": {
+      "message": "[%key:component::plugwise::config::error::response_error%]"
+    },
+    "unsupported_firmware": {
+      "message": "[%key:component::plugwise::config::error::unsupported%]"
     },
     "unsupported_hvac_mode_requested": {
       "message": "Unsupported mode {hvac_mode} requested, valid modes are: {hvac_modes}."

--- a/homeassistant/components/plugwise/util.py
+++ b/homeassistant/components/plugwise/util.py
@@ -7,6 +7,7 @@ from plugwise.exceptions import PlugwiseException
 
 from homeassistant.exceptions import HomeAssistantError
 
+from .const import DOMAIN
 from .entity import PlugwiseEntity
 
 
@@ -24,10 +25,14 @@ def plugwise_command[_PlugwiseEntityT: PlugwiseEntity, **_P, _R](
     ) -> _R:
         try:
             return await func(self, *args, **kwargs)
-        except PlugwiseException as error:
+        except PlugwiseException as err:
             raise HomeAssistantError(
-                f"Error communicating with API: {error}"
-            ) from error
+                translation_domain=DOMAIN,
+                translation_key="error_communicating_with_api",
+                translation_placeholders={
+                    "error": str(err),
+                },
+            ) from err
         finally:
             await self.coordinator.async_request_refresh()
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Follow-up from https://github.com/home-assistant/core/pull/131888 review comments.
Dropped `invalid_temperature_change_requested` translation that was introduced-but-code-removed by #132175

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #131888 #132175
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
