### PR TITLE
Improve config flow test coverage for Russound RIO

### DIFF
--- a/homeassistant/components/russound_rio/quality_scale.yaml
+++ b/homeassistant/components/russound_rio/quality_scale.yaml
@@ -10,10 +10,7 @@ rules:
       This integration uses a push API. No polling required.
   brands: done
   common-modules: done
-  config-flow-test-coverage:
-    status: todo
-    comment: |
-      Missing unique_id check in test_form() and test_import(). Test for adding same device twice missing.
+  config-flow-test-coverage: done
   config-flow: done
   dependency-transparency: done
   docs-actions:

--- a/tests/components/russound_rio/__init__.py
+++ b/tests/components/russound_rio/__init__.py
@@ -1,5 +1,9 @@
 """Tests for the Russound RIO integration."""
 
+from unittest.mock import AsyncMock
+
+from aiorussound.models import CallbackType
+
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
@@ -11,3 +15,11 @@ async def setup_integration(hass: HomeAssistant, config_entry: MockConfigEntry) 
 
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
+
+
+async def mock_state_update(
+    client: AsyncMock, callback_type: CallbackType = CallbackType.STATE
+) -> None:
+    """Trigger a callback in the media player."""
+    for callback in client.register_state_update_callbacks.call_args_list:
+        await callback[0][0](client, callback_type)

--- a/tests/components/russound_rio/test_config_flow.py
+++ b/tests/components/russound_rio/test_config_flow.py
@@ -9,6 +9,8 @@ from homeassistant.data_entry_flow import FlowResultType
 
 from .const import MOCK_CONFIG, MODEL
 
+from tests.common import MockConfigEntry
+
 
 async def test_form(
     hass: HomeAssistant, mock_setup_entry: AsyncMock, mock_russound_client: AsyncMock
@@ -29,6 +31,7 @@ async def test_form(
     assert result["title"] == MODEL
     assert result["data"] == MOCK_CONFIG
     assert len(mock_setup_entry.mock_calls) == 1
+    assert result["result"].unique_id == "00:11:22:33:44:55"
 
 
 async def test_form_cannot_connect(
@@ -60,6 +63,31 @@ async def test_form_cannot_connect(
     assert len(mock_setup_entry.mock_calls) == 1
 
 
+async def test_duplicate(
+    hass: HomeAssistant,
+    mock_russound_client: AsyncMock,
+    mock_setup_entry: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test duplicate flow."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        MOCK_CONFIG,
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
 async def test_import(
     hass: HomeAssistant, mock_setup_entry: AsyncMock, mock_russound_client: AsyncMock
 ) -> None:
@@ -74,6 +102,7 @@ async def test_import(
     assert result["title"] == MODEL
     assert result["data"] == MOCK_CONFIG
     assert len(mock_setup_entry.mock_calls) == 1
+    assert result["result"].unique_id == "00:11:22:33:44:55"
 
 
 async def test_import_cannot_connect(

--- a/tests/components/russound_rio/test_init.py
+++ b/tests/components/russound_rio/test_init.py
@@ -1,7 +1,9 @@
 """Tests for the Russound RIO integration."""
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
+from aiorussound.models import CallbackType
+import pytest
 from syrupy import SnapshotAssertion
 
 from homeassistant.components.russound_rio.const import DOMAIN
@@ -9,7 +11,7 @@ from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
-from . import setup_integration
+from . import mock_state_update, setup_integration
 
 from tests.common import MockConfigEntry
 
@@ -42,3 +44,23 @@ async def test_device_info(
     )
     assert device_entry is not None
     assert device_entry == snapshot
+
+
+async def test_disconnect_reconnect_log(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    mock_russound_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    device_registry: dr.DeviceRegistry,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test device registry integration."""
+    await setup_integration(hass, mock_config_entry)
+
+    mock_russound_client.is_connected = Mock(return_value=False)
+    await mock_state_update(mock_russound_client, CallbackType.CONNECTION)
+    assert "Disconnected from device at 127.0.0.1" in caplog.text
+
+    mock_russound_client.is_connected = Mock(return_value=True)
+    await mock_state_update(mock_russound_client, CallbackType.CONNECTION)
+    assert "Reconnected to device at 127.0.0.1" in caplog.text

--- a/tests/components/russound_rio/test_media_player.py
+++ b/tests/components/russound_rio/test_media_player.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import AsyncMock
 
-from aiorussound.models import CallbackType, PlayStatus
+from aiorussound.models import PlayStatus
 import pytest
 
 from homeassistant.const import (
@@ -15,16 +15,10 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 
-from . import setup_integration
+from . import mock_state_update, setup_integration
 from .const import ENTITY_ID_ZONE_1
 
 from tests.common import MockConfigEntry
-
-
-async def mock_state_update(client: AsyncMock) -> None:
-    """Trigger a callback in the media player."""
-    for callback in client.register_state_update_callbacks.call_args_list:
-        await callback[0][0](client, CallbackType.STATE)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds additional checks to the config flow tests. Also checks for connect/disconnect log events.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
