### PR TITLE
Remove deprecated supported features warning in Vacuum

### DIFF
--- a/homeassistant/components/vacuum/__init__.py
+++ b/homeassistant/components/vacuum/__init__.py
@@ -312,7 +312,7 @@ class StateVacuumEntity(
     @property
     def capability_attributes(self) -> dict[str, Any] | None:
         """Return capability attributes."""
-        if VacuumEntityFeature.FAN_SPEED in self.supported_features_compat:
+        if VacuumEntityFeature.FAN_SPEED in self.supported_features:
             return {ATTR_FAN_SPEED_LIST: self.fan_speed_list}
         return None
 
@@ -330,7 +330,7 @@ class StateVacuumEntity(
     def state_attributes(self) -> dict[str, Any]:
         """Return the state attributes of the vacuum cleaner."""
         data: dict[str, Any] = {}
-        supported_features = self.supported_features_compat
+        supported_features = self.supported_features
 
         if VacuumEntityFeature.BATTERY in supported_features:
             data[ATTR_BATTERY_LEVEL] = self.battery_level
@@ -368,19 +368,6 @@ class StateVacuumEntity(
     def supported_features(self) -> VacuumEntityFeature:
         """Flag vacuum cleaner features that are supported."""
         return self._attr_supported_features
-
-    @property
-    def supported_features_compat(self) -> VacuumEntityFeature:
-        """Return the supported features as VacuumEntityFeature.
-
-        Remove this compatibility shim in 2025.1 or later.
-        """
-        features = self.supported_features
-        if type(features) is int:  # noqa: E721
-            new_features = VacuumEntityFeature(features)
-            self._report_deprecated_supported_features_values(new_features)
-            return new_features
-        return features
 
     def stop(self, **kwargs: Any) -> None:
         """Stop the vacuum cleaner."""

--- a/tests/components/vacuum/test_init.py
+++ b/tests/components/vacuum/test_init.py
@@ -272,42 +272,6 @@ async def test_send_command(hass: HomeAssistant, config_flow_fixture: None) -> N
     assert "test" in strings
 
 
-async def test_supported_features_compat(hass: HomeAssistant) -> None:
-    """Test StateVacuumEntity using deprecated feature constants features."""
-
-    features = (
-        VacuumEntityFeature.BATTERY
-        | VacuumEntityFeature.FAN_SPEED
-        | VacuumEntityFeature.START
-        | VacuumEntityFeature.STOP
-        | VacuumEntityFeature.PAUSE
-    )
-
-    class _LegacyConstantsStateVacuum(StateVacuumEntity):
-        _attr_supported_features = int(features)
-        _attr_fan_speed_list = ["silent", "normal", "pet hair"]
-
-    entity = _LegacyConstantsStateVacuum()
-    assert isinstance(entity.supported_features, int)
-    assert entity.supported_features == int(features)
-    assert entity.supported_features_compat is (
-        VacuumEntityFeature.BATTERY
-        | VacuumEntityFeature.FAN_SPEED
-        | VacuumEntityFeature.START
-        | VacuumEntityFeature.STOP
-        | VacuumEntityFeature.PAUSE
-    )
-    assert entity.state_attributes == {
-        "battery_level": None,
-        "battery_icon": "mdi:battery-unknown",
-        "fan_speed": None,
-    }
-    assert entity.capability_attributes == {
-        "fan_speed_list": ["silent", "normal", "pet hair"]
-    }
-    assert entity._deprecated_supported_features_reported
-
-
 async def test_vacuum_not_log_deprecated_state_warning(
     hass: HomeAssistant,
     mock_vacuum_entity: MockVacuum,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
For developpers only: following deprecation period, the use of integers for supported_features is no longer supported.
Please use the corresponding `VacuumEntityFeature` enum.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
History:
- https://developers.home-assistant.io/blog/2022/04/02/support-constants-deprecation/
- https://developers.home-assistant.io/blog/2023/12/28/support-feature-magic-numbers-deprecation/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
