### PR TITLE
Use ConfigEntry runtime_data in EnergyZero

### DIFF
--- a/homeassistant/components/energyzero/__init__.py
+++ b/homeassistant/components/energyzero/__init__.py
@@ -13,8 +13,10 @@ from .const import DOMAIN
 from .coordinator import EnergyZeroDataUpdateCoordinator
 from .services import async_setup_services
 
-PLATFORMS = [Platform.SENSOR]
+PLATFORMS: list[Platform] = [Platform.SENSOR]
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
+
+type EnergyZeroConfigEntry = ConfigEntry[EnergyZeroDataUpdateCoordinator]
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
@@ -25,7 +27,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     return True
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: EnergyZeroConfigEntry) -> bool:
     """Set up EnergyZero from a config entry."""
 
     coordinator = EnergyZeroDataUpdateCoordinator(hass)
@@ -35,15 +37,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         await coordinator.energyzero.close()
         raise
 
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
+    entry.runtime_data = coordinator
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: EnergyZeroConfigEntry) -> bool:
     """Unload EnergyZero config entry."""
-    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        hass.data[DOMAIN].pop(entry.entry_id)
-    return unload_ok
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/energyzero/diagnostics.py
+++ b/homeassistant/components/energyzero/diagnostics.py
@@ -5,11 +5,9 @@ from __future__ import annotations
 from datetime import timedelta
 from typing import Any
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from . import EnergyZeroDataUpdateCoordinator
-from .const import DOMAIN
+from . import EnergyZeroConfigEntry
 from .coordinator import EnergyZeroData
 
 
@@ -32,30 +30,28 @@ def get_gas_price(data: EnergyZeroData, hours: int) -> float | None:
 
 
 async def async_get_config_entry_diagnostics(
-    hass: HomeAssistant, entry: ConfigEntry
+    hass: HomeAssistant, entry: EnergyZeroConfigEntry
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
-    coordinator: EnergyZeroDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
-
     return {
         "entry": {
             "title": entry.title,
         },
         "energy": {
-            "current_hour_price": coordinator.data.energy_today.current_price,
-            "next_hour_price": coordinator.data.energy_today.price_at_time(
-                coordinator.data.energy_today.utcnow() + timedelta(hours=1)
+            "current_hour_price": entry.runtime_data.data.energy_today.current_price,
+            "next_hour_price": entry.runtime_data.data.energy_today.price_at_time(
+                entry.runtime_data.data.energy_today.utcnow() + timedelta(hours=1)
             ),
-            "average_price": coordinator.data.energy_today.average_price,
-            "max_price": coordinator.data.energy_today.extreme_prices[1],
-            "min_price": coordinator.data.energy_today.extreme_prices[0],
-            "highest_price_time": coordinator.data.energy_today.highest_price_time,
-            "lowest_price_time": coordinator.data.energy_today.lowest_price_time,
-            "percentage_of_max": coordinator.data.energy_today.pct_of_max_price,
-            "hours_priced_equal_or_lower": coordinator.data.energy_today.hours_priced_equal_or_lower,
+            "average_price": entry.runtime_data.data.energy_today.average_price,
+            "max_price": entry.runtime_data.data.energy_today.extreme_prices[1],
+            "min_price": entry.runtime_data.data.energy_today.extreme_prices[0],
+            "highest_price_time": entry.runtime_data.data.energy_today.highest_price_time,
+            "lowest_price_time": entry.runtime_data.data.energy_today.lowest_price_time,
+            "percentage_of_max": entry.runtime_data.data.energy_today.pct_of_max_price,
+            "hours_priced_equal_or_lower": entry.runtime_data.data.energy_today.hours_priced_equal_or_lower,
         },
         "gas": {
-            "current_hour_price": get_gas_price(coordinator.data, 0),
-            "next_hour_price": get_gas_price(coordinator.data, 1),
+            "current_hour_price": get_gas_price(entry.runtime_data.data, 0),
+            "next_hour_price": get_gas_price(entry.runtime_data.data, 1),
         },
     }

--- a/homeassistant/components/energyzero/sensor.py
+++ b/homeassistant/components/energyzero/sensor.py
@@ -13,7 +13,6 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CURRENCY_EURO,
     PERCENTAGE,
@@ -26,6 +25,7 @@ from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from . import EnergyZeroConfigEntry
 from .const import DOMAIN, SERVICE_TYPE_DEVICE_NAMES
 from .coordinator import EnergyZeroData, EnergyZeroDataUpdateCoordinator
 
@@ -142,10 +142,12 @@ def get_gas_price(data: EnergyZeroData, hours: int) -> float | None:
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+    hass: HomeAssistant,
+    entry: EnergyZeroConfigEntry,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up EnergyZero Sensors based on a config entry."""
-    coordinator: EnergyZeroDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator = entry.runtime_data
     async_add_entities(
         EnergyZeroSensorEntity(
             coordinator=coordinator,

--- a/homeassistant/components/energyzero/services.py
+++ b/homeassistant/components/energyzero/services.py
@@ -107,7 +107,7 @@ def __get_coordinator(
             },
         )
 
-    coordinator: EnergyZeroDataUpdateCoordinator = hass.data[DOMAIN][entry_id]
+    coordinator: EnergyZeroDataUpdateCoordinator = entry.runtime_data
     return coordinator
 
 

--- a/tests/components/energyzero/test_init.py
+++ b/tests/components/energyzero/test_init.py
@@ -5,7 +5,6 @@ from unittest.mock import MagicMock, patch
 from energyzero import EnergyZeroConnectionError
 import pytest
 
-from homeassistant.components.energyzero.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 
@@ -26,7 +25,6 @@ async def test_load_unload_config_entry(
     await hass.config_entries.async_unload(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert not hass.data.get(DOMAIN)
     assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Moves the EnergyZero integration to use the `runtime_data` attribute of the ConfigEntry instead of `hass.data`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
