### PR TITLE
Migrate elgato lights to use Kelvin

### DIFF
--- a/homeassistant/components/elgato/light.py
+++ b/homeassistant/components/elgato/light.py
@@ -8,7 +8,7 @@ from elgato import ElgatoError
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
-    ATTR_COLOR_TEMP,
+    ATTR_COLOR_TEMP_KELVIN,
     ATTR_HS_COLOR,
     ColorMode,
     LightEntity,
@@ -19,6 +19,7 @@ from homeassistant.helpers.entity_platform import (
     AddEntitiesCallback,
     async_get_current_platform,
 )
+from homeassistant.util import color as color_util
 
 from . import ElgatorConfigEntry
 from .const import SERVICE_IDENTIFY
@@ -49,8 +50,8 @@ class ElgatoLight(ElgatoEntity, LightEntity):
     """Defines an Elgato Light."""
 
     _attr_name = None
-    _attr_min_mireds = 143
-    _attr_max_mireds = 344
+    _attr_min_color_temp_kelvin = 2900  # 344 Mireds
+    _attr_max_color_temp_kelvin = 7000  # 143 Mireds
 
     def __init__(self, coordinator: ElgatoDataUpdateCoordinator) -> None:
         """Initialize Elgato Light."""
@@ -69,8 +70,8 @@ class ElgatoLight(ElgatoEntity, LightEntity):
             or self.coordinator.data.state.hue is not None
         ):
             self._attr_supported_color_modes = {ColorMode.COLOR_TEMP, ColorMode.HS}
-            self._attr_min_mireds = 153
-            self._attr_max_mireds = 285
+            self._attr_min_color_temp_kelvin = 3500  # 285 Mireds
+            self._attr_max_color_temp_kelvin = 6500  # 153 Mireds
 
     @property
     def brightness(self) -> int | None:
@@ -78,9 +79,11 @@ class ElgatoLight(ElgatoEntity, LightEntity):
         return round((self.coordinator.data.state.brightness * 255) / 100)
 
     @property
-    def color_temp(self) -> int | None:
-        """Return the CT color value in mireds."""
-        return self.coordinator.data.state.temperature
+    def color_temp_kelvin(self) -> int | None:
+        """Return the color temperature value in Kelvin."""
+        if (mired_temperature := self.coordinator.data.state.temperature) is None:
+            return None
+        return color_util.color_temperature_mired_to_kelvin(mired_temperature)
 
     @property
     def color_mode(self) -> str | None:
@@ -116,7 +119,7 @@ class ElgatoLight(ElgatoEntity, LightEntity):
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the light."""
-        temperature = kwargs.get(ATTR_COLOR_TEMP)
+        temperature_kelvin = kwargs.get(ATTR_COLOR_TEMP_KELVIN)
 
         hue = None
         saturation = None
@@ -133,12 +136,18 @@ class ElgatoLight(ElgatoEntity, LightEntity):
         if (
             brightness
             and ATTR_HS_COLOR not in kwargs
-            and ATTR_COLOR_TEMP not in kwargs
+            and ATTR_COLOR_TEMP_KELVIN not in kwargs
             and self.supported_color_modes
             and ColorMode.HS in self.supported_color_modes
             and self.color_mode == ColorMode.COLOR_TEMP
         ):
-            temperature = self.color_temp
+            temperature_kelvin = self.color_temp_kelvin
+
+        temperature = (
+            None
+            if temperature_kelvin is None
+            else color_util.color_temperature_kelvin_to_mired(temperature_kelvin)
+        )
 
         try:
             await self.coordinator.client.light(

--- a/tests/components/elgato/snapshots/test_light.ambr
+++ b/tests/components/elgato/snapshots/test_light.ambr
@@ -11,10 +11,10 @@
         27.316,
         47.743,
       ),
-      'max_color_temp_kelvin': 6993,
+      'max_color_temp_kelvin': 7000,
       'max_mireds': 344,
-      'min_color_temp_kelvin': 2906,
-      'min_mireds': 143,
+      'min_color_temp_kelvin': 2900,
+      'min_mireds': 142,
       'rgb_color': tuple(
         255,
         189,
@@ -43,10 +43,10 @@
     }),
     'area_id': None,
     'capabilities': dict({
-      'max_color_temp_kelvin': 6993,
+      'max_color_temp_kelvin': 7000,
       'max_mireds': 344,
-      'min_color_temp_kelvin': 2906,
-      'min_mireds': 143,
+      'min_color_temp_kelvin': 2900,
+      'min_mireds': 142,
       'supported_color_modes': list([
         <ColorMode.COLOR_TEMP: 'color_temp'>,
       ]),
@@ -126,9 +126,9 @@
         27.316,
         47.743,
       ),
-      'max_color_temp_kelvin': 6535,
+      'max_color_temp_kelvin': 6500,
       'max_mireds': 285,
-      'min_color_temp_kelvin': 3508,
+      'min_color_temp_kelvin': 3500,
       'min_mireds': 153,
       'rgb_color': tuple(
         255,
@@ -159,9 +159,9 @@
     }),
     'area_id': None,
     'capabilities': dict({
-      'max_color_temp_kelvin': 6535,
+      'max_color_temp_kelvin': 6500,
       'max_mireds': 285,
-      'min_color_temp_kelvin': 3508,
+      'min_color_temp_kelvin': 3500,
       'min_mireds': 153,
       'supported_color_modes': list([
         <ColorMode.COLOR_TEMP: 'color_temp'>,
@@ -243,9 +243,9 @@
         358.0,
         6.0,
       ),
-      'max_color_temp_kelvin': 6535,
+      'max_color_temp_kelvin': 6500,
       'max_mireds': 285,
-      'min_color_temp_kelvin': 3508,
+      'min_color_temp_kelvin': 3500,
       'min_mireds': 153,
       'rgb_color': tuple(
         255,
@@ -276,9 +276,9 @@
     }),
     'area_id': None,
     'capabilities': dict({
-      'max_color_temp_kelvin': 6535,
+      'max_color_temp_kelvin': 6500,
       'max_mireds': 285,
-      'min_color_temp_kelvin': 3508,
+      'min_color_temp_kelvin': 3500,
       'min_mireds': 153,
       'supported_color_modes': list([
         <ColorMode.COLOR_TEMP: 'color_temp'>,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Based on #79591, needed for #132680 and #132723

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
