### PR TITLE
Update demetriek to v1.0.0

### DIFF
--- a/homeassistant/components/lametric/diagnostics.py
+++ b/homeassistant/components/lametric/diagnostics.py
@@ -26,5 +26,5 @@ async def async_get_config_entry_diagnostics(
     """Return diagnostics for a config entry."""
     coordinator: LaMetricDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
     # Round-trip via JSON to trigger serialization
-    data = json.loads(coordinator.data.json())
+    data = json.loads(coordinator.data.to_json())
     return async_redact_data(data, TO_REDACT)

--- a/homeassistant/components/lametric/manifest.json
+++ b/homeassistant/components/lametric/manifest.json
@@ -13,7 +13,7 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "loggers": ["demetriek"],
-  "requirements": ["demetriek==0.4.0"],
+  "requirements": ["demetriek==1.0.0"],
   "ssdp": [
     {
       "deviceType": "urn:schemas-upnp-org:device:LaMetric:1"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -746,7 +746,7 @@ defusedxml==0.7.1
 deluge-client==1.10.2
 
 # homeassistant.components.lametric
-demetriek==0.4.0
+demetriek==1.0.0
 
 # homeassistant.components.denonavr
 denonavr==1.0.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -636,7 +636,7 @@ defusedxml==0.7.1
 deluge-client==1.10.2
 
 # homeassistant.components.lametric
-demetriek==0.4.0
+demetriek==1.0.0
 
 # homeassistant.components.denonavr
 denonavr==1.0.1

--- a/tests/components/lametric/conftest.py
+++ b/tests/components/lametric/conftest.py
@@ -6,7 +6,6 @@ from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from demetriek import CloudDevice, Device
-from pydantic import parse_raw_as  # pylint: disable=no-name-in-module
 import pytest
 
 from homeassistant.components.application_credentials import (
@@ -18,7 +17,7 @@ from homeassistant.const import CONF_API_KEY, CONF_HOST, CONF_MAC
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
-from tests.common import MockConfigEntry, load_fixture
+from tests.common import MockConfigEntry, load_fixture, load_json_array_fixture
 
 
 @pytest.fixture(autouse=True)
@@ -61,9 +60,10 @@ def mock_lametric_cloud() -> Generator[MagicMock]:
         "homeassistant.components.lametric.config_flow.LaMetricCloud", autospec=True
     ) as lametric_mock:
         lametric = lametric_mock.return_value
-        lametric.devices.return_value = parse_raw_as(
-            list[CloudDevice], load_fixture("cloud_devices.json", DOMAIN)
-        )
+        lametric.devices.return_value = [
+            CloudDevice.from_dict(cloud_device)
+            for cloud_device in load_json_array_fixture("cloud_devices.json", DOMAIN)
+        ]
         yield lametric
 
 
@@ -89,7 +89,7 @@ def mock_lametric(device_fixture: str) -> Generator[MagicMock]:
         lametric = lametric_mock.return_value
         lametric.api_key = "mock-api-key"
         lametric.host = "127.0.0.1"
-        lametric.device.return_value = Device.parse_raw(
+        lametric.device.return_value = Device.from_json(
             load_fixture(f"{device_fixture}.json", DOMAIN)
         )
         yield lametric

--- a/tests/components/lametric/snapshots/test_diagnostics.ambr
+++ b/tests/components/lametric/snapshots/test_diagnostics.ambr
@@ -26,6 +26,9 @@
       'brightness_mode': 'auto',
       'display_type': 'mixed',
       'height': 8,
+      'screensaver': dict({
+        'enabled': False,
+      }),
       'width': 37,
     }),
     'mode': 'auto',

--- a/tests/components/lametric/test_notify.py
+++ b/tests/components/lametric/test_notify.py
@@ -100,7 +100,7 @@ async def test_notification_options(
     assert len(notification.model.frames) == 1
     frame = notification.model.frames[0]
     assert type(frame) is Simple
-    assert frame.icon == 1234
+    assert frame.icon == "1234"
     assert frame.text == "The secret of getting ahead is getting started"
 
 

--- a/tests/components/lametric/test_services.py
+++ b/tests/components/lametric/test_services.py
@@ -190,7 +190,7 @@ async def test_service_message(
     assert len(notification.model.frames) == 1
     frame = notification.model.frames[0]
     assert type(frame) is Simple
-    assert frame.icon == 6916
+    assert frame.icon == "6916"
     assert frame.text == "Meow!"
 
     mock_lametric.notify.side_effect = LaMetricError


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Updates `demetriek` with the minimal effort/changes possible.
Release notes: https://github.com/frenck/python-demetriek/releases/tag/v1.0.0

More improvements are possible, but the goal of this PR is to bump the dependency while maintaining a working integration.

This should free up the upgrade of Pydantic for Home Assistant.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
