### PR TITLE
Migrate mqtt lights to use Kelvin

### DIFF
--- a/homeassistant/components/mqtt/light/schema_basic.py
+++ b/homeassistant/components/mqtt/light/schema_basic.py
@@ -246,7 +246,7 @@ class MqttLight(MqttEntity, LightEntity, RestoreEntity):
     _optimistic: bool
     _optimistic_brightness: bool
     _optimistic_color_mode: bool
-    _optimistic_color_temp: bool
+    _optimistic_color_temp_kelvin: bool
     _optimistic_effect: bool
     _optimistic_hs_color: bool
     _optimistic_rgb_color: bool
@@ -327,7 +327,7 @@ class MqttLight(MqttEntity, LightEntity, RestoreEntity):
                 and topic[CONF_RGB_STATE_TOPIC] is None
             )
         )
-        self._optimistic_color_temp = (
+        self._optimistic_color_temp_kelvin = (
             optimistic or topic[CONF_COLOR_TEMP_STATE_TOPIC] is None
         )
         self._optimistic_effect = optimistic or topic[CONF_EFFECT_STATE_TOPIC] is None
@@ -518,7 +518,9 @@ class MqttLight(MqttEntity, LightEntity, RestoreEntity):
 
         if self._optimistic_color_mode:
             self._attr_color_mode = ColorMode.COLOR_TEMP
-        self._attr_color_temp = int(payload)
+        self._attr_color_temp_kelvin = color_util.color_temperature_mired_to_kelvin(
+            int(payload)
+        )
 
     @callback
     def _effect_received(self, msg: ReceiveMessage) -> None:
@@ -592,7 +594,7 @@ class MqttLight(MqttEntity, LightEntity, RestoreEntity):
         self.add_subscription(
             CONF_COLOR_TEMP_STATE_TOPIC,
             self._color_temp_received,
-            {"_attr_color_mode", "_attr_color_temp"},
+            {"_attr_color_mode", "_attr_color_temp_kelvin"},
         )
         self.add_subscription(
             CONF_EFFECT_STATE_TOPIC, self._effect_received, {"_attr_effect"}
@@ -631,7 +633,7 @@ class MqttLight(MqttEntity, LightEntity, RestoreEntity):
         restore_state(ATTR_RGBW_COLOR)
         restore_state(ATTR_RGBWW_COLOR)
         restore_state(ATTR_COLOR_MODE)
-        restore_state(ATTR_COLOR_TEMP)
+        restore_state(ATTR_COLOR_TEMP_KELVIN)
         restore_state(ATTR_EFFECT)
         restore_state(ATTR_HS_COLOR)
         restore_state(ATTR_XY_COLOR)
@@ -803,14 +805,21 @@ class MqttLight(MqttEntity, LightEntity, RestoreEntity):
             await publish(CONF_RGBWW_COMMAND_TOPIC, rgbww_s)
             should_update |= set_optimistic(ATTR_BRIGHTNESS, kwargs[ATTR_BRIGHTNESS])
         if (
-            ATTR_COLOR_TEMP in kwargs
+            ATTR_COLOR_TEMP_KELVIN in kwargs
             and self._topic[CONF_COLOR_TEMP_COMMAND_TOPIC] is not None
         ):
             ct_command_tpl = self._command_templates[CONF_COLOR_TEMP_COMMAND_TEMPLATE]
-            color_temp = ct_command_tpl(int(kwargs[ATTR_COLOR_TEMP]), None)
+            color_temp = ct_command_tpl(
+                color_util.color_temperature_kelvin_to_mired(
+                    kwargs[ATTR_COLOR_TEMP_KELVIN]
+                ),
+                None,
+            )
             await publish(CONF_COLOR_TEMP_COMMAND_TOPIC, color_temp)
             should_update |= set_optimistic(
-                ATTR_COLOR_TEMP, kwargs[ATTR_COLOR_TEMP], ColorMode.COLOR_TEMP
+                ATTR_COLOR_TEMP_KELVIN,
+                kwargs[ATTR_COLOR_TEMP_KELVIN],
+                ColorMode.COLOR_TEMP,
             )
 
         if (

--- a/homeassistant/components/mqtt/light/schema_json.py
+++ b/homeassistant/components/mqtt/light/schema_json.py
@@ -12,7 +12,7 @@ import voluptuous as vol
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     ATTR_COLOR_MODE,
-    ATTR_COLOR_TEMP,
+    ATTR_COLOR_TEMP_KELVIN,
     ATTR_EFFECT,
     ATTR_FLASH,
     ATTR_HS_COLOR,
@@ -273,8 +273,16 @@ class MqttLightJson(MqttEntity, LightEntity, RestoreEntity):
 
     def _setup_from_config(self, config: ConfigType) -> None:
         """(Re)Setup the entity."""
-        self._attr_max_mireds = config.get(CONF_MAX_MIREDS, super().max_mireds)
-        self._attr_min_mireds = config.get(CONF_MIN_MIREDS, super().min_mireds)
+        self._attr_min_color_temp_kelvin = (
+            color_util.color_temperature_mired_to_kelvin(max_mireds)
+            if (max_mireds := config.get(CONF_MAX_MIREDS))
+            else super().min_color_temp_kelvin
+        )
+        self._attr_max_color_temp_kelvin = (
+            color_util.color_temperature_mired_to_kelvin(min_mireds)
+            if (min_mireds := config.get(CONF_MIN_MIREDS))
+            else super().max_color_temp_kelvin
+        )
         self._attr_effect_list = config.get(CONF_EFFECT_LIST)
 
         self._topic = {
@@ -370,7 +378,11 @@ class MqttLightJson(MqttEntity, LightEntity, RestoreEntity):
                 return
             try:
                 if color_mode == ColorMode.COLOR_TEMP:
-                    self._attr_color_temp = int(values["color_temp"])
+                    self._attr_color_temp_kelvin = (
+                        color_util.color_temperature_mired_to_kelvin(
+                            values["color_temp"]
+                        )
+                    )
                     self._attr_color_mode = ColorMode.COLOR_TEMP
                 elif color_mode == ColorMode.HS:
                     hue = float(values["color"]["h"])
@@ -469,9 +481,13 @@ class MqttLightJson(MqttEntity, LightEntity, RestoreEntity):
             # Deprecated color handling
             try:
                 if values["color_temp"] is None:
-                    self._attr_color_temp = None
+                    self._attr_color_temp_kelvin = None
                 else:
-                    self._attr_color_temp = int(values["color_temp"])  # type: ignore[arg-type]
+                    self._attr_color_temp_kelvin = (
+                        color_util.color_temperature_mired_to_kelvin(
+                            values["color_temp"]  # type: ignore[arg-type]
+                        )
+                    )
             except KeyError:
                 pass
             except ValueError:
@@ -496,7 +512,7 @@ class MqttLightJson(MqttEntity, LightEntity, RestoreEntity):
             self._state_received,
             {
                 "_attr_brightness",
-                "_attr_color_temp",
+                "_attr_color_temp_kelvin",
                 "_attr_effect",
                 "_attr_hs_color",
                 "_attr_is_on",
@@ -522,8 +538,8 @@ class MqttLightJson(MqttEntity, LightEntity, RestoreEntity):
             self._attr_color_mode = last_attributes.get(
                 ATTR_COLOR_MODE, self.color_mode
             )
-            self._attr_color_temp = last_attributes.get(
-                ATTR_COLOR_TEMP, self.color_temp
+            self._attr_color_temp_kelvin = last_attributes.get(
+                ATTR_COLOR_TEMP_KELVIN, self.color_temp_kelvin
             )
             self._attr_effect = last_attributes.get(ATTR_EFFECT, self.effect)
             self._attr_hs_color = last_attributes.get(ATTR_HS_COLOR, self.hs_color)
@@ -690,12 +706,14 @@ class MqttLightJson(MqttEntity, LightEntity, RestoreEntity):
                 self._attr_brightness = kwargs[ATTR_BRIGHTNESS]
                 should_update = True
 
-        if ATTR_COLOR_TEMP in kwargs:
-            message["color_temp"] = int(kwargs[ATTR_COLOR_TEMP])
+        if ATTR_COLOR_TEMP_KELVIN in kwargs:
+            message["color_temp"] = color_util.color_temperature_kelvin_to_mired(
+                kwargs[ATTR_COLOR_TEMP_KELVIN]
+            )
 
             if self._optimistic:
                 self._attr_color_mode = ColorMode.COLOR_TEMP
-                self._attr_color_temp = kwargs[ATTR_COLOR_TEMP]
+                self._attr_color_temp_kelvin = kwargs[ATTR_COLOR_TEMP_KELVIN]
                 self._attr_hs_color = None
                 should_update = True
 

--- a/homeassistant/components/mqtt/light/schema_template.py
+++ b/homeassistant/components/mqtt/light/schema_template.py
@@ -10,7 +10,7 @@ import voluptuous as vol
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
-    ATTR_COLOR_TEMP,
+    ATTR_COLOR_TEMP_KELVIN,
     ATTR_EFFECT,
     ATTR_FLASH,
     ATTR_HS_COLOR,
@@ -126,8 +126,16 @@ class MqttLightTemplate(MqttEntity, LightEntity, RestoreEntity):
 
     def _setup_from_config(self, config: ConfigType) -> None:
         """(Re)Setup the entity."""
-        self._attr_max_mireds = config.get(CONF_MAX_MIREDS, super().max_mireds)
-        self._attr_min_mireds = config.get(CONF_MIN_MIREDS, super().min_mireds)
+        self._attr_min_color_temp_kelvin = (
+            color_util.color_temperature_mired_to_kelvin(max_mireds)
+            if (max_mireds := config.get(CONF_MAX_MIREDS))
+            else super().min_color_temp_kelvin
+        )
+        self._attr_max_color_temp_kelvin = (
+            color_util.color_temperature_mired_to_kelvin(min_mireds)
+            if (min_mireds := config.get(CONF_MIN_MIREDS))
+            else super().max_color_temp_kelvin
+        )
         self._attr_effect_list = config.get(CONF_EFFECT_LIST)
 
         self._topics = {
@@ -213,8 +221,10 @@ class MqttLightTemplate(MqttEntity, LightEntity, RestoreEntity):
                 color_temp = self._value_templates[CONF_COLOR_TEMP_TEMPLATE](
                     msg.payload
                 )
-                self._attr_color_temp = (
-                    int(color_temp) if color_temp != "None" else None
+                self._attr_color_temp_kelvin = (
+                    color_util.color_temperature_mired_to_kelvin(int(color_temp))
+                    if color_temp != "None"
+                    else None
                 )
             except ValueError:
                 _LOGGER.warning("Invalid color temperature value received")
@@ -256,7 +266,7 @@ class MqttLightTemplate(MqttEntity, LightEntity, RestoreEntity):
             {
                 "_attr_brightness",
                 "_attr_color_mode",
-                "_attr_color_temp",
+                "_attr_color_temp_kelvin",
                 "_attr_effect",
                 "_attr_hs_color",
                 "_attr_is_on",
@@ -275,8 +285,10 @@ class MqttLightTemplate(MqttEntity, LightEntity, RestoreEntity):
             if last_state.attributes.get(ATTR_HS_COLOR):
                 self._attr_hs_color = last_state.attributes.get(ATTR_HS_COLOR)
                 self._update_color_mode()
-            if last_state.attributes.get(ATTR_COLOR_TEMP):
-                self._attr_color_temp = last_state.attributes.get(ATTR_COLOR_TEMP)
+            if last_state.attributes.get(ATTR_COLOR_TEMP_KELVIN):
+                self._attr_color_temp_kelvin = last_state.attributes.get(
+                    ATTR_COLOR_TEMP_KELVIN
+                )
             if last_state.attributes.get(ATTR_EFFECT):
                 self._attr_effect = last_state.attributes.get(ATTR_EFFECT)
 
@@ -295,11 +307,13 @@ class MqttLightTemplate(MqttEntity, LightEntity, RestoreEntity):
             if self._optimistic:
                 self._attr_brightness = kwargs[ATTR_BRIGHTNESS]
 
-        if ATTR_COLOR_TEMP in kwargs:
-            values["color_temp"] = int(kwargs[ATTR_COLOR_TEMP])
+        if ATTR_COLOR_TEMP_KELVIN in kwargs:
+            values["color_temp"] = color_util.color_temperature_kelvin_to_mired(
+                kwargs[ATTR_COLOR_TEMP_KELVIN]
+            )
 
             if self._optimistic:
-                self._attr_color_temp = kwargs[ATTR_COLOR_TEMP]
+                self._attr_color_temp_kelvin = kwargs[ATTR_COLOR_TEMP_KELVIN]
                 self._attr_hs_color = None
                 self._update_color_mode()
 
@@ -325,7 +339,7 @@ class MqttLightTemplate(MqttEntity, LightEntity, RestoreEntity):
             values["sat"] = hs_color[1]
 
             if self._optimistic:
-                self._attr_color_temp = None
+                self._attr_color_temp_kelvin = None
                 self._attr_hs_color = kwargs[ATTR_HS_COLOR]
                 self._update_color_mode()
 

--- a/tests/components/mqtt/test_light.py
+++ b/tests/components/mqtt/test_light.py
@@ -1008,7 +1008,7 @@ async def test_sending_mqtt_commands_and_optimistic(
             "brightness": 95,
             "hs_color": [100, 100],
             "effect": "random",
-            "color_temp": 100,
+            "color_temp_kelvin": 100000,
             "color_mode": "hs",
         },
     )
@@ -1021,7 +1021,7 @@ async def test_sending_mqtt_commands_and_optimistic(
     assert state.attributes.get("brightness") == 95
     assert state.attributes.get("hs_color") == (100, 100)
     assert state.attributes.get("effect") == "random"
-    assert state.attributes.get("color_temp") is None
+    assert state.attributes.get("color_temp_kelvin") is None
     assert state.attributes.get(light.ATTR_COLOR_MODE) == "hs"
     assert state.attributes.get(light.ATTR_SUPPORTED_COLOR_MODES) == color_modes
     assert state.attributes.get(ATTR_ASSUMED_STATE)

--- a/tests/components/mqtt/test_light_json.py
+++ b/tests/components/mqtt/test_light_json.py
@@ -1065,7 +1065,7 @@ async def test_sending_mqtt_commands_and_optimistic(
     assert state.attributes.get("brightness") == 95
     assert state.attributes.get("hs_color") == (100, 100)
     assert state.attributes.get("effect") == "random"
-    assert state.attributes.get("color_temp") is None  # hs_color has priority
+    assert state.attributes.get("color_temp_kelvin") is None  # hs_color has priority
     color_modes = [light.ColorMode.COLOR_TEMP, light.ColorMode.HS]
     assert state.attributes.get(light.ATTR_SUPPORTED_COLOR_MODES) == color_modes
     expected_features = (

--- a/tests/components/mqtt/test_light_json.py
+++ b/tests/components/mqtt/test_light_json.py
@@ -1053,7 +1053,7 @@ async def test_sending_mqtt_commands_and_optimistic(
             "brightness": 95,
             "hs_color": [100, 100],
             "effect": "random",
-            "color_temp": 100,
+            "color_temp_kelvin": 10000,
         },
     )
     mock_restore_cache(hass, (fake_state,))
@@ -1205,7 +1205,7 @@ async def test_sending_mqtt_commands_and_optimistic2(
         "on",
         {
             "brightness": 95,
-            "color_temp": 100,
+            "color_temp_kelvin": 10000,
             "color_mode": "rgb",
             "effect": "random",
             "hs_color": [100, 100],

--- a/tests/components/mqtt/test_light_template.py
+++ b/tests/components/mqtt/test_light_template.py
@@ -443,7 +443,7 @@ async def test_sending_mqtt_commands_and_optimistic(
     assert state.state == STATE_ON
     assert state.attributes.get("hs_color") == (100, 100)
     assert state.attributes.get("effect") == "random"
-    assert state.attributes.get("color_temp") is None  # hs_color has priority
+    assert state.attributes.get("color_temp_kelvin") is None  # hs_color has priority
     assert state.attributes.get(ATTR_ASSUMED_STATE)
 
     await common.async_turn_off(hass, "light.test")

--- a/tests/components/mqtt/test_light_template.py
+++ b/tests/components/mqtt/test_light_template.py
@@ -432,7 +432,7 @@ async def test_sending_mqtt_commands_and_optimistic(
             "brightness": 95,
             "hs_color": [100, 100],
             "effect": "random",
-            "color_temp": 100,
+            "color_temp_kelvin": 10000,
         },
     )
     mock_restore_cache(hass, (fake_state,))


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Based on #79591, needed for #132680 and #132723

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
