### PR TITLE
Use ConfigEntry runtime_data in easyEnergy

### DIFF
--- a/homeassistant/components/easyenergy/__init__.py
+++ b/homeassistant/components/easyenergy/__init__.py
@@ -13,8 +13,10 @@ from .const import DOMAIN
 from .coordinator import EasyEnergyDataUpdateCoordinator
 from .services import async_setup_services
 
-PLATFORMS = [Platform.SENSOR]
+PLATFORMS: list[Platform] = [Platform.SENSOR]
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
+
+type EasyEnergyConfigEntry = ConfigEntry[EasyEnergyDataUpdateCoordinator]
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
@@ -25,7 +27,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     return True
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: EasyEnergyConfigEntry) -> bool:
     """Set up easyEnergy from a config entry."""
 
     coordinator = EasyEnergyDataUpdateCoordinator(hass)
@@ -35,15 +37,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         await coordinator.easyenergy.close()
         raise
 
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
+    entry.runtime_data = coordinator
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: EasyEnergyConfigEntry) -> bool:
     """Unload easyEnergy config entry."""
-    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        hass.data[DOMAIN].pop(entry.entry_id)
-    return unload_ok
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/easyenergy/__init__.py
+++ b/homeassistant/components/easyenergy/__init__.py
@@ -27,7 +27,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 async def async_setup_entry(hass: HomeAssistant, entry: EasyEnergyConfigEntry) -> bool:
     """Set up easyEnergy from a config entry."""
 
-    coordinator = EasyEnergyDataUpdateCoordinator(hass)
+    coordinator = EasyEnergyDataUpdateCoordinator(hass, entry)
     try:
         await coordinator.async_config_entry_first_refresh()
     except ConfigEntryNotReady:

--- a/homeassistant/components/easyenergy/__init__.py
+++ b/homeassistant/components/easyenergy/__init__.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
@@ -10,13 +9,11 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 
 from .const import DOMAIN
-from .coordinator import EasyEnergyDataUpdateCoordinator
+from .coordinator import EasyEnergyConfigEntry, EasyEnergyDataUpdateCoordinator
 from .services import async_setup_services
 
 PLATFORMS: list[Platform] = [Platform.SENSOR]
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
-
-type EasyEnergyConfigEntry = ConfigEntry[EasyEnergyDataUpdateCoordinator]
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:

--- a/homeassistant/components/easyenergy/coordinator.py
+++ b/homeassistant/components/easyenergy/coordinator.py
@@ -35,15 +35,16 @@ class EasyEnergyData(NamedTuple):
 class EasyEnergyDataUpdateCoordinator(DataUpdateCoordinator[EasyEnergyData]):
     """Class to manage fetching easyEnergy data from single endpoint."""
 
-    config_entry: ConfigEntry
+    config_entry: EasyEnergyConfigEntry
 
-    def __init__(self, hass: HomeAssistant) -> None:
+    def __init__(self, hass: HomeAssistant, entry: EasyEnergyConfigEntry) -> None:
         """Initialize global easyEnergy data updater."""
         super().__init__(
             hass,
             LOGGER,
             name=DOMAIN,
             update_interval=SCAN_INTERVAL,
+            config_entry=entry,
         )
 
         self.easyenergy = EasyEnergy(session=async_get_clientsession(hass))

--- a/homeassistant/components/easyenergy/coordinator.py
+++ b/homeassistant/components/easyenergy/coordinator.py
@@ -21,6 +21,8 @@ from homeassistant.util import dt as dt_util
 
 from .const import DOMAIN, LOGGER, SCAN_INTERVAL, THRESHOLD_HOUR
 
+type EasyEnergyConfigEntry = ConfigEntry[EasyEnergyDataUpdateCoordinator]
+
 
 class EasyEnergyData(NamedTuple):
     """Class for defining data in dict."""

--- a/homeassistant/components/easyenergy/diagnostics.py
+++ b/homeassistant/components/easyenergy/diagnostics.py
@@ -7,8 +7,7 @@ from typing import Any
 
 from homeassistant.core import HomeAssistant
 
-from . import EasyEnergyConfigEntry
-from .coordinator import EasyEnergyData
+from .coordinator import EasyEnergyConfigEntry, EasyEnergyData
 
 
 def get_gas_price(data: EasyEnergyData, hours: int) -> float | None:

--- a/homeassistant/components/easyenergy/diagnostics.py
+++ b/homeassistant/components/easyenergy/diagnostics.py
@@ -5,11 +5,9 @@ from __future__ import annotations
 from datetime import timedelta
 from typing import Any
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from . import EasyEnergyDataUpdateCoordinator
-from .const import DOMAIN
+from . import EasyEnergyConfigEntry
 from .coordinator import EasyEnergyData
 
 
@@ -32,41 +30,42 @@ def get_gas_price(data: EasyEnergyData, hours: int) -> float | None:
 
 
 async def async_get_config_entry_diagnostics(
-    hass: HomeAssistant, entry: ConfigEntry
+    hass: HomeAssistant, entry: EasyEnergyConfigEntry
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
-    coordinator: EasyEnergyDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator_data = entry.runtime_data.data
+    energy_today = coordinator_data.energy_today
 
     return {
         "entry": {
             "title": entry.title,
         },
         "energy_usage": {
-            "current_hour_price": coordinator.data.energy_today.current_usage_price,
-            "next_hour_price": coordinator.data.energy_today.price_at_time(
-                coordinator.data.energy_today.utcnow() + timedelta(hours=1)
+            "current_hour_price": energy_today.current_usage_price,
+            "next_hour_price": energy_today.price_at_time(
+                energy_today.utcnow() + timedelta(hours=1)
             ),
-            "average_price": coordinator.data.energy_today.average_usage_price,
-            "max_price": coordinator.data.energy_today.extreme_usage_prices[1],
-            "min_price": coordinator.data.energy_today.extreme_usage_prices[0],
-            "highest_price_time": coordinator.data.energy_today.highest_usage_price_time,
-            "lowest_price_time": coordinator.data.energy_today.lowest_usage_price_time,
-            "percentage_of_max": coordinator.data.energy_today.pct_of_max_usage,
+            "average_price": energy_today.average_usage_price,
+            "max_price": energy_today.extreme_usage_prices[1],
+            "min_price": energy_today.extreme_usage_prices[0],
+            "highest_price_time": energy_today.highest_usage_price_time,
+            "lowest_price_time": energy_today.lowest_usage_price_time,
+            "percentage_of_max": energy_today.pct_of_max_usage,
         },
         "energy_return": {
-            "current_hour_price": coordinator.data.energy_today.current_return_price,
-            "next_hour_price": coordinator.data.energy_today.price_at_time(
-                coordinator.data.energy_today.utcnow() + timedelta(hours=1), "return"
+            "current_hour_price": energy_today.current_return_price,
+            "next_hour_price": energy_today.price_at_time(
+                energy_today.utcnow() + timedelta(hours=1), "return"
             ),
-            "average_price": coordinator.data.energy_today.average_return_price,
-            "max_price": coordinator.data.energy_today.extreme_return_prices[1],
-            "min_price": coordinator.data.energy_today.extreme_return_prices[0],
-            "highest_price_time": coordinator.data.energy_today.highest_return_price_time,
-            "lowest_price_time": coordinator.data.energy_today.lowest_return_price_time,
-            "percentage_of_max": coordinator.data.energy_today.pct_of_max_return,
+            "average_price": energy_today.average_return_price,
+            "max_price": energy_today.extreme_return_prices[1],
+            "min_price": energy_today.extreme_return_prices[0],
+            "highest_price_time": energy_today.highest_return_price_time,
+            "lowest_price_time": energy_today.lowest_return_price_time,
+            "percentage_of_max": energy_today.pct_of_max_return,
         },
         "gas": {
-            "current_hour_price": get_gas_price(coordinator.data, 0),
-            "next_hour_price": get_gas_price(coordinator.data, 1),
+            "current_hour_price": get_gas_price(coordinator_data, 0),
+            "next_hour_price": get_gas_price(coordinator_data, 1),
         },
     }

--- a/homeassistant/components/easyenergy/sensor.py
+++ b/homeassistant/components/easyenergy/sensor.py
@@ -25,9 +25,12 @@ from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from . import EasyEnergyConfigEntry
 from .const import DOMAIN, SERVICE_TYPE_DEVICE_NAMES
-from .coordinator import EasyEnergyData, EasyEnergyDataUpdateCoordinator
+from .coordinator import (
+    EasyEnergyConfigEntry,
+    EasyEnergyData,
+    EasyEnergyDataUpdateCoordinator,
+)
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/homeassistant/components/easyenergy/sensor.py
+++ b/homeassistant/components/easyenergy/sensor.py
@@ -13,7 +13,6 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CURRENCY_EURO,
     PERCENTAGE,
@@ -26,6 +25,7 @@ from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from . import EasyEnergyConfigEntry
 from .const import DOMAIN, SERVICE_TYPE_DEVICE_NAMES
 from .coordinator import EasyEnergyData, EasyEnergyDataUpdateCoordinator
 
@@ -208,10 +208,12 @@ def get_gas_price(data: EasyEnergyData, hours: int) -> float | None:
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+    hass: HomeAssistant,
+    entry: EasyEnergyConfigEntry,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up easyEnergy sensors based on a config entry."""
-    coordinator: EasyEnergyDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator = entry.runtime_data
     async_add_entities(
         EasyEnergySensorEntity(coordinator=coordinator, description=description)
         for description in SENSORS

--- a/homeassistant/components/easyenergy/services.py
+++ b/homeassistant/components/easyenergy/services.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import date, datetime
 from enum import Enum
 from functools import partial
-from typing import TYPE_CHECKING, Final
+from typing import Final
 
 from easyenergy import Electricity, Gas, VatOption
 import voluptuous as vol
@@ -22,11 +22,8 @@ from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import selector
 from homeassistant.util import dt as dt_util
 
-if TYPE_CHECKING:
-    from . import EasyEnergyConfigEntry
-
 from .const import DOMAIN
-from .coordinator import EasyEnergyDataUpdateCoordinator
+from .coordinator import EasyEnergyConfigEntry, EasyEnergyDataUpdateCoordinator
 
 ATTR_CONFIG_ENTRY: Final = "config_entry"
 ATTR_START: Final = "start"

--- a/homeassistant/components/easyenergy/services.py
+++ b/homeassistant/components/easyenergy/services.py
@@ -5,12 +5,12 @@ from __future__ import annotations
 from datetime import date, datetime
 from enum import Enum
 from functools import partial
-from typing import Final
+from typing import TYPE_CHECKING, Final
 
 from easyenergy import Electricity, Gas, VatOption
 import voluptuous as vol
 
-from homeassistant.config_entries import ConfigEntry, ConfigEntryState
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import (
     HomeAssistant,
     ServiceCall,
@@ -21,6 +21,9 @@ from homeassistant.core import (
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import selector
 from homeassistant.util import dt as dt_util
+
+if TYPE_CHECKING:
+    from . import EasyEnergyConfigEntry
 
 from .const import DOMAIN
 from .coordinator import EasyEnergyDataUpdateCoordinator
@@ -91,7 +94,7 @@ def __get_coordinator(
 ) -> EasyEnergyDataUpdateCoordinator:
     """Get the coordinator from the entry."""
     entry_id: str = call.data[ATTR_CONFIG_ENTRY]
-    entry: ConfigEntry | None = hass.config_entries.async_get_entry(entry_id)
+    entry: EasyEnergyConfigEntry | None = hass.config_entries.async_get_entry(entry_id)
 
     if not entry:
         raise ServiceValidationError(
@@ -110,8 +113,7 @@ def __get_coordinator(
             },
         )
 
-    coordinator: EasyEnergyDataUpdateCoordinator = hass.data[DOMAIN][entry_id]
-    return coordinator
+    return entry.runtime_data
 
 
 async def __get_prices(

--- a/tests/components/easyenergy/test_init.py
+++ b/tests/components/easyenergy/test_init.py
@@ -4,7 +4,6 @@ from unittest.mock import MagicMock, patch
 
 from easyenergy import EasyEnergyConnectionError
 
-from homeassistant.components.easyenergy.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 
@@ -24,7 +23,6 @@ async def test_load_unload_config_entry(
     await hass.config_entries.async_unload(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert not hass.data.get(DOMAIN)
     assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Moves the easyEnergy integration to use the `runtime_data` attribute of the ConfigEntry instead of `hass.data`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
