### PR TITLE
Migrate vesync lights to use Kelvin

### DIFF
--- a/homeassistant/components/vesync/light.py
+++ b/homeassistant/components/vesync/light.py
@@ -20,7 +20,7 @@ from .entity import VeSyncDevice
 
 _LOGGER = logging.getLogger(__name__)
 MAX_MIREDS = 370  # 1,000,000 divided by 2700 Kelvin = 370 Mireds
-MIN_MIREDS = 154  # 1,000,000 divided by 6500 Kelvin = 154 Mireds
+MIN_MIREDS = 153  # 1,000,000 divided by 6500 Kelvin = 153 Mireds
 
 
 async def async_setup_entry(
@@ -143,7 +143,7 @@ class VeSyncTunableWhiteLightHA(VeSyncBaseLight, LightEntity):
 
     _attr_color_mode = ColorMode.COLOR_TEMP
     _attr_min_color_temp_kelvin = 2700  # 370 Mireds
-    _attr_max_color_temp_kelvin = 6500  # 154 Mireds
+    _attr_max_color_temp_kelvin = 6500  # 153 Mireds
     _attr_supported_color_modes = {ColorMode.COLOR_TEMP}
 
     @property

--- a/homeassistant/components/vesync/light.py
+++ b/homeassistant/components/vesync/light.py
@@ -5,7 +5,7 @@ from typing import Any
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
-    ATTR_COLOR_TEMP,
+    ATTR_COLOR_TEMP_KELVIN,
     ColorMode,
     LightEntity,
 )
@@ -13,11 +13,14 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.util import color as color_util
 
 from .const import DEV_TYPE_TO_HA, DOMAIN, VS_DISCOVERY, VS_LIGHTS
 from .entity import VeSyncDevice
 
 _LOGGER = logging.getLogger(__name__)
+MAX_MIREDS = 370  # 1,000,000 divided by 2700 Kelvin = 370 Mireds
+MIN_MIREDS = 154  # 1,000,000 divided by 6500 Kelvin = 154 Mireds
 
 
 async def async_setup_entry(
@@ -84,15 +87,16 @@ class VeSyncBaseLight(VeSyncDevice, LightEntity):
         """Turn the device on."""
         attribute_adjustment_only = False
         # set white temperature
-        if self.color_mode == ColorMode.COLOR_TEMP and ATTR_COLOR_TEMP in kwargs:
+        if self.color_mode == ColorMode.COLOR_TEMP and ATTR_COLOR_TEMP_KELVIN in kwargs:
             # get white temperature from HA data
-            color_temp = int(kwargs[ATTR_COLOR_TEMP])
+            color_temp = color_util.color_temperature_kelvin_to_mired(
+                kwargs[ATTR_COLOR_TEMP_KELVIN]
+            )
             # ensure value between min-max supported Mireds
-            color_temp = max(self.min_mireds, min(color_temp, self.max_mireds))
+            color_temp = max(MIN_MIREDS, min(color_temp, MAX_MIREDS))
             # convert Mireds to Percent value that api expects
             color_temp = round(
-                ((color_temp - self.min_mireds) / (self.max_mireds - self.min_mireds))
-                * 100
+                ((color_temp - MIN_MIREDS) / (MAX_MIREDS - MIN_MIREDS)) * 100
             )
             # flip cold/warm to what pyvesync api expects
             color_temp = 100 - color_temp
@@ -138,13 +142,13 @@ class VeSyncTunableWhiteLightHA(VeSyncBaseLight, LightEntity):
     """Representation of a VeSync Tunable White Light device."""
 
     _attr_color_mode = ColorMode.COLOR_TEMP
-    _attr_max_mireds = 370  # 1,000,000 divided by 2700 Kelvin = 370 Mireds
-    _attr_min_mireds = 154  # 1,000,000 divided by 6500 Kelvin = 154 Mireds
+    _attr_min_color_temp_kelvin = 2700  # 370 Mireds
+    _attr_max_color_temp_kelvin = 6500  # 154 Mireds
     _attr_supported_color_modes = {ColorMode.COLOR_TEMP}
 
     @property
-    def color_temp(self) -> int:
-        """Get device white temperature."""
+    def color_temp_kelvin(self) -> int | None:
+        """Return the color temperature value in Kelvin."""
         # get value from pyvesync library api,
         result = self.device.color_temp_pct
         try:
@@ -159,15 +163,16 @@ class VeSyncTunableWhiteLightHA(VeSyncBaseLight, LightEntity):
                 ),
                 result,
             )
-            return 0
+            return None
         # flip cold/warm
         color_temp_value = 100 - color_temp_value
         # ensure value between 0-100
         color_temp_value = max(0, min(color_temp_value, 100))
         # convert percent value to Mireds
         color_temp_value = round(
-            self.min_mireds
-            + ((self.max_mireds - self.min_mireds) / 100 * color_temp_value)
+            MIN_MIREDS + ((MAX_MIREDS - MIN_MIREDS) / 100 * color_temp_value)
         )
         # ensure value between minimum and maximum Mireds
-        return max(self.min_mireds, min(color_temp_value, self.max_mireds))
+        return color_util.color_temperature_mired_to_kelvin(
+            max(MIN_MIREDS, min(color_temp_value, MAX_MIREDS))
+        )

--- a/tests/components/vesync/snapshots/test_light.ambr
+++ b/tests/components/vesync/snapshots/test_light.ambr
@@ -428,10 +428,10 @@
       }),
       'area_id': None,
       'capabilities': dict({
-        'max_color_temp_kelvin': 6493,
+        'max_color_temp_kelvin': 6500,
         'max_mireds': 370,
-        'min_color_temp_kelvin': 2702,
-        'min_mireds': 154,
+        'min_color_temp_kelvin': 2700,
+        'min_mireds': 153,
         'supported_color_modes': list([
           <ColorMode.COLOR_TEMP: 'color_temp'>,
         ]),
@@ -473,10 +473,10 @@
       'color_temp_kelvin': None,
       'friendly_name': 'Temperature Light',
       'hs_color': None,
-      'max_color_temp_kelvin': 6493,
+      'max_color_temp_kelvin': 6500,
       'max_mireds': 370,
-      'min_color_temp_kelvin': 2702,
-      'min_mireds': 154,
+      'min_color_temp_kelvin': 2700,
+      'min_mireds': 153,
       'rgb_color': None,
       'supported_color_modes': list([
         <ColorMode.COLOR_TEMP: 'color_temp'>,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Based on #79591, needed for #132680 and #132723

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
