### PR TITLE
2024.12.3

### DIFF
--- a/homeassistant/components/androidtv/__init__.py
+++ b/homeassistant/components/androidtv/__init__.py
@@ -135,15 +135,16 @@ async def async_connect_androidtv(
     )
 
     aftv = await async_androidtv_setup(
-        config[CONF_HOST],
-        config[CONF_PORT],
-        adbkey,
-        config.get(CONF_ADB_SERVER_IP),
-        config.get(CONF_ADB_SERVER_PORT, DEFAULT_ADB_SERVER_PORT),
-        state_detection_rules,
-        config[CONF_DEVICE_CLASS],
-        timeout,
-        signer,
+        host=config[CONF_HOST],
+        port=config[CONF_PORT],
+        adbkey=adbkey,
+        adb_server_ip=config.get(CONF_ADB_SERVER_IP),
+        adb_server_port=config.get(CONF_ADB_SERVER_PORT, DEFAULT_ADB_SERVER_PORT),
+        state_detection_rules=state_detection_rules,
+        device_class=config[CONF_DEVICE_CLASS],
+        auth_timeout_s=timeout,
+        signer=signer,
+        log_errors=False,
     )
 
     if not aftv.available:

--- a/homeassistant/components/aosmith/manifest.json
+++ b/homeassistant/components/aosmith/manifest.json
@@ -5,5 +5,5 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/aosmith",
   "iot_class": "cloud_polling",
-  "requirements": ["py-aosmith==1.0.11"]
+  "requirements": ["py-aosmith==1.0.12"]
 }

--- a/homeassistant/components/assist_pipeline/pipeline.py
+++ b/homeassistant/components/assist_pipeline/pipeline.py
@@ -29,6 +29,7 @@ from homeassistant.components import (
 from homeassistant.components.tts import (
     generate_media_source_id as tts_generate_media_source_id,
 )
+from homeassistant.const import MATCH_ALL
 from homeassistant.core import Context, HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import intent
@@ -1009,12 +1010,19 @@ class PipelineRun:
         if self.intent_agent is None:
             raise RuntimeError("Recognize intent was not prepared")
 
+        if self.pipeline.conversation_language == MATCH_ALL:
+            # LLMs support all languages ('*') so use pipeline language for
+            # intent fallback.
+            input_language = self.pipeline.language
+        else:
+            input_language = self.pipeline.conversation_language
+
         self.process_event(
             PipelineEvent(
                 PipelineEventType.INTENT_START,
                 {
                     "engine": self.intent_agent,
-                    "language": self.pipeline.conversation_language,
+                    "language": input_language,
                     "intent_input": intent_input,
                     "conversation_id": conversation_id,
                     "device_id": device_id,
@@ -1029,7 +1037,7 @@ class PipelineRun:
                 context=self.context,
                 conversation_id=conversation_id,
                 device_id=device_id,
-                language=self.pipeline.language,
+                language=input_language,
                 agent_id=self.intent_agent,
             )
             processed_locally = self.intent_agent == conversation.HOME_ASSISTANT_AGENT

--- a/homeassistant/components/assist_pipeline/vad.py
+++ b/homeassistant/components/assist_pipeline/vad.py
@@ -140,7 +140,7 @@ class VoiceCommandSegmenter:
 
         self._timeout_seconds_left -= chunk_seconds
         if self._timeout_seconds_left <= 0:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "VAD end of speech detection timed out after %s seconds",
                 self.timeout_seconds,
             )

--- a/homeassistant/components/daikin/manifest.json
+++ b/homeassistant/components/daikin/manifest.json
@@ -6,6 +6,6 @@
   "documentation": "https://www.home-assistant.io/integrations/daikin",
   "iot_class": "local_polling",
   "loggers": ["pydaikin"],
-  "requirements": ["pydaikin==2.13.7"],
+  "requirements": ["pydaikin==2.13.8"],
   "zeroconf": ["_dkapi._tcp.local."]
 }

--- a/homeassistant/components/ecovacs/manifest.json
+++ b/homeassistant/components/ecovacs/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/ecovacs",
   "iot_class": "cloud_push",
   "loggers": ["sleekxmppfs", "sucks", "deebot_client"],
-  "requirements": ["py-sucks==0.9.10", "deebot-client==9.3.0"]
+  "requirements": ["py-sucks==0.9.10", "deebot-client==9.4.0"]
 }

--- a/homeassistant/components/evohome/manifest.json
+++ b/homeassistant/components/evohome/manifest.json
@@ -6,5 +6,5 @@
   "iot_class": "cloud_polling",
   "loggers": ["evohomeasync", "evohomeasync2"],
   "quality_scale": "legacy",
-  "requirements": ["evohome-async==0.4.20"]
+  "requirements": ["evohome-async==0.4.21"]
 }

--- a/homeassistant/components/frontend/manifest.json
+++ b/homeassistant/components/frontend/manifest.json
@@ -20,5 +20,5 @@
   "documentation": "https://www.home-assistant.io/integrations/frontend",
   "integration_type": "system",
   "quality_scale": "internal",
-  "requirements": ["home-assistant-frontend==20241127.7"]
+  "requirements": ["home-assistant-frontend==20241127.8"]
 }

--- a/homeassistant/components/lametric/config_flow.py
+++ b/homeassistant/components/lametric/config_flow.py
@@ -249,7 +249,10 @@ class LaMetricFlowHandler(AbstractOAuth2FlowHandler, domain=DOMAIN):
         device = await lametric.device()
 
         if self.source != SOURCE_REAUTH:
-            await self.async_set_unique_id(device.serial_number)
+            await self.async_set_unique_id(
+                device.serial_number,
+                raise_on_progress=False,
+            )
             self._abort_if_unique_id_configured(
                 updates={CONF_HOST: lametric.host, CONF_API_KEY: lametric.api_key}
             )

--- a/homeassistant/components/lametric/strings.json
+++ b/homeassistant/components/lametric/strings.json
@@ -21,8 +21,11 @@
           "api_key": "You can find this API key in [devices page in your LaMetric developer account](https://developer.lametric.com/user/devices)."
         }
       },
-      "user_cloud_select_device": {
+      "cloud_select_device": {
         "data": {
+          "device": "Device"
+        },
+        "data_description": {
           "device": "Select the LaMetric device to add"
         }
       }

--- a/homeassistant/components/led_ble/manifest.json
+++ b/homeassistant/components/led_ble/manifest.json
@@ -35,5 +35,5 @@
   "dependencies": ["bluetooth_adapters"],
   "documentation": "https://www.home-assistant.io/integrations/led_ble",
   "iot_class": "local_polling",
-  "requirements": ["bluetooth-data-tools==1.20.0", "led-ble==1.0.2"]
+  "requirements": ["bluetooth-data-tools==1.20.0", "led-ble==1.1.1"]
 }

--- a/homeassistant/components/linkplay/manifest.json
+++ b/homeassistant/components/linkplay/manifest.json
@@ -7,6 +7,6 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "loggers": ["linkplay"],
-  "requirements": ["python-linkplay==0.0.20"],
+  "requirements": ["python-linkplay==0.1.1"],
   "zeroconf": ["_linkplay._tcp.local."]
 }

--- a/homeassistant/components/suez_water/manifest.json
+++ b/homeassistant/components/suez_water/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/suez_water",
   "iot_class": "cloud_polling",
   "loggers": ["pysuez", "regex"],
-  "requirements": ["pysuezV2==1.3.2"]
+  "requirements": ["pysuezV2==1.3.5"]
 }

--- a/homeassistant/components/vodafone_station/coordinator.py
+++ b/homeassistant/components/vodafone_station/coordinator.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass
 from datetime import datetime, timedelta
+from json.decoder import JSONDecodeError
 from typing import Any
 
 from aiovodafone import VodafoneStationDevice, VodafoneStationSercommApi, exceptions
@@ -107,6 +108,7 @@ class VodafoneStationRouter(DataUpdateCoordinator[UpdateCoordinatorDataType]):
                 exceptions.CannotConnect,
                 exceptions.AlreadyLogged,
                 exceptions.GenericLoginError,
+                JSONDecodeError,
             ) as err:
                 raise UpdateFailed(f"Error fetching data: {err!r}") from err
         except (ConfigEntryAuthFailed, UpdateFailed):

--- a/homeassistant/components/withings/manifest.json
+++ b/homeassistant/components/withings/manifest.json
@@ -8,5 +8,5 @@
   "documentation": "https://www.home-assistant.io/integrations/withings",
   "iot_class": "cloud_push",
   "loggers": ["aiowithings"],
-  "requirements": ["aiowithings==3.1.3"]
+  "requirements": ["aiowithings==3.1.4"]
 }

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
 APPLICATION_NAME: Final = "HomeAssistant"
 MAJOR_VERSION: Final = 2024
 MINOR_VERSION: Final = 12
-PATCH_VERSION: Final = "2"
+PATCH_VERSION: Final = "3"
 __short_version__: Final = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__: Final = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER: Final[tuple[int, int, int]] = (3, 12, 0)

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -34,7 +34,7 @@ habluetooth==3.6.0
 hass-nabucasa==0.86.0
 hassil==2.0.5
 home-assistant-bluetooth==1.13.0
-home-assistant-frontend==20241127.7
+home-assistant-frontend==20241127.8
 home-assistant-intents==2024.12.9
 httpx==0.27.2
 ifaddr==0.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name        = "homeassistant"
-version     = "2024.12.2"
+version     = "2024.12.3"
 license     = {text = "Apache-2.0"}
 description = "Open-source home automation platform running on Python 3."
 readme      = "README.rst"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -878,7 +878,7 @@ eufylife-ble-client==0.1.8
 # evdev==1.6.1
 
 # homeassistant.components.evohome
-evohome-async==0.4.20
+evohome-async==0.4.21
 
 # homeassistant.components.bryant_evolution
 evolutionhttp==0.0.18

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2293,7 +2293,7 @@ pysqueezebox==0.10.0
 pystiebeleltron==0.0.1.dev2
 
 # homeassistant.components.suez_water
-pysuezV2==1.3.2
+pysuezV2==1.3.5
 
 # homeassistant.components.switchbee
 pyswitchbee==1.8.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1672,7 +1672,7 @@ pushover_complete==1.1.1
 pvo==2.1.1
 
 # homeassistant.components.aosmith
-py-aosmith==1.0.11
+py-aosmith==1.0.12
 
 # homeassistant.components.canary
 py-canary==0.5.4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2365,7 +2365,7 @@ python-juicenet==1.1.0
 python-kasa[speedups]==0.8.1
 
 # homeassistant.components.linkplay
-python-linkplay==0.0.20
+python-linkplay==0.1.1
 
 # homeassistant.components.lirc
 # python-lirc==1.2.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1130,7 +1130,7 @@ hole==0.8.0
 holidays==0.62
 
 # homeassistant.components.frontend
-home-assistant-frontend==20241127.7
+home-assistant-frontend==20241127.8
 
 # homeassistant.components.conversation
 home-assistant-intents==2024.12.9

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -420,7 +420,7 @@ aiowatttime==0.1.1
 aiowebostv==0.4.2
 
 # homeassistant.components.withings
-aiowithings==3.1.3
+aiowithings==3.1.4
 
 # homeassistant.components.yandex_transport
 aioymaps==1.2.5

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1835,7 +1835,7 @@ pycsspeechtts==1.0.8
 # pycups==2.0.4
 
 # homeassistant.components.daikin
-pydaikin==2.13.7
+pydaikin==2.13.8
 
 # homeassistant.components.danfoss_air
 pydanfossair==0.1.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1280,7 +1280,7 @@ ld2410-ble==0.1.1
 leaone-ble==0.1.0
 
 # homeassistant.components.led_ble
-led-ble==1.0.2
+led-ble==1.1.1
 
 # homeassistant.components.lektrico
 lektricowifi==0.0.43

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -738,7 +738,7 @@ debugpy==1.8.8
 # decora==0.6
 
 # homeassistant.components.ecovacs
-deebot-client==9.3.0
+deebot-client==9.4.0
 
 # homeassistant.components.ihc
 # homeassistant.components.namecheapdns

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -402,7 +402,7 @@ aiowatttime==0.1.1
 aiowebostv==0.4.2
 
 # homeassistant.components.withings
-aiowithings==3.1.3
+aiowithings==3.1.4
 
 # homeassistant.components.yandex_transport
 aioymaps==1.2.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1367,7 +1367,7 @@ pushover_complete==1.1.1
 pvo==2.1.1
 
 # homeassistant.components.aosmith
-py-aosmith==1.0.11
+py-aosmith==1.0.12
 
 # homeassistant.components.canary
 py-canary==0.5.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1892,7 +1892,7 @@ python-juicenet==1.1.0
 python-kasa[speedups]==0.8.1
 
 # homeassistant.components.linkplay
-python-linkplay==0.0.20
+python-linkplay==0.1.1
 
 # homeassistant.components.matter
 python-matter-server==6.6.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -628,7 +628,7 @@ dbus-fast==2.24.3
 debugpy==1.8.8
 
 # homeassistant.components.ecovacs
-deebot-client==9.3.0
+deebot-client==9.4.0
 
 # homeassistant.components.ihc
 # homeassistant.components.namecheapdns

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1850,7 +1850,7 @@ pyspeex-noise==1.0.2
 pysqueezebox==0.10.0
 
 # homeassistant.components.suez_water
-pysuezV2==1.3.2
+pysuezV2==1.3.5
 
 # homeassistant.components.switchbee
 pyswitchbee==1.8.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -956,7 +956,7 @@ hole==0.8.0
 holidays==0.62
 
 # homeassistant.components.frontend
-home-assistant-frontend==20241127.7
+home-assistant-frontend==20241127.8
 
 # homeassistant.components.conversation
 home-assistant-intents==2024.12.9

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1076,7 +1076,7 @@ ld2410-ble==0.1.1
 leaone-ble==0.1.0
 
 # homeassistant.components.led_ble
-led-ble==1.0.2
+led-ble==1.1.1
 
 # homeassistant.components.lektrico
 lektricowifi==0.0.43

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1485,7 +1485,7 @@ pycountry==24.6.1
 pycsspeechtts==1.0.8
 
 # homeassistant.components.daikin
-pydaikin==2.13.7
+pydaikin==2.13.8
 
 # homeassistant.components.deako
 pydeako==0.6.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -744,7 +744,7 @@ eternalegypt==0.0.16
 eufylife-ble-client==0.1.8
 
 # homeassistant.components.evohome
-evohome-async==0.4.20
+evohome-async==0.4.21
 
 # homeassistant.components.bryant_evolution
 evolutionhttp==0.0.18

--- a/tests/components/assist_pipeline/snapshots/test_init.ambr
+++ b/tests/components/assist_pipeline/snapshots/test_init.ambr
@@ -142,7 +142,7 @@
             'data': dict({
               'code': 'no_intent_match',
             }),
-            'language': 'en',
+            'language': 'en-US',
             'response_type': 'error',
             'speech': dict({
               'plain': dict({
@@ -233,7 +233,7 @@
             'data': dict({
               'code': 'no_intent_match',
             }),
-            'language': 'en',
+            'language': 'en-US',
             'response_type': 'error',
             'speech': dict({
               'plain': dict({
@@ -380,6 +380,57 @@
         }),
       }),
       'type': <PipelineEventType.TTS_END: 'tts-end'>,
+    }),
+    dict({
+      'data': None,
+      'type': <PipelineEventType.RUN_END: 'run-end'>,
+    }),
+  ])
+# ---
+# name: test_pipeline_language_used_instead_of_conversation_language
+  list([
+    dict({
+      'data': dict({
+        'language': 'en',
+        'pipeline': <ANY>,
+      }),
+      'type': <PipelineEventType.RUN_START: 'run-start'>,
+    }),
+    dict({
+      'data': dict({
+        'conversation_id': None,
+        'device_id': None,
+        'engine': 'conversation.home_assistant',
+        'intent_input': 'test input',
+        'language': 'en',
+        'prefer_local_intents': False,
+      }),
+      'type': <PipelineEventType.INTENT_START: 'intent-start'>,
+    }),
+    dict({
+      'data': dict({
+        'intent_output': dict({
+          'conversation_id': None,
+          'response': dict({
+            'card': dict({
+            }),
+            'data': dict({
+              'failed': list([
+              ]),
+              'success': list([
+              ]),
+              'targets': list([
+              ]),
+            }),
+            'language': 'en',
+            'response_type': 'action_done',
+            'speech': dict({
+            }),
+          }),
+        }),
+        'processed_locally': True,
+      }),
+      'type': <PipelineEventType.INTENT_END: 'intent-end'>,
     }),
     dict({
       'data': None,

--- a/tests/components/assist_pipeline/test_init.py
+++ b/tests/components/assist_pipeline/test_init.py
@@ -23,6 +23,7 @@ from homeassistant.components.assist_pipeline.const import (
     CONF_DEBUG_RECORDING_DIR,
     DOMAIN,
 )
+from homeassistant.const import MATCH_ALL
 from homeassistant.core import Context, HomeAssistant
 from homeassistant.helpers import intent
 from homeassistant.setup import async_setup_component
@@ -1097,4 +1098,78 @@ async def test_prefer_local_intents(
                 "speech"
             ]
             == "Order confirmed"
+        )
+
+
+async def test_pipeline_language_used_instead_of_conversation_language(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    init_components,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test that the pipeline language is used when the conversation language is '*' (all languages)."""
+    client = await hass_ws_client(hass)
+
+    events: list[assist_pipeline.PipelineEvent] = []
+
+    await client.send_json_auto_id(
+        {
+            "type": "assist_pipeline/pipeline/create",
+            "conversation_engine": "homeassistant",
+            "conversation_language": MATCH_ALL,
+            "language": "en",
+            "name": "test_name",
+            "stt_engine": "test",
+            "stt_language": "en-US",
+            "tts_engine": "test",
+            "tts_language": "en-US",
+            "tts_voice": "Arnold Schwarzenegger",
+            "wake_word_entity": None,
+            "wake_word_id": None,
+        }
+    )
+    msg = await client.receive_json()
+    assert msg["success"]
+    pipeline_id = msg["result"]["id"]
+    pipeline = assist_pipeline.async_get_pipeline(hass, pipeline_id)
+
+    pipeline_input = assist_pipeline.pipeline.PipelineInput(
+        intent_input="test input",
+        run=assist_pipeline.pipeline.PipelineRun(
+            hass,
+            context=Context(),
+            pipeline=pipeline,
+            start_stage=assist_pipeline.PipelineStage.INTENT,
+            end_stage=assist_pipeline.PipelineStage.INTENT,
+            event_callback=events.append,
+        ),
+    )
+    await pipeline_input.validate()
+
+    with patch(
+        "homeassistant.components.assist_pipeline.pipeline.conversation.async_converse",
+        return_value=conversation.ConversationResult(
+            intent.IntentResponse(pipeline.language)
+        ),
+    ) as mock_async_converse:
+        await pipeline_input.execute()
+
+        # Check intent start event
+        assert process_events(events) == snapshot
+        intent_start: assist_pipeline.PipelineEvent | None = None
+        for event in events:
+            if event.type == assist_pipeline.PipelineEventType.INTENT_START:
+                intent_start = event
+                break
+
+        assert intent_start is not None
+
+        # Pipeline language (en) should be used instead of '*'
+        assert intent_start.data.get("language") == pipeline.language
+
+        # Check input to async_converse
+        mock_async_converse.assert_called_once()
+        assert (
+            mock_async_converse.call_args_list[0].kwargs.get("language")
+            == pipeline.language
         )

--- a/tests/components/linkplay/test_diagnostics.py
+++ b/tests/components/linkplay/test_diagnostics.py
@@ -31,8 +31,10 @@ async def test_diagnostics(
         patch.object(LinkPlayMultiroom, "update_status", return_value=None),
     ):
         endpoints = [
-            LinkPlayApiEndpoint(protocol="https", endpoint=HOST, session=None),
-            LinkPlayApiEndpoint(protocol="http", endpoint=HOST, session=None),
+            LinkPlayApiEndpoint(
+                protocol="https", port=443, endpoint=HOST, session=None
+            ),
+            LinkPlayApiEndpoint(protocol="http", port=80, endpoint=HOST, session=None),
         ]
         for endpoint in endpoints:
             mock_session.get(


### PR DESCRIPTION
- Bump python-linkplay to v0.1.1 ([@silamon] - [#132091]) ([linkplay docs]) (dependency)
- Bump pydaikin to 2.13.8 ([@weltall] - [#132759]) ([daikin docs]) (dependency)
- Fix pipeline conversation language ([@synesthesiam] - [#132896]) ([conversation docs]) ([assist_pipeline docs])
- fix AndroidTV logging when disconnected ([@chemelli74] - [#132919]) ([androidtv docs])
- Guard Vodafone Station updates against bad data ([@chemelli74] - [#132921]) ([vodafone_station docs])
- Bump led-ble to 1.1.1 ([@bdraco] - [#132977]) ([led_ble docs]) (dependency)
- Change warning to debug for VAD timeout ([@synesthesiam] - [#132987]) ([assist_pipeline docs])
- Fix LaMetric config flow for cloud import path ([@frenck] - [#133039]) ([lametric docs])
- Update frontend to 20241127.8 ([@bramkragten] - [#133066]) ([frontend docs]) (dependency)
- Bump pysuezV2 to 1.3.5 ([@jb101010-2] - [#133076]) ([suez_water docs]) (dependency)
- Bugfix to use evohome's new hostname ([@zxdavb] - [#133085]) ([evohome docs]) (dependency)
- Bump py-aosmith to 1.0.12 ([@bdr99] - [#133100]) ([aosmith docs]) (dependency)
- Bump deebot-client to 9.4.0 ([@edenhaus] - [#133114]) ([ecovacs docs]) (dependency)
- Bump aiowithings to 3.1.4 ([@joostlek] - [#133117]) ([withings docs])

[#132091]: https://github.com/home-assistant/core/pull/132091
[#132195]: https://github.com/home-assistant/core/pull/132195
[#132509]: https://github.com/home-assistant/core/pull/132509
[#132759]: https://github.com/home-assistant/core/pull/132759
[#132846]: https://github.com/home-assistant/core/pull/132846
[#132896]: https://github.com/home-assistant/core/pull/132896
[#132919]: https://github.com/home-assistant/core/pull/132919
[#132921]: https://github.com/home-assistant/core/pull/132921
[#132977]: https://github.com/home-assistant/core/pull/132977
[#132987]: https://github.com/home-assistant/core/pull/132987
[#133039]: https://github.com/home-assistant/core/pull/133039
[#133066]: https://github.com/home-assistant/core/pull/133066
[#133076]: https://github.com/home-assistant/core/pull/133076
[#133085]: https://github.com/home-assistant/core/pull/133085
[#133100]: https://github.com/home-assistant/core/pull/133100
[#133114]: https://github.com/home-assistant/core/pull/133114
[#133117]: https://github.com/home-assistant/core/pull/133117
[@bdr99]: https://github.com/bdr99
[@bdraco]: https://github.com/bdraco
[@bramkragten]: https://github.com/bramkragten
[@chemelli74]: https://github.com/chemelli74
[@edenhaus]: https://github.com/edenhaus
[@frenck]: https://github.com/frenck
[@jb101010-2]: https://github.com/jb101010-2
[@joostlek]: https://github.com/joostlek
[@silamon]: https://github.com/silamon
[@synesthesiam]: https://github.com/synesthesiam
[@weltall]: https://github.com/weltall
[@zxdavb]: https://github.com/zxdavb
[abode docs]: https://www.home-assistant.io/integrations/abode/
[acaia docs]: https://www.home-assistant.io/integrations/acaia/
[androidtv docs]: https://www.home-assistant.io/integrations/androidtv/
[aosmith docs]: https://www.home-assistant.io/integrations/aosmith/
[assist_pipeline docs]: https://www.home-assistant.io/integrations/assist_pipeline/
[conversation docs]: https://www.home-assistant.io/integrations/conversation/
[daikin docs]: https://www.home-assistant.io/integrations/daikin/
[ecovacs docs]: https://www.home-assistant.io/integrations/ecovacs/
[evohome docs]: https://www.home-assistant.io/integrations/evohome/
[frontend docs]: https://www.home-assistant.io/integrations/frontend/
[lametric docs]: https://www.home-assistant.io/integrations/lametric/
[led_ble docs]: https://www.home-assistant.io/integrations/led_ble/
[linkplay docs]: https://www.home-assistant.io/integrations/linkplay/
[suez_water docs]: https://www.home-assistant.io/integrations/suez_water/
[vodafone_station docs]: https://www.home-assistant.io/integrations/vodafone_station/
[withings docs]: https://www.home-assistant.io/integrations/withings/