### PR TITLE
Update yolink "play on speaker hub" action to allow optional values (to match YoLink API)

### DIFF
--- a/homeassistant/components/yolink/services.py
+++ b/homeassistant/components/yolink/services.py
@@ -19,6 +19,11 @@ from .const import (
 
 SERVICE_PLAY_ON_SPEAKER_HUB = "play_on_speaker_hub"
 
+_SPEAKER_HUB_PLAY_CALL_OPTIONAL_ATTRS = (
+    (ATTR_VOLUME, lambda x: x),
+    (ATTR_TONE, lambda x: x.capitalize()),
+)
+
 
 def async_register_services(hass: HomeAssistant) -> None:
     """Register services for YoLink integration."""
@@ -46,16 +51,16 @@ def async_register_services(hass: HomeAssistant) -> None:
                         identifier[1]
                     )
                 ) is not None:
-                    tone_param = service_data[ATTR_TONE].capitalize()
-                    play_request = ClientRequest(
-                        "playAudio",
-                        {
-                            ATTR_TONE: tone_param,
-                            ATTR_TEXT_MESSAGE: service_data[ATTR_TEXT_MESSAGE],
-                            ATTR_VOLUME: service_data[ATTR_VOLUME],
-                            ATTR_REPEAT: service_data[ATTR_REPEAT],
-                        },
-                    )
+                    params = {
+                        ATTR_TEXT_MESSAGE: service_data[ATTR_TEXT_MESSAGE],
+                        ATTR_REPEAT: service_data[ATTR_REPEAT],
+                    }
+
+                    for attr, transform in _SPEAKER_HUB_PLAY_CALL_OPTIONAL_ATTRS:
+                        if attr in service_data:
+                            params[attr] = transform(service_data[attr])
+
+                    play_request = ClientRequest("playAudio", params)
                     await device_coordinator.device.call_device(play_request)
 
     hass.services.async_register(
@@ -64,9 +69,9 @@ def async_register_services(hass: HomeAssistant) -> None:
         schema=vol.Schema(
             {
                 vol.Required(ATTR_TARGET_DEVICE): cv.string,
-                vol.Required(ATTR_TONE): cv.string,
+                vol.Optional(ATTR_TONE): cv.string,
                 vol.Required(ATTR_TEXT_MESSAGE): cv.string,
-                vol.Required(ATTR_VOLUME): vol.All(
+                vol.Optional(ATTR_VOLUME): vol.All(
                     vol.Coerce(int), vol.Range(min=0, max=15)
                 ),
                 vol.Optional(ATTR_REPEAT, default=0): vol.All(

--- a/homeassistant/components/yolink/services.yaml
+++ b/homeassistant/components/yolink/services.yaml
@@ -14,7 +14,6 @@ play_on_speaker_hub:
       selector:
         text:
     tone:
-      required: true
       default: "tip"
       selector:
         select:
@@ -25,7 +24,6 @@ play_on_speaker_hub:
             - "tip"
           translation_key: speaker_tone
     volume:
-      required: true
       default: 8
       selector:
         number:
@@ -33,7 +31,6 @@ play_on_speaker_hub:
           max: 15
           step: 1
     repeat:
-      required: true
       default: 0
       selector:
         number:

--- a/homeassistant/components/yolink/strings.json
+++ b/homeassistant/components/yolink/strings.json
@@ -111,15 +111,15 @@
         },
         "tone": {
           "name": "Tone",
-          "description": "Tone before playing audio (if unset, no tone is played)."
+          "description": "Tone before playing audio."
         },
         "volume": {
           "name": "Volume",
-          "description": "Speaker volume during playback (if unset, uses the current global volume)."
+          "description": "Override the speaker volume during playback of this message only."
         },
         "repeat": {
           "name": "Repeat",
-          "description": "The amount of times the text will be repeated (if unset, will not repeat)."
+          "description": "The amount of times the text will be repeated."
         }
       }
     }

--- a/homeassistant/components/yolink/strings.json
+++ b/homeassistant/components/yolink/strings.json
@@ -115,7 +115,7 @@
         },
         "volume": {
           "name": "Volume",
-          "description": "Speaker volume during playback (if unset, uses the default volume)."
+          "description": "Speaker volume during playback (if unset, uses the current global volume)."
         },
         "repeat": {
           "name": "Repeat",

--- a/homeassistant/components/yolink/strings.json
+++ b/homeassistant/components/yolink/strings.json
@@ -111,15 +111,15 @@
         },
         "tone": {
           "name": "Tone",
-          "description": "Tone before playing audio."
+          "description": "Tone before playing audio (if unset, no tone is played)."
         },
         "volume": {
           "name": "Volume",
-          "description": "Speaker volume during playback."
+          "description": "Speaker volume during playback (if unset, uses the default volume)."
         },
         "repeat": {
           "name": "Repeat",
-          "description": "The amount of times the text will be repeated."
+          "description": "The amount of times the text will be repeated (if unset, will not repeat)."
         }
       }
     }


### PR DESCRIPTION
## Proposed change
The `SpeakerHub.playAudio` accepts optional arguments for the `tone`, `repeat`, and `volume` parameters. But the HA service definition makes these arguments required. I've updated the service definition so that the arguments are optional.

Note that the current logic also sets `repeat` to `0` when it's unset by the user so I have preserved that logic.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/36324

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works. ← this part of the code doesn't have existing tests, and I struggled a bunch to add tests, but wasn't able to. I got stuck with trying to run this integration's `async_setup` in the test environment.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
