### PR TITLE
Update Fronius translations

### DIFF
--- a/homeassistant/components/fronius/config_flow.py
+++ b/homeassistant/components/fronius/config_flow.py
@@ -52,11 +52,9 @@ async def validate_host(
     try:
         inverter_info = await fronius.inverter_info()
         first_inverter = next(inverter for inverter in inverter_info["inverters"])
-    except FroniusError as err:
+    except (FroniusError, StopIteration) as err:
         _LOGGER.debug(err)
         raise CannotConnect from err
-    except StopIteration as err:
-        raise CannotConnect("No supported Fronius SolarNet device found.") from err
     first_inverter_uid: str = first_inverter["unique_id"]["value"]
     return first_inverter_uid, FroniusConfigEntryData(
         host=host,

--- a/homeassistant/components/fronius/config_flow.py
+++ b/homeassistant/components/fronius/config_flow.py
@@ -56,10 +56,7 @@ async def validate_host(
         _LOGGER.debug(err)
         raise CannotConnect from err
     except StopIteration as err:
-        raise CannotConnect(
-            translation_domain=DOMAIN,
-            translation_key="no_supported_device_found",
-        ) from err
+        raise CannotConnect("No supported Fronius SolarNet device found.") from err
     first_inverter_uid: str = first_inverter["unique_id"]["value"]
     return first_inverter_uid, FroniusConfigEntryData(
         host=host,

--- a/homeassistant/components/fronius/strings.json
+++ b/homeassistant/components/fronius/strings.json
@@ -3,10 +3,12 @@
     "flow_title": "{device}",
     "step": {
       "user": {
-        "title": "Fronius SolarNet",
-        "description": "Configure the IP address or local hostname of your Fronius device.",
+        "description": "Configure your Fronius SolarAPI device.",
         "data": {
           "host": "[%key:common::config_flow::data::host%]"
+        },
+        "data_description": {
+          "host": "The IP address or hostname of your Fronius device."
         }
       },
       "confirm_discovery": {

--- a/homeassistant/components/fronius/strings.json
+++ b/homeassistant/components/fronius/strings.json
@@ -41,9 +41,6 @@
       "energy_total": {
         "name": "Total energy"
       },
-      "frequency_ac": {
-        "name": "[%key:component::sensor::entity_component::frequency::name%]"
-      },
       "current_ac": {
         "name": "AC current"
       },
@@ -156,9 +153,6 @@
       "power_apparent_phase_3": {
         "name": "Apparent power phase 3"
       },
-      "power_apparent": {
-        "name": "[%key:component::sensor::entity_component::apparent_power::name%]"
-      },
       "power_factor_phase_1": {
         "name": "Power factor phase 1"
       },
@@ -167,9 +161,6 @@
       },
       "power_factor_phase_3": {
         "name": "Power factor phase 3"
-      },
-      "power_factor": {
-        "name": "[%key:component::sensor::entity_component::power_factor::name%]"
       },
       "power_reactive_phase_1": {
         "name": "Reactive power phase 1"
@@ -215,12 +206,6 @@
       },
       "energy_real_ac_consumed": {
         "name": "Energy consumed"
-      },
-      "power_real_ac": {
-        "name": "[%key:component::sensor::entity_component::power::name%]"
-      },
-      "temperature_channel_1": {
-        "name": "[%key:component::sensor::entity_component::temperature::name%]"
       },
       "state_code": {
         "name": "State code"

--- a/homeassistant/components/fronius/strings.json
+++ b/homeassistant/components/fronius/strings.json
@@ -296,9 +296,6 @@
     }
   },
   "exceptions": {
-    "no_supported_device_found": {
-      "message": "No supported Fronius SolarNet device found."
-    },
     "entry_cannot_connect": {
       "message": "Failed to connect to Fronius device at {host}: {fronius_error}"
     },

--- a/tests/components/fronius/test_config_flow.py
+++ b/tests/components/fronius/test_config_flow.py
@@ -145,33 +145,6 @@ async def test_form_cannot_connect(hass: HomeAssistant) -> None:
     assert result2["errors"] == {"base": "cannot_connect"}
 
 
-async def test_form_no_device(hass: HomeAssistant) -> None:
-    """Test we handle no device found error."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
-
-    with (
-        patch(
-            "pyfronius.Fronius.current_logger_info",
-            side_effect=FroniusError,
-        ),
-        patch(
-            "pyfronius.Fronius.inverter_info",
-            return_value={"inverters": []},
-        ),
-    ):
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {
-                "host": "1.1.1.1",
-            },
-        )
-
-    assert result2["type"] is FlowResultType.FORM
-    assert result2["errors"] == {"base": "cannot_connect"}
-
-
 async def test_form_unexpected(hass: HomeAssistant) -> None:
     """Test we handle unexpected error."""
     result = await hass.config_entries.flow.async_init(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- [Remove exception translation that's handled by configflow errors dict](https://github.com/home-assistant/core/commit/ad60bf6096b0c9a93f578c64bec0b447c3ba027b)
- [Remove entity name translations handled by device class](https://github.com/home-assistant/core/commit/2bc6b368ba9f3416d88a814ad30c4f7a15378bcb)
- [Add data_description for Fronius config flow](https://github.com/home-assistant/core/commit/e41957a0133dba1a6d450a1a0ed625732e66d215)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #131770
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
