### PR TITLE
Add reconfigure flow to Russound RIO

### DIFF
--- a/homeassistant/components/russound_rio/quality_scale.yaml
+++ b/homeassistant/components/russound_rio/quality_scale.yaml
@@ -65,7 +65,7 @@ rules:
   diagnostics: done
   exception-translations: done
   icon-translations: todo
-  reconfiguration-flow: todo
+  reconfiguration-flow: done
   dynamic-devices: todo
   discovery-update-info: todo
   repair-issues: done

--- a/homeassistant/components/russound_rio/quality_scale.yaml
+++ b/homeassistant/components/russound_rio/quality_scale.yaml
@@ -11,10 +11,7 @@ rules:
   brands: done
   common-modules: done
   config-flow-test-coverage: done
-  config-flow:
-    status: todo
-    comment: |
-      The data_description fields in translations are missing.
+  config-flow: done
   dependency-transparency: done
   docs-actions:
     status: exempt

--- a/homeassistant/components/russound_rio/strings.json
+++ b/homeassistant/components/russound_rio/strings.json
@@ -9,6 +9,21 @@
           "host": "[%key:common::config_flow::data::host%]",
           "name": "[%key:common::config_flow::data::name%]",
           "port": "[%key:common::config_flow::data::port%]"
+        },
+        "data_description": {
+          "host": "The IP address of the Russound controller.",
+          "port": "The port of the Russound controller."
+        }
+      },
+      "reconfigure": {
+        "description": "Reconfigure your Russound controller.",
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]",
+          "port": "[%key:common::config_flow::data::port%]"
+        },
+        "data_description": {
+          "host": "[%key:component::russound_rio::config::step::user::data_description::host%]",
+          "port": "[%key:component::russound_rio::config::step::user::data_description::port%]"
         }
       }
     },
@@ -17,7 +32,9 @@
     },
     "abort": {
       "cannot_connect": "[%key:component::russound_rio::common::error_cannot_connect%]",
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]",
+      "wrong_device": "This Russound controller does not match the existing device id. Please make sure you entered the correct IP address."
     }
   },
   "issues": {

--- a/tests/components/russound_rio/conftest.py
+++ b/tests/components/russound_rio/conftest.py
@@ -9,9 +9,10 @@ from aiorussound.util import controller_device_str, zone_device_str
 import pytest
 
 from homeassistant.components.russound_rio.const import DOMAIN
+from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import HomeAssistant
 
-from .const import API_VERSION, HARDWARE_MAC, HOST, MOCK_CONFIG, MODEL, PORT
+from .const import API_VERSION, HARDWARE_MAC, MOCK_CONFIG, MODEL
 
 from tests.common import MockConfigEntry, load_json_object_fixture
 
@@ -68,7 +69,9 @@ def mock_russound_client() -> Generator[AsyncMock]:
                 1, "MCA-C5", client, controller_device_str(1), HARDWARE_MAC, None, zones
             )
         }
-        client.connection_handler = RussoundTcpConnectionHandler(HOST, PORT)
+        client.connection_handler = RussoundTcpConnectionHandler(
+            MOCK_CONFIG[CONF_HOST], MOCK_CONFIG[CONF_PORT]
+        )
         client.is_connected = Mock(return_value=True)
         client.unregister_state_update_callbacks.return_value = True
         client.rio_version = API_VERSION

--- a/tests/components/russound_rio/const.py
+++ b/tests/components/russound_rio/const.py
@@ -3,16 +3,20 @@
 from collections import namedtuple
 
 from homeassistant.components.media_player import DOMAIN as MP_DOMAIN
+from homeassistant.const import CONF_HOST, CONF_PORT
 
-HOST = "127.0.0.1"
-PORT = 9621
 MODEL = "MCA-C5"
 HARDWARE_MAC = "00:11:22:33:44:55"
 API_VERSION = "1.08.00"
 
 MOCK_CONFIG = {
-    "host": HOST,
-    "port": PORT,
+    CONF_HOST: "192.168.20.75",
+    CONF_PORT: 9621,
+}
+
+MOCK_RECONFIGURATION_CONFIG = {
+    CONF_HOST: "192.168.20.70",
+    CONF_PORT: 9622,
 }
 
 _CONTROLLER = namedtuple("Controller", ["mac_address", "controller_type"])  # noqa: PYI024

--- a/tests/components/russound_rio/snapshots/test_init.ambr
+++ b/tests/components/russound_rio/snapshots/test_init.ambr
@@ -3,7 +3,7 @@
   DeviceRegistryEntrySnapshot({
     'area_id': None,
     'config_entries': <ANY>,
-    'configuration_url': 'http://127.0.0.1',
+    'configuration_url': 'http://192.168.20.75',
     'connections': set({
       tuple(
         'mac',

--- a/tests/components/russound_rio/test_config_flow.py
+++ b/tests/components/russound_rio/test_config_flow.py
@@ -3,11 +3,12 @@
 from unittest.mock import AsyncMock
 
 from homeassistant.components.russound_rio.const import DOMAIN
-from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
+from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER, ConfigFlowResult
+from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
-from .const import MOCK_CONFIG, MODEL
+from .const import MOCK_CONFIG, MOCK_RECONFIGURATION_CONFIG, MODEL
 
 from tests.common import MockConfigEntry
 
@@ -117,3 +118,56 @@ async def test_import_cannot_connect(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "cannot_connect"
+
+
+async def _start_reconfigure_flow(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> ConfigFlowResult:
+    """Initialize a reconfigure flow."""
+    mock_config_entry.add_to_hass(hass)
+
+    reconfigure_result = await mock_config_entry.start_reconfigure_flow(hass)
+
+    assert reconfigure_result["type"] is FlowResultType.FORM
+    assert reconfigure_result["step_id"] == "reconfigure"
+
+    return await hass.config_entries.flow.async_configure(
+        reconfigure_result["flow_id"],
+        MOCK_RECONFIGURATION_CONFIG,
+    )
+
+
+async def test_reconfigure_flow(
+    hass: HomeAssistant,
+    mock_russound_client: AsyncMock,
+    mock_setup_entry: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test reconfigure flow."""
+
+    result = await _start_reconfigure_flow(hass, mock_config_entry)
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+
+    entry = hass.config_entries.async_get_entry(mock_config_entry.entry_id)
+    assert entry
+    assert entry.data == {
+        CONF_HOST: "192.168.20.70",
+        CONF_PORT: 9622,
+    }
+
+
+async def test_reconfigure_unique_id_mismatch(
+    hass: HomeAssistant,
+    mock_russound_client: AsyncMock,
+    mock_setup_entry: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Ensure reconfigure flow aborts when the bride changes."""
+    mock_russound_client.controllers[1].mac_address = "different_mac"
+
+    result = await _start_reconfigure_flow(hass, mock_config_entry)
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "wrong_device"

--- a/tests/components/russound_rio/test_config_flow.py
+++ b/tests/components/russound_rio/test_config_flow.py
@@ -131,10 +131,7 @@ async def _start_reconfigure_flow(
     assert reconfigure_result["type"] is FlowResultType.FORM
     assert reconfigure_result["step_id"] == "reconfigure"
 
-    return await hass.config_entries.flow.async_configure(
-        reconfigure_result["flow_id"],
-        MOCK_RECONFIGURATION_CONFIG,
-    )
+    return reconfigure_result
 
 
 async def test_reconfigure_flow(
@@ -145,7 +142,12 @@ async def test_reconfigure_flow(
 ) -> None:
     """Test reconfigure flow."""
 
-    result = await _start_reconfigure_flow(hass, mock_config_entry)
+    reconfigure_result = await _start_reconfigure_flow(hass, mock_config_entry)
+
+    result = await hass.config_entries.flow.async_configure(
+        reconfigure_result["flow_id"],
+        MOCK_RECONFIGURATION_CONFIG,
+    )
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reconfigure_successful"
@@ -167,7 +169,12 @@ async def test_reconfigure_unique_id_mismatch(
     """Ensure reconfigure flow aborts when the bride changes."""
     mock_russound_client.controllers[1].mac_address = "different_mac"
 
-    result = await _start_reconfigure_flow(hass, mock_config_entry)
+    reconfigure_result = await _start_reconfigure_flow(hass, mock_config_entry)
+
+    result = await hass.config_entries.flow.async_configure(
+        reconfigure_result["flow_id"],
+        MOCK_RECONFIGURATION_CONFIG,
+    )
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "wrong_device"

--- a/tests/components/russound_rio/test_init.py
+++ b/tests/components/russound_rio/test_init.py
@@ -59,8 +59,8 @@ async def test_disconnect_reconnect_log(
 
     mock_russound_client.is_connected = Mock(return_value=False)
     await mock_state_update(mock_russound_client, CallbackType.CONNECTION)
-    assert "Disconnected from device at 127.0.0.1" in caplog.text
+    assert "Disconnected from device at 192.168.20.75" in caplog.text
 
     mock_russound_client.is_connected = Mock(return_value=True)
     await mock_state_update(mock_russound_client, CallbackType.CONNECTION)
-    assert "Reconnected to device at 127.0.0.1" in caplog.text
+    assert "Reconnected to device at 192.168.20.75" in caplog.text


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds reconfigure flow to Russound RIO. Some small changes made to test fixtures to accommodate reconfiguration flow.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
