### PR TITLE
Migrate homematic lights to use Kelvin

### DIFF
--- a/homeassistant/components/homematic/light.py
+++ b/homeassistant/components/homematic/light.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
-    ATTR_COLOR_TEMP,
+    ATTR_COLOR_TEMP_KELVIN,
     ATTR_EFFECT,
     ATTR_HS_COLOR,
     ATTR_TRANSITION,
@@ -17,9 +17,13 @@ from homeassistant.components.light import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.util import color as color_util
 
 from .const import ATTR_DISCOVER_DEVICES
 from .entity import HMDevice
+
+MAX_MIREDS = 500  # 2000 K
+MIN_MIREDS = 153  # 6500 K
 
 
 def setup_platform(
@@ -42,6 +46,9 @@ def setup_platform(
 
 class HMLight(HMDevice, LightEntity):
     """Representation of a Homematic light."""
+
+    _attr_min_color_temp_kelvin = 2000  # 500 Mireds
+    _attr_max_color_temp_kelvin = 6500  # 153 Mireds
 
     @property
     def brightness(self):
@@ -99,12 +106,14 @@ class HMLight(HMDevice, LightEntity):
         return hue * 360.0, sat * 100.0
 
     @property
-    def color_temp(self):
-        """Return the color temp in mireds [int]."""
+    def color_temp_kelvin(self) -> int | None:
+        """Return the color temperature value in Kelvin."""
         if ColorMode.COLOR_TEMP not in self.supported_color_modes:
             return None
         hm_color_temp = self._hmdevice.get_color_temp(self._channel)
-        return self.max_mireds - (self.max_mireds - self.min_mireds) * hm_color_temp
+        return color_util.color_temperature_mired_to_kelvin(
+            MAX_MIREDS - (MAX_MIREDS - MIN_MIREDS) * hm_color_temp
+        )
 
     @property
     def effect_list(self):
@@ -130,7 +139,7 @@ class HMLight(HMDevice, LightEntity):
             self._hmdevice.set_level(percent_bright, self._channel)
         elif (
             ATTR_HS_COLOR not in kwargs
-            and ATTR_COLOR_TEMP not in kwargs
+            and ATTR_COLOR_TEMP_KELVIN not in kwargs
             and ATTR_EFFECT not in kwargs
         ):
             self._hmdevice.on(self._channel)
@@ -141,10 +150,11 @@ class HMLight(HMDevice, LightEntity):
                 saturation=kwargs[ATTR_HS_COLOR][1] / 100.0,
                 channel=self._channel,
             )
-        if ATTR_COLOR_TEMP in kwargs:
-            hm_temp = (self.max_mireds - kwargs[ATTR_COLOR_TEMP]) / (
-                self.max_mireds - self.min_mireds
+        if ATTR_COLOR_TEMP_KELVIN in kwargs:
+            mireds = color_util.color_temperature_kelvin_to_mired(
+                kwargs[ATTR_COLOR_TEMP_KELVIN]
             )
+            hm_temp = (MAX_MIREDS - mireds) / (MAX_MIREDS - MIN_MIREDS)
             self._hmdevice.set_color_temp(hm_temp)
         if ATTR_EFFECT in kwargs:
             self._hmdevice.set_effect(kwargs[ATTR_EFFECT])


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Based on #79591, needed for #132680 and #132723

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
