### PR TITLE
Add missing `last_reported_timestamp` to `LazyState`

### DIFF
--- a/homeassistant/components/recorder/models/state.py
+++ b/homeassistant/components/recorder/models/state.py
@@ -111,6 +111,14 @@ class LazyState(State):
             assert ts is not None
         return ts
 
+    @cached_property
+    def last_reported_timestamp(self) -> float:  # type: ignore[override]
+        """Last reported timestamp."""
+        ts = self._last_reported_ts or self._last_updated_ts
+        if TYPE_CHECKING:
+            assert ts is not None
+        return ts
+
     def as_dict(self) -> dict[str, Any]:  # type: ignore[override]
         """Return a dict representation of the LazyState.
 

--- a/tests/components/recorder/test_models.py
+++ b/tests/components/recorder/test_models.py
@@ -325,6 +325,7 @@ async def test_lazy_state_handles_different_last_updated_and_last_changed(
         state="off",
         attributes='{"shared":true}',
         last_updated_ts=now.timestamp(),
+        last_reported_ts=now.timestamp(),
         last_changed_ts=(now - timedelta(seconds=60)).timestamp(),
     )
     lstate = LazyState(
@@ -339,6 +340,7 @@ async def test_lazy_state_handles_different_last_updated_and_last_changed(
     }
     assert lstate.last_updated.timestamp() == row.last_updated_ts
     assert lstate.last_changed.timestamp() == row.last_changed_ts
+    assert lstate.last_reported.timestamp() == row.last_updated_ts
     assert lstate.as_dict() == {
         "attributes": {"shared": True},
         "entity_id": "sensor.valid",
@@ -348,6 +350,7 @@ async def test_lazy_state_handles_different_last_updated_and_last_changed(
     }
     assert lstate.last_changed_timestamp == row.last_changed_ts
     assert lstate.last_updated_timestamp == row.last_updated_ts
+    assert lstate.last_reported_timestamp == row.last_updated_ts
 
 
 async def test_lazy_state_handles_same_last_updated_and_last_changed(
@@ -361,6 +364,7 @@ async def test_lazy_state_handles_same_last_updated_and_last_changed(
         attributes='{"shared":true}',
         last_updated_ts=now.timestamp(),
         last_changed_ts=now.timestamp(),
+        last_reported_ts=None,
     )
     lstate = LazyState(
         row, {}, None, row.entity_id, row.state, row.last_updated_ts, False
@@ -374,6 +378,7 @@ async def test_lazy_state_handles_same_last_updated_and_last_changed(
     }
     assert lstate.last_updated.timestamp() == row.last_updated_ts
     assert lstate.last_changed.timestamp() == row.last_changed_ts
+    assert lstate.last_reported.timestamp() == row.last_updated_ts
     assert lstate.as_dict() == {
         "attributes": {"shared": True},
         "entity_id": "sensor.valid",
@@ -383,3 +388,35 @@ async def test_lazy_state_handles_same_last_updated_and_last_changed(
     }
     assert lstate.last_changed_timestamp == row.last_changed_ts
     assert lstate.last_updated_timestamp == row.last_updated_ts
+    assert lstate.last_reported_timestamp == row.last_updated_ts
+
+
+async def test_lazy_state_handles_different_last_reported(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that the LazyState handles last_reported different from last_updated."""
+    now = datetime(2021, 6, 12, 3, 4, 1, 323, tzinfo=dt_util.UTC)
+    row = PropertyMock(
+        entity_id="sensor.valid",
+        state="off",
+        attributes='{"shared":true}',
+        last_updated_ts=(now - timedelta(seconds=60)).timestamp(),
+        last_reported_ts=now.timestamp(),
+        last_changed_ts=(now - timedelta(seconds=60)).timestamp(),
+    )
+    lstate = LazyState(
+        row, {}, None, row.entity_id, row.state, row.last_updated_ts, False
+    )
+    assert lstate.as_dict() == {
+        "attributes": {"shared": True},
+        "entity_id": "sensor.valid",
+        "last_changed": "2021-06-12T03:03:01.000323+00:00",
+        "last_updated": "2021-06-12T03:03:01.000323+00:00",
+        "state": "off",
+    }
+    assert lstate.last_updated.timestamp() == row.last_updated_ts
+    assert lstate.last_changed.timestamp() == row.last_changed_ts
+    assert lstate.last_reported.timestamp() == row.last_reported_ts
+    assert lstate.last_changed_timestamp == row.last_changed_ts
+    assert lstate.last_updated_timestamp == row.last_updated_ts
+    assert lstate.last_reported_timestamp == row.last_reported_ts


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
followup to #132752


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
