### PR TITLE
Use unique_id in devolo Home Network tests

### DIFF
--- a/tests/components/devolo_home_network/__init__.py
+++ b/tests/components/devolo_home_network/__init__.py
@@ -4,7 +4,7 @@ from homeassistant.components.devolo_home_network.const import DOMAIN
 from homeassistant.const import CONF_IP_ADDRESS, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
 
-from .const import IP
+from .const import DISCOVERY_INFO, IP
 
 from tests.common import MockConfigEntry
 
@@ -15,7 +15,12 @@ def configure_integration(hass: HomeAssistant) -> MockConfigEntry:
         CONF_IP_ADDRESS: IP,
         CONF_PASSWORD: "test",
     }
-    entry = MockConfigEntry(domain=DOMAIN, data=config, entry_id="123456")
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=config,
+        entry_id="123456",
+        unique_id=DISCOVERY_INFO.properties["SN"],
+    )
     entry.add_to_hass(hass)
 
     return entry

--- a/tests/components/devolo_home_network/snapshots/test_diagnostics.ambr
+++ b/tests/components/devolo_home_network/snapshots/test_diagnostics.ambr
@@ -35,7 +35,7 @@
       'subentries': list([
       ]),
       'title': 'Mock Title',
-      'unique_id': None,
+      'unique_id': '1234567890',
       'version': 1,
     }),
   })

--- a/tests/components/devolo_home_network/test_config_flow.py
+++ b/tests/components/devolo_home_network/test_config_flow.py
@@ -29,8 +29,6 @@ from .const import (
 )
 from .mock import MockDevice
 
-from tests.common import MockConfigEntry
-
 
 async def test_form(hass: HomeAssistant, info: dict[str, Any]) -> None:
     """Test we get the form."""
@@ -87,7 +85,7 @@ async def test_form_error(hass: HomeAssistant, exception_type, expected_error) -
     assert result2["errors"] == {CONF_BASE: expected_error}
 
 
-async def test_zeroconf(hass: HomeAssistant) -> None:
+async def test_zeroconf(hass: HomeAssistant, info: dict[str, Any]) -> None:
     """Test that the zeroconf form is served."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -125,6 +123,7 @@ async def test_zeroconf(hass: HomeAssistant) -> None:
         CONF_IP_ADDRESS: IP,
         CONF_PASSWORD: "",
     }
+    assert result2["result"].unique_id == info["serial_number"]
 
 
 async def test_abort_zeroconf_wrong_device(hass: HomeAssistant) -> None:
@@ -141,11 +140,7 @@ async def test_abort_zeroconf_wrong_device(hass: HomeAssistant) -> None:
 @pytest.mark.usefixtures("info")
 async def test_abort_if_configued(hass: HomeAssistant) -> None:
     """Test we abort config flow if already configured."""
-    serial_number = DISCOVERY_INFO.properties["SN"]
-    entry = MockConfigEntry(
-        domain=DOMAIN, unique_id=serial_number, data={CONF_IP_ADDRESS: IP}
-    )
-    entry.add_to_hass(hass)
+    entry = configure_integration(hass)
 
     # Abort on concurrent user flow
     result = await hass.config_entries.flow.async_init(

--- a/tests/components/devolo_home_network/test_config_flow.py
+++ b/tests/components/devolo_home_network/test_config_flow.py
@@ -85,7 +85,7 @@ async def test_form_error(hass: HomeAssistant, exception_type, expected_error) -
     assert result2["errors"] == {CONF_BASE: expected_error}
 
 
-async def test_zeroconf(hass: HomeAssistant, info: dict[str, Any]) -> None:
+async def test_zeroconf(hass: HomeAssistant) -> None:
     """Test that the zeroconf form is served."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -123,7 +123,8 @@ async def test_zeroconf(hass: HomeAssistant, info: dict[str, Any]) -> None:
         CONF_IP_ADDRESS: IP,
         CONF_PASSWORD: "",
     }
-    assert result2["result"].unique_id == info["serial_number"]
+    assert result2["type"] is FlowResultType.CREATE_ENTRY
+    assert result2["result"].unique_id == "1234567890"
 
 
 async def test_abort_zeroconf_wrong_device(hass: HomeAssistant) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Sets the unique_id in the mocked ConfigEntry. This allows saving a few lines of code. With it, I explicitly assert the unique_id in test_zeroconf.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
