### PR TITLE
Improve MQTT json color_temp validation

### DIFF
--- a/homeassistant/components/mqtt/light/schema_json.py
+++ b/homeassistant/components/mqtt/light/schema_json.py
@@ -490,7 +490,7 @@ class MqttLightJson(MqttEntity, LightEntity, RestoreEntity):
                     )
             except KeyError:
                 pass
-            except ValueError:
+            except (TypeError, ValueError):
                 _LOGGER.warning(
                     "Invalid color temp value '%s' received for entity %s",
                     values["color_temp"],

--- a/tests/components/mqtt/test_light_json.py
+++ b/tests/components/mqtt/test_light_json.py
@@ -2275,18 +2275,20 @@ async def test_invalid_values(
     assert state.state == STATE_ON
     assert state.attributes.get("brightness") == 255
 
-    # Unset color and set a valid color temperature
-    async_fire_mqtt_message(
-        hass, "test_light_rgb", '{"state":"ON", "color": null, "color_temp": 100}'
-    )
-    state = hass.states.get("light.test")
-    assert state.state == STATE_ON
-    assert state.attributes.get("color_temp") == 100
-
     # Bad color temperature
     async_fire_mqtt_message(
         hass, "test_light_rgb", '{"state":"ON", "color_temp": "badValue"}'
     )
+
+    # Unset color and set a valid color temperature
+    async_fire_mqtt_message(
+        hass,
+        "test_light_rgb",
+        '{"state":"ON", "color_mode": "color_temp", "color_temp": 100}',
+    )
+    state = hass.states.get("light.test")
+    assert state.state == STATE_ON
+    assert state.attributes.get("color_temp") == 100
 
     # Color temperature should not have changed
     state = hass.states.get("light.test")

--- a/tests/components/mqtt/test_light_json.py
+++ b/tests/components/mqtt/test_light_json.py
@@ -2279,7 +2279,7 @@ async def test_invalid_values(
 
     # Unset color and set a valid color temperature
     async_fire_mqtt_message(
-        hass, "test_light_rgb", '{"state":"ON", "color_mode": null, "color_temp": 100}'
+        hass, "test_light_rgb", '{"state":"ON", "color": null, "color_temp": 100}'
     )
     state = hass.states.get("light.test")
     assert state.state == STATE_ON

--- a/tests/components/mqtt/test_light_json.py
+++ b/tests/components/mqtt/test_light_json.py
@@ -2185,7 +2185,9 @@ async def test_white_scale(
     ],
 )
 async def test_invalid_values(
-    hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
+    hass: HomeAssistant,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test that invalid color/brightness/etc. values are ignored."""
     await mqtt_mock_entry()
@@ -2275,20 +2277,22 @@ async def test_invalid_values(
     assert state.state == STATE_ON
     assert state.attributes.get("brightness") == 255
 
-    # Bad color temperature
-    async_fire_mqtt_message(
-        hass, "test_light_rgb", '{"state":"ON", "color_temp": "badValue"}'
-    )
-
     # Unset color and set a valid color temperature
     async_fire_mqtt_message(
-        hass,
-        "test_light_rgb",
-        '{"state":"ON", "color_mode": "color_temp", "color_temp": 100}',
+        hass, "test_light_rgb", '{"state":"ON", "color_mode": null, "color_temp": 100}'
     )
     state = hass.states.get("light.test")
     assert state.state == STATE_ON
     assert state.attributes.get("color_temp") == 100
+
+    # Bad color temperature
+    async_fire_mqtt_message(
+        hass, "test_light_rgb", '{"state":"ON", "color_temp": "badValue"}'
+    )
+    assert (
+        "Invalid color temp value 'badValue' received for entity light.test"
+        in caplog.text
+    )
 
     # Color temperature should not have changed
     state = hass.states.get("light.test")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve MQTT json color_temp validation.
The conversion from millired to Kelvin will raise a `TypeError` in case a string is received instead of a number.
This is regression from #132828

Caught when the code coverage seemed to have been decreased on the error handling code.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
