### PR TITLE
Migrate tradfri lights to use Kelvin

### DIFF
--- a/homeassistant/components/tradfri/light.py
+++ b/homeassistant/components/tradfri/light.py
@@ -9,7 +9,7 @@ from pytradfri.command import Command
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
-    ATTR_COLOR_TEMP,
+    ATTR_COLOR_TEMP_KELVIN,
     ATTR_HS_COLOR,
     ATTR_TRANSITION,
     ColorMode,
@@ -87,8 +87,16 @@ class TradfriLight(TradfriBaseEntity, LightEntity):
             self._fixed_color_mode = next(iter(self._attr_supported_color_modes))
 
         if self._device_control:
-            self._attr_min_mireds = self._device_control.min_mireds
-            self._attr_max_mireds = self._device_control.max_mireds
+            self._attr_max_color_temp_kelvin = (
+                color_util.color_temperature_mired_to_kelvin(
+                    self._device_control.min_mireds
+                )
+            )
+            self._attr_min_color_temp_kelvin = (
+                color_util.color_temperature_mired_to_kelvin(
+                    self._device_control.max_mireds
+                )
+            )
 
     def _refresh(self) -> None:
         """Refresh the device."""
@@ -118,11 +126,11 @@ class TradfriLight(TradfriBaseEntity, LightEntity):
         return cast(int, self._device_data.dimmer)
 
     @property
-    def color_temp(self) -> int | None:
-        """Return the color temp value in mireds."""
-        if not self._device_data:
+    def color_temp_kelvin(self) -> int | None:
+        """Return the color temperature value in Kelvin."""
+        if not self._device_data or not (color_temp := self._device_data.color_temp):
             return None
-        return cast(int, self._device_data.color_temp)
+        return color_util.color_temperature_mired_to_kelvin(color_temp)
 
     @property
     def hs_color(self) -> tuple[float, float] | None:
@@ -191,18 +199,19 @@ class TradfriLight(TradfriBaseEntity, LightEntity):
             transition_time = None
 
         temp_command = None
-        if ATTR_COLOR_TEMP in kwargs and (
+        if ATTR_COLOR_TEMP_KELVIN in kwargs and (
             self._device_control.can_set_temp or self._device_control.can_set_color
         ):
-            temp = kwargs[ATTR_COLOR_TEMP]
+            temp_k = kwargs[ATTR_COLOR_TEMP_KELVIN]
             # White Spectrum bulb
             if self._device_control.can_set_temp:
-                if temp > self.max_mireds:
-                    temp = self.max_mireds
-                elif temp < self.min_mireds:
-                    temp = self.min_mireds
+                temp = color_util.color_temperature_kelvin_to_mired(temp_k)
+                if temp < (min_mireds := self._device_control.min_mireds):
+                    temp = min_mireds
+                elif temp > (max_mireds := self._device_control.max_mireds):
+                    temp = max_mireds
                 temp_data = {
-                    ATTR_COLOR_TEMP: temp,
+                    "color_temp": temp,
                     "transition_time": transition_time,
                 }
                 temp_command = self._device_control.set_color_temp(**temp_data)
@@ -210,7 +219,6 @@ class TradfriLight(TradfriBaseEntity, LightEntity):
             # Color bulb (CWS)
             # color_temp needs to be set with hue/saturation
             elif self._device_control.can_set_color:
-                temp_k = color_util.color_temperature_mired_to_kelvin(temp)
                 hs_color = color_util.color_temperature_to_hs(temp_k)
                 hue = int(hs_color[0] * (self._device_control.max_hue / 360))
                 sat = int(hs_color[1] * (self._device_control.max_saturation / 100))


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Based on #79591, needed for #132680 and #132723

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
