### PR TITLE
Fix strptime in python_script

### DIFF
--- a/homeassistant/components/python_script/__init__.py
+++ b/homeassistant/components/python_script/__init__.py
@@ -176,7 +176,8 @@ def guarded_import(
     fromlist: Sequence[str] = (),
     level: int = 0,
 ) -> types.ModuleType:
-    """Guard imports. Only allow datetime to import _strptime."""
+    """Guard imports."""
+    # Allow import of _strptime needed by datetime.datetime.strptime
     if name == "_strptime":
         return __import__(name, globals, locals, fromlist, level)
     raise ScriptError(f"Not allowed to import {name}")

--- a/homeassistant/components/python_script/__init__.py
+++ b/homeassistant/components/python_script/__init__.py
@@ -1,5 +1,6 @@
 """Component to allow running Python scripts."""
 
+from collections.abc import Mapping, Sequence
 import datetime
 import glob
 import logging
@@ -7,6 +8,7 @@ from numbers import Number
 import operator
 import os
 import time
+import types
 from typing import Any
 
 from RestrictedPython import (
@@ -167,6 +169,19 @@ IOPERATOR_TO_OPERATOR = {
 }
 
 
+def guarded_import(
+    name: str,
+    globals: Mapping[str, object] | None = None,
+    locals: Mapping[str, object] | None = None,
+    fromlist: Sequence[str] = (),
+    level: int = 0,
+) -> types.ModuleType:
+    """Guard imports. Only allow datetime to import _strptime."""
+    if name == "_strptime":
+        return __import__(name, globals, locals, fromlist, level)
+    raise ScriptError(f"Not allowed to import {name}")
+
+
 def guarded_inplacevar(op: str, target: Any, operand: Any) -> Any:
     """Implement augmented-assign (+=, -=, etc.) operators for restricted code.
 
@@ -232,6 +247,7 @@ def execute(hass, filename, source, data=None, return_response=False):
         return getattr(obj, name, default)
 
     extra_builtins = {
+        "__import__": guarded_import,
         "datetime": datetime,
         "sorted": sorted,
         "time": TimeWrapper(),

--- a/tests/components/python_script/test_init.py
+++ b/tests/components/python_script/test_init.py
@@ -693,7 +693,7 @@ async def test_prohibited_augmented_assignment_operations(
 async def test_import_allow_strptime(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """Test that prohibited augmented assignment operations raise an error."""
+    """Test calling datetime.datetime.strptime works."""
     source = """
 test_date = datetime.datetime.strptime('2024-04-01', '%Y-%m-%d')
 logger.info(f'Date {test_date}')
@@ -707,7 +707,7 @@ logger.info(f'Date {test_date}')
 async def test_no_other_imports_allowed(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """Test that prohibited augmented assignment operations raise an error."""
+    """Test imports are not allowed."""
     source = "import sys"
     hass.async_add_executor_job(execute, hass, "test.py", source, {})
     await hass.async_block_till_done(wait_background_tasks=True)

--- a/tests/components/python_script/test_init.py
+++ b/tests/components/python_script/test_init.py
@@ -688,3 +688,27 @@ async def test_prohibited_augmented_assignment_operations(
     hass.async_add_executor_job(execute, hass, "aug_assign_prohibited.py", case, {})
     await hass.async_block_till_done(wait_background_tasks=True)
     assert error in caplog.text
+
+
+async def test_import_allow_strptime(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test that prohibited augmented assignment operations raise an error."""
+    source = """
+test_date = datetime.datetime.strptime('2024-04-01', '%Y-%m-%d')
+logger.info(f'Date {test_date}')
+    """
+    hass.async_add_executor_job(execute, hass, "test.py", source, {})
+    await hass.async_block_till_done(wait_background_tasks=True)
+    assert "Error executing script: Not allowed to import _strptime" not in caplog.text
+    assert "Date 2024-04-01 00:00:00" in caplog.text
+
+
+async def test_no_other_imports_allowed(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test that prohibited augmented assignment operations raise an error."""
+    source = "import sys"
+    hass.async_add_executor_job(execute, hass, "test.py", source, {})
+    await hass.async_block_till_done(wait_background_tasks=True)
+    assert "Error executing script: Not allowed to import sys" in caplog.text


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In Python 3.13, `datetime.datetime.strptime` does a local import of `_strptime`.
This breaks `python_script` scripts which call `datetime.datetime.strptime` because we don't allow imports.

As a workaround, we add an allow-list of safe import, `_strptime` is currently the only allowed import.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #132469
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 