### PR TITLE
Fix `LazyState` compatibility with `State` `under_cached_property` change

### DIFF
--- a/homeassistant/components/recorder/models/state.py
+++ b/homeassistant/components/recorder/models/state.py
@@ -6,7 +6,7 @@ from datetime import datetime
 import logging
 from typing import TYPE_CHECKING, Any
 
-from propcache import cached_property
+from propcache import under_cached_property
 from sqlalchemy.engine.row import Row
 
 from homeassistant.const import (
@@ -50,6 +50,7 @@ class LazyState(State):
         no_attributes: bool,
     ) -> None:
         """Init the lazy state."""
+        self._cache: dict[str, Any] = {}
         self._row = row
         self.entity_id = entity_id
         self.state = state or ""
@@ -58,43 +59,50 @@ class LazyState(State):
         self.attr_cache = attr_cache
         self.context = EMPTY_CONTEXT
 
-    @cached_property  # type: ignore[override]
+    @under_cached_property  # type: ignore[override]
     def attributes(self) -> dict[str, Any]:
         """State attributes."""
         return decode_attributes_from_source(
             getattr(self._row, "attributes", None), self.attr_cache
         )
 
-    @cached_property
+    @under_cached_property
     def _last_changed_ts(self) -> float | None:
         """Last changed timestamp."""
         return getattr(self._row, "last_changed_ts", None)
 
-    @cached_property
+    @under_cached_property
     def last_changed(self) -> datetime:  # type: ignore[override]
         """Last changed datetime."""
         return dt_util.utc_from_timestamp(
             self._last_changed_ts or self._last_updated_ts  # type: ignore[arg-type]
         )
 
-    @cached_property
+    @under_cached_property
     def _last_reported_ts(self) -> float | None:
         """Last reported timestamp."""
         return getattr(self._row, "last_reported_ts", None)
 
-    @cached_property
+    @under_cached_property
     def last_reported(self) -> datetime:  # type: ignore[override]
         """Last reported datetime."""
         return dt_util.utc_from_timestamp(
             self._last_reported_ts or self._last_updated_ts  # type: ignore[arg-type]
         )
 
-    @cached_property
+    @under_cached_property
     def last_updated(self) -> datetime:  # type: ignore[override]
         """Last updated datetime."""
         if TYPE_CHECKING:
             assert self._last_updated_ts is not None
         return dt_util.utc_from_timestamp(self._last_updated_ts)
+
+    @under_cached_property
+    def last_updated_timestamp(self) -> float:  # type: ignore[override]
+        """Last updated timestamp."""
+        if TYPE_CHECKING:
+            assert self._last_updated_ts is not None
+        return self._last_updated_ts
 
     def as_dict(self) -> dict[str, Any]:  # type: ignore[override]
         """Return a dict representation of the LazyState.

--- a/homeassistant/components/recorder/models/state.py
+++ b/homeassistant/components/recorder/models/state.py
@@ -6,7 +6,7 @@ from datetime import datetime
 import logging
 from typing import TYPE_CHECKING, Any
 
-from propcache import under_cached_property
+from propcache import cached_property
 from sqlalchemy.engine.row import Row
 
 from homeassistant.const import (
@@ -50,7 +50,6 @@ class LazyState(State):
         no_attributes: bool,
     ) -> None:
         """Init the lazy state."""
-        self._cache: dict[str, Any] = {}
         self._row = row
         self.entity_id = entity_id
         self.state = state or ""
@@ -59,50 +58,58 @@ class LazyState(State):
         self.attr_cache = attr_cache
         self.context = EMPTY_CONTEXT
 
-    @under_cached_property  # type: ignore[override]
+    @cached_property  # type: ignore[override]
     def attributes(self) -> dict[str, Any]:
         """State attributes."""
         return decode_attributes_from_source(
             getattr(self._row, "attributes", None), self.attr_cache
         )
 
-    @under_cached_property
+    @cached_property
     def _last_changed_ts(self) -> float | None:
         """Last changed timestamp."""
         return getattr(self._row, "last_changed_ts", None)
 
-    @under_cached_property
+    @cached_property
     def last_changed(self) -> datetime:  # type: ignore[override]
         """Last changed datetime."""
         return dt_util.utc_from_timestamp(
             self._last_changed_ts or self._last_updated_ts  # type: ignore[arg-type]
         )
 
-    @under_cached_property
+    @cached_property
     def _last_reported_ts(self) -> float | None:
         """Last reported timestamp."""
         return getattr(self._row, "last_reported_ts", None)
 
-    @under_cached_property
+    @cached_property
     def last_reported(self) -> datetime:  # type: ignore[override]
         """Last reported datetime."""
         return dt_util.utc_from_timestamp(
             self._last_reported_ts or self._last_updated_ts  # type: ignore[arg-type]
         )
 
-    @under_cached_property
+    @cached_property
     def last_updated(self) -> datetime:  # type: ignore[override]
         """Last updated datetime."""
         if TYPE_CHECKING:
             assert self._last_updated_ts is not None
         return dt_util.utc_from_timestamp(self._last_updated_ts)
 
-    @under_cached_property
+    @cached_property
     def last_updated_timestamp(self) -> float:  # type: ignore[override]
         """Last updated timestamp."""
         if TYPE_CHECKING:
             assert self._last_updated_ts is not None
         return self._last_updated_ts
+
+    @cached_property
+    def last_changed_timestamp(self) -> float:  # type: ignore[override]
+        """Last changed timestamp."""
+        ts = self._last_changed_ts or self._last_updated_ts
+        if TYPE_CHECKING:
+            assert ts is not None
+        return ts
 
     def as_dict(self) -> dict[str, Any]:  # type: ignore[override]
         """Return a dict representation of the LazyState.

--- a/tests/components/recorder/test_models.py
+++ b/tests/components/recorder/test_models.py
@@ -346,6 +346,8 @@ async def test_lazy_state_handles_different_last_updated_and_last_changed(
         "last_updated": "2021-06-12T03:04:01.000323+00:00",
         "state": "off",
     }
+    assert lstate.last_changed_timestamp == row.last_changed_ts
+    assert lstate.last_updated_timestamp == row.last_updated_ts
 
 
 async def test_lazy_state_handles_same_last_updated_and_last_changed(
@@ -379,3 +381,5 @@ async def test_lazy_state_handles_same_last_updated_and_last_changed(
         "last_updated": "2021-06-12T03:04:01.000323+00:00",
         "state": "off",
     }
+    assert lstate.last_changed_timestamp == row.last_changed_ts
+    assert lstate.last_updated_timestamp == row.last_updated_ts


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
`State` was converted to using `under_cached_property` in #127339 

This meant some calls like `last_updated_timestamp` would fail and needed to be implemented in `LazyState`.

`LazyState` needs to keep using `@cached_property` since it needs work with `copy` for backwards compatibility.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
