### PR TITLE
Move coordinator for TwenteMilieu into own module

### DIFF
--- a/homeassistant/components/twentemilieu/__init__.py
+++ b/homeassistant/components/twentemilieu/__init__.py
@@ -2,53 +2,25 @@
 
 from __future__ import annotations
 
-from datetime import date, timedelta
-
-from twentemilieu import TwenteMilieu, WasteType
 import voluptuous as vol
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ID, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from .const import CONF_HOUSE_LETTER, CONF_HOUSE_NUMBER, CONF_POST_CODE, DOMAIN, LOGGER
-
-SCAN_INTERVAL = timedelta(seconds=3600)
+from .coordinator import TwenteMilieuConfigEntry, TwenteMilieuDataUpdateCoordinator
 
 SERVICE_UPDATE = "update"
 SERVICE_SCHEMA = vol.Schema({vol.Optional(CONF_ID): cv.string})
 
 PLATFORMS = [Platform.CALENDAR, Platform.SENSOR]
 
-type TwenteMilieuDataUpdateCoordinator = DataUpdateCoordinator[
-    dict[WasteType, list[date]]
-]
-type TwenteMilieuConfigEntry = ConfigEntry[TwenteMilieuDataUpdateCoordinator]
-
 
 async def async_setup_entry(
     hass: HomeAssistant, entry: TwenteMilieuConfigEntry
 ) -> bool:
     """Set up Twente Milieu from a config entry."""
-    session = async_get_clientsession(hass)
-    twentemilieu = TwenteMilieu(
-        post_code=entry.data[CONF_POST_CODE],
-        house_number=entry.data[CONF_HOUSE_NUMBER],
-        house_letter=entry.data[CONF_HOUSE_LETTER],
-        session=session,
-    )
-
-    coordinator: TwenteMilieuDataUpdateCoordinator = DataUpdateCoordinator(
-        hass,
-        LOGGER,
-        config_entry=entry,
-        name=DOMAIN,
-        update_interval=SCAN_INTERVAL,
-        update_method=twentemilieu.update,
-    )
+    coordinator = TwenteMilieuDataUpdateCoordinator(hass, entry)
     await coordinator.async_config_entry_first_refresh()
 
     entry.runtime_data = coordinator

--- a/homeassistant/components/twentemilieu/calendar.py
+++ b/homeassistant/components/twentemilieu/calendar.py
@@ -10,8 +10,8 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 import homeassistant.util.dt as dt_util
 
-from . import TwenteMilieuConfigEntry
 from .const import WASTE_TYPE_TO_DESCRIPTION
+from .coordinator import TwenteMilieuConfigEntry
 from .entity import TwenteMilieuEntity
 
 

--- a/homeassistant/components/twentemilieu/coordinator.py
+++ b/homeassistant/components/twentemilieu/coordinator.py
@@ -1,0 +1,48 @@
+"""Data update coordinator for Twente Milieu."""
+
+from __future__ import annotations
+
+from datetime import date
+
+from twentemilieu import TwenteMilieu, WasteType
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+from .const import (
+    CONF_HOUSE_LETTER,
+    CONF_HOUSE_NUMBER,
+    CONF_POST_CODE,
+    DOMAIN,
+    LOGGER,
+    SCAN_INTERVAL,
+)
+
+type TwenteMilieuConfigEntry = ConfigEntry[TwenteMilieuDataUpdateCoordinator]
+
+
+class TwenteMilieuDataUpdateCoordinator(
+    DataUpdateCoordinator[dict[WasteType, list[date]]]
+):
+    """Class to manage fetching Twente Milieu data."""
+
+    def __init__(self, hass: HomeAssistant, entry: TwenteMilieuConfigEntry) -> None:
+        """Initialize Twente Milieu data update coordinator."""
+        self.twentemilieu = TwenteMilieu(
+            post_code=entry.data[CONF_POST_CODE],
+            house_number=entry.data[CONF_HOUSE_NUMBER],
+            house_letter=entry.data[CONF_HOUSE_LETTER],
+            session=async_get_clientsession(hass),
+        )
+        super().__init__(
+            hass,
+            LOGGER,
+            name=DOMAIN,
+            update_interval=SCAN_INTERVAL,
+        )
+
+    async def _async_update_data(self) -> dict[WasteType, list[date]]:
+        """Fetch Twente Milieu data."""
+        return await self.twentemilieu.update()

--- a/homeassistant/components/twentemilieu/coordinator.py
+++ b/homeassistant/components/twentemilieu/coordinator.py
@@ -41,6 +41,7 @@ class TwenteMilieuDataUpdateCoordinator(
             LOGGER,
             name=DOMAIN,
             update_interval=SCAN_INTERVAL,
+            config_entry=entry,
         )
 
     async def _async_update_data(self) -> dict[WasteType, list[date]]:

--- a/homeassistant/components/twentemilieu/entity.py
+++ b/homeassistant/components/twentemilieu/entity.py
@@ -7,8 +7,8 @@ from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from . import TwenteMilieuConfigEntry, TwenteMilieuDataUpdateCoordinator
 from .const import DOMAIN
+from .coordinator import TwenteMilieuConfigEntry, TwenteMilieuDataUpdateCoordinator
 
 
 class TwenteMilieuEntity(CoordinatorEntity[TwenteMilieuDataUpdateCoordinator], Entity):

--- a/homeassistant/components/twentemilieu/quality_scale.yaml
+++ b/homeassistant/components/twentemilieu/quality_scale.yaml
@@ -6,10 +6,7 @@ rules:
       This integration does not provide additional actions.
   appropriate-polling: done
   brands: done
-  common-modules:
-    status: todo
-    comment: |
-      The coordinator isn't in the common module yet.
+  common-modules: done
   config-flow-test-coverage: done
   config-flow:
     status: todo

--- a/homeassistant/components/twentemilieu/sensor.py
+++ b/homeassistant/components/twentemilieu/sensor.py
@@ -16,8 +16,8 @@ from homeassistant.const import CONF_ID
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import TwenteMilieuConfigEntry
 from .const import DOMAIN
+from .coordinator import TwenteMilieuConfigEntry
 from .entity import TwenteMilieuEntity
 
 

--- a/tests/components/twentemilieu/conftest.py
+++ b/tests/components/twentemilieu/conftest.py
@@ -51,7 +51,8 @@ def mock_twentemilieu() -> Generator[MagicMock]:
     """Return a mocked Twente Milieu client."""
     with (
         patch(
-            "homeassistant.components.twentemilieu.TwenteMilieu", autospec=True
+            "homeassistant.components.twentemilieu.coordinator.TwenteMilieu",
+            autospec=True,
         ) as twentemilieu_mock,
         patch(
             "homeassistant.components.twentemilieu.config_flow.TwenteMilieu",

--- a/tests/components/twentemilieu/test_init.py
+++ b/tests/components/twentemilieu/test_init.py
@@ -29,7 +29,7 @@ async def test_load_unload_config_entry(
 
 
 @patch(
-    "homeassistant.components.twentemilieu.TwenteMilieu.update",
+    "homeassistant.components.twentemilieu.coordinator.TwenteMilieu.update",
     side_effect=RuntimeError,
 )
 async def test_config_entry_not_ready(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR moves the data update coordinator for Twente Milieu into its own module.
Otherwise, there is no change.

This checks off an item from the integration quality scale checklist.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
