### PR TITLE
Remove port from Elgato configuration flow

### DIFF
--- a/homeassistant/components/elgato/config_flow.py
+++ b/homeassistant/components/elgato/config_flow.py
@@ -9,7 +9,7 @@ import voluptuous as vol
 
 from homeassistant.components import onboarding, zeroconf
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
-from homeassistant.const import CONF_HOST, CONF_MAC, CONF_PORT
+from homeassistant.const import CONF_HOST, CONF_MAC
 from homeassistant.core import callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
@@ -34,7 +34,6 @@ class ElgatoFlowHandler(ConfigFlow, domain=DOMAIN):
             return self._async_show_setup_form()
 
         self.host = user_input[CONF_HOST]
-        self.port = user_input[CONF_PORT]
 
         try:
             await self._get_elgato_serial_number(raise_on_progress=False)
@@ -49,7 +48,6 @@ class ElgatoFlowHandler(ConfigFlow, domain=DOMAIN):
         """Handle zeroconf discovery."""
         self.host = discovery_info.host
         self.mac = discovery_info.properties.get("id")
-        self.port = discovery_info.port or 9123
 
         try:
             await self._get_elgato_serial_number()
@@ -81,7 +79,6 @@ class ElgatoFlowHandler(ConfigFlow, domain=DOMAIN):
             data_schema=vol.Schema(
                 {
                     vol.Required(CONF_HOST): str,
-                    vol.Optional(CONF_PORT, default=9123): int,
                 }
             ),
             errors=errors or {},
@@ -93,7 +90,6 @@ class ElgatoFlowHandler(ConfigFlow, domain=DOMAIN):
             title=self.serial_number,
             data={
                 CONF_HOST: self.host,
-                CONF_PORT: self.port,
                 CONF_MAC: self.mac,
             },
         )
@@ -103,7 +99,6 @@ class ElgatoFlowHandler(ConfigFlow, domain=DOMAIN):
         session = async_get_clientsession(self.hass)
         elgato = Elgato(
             host=self.host,
-            port=self.port,
             session=session,
         )
         info = await elgato.info()
@@ -113,7 +108,7 @@ class ElgatoFlowHandler(ConfigFlow, domain=DOMAIN):
             info.serial_number, raise_on_progress=raise_on_progress
         )
         self._abort_if_unique_id_configured(
-            updates={CONF_HOST: self.host, CONF_PORT: self.port, CONF_MAC: self.mac}
+            updates={CONF_HOST: self.host, CONF_MAC: self.mac}
         )
 
         self.serial_number = info.serial_number

--- a/homeassistant/components/elgato/coordinator.py
+++ b/homeassistant/components/elgato/coordinator.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from elgato import BatteryInfo, Elgato, ElgatoConnectionError, Info, Settings, State
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -34,7 +34,6 @@ class ElgatoDataUpdateCoordinator(DataUpdateCoordinator[ElgatoData]):
         self.config_entry = entry
         self.client = Elgato(
             entry.data[CONF_HOST],
-            port=entry.data[CONF_PORT],
             session=async_get_clientsession(hass),
         )
         super().__init__(

--- a/homeassistant/components/elgato/quality_scale.yaml
+++ b/homeassistant/components/elgato/quality_scale.yaml
@@ -5,10 +5,7 @@ rules:
   brands: done
   common-modules: done
   config-flow-test-coverage: done
-  config-flow:
-    status: todo
-    comment: |
-      The data_description for port is missing.
+  config-flow: done
   dependency-transparency: done
   docs-actions: done
   docs-high-level-description: done

--- a/homeassistant/components/elgato/strings.json
+++ b/homeassistant/components/elgato/strings.json
@@ -5,8 +5,7 @@
       "user": {
         "description": "Set up your Elgato Light to integrate with Home Assistant.",
         "data": {
-          "host": "[%key:common::config_flow::data::host%]",
-          "port": "[%key:common::config_flow::data::port%]"
+          "host": "[%key:common::config_flow::data::host%]"
         },
         "data_description": {
           "host": "The hostname or IP address of your Elgato device."

--- a/tests/components/elgato/conftest.py
+++ b/tests/components/elgato/conftest.py
@@ -7,7 +7,7 @@ from elgato import BatteryInfo, ElgatoNoBatteryError, Info, Settings, State
 import pytest
 
 from homeassistant.components.elgato.const import DOMAIN
-from homeassistant.const import CONF_HOST, CONF_MAC, CONF_PORT
+from homeassistant.const import CONF_HOST, CONF_MAC
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry, get_fixture_path, load_fixture
@@ -35,7 +35,6 @@ def mock_config_entry() -> MockConfigEntry:
         data={
             CONF_HOST: "127.0.0.1",
             CONF_MAC: "AA:BB:CC:DD:EE:FF",
-            CONF_PORT: 9123,
         },
         unique_id="CN11A1A00001",
     )

--- a/tests/components/elgato/snapshots/test_config_flow.ambr
+++ b/tests/components/elgato/snapshots/test_config_flow.ambr
@@ -8,7 +8,6 @@
     'data': dict({
       'host': '127.0.0.1',
       'mac': None,
-      'port': 9123,
     }),
     'description': None,
     'description_placeholders': None,
@@ -21,7 +20,6 @@
       'data': dict({
         'host': '127.0.0.1',
         'mac': None,
-        'port': 9123,
       }),
       'disabled_by': None,
       'discovery_keys': dict({
@@ -53,7 +51,6 @@
     'data': dict({
       'host': '127.0.0.1',
       'mac': 'AA:BB:CC:DD:EE:FF',
-      'port': 9123,
     }),
     'description': None,
     'description_placeholders': None,
@@ -66,7 +63,6 @@
       'data': dict({
         'host': '127.0.0.1',
         'mac': 'AA:BB:CC:DD:EE:FF',
-        'port': 9123,
       }),
       'disabled_by': None,
       'discovery_keys': dict({
@@ -97,7 +93,6 @@
     'data': dict({
       'host': '127.0.0.1',
       'mac': 'AA:BB:CC:DD:EE:FF',
-      'port': 9123,
     }),
     'description': None,
     'description_placeholders': None,
@@ -110,7 +105,6 @@
       'data': dict({
         'host': '127.0.0.1',
         'mac': 'AA:BB:CC:DD:EE:FF',
-        'port': 9123,
       }),
       'disabled_by': None,
       'discovery_keys': dict({

--- a/tests/components/elgato/test_config_flow.py
+++ b/tests/components/elgato/test_config_flow.py
@@ -10,7 +10,7 @@ from syrupy.assertion import SnapshotAssertion
 from homeassistant.components import zeroconf
 from homeassistant.components.elgato.const import DOMAIN
 from homeassistant.config_entries import SOURCE_USER, SOURCE_ZEROCONF
-from homeassistant.const import CONF_HOST, CONF_PORT, CONF_SOURCE
+from homeassistant.const import CONF_HOST, CONF_SOURCE
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
@@ -33,7 +33,7 @@ async def test_full_user_flow_implementation(
     assert result.get("step_id") == "user"
 
     result2 = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input={CONF_HOST: "127.0.0.1", CONF_PORT: 9123}
+        result["flow_id"], user_input={CONF_HOST: "127.0.0.1"}
     )
 
     assert result2.get("type") is FlowResultType.CREATE_ENTRY
@@ -94,7 +94,7 @@ async def test_connection_error(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_USER},
-        data={CONF_HOST: "127.0.0.1", CONF_PORT: 9123},
+        data={CONF_HOST: "127.0.0.1"},
     )
 
     assert result.get("type") is FlowResultType.FORM
@@ -135,7 +135,7 @@ async def test_user_device_exists_abort(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_USER},
-        data={CONF_HOST: "127.0.0.1", CONF_PORT: 9123},
+        data={CONF_HOST: "127.0.0.1"},
     )
 
     assert result.get("type") is FlowResultType.ABORT


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR removes the port configuration option from the Elgato integration.

Why was it in there? I really don't know 🤷  It cannot be changed, so let's not make things more difficult than they are.

This also completes an item on the quality_scale, as with the removal of the port, all fields now have a data_description.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
