### PR TITLE
Migrate homekit_controller lights to use Kelvin

### DIFF
--- a/homeassistant/components/homekit_controller/light.py
+++ b/homeassistant/components/homekit_controller/light.py
@@ -10,7 +10,7 @@ from propcache import cached_property
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
-    ATTR_COLOR_TEMP,
+    ATTR_COLOR_TEMP_KELVIN,
     ATTR_HS_COLOR,
     ColorMode,
     LightEntity,
@@ -57,7 +57,12 @@ class HomeKitLight(HomeKitEntity, LightEntity):
     def _async_reconfigure(self) -> None:
         """Reconfigure entity."""
         self._async_clear_property_cache(
-            ("supported_features", "min_mireds", "max_mireds", "supported_color_modes")
+            (
+                "supported_features",
+                "min_color_temp_kelvin",
+                "max_color_temp_kelvin",
+                "supported_color_modes",
+            )
         )
         super()._async_reconfigure()
 
@@ -90,25 +95,35 @@ class HomeKitLight(HomeKitEntity, LightEntity):
         )
 
     @cached_property
-    def min_mireds(self) -> int:
-        """Return minimum supported color temperature."""
+    def max_color_temp_kelvin(self) -> int:
+        """Return the coldest color_temp_kelvin that this light supports."""
         if not self.service.has(CharacteristicsTypes.COLOR_TEMPERATURE):
-            return super().min_mireds
-        min_value = self.service[CharacteristicsTypes.COLOR_TEMPERATURE].minValue
-        return int(min_value) if min_value else super().min_mireds
+            return super().max_color_temp_kelvin
+        min_value_mireds = self.service[CharacteristicsTypes.COLOR_TEMPERATURE].minValue
+        return (
+            color_util.color_temperature_mired_to_kelvin(min_value_mireds)
+            if min_value_mireds
+            else super().max_color_temp_kelvin
+        )
 
     @cached_property
-    def max_mireds(self) -> int:
-        """Return the maximum color temperature."""
+    def min_color_temp_kelvin(self) -> int:
+        """Return the warmest color_temp_kelvin that this light supports."""
         if not self.service.has(CharacteristicsTypes.COLOR_TEMPERATURE):
-            return super().max_mireds
-        max_value = self.service[CharacteristicsTypes.COLOR_TEMPERATURE].maxValue
-        return int(max_value) if max_value else super().max_mireds
+            return super().min_color_temp_kelvin
+        max_value_mireds = self.service[CharacteristicsTypes.COLOR_TEMPERATURE].maxValue
+        return (
+            color_util.color_temperature_mired_to_kelvin(max_value_mireds)
+            if max_value_mireds
+            else super().min_color_temp_kelvin
+        )
 
     @property
-    def color_temp(self) -> int:
-        """Return the color temperature."""
-        return self.service.value(CharacteristicsTypes.COLOR_TEMPERATURE)
+    def color_temp_kelvin(self) -> int:
+        """Return the color temperature value in Kelvin."""
+        return color_util.color_temperature_mired_to_kelvin(
+            self.service.value(CharacteristicsTypes.COLOR_TEMPERATURE)
+        )
 
     @property
     def color_mode(self) -> str:
@@ -153,7 +168,7 @@ class HomeKitLight(HomeKitEntity, LightEntity):
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the specified light on."""
         hs_color = kwargs.get(ATTR_HS_COLOR)
-        temperature = kwargs.get(ATTR_COLOR_TEMP)
+        temperature_kelvin = kwargs.get(ATTR_COLOR_TEMP_KELVIN)
         brightness = kwargs.get(ATTR_BRIGHTNESS)
 
         characteristics: dict[str, Any] = {}
@@ -167,19 +182,18 @@ class HomeKitLight(HomeKitEntity, LightEntity):
         # does not support both, temperature will win. This is not
         # expected to happen in the UI, but it is possible via a manual
         # service call.
-        if temperature is not None:
+        if temperature_kelvin is not None:
             if self.service.has(CharacteristicsTypes.COLOR_TEMPERATURE):
-                characteristics[CharacteristicsTypes.COLOR_TEMPERATURE] = int(
-                    temperature
+                characteristics[CharacteristicsTypes.COLOR_TEMPERATURE] = (
+                    color_util.color_temperature_kelvin_to_mired(temperature_kelvin)
                 )
+
             elif hs_color is None:
                 # Some HomeKit devices implement color temperature with HS
                 # since the spec "technically" does not permit the COLOR_TEMPERATURE
                 # characteristic and the HUE and SATURATION characteristics to be
                 # present at the same time.
-                hue_sat = color_util.color_temperature_to_hs(
-                    color_util.color_temperature_mired_to_kelvin(temperature)
-                )
+                hue_sat = color_util.color_temperature_to_hs(temperature_kelvin)
                 characteristics[CharacteristicsTypes.HUE] = hue_sat[0]
                 characteristics[CharacteristicsTypes.SATURATION] = hue_sat[1]
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Based on #79591, needed for #132680 and #132723

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
