### PR TITLE
Migrate yeelight lights to use Kelvin

### DIFF
--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -16,7 +16,7 @@ from yeelight.main import BulbException
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
-    ATTR_COLOR_TEMP,
+    ATTR_COLOR_TEMP_KELVIN,
     ATTR_EFFECT,
     ATTR_FLASH,
     ATTR_HS_COLOR,
@@ -39,10 +39,6 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.typing import VolDictType
 import homeassistant.util.color as color_util
-from homeassistant.util.color import (
-    color_temperature_kelvin_to_mired as kelvin_to_mired,
-    color_temperature_mired_to_kelvin as mired_to_kelvin,
-)
 
 from . import YEELIGHT_FLOW_TRANSITION_SCHEMA
 from .const import (
@@ -440,8 +436,8 @@ class YeelightBaseLight(YeelightEntity, LightEntity):
         self._effect = None
 
         model_specs = self._bulb.get_model_specs()
-        self._attr_min_mireds = kelvin_to_mired(model_specs["color_temp"]["max"])
-        self._attr_max_mireds = kelvin_to_mired(model_specs["color_temp"]["min"])
+        self._attr_max_color_temp_kelvin = model_specs["color_temp"]["max"]
+        self._attr_min_color_temp_kelvin = model_specs["color_temp"]["min"]
 
         self._light_type = LightType.Main
 
@@ -476,10 +472,10 @@ class YeelightBaseLight(YeelightEntity, LightEntity):
         return self._predefined_effects + self.custom_effects_names
 
     @property
-    def color_temp(self) -> int | None:
-        """Return the color temperature."""
+    def color_temp_kelvin(self) -> int | None:
+        """Return the color temperature value in Kelvin."""
         if temp_in_k := self._get_property("ct"):
-            self._color_temp = kelvin_to_mired(int(temp_in_k))
+            self._color_temp = int(temp_in_k)
         return self._color_temp
 
     @property
@@ -678,20 +674,19 @@ class YeelightBaseLight(YeelightEntity, LightEntity):
         )
 
     @_async_cmd
-    async def async_set_colortemp(self, colortemp, duration) -> None:
+    async def async_set_colortemp(self, temp_in_k, duration) -> None:
         """Set bulb's color temperature."""
         if (
-            not colortemp
+            not temp_in_k
             or not self.supported_color_modes
             or ColorMode.COLOR_TEMP not in self.supported_color_modes
         ):
             return
-        temp_in_k = mired_to_kelvin(colortemp)
 
         if (
             not self.device.is_color_flow_enabled
             and self.color_mode == ColorMode.COLOR_TEMP
-            and self.color_temp == colortemp
+            and self.color_temp_kelvin == temp_in_k
         ):
             _LOGGER.debug("Color temp already set to: %s", temp_in_k)
             # Already set, and since we get pushed updates
@@ -779,7 +774,7 @@ class YeelightBaseLight(YeelightEntity, LightEntity):
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the bulb on."""
         brightness = kwargs.get(ATTR_BRIGHTNESS)
-        colortemp = kwargs.get(ATTR_COLOR_TEMP)
+        colortemp = kwargs.get(ATTR_COLOR_TEMP_KELVIN)
         hs_color = kwargs.get(ATTR_HS_COLOR)
         rgb = kwargs.get(ATTR_RGB_COLOR)
         flash = kwargs.get(ATTR_FLASH)
@@ -933,12 +928,12 @@ class YeelightWithoutNightlightSwitchMixIn(YeelightBaseLight):
         return super()._brightness_property
 
     @property
-    def color_temp(self) -> int | None:
-        """Return the color temperature."""
+    def color_temp_kelvin(self) -> int | None:
+        """Return the color temperature value in Kelvin."""
         if self.device.is_nightlight_enabled:
             # Enabling the nightlight locks the colortemp to max
-            return self.max_mireds
-        return super().color_temp
+            return self.min_color_temp_kelvin
+        return super().color_temp_kelvin
 
 
 class YeelightColorLightWithoutNightlightSwitch(
@@ -1081,8 +1076,8 @@ class YeelightAmbientLight(YeelightColorLightWithoutNightlightSwitch):
     def __init__(self, *args, **kwargs):
         """Initialize the Yeelight Ambient light."""
         super().__init__(*args, **kwargs)
-        self._attr_min_mireds = kelvin_to_mired(6500)
-        self._attr_max_mireds = kelvin_to_mired(1700)
+        self._attr_max_color_temp_kelvin = 6500
+        self._attr_min_color_temp_kelvin = 1700
 
         self._light_type = LightType.Ambient
 

--- a/tests/components/yeelight/test_light.py
+++ b/tests/components/yeelight/test_light.py
@@ -35,6 +35,7 @@ from homeassistant.components.light import (
     FLASH_SHORT,
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
+    ColorMode,
     LightEntityFeature,
 )
 from homeassistant.components.yeelight.const import (
@@ -931,9 +932,7 @@ async def test_device_types(
             "effect": None,
             "supported_features": SUPPORT_YEELIGHT,
             "min_color_temp_kelvin": model_specs["color_temp"]["min"],
-            "max_color_temp_kelvin": color_temperature_mired_to_kelvin(
-                color_temperature_kelvin_to_mired(model_specs["color_temp"]["max"])
-            ),
+            "max_color_temp_kelvin": model_specs["color_temp"]["max"],
             "min_mireds": color_temperature_kelvin_to_mired(
                 model_specs["color_temp"]["max"]
             ),
@@ -962,9 +961,7 @@ async def test_device_types(
             "rgb_color": (255, 121, 0),
             "xy_color": (0.62, 0.368),
             "min_color_temp_kelvin": model_specs["color_temp"]["min"],
-            "max_color_temp_kelvin": color_temperature_mired_to_kelvin(
-                color_temperature_kelvin_to_mired(model_specs["color_temp"]["max"])
-            ),
+            "max_color_temp_kelvin": model_specs["color_temp"]["max"],
             "min_mireds": color_temperature_kelvin_to_mired(
                 model_specs["color_temp"]["max"]
             ),
@@ -992,9 +989,7 @@ async def test_device_types(
             "effect": None,
             "supported_features": SUPPORT_YEELIGHT,
             "min_color_temp_kelvin": model_specs["color_temp"]["min"],
-            "max_color_temp_kelvin": color_temperature_mired_to_kelvin(
-                color_temperature_kelvin_to_mired(model_specs["color_temp"]["max"])
-            ),
+            "max_color_temp_kelvin": model_specs["color_temp"]["max"],
             "min_mireds": color_temperature_kelvin_to_mired(
                 model_specs["color_temp"]["max"]
             ),
@@ -1028,9 +1023,7 @@ async def test_device_types(
             "effect": None,
             "supported_features": SUPPORT_YEELIGHT,
             "min_color_temp_kelvin": model_specs["color_temp"]["min"],
-            "max_color_temp_kelvin": color_temperature_mired_to_kelvin(
-                color_temperature_kelvin_to_mired(model_specs["color_temp"]["max"])
-            ),
+            "max_color_temp_kelvin": model_specs["color_temp"]["max"],
             "min_mireds": color_temperature_kelvin_to_mired(
                 model_specs["color_temp"]["max"]
             ),
@@ -1065,9 +1058,7 @@ async def test_device_types(
             "effect": None,
             "supported_features": SUPPORT_YEELIGHT,
             "min_color_temp_kelvin": model_specs["color_temp"]["min"],
-            "max_color_temp_kelvin": color_temperature_mired_to_kelvin(
-                color_temperature_kelvin_to_mired(model_specs["color_temp"]["max"])
-            ),
+            "max_color_temp_kelvin": model_specs["color_temp"]["max"],
             "min_mireds": color_temperature_kelvin_to_mired(
                 model_specs["color_temp"]["max"]
             ),
@@ -1102,9 +1093,7 @@ async def test_device_types(
             "effect": None,
             "supported_features": SUPPORT_YEELIGHT,
             "min_color_temp_kelvin": model_specs["color_temp"]["min"],
-            "max_color_temp_kelvin": color_temperature_mired_to_kelvin(
-                color_temperature_kelvin_to_mired(model_specs["color_temp"]["max"])
-            ),
+            "max_color_temp_kelvin": model_specs["color_temp"]["max"],
             "min_mireds": color_temperature_kelvin_to_mired(
                 model_specs["color_temp"]["max"]
             ),
@@ -1138,9 +1127,7 @@ async def test_device_types(
             "effect": None,
             "supported_features": SUPPORT_YEELIGHT,
             "min_color_temp_kelvin": model_specs["color_temp"]["min"],
-            "max_color_temp_kelvin": color_temperature_mired_to_kelvin(
-                color_temperature_kelvin_to_mired(model_specs["color_temp"]["max"])
-            ),
+            "max_color_temp_kelvin": model_specs["color_temp"]["max"],
             "min_mireds": color_temperature_kelvin_to_mired(
                 model_specs["color_temp"]["max"]
             ),
@@ -1173,12 +1160,8 @@ async def test_device_types(
             "effect_list": YEELIGHT_TEMP_ONLY_EFFECT_LIST,
             "effect": None,
             "supported_features": SUPPORT_YEELIGHT,
-            "min_color_temp_kelvin": color_temperature_mired_to_kelvin(
-                color_temperature_kelvin_to_mired(model_specs["color_temp"]["min"])
-            ),
-            "max_color_temp_kelvin": color_temperature_mired_to_kelvin(
-                color_temperature_kelvin_to_mired(model_specs["color_temp"]["max"])
-            ),
+            "min_color_temp_kelvin": model_specs["color_temp"]["min"],
+            "max_color_temp_kelvin": model_specs["color_temp"]["max"],
             "min_mireds": color_temperature_kelvin_to_mired(
                 model_specs["color_temp"]["max"]
             ),
@@ -1204,12 +1187,8 @@ async def test_device_types(
             "effect_list": YEELIGHT_TEMP_ONLY_EFFECT_LIST,
             "effect": None,
             "supported_features": SUPPORT_YEELIGHT,
-            "min_color_temp_kelvin": color_temperature_mired_to_kelvin(
-                color_temperature_kelvin_to_mired(model_specs["color_temp"]["min"])
-            ),
-            "max_color_temp_kelvin": color_temperature_mired_to_kelvin(
-                color_temperature_kelvin_to_mired(model_specs["color_temp"]["max"])
-            ),
+            "min_color_temp_kelvin": model_specs["color_temp"]["min"],
+            "max_color_temp_kelvin": model_specs["color_temp"]["max"],
             "min_mireds": color_temperature_kelvin_to_mired(
                 model_specs["color_temp"]["max"]
             ),
@@ -1217,17 +1196,15 @@ async def test_device_types(
                 model_specs["color_temp"]["min"]
             ),
             "brightness": nl_br,
-            "color_temp_kelvin": color_temperature_mired_to_kelvin(
-                color_temperature_kelvin_to_mired(model_specs["color_temp"]["min"])
-            ),
+            "color_temp_kelvin": model_specs["color_temp"]["min"],
             "color_temp": color_temperature_kelvin_to_mired(
                 model_specs["color_temp"]["min"]
             ),
             "color_mode": "color_temp",
             "supported_color_modes": ["color_temp"],
-            "hs_color": (28.391, 65.659),
-            "rgb_color": (255, 167, 88),
-            "xy_color": (0.524, 0.388),
+            "hs_color": (28.395, 65.723),
+            "rgb_color": (255, 167, 87),
+            "xy_color": (0.525, 0.388),
         },
     )
 
@@ -1245,12 +1222,8 @@ async def test_device_types(
             "flowing": False,
             "night_light": True,
             "supported_features": SUPPORT_YEELIGHT,
-            "min_color_temp_kelvin": color_temperature_mired_to_kelvin(
-                color_temperature_kelvin_to_mired(model_specs["color_temp"]["min"])
-            ),
-            "max_color_temp_kelvin": color_temperature_mired_to_kelvin(
-                color_temperature_kelvin_to_mired(model_specs["color_temp"]["max"])
-            ),
+            "min_color_temp_kelvin": model_specs["color_temp"]["min"],
+            "max_color_temp_kelvin": model_specs["color_temp"]["max"],
             "min_mireds": color_temperature_kelvin_to_mired(
                 model_specs["color_temp"]["max"]
             ),
@@ -1279,12 +1252,8 @@ async def test_device_types(
             "flowing": False,
             "night_light": True,
             "supported_features": SUPPORT_YEELIGHT,
-            "min_color_temp_kelvin": color_temperature_mired_to_kelvin(
-                color_temperature_kelvin_to_mired(model_specs["color_temp"]["min"])
-            ),
-            "max_color_temp_kelvin": color_temperature_mired_to_kelvin(
-                color_temperature_kelvin_to_mired(model_specs["color_temp"]["max"])
-            ),
+            "min_color_temp_kelvin": model_specs["color_temp"]["min"],
+            "max_color_temp_kelvin": model_specs["color_temp"]["max"],
             "min_mireds": color_temperature_kelvin_to_mired(
                 model_specs["color_temp"]["max"]
             ),
@@ -1292,17 +1261,15 @@ async def test_device_types(
                 model_specs["color_temp"]["min"]
             ),
             "brightness": nl_br,
-            "color_temp_kelvin": color_temperature_mired_to_kelvin(
-                color_temperature_kelvin_to_mired(model_specs["color_temp"]["min"])
-            ),
+            "color_temp_kelvin": model_specs["color_temp"]["min"],
             "color_temp": color_temperature_kelvin_to_mired(
                 model_specs["color_temp"]["min"]
             ),
             "color_mode": "color_temp",
             "supported_color_modes": ["color_temp"],
-            "hs_color": (28.391, 65.659),
-            "rgb_color": (255, 167, 88),
-            "xy_color": (0.524, 0.388),
+            "hs_color": (28.395, 65.723),
+            "rgb_color": (255, 167, 87),
+            "xy_color": (0.525, 0.388),
         },
     )
     # Background light - color mode CT
@@ -1315,16 +1282,18 @@ async def test_device_types(
             "effect": None,
             "supported_features": SUPPORT_YEELIGHT,
             "min_color_temp_kelvin": 1700,
-            "max_color_temp_kelvin": color_temperature_mired_to_kelvin(
-                color_temperature_kelvin_to_mired(6500)
-            ),
+            "max_color_temp_kelvin": 6500,
             "min_mireds": color_temperature_kelvin_to_mired(6500),
             "max_mireds": color_temperature_kelvin_to_mired(1700),
             "brightness": bg_bright,
             "color_temp_kelvin": bg_ct,
             "color_temp": bg_ct_kelvin,
             "color_mode": "color_temp",
-            "supported_color_modes": ["color_temp", "hs", "rgb"],
+            "supported_color_modes": [
+                ColorMode.COLOR_TEMP,
+                ColorMode.HS,
+                ColorMode.RGB,
+            ],
             "hs_color": (27.001, 19.243),
             "rgb_color": (255, 228, 206),
             "xy_color": (0.371, 0.349),
@@ -1343,9 +1312,7 @@ async def test_device_types(
             "effect": None,
             "supported_features": SUPPORT_YEELIGHT,
             "min_color_temp_kelvin": 1700,
-            "max_color_temp_kelvin": color_temperature_mired_to_kelvin(
-                color_temperature_kelvin_to_mired(6500)
-            ),
+            "max_color_temp_kelvin": 6500,
             "min_mireds": color_temperature_kelvin_to_mired(6500),
             "max_mireds": color_temperature_kelvin_to_mired(1700),
             "brightness": bg_bright,
@@ -1355,7 +1322,11 @@ async def test_device_types(
             "color_temp": None,
             "color_temp_kelvin": None,
             "color_mode": "hs",
-            "supported_color_modes": ["color_temp", "hs", "rgb"],
+            "supported_color_modes": [
+                ColorMode.COLOR_TEMP,
+                ColorMode.HS,
+                ColorMode.RGB,
+            ],
         },
         name=f"{UNIQUE_FRIENDLY_NAME} Ambilight",
         entity_id=f"{ENTITY_LIGHT}_ambilight",
@@ -1371,9 +1342,7 @@ async def test_device_types(
             "effect": None,
             "supported_features": SUPPORT_YEELIGHT,
             "min_color_temp_kelvin": 1700,
-            "max_color_temp_kelvin": color_temperature_mired_to_kelvin(
-                color_temperature_kelvin_to_mired(6500)
-            ),
+            "max_color_temp_kelvin": 6500,
             "min_mireds": color_temperature_kelvin_to_mired(6500),
             "max_mireds": color_temperature_kelvin_to_mired(1700),
             "brightness": bg_bright,
@@ -1383,7 +1352,11 @@ async def test_device_types(
             "color_temp": None,
             "color_temp_kelvin": None,
             "color_mode": "rgb",
-            "supported_color_modes": ["color_temp", "hs", "rgb"],
+            "supported_color_modes": [
+                ColorMode.COLOR_TEMP,
+                ColorMode.HS,
+                ColorMode.RGB,
+            ],
         },
         name=f"{UNIQUE_FRIENDLY_NAME} Ambilight",
         entity_id=f"{ENTITY_LIGHT}_ambilight",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Based on #79591, needed for #132680 and #132723

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
