### PR TITLE
Migrate google_assistant color_temp handlers to use Kelvin

### DIFF
--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -553,15 +553,9 @@ class ColorSettingTrait(_Trait):
             response["colorModel"] = "hsv"
 
         if light.color_temp_supported(color_modes):
-            # Max Kelvin is Min Mireds K = 1000000 / mireds
-            # Min Kelvin is Max Mireds K = 1000000 / mireds
             response["colorTemperatureRange"] = {
-                "temperatureMaxK": color_util.color_temperature_mired_to_kelvin(
-                    attrs.get(light.ATTR_MIN_MIREDS)
-                ),
-                "temperatureMinK": color_util.color_temperature_mired_to_kelvin(
-                    attrs.get(light.ATTR_MAX_MIREDS)
-                ),
+                "temperatureMaxK": int(attrs.get(light.ATTR_MAX_COLOR_TEMP_KELVIN)),
+                "temperatureMinK": int(attrs.get(light.ATTR_MIN_COLOR_TEMP_KELVIN)),
             }
 
         return response
@@ -583,7 +577,7 @@ class ColorSettingTrait(_Trait):
                 }
 
         if light.color_temp_supported([color_mode]):
-            temp = self.state.attributes.get(light.ATTR_COLOR_TEMP)
+            temp = self.state.attributes.get(light.ATTR_COLOR_TEMP_KELVIN)
             # Some faulty integrations might put 0 in here, raising exception.
             if temp == 0:
                 _LOGGER.warning(
@@ -592,9 +586,7 @@ class ColorSettingTrait(_Trait):
                     temp,
                 )
             elif temp is not None:
-                color["temperatureK"] = color_util.color_temperature_mired_to_kelvin(
-                    temp
-                )
+                color["temperatureK"] = temp
 
         response = {}
 
@@ -606,11 +598,9 @@ class ColorSettingTrait(_Trait):
     async def execute(self, command, data, params, challenge):
         """Execute a color temperature command."""
         if "temperature" in params["color"]:
-            temp = color_util.color_temperature_kelvin_to_mired(
-                params["color"]["temperature"]
-            )
-            min_temp = self.state.attributes[light.ATTR_MIN_MIREDS]
-            max_temp = self.state.attributes[light.ATTR_MAX_MIREDS]
+            temp = params["color"]["temperature"]
+            max_temp = self.state.attributes[light.ATTR_MAX_COLOR_TEMP_KELVIN]
+            min_temp = self.state.attributes[light.ATTR_MIN_COLOR_TEMP_KELVIN]
 
             if temp < min_temp or temp > max_temp:
                 raise SmartHomeError(
@@ -621,7 +611,10 @@ class ColorSettingTrait(_Trait):
             await self.hass.services.async_call(
                 light.DOMAIN,
                 SERVICE_TURN_ON,
-                {ATTR_ENTITY_ID: self.state.entity_id, light.ATTR_COLOR_TEMP: temp},
+                {
+                    ATTR_ENTITY_ID: self.state.entity_id,
+                    light.ATTR_COLOR_TEMP_KELVIN: temp,
+                },
                 blocking=not self.config.should_report_state,
                 context=data.context,
             )

--- a/tests/components/google_assistant/test_google_assistant.py
+++ b/tests/components/google_assistant/test_google_assistant.py
@@ -491,7 +491,7 @@ async def test_execute_request(hass_fixture, assistant_client, auth_header) -> N
     assert kitchen.attributes.get(light.ATTR_RGB_COLOR) == (255, 0, 0)
 
     bed = hass_fixture.states.get("light.bed_light")
-    assert bed.attributes.get(light.ATTR_COLOR_TEMP) == 212
+    assert bed.attributes.get(light.ATTR_COLOR_TEMP_KELVIN) == 4700
 
     assert hass_fixture.states.get("switch.decorative_lights").state == "off"
 

--- a/tests/components/google_assistant/test_smart_home.py
+++ b/tests/components/google_assistant/test_smart_home.py
@@ -1450,7 +1450,7 @@ async def test_sync_message_recovery(
         "light.bad_light",
         "on",
         {
-            "min_mireds": "badvalue",
+            "max_color_temp_kelvin": "badvalue",
             "supported_color_modes": ["color_temp"],
         },
     )

--- a/tests/components/google_assistant/test_trait.py
+++ b/tests/components/google_assistant/test_trait.py
@@ -77,7 +77,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant, State
 from homeassistant.core_config import async_process_ha_core_config
-from homeassistant.util import color, dt as dt_util
+from homeassistant.util import dt as dt_util
 from homeassistant.util.unit_conversion import TemperatureConverter
 
 from . import BASIC_CONFIG, MockConfig
@@ -870,10 +870,10 @@ async def test_color_setting_temperature_light(hass: HomeAssistant) -> None:
             "light.bla",
             STATE_ON,
             {
-                light.ATTR_MIN_MIREDS: 200,
+                light.ATTR_MAX_COLOR_TEMP_KELVIN: 5000,
                 light.ATTR_COLOR_MODE: "color_temp",
-                light.ATTR_COLOR_TEMP: 300,
-                light.ATTR_MAX_MIREDS: 500,
+                light.ATTR_COLOR_TEMP_KELVIN: 3333,
+                light.ATTR_MIN_COLOR_TEMP_KELVIN: 2000,
                 "supported_color_modes": ["color_temp"],
             },
         ),
@@ -906,7 +906,7 @@ async def test_color_setting_temperature_light(hass: HomeAssistant) -> None:
     assert len(calls) == 1
     assert calls[0].data == {
         ATTR_ENTITY_ID: "light.bla",
-        light.ATTR_COLOR_TEMP: color.color_temperature_kelvin_to_mired(2857),
+        light.ATTR_COLOR_TEMP_KELVIN: 2857,
     }
 
 

--- a/tests/components/google_assistant/test_trait.py
+++ b/tests/components/google_assistant/test_trait.py
@@ -924,9 +924,9 @@ async def test_color_light_temperature_light_bad_temp(hass: HomeAssistant) -> No
             "light.bla",
             STATE_ON,
             {
-                light.ATTR_MIN_MIREDS: 200,
-                light.ATTR_COLOR_TEMP: 0,
-                light.ATTR_MAX_MIREDS: 500,
+                light.ATTR_MAX_COLOR_TEMP_KELVIN: 5000,
+                light.ATTR_COLOR_TEMP_KELVIN: 0,
+                light.ATTR_MIN_COLOR_TEMP_KELVIN: 2000,
             },
         ),
         BASIC_CONFIG,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Based on #79591, needed for #132680

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
