### PR TITLE
Revert "Bump pyezviz to 0.2.2.3"

### DIFF
--- a/homeassistant/components/ezviz/manifest.json
+++ b/homeassistant/components/ezviz/manifest.json
@@ -7,5 +7,5 @@
   "documentation": "https://www.home-assistant.io/integrations/ezviz",
   "iot_class": "cloud_polling",
   "loggers": ["paho_mqtt", "pyezviz"],
-  "requirements": ["pyezviz==0.2.2.3"]
+  "requirements": ["pyezviz==0.2.1.2"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1907,7 +1907,7 @@ pyeverlights==0.1.0
 pyevilgenius==2.0.0
 
 # homeassistant.components.ezviz
-pyezviz==0.2.2.3
+pyezviz==0.2.1.2
 
 # homeassistant.components.fibaro
 pyfibaro==0.8.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1539,7 +1539,7 @@ pyeverlights==0.1.0
 pyevilgenius==2.0.0
 
 # homeassistant.components.ezviz
-pyezviz==0.2.2.3
+pyezviz==0.2.1.2
 
 # homeassistant.components.fibaro
 pyfibaro==0.8.0


### PR DESCRIPTION
Reverts:

- #132060

fix issue:

- #132345

it appears latest version of pyezviz `0.2.2.3` had an undiscovered bug on the way it fetches battery data, resulting in no-battery powered devices and devices not listing the foreseen operation modes will result in an error making the HA integration not operational anymore

because its unclear yet how to publish an updated version of the lib and having no ETA on a fix on it, I think reverting is the best course of action so integration returns working as previously, while battery functionality will have to wait till the library is properly fixed