### PR TITLE
Catch Hydrawise authorization errors in the correct place

### DIFF
--- a/homeassistant/components/hydrawise/config_flow.py
+++ b/homeassistant/components/hydrawise/config_flow.py
@@ -30,8 +30,9 @@ class HydrawiseConfigFlow(ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Create the config entry."""
         # Verify that the provided credentials work."""
+        auth = pydrawise_auth.Auth(username, password)
         try:
-            auth = pydrawise_auth.Auth(username, password)
+            await auth.token()
         except NotAuthorizedError:
             return on_failure("invalid_auth")
         except TimeoutError:

--- a/tests/components/hydrawise/conftest.py
+++ b/tests/components/hydrawise/conftest.py
@@ -56,7 +56,6 @@ def mock_legacy_pydrawise(
 
 @pytest.fixture
 def mock_pydrawise(
-    mock_auth: AsyncMock,
     user: User,
     controller: Controller,
     zones: list[Zone],
@@ -76,10 +75,16 @@ def mock_pydrawise(
 
 
 @pytest.fixture
-def mock_auth() -> Generator[AsyncMock]:
-    """Mock pydrawise Auth."""
+def mock_auth_cls() -> Generator[AsyncMock]:
+    """Mock pydrawise Auth class."""
     with patch("pydrawise.auth.Auth", autospec=True) as mock_auth:
-        yield mock_auth.return_value
+        yield mock_auth
+
+
+@pytest.fixture
+def mock_auth(mock_auth_cls: AsyncMock) -> AsyncMock:
+    """Mock pydrawise Auth."""
+    return mock_auth_cls.return_value
 
 
 @pytest.fixture

--- a/tests/components/hydrawise/conftest.py
+++ b/tests/components/hydrawise/conftest.py
@@ -75,16 +75,10 @@ def mock_pydrawise(
 
 
 @pytest.fixture
-def mock_auth_cls() -> Generator[AsyncMock]:
-    """Mock pydrawise Auth class."""
-    with patch("pydrawise.auth.Auth", autospec=True) as mock_auth:
-        yield mock_auth
-
-
-@pytest.fixture
-def mock_auth(mock_auth_cls: AsyncMock) -> AsyncMock:
+def mock_auth() -> Generator[AsyncMock]:
     """Mock pydrawise Auth."""
-    return mock_auth_cls.return_value
+    with patch("pydrawise.auth.Auth", autospec=True) as mock_auth:
+        yield mock_auth.return_value
 
 
 @pytest.fixture


### PR DESCRIPTION
## Proposed change
Make sure we're catching `NotAuthorizedError` in the right place, and that we're testing for the correct condition. The exception is never raised (directly) from the `Hydrawise` class, but instead always comes from the `Auth` class when performing authentication. During config flow, this is the place where we want to catch the error.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
