### PR TITLE
Make Twitch sensor state and attributes translatable

### DIFF
--- a/homeassistant/components/twitch/sensor.py
+++ b/homeassistant/components/twitch/sensor.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from homeassistant.components.sensor import SensorEntity
+from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -49,6 +49,8 @@ class TwitchSensor(CoordinatorEntity[TwitchCoordinator], SensorEntity):
     """Representation of a Twitch channel."""
 
     _attr_translation_key = "channel"
+    _attr_device_class = SensorDeviceClass.ENUM
+    _attr_options = [STATE_OFFLINE, STATE_STREAMING]
 
     def __init__(self, coordinator: TwitchCoordinator, channel_id: str) -> None:
         """Initialize the sensor."""
@@ -82,8 +84,8 @@ class TwitchSensor(CoordinatorEntity[TwitchCoordinator], SensorEntity):
             ATTR_TITLE: channel.title,
             ATTR_STARTED_AT: channel.started_at,
             ATTR_VIEWERS: channel.viewers,
+            ATTR_SUBSCRIPTION: False,
         }
-        resp[ATTR_SUBSCRIPTION] = False
         if channel.subscribed is not None:
             resp[ATTR_SUBSCRIPTION] = channel.subscribed
             resp[ATTR_SUBSCRIPTION_GIFTED] = channel.subscription_gifted

--- a/homeassistant/components/twitch/strings.json
+++ b/homeassistant/components/twitch/strings.json
@@ -16,5 +16,47 @@
       "oauth_unauthorized": "[%key:common::config_flow::abort::oauth2_unauthorized%]",
       "oauth_failed": "[%key:common::config_flow::abort::oauth2_failed%]"
     }
+  },
+  "entity": {
+    "sensor": {
+      "channel": {
+        "state": {
+          "streaming": "Streaming",
+          "offline": "Offline"
+        },
+        "state_attributes": {
+          "followers": {
+            "name": "Followers"
+          },
+          "game": {
+            "name": "Game"
+          },
+          "title": {
+            "name": "Title"
+          },
+          "started_at": {
+            "name": "Started at"
+          },
+          "viewers": {
+            "name": "Viewers"
+          },
+          "subscribed": {
+            "name": "Subscribed"
+          },
+          "subscription_is_gifted": {
+            "name": "Subscription is gifted"
+          },
+          "subscription_tier": {
+            "name": "Subscription tier"
+          },
+          "following": {
+            "name": "Following"
+          },
+          "following_since": {
+            "name": "Following since"
+          }
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## Proposed change
Make the Twitch sensor state and attributes translatable. this also adds the enum device class.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
