### PR TITLE
Remove legacy behavior from Teslemetry

### DIFF
--- a/tests/components/teslemetry/const.py
+++ b/tests/components/teslemetry/const.py
@@ -12,6 +12,8 @@ WAKE_UP_ASLEEP = {"response": {"state": TeslemetryState.ASLEEP}, "error": None}
 
 PRODUCTS = load_json_object_fixture("products.json", DOMAIN)
 VEHICLE_DATA = load_json_object_fixture("vehicle_data.json", DOMAIN)
+VEHICLE_DATA_ASLEEP = load_json_object_fixture("vehicle_data.json", DOMAIN)
+VEHICLE_DATA_ASLEEP["response"]["state"] = TeslemetryState.OFFLINE
 VEHICLE_DATA_ALT = load_json_object_fixture("vehicle_data_alt.json", DOMAIN)
 LIVE_STATUS = load_json_object_fixture("live_status.json", DOMAIN)
 SITE_INFO = load_json_object_fixture("site_info.json", DOMAIN)

--- a/tests/components/teslemetry/const.py
+++ b/tests/components/teslemetry/const.py
@@ -12,8 +12,6 @@ WAKE_UP_ASLEEP = {"response": {"state": TeslemetryState.ASLEEP}, "error": None}
 
 PRODUCTS = load_json_object_fixture("products.json", DOMAIN)
 VEHICLE_DATA = load_json_object_fixture("vehicle_data.json", DOMAIN)
-VEHICLE_DATA_ASLEEP = load_json_object_fixture("vehicle_data.json", DOMAIN)
-VEHICLE_DATA_ASLEEP["response"]["state"] = TeslemetryState.OFFLINE
 VEHICLE_DATA_ALT = load_json_object_fixture("vehicle_data_alt.json", DOMAIN)
 LIVE_STATUS = load_json_object_fixture("live_status.json", DOMAIN)
 SITE_INFO = load_json_object_fixture("site_info.json", DOMAIN)

--- a/tests/components/teslemetry/fixtures/products.json
+++ b/tests/components/teslemetry/fixtures/products.json
@@ -4,7 +4,7 @@
       "id": 1234,
       "user_id": 1234,
       "vehicle_id": 1234,
-      "vin": "LRWXF7EK4KC700000",
+      "vin": "LRW3F7EK4NC700000",
       "color": null,
       "access_type": "OWNER",
       "display_name": "Test",

--- a/tests/components/teslemetry/fixtures/vehicle_data.json
+++ b/tests/components/teslemetry/fixtures/vehicle_data.json
@@ -3,7 +3,7 @@
     "id": 1234,
     "user_id": 1234,
     "vehicle_id": 1234,
-    "vin": "LRWXF7EK4KC700000",
+    "vin": "LRW3F7EK4NC700000",
     "color": null,
     "access_type": "OWNER",
     "granular_access": {

--- a/tests/components/teslemetry/fixtures/vehicle_data_alt.json
+++ b/tests/components/teslemetry/fixtures/vehicle_data_alt.json
@@ -3,7 +3,7 @@
     "id": 1234,
     "user_id": 1234,
     "vehicle_id": 1234,
-    "vin": "LRWXF7EK4KC700000",
+    "vin": "LRW3F7EK4NC700000",
     "color": null,
     "access_type": "OWNER",
     "granular_access": {

--- a/tests/components/teslemetry/snapshots/test_binary_sensors.ambr
+++ b/tests/components/teslemetry/snapshots/test_binary_sensors.ambr
@@ -212,7 +212,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'charge_state_battery_heater_on',
-    'unique_id': 'LRWXF7EK4KC700000-charge_state_battery_heater_on',
+    'unique_id': 'LRW3F7EK4NC700000-charge_state_battery_heater_on',
     'unit_of_measurement': None,
   })
 # ---
@@ -259,7 +259,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'climate_state_cabin_overheat_protection_actively_cooling',
-    'unique_id': 'LRWXF7EK4KC700000-climate_state_cabin_overheat_protection_actively_cooling',
+    'unique_id': 'LRW3F7EK4NC700000-climate_state_cabin_overheat_protection_actively_cooling',
     'unit_of_measurement': None,
   })
 # ---
@@ -306,7 +306,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'charge_state_conn_charge_cable',
-    'unique_id': 'LRWXF7EK4KC700000-charge_state_conn_charge_cable',
+    'unique_id': 'LRW3F7EK4NC700000-charge_state_conn_charge_cable',
     'unit_of_measurement': None,
   })
 # ---
@@ -353,7 +353,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'charge_state_charger_phases',
-    'unique_id': 'LRWXF7EK4KC700000-charge_state_charger_phases',
+    'unique_id': 'LRW3F7EK4NC700000-charge_state_charger_phases',
     'unit_of_measurement': None,
   })
 # ---
@@ -399,7 +399,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'vehicle_state_dashcam_state',
-    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_dashcam_state',
+    'unique_id': 'LRW3F7EK4NC700000-vehicle_state_dashcam_state',
     'unit_of_measurement': None,
   })
 # ---
@@ -446,7 +446,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'vehicle_state_df',
-    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_df',
+    'unique_id': 'LRW3F7EK4NC700000-vehicle_state_df',
     'unit_of_measurement': None,
   })
 # ---
@@ -493,7 +493,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'vehicle_state_fd_window',
-    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_fd_window',
+    'unique_id': 'LRW3F7EK4NC700000-vehicle_state_fd_window',
     'unit_of_measurement': None,
   })
 # ---
@@ -540,7 +540,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'vehicle_state_pf',
-    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_pf',
+    'unique_id': 'LRW3F7EK4NC700000-vehicle_state_pf',
     'unit_of_measurement': None,
   })
 # ---
@@ -587,7 +587,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'vehicle_state_fp_window',
-    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_fp_window',
+    'unique_id': 'LRW3F7EK4NC700000-vehicle_state_fp_window',
     'unit_of_measurement': None,
   })
 # ---
@@ -634,7 +634,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'climate_state_is_preconditioning',
-    'unique_id': 'LRWXF7EK4KC700000-climate_state_is_preconditioning',
+    'unique_id': 'LRW3F7EK4NC700000-climate_state_is_preconditioning',
     'unit_of_measurement': None,
   })
 # ---
@@ -680,7 +680,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'charge_state_preconditioning_enabled',
-    'unique_id': 'LRWXF7EK4KC700000-charge_state_preconditioning_enabled',
+    'unique_id': 'LRW3F7EK4NC700000-charge_state_preconditioning_enabled',
     'unit_of_measurement': None,
   })
 # ---
@@ -726,7 +726,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'vehicle_state_dr',
-    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_dr',
+    'unique_id': 'LRW3F7EK4NC700000-vehicle_state_dr',
     'unit_of_measurement': None,
   })
 # ---
@@ -773,7 +773,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'vehicle_state_rd_window',
-    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_rd_window',
+    'unique_id': 'LRW3F7EK4NC700000-vehicle_state_rd_window',
     'unit_of_measurement': None,
   })
 # ---
@@ -820,7 +820,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'vehicle_state_pr',
-    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_pr',
+    'unique_id': 'LRW3F7EK4NC700000-vehicle_state_pr',
     'unit_of_measurement': None,
   })
 # ---
@@ -867,7 +867,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'vehicle_state_rp_window',
-    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_rp_window',
+    'unique_id': 'LRW3F7EK4NC700000-vehicle_state_rp_window',
     'unit_of_measurement': None,
   })
 # ---
@@ -914,7 +914,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'charge_state_scheduled_charging_pending',
-    'unique_id': 'LRWXF7EK4KC700000-charge_state_scheduled_charging_pending',
+    'unique_id': 'LRW3F7EK4NC700000-charge_state_scheduled_charging_pending',
     'unit_of_measurement': None,
   })
 # ---
@@ -960,7 +960,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'state',
-    'unique_id': 'LRWXF7EK4KC700000-state',
+    'unique_id': 'LRW3F7EK4NC700000-state',
     'unit_of_measurement': None,
   })
 # ---
@@ -1007,7 +1007,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'vehicle_state_tpms_soft_warning_fl',
-    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_tpms_soft_warning_fl',
+    'unique_id': 'LRW3F7EK4NC700000-vehicle_state_tpms_soft_warning_fl',
     'unit_of_measurement': None,
   })
 # ---
@@ -1054,7 +1054,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'vehicle_state_tpms_soft_warning_fr',
-    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_tpms_soft_warning_fr',
+    'unique_id': 'LRW3F7EK4NC700000-vehicle_state_tpms_soft_warning_fr',
     'unit_of_measurement': None,
   })
 # ---
@@ -1101,7 +1101,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'vehicle_state_tpms_soft_warning_rl',
-    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_tpms_soft_warning_rl',
+    'unique_id': 'LRW3F7EK4NC700000-vehicle_state_tpms_soft_warning_rl',
     'unit_of_measurement': None,
   })
 # ---
@@ -1148,7 +1148,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'vehicle_state_tpms_soft_warning_rr',
-    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_tpms_soft_warning_rr',
+    'unique_id': 'LRW3F7EK4NC700000-vehicle_state_tpms_soft_warning_rr',
     'unit_of_measurement': None,
   })
 # ---
@@ -1195,7 +1195,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'charge_state_trip_charging',
-    'unique_id': 'LRWXF7EK4KC700000-charge_state_trip_charging',
+    'unique_id': 'LRW3F7EK4NC700000-charge_state_trip_charging',
     'unit_of_measurement': None,
   })
 # ---
@@ -1241,7 +1241,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'vehicle_state_is_user_present',
-    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_is_user_present',
+    'unique_id': 'LRW3F7EK4NC700000-vehicle_state_is_user_present',
     'unit_of_measurement': None,
   })
 # ---

--- a/tests/components/teslemetry/snapshots/test_button.ambr
+++ b/tests/components/teslemetry/snapshots/test_button.ambr
@@ -28,7 +28,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'flash_lights',
-    'unique_id': 'LRWXF7EK4KC700000-flash_lights',
+    'unique_id': 'LRW3F7EK4NC700000-flash_lights',
     'unit_of_measurement': None,
   })
 # ---
@@ -74,7 +74,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'homelink',
-    'unique_id': 'LRWXF7EK4KC700000-homelink',
+    'unique_id': 'LRW3F7EK4NC700000-homelink',
     'unit_of_measurement': None,
   })
 # ---
@@ -120,7 +120,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'honk',
-    'unique_id': 'LRWXF7EK4KC700000-honk',
+    'unique_id': 'LRW3F7EK4NC700000-honk',
     'unit_of_measurement': None,
   })
 # ---
@@ -166,7 +166,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'enable_keyless_driving',
-    'unique_id': 'LRWXF7EK4KC700000-enable_keyless_driving',
+    'unique_id': 'LRW3F7EK4NC700000-enable_keyless_driving',
     'unit_of_measurement': None,
   })
 # ---
@@ -212,7 +212,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'boombox',
-    'unique_id': 'LRWXF7EK4KC700000-boombox',
+    'unique_id': 'LRW3F7EK4NC700000-boombox',
     'unit_of_measurement': None,
   })
 # ---
@@ -258,7 +258,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'wake',
-    'unique_id': 'LRWXF7EK4KC700000-wake',
+    'unique_id': 'LRW3F7EK4NC700000-wake',
     'unit_of_measurement': None,
   })
 # ---

--- a/tests/components/teslemetry/snapshots/test_climate.ambr
+++ b/tests/components/teslemetry/snapshots/test_climate.ambr
@@ -43,7 +43,7 @@
     'previous_unique_id': None,
     'supported_features': <ClimateEntityFeature: 385>,
     'translation_key': 'climate_state_cabin_overheat_protection',
-    'unique_id': 'LRWXF7EK4KC700000-climate_state_cabin_overheat_protection',
+    'unique_id': 'LRW3F7EK4NC700000-climate_state_cabin_overheat_protection',
     'unit_of_measurement': None,
   })
 # ---
@@ -113,7 +113,7 @@
     'previous_unique_id': None,
     'supported_features': <ClimateEntityFeature: 401>,
     'translation_key': <TeslemetryClimateSide.DRIVER: 'driver_temp'>,
-    'unique_id': 'LRWXF7EK4KC700000-driver_temp',
+    'unique_id': 'LRW3F7EK4NC700000-driver_temp',
     'unit_of_measurement': None,
   })
 # ---
@@ -184,7 +184,7 @@
     'previous_unique_id': None,
     'supported_features': <ClimateEntityFeature: 384>,
     'translation_key': 'climate_state_cabin_overheat_protection',
-    'unique_id': 'LRWXF7EK4KC700000-climate_state_cabin_overheat_protection',
+    'unique_id': 'LRW3F7EK4NC700000-climate_state_cabin_overheat_protection',
     'unit_of_measurement': None,
   })
 # ---
@@ -253,7 +253,7 @@
     'previous_unique_id': None,
     'supported_features': <ClimateEntityFeature: 401>,
     'translation_key': <TeslemetryClimateSide.DRIVER: 'driver_temp'>,
-    'unique_id': 'LRWXF7EK4KC700000-driver_temp',
+    'unique_id': 'LRW3F7EK4NC700000-driver_temp',
     'unit_of_measurement': None,
   })
 # ---
@@ -322,7 +322,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'climate_state_cabin_overheat_protection',
-    'unique_id': 'LRWXF7EK4KC700000-climate_state_cabin_overheat_protection',
+    'unique_id': 'LRW3F7EK4NC700000-climate_state_cabin_overheat_protection',
     'unit_of_measurement': None,
   })
 # ---
@@ -361,7 +361,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': <TeslemetryClimateSide.DRIVER: 'driver_temp'>,
-    'unique_id': 'LRWXF7EK4KC700000-driver_temp',
+    'unique_id': 'LRW3F7EK4NC700000-driver_temp',
     'unit_of_measurement': None,
   })
 # ---
@@ -403,7 +403,7 @@
     'previous_unique_id': None,
     'supported_features': <ClimateEntityFeature: 384>,
     'translation_key': 'climate_state_cabin_overheat_protection',
-    'unique_id': 'LRWXF7EK4KC700000-climate_state_cabin_overheat_protection',
+    'unique_id': 'LRW3F7EK4NC700000-climate_state_cabin_overheat_protection',
     'unit_of_measurement': None,
   })
 # ---
@@ -472,7 +472,7 @@
     'previous_unique_id': None,
     'supported_features': <ClimateEntityFeature: 401>,
     'translation_key': <TeslemetryClimateSide.DRIVER: 'driver_temp'>,
-    'unique_id': 'LRWXF7EK4KC700000-driver_temp',
+    'unique_id': 'LRW3F7EK4NC700000-driver_temp',
     'unit_of_measurement': None,
   })
 # ---

--- a/tests/components/teslemetry/snapshots/test_cover.ambr
+++ b/tests/components/teslemetry/snapshots/test_cover.ambr
@@ -28,7 +28,7 @@
     'previous_unique_id': None,
     'supported_features': <CoverEntityFeature: 3>,
     'translation_key': 'charge_state_charge_port_door_open',
-    'unique_id': 'LRWXF7EK4KC700000-charge_state_charge_port_door_open',
+    'unique_id': 'LRW3F7EK4NC700000-charge_state_charge_port_door_open',
     'unit_of_measurement': None,
   })
 # ---
@@ -76,7 +76,7 @@
     'previous_unique_id': None,
     'supported_features': <CoverEntityFeature: 1>,
     'translation_key': 'vehicle_state_ft',
-    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_ft',
+    'unique_id': 'LRW3F7EK4NC700000-vehicle_state_ft',
     'unit_of_measurement': None,
   })
 # ---
@@ -124,7 +124,7 @@
     'previous_unique_id': None,
     'supported_features': <CoverEntityFeature: 11>,
     'translation_key': 'vehicle_state_sun_roof_state',
-    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_sun_roof_state',
+    'unique_id': 'LRW3F7EK4NC700000-vehicle_state_sun_roof_state',
     'unit_of_measurement': None,
   })
 # ---
@@ -172,7 +172,7 @@
     'previous_unique_id': None,
     'supported_features': <CoverEntityFeature: 3>,
     'translation_key': 'vehicle_state_rt',
-    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_rt',
+    'unique_id': 'LRW3F7EK4NC700000-vehicle_state_rt',
     'unit_of_measurement': None,
   })
 # ---
@@ -220,7 +220,7 @@
     'previous_unique_id': None,
     'supported_features': <CoverEntityFeature: 3>,
     'translation_key': 'windows',
-    'unique_id': 'LRWXF7EK4KC700000-windows',
+    'unique_id': 'LRW3F7EK4NC700000-windows',
     'unit_of_measurement': None,
   })
 # ---
@@ -268,7 +268,7 @@
     'previous_unique_id': None,
     'supported_features': <CoverEntityFeature: 3>,
     'translation_key': 'charge_state_charge_port_door_open',
-    'unique_id': 'LRWXF7EK4KC700000-charge_state_charge_port_door_open',
+    'unique_id': 'LRW3F7EK4NC700000-charge_state_charge_port_door_open',
     'unit_of_measurement': None,
   })
 # ---
@@ -316,7 +316,7 @@
     'previous_unique_id': None,
     'supported_features': <CoverEntityFeature: 1>,
     'translation_key': 'vehicle_state_ft',
-    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_ft',
+    'unique_id': 'LRW3F7EK4NC700000-vehicle_state_ft',
     'unit_of_measurement': None,
   })
 # ---
@@ -364,7 +364,7 @@
     'previous_unique_id': None,
     'supported_features': <CoverEntityFeature: 11>,
     'translation_key': 'vehicle_state_sun_roof_state',
-    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_sun_roof_state',
+    'unique_id': 'LRW3F7EK4NC700000-vehicle_state_sun_roof_state',
     'unit_of_measurement': None,
   })
 # ---
@@ -412,7 +412,7 @@
     'previous_unique_id': None,
     'supported_features': <CoverEntityFeature: 3>,
     'translation_key': 'vehicle_state_rt',
-    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_rt',
+    'unique_id': 'LRW3F7EK4NC700000-vehicle_state_rt',
     'unit_of_measurement': None,
   })
 # ---
@@ -460,7 +460,7 @@
     'previous_unique_id': None,
     'supported_features': <CoverEntityFeature: 3>,
     'translation_key': 'windows',
-    'unique_id': 'LRWXF7EK4KC700000-windows',
+    'unique_id': 'LRW3F7EK4NC700000-windows',
     'unit_of_measurement': None,
   })
 # ---
@@ -508,7 +508,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'charge_state_charge_port_door_open',
-    'unique_id': 'LRWXF7EK4KC700000-charge_state_charge_port_door_open',
+    'unique_id': 'LRW3F7EK4NC700000-charge_state_charge_port_door_open',
     'unit_of_measurement': None,
   })
 # ---
@@ -556,7 +556,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'vehicle_state_ft',
-    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_ft',
+    'unique_id': 'LRW3F7EK4NC700000-vehicle_state_ft',
     'unit_of_measurement': None,
   })
 # ---
@@ -604,7 +604,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'vehicle_state_sun_roof_state',
-    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_sun_roof_state',
+    'unique_id': 'LRW3F7EK4NC700000-vehicle_state_sun_roof_state',
     'unit_of_measurement': None,
   })
 # ---
@@ -652,7 +652,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'vehicle_state_rt',
-    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_rt',
+    'unique_id': 'LRW3F7EK4NC700000-vehicle_state_rt',
     'unit_of_measurement': None,
   })
 # ---
@@ -700,7 +700,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'windows',
-    'unique_id': 'LRWXF7EK4KC700000-windows',
+    'unique_id': 'LRW3F7EK4NC700000-windows',
     'unit_of_measurement': None,
   })
 # ---

--- a/tests/components/teslemetry/snapshots/test_device_tracker.ambr
+++ b/tests/components/teslemetry/snapshots/test_device_tracker.ambr
@@ -28,7 +28,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'location',
-    'unique_id': 'LRWXF7EK4KC700000-location',
+    'unique_id': 'LRW3F7EK4NC700000-location',
     'unit_of_measurement': None,
   })
 # ---
@@ -78,7 +78,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'route',
-    'unique_id': 'LRWXF7EK4KC700000-route',
+    'unique_id': 'LRW3F7EK4NC700000-route',
     'unit_of_measurement': None,
   })
 # ---

--- a/tests/components/teslemetry/snapshots/test_init.ambr
+++ b/tests/components/teslemetry/snapshots/test_init.ambr
@@ -31,7 +31,7 @@
     'via_device_id': None,
   })
 # ---
-# name: test_devices[{('teslemetry', 'LRWXF7EK4KC700000')}]
+# name: test_devices[{('teslemetry', 'LRW3F7EK4NC700000')}]
   DeviceRegistryEntrySnapshot({
     'area_id': None,
     'config_entries': <ANY>,
@@ -45,19 +45,19 @@
     'identifiers': set({
       tuple(
         'teslemetry',
-        'LRWXF7EK4KC700000',
+        'LRW3F7EK4NC700000',
       ),
     }),
     'is_new': False,
     'labels': set({
     }),
     'manufacturer': 'Tesla',
-    'model': 'Model X',
+    'model': 'Model 3',
     'model_id': None,
     'name': 'Test',
     'name_by_user': None,
     'primary_config_entry': <ANY>,
-    'serial_number': 'LRWXF7EK4KC700000',
+    'serial_number': 'LRW3F7EK4NC700000',
     'suggested_area': None,
     'sw_version': None,
     'via_device_id': None,

--- a/tests/components/teslemetry/snapshots/test_lock.ambr
+++ b/tests/components/teslemetry/snapshots/test_lock.ambr
@@ -28,7 +28,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'charge_state_charge_port_latch',
-    'unique_id': 'LRWXF7EK4KC700000-charge_state_charge_port_latch',
+    'unique_id': 'LRW3F7EK4NC700000-charge_state_charge_port_latch',
     'unit_of_measurement': None,
   })
 # ---
@@ -75,7 +75,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'vehicle_state_locked',
-    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_locked',
+    'unique_id': 'LRW3F7EK4NC700000-vehicle_state_locked',
     'unit_of_measurement': None,
   })
 # ---

--- a/tests/components/teslemetry/snapshots/test_media_player.ambr
+++ b/tests/components/teslemetry/snapshots/test_media_player.ambr
@@ -29,7 +29,7 @@
     'previous_unique_id': None,
     'supported_features': <MediaPlayerEntityFeature: 16437>,
     'translation_key': 'media',
-    'unique_id': 'LRWXF7EK4KC700000-media',
+    'unique_id': 'LRW3F7EK4NC700000-media',
     'unit_of_measurement': None,
   })
 # ---
@@ -107,7 +107,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'media',
-    'unique_id': 'LRWXF7EK4KC700000-media',
+    'unique_id': 'LRW3F7EK4NC700000-media',
     'unit_of_measurement': None,
   })
 # ---

--- a/tests/components/teslemetry/snapshots/test_number.ambr
+++ b/tests/components/teslemetry/snapshots/test_number.ambr
@@ -149,7 +149,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'charge_state_charge_current_request',
-    'unique_id': 'LRWXF7EK4KC700000-charge_state_charge_current_request',
+    'unique_id': 'LRW3F7EK4NC700000-charge_state_charge_current_request',
     'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
   })
 # ---
@@ -206,7 +206,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'charge_state_charge_limit_soc',
-    'unique_id': 'LRWXF7EK4KC700000-charge_state_charge_limit_soc',
+    'unique_id': 'LRW3F7EK4NC700000-charge_state_charge_limit_soc',
     'unit_of_measurement': '%',
   })
 # ---

--- a/tests/components/teslemetry/snapshots/test_select.ambr
+++ b/tests/components/teslemetry/snapshots/test_select.ambr
@@ -149,7 +149,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'climate_state_seat_heater_left',
-    'unique_id': 'LRWXF7EK4KC700000-climate_state_seat_heater_left',
+    'unique_id': 'LRW3F7EK4NC700000-climate_state_seat_heater_left',
     'unit_of_measurement': None,
   })
 # ---
@@ -208,7 +208,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'climate_state_seat_heater_right',
-    'unique_id': 'LRWXF7EK4KC700000-climate_state_seat_heater_right',
+    'unique_id': 'LRW3F7EK4NC700000-climate_state_seat_heater_right',
     'unit_of_measurement': None,
   })
 # ---
@@ -267,7 +267,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'climate_state_seat_heater_rear_center',
-    'unique_id': 'LRWXF7EK4KC700000-climate_state_seat_heater_rear_center',
+    'unique_id': 'LRW3F7EK4NC700000-climate_state_seat_heater_rear_center',
     'unit_of_measurement': None,
   })
 # ---
@@ -326,7 +326,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'climate_state_seat_heater_rear_left',
-    'unique_id': 'LRWXF7EK4KC700000-climate_state_seat_heater_rear_left',
+    'unique_id': 'LRW3F7EK4NC700000-climate_state_seat_heater_rear_left',
     'unit_of_measurement': None,
   })
 # ---
@@ -385,7 +385,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'climate_state_seat_heater_rear_right',
-    'unique_id': 'LRWXF7EK4KC700000-climate_state_seat_heater_rear_right',
+    'unique_id': 'LRW3F7EK4NC700000-climate_state_seat_heater_rear_right',
     'unit_of_measurement': None,
   })
 # ---
@@ -444,7 +444,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'climate_state_seat_heater_third_row_left',
-    'unique_id': 'LRWXF7EK4KC700000-climate_state_seat_heater_third_row_left',
+    'unique_id': 'LRW3F7EK4NC700000-climate_state_seat_heater_third_row_left',
     'unit_of_measurement': None,
   })
 # ---
@@ -503,7 +503,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'climate_state_seat_heater_third_row_right',
-    'unique_id': 'LRWXF7EK4KC700000-climate_state_seat_heater_third_row_right',
+    'unique_id': 'LRW3F7EK4NC700000-climate_state_seat_heater_third_row_right',
     'unit_of_measurement': None,
   })
 # ---
@@ -561,7 +561,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'climate_state_steering_wheel_heat_level',
-    'unique_id': 'LRWXF7EK4KC700000-climate_state_steering_wheel_heat_level',
+    'unique_id': 'LRW3F7EK4NC700000-climate_state_steering_wheel_heat_level',
     'unit_of_measurement': None,
   })
 # ---

--- a/tests/components/teslemetry/snapshots/test_sensor.ambr
+++ b/tests/components/teslemetry/snapshots/test_sensor.ambr
@@ -2422,7 +2422,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'charge_state_battery_level',
-    'unique_id': 'LRWXF7EK4KC700000-charge_state_battery_level',
+    'unique_id': 'LRW3F7EK4NC700000-charge_state_battery_level',
     'unit_of_measurement': '%',
   })
 # ---
@@ -2495,7 +2495,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'charge_state_battery_range',
-    'unique_id': 'LRWXF7EK4KC700000-charge_state_battery_range',
+    'unique_id': 'LRW3F7EK4NC700000-charge_state_battery_range',
     'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
   })
 # ---
@@ -2560,7 +2560,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'charge_state_conn_charge_cable',
-    'unique_id': 'LRWXF7EK4KC700000-charge_state_conn_charge_cable',
+    'unique_id': 'LRW3F7EK4NC700000-charge_state_conn_charge_cable',
     'unit_of_measurement': None,
   })
 # ---
@@ -2624,7 +2624,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'charge_state_charge_energy_added',
-    'unique_id': 'LRWXF7EK4KC700000-charge_state_charge_energy_added',
+    'unique_id': 'LRW3F7EK4NC700000-charge_state_charge_energy_added',
     'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
   })
 # ---
@@ -2694,7 +2694,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'charge_state_charge_rate',
-    'unique_id': 'LRWXF7EK4KC700000-charge_state_charge_rate',
+    'unique_id': 'LRW3F7EK4NC700000-charge_state_charge_rate',
     'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
   })
 # ---
@@ -2761,7 +2761,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'charge_state_charger_actual_current',
-    'unique_id': 'LRWXF7EK4KC700000-charge_state_charger_actual_current',
+    'unique_id': 'LRW3F7EK4NC700000-charge_state_charger_actual_current',
     'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
   })
 # ---
@@ -2828,7 +2828,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'charge_state_charger_power',
-    'unique_id': 'LRWXF7EK4KC700000-charge_state_charger_power',
+    'unique_id': 'LRW3F7EK4NC700000-charge_state_charger_power',
     'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
   })
 # ---
@@ -2895,7 +2895,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'charge_state_charger_voltage',
-    'unique_id': 'LRWXF7EK4KC700000-charge_state_charger_voltage',
+    'unique_id': 'LRW3F7EK4NC700000-charge_state_charger_voltage',
     'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
   })
 # ---
@@ -2969,7 +2969,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'charge_state_charging_state',
-    'unique_id': 'LRWXF7EK4KC700000-charge_state_charging_state',
+    'unique_id': 'LRW3F7EK4NC700000-charge_state_charging_state',
     'unit_of_measurement': None,
   })
 # ---
@@ -3051,7 +3051,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'drive_state_active_route_miles_to_arrival',
-    'unique_id': 'LRWXF7EK4KC700000-drive_state_active_route_miles_to_arrival',
+    'unique_id': 'LRW3F7EK4NC700000-drive_state_active_route_miles_to_arrival',
     'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
   })
 # ---
@@ -3121,7 +3121,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'climate_state_driver_temp_setting',
-    'unique_id': 'LRWXF7EK4KC700000-climate_state_driver_temp_setting',
+    'unique_id': 'LRW3F7EK4NC700000-climate_state_driver_temp_setting',
     'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })
 # ---
@@ -3194,7 +3194,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'charge_state_est_battery_range',
-    'unique_id': 'LRWXF7EK4KC700000-charge_state_est_battery_range',
+    'unique_id': 'LRW3F7EK4NC700000-charge_state_est_battery_range',
     'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
   })
 # ---
@@ -3259,7 +3259,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'charge_state_fast_charger_type',
-    'unique_id': 'LRWXF7EK4KC700000-charge_state_fast_charger_type',
+    'unique_id': 'LRW3F7EK4NC700000-charge_state_fast_charger_type',
     'unit_of_measurement': None,
   })
 # ---
@@ -3326,7 +3326,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'charge_state_ideal_battery_range',
-    'unique_id': 'LRWXF7EK4KC700000-charge_state_ideal_battery_range',
+    'unique_id': 'LRW3F7EK4NC700000-charge_state_ideal_battery_range',
     'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
   })
 # ---
@@ -3396,7 +3396,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'climate_state_inside_temp',
-    'unique_id': 'LRWXF7EK4KC700000-climate_state_inside_temp',
+    'unique_id': 'LRW3F7EK4NC700000-climate_state_inside_temp',
     'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })
 # ---
@@ -3469,7 +3469,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'vehicle_state_odometer',
-    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_odometer',
+    'unique_id': 'LRW3F7EK4NC700000-vehicle_state_odometer',
     'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
   })
 # ---
@@ -3539,7 +3539,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'climate_state_outside_temp',
-    'unique_id': 'LRWXF7EK4KC700000-climate_state_outside_temp',
+    'unique_id': 'LRW3F7EK4NC700000-climate_state_outside_temp',
     'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })
 # ---
@@ -3609,7 +3609,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'climate_state_passenger_temp_setting',
-    'unique_id': 'LRWXF7EK4KC700000-climate_state_passenger_temp_setting',
+    'unique_id': 'LRW3F7EK4NC700000-climate_state_passenger_temp_setting',
     'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })
 # ---
@@ -3676,7 +3676,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'drive_state_power',
-    'unique_id': 'LRWXF7EK4KC700000-drive_state_power',
+    'unique_id': 'LRW3F7EK4NC700000-drive_state_power',
     'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
   })
 # ---
@@ -3748,7 +3748,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'drive_state_shift_state',
-    'unique_id': 'LRWXF7EK4KC700000-drive_state_shift_state',
+    'unique_id': 'LRW3F7EK4NC700000-drive_state_shift_state',
     'unit_of_measurement': None,
   })
 # ---
@@ -3826,7 +3826,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'drive_state_speed',
-    'unique_id': 'LRWXF7EK4KC700000-drive_state_speed',
+    'unique_id': 'LRW3F7EK4NC700000-drive_state_speed',
     'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
   })
 # ---
@@ -3893,7 +3893,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'drive_state_active_route_energy_at_arrival',
-    'unique_id': 'LRWXF7EK4KC700000-drive_state_active_route_energy_at_arrival',
+    'unique_id': 'LRW3F7EK4NC700000-drive_state_active_route_energy_at_arrival',
     'unit_of_measurement': '%',
   })
 # ---
@@ -3958,7 +3958,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'drive_state_active_route_minutes_to_arrival',
-    'unique_id': 'LRWXF7EK4KC700000-drive_state_active_route_minutes_to_arrival',
+    'unique_id': 'LRW3F7EK4NC700000-drive_state_active_route_minutes_to_arrival',
     'unit_of_measurement': None,
   })
 # ---
@@ -4019,7 +4019,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'charge_state_minutes_to_full_charge',
-    'unique_id': 'LRWXF7EK4KC700000-charge_state_minutes_to_full_charge',
+    'unique_id': 'LRW3F7EK4NC700000-charge_state_minutes_to_full_charge',
     'unit_of_measurement': None,
   })
 # ---
@@ -4088,7 +4088,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'vehicle_state_tpms_pressure_fl',
-    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_tpms_pressure_fl',
+    'unique_id': 'LRW3F7EK4NC700000-vehicle_state_tpms_pressure_fl',
     'unit_of_measurement': <UnitOfPressure.PSI: 'psi'>,
   })
 # ---
@@ -4161,7 +4161,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'vehicle_state_tpms_pressure_fr',
-    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_tpms_pressure_fr',
+    'unique_id': 'LRW3F7EK4NC700000-vehicle_state_tpms_pressure_fr',
     'unit_of_measurement': <UnitOfPressure.PSI: 'psi'>,
   })
 # ---
@@ -4234,7 +4234,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'vehicle_state_tpms_pressure_rl',
-    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_tpms_pressure_rl',
+    'unique_id': 'LRW3F7EK4NC700000-vehicle_state_tpms_pressure_rl',
     'unit_of_measurement': <UnitOfPressure.PSI: 'psi'>,
   })
 # ---
@@ -4307,7 +4307,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'vehicle_state_tpms_pressure_rr',
-    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_tpms_pressure_rr',
+    'unique_id': 'LRW3F7EK4NC700000-vehicle_state_tpms_pressure_rr',
     'unit_of_measurement': <UnitOfPressure.PSI: 'psi'>,
   })
 # ---
@@ -4374,7 +4374,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'drive_state_active_route_traffic_minutes_delay',
-    'unique_id': 'LRWXF7EK4KC700000-drive_state_active_route_traffic_minutes_delay',
+    'unique_id': 'LRW3F7EK4NC700000-drive_state_active_route_traffic_minutes_delay',
     'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
   })
 # ---
@@ -4441,7 +4441,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'charge_state_usable_battery_level',
-    'unique_id': 'LRWXF7EK4KC700000-charge_state_usable_battery_level',
+    'unique_id': 'LRW3F7EK4NC700000-charge_state_usable_battery_level',
     'unit_of_measurement': '%',
   })
 # ---

--- a/tests/components/teslemetry/snapshots/test_switch.ambr
+++ b/tests/components/teslemetry/snapshots/test_switch.ambr
@@ -122,7 +122,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'climate_state_auto_seat_climate_left',
-    'unique_id': 'LRWXF7EK4KC700000-climate_state_auto_seat_climate_left',
+    'unique_id': 'LRW3F7EK4NC700000-climate_state_auto_seat_climate_left',
     'unit_of_measurement': None,
   })
 # ---
@@ -169,7 +169,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'climate_state_auto_seat_climate_right',
-    'unique_id': 'LRWXF7EK4KC700000-climate_state_auto_seat_climate_right',
+    'unique_id': 'LRW3F7EK4NC700000-climate_state_auto_seat_climate_right',
     'unit_of_measurement': None,
   })
 # ---
@@ -216,7 +216,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'climate_state_auto_steering_wheel_heat',
-    'unique_id': 'LRWXF7EK4KC700000-climate_state_auto_steering_wheel_heat',
+    'unique_id': 'LRW3F7EK4NC700000-climate_state_auto_steering_wheel_heat',
     'unit_of_measurement': None,
   })
 # ---
@@ -263,7 +263,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'charge_state_user_charge_enable_request',
-    'unique_id': 'LRWXF7EK4KC700000-charge_state_user_charge_enable_request',
+    'unique_id': 'LRW3F7EK4NC700000-charge_state_user_charge_enable_request',
     'unit_of_measurement': None,
   })
 # ---
@@ -310,7 +310,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'climate_state_defrost_mode',
-    'unique_id': 'LRWXF7EK4KC700000-climate_state_defrost_mode',
+    'unique_id': 'LRW3F7EK4NC700000-climate_state_defrost_mode',
     'unit_of_measurement': None,
   })
 # ---
@@ -357,7 +357,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'vehicle_state_sentry_mode',
-    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_sentry_mode',
+    'unique_id': 'LRW3F7EK4NC700000-vehicle_state_sentry_mode',
     'unit_of_measurement': None,
   })
 # ---

--- a/tests/components/teslemetry/snapshots/test_update.ambr
+++ b/tests/components/teslemetry/snapshots/test_update.ambr
@@ -28,7 +28,7 @@
     'previous_unique_id': None,
     'supported_features': <UpdateEntityFeature: 5>,
     'translation_key': 'vehicle_state_software_update_status',
-    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_software_update_status',
+    'unique_id': 'LRW3F7EK4NC700000-vehicle_state_software_update_status',
     'unit_of_measurement': None,
   })
 # ---
@@ -86,7 +86,7 @@
     'previous_unique_id': None,
     'supported_features': <UpdateEntityFeature: 4>,
     'translation_key': 'vehicle_state_software_update_status',
-    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_software_update_status',
+    'unique_id': 'LRW3F7EK4NC700000-vehicle_state_software_update_status',
     'unit_of_measurement': None,
   })
 # ---

--- a/tests/components/teslemetry/test_init.py
+++ b/tests/components/teslemetry/test_init.py
@@ -12,10 +12,7 @@ from tesla_fleet_api.exceptions import (
     VehicleOffline,
 )
 
-from homeassistant.components.teslemetry.coordinator import (
-    VEHICLE_INTERVAL,
-    VEHICLE_WAIT,
-)
+from homeassistant.components.teslemetry.coordinator import VEHICLE_INTERVAL
 from homeassistant.components.teslemetry.models import TeslemetryData
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import STATE_OFF, STATE_ON, Platform
@@ -115,63 +112,6 @@ async def test_vehicle_refresh_error(
     mock_vehicle_data.side_effect = side_effect
     entry = await setup_platform(hass)
     assert entry.state is state
-
-
-async def test_vehicle_sleep(
-    hass: HomeAssistant, mock_vehicle_data: AsyncMock, freezer: FrozenDateTimeFactory
-) -> None:
-    """Test coordinator refresh with an error."""
-    await setup_platform(hass, [Platform.CLIMATE])
-    assert mock_vehicle_data.call_count == 1
-
-    freezer.tick(VEHICLE_WAIT + VEHICLE_INTERVAL)
-    async_fire_time_changed(hass)
-    # Let vehicle sleep, no updates for 15 minutes
-    await hass.async_block_till_done()
-    assert mock_vehicle_data.call_count == 2
-
-    freezer.tick(VEHICLE_INTERVAL)
-    async_fire_time_changed(hass)
-    # No polling, call_count should not increase
-    await hass.async_block_till_done()
-    assert mock_vehicle_data.call_count == 2
-
-    freezer.tick(VEHICLE_INTERVAL)
-    async_fire_time_changed(hass)
-    # No polling, call_count should not increase
-    await hass.async_block_till_done()
-    assert mock_vehicle_data.call_count == 2
-
-    freezer.tick(VEHICLE_WAIT)
-    async_fire_time_changed(hass)
-    # Vehicle didn't sleep, go back to normal
-    await hass.async_block_till_done()
-    assert mock_vehicle_data.call_count == 3
-
-    freezer.tick(VEHICLE_INTERVAL)
-    async_fire_time_changed(hass)
-    # Regular polling
-    await hass.async_block_till_done()
-    assert mock_vehicle_data.call_count == 4
-
-    mock_vehicle_data.return_value = VEHICLE_DATA_ALT
-    freezer.tick(VEHICLE_INTERVAL)
-    async_fire_time_changed(hass)
-    # Vehicle active
-    await hass.async_block_till_done()
-    assert mock_vehicle_data.call_count == 5
-
-    freezer.tick(VEHICLE_WAIT)
-    async_fire_time_changed(hass)
-    # Dont let sleep when active
-    await hass.async_block_till_done()
-    assert mock_vehicle_data.call_count == 6
-
-    freezer.tick(VEHICLE_WAIT)
-    async_fire_time_changed(hass)
-    # Dont let sleep when active
-    await hass.async_block_till_done()
-    assert mock_vehicle_data.call_count == 7
 
 
 # Test Energy Live Coordinator


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The integration has special logic for handling vehicles made before 2021, however before  January 2025 Teslemetry is moving all data polling server side to control costs from Tesla. This includes the special 2021 vehicle handling, so its no longer required to be handled locally.

Announcement here: https://teslemetry.com/blog/vehicle-data-caching

This PR also is a pre-requisite for the data streaming PR coming next, since the VIN in tests had to change.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
