### PR TITLE
Change BMW reauth/reconfigure to only allow password

### DIFF
--- a/homeassistant/components/bmw_connected_drive/config_flow.py
+++ b/homeassistant/components/bmw_connected_drive/config_flow.py
@@ -53,6 +53,12 @@ DATA_SCHEMA = vol.Schema(
     },
     extra=vol.REMOVE_EXTRA,
 )
+RECONFIGURE_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_PASSWORD): str,
+    },
+    extra=vol.REMOVE_EXTRA,
+)
 CAPTCHA_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_CAPTCHA_TOKEN): str,
@@ -111,9 +117,8 @@ class BMWConfigFlow(ConfigFlow, domain=DOMAIN):
             unique_id = f"{user_input[CONF_REGION]}-{user_input[CONF_USERNAME]}"
             await self.async_set_unique_id(unique_id)
 
-            if self.source in {SOURCE_REAUTH, SOURCE_RECONFIGURE}:
-                self._abort_if_unique_id_mismatch(reason="account_mismatch")
-            else:
+            # Unique ID cannot change for reauth/reconfigure
+            if self.source not in {SOURCE_REAUTH, SOURCE_RECONFIGURE}:
                 self._abort_if_unique_id_configured()
 
             # Store user input for later use
@@ -166,19 +171,39 @@ class BMWConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(step_id="user", data_schema=schema, errors=errors)
 
+    async def async_step_change_password(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Show the change password step."""
+        existing_data = (
+            dict(self._existing_entry_data) if self._existing_entry_data else {}
+        )
+
+        if user_input is not None:
+            return await self.async_step_user(existing_data | user_input)
+
+        return self.async_show_form(
+            step_id="change_password",
+            data_schema=RECONFIGURE_SCHEMA,
+            description_placeholders={
+                CONF_USERNAME: existing_data[CONF_USERNAME],
+                CONF_REGION: existing_data[CONF_REGION],
+            },
+        )
+
     async def async_step_reauth(
         self, entry_data: Mapping[str, Any]
     ) -> ConfigFlowResult:
         """Handle configuration by re-auth."""
         self._existing_entry_data = entry_data
-        return await self.async_step_user()
+        return await self.async_step_change_password()
 
     async def async_step_reconfigure(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle a reconfiguration flow initialized by the user."""
         self._existing_entry_data = self._get_reconfigure_entry().data
-        return await self.async_step_user()
+        return await self.async_step_change_password()
 
     async def async_step_captcha(
         self, user_input: dict[str, Any] | None = None

--- a/homeassistant/components/bmw_connected_drive/strings.json
+++ b/homeassistant/components/bmw_connected_drive/strings.json
@@ -20,7 +20,7 @@
         }
       },
       "change_password": {
-        "description": "Update your MyBMW/MINI Connected password for account `{username}` in  region `{region}`.",
+        "description": "Update your MyBMW/MINI Connected password for account `{username}` in region `{region}`.",
         "data": {
           "password": "[%key:common::config_flow::data::password%]"
         }

--- a/homeassistant/components/bmw_connected_drive/strings.json
+++ b/homeassistant/components/bmw_connected_drive/strings.json
@@ -2,6 +2,7 @@
   "config": {
     "step": {
       "user": {
+        "description": "Enter your MyBMW/MINI Connected credentials.",
         "data": {
           "username": "[%key:common::config_flow::data::username%]",
           "password": "[%key:common::config_flow::data::password%]",
@@ -17,6 +18,12 @@
         "data_description": {
           "captcha_token": "One-time token retrieved from the captcha challenge."
         }
+      },
+      "change_password": {
+        "description": "Update your MyBMW/MINI Connected password for account `{username}` in  region `{region}`.",
+        "data": {
+          "password": "[%key:common::config_flow::data::password%]"
+        }
       }
     },
     "error": {
@@ -27,8 +34,7 @@
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
-      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]",
-      "account_mismatch": "Username and region are not allowed to change"
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
     }
   },
   "options": {


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds a new step for reauth/reconfigure that only allows changing the password. Username and region are part of the config entry unique id and weren't allowed to be changed beforehand either (there by aborting the config flow).
Now, the user cannot change an existing entry (as the account does actually exist).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
