### PR TITLE
Migrate alexa color_temp handlers to use Kelvin

### DIFF
--- a/homeassistant/components/alexa/handlers.py
+++ b/homeassistant/components/alexa/handlers.py
@@ -376,14 +376,14 @@ async def async_api_decrease_color_temp(
 ) -> AlexaResponse:
     """Process a decrease color temperature request."""
     entity = directive.entity
-    current = int(entity.attributes[light.ATTR_COLOR_TEMP])
-    max_mireds = int(entity.attributes[light.ATTR_MAX_MIREDS])
+    current = int(entity.attributes[light.ATTR_COLOR_TEMP_KELVIN])
+    min_kelvin = int(entity.attributes[light.ATTR_MIN_COLOR_TEMP_KELVIN])
 
-    value = min(max_mireds, current + 50)
+    value = max(min_kelvin, current - 500)
     await hass.services.async_call(
         entity.domain,
         SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: entity.entity_id, light.ATTR_COLOR_TEMP: value},
+        {ATTR_ENTITY_ID: entity.entity_id, light.ATTR_COLOR_TEMP_KELVIN: value},
         blocking=False,
         context=context,
     )
@@ -400,14 +400,14 @@ async def async_api_increase_color_temp(
 ) -> AlexaResponse:
     """Process an increase color temperature request."""
     entity = directive.entity
-    current = int(entity.attributes[light.ATTR_COLOR_TEMP])
-    min_mireds = int(entity.attributes[light.ATTR_MIN_MIREDS])
+    current = int(entity.attributes[light.ATTR_COLOR_TEMP_KELVIN])
+    max_kelvin = int(entity.attributes[light.ATTR_MAX_COLOR_TEMP_KELVIN])
 
-    value = max(min_mireds, current - 50)
+    value = min(max_kelvin, current + 500)
     await hass.services.async_call(
         entity.domain,
         SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: entity.entity_id, light.ATTR_COLOR_TEMP: value},
+        {ATTR_ENTITY_ID: entity.entity_id, light.ATTR_COLOR_TEMP_KELVIN: value},
         blocking=False,
         context=context,
     )

--- a/tests/components/alexa/test_capabilities.py
+++ b/tests/components/alexa/test_capabilities.py
@@ -163,7 +163,7 @@ async def test_api_set_color_temperature(hass: HomeAssistant) -> None:
     assert msg["header"]["name"] == "Response"
 
 
-@pytest.mark.parametrize(("result", "initial"), [(383, "333"), (500, "500")])
+@pytest.mark.parametrize(("result", "initial"), [(2500, "3000"), (2000, "2000")])
 async def test_api_decrease_color_temp(
     hass: HomeAssistant, result: int, initial: str
 ) -> None:
@@ -176,7 +176,11 @@ async def test_api_decrease_color_temp(
     hass.states.async_set(
         "light.test",
         "off",
-        {"friendly_name": "Test light", "color_temp": initial, "max_mireds": 500},
+        {
+            "friendly_name": "Test light",
+            "color_temp_kelvin": initial,
+            "min_color_temp_kelvin": 2000,
+        },
     )
 
     call_light = async_mock_service(hass, "light", "turn_on")
@@ -189,11 +193,11 @@ async def test_api_decrease_color_temp(
 
     assert len(call_light) == 1
     assert call_light[0].data["entity_id"] == "light.test"
-    assert call_light[0].data["color_temp"] == result
+    assert call_light[0].data["color_temp_kelvin"] == result
     assert msg["header"]["name"] == "Response"
 
 
-@pytest.mark.parametrize(("result", "initial"), [(283, "333"), (142, "142")])
+@pytest.mark.parametrize(("result", "initial"), [(3500, "3000"), (7000, "7000")])
 async def test_api_increase_color_temp(
     hass: HomeAssistant, result: int, initial: str
 ) -> None:
@@ -206,7 +210,11 @@ async def test_api_increase_color_temp(
     hass.states.async_set(
         "light.test",
         "off",
-        {"friendly_name": "Test light", "color_temp": initial, "min_mireds": 142},
+        {
+            "friendly_name": "Test light",
+            "color_temp_kelvin": initial,
+            "max_color_temp_kelvin": 7000,
+        },
     )
 
     call_light = async_mock_service(hass, "light", "turn_on")
@@ -219,7 +227,7 @@ async def test_api_increase_color_temp(
 
     assert len(call_light) == 1
     assert call_light[0].data["entity_id"] == "light.test"
-    assert call_light[0].data["color_temp"] == result
+    assert call_light[0].data["color_temp_kelvin"] == result
     assert msg["header"]["name"] == "Response"
 
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Based on #79591, needed for #132680

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
