### PR TITLE
Migrate flux to use Kelvin over Mireds

### DIFF
--- a/homeassistant/components/flux/switch.py
+++ b/homeassistant/components/flux/switch.py
@@ -13,7 +13,7 @@ import voluptuous as vol
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
-    ATTR_COLOR_TEMP,
+    ATTR_COLOR_TEMP_KELVIN,
     ATTR_RGB_COLOR,
     ATTR_TRANSITION,
     ATTR_XY_COLOR,
@@ -43,7 +43,6 @@ from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.util import slugify
 from homeassistant.util.color import (
     color_RGB_to_xy_brightness,
-    color_temperature_kelvin_to_mired,
     color_temperature_to_rgb,
 )
 from homeassistant.util.dt import as_local, utcnow as dt_utcnow
@@ -109,13 +108,13 @@ async def async_set_lights_xy(hass, lights, x_val, y_val, brightness, transition
             await hass.services.async_call(LIGHT_DOMAIN, SERVICE_TURN_ON, service_data)
 
 
-async def async_set_lights_temp(hass, lights, mired, brightness, transition):
+async def async_set_lights_temp(hass, lights, kelvin, brightness, transition):
     """Set color of array of lights."""
     for light in lights:
         if is_on(hass, light):
             service_data = {ATTR_ENTITY_ID: light}
-            if mired is not None:
-                service_data[ATTR_COLOR_TEMP] = int(mired)
+            if kelvin is not None:
+                service_data[ATTR_COLOR_TEMP_KELVIN] = kelvin
             if brightness is not None:
                 service_data[ATTR_BRIGHTNESS] = brightness
             if transition is not None:
@@ -350,17 +349,15 @@ class FluxSwitch(SwitchEntity, RestoreEntity):
                 now,
             )
         else:
-            # Convert to mired and clamp to allowed values
-            mired = color_temperature_kelvin_to_mired(temp)
             await async_set_lights_temp(
-                self.hass, self._lights, mired, brightness, self._transition
+                self.hass, self._lights, int(temp), brightness, self._transition
             )
             _LOGGER.debug(
                 (
-                    "Lights updated to mired:%s brightness:%s, %s%% "
+                    "Lights updated to kelvin:%s brightness:%s, %s%% "
                     "of %s cycle complete at %s"
                 ),
-                mired,
+                temp,
                 brightness,
                 round(percentage_complete * 100),
                 time_state,

--- a/tests/components/flux/test_switch.py
+++ b/tests/components/flux/test_switch.py
@@ -1164,7 +1164,7 @@ async def test_flux_with_multiple_lights(
     assert call.data[light.ATTR_XY_COLOR] == [0.46, 0.376]
 
 
-async def test_flux_with_mired(
+async def test_flux_with_temp(
     hass: HomeAssistant,
     mock_light_entities: list[MockLight],
 ) -> None:
@@ -1224,7 +1224,7 @@ async def test_flux_with_mired(
         async_fire_time_changed(hass, test_time)
         await hass.async_block_till_done()
     call = turn_on_calls[-1]
-    assert call.data[light.ATTR_COLOR_TEMP] == 269
+    assert call.data[light.ATTR_COLOR_TEMP_KELVIN] == 3708
 
 
 async def test_flux_with_rgb(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Based on #79591, needed for #132680

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
