### PR TITLE
fix AndroidTV logging when disconnected

### DIFF
--- a/homeassistant/components/androidtv/__init__.py
+++ b/homeassistant/components/androidtv/__init__.py
@@ -17,7 +17,6 @@ from adb_shell.exceptions import (
     TcpTimeoutException,
 )
 from androidtv.adb_manager.adb_manager_sync import ADBPythonSync, PythonRSASigner
-from androidtv.constants import DEFAULT_TRANSPORT_TIMEOUT_S
 from androidtv.setup_async import (
     AndroidTVAsync,
     FireTVAsync,
@@ -136,17 +135,16 @@ async def async_connect_androidtv(
     )
 
     aftv = await async_androidtv_setup(
-        config[CONF_HOST],
-        config[CONF_PORT],
-        adbkey,
-        config.get(CONF_ADB_SERVER_IP),
-        config.get(CONF_ADB_SERVER_PORT, DEFAULT_ADB_SERVER_PORT),
-        state_detection_rules,
-        config[CONF_DEVICE_CLASS],
-        timeout,
-        signer,
-        DEFAULT_TRANSPORT_TIMEOUT_S,
-        False,
+        host=config[CONF_HOST],
+        port=config[CONF_PORT],
+        adbkey=adbkey,
+        adb_server_ip=config.get(CONF_ADB_SERVER_IP),
+        adb_server_port=config.get(CONF_ADB_SERVER_PORT, DEFAULT_ADB_SERVER_PORT),
+        state_detection_rules=state_detection_rules,
+        device_class=config[CONF_DEVICE_CLASS],
+        auth_timeout_s=timeout,
+        signer=signer,
+        log_errors=False,
     )
 
     if not aftv.available:

--- a/homeassistant/components/androidtv/__init__.py
+++ b/homeassistant/components/androidtv/__init__.py
@@ -17,6 +17,7 @@ from adb_shell.exceptions import (
     TcpTimeoutException,
 )
 from androidtv.adb_manager.adb_manager_sync import ADBPythonSync, PythonRSASigner
+from androidtv.constants import DEFAULT_TRANSPORT_TIMEOUT_S
 from androidtv.setup_async import (
     AndroidTVAsync,
     FireTVAsync,
@@ -144,6 +145,8 @@ async def async_connect_androidtv(
         config[CONF_DEVICE_CLASS],
         timeout,
         signer,
+        DEFAULT_TRANSPORT_TIMEOUT_S,
+        False,
     )
 
     if not aftv.available:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Change logging level to avoid filling up the log while the device is off:

```
2024-12-11 12:18:04.767 WARNING (MainThread) [androidtv.adb_manager.adb_manager_async] Couldn't connect to 192.168.1.84:5555.  TcpTimeoutException: Connecting to 192.168.1.84:5555 timed out (1.0 seconds)
2024-12-11 12:19:26.024 WARNING (MainThread) [androidtv.adb_manager.adb_manager_async] Couldn't connect to 192.168.1.84:5555.  TcpTimeoutException: Connecting to 192.168.1.84:5555 timed out (1.0 seconds)
2024-12-11 12:20:47.162 WARNING (MainThread) [androidtv.adb_manager.adb_manager_async] Couldn't connect to 192.168.1.84:5555.  TcpTimeoutException: Connecting to 192.168.1.84:5555 timed out (1.0 seconds)
2024-12-11 12:22:08.523 WARNING (MainThread) [androidtv.adb_manager.adb_manager_async] Couldn't connect to 192.168.1.84:5555.  TcpTimeoutException: Connecting to 192.168.1.84:5555 timed out (1.0 seconds)
2024-12-11 12:23:30.003 WARNING (MainThread) [androidtv.adb_manager.adb_manager_async] Couldn't connect to 192.168.1.84:5555.  TcpTimeoutException: Connecting to 192.168.1.84:5555 timed out (1.0 seconds)
2024-12-11 12:24:51.397 WARNING (MainThread) [androidtv.adb_manager.adb_manager_async] Couldn't connect to 192.168.1.84:5555.  TcpTimeoutException: Connecting to 192.168.1.84:5555 timed out (1.0 seconds)
2024-12-11 12:26:12.708 WARNING (MainThread) [androidtv.adb_manager.adb_manager_async] Couldn't connect to 192.168.1.84:5555.  TcpTimeoutException: Connecting to 192.168.1.84:5555 timed out (1.0 seconds)
2024-12-11 12:27:33.878 WARNING (MainThread) [androidtv.adb_manager.adb_manager_async] Couldn't connect to 192.168.1.84:5555.  TcpTimeoutException: Connecting to 192.168.1.84:5555 timed out (1.0 seconds)
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
