### PR TITLE
Switcher move _async_call_api to entity.py

### DIFF
--- a/homeassistant/components/switcher_kis/cover.py
+++ b/homeassistant/components/switcher_kis/cover.py
@@ -2,10 +2,8 @@
 
 from __future__ import annotations
 
-import logging
 from typing import Any, cast
 
-from aioswitcher.api import SwitcherApi, SwitcherBaseResponse
 from aioswitcher.device import DeviceCategory, ShutterDirection, SwitcherShutter
 
 from homeassistant.components.cover import (
@@ -16,15 +14,12 @@ from homeassistant.components.cover import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import SIGNAL_DEVICE_ADD
 from .coordinator import SwitcherDataUpdateCoordinator
 from .entity import SwitcherEntity
-
-_LOGGER = logging.getLogger(__name__)
 
 API_SET_POSITON = "set_position"
 API_STOP = "stop_shutter"
@@ -91,32 +86,6 @@ class SwitcherBaseCoverEntity(SwitcherEntity, CoverEntity):
         self._attr_is_opening = (
             data.direction[self._cover_id] == ShutterDirection.SHUTTER_UP
         )
-
-    async def _async_call_api(self, api: str, *args: Any) -> None:
-        """Call Switcher API."""
-        _LOGGER.debug("Calling api for %s, api: '%s', args: %s", self.name, api, args)
-        response: SwitcherBaseResponse | None = None
-        error = None
-
-        try:
-            async with SwitcherApi(
-                self.coordinator.data.device_type,
-                self.coordinator.data.ip_address,
-                self.coordinator.data.device_id,
-                self.coordinator.data.device_key,
-                self.coordinator.token,
-            ) as swapi:
-                response = await getattr(swapi, api)(*args)
-        except (TimeoutError, OSError, RuntimeError) as err:
-            error = repr(err)
-
-        if error or not response or not response.successful:
-            self.coordinator.last_update_success = False
-            self.async_write_ha_state()
-            raise HomeAssistantError(
-                f"Call api for {self.name} failed, api: '{api}', "
-                f"args: {args}, response/error: {response or error}"
-            )
 
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close cover."""

--- a/homeassistant/components/switcher_kis/entity.py
+++ b/homeassistant/components/switcher_kis/entity.py
@@ -1,10 +1,18 @@
 """Base class for Switcher entities."""
 
+import logging
+from typing import Any
+
+from aioswitcher.api import SwitcherApi, SwitcherBaseResponse
+
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .coordinator import SwitcherDataUpdateCoordinator
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class SwitcherEntity(CoordinatorEntity[SwitcherDataUpdateCoordinator]):
@@ -18,3 +26,29 @@ class SwitcherEntity(CoordinatorEntity[SwitcherDataUpdateCoordinator]):
         self._attr_device_info = DeviceInfo(
             connections={(dr.CONNECTION_NETWORK_MAC, coordinator.mac_address)}
         )
+
+    async def _async_call_api(self, api: str, *args: Any) -> None:
+        """Call Switcher API."""
+        _LOGGER.debug("Calling api for %s, api: '%s', args: %s", self.name, api, args)
+        response: SwitcherBaseResponse | None = None
+        error = None
+
+        try:
+            async with SwitcherApi(
+                self.coordinator.data.device_type,
+                self.coordinator.data.ip_address,
+                self.coordinator.data.device_id,
+                self.coordinator.data.device_key,
+                self.coordinator.token,
+            ) as swapi:
+                response = await getattr(swapi, api)(*args)
+        except (TimeoutError, OSError, RuntimeError) as err:
+            error = repr(err)
+
+        if error or not response or not response.successful:
+            self.coordinator.last_update_success = False
+            self.async_write_ha_state()
+            raise HomeAssistantError(
+                f"Call api for {self.name} failed, api: '{api}', "
+                f"args: {args}, response/error: {response or error}"
+            )

--- a/homeassistant/components/switcher_kis/light.py
+++ b/homeassistant/components/switcher_kis/light.py
@@ -2,24 +2,19 @@
 
 from __future__ import annotations
 
-import logging
 from typing import Any, cast
 
-from aioswitcher.api import SwitcherApi, SwitcherBaseResponse
 from aioswitcher.device import DeviceCategory, DeviceState, SwitcherLight
 
 from homeassistant.components.light import ColorMode, LightEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import SIGNAL_DEVICE_ADD
 from .coordinator import SwitcherDataUpdateCoordinator
 from .entity import SwitcherEntity
-
-_LOGGER = logging.getLogger(__name__)
 
 API_SET_LIGHT = "set_light"
 
@@ -78,32 +73,6 @@ class SwitcherBaseLightEntity(SwitcherEntity, LightEntity):
 
         data = cast(SwitcherLight, self.coordinator.data)
         return bool(data.light[self._light_id] == DeviceState.ON)
-
-    async def _async_call_api(self, api: str, *args: Any) -> None:
-        """Call Switcher API."""
-        _LOGGER.debug("Calling api for %s, api: '%s', args: %s", self.name, api, args)
-        response: SwitcherBaseResponse | None = None
-        error = None
-
-        try:
-            async with SwitcherApi(
-                self.coordinator.data.device_type,
-                self.coordinator.data.ip_address,
-                self.coordinator.data.device_id,
-                self.coordinator.data.device_key,
-                self.coordinator.token,
-            ) as swapi:
-                response = await getattr(swapi, api)(*args)
-        except (TimeoutError, OSError, RuntimeError) as err:
-            error = repr(err)
-
-        if error or not response or not response.successful:
-            self.coordinator.last_update_success = False
-            self.async_write_ha_state()
-            raise HomeAssistantError(
-                f"Call api for {self.name} failed, api: '{api}', "
-                f"args: {args}, response/error: {response or error}"
-            )
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the light on."""

--- a/homeassistant/components/switcher_kis/switch.py
+++ b/homeassistant/components/switcher_kis/switch.py
@@ -6,7 +6,7 @@ from datetime import timedelta
 import logging
 from typing import Any
 
-from aioswitcher.api import Command, SwitcherApi, SwitcherBaseResponse
+from aioswitcher.api import Command
 from aioswitcher.device import DeviceCategory, DeviceState
 import voluptuous as vol
 
@@ -95,35 +95,6 @@ class SwitcherBaseSwitchEntity(SwitcherEntity, SwitchEntity):
         """When device updates, clear control result that overrides state."""
         self.control_result = None
         self.async_write_ha_state()
-
-    async def _async_call_api(self, api: str, *args: Any) -> None:
-        """Call Switcher API."""
-        _LOGGER.debug(
-            "Calling api for %s, api: '%s', args: %s", self.coordinator.name, api, args
-        )
-        response: SwitcherBaseResponse | None = None
-        error = None
-
-        try:
-            async with SwitcherApi(
-                self.coordinator.data.device_type,
-                self.coordinator.data.ip_address,
-                self.coordinator.data.device_id,
-                self.coordinator.data.device_key,
-            ) as swapi:
-                response = await getattr(swapi, api)(*args)
-        except (TimeoutError, OSError, RuntimeError) as err:
-            error = repr(err)
-
-        if error or not response or not response.successful:
-            _LOGGER.error(
-                "Call api for %s failed, api: '%s', args: %s, response/error: %s",
-                self.coordinator.name,
-                api,
-                args,
-                response or error,
-            )
-            self.coordinator.last_update_success = False
 
     @property
     def is_on(self) -> bool:

--- a/tests/components/switcher_kis/conftest.py
+++ b/tests/components/switcher_kis/conftest.py
@@ -60,19 +60,19 @@ def mock_api():
 
     patchers = [
         patch(
-            "homeassistant.components.switcher_kis.switch.SwitcherApi.connect",
+            "homeassistant.components.switcher_kis.entity.SwitcherApi.connect",
             new=api_mock,
         ),
         patch(
-            "homeassistant.components.switcher_kis.switch.SwitcherApi.disconnect",
+            "homeassistant.components.switcher_kis.entity.SwitcherApi.disconnect",
             new=api_mock,
         ),
         patch(
-            "homeassistant.components.switcher_kis.climate.SwitcherApi.connect",
+            "homeassistant.components.switcher_kis.entity.SwitcherApi.connect",
             new=api_mock,
         ),
         patch(
-            "homeassistant.components.switcher_kis.climate.SwitcherApi.disconnect",
+            "homeassistant.components.switcher_kis.entity.SwitcherApi.disconnect",
             new=api_mock,
         ),
     ]

--- a/tests/components/switcher_kis/conftest.py
+++ b/tests/components/switcher_kis/conftest.py
@@ -67,14 +67,6 @@ def mock_api():
             "homeassistant.components.switcher_kis.entity.SwitcherApi.disconnect",
             new=api_mock,
         ),
-        patch(
-            "homeassistant.components.switcher_kis.entity.SwitcherApi.connect",
-            new=api_mock,
-        ),
-        patch(
-            "homeassistant.components.switcher_kis.entity.SwitcherApi.disconnect",
-            new=api_mock,
-        ),
     ]
 
     for patcher in patchers:

--- a/tests/components/switcher_kis/test_button.py
+++ b/tests/components/switcher_kis/test_button.py
@@ -42,7 +42,7 @@ async def test_assume_button(
     assert hass.states.get(SWING_OFF_EID) is None
 
     with patch(
-        "homeassistant.components.switcher_kis.climate.SwitcherApi.control_breeze_device",
+        "homeassistant.components.switcher_kis.entity.SwitcherApi.control_breeze_device",
     ) as mock_control_device:
         await hass.services.async_call(
             BUTTON_DOMAIN,
@@ -79,7 +79,7 @@ async def test_swing_button(
     assert hass.states.get(SWING_OFF_EID) is not None
 
     with patch(
-        "homeassistant.components.switcher_kis.climate.SwitcherApi.control_breeze_device",
+        "homeassistant.components.switcher_kis.entity.SwitcherApi.control_breeze_device",
     ) as mock_control_device:
         await hass.services.async_call(
             BUTTON_DOMAIN,
@@ -103,7 +103,7 @@ async def test_control_device_fail(
 
     # Test exception during set hvac mode
     with patch(
-        "homeassistant.components.switcher_kis.climate.SwitcherApi.control_breeze_device",
+        "homeassistant.components.switcher_kis.entity.SwitcherApi.control_breeze_device",
         side_effect=RuntimeError("fake error"),
     ) as mock_control_device:
         with pytest.raises(HomeAssistantError):
@@ -130,7 +130,7 @@ async def test_control_device_fail(
 
     # Test error response during turn on
     with patch(
-        "homeassistant.components.switcher_kis.climate.SwitcherApi.control_breeze_device",
+        "homeassistant.components.switcher_kis.entity.SwitcherApi.control_breeze_device",
         return_value=SwitcherBaseResponse(None),
     ) as mock_control_device:
         with pytest.raises(HomeAssistantError):

--- a/tests/components/switcher_kis/test_climate.py
+++ b/tests/components/switcher_kis/test_climate.py
@@ -49,7 +49,7 @@ async def test_climate_hvac_mode(
 
     # Test set hvac mode heat
     with patch(
-        "homeassistant.components.switcher_kis.climate.SwitcherApi.control_breeze_device",
+        "homeassistant.components.switcher_kis.entity.SwitcherApi.control_breeze_device",
     ) as mock_control_device:
         await hass.services.async_call(
             CLIMATE_DOMAIN,
@@ -71,7 +71,7 @@ async def test_climate_hvac_mode(
 
     # Test set hvac mode off
     with patch(
-        "homeassistant.components.switcher_kis.climate.SwitcherApi.control_breeze_device",
+        "homeassistant.components.switcher_kis.entity.SwitcherApi.control_breeze_device",
     ) as mock_control_device:
         await hass.services.async_call(
             CLIMATE_DOMAIN,
@@ -108,7 +108,7 @@ async def test_climate_temperature(
 
     # Test set target temperature
     with patch(
-        "homeassistant.components.switcher_kis.climate.SwitcherApi.control_breeze_device",
+        "homeassistant.components.switcher_kis.entity.SwitcherApi.control_breeze_device",
     ) as mock_control_device:
         await hass.services.async_call(
             CLIMATE_DOMAIN,
@@ -128,7 +128,7 @@ async def test_climate_temperature(
 
     # Test set target temperature - incorrect params
     with patch(
-        "homeassistant.components.switcher_kis.climate.SwitcherApi.control_breeze_device",
+        "homeassistant.components.switcher_kis.entity.SwitcherApi.control_breeze_device",
     ) as mock_control_device:
         with pytest.raises(ServiceValidationError):
             await hass.services.async_call(
@@ -160,7 +160,7 @@ async def test_climate_fan_level(
 
     # Test set fan level to high
     with patch(
-        "homeassistant.components.switcher_kis.climate.SwitcherApi.control_breeze_device",
+        "homeassistant.components.switcher_kis.entity.SwitcherApi.control_breeze_device",
     ) as mock_control_device:
         await hass.services.async_call(
             CLIMATE_DOMAIN,
@@ -195,7 +195,7 @@ async def test_climate_swing(
 
     # Test set swing mode on
     with patch(
-        "homeassistant.components.switcher_kis.climate.SwitcherApi.control_breeze_device",
+        "homeassistant.components.switcher_kis.entity.SwitcherApi.control_breeze_device",
     ) as mock_control_device:
         await hass.services.async_call(
             CLIMATE_DOMAIN,
@@ -218,7 +218,7 @@ async def test_climate_swing(
 
     # Test set swing mode off
     with patch(
-        "homeassistant.components.switcher_kis.climate.SwitcherApi.control_breeze_device",
+        "homeassistant.components.switcher_kis.entity.SwitcherApi.control_breeze_device",
     ) as mock_control_device:
         await hass.services.async_call(
             CLIMATE_DOMAIN,
@@ -249,7 +249,7 @@ async def test_control_device_fail(hass: HomeAssistant, mock_bridge, mock_api) -
 
     # Test exception during set hvac mode
     with patch(
-        "homeassistant.components.switcher_kis.climate.SwitcherApi.control_breeze_device",
+        "homeassistant.components.switcher_kis.entity.SwitcherApi.control_breeze_device",
         side_effect=RuntimeError("fake error"),
     ) as mock_control_device:
         with pytest.raises(HomeAssistantError):
@@ -276,7 +276,7 @@ async def test_control_device_fail(hass: HomeAssistant, mock_bridge, mock_api) -
 
     # Test error response during turn on
     with patch(
-        "homeassistant.components.switcher_kis.climate.SwitcherApi.control_breeze_device",
+        "homeassistant.components.switcher_kis.entity.SwitcherApi.control_breeze_device",
         return_value=SwitcherBaseResponse(None),
     ) as mock_control_device:
         with pytest.raises(HomeAssistantError):

--- a/tests/components/switcher_kis/test_cover.py
+++ b/tests/components/switcher_kis/test_cover.py
@@ -115,7 +115,7 @@ async def test_cover(
 
     # Test set position
     with patch(
-        "homeassistant.components.switcher_kis.cover.SwitcherApi.set_position"
+        "homeassistant.components.switcher_kis.entity.SwitcherApi.set_position"
     ) as mock_control_device:
         await hass.services.async_call(
             COVER_DOMAIN,
@@ -136,7 +136,7 @@ async def test_cover(
 
     # Test open
     with patch(
-        "homeassistant.components.switcher_kis.cover.SwitcherApi.set_position"
+        "homeassistant.components.switcher_kis.entity.SwitcherApi.set_position"
     ) as mock_control_device:
         await hass.services.async_call(
             COVER_DOMAIN,
@@ -156,7 +156,7 @@ async def test_cover(
 
     # Test close
     with patch(
-        "homeassistant.components.switcher_kis.cover.SwitcherApi.set_position"
+        "homeassistant.components.switcher_kis.entity.SwitcherApi.set_position"
     ) as mock_control_device:
         await hass.services.async_call(
             COVER_DOMAIN,
@@ -176,7 +176,7 @@ async def test_cover(
 
     # Test stop
     with patch(
-        "homeassistant.components.switcher_kis.cover.SwitcherApi.stop_shutter"
+        "homeassistant.components.switcher_kis.entity.SwitcherApi.stop_shutter"
     ) as mock_control_device:
         await hass.services.async_call(
             COVER_DOMAIN,
@@ -232,7 +232,7 @@ async def test_cover_control_fail(
 
     # Test exception during set position
     with patch(
-        "homeassistant.components.switcher_kis.cover.SwitcherApi.set_position",
+        "homeassistant.components.switcher_kis.entity.SwitcherApi.set_position",
         side_effect=RuntimeError("fake error"),
     ) as mock_control_device:
         with pytest.raises(HomeAssistantError):
@@ -257,7 +257,7 @@ async def test_cover_control_fail(
 
     # Test error response during set position
     with patch(
-        "homeassistant.components.switcher_kis.cover.SwitcherApi.set_position",
+        "homeassistant.components.switcher_kis.entity.SwitcherApi.set_position",
         return_value=SwitcherBaseResponse(None),
     ) as mock_control_device:
         with pytest.raises(HomeAssistantError):

--- a/tests/components/switcher_kis/test_light.py
+++ b/tests/components/switcher_kis/test_light.py
@@ -86,7 +86,7 @@ async def test_light(
 
     # Test turning on light
     with patch(
-        "homeassistant.components.switcher_kis.light.SwitcherApi.set_light",
+        "homeassistant.components.switcher_kis.entity.SwitcherApi.set_light",
     ) as mock_set_light:
         await hass.services.async_call(
             LIGHT_DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: entity_id}, blocking=True
@@ -99,7 +99,7 @@ async def test_light(
 
     # Test turning off light
     with patch(
-        "homeassistant.components.switcher_kis.light.SwitcherApi.set_light"
+        "homeassistant.components.switcher_kis.entity.SwitcherApi.set_light"
     ) as mock_set_light:
         await hass.services.async_call(
             LIGHT_DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: entity_id}, blocking=True
@@ -153,7 +153,7 @@ async def test_light_control_fail(
 
     # Test exception during turn on
     with patch(
-        "homeassistant.components.switcher_kis.cover.SwitcherApi.set_light",
+        "homeassistant.components.switcher_kis.entity.SwitcherApi.set_light",
         side_effect=RuntimeError("fake error"),
     ) as mock_control_device:
         with pytest.raises(HomeAssistantError):
@@ -178,7 +178,7 @@ async def test_light_control_fail(
 
     # Test error response during turn on
     with patch(
-        "homeassistant.components.switcher_kis.cover.SwitcherApi.set_light",
+        "homeassistant.components.switcher_kis.entity.SwitcherApi.set_light",
         return_value=SwitcherBaseResponse(None),
     ) as mock_control_device:
         with pytest.raises(HomeAssistantError):

--- a/tests/components/switcher_kis/test_services.py
+++ b/tests/components/switcher_kis/test_services.py
@@ -96,7 +96,7 @@ async def test_set_auto_off_service(hass: HomeAssistant, mock_bridge, mock_api) 
 
 @pytest.mark.parametrize("mock_bridge", [[DUMMY_WATER_HEATER_DEVICE]], indirect=True)
 async def test_set_auto_off_service_fail(
-    hass: HomeAssistant, mock_bridge, mock_api, caplog: pytest.LogCaptureFixture
+    hass: HomeAssistant, mock_bridge, mock_api
 ) -> None:
     """Test set auto off service failed."""
     await init_integration(hass)

--- a/tests/components/switcher_kis/test_services.py
+++ b/tests/components/switcher_kis/test_services.py
@@ -16,6 +16,7 @@ from homeassistant.components.switcher_kis.const import (
 )
 from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.config_validation import time_period_str
 from homeassistant.util import slugify
 
@@ -48,7 +49,7 @@ async def test_turn_on_with_timer_service(
     assert state.state == STATE_OFF
 
     with patch(
-        "homeassistant.components.switcher_kis.switch.SwitcherApi.control_device"
+        "homeassistant.components.switcher_kis.entity.SwitcherApi.control_device"
     ) as mock_control_device:
         await hass.services.async_call(
             DOMAIN,
@@ -78,7 +79,7 @@ async def test_set_auto_off_service(hass: HomeAssistant, mock_bridge, mock_api) 
     entity_id = f"{SWITCH_DOMAIN}.{slugify(device.name)}"
 
     with patch(
-        "homeassistant.components.switcher_kis.switch.SwitcherApi.set_auto_shutdown"
+        "homeassistant.components.switcher_kis.entity.SwitcherApi.set_auto_shutdown"
     ) as mock_set_auto_shutdown:
         await hass.services.async_call(
             DOMAIN,
@@ -105,23 +106,20 @@ async def test_set_auto_off_service_fail(
     entity_id = f"{SWITCH_DOMAIN}.{slugify(device.name)}"
 
     with patch(
-        "homeassistant.components.switcher_kis.switch.SwitcherApi.set_auto_shutdown",
+        "homeassistant.components.switcher_kis.entity.SwitcherApi.set_auto_shutdown",
         return_value=None,
     ) as mock_set_auto_shutdown:
-        await hass.services.async_call(
-            DOMAIN,
-            SERVICE_SET_AUTO_OFF_NAME,
-            {ATTR_ENTITY_ID: entity_id, CONF_AUTO_OFF: DUMMY_AUTO_OFF_SET},
-            blocking=True,
-        )
+        with pytest.raises(HomeAssistantError):
+            await hass.services.async_call(
+                DOMAIN,
+                SERVICE_SET_AUTO_OFF_NAME,
+                {ATTR_ENTITY_ID: entity_id, CONF_AUTO_OFF: DUMMY_AUTO_OFF_SET},
+                blocking=True,
+            )
 
         assert mock_api.call_count == 2
         mock_set_auto_shutdown.assert_called_once_with(
             time_period_str(DUMMY_AUTO_OFF_SET)
-        )
-        assert (
-            f"Call api for {device.name} failed, api: 'set_auto_shutdown'"
-            in caplog.text
         )
         state = hass.states.get(entity_id)
         assert state.state == STATE_UNAVAILABLE

--- a/tests/components/switcher_kis/test_switch.py
+++ b/tests/components/switcher_kis/test_switch.py
@@ -79,7 +79,6 @@ async def test_switch_control_fail(
     mock_bridge,
     mock_api,
     monkeypatch: pytest.MonkeyPatch,
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test switch control fail."""
     await init_integration(hass)

--- a/tests/components/switcher_kis/test_switch.py
+++ b/tests/components/switcher_kis/test_switch.py
@@ -16,6 +16,7 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.util import slugify
 
 from . import init_integration
@@ -47,7 +48,7 @@ async def test_switch(
 
     # Test turning on
     with patch(
-        "homeassistant.components.switcher_kis.switch.SwitcherApi.control_device",
+        "homeassistant.components.switcher_kis.entity.SwitcherApi.control_device",
     ) as mock_control_device:
         await hass.services.async_call(
             SWITCH_DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: entity_id}, blocking=True
@@ -60,7 +61,7 @@ async def test_switch(
 
     # Test turning off
     with patch(
-        "homeassistant.components.switcher_kis.switch.SwitcherApi.control_device"
+        "homeassistant.components.switcher_kis.entity.SwitcherApi.control_device"
     ) as mock_control_device:
         await hass.services.async_call(
             SWITCH_DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: entity_id}, blocking=True
@@ -97,18 +98,19 @@ async def test_switch_control_fail(
 
     # Test exception during turn on
     with patch(
-        "homeassistant.components.switcher_kis.switch.SwitcherApi.control_device",
+        "homeassistant.components.switcher_kis.entity.SwitcherApi.control_device",
         side_effect=RuntimeError("fake error"),
     ) as mock_control_device:
-        await hass.services.async_call(
-            SWITCH_DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: entity_id}, blocking=True
-        )
+        with pytest.raises(HomeAssistantError):
+            await hass.services.async_call(
+                SWITCH_DOMAIN,
+                SERVICE_TURN_ON,
+                {ATTR_ENTITY_ID: entity_id},
+                blocking=True,
+            )
 
         assert mock_api.call_count == 2
         mock_control_device.assert_called_once_with(Command.ON)
-        assert (
-            f"Call api for {device.name} failed, api: 'control_device'" in caplog.text
-        )
         state = hass.states.get(entity_id)
         assert state.state == STATE_UNAVAILABLE
 
@@ -121,17 +123,18 @@ async def test_switch_control_fail(
 
     # Test error response during turn on
     with patch(
-        "homeassistant.components.switcher_kis.switch.SwitcherApi.control_device",
+        "homeassistant.components.switcher_kis.entity.SwitcherApi.control_device",
         return_value=SwitcherBaseResponse(None),
     ) as mock_control_device:
-        await hass.services.async_call(
-            SWITCH_DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: entity_id}, blocking=True
-        )
+        with pytest.raises(HomeAssistantError):
+            await hass.services.async_call(
+                SWITCH_DOMAIN,
+                SERVICE_TURN_ON,
+                {ATTR_ENTITY_ID: entity_id},
+                blocking=True,
+            )
 
         assert mock_api.call_count == 4
         mock_control_device.assert_called_once_with(Command.ON)
-        assert (
-            f"Call api for {device.name} failed, api: 'control_device'" in caplog.text
-        )
         state = hass.states.get(entity_id)
         assert state.state == STATE_UNAVAILABLE


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Refactoring Switcher _async_call_api to make one instance of it in entity.py

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
