### PR TITLE
Migrate switchbot lights to use Kelvin

### DIFF
--- a/homeassistant/components/switchbot/light.py
+++ b/homeassistant/components/switchbot/light.py
@@ -15,7 +15,6 @@ from homeassistant.components.light import (
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.util.color import color_temperature_kelvin_to_mired
 
 from .coordinator import SwitchbotConfigEntry, SwitchbotDataUpdateCoordinator
 from .entity import SwitchbotEntity
@@ -47,8 +46,8 @@ class SwitchbotLightEntity(SwitchbotEntity, LightEntity):
         """Initialize the Switchbot light."""
         super().__init__(coordinator)
         device = self._device
-        self._attr_min_mireds = color_temperature_kelvin_to_mired(device.max_temp)
-        self._attr_max_mireds = color_temperature_kelvin_to_mired(device.min_temp)
+        self._attr_max_color_temp_kelvin = device.max_temp
+        self._attr_min_color_temp_kelvin = device.min_temp
         self._attr_supported_color_modes = {
             SWITCHBOT_COLOR_MODE_TO_HASS[mode] for mode in device.color_modes
         }
@@ -61,7 +60,7 @@ class SwitchbotLightEntity(SwitchbotEntity, LightEntity):
         self._attr_is_on = self._device.on
         self._attr_brightness = max(0, min(255, round(device.brightness * 2.55)))
         if device.color_mode == SwitchBotColorMode.COLOR_TEMP:
-            self._attr_color_temp = color_temperature_kelvin_to_mired(device.color_temp)
+            self._attr_color_temp_kelvin = device.color_temp
             self._attr_color_mode = ColorMode.COLOR_TEMP
             return
         self._attr_rgb_color = device.rgb

--- a/homeassistant/components/switchbot/light.py
+++ b/homeassistant/components/switchbot/light.py
@@ -8,17 +8,14 @@ from switchbot import ColorMode as SwitchBotColorMode, SwitchbotBaseLight
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
-    ATTR_COLOR_TEMP,
+    ATTR_COLOR_TEMP_KELVIN,
     ATTR_RGB_COLOR,
     ColorMode,
     LightEntity,
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.util.color import (
-    color_temperature_kelvin_to_mired,
-    color_temperature_mired_to_kelvin,
-)
+from homeassistant.util.color import color_temperature_kelvin_to_mired
 
 from .coordinator import SwitchbotConfigEntry, SwitchbotDataUpdateCoordinator
 from .entity import SwitchbotEntity
@@ -77,10 +74,9 @@ class SwitchbotLightEntity(SwitchbotEntity, LightEntity):
         if (
             self.supported_color_modes
             and ColorMode.COLOR_TEMP in self.supported_color_modes
-            and ATTR_COLOR_TEMP in kwargs
+            and ATTR_COLOR_TEMP_KELVIN in kwargs
         ):
-            color_temp = kwargs[ATTR_COLOR_TEMP]
-            kelvin = max(2700, min(6500, color_temperature_mired_to_kelvin(color_temp)))
+            kelvin = max(2700, min(6500, kwargs[ATTR_COLOR_TEMP_KELVIN]))
             await self._device.set_color_temp(brightness, kelvin)
             return
         if ATTR_RGB_COLOR in kwargs:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Based on #79591, needed for #132680

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
