### PR TITLE
Add Starlink usage sensors

### DIFF
--- a/homeassistant/components/starlink/coordinator.py
+++ b/homeassistant/components/starlink/coordinator.py
@@ -16,6 +16,7 @@ from starlink_grpc import (
     ObstructionDict,
     PowerDict,
     StatusDict,
+    UsageDict,
     get_sleep_config,
     history_stats,
     location_data,
@@ -41,6 +42,7 @@ class StarlinkData:
     status: StatusDict
     obstruction: ObstructionDict
     alert: AlertDict
+    usage: UsageDict
     consumption: PowerDict
 
 
@@ -60,12 +62,15 @@ class StarlinkUpdateCoordinator(DataUpdateCoordinator[StarlinkData]):
 
     def _get_starlink_data(self) -> StarlinkData:
         """Retrieve Starlink data."""
-        channel_context = self.channel_context
-        location = location_data(channel_context)
-        sleep = get_sleep_config(channel_context)
-        status, obstruction, alert = status_data(channel_context)
-        statistics = history_stats(parse_samples=-1, context=channel_context)
-        return StarlinkData(location, sleep, status, obstruction, alert, statistics[-1])
+        context = self.channel_context
+        status = status_data(context)
+        location = location_data(context)
+        sleep = get_sleep_config(context)
+        status, obstruction, alert = status_data(context)
+        usage, consumption = history_stats(parse_samples=-1, context=context)[-2:]
+        return StarlinkData(
+            location, sleep, status, obstruction, alert, usage, consumption
+        )
 
     async def _async_update_data(self) -> StarlinkData:
         async with asyncio.timeout(4):

--- a/homeassistant/components/starlink/icons.json
+++ b/homeassistant/components/starlink/icons.json
@@ -18,6 +18,12 @@
       },
       "last_boot_time": {
         "default": "mdi:clock"
+      },
+      "upload": {
+        "default": "mdi:upload"
+      },
+      "download": {
+        "default": "mdi:download"
       }
     }
   }

--- a/homeassistant/components/starlink/sensor.py
+++ b/homeassistant/components/starlink/sensor.py
@@ -19,6 +19,7 @@ from homeassistant.const import (
     EntityCategory,
     UnitOfDataRate,
     UnitOfEnergy,
+    UnitOfInformation,
     UnitOfPower,
     UnitOfTime,
 )
@@ -121,6 +122,22 @@ SENSORS: tuple[StarlinkSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=PERCENTAGE,
         value_fn=lambda data: data.status["pop_ping_drop_rate"] * 100,
+    ),
+    StarlinkSensorEntityDescription(
+        key="upload",
+        translation_key="upload",
+        device_class=SensorDeviceClass.DATA_SIZE,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        native_unit_of_measurement=UnitOfInformation.BYTES,
+        value_fn=lambda data: data.usage["upload_usage"],
+    ),
+    StarlinkSensorEntityDescription(
+        key="download",
+        translation_key="download",
+        device_class=SensorDeviceClass.DATA_SIZE,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        native_unit_of_measurement=UnitOfInformation.BYTES,
+        value_fn=lambda data: data.usage["download_usage"],
     ),
     StarlinkSensorEntityDescription(
         key="power",

--- a/homeassistant/components/starlink/sensor.py
+++ b/homeassistant/components/starlink/sensor.py
@@ -129,6 +129,7 @@ SENSORS: tuple[StarlinkSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.DATA_SIZE,
         state_class=SensorStateClass.TOTAL_INCREASING,
         native_unit_of_measurement=UnitOfInformation.BYTES,
+        suggested_unit_of_measurement=UnitOfInformation.GIGABYTES,
         value_fn=lambda data: data.usage["upload_usage"],
     ),
     StarlinkSensorEntityDescription(
@@ -137,6 +138,7 @@ SENSORS: tuple[StarlinkSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.DATA_SIZE,
         state_class=SensorStateClass.TOTAL_INCREASING,
         native_unit_of_measurement=UnitOfInformation.BYTES,
+        suggested_unit_of_measurement=UnitOfInformation.GIGABYTES,
         value_fn=lambda data: data.usage["download_usage"],
     ),
     StarlinkSensorEntityDescription(

--- a/homeassistant/components/starlink/strings.json
+++ b/homeassistant/components/starlink/strings.json
@@ -70,6 +70,12 @@
       },
       "ping_drop_rate": {
         "name": "Ping drop rate"
+      },
+      "upload": {
+        "name": "Upload"
+      },
+      "download": {
+        "name": "Download"
       }
     },
     "switch": {

--- a/tests/components/starlink/snapshots/test_diagnostics.ambr
+++ b/tests/components/starlink/snapshots/test_diagnostics.ambr
@@ -86,5 +86,9 @@
       'uplink_throughput_bps': 11802.771484375,
       'uptime': 804138,
     }),
+    'usage': dict({
+      'download_usage': 72504227,
+      'upload_usage': 5719755,
+    }),
   })
 # ---


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add upload and download usage sensors and utilize already polled data w/ history_stats from starlink-grpc-core.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: home-assistant/home-assistant.io#36258

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
