### PR TITLE
Remove config flow option to set mydevolo URL

### DIFF
--- a/homeassistant/components/devolo_home_control/__init__.py
+++ b/homeassistant/components/devolo_home_control/__init__.py
@@ -18,7 +18,7 @@ from homeassistant.core import Event, HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers.device_registry import DeviceEntry
 
-from .const import CONF_MYDEVOLO, DEFAULT_MYDEVOLO, GATEWAY_SERIAL_PATTERN, PLATFORMS
+from .const import GATEWAY_SERIAL_PATTERN, PLATFORMS
 
 type DevoloHomeControlConfigEntry = ConfigEntry[list[HomeControl]]
 
@@ -102,5 +102,4 @@ def configure_mydevolo(conf: dict[str, Any] | MappingProxyType[str, Any]) -> Myd
     mydevolo = Mydevolo()
     mydevolo.user = conf[CONF_USERNAME]
     mydevolo.password = conf[CONF_PASSWORD]
-    mydevolo.url = conf.get(CONF_MYDEVOLO, DEFAULT_MYDEVOLO)
     return mydevolo

--- a/homeassistant/components/devolo_home_control/config_flow.py
+++ b/homeassistant/components/devolo_home_control/config_flow.py
@@ -18,7 +18,7 @@ from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import callback
 
 from . import configure_mydevolo
-from .const import CONF_MYDEVOLO, DEFAULT_MYDEVOLO, DOMAIN, SUPPORTED_MODEL_TYPES
+from .const import DOMAIN, SUPPORTED_MODEL_TYPES
 from .exceptions import CredentialsInvalid, UuidChanged
 
 
@@ -35,14 +35,11 @@ class DevoloHomeControlFlowHandler(ConfigFlow, domain=DOMAIN):
             vol.Required(CONF_USERNAME): str,
             vol.Required(CONF_PASSWORD): str,
         }
-        self._url = DEFAULT_MYDEVOLO
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle a flow initiated by the user."""
-        if self.show_advanced_options:
-            self.data_schema[vol.Required(CONF_MYDEVOLO, default=self._url)] = str
         if user_input is None:
             return self._show_form(step_id="user")
         try:
@@ -78,7 +75,6 @@ class DevoloHomeControlFlowHandler(ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Handle reauthentication."""
         self._reauth_entry = self._get_reauth_entry()
-        self._url = entry_data[CONF_MYDEVOLO]
         self.data_schema = {
             vol.Required(CONF_USERNAME, default=entry_data[CONF_USERNAME]): str,
             vol.Required(CONF_PASSWORD): str,
@@ -104,7 +100,6 @@ class DevoloHomeControlFlowHandler(ConfigFlow, domain=DOMAIN):
 
     async def _connect_mydevolo(self, user_input: dict[str, Any]) -> ConfigFlowResult:
         """Connect to mydevolo."""
-        user_input[CONF_MYDEVOLO] = user_input.get(CONF_MYDEVOLO, self._url)
         mydevolo = configure_mydevolo(conf=user_input)
         credentials_valid = await self.hass.async_add_executor_job(
             mydevolo.credentials_valid
@@ -121,7 +116,6 @@ class DevoloHomeControlFlowHandler(ConfigFlow, domain=DOMAIN):
                 data={
                     CONF_PASSWORD: mydevolo.password,
                     CONF_USERNAME: mydevolo.user,
-                    CONF_MYDEVOLO: mydevolo.url,
                 },
             )
 

--- a/homeassistant/components/devolo_home_control/const.py
+++ b/homeassistant/components/devolo_home_control/const.py
@@ -5,7 +5,6 @@ import re
 from homeassistant.const import Platform
 
 DOMAIN = "devolo_home_control"
-DEFAULT_MYDEVOLO = "https://www.mydevolo.com"
 PLATFORMS = [
     Platform.BINARY_SENSOR,
     Platform.CLIMATE,
@@ -15,6 +14,5 @@ PLATFORMS = [
     Platform.SIREN,
     Platform.SWITCH,
 ]
-CONF_MYDEVOLO = "mydevolo_url"
 GATEWAY_SERIAL_PATTERN = re.compile(r"\d{16}")
 SUPPORTED_MODEL_TYPES = ["2600", "2601"]

--- a/tests/components/devolo_home_control/__init__.py
+++ b/tests/components/devolo_home_control/__init__.py
@@ -11,7 +11,6 @@ def configure_integration(hass: HomeAssistant) -> MockConfigEntry:
     config = {
         "username": "test-username",
         "password": "test-password",
-        "mydevolo_url": "https://test_mydevolo_url.test",
     }
     entry = MockConfigEntry(
         domain=DOMAIN, data=config, entry_id="123456", unique_id="123456"

--- a/tests/components/devolo_home_control/snapshots/test_diagnostics.ambr
+++ b/tests/components/devolo_home_control/snapshots/test_diagnostics.ambr
@@ -33,7 +33,6 @@
     ]),
     'entry': dict({
       'data': dict({
-        'mydevolo_url': 'https://test_mydevolo_url.test',
         'password': '**REDACTED**',
         'username': '**REDACTED**',
       }),

--- a/tests/components/devolo_home_control/test_config_flow.py
+++ b/tests/components/devolo_home_control/test_config_flow.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 import pytest
 
 from homeassistant import config_entries
-from homeassistant.components.devolo_home_control.const import DEFAULT_MYDEVOLO, DOMAIN
+from homeassistant.components.devolo_home_control.const import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult, FlowResultType
 
@@ -90,7 +90,6 @@ async def test_form_advanced_options(hass: HomeAssistant) -> None:
             {
                 "username": "test-username",
                 "password": "test-password",
-                "mydevolo_url": "https://test_mydevolo_url.test",
             },
         )
         await hass.async_block_till_done()
@@ -100,7 +99,6 @@ async def test_form_advanced_options(hass: HomeAssistant) -> None:
     assert result2["data"] == {
         "username": "test-username",
         "password": "test-password",
-        "mydevolo_url": "https://test_mydevolo_url.test",
     }
 
     assert len(mock_setup_entry.mock_calls) == 1
@@ -170,7 +168,6 @@ async def test_form_reauth(hass: HomeAssistant) -> None:
         data={
             "username": "test-username",
             "password": "test-password",
-            "mydevolo_url": "https://test_mydevolo_url.test",
         },
     )
     mock_config.add_to_hass(hass)
@@ -207,7 +204,6 @@ async def test_form_invalid_credentials_reauth(hass: HomeAssistant) -> None:
         data={
             "username": "test-username",
             "password": "test-password",
-            "mydevolo_url": "https://test_mydevolo_url.test",
         },
     )
     mock_config.add_to_hass(hass)
@@ -229,7 +225,6 @@ async def test_form_uuid_change_reauth(hass: HomeAssistant) -> None:
         data={
             "username": "test-username",
             "password": "test-password",
-            "mydevolo_url": "https://test_mydevolo_url.test",
         },
     )
     mock_config.add_to_hass(hass)
@@ -281,7 +276,6 @@ async def _setup(hass: HomeAssistant, result: FlowResult) -> None:
     assert result2["data"] == {
         "username": "test-username",
         "password": "test-password",
-        "mydevolo_url": DEFAULT_MYDEVOLO,
     }
 
     assert len(mock_setup_entry.mock_calls) == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Users on a different stage than production won't be able to use the integration any longer.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In https://github.com/home-assistant/home-assistant.io/pull/36254 @frenck suggested to remove the config flow option to set mydevolo URL as only a few user benefit from it and others might be confused.

I don't know, if I need to handle/migrate existing configurations somehow? I guess, users with the default URL won't notice this change and user with different URLs won't be able to use the integration anyhow.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/36269

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
