### PR TITLE
Bump aioswitcher to 5.1.0

### DIFF
--- a/homeassistant/components/switcher_kis/manifest.json
+++ b/homeassistant/components/switcher_kis/manifest.json
@@ -6,6 +6,6 @@
   "documentation": "https://www.home-assistant.io/integrations/switcher_kis",
   "iot_class": "local_push",
   "loggers": ["aioswitcher"],
-  "requirements": ["aioswitcher==5.0.0"],
+  "requirements": ["aioswitcher==5.1.0"],
   "single_config_entry": true
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -384,7 +384,7 @@ aiosteamist==1.0.0
 aiostreammagic==2.10.0
 
 # homeassistant.components.switcher_kis
-aioswitcher==5.0.0
+aioswitcher==5.1.0
 
 # homeassistant.components.syncthing
 aiosyncthing==0.5.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -366,7 +366,7 @@ aiosteamist==1.0.0
 aiostreammagic==2.10.0
 
 # homeassistant.components.switcher_kis
-aioswitcher==5.0.0
+aioswitcher==5.1.0
 
 # homeassistant.components.syncthing
 aiosyncthing==0.5.1

--- a/tests/components/switcher_kis/consts.py
+++ b/tests/components/switcher_kis/consts.py
@@ -3,6 +3,7 @@
 from aioswitcher.device import (
     DeviceState,
     DeviceType,
+    ShutterChildLock,
     ShutterDirection,
     SwitcherDualShutterSingleLight,
     SwitcherLight,
@@ -90,6 +91,8 @@ DUMMY_POSITION = [54]
 DUMMY_POSITION_2 = [54, 54]
 DUMMY_DIRECTION = [ShutterDirection.SHUTTER_STOP]
 DUMMY_DIRECTION_2 = [ShutterDirection.SHUTTER_STOP, ShutterDirection.SHUTTER_STOP]
+DUMMY_CHILD_LOCK = [ShutterChildLock.OFF]
+DUMMY_CHILD_LOCK_2 = [ShutterChildLock.OFF, ShutterChildLock.OFF]
 DUMMY_USERNAME = "email"
 DUMMY_TOKEN = "zvVvd7JxtN7CgvkD1Psujw=="
 DUMMY_LIGHT = [DeviceState.ON]
@@ -135,6 +138,7 @@ DUMMY_SHUTTER_DEVICE = SwitcherShutter(
     DUMMY_TOKEN_NEEDED4,
     DUMMY_POSITION,
     DUMMY_DIRECTION,
+    DUMMY_CHILD_LOCK,
 )
 
 DUMMY_SINGLE_SHUTTER_DUAL_LIGHT_DEVICE = SwitcherSingleShutterDualLight(
@@ -148,6 +152,7 @@ DUMMY_SINGLE_SHUTTER_DUAL_LIGHT_DEVICE = SwitcherSingleShutterDualLight(
     DUMMY_TOKEN_NEEDED5,
     DUMMY_POSITION,
     DUMMY_DIRECTION,
+    DUMMY_CHILD_LOCK,
     DUMMY_LIGHT_2,
 )
 
@@ -162,6 +167,7 @@ DUMMY_DUAL_SHUTTER_SINGLE_LIGHT_DEVICE = SwitcherDualShutterSingleLight(
     DUMMY_TOKEN_NEEDED6,
     DUMMY_POSITION_2,
     DUMMY_DIRECTION_2,
+    DUMMY_CHILD_LOCK_2,
     DUMMY_LIGHT,
 )
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump aioswitcher to 5.1.0

GitHub diff: https://github.com/TomerFi/aioswitcher/compare/5.0.0...5.1.0
Release notes: https://github.com/TomerFi/aioswitcher/releases/tag/5.1.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
