### PR TITLE
Mark Cambridge Audio quality scale as platinum

### DIFF
--- a/homeassistant/components/cambridge_audio/manifest.json
+++ b/homeassistant/components/cambridge_audio/manifest.json
@@ -7,6 +7,7 @@
   "integration_type": "device",
   "iot_class": "local_push",
   "loggers": ["aiostreammagic"],
+  "quality_scale": "platinum",
   "requirements": ["aiostreammagic==2.10.0"],
   "zeroconf": ["_stream-magic._tcp.local.", "_smoip._tcp.local."]
 }


### PR DESCRIPTION
## Proposed change
SSIA

## Bronze
- [x] `config-flow` - Integration needs to be able to be set up via the UI
https://github.com/home-assistant/core/blob/d2d3ab2d98efc00efb18ed93fda0f616f5148da9/homeassistant/components/cambridge_audio/config_flow.py#L16
    - [x] Uses `data-description` to give context to fields
    - [x] Uses `ConfigEntry.data` and `ConfigEntry.options` correctly
- [x] `test-before-configure` - Test a connection in the config flow
https://github.com/home-assistant/core/blob/d2d3ab2d98efc00efb18ed93fda0f616f5148da9/homeassistant/components/cambridge_audio/config_flow.py#L72-L77
- [x] `unique-config-entry` - Don't allow the same device or service to be able to be set up twice
https://github.com/home-assistant/core/blob/d2d3ab2d98efc00efb18ed93fda0f616f5148da9/homeassistant/components/cambridge_audio/config_flow.py#L79-L81
- [x] `config-flow-test-coverage` - Full test coverage for the config flow
*See `test-coverage`*
- [x] `runtime-data` - Use ConfigEntry.runtime_data to store runtime data
https://github.com/home-assistant/core/blob/d2d3ab2d98efc00efb18ed93fda0f616f5148da9/homeassistant/components/cambridge_audio/__init__.py#L49
- [x] `test-before-setup` - Check during integration initialization if we are able to set it up correctly
https://github.com/home-assistant/core/blob/d2d3ab2d98efc00efb18ed93fda0f616f5148da9/homeassistant/components/cambridge_audio/__init__.py#L44-L48
- [ ] `appropriate-polling` - If it's a polling integration, set an appropriate polling interval
*Not a polling integration*
- [x] `entity-unique-id` - Entities have a unique ID
https://github.com/home-assistant/core/blob/b139af9a9c8ed581f18b25e7bc79c2df998583f7/homeassistant/components/cambridge_audio/media_player.py#L83
- [x] `has-entity-name` - Entities use has_entity_name = True
https://github.com/home-assistant/core/blob/d2d3ab2d98efc00efb18ed93fda0f616f5148da9/homeassistant/components/cambridge_audio/entity.py#L38
- [x] `entity-event-setup` - Entities event setup
https://github.com/home-assistant/core/blob/d2d3ab2d98efc00efb18ed93fda0f616f5148da9/homeassistant/components/cambridge_audio/entity.py#L59-L65
- [x] `dependency-transparency` - Dependency transparency
*aiostreammagic uses MIT license and is available on GH*
- [x] `action-setup` - Service actions are registered in async_setup
*No custom actions*
- [x] `common-modules` - Place common patterns in common modules
*Common variables moved to const.py, common entity methods moved to entity.py*
- [x] `docs-high-level-description` - The documentation includes a high-level description of the integration brand, product, or service
https://github.com/home-assistant/home-assistant.io/blob/472b32a3df2950e5240e5070f103e36540d7d53a/source/_integrations/cambridge_audio.markdown?plain=1#L19-L21
- [x] `docs-installation-instructions` - The documentation provides step-by-step installation instructions for the integration, including, if needed, prerequisites
- [x] `docs-removal-instructions` - The documentation provides removal instructions
- [x] `docs-actions` - The documentation describes the provided service actions that can be used
- [x] `brands` - Has branding assets available for the integration

## Silver
- [x] `config-entry-unloading` - Support config entry unloading
https://github.com/home-assistant/core/blob/b139af9a9c8ed581f18b25e7bc79c2df998583f7/homeassistant/components/cambridge_audio/__init__.py#L63-L65
- [x] `log-when-unavailable` - If internet/device/service is unavailable, log once when unavailable and once when back connected
https://github.com/home-assistant/core/blob/d2d3ab2d98efc00efb18ed93fda0f616f5148da9/homeassistant/components/cambridge_audio/__init__.py#L32-L40
- [x] `entity-unavailable` - Mark entity unavailable if appropriate
https://github.com/home-assistant/core/blob/d2d3ab2d98efc00efb18ed93fda0f616f5148da9/homeassistant/components/cambridge_audio/entity.py#L52-L57
- [x] `action-exceptions` - Service actions raise exceptions when encountering failures
https://github.com/home-assistant/core/blob/d2d3ab2d98efc00efb18ed93fda0f616f5148da9/homeassistant/components/cambridge_audio/entity.py#L17-L32
- [ ] `reauthentication-flow` - Reauthentication flow
*No authentication necessary*
- [x] `parallel-updates` - Set Parallel updates
PARALLEL_UPDATES = 0
- [x] `test-coverage` - Above 95% test coverage for all integration modules
<img width="769" alt="Screenshot 2024-12-09 at 4 06 06 PM" src="https://github.com/user-attachments/assets/36e64d01-3da3-487e-b574-1d724d6731e4">
- [x] `integration-owner` - Has an integration owner
https://github.com/home-assistant/core/pull/125920#:~:text=core/homeassistant/components/cambridge_audio/manifest.json
- [x] `docs-installation-parameters` - The documentation describes all integration installation parameters
- [ ] `docs-configuration-parameters` - The documentation describes all integration configuration options
*No configuration parameters*

## Gold
- [x] `entity-translations` - Entities have translated names
https://github.com/home-assistant/core/blob/82e9792b4d44c653cfc38c495e8e6907d08878cd/homeassistant/components/cambridge_audio/strings.json#L26-L29
- [x] `entity-device-class` - Entities use device classes where possible
https://github.com/home-assistant/core/blob/b139af9a9c8ed581f18b25e7bc79c2df998583f7/homeassistant/components/cambridge_audio/media_player.py#L78
- [x] `devices` - The integration creates devices
https://github.com/home-assistant/core/blob/d2d3ab2d98efc00efb18ed93fda0f616f5148da9/homeassistant/components/cambridge_audio/entity.py#L35-L50
- [x] `entity-category` - Entities are assigned an appropriate EntityCategory
https://github.com/home-assistant/core/blob/82e9792b4d44c653cfc38c495e8e6907d08878cd/homeassistant/components/cambridge_audio/select.py#L31
- [ ] `entity-disabled-by-default` - Integration disables less popular (or noisy) entities
Not many entities, and none that update frequently enough to be considered noisy.
- [x] `discovery` - Can be discovered
https://github.com/home-assistant/core/blob/d2d3ab2d98efc00efb18ed93fda0f616f5148da9/homeassistant/components/cambridge_audio/config_flow.py#L25
- [ ] `stale-devices` - Clean up stale devices
One device per entry, no hub.
- [x] `diagnostics` - Implements diagnostics
https://github.com/home-assistant/core/pull/125920#:~:text=core/homeassistant/components/cambridge_audio/diagnostics.py
- [x] `exception-translations` - Exception messages are translatable
https://github.com/home-assistant/core/blob/a948c7d69d78e538b0119e378fb2e597a5d03bfc/homeassistant/components/cambridge_audio/media_player.py#L309-L313
- [x] `icon-translations` - Icon translations
https://github.com/home-assistant/core/blob/82e9792b4d44c653cfc38c495e8e6907d08878cd/homeassistant/components/cambridge_audio/icons.json#L2-L5
- [x] `reconfiguration-flow` - Integrations should have a reconfigure flow
https://github.com/home-assistant/core/blob/b139af9a9c8ed581f18b25e7bc79c2df998583f7/homeassistant/components/cambridge_audio/config_flow.py#L73
- [ ] `dynamic-devices` - Devices added after integration setup
*Not a hub*
- [x] `discovery-update-info` - Integration uses discovery info to update network information
https://github.com/home-assistant/core/blob/b139af9a9c8ed581f18b25e7bc79c2df998583f7/homeassistant/components/cambridge_audio/config_flow.py#L39
- [ ] `repair-issues` - Repair issues and repair flows are used when user intervention is needed
*No issues currently implemented*
- [x] `docs-use-cases` - The documentation describes use cases to illustrate how this integration can be used
- [x] `docs-supported-devices` - The documentation describes known supported / unsupported devices
- [x] `docs-supported-functions` - The documentation describes the supported functionality, including entities, and platforms
- [x] `docs-data-update` - The documentation describes how data is updated
- [x] `docs-known-limitations` - The documentation describes known limitations of the integration (not to be confused with bugs)
- [x] `docs-troubleshooting` - The documentation provides troubleshooting information
- [x] `docs-examples` - The documentation provides automation examples the user can use.

## Platinum
- [x] `async-dependency` - Dependency is async
https://github.com/noahhusby/aiostreammagic
- [x] `inject-websession` - The integration dependency supports passing in a websession
https://github.com/home-assistant/core/blob/b139af9a9c8ed581f18b25e7bc79c2df998583f7/homeassistant/components/cambridge_audio/__init__.py#L31
- [x] `strict-typing` - Strict typing
https://github.com/home-assistant/core/blob/c97b8326482632a1d572758a1abd959e6129b5cf/.strict-typing#L127


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
