### PR TITLE
Improve BMW translations

### DIFF
--- a/homeassistant/components/bmw_connected_drive/button.py
+++ b/homeassistant/components/bmw_connected_drive/button.py
@@ -55,7 +55,6 @@ BUTTON_TYPES: tuple[BMWButtonEntityDescription, ...] = (
     BMWButtonEntityDescription(
         key="deactivate_air_conditioning",
         translation_key="deactivate_air_conditioning",
-        name="Deactivate air conditioning",
         remote_function=lambda vehicle: vehicle.remote_services.trigger_remote_air_conditioning_stop(),
         is_available=lambda vehicle: vehicle.is_remote_climate_stop_enabled,
     ),

--- a/homeassistant/components/bmw_connected_drive/button.py
+++ b/homeassistant/components/bmw_connected_drive/button.py
@@ -16,7 +16,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import BMWConfigEntry
+from . import DOMAIN as BMW_DOMAIN, BMWConfigEntry
 from .entity import BMWBaseEntity
 
 if TYPE_CHECKING:
@@ -111,6 +111,10 @@ class BMWButton(BMWBaseEntity, ButtonEntity):
         try:
             await self.entity_description.remote_function(self.vehicle)
         except MyBMWAPIError as ex:
-            raise HomeAssistantError(ex) from ex
+            raise HomeAssistantError(
+                translation_domain=BMW_DOMAIN,
+                translation_key="remote_service_error",
+                translation_placeholders={"exception": str(ex)},
+            ) from ex
 
         self.coordinator.async_update_listeners()

--- a/homeassistant/components/bmw_connected_drive/coordinator.py
+++ b/homeassistant/components/bmw_connected_drive/coordinator.py
@@ -22,7 +22,13 @@ from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util.ssl import get_default_context
 
-from .const import CONF_GCID, CONF_READ_ONLY, CONF_REFRESH_TOKEN, DOMAIN, SCAN_INTERVALS
+from .const import (
+    CONF_GCID,
+    CONF_READ_ONLY,
+    CONF_REFRESH_TOKEN,
+    DOMAIN as BMW_DOMAIN,
+    SCAN_INTERVALS,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -57,7 +63,7 @@ class BMWDataUpdateCoordinator(DataUpdateCoordinator[None]):
             hass,
             _LOGGER,
             config_entry=config_entry,
-            name=f"{DOMAIN}-{config_entry.data[CONF_USERNAME]}",
+            name=f"{BMW_DOMAIN}-{config_entry.data[CONF_USERNAME]}",
             update_interval=timedelta(
                 seconds=SCAN_INTERVALS[config_entry.data[CONF_REGION]]
             ),
@@ -75,18 +81,29 @@ class BMWDataUpdateCoordinator(DataUpdateCoordinator[None]):
         except MyBMWCaptchaMissingError as err:
             # If a captcha is required (user/password login flow), always trigger the reauth flow
             raise ConfigEntryAuthFailed(
-                translation_domain=DOMAIN,
+                translation_domain=BMW_DOMAIN,
                 translation_key="missing_captcha",
             ) from err
         except MyBMWAuthError as err:
             # Allow one retry interval before raising AuthFailed to avoid flaky API issues
             if self.last_update_success:
-                raise UpdateFailed(err) from err
+                raise UpdateFailed(
+                    translation_domain=BMW_DOMAIN,
+                    translation_key="update_failed",
+                    translation_placeholders={"exception": str(err)},
+                ) from err
             # Clear refresh token and trigger reauth if previous update failed as well
             self._update_config_entry_refresh_token(None)
-            raise ConfigEntryAuthFailed(err) from err
+            raise ConfigEntryAuthFailed(
+                translation_domain=BMW_DOMAIN,
+                translation_key="invalid_auth",
+            ) from err
         except (MyBMWAPIError, RequestError) as err:
-            raise UpdateFailed(err) from err
+            raise UpdateFailed(
+                translation_domain=BMW_DOMAIN,
+                translation_key="update_failed",
+                translation_placeholders={"exception": str(err)},
+            ) from err
 
         if self.account.refresh_token != old_refresh_token:
             self._update_config_entry_refresh_token(self.account.refresh_token)

--- a/homeassistant/components/bmw_connected_drive/device_tracker.py
+++ b/homeassistant/components/bmw_connected_drive/device_tracker.py
@@ -49,7 +49,7 @@ class BMWDeviceTracker(BMWBaseEntity, TrackerEntity):
 
     _attr_force_update = False
     _attr_translation_key = "car"
-    _attr_icon = "mdi:car"
+    _attr_name = None
 
     def __init__(
         self,
@@ -58,9 +58,7 @@ class BMWDeviceTracker(BMWBaseEntity, TrackerEntity):
     ) -> None:
         """Initialize the Tracker."""
         super().__init__(coordinator, vehicle)
-
         self._attr_unique_id = vehicle.vin
-        self._attr_name = None
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:

--- a/homeassistant/components/bmw_connected_drive/lock.py
+++ b/homeassistant/components/bmw_connected_drive/lock.py
@@ -14,7 +14,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import BMWConfigEntry
+from . import DOMAIN as BMW_DOMAIN, BMWConfigEntry
 from .coordinator import BMWDataUpdateCoordinator
 from .entity import BMWBaseEntity
 
@@ -70,7 +70,11 @@ class BMWLock(BMWBaseEntity, LockEntity):
             # Set the state to unknown if the command fails
             self._attr_is_locked = None
             self.async_write_ha_state()
-            raise HomeAssistantError(ex) from ex
+            raise HomeAssistantError(
+                translation_domain=BMW_DOMAIN,
+                translation_key="remote_service_error",
+                translation_placeholders={"exception": str(ex)},
+            ) from ex
         finally:
             # Always update the listeners to get the latest state
             self.coordinator.async_update_listeners()
@@ -90,7 +94,11 @@ class BMWLock(BMWBaseEntity, LockEntity):
             # Set the state to unknown if the command fails
             self._attr_is_locked = None
             self.async_write_ha_state()
-            raise HomeAssistantError(ex) from ex
+            raise HomeAssistantError(
+                translation_domain=BMW_DOMAIN,
+                translation_key="remote_service_error",
+                translation_placeholders={"exception": str(ex)},
+            ) from ex
         finally:
             # Always update the listeners to get the latest state
             self.coordinator.async_update_listeners()

--- a/homeassistant/components/bmw_connected_drive/notify.py
+++ b/homeassistant/components/bmw_connected_drive/notify.py
@@ -20,7 +20,7 @@ from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from . import DOMAIN, BMWConfigEntry
+from . import DOMAIN as BMW_DOMAIN, BMWConfigEntry
 
 PARALLEL_UPDATES = 1
 
@@ -92,7 +92,7 @@ class BMWNotificationService(BaseNotificationService):
 
         except (vol.Invalid, TypeError, ValueError) as ex:
             raise ServiceValidationError(
-                translation_domain=DOMAIN,
+                translation_domain=BMW_DOMAIN,
                 translation_key="invalid_poi",
                 translation_placeholders={
                     "poi_exception": str(ex),
@@ -106,4 +106,8 @@ class BMWNotificationService(BaseNotificationService):
             try:
                 await vehicle.remote_services.trigger_send_poi(poi)
             except MyBMWAPIError as ex:
-                raise HomeAssistantError(ex) from ex
+                raise HomeAssistantError(
+                    translation_domain=BMW_DOMAIN,
+                    translation_key="remote_service_error",
+                    translation_placeholders={"exception": str(ex)},
+                ) from ex

--- a/homeassistant/components/bmw_connected_drive/number.py
+++ b/homeassistant/components/bmw_connected_drive/number.py
@@ -18,7 +18,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import BMWConfigEntry
+from . import DOMAIN as BMW_DOMAIN, BMWConfigEntry
 from .coordinator import BMWDataUpdateCoordinator
 from .entity import BMWBaseEntity
 
@@ -109,6 +109,10 @@ class BMWNumber(BMWBaseEntity, NumberEntity):
         try:
             await self.entity_description.remote_service(self.vehicle, value)
         except MyBMWAPIError as ex:
-            raise HomeAssistantError(ex) from ex
+            raise HomeAssistantError(
+                translation_domain=BMW_DOMAIN,
+                translation_key="remote_service_error",
+                translation_placeholders={"exception": str(ex)},
+            ) from ex
 
         self.coordinator.async_update_listeners()

--- a/homeassistant/components/bmw_connected_drive/select.py
+++ b/homeassistant/components/bmw_connected_drive/select.py
@@ -15,7 +15,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import BMWConfigEntry
+from . import DOMAIN as BMW_DOMAIN, BMWConfigEntry
 from .coordinator import BMWDataUpdateCoordinator
 from .entity import BMWBaseEntity
 
@@ -123,6 +123,10 @@ class BMWSelect(BMWBaseEntity, SelectEntity):
         try:
             await self.entity_description.remote_service(self.vehicle, option)
         except MyBMWAPIError as ex:
-            raise HomeAssistantError(ex) from ex
+            raise HomeAssistantError(
+                translation_domain=BMW_DOMAIN,
+                translation_key="remote_service_error",
+                translation_placeholders={"exception": str(ex)},
+            ) from ex
 
         self.coordinator.async_update_listeners()

--- a/homeassistant/components/bmw_connected_drive/strings.json
+++ b/homeassistant/components/bmw_connected_drive/strings.json
@@ -2,11 +2,16 @@
   "config": {
     "step": {
       "user": {
-        "description": "Enter your MyBMW/MINI Connected credentials.",
+        "description": "Connect to your MyBMW/MINI Connected account to retrieve vehicle data.",
         "data": {
           "username": "[%key:common::config_flow::data::username%]",
           "password": "[%key:common::config_flow::data::password%]",
           "region": "ConnectedDrive Region"
+        },
+        "data_description": {
+          "username": "The email address of your MyBMW/MINI Connected account.",
+          "password": "The password of your MyBMW/MINI Connected account.",
+          "region": "The region of your MyBMW/MINI Connected account."
         }
       },
       "captcha": {
@@ -23,6 +28,9 @@
         "description": "Update your MyBMW/MINI Connected password for account `{username}` in region `{region}`.",
         "data": {
           "password": "[%key:common::config_flow::data::password%]"
+        },
+        "data_description": {
+          "password": "[%key:component::bmw_connected_drive::config::step::user::data_description::password%]"
         }
       }
     },
@@ -41,7 +49,10 @@
     "step": {
       "account_options": {
         "data": {
-          "read_only": "Read-only (only sensors and notify, no execution of services, no lock)"
+          "read_only": "Read-only mode"
+        },
+        "data_description": {
+          "read_only": "Only retrieve values and send POI data, but don't offer any services that can change the vehicle state."
         }
       }
     }
@@ -220,6 +231,15 @@
     },
     "missing_captcha": {
       "message": "Login requires captcha validation"
+    },
+    "invalid_auth": {
+      "message": "[%key:common::config_flow::error::invalid_auth%]"
+    },
+    "remote_service_error": {
+      "message": "Error executing remote service on vehicle. {exception}"
+    },
+    "update_failed": {
+      "message": "Error updating vehicle data. {exception}"
     }
   }
 }

--- a/homeassistant/components/bmw_connected_drive/strings.json
+++ b/homeassistant/components/bmw_connected_drive/strings.json
@@ -94,6 +94,9 @@
       "activate_air_conditioning": {
         "name": "Activate air conditioning"
       },
+      "deactivate_air_conditioning": {
+        "name": "Deactivate air conditioning"
+      },
       "find_vehicle": {
         "name": "Find vehicle"
       }

--- a/homeassistant/components/bmw_connected_drive/switch.py
+++ b/homeassistant/components/bmw_connected_drive/switch.py
@@ -14,7 +14,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import BMWConfigEntry
+from . import DOMAIN as BMW_DOMAIN, BMWConfigEntry
 from .coordinator import BMWDataUpdateCoordinator
 from .entity import BMWBaseEntity
 
@@ -111,8 +111,11 @@ class BMWSwitch(BMWBaseEntity, SwitchEntity):
         try:
             await self.entity_description.remote_service_on(self.vehicle)
         except MyBMWAPIError as ex:
-            raise HomeAssistantError(ex) from ex
-
+            raise HomeAssistantError(
+                translation_domain=BMW_DOMAIN,
+                translation_key="remote_service_error",
+                translation_placeholders={"exception": str(ex)},
+            ) from ex
         self.coordinator.async_update_listeners()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
@@ -120,6 +123,9 @@ class BMWSwitch(BMWBaseEntity, SwitchEntity):
         try:
             await self.entity_description.remote_service_off(self.vehicle)
         except MyBMWAPIError as ex:
-            raise HomeAssistantError(ex) from ex
-
+            raise HomeAssistantError(
+                translation_domain=BMW_DOMAIN,
+                translation_key="remote_service_error",
+                translation_placeholders={"exception": str(ex)},
+            ) from ex
         self.coordinator.async_update_listeners()

--- a/tests/components/bmw_connected_drive/__init__.py
+++ b/tests/components/bmw_connected_drive/__init__.py
@@ -48,6 +48,11 @@ FIXTURE_CONFIG_ENTRY = {
     "unique_id": f"{FIXTURE_USER_INPUT[CONF_REGION]}-{FIXTURE_USER_INPUT[CONF_USERNAME]}",
 }
 
+REMOTE_SERVICE_EXC_REASON = "HTTPStatusError: 502 Bad Gateway"
+REMOTE_SERVICE_EXC_TRANSLATION = (
+    "Error executing remote service on vehicle. HTTPStatusError: 502 Bad Gateway"
+)
+
 
 async def setup_mocked_integration(hass: HomeAssistant) -> MockConfigEntry:
     """Mock a fully setup config entry and all components based on fixtures."""

--- a/tests/components/bmw_connected_drive/test_button.py
+++ b/tests/components/bmw_connected_drive/test_button.py
@@ -13,7 +13,11 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 
-from . import check_remote_service_call, setup_mocked_integration
+from . import (
+    REMOTE_SERVICE_EXC_TRANSLATION,
+    check_remote_service_call,
+    setup_mocked_integration,
+)
 
 from tests.common import snapshot_platform
 
@@ -81,11 +85,13 @@ async def test_service_call_fail(
     monkeypatch.setattr(
         RemoteServices,
         "trigger_remote_service",
-        AsyncMock(side_effect=MyBMWRemoteServiceError),
+        AsyncMock(
+            side_effect=MyBMWRemoteServiceError("HTTPStatusError: 502 Bad Gateway")
+        ),
     )
 
     # Test
-    with pytest.raises(HomeAssistantError):
+    with pytest.raises(HomeAssistantError, match=REMOTE_SERVICE_EXC_TRANSLATION):
         await hass.services.async_call(
             "button",
             "press",

--- a/tests/components/bmw_connected_drive/test_lock.py
+++ b/tests/components/bmw_connected_drive/test_lock.py
@@ -16,7 +16,12 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 from homeassistant.util import dt as dt_util
 
-from . import check_remote_service_call, setup_mocked_integration
+from . import (
+    REMOTE_SERVICE_EXC_REASON,
+    REMOTE_SERVICE_EXC_TRANSLATION,
+    check_remote_service_call,
+    setup_mocked_integration,
+)
 
 from tests.common import snapshot_platform
 from tests.components.recorder.common import async_wait_recording_done
@@ -118,11 +123,11 @@ async def test_service_call_fail(
     monkeypatch.setattr(
         RemoteServices,
         "trigger_remote_service",
-        AsyncMock(side_effect=MyBMWRemoteServiceError),
+        AsyncMock(side_effect=MyBMWRemoteServiceError(REMOTE_SERVICE_EXC_REASON)),
     )
 
     # Test
-    with pytest.raises(HomeAssistantError):
+    with pytest.raises(HomeAssistantError, match=REMOTE_SERVICE_EXC_TRANSLATION):
         await hass.services.async_call(
             "lock",
             service,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds exception translations to all BMW exceptions.

Also fixes two minor translation-related issues found in #132017:
- Missing translation in button
- Hardcoded icon in device tracker

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
