### PR TITLE
Add character usage sensors to ElevenLabs

### DIFF
--- a/homeassistant/components/elevenlabs/coordinator.py
+++ b/homeassistant/components/elevenlabs/coordinator.py
@@ -1,0 +1,96 @@
+"""The coordinator for the ElevenLabs integration."""
+
+from datetime import UTC, datetime, timedelta
+from logging import getLogger
+
+from elevenlabs.client import AsyncElevenLabs
+from elevenlabs.core import ApiError
+from elevenlabs.types import UsageCharactersResponseModel
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import DOMAIN
+
+_LOGGER = getLogger(__name__)
+SCAN_INTERVAL = timedelta(seconds=120)
+BREAKDOWN_KEY = "All"
+
+
+class ElevenLabsDataUpdateCoordinator(
+    DataUpdateCoordinator[UsageCharactersResponseModel]
+):
+    """Class to manage fetching ElevenLabs data."""
+
+    def __init__(self, hass: HomeAssistant, client: AsyncElevenLabs) -> None:
+        """Initialize the ElevenLabs data updater."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=DOMAIN,
+            update_interval=SCAN_INTERVAL,
+            always_update=False,
+        )
+        self.client = client
+        self.usage_data: list[int] = []
+        self.times: list[int] = []
+        self.last_unix_update = 1
+
+    def merge_usage_data(
+        self, usage_data: UsageCharactersResponseModel
+    ) -> UsageCharactersResponseModel:
+        """Merge new usage data to the coordinator. Returns the merged data."""
+        if BREAKDOWN_KEY not in usage_data.usage:
+            _LOGGER.warning(
+                "No data found for breakdown key %s in ElevenLabs usage response!",
+                BREAKDOWN_KEY,
+            )
+            return UsageCharactersResponseModel(
+                time=self.times, usage={BREAKDOWN_KEY: self.usage_data}
+            )
+        for idx, time in enumerate(usage_data.time):
+            if time not in self.times:
+                self.times.append(time)
+                self.usage_data.append(usage_data.usage[BREAKDOWN_KEY][idx])
+            else:
+                self.usage_data[self.times.index(time)] = usage_data.usage[
+                    BREAKDOWN_KEY
+                ][idx]
+        return UsageCharactersResponseModel(
+            time=self.times, usage={BREAKDOWN_KEY: self.usage_data}
+        )
+
+    async def _async_update_data(self) -> UsageCharactersResponseModel:
+        """Fetch data from ElevenLabs."""
+        now = datetime.now(UTC)
+        # Convert to milliseconds
+        current_time_unix = int(now.timestamp() * 1_000)
+        _LOGGER.debug(
+            "Updating ElevenLabs usage data, start: %s, end: %s",
+            self.last_unix_update,
+            current_time_unix,
+        )
+        try:
+            response = await self.client.usage.get_characters_usage_metrics(
+                start_unix=self.last_unix_update, end_unix=current_time_unix
+            )
+            merged_response = self.merge_usage_data(response)
+            current_date_unix = int(
+                datetime(now.year, now.month, now.day, tzinfo=UTC).timestamp() * 1_000
+            )
+            self.last_unix_update = current_date_unix
+        except ApiError as e:
+            _LOGGER.exception(
+                "API Error when fetching usage data in ElevenLabs integration!"
+            )
+            raise UpdateFailed(
+                "Error fetching usage data for ElevenLabs integration"
+            ) from e
+        except Exception as e:
+            _LOGGER.exception(
+                "Unknown error when fetching usage data in ElevenLabs integration!"
+            )
+            raise UpdateFailed(
+                "Unknown error fetching usage data for ElevenLabs integration"
+            ) from e
+        return merged_response

--- a/homeassistant/components/elevenlabs/sensor.py
+++ b/homeassistant/components/elevenlabs/sensor.py
@@ -1,0 +1,143 @@
+"""The sensor entities for the ElevenLabs integration."""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from logging import getLogger
+
+from elevenlabs.types import UsageCharactersResponseModel
+from propcache import cached_property
+
+from homeassistant.components.sensor import (
+    SensorEntity,
+    SensorEntityDescription,
+    SensorStateClass,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from . import ElevenLabsConfigEntry
+from .coordinator import BREAKDOWN_KEY, ElevenLabsDataUpdateCoordinator
+
+_LOGGER = getLogger(__name__)
+
+
+@dataclass(frozen=True, kw_only=True)
+class ElevenLabsSensorEntityDescription(SensorEntityDescription):
+    """Describes ElevenLabs sensor entity."""
+
+    value_fn: Callable[[UsageCharactersResponseModel], int]
+
+
+def characters_sum_from_timestamp(
+    data: UsageCharactersResponseModel, timestamp: datetime
+) -> int:
+    """Return the sum of characters used since the given timestamp."""
+    # ElevenLabs timestamps are 0:00 UTC, so we need to adjust the time to match
+    timestamp = datetime(timestamp.year, timestamp.month, timestamp.day, tzinfo=UTC)
+    now = datetime.now(UTC)
+    curr = timestamp
+    characters = 0
+    while curr < now:
+        curr_unix = int(curr.timestamp() * 1_000)
+        curr_idx = data.time.index(curr_unix)
+        _LOGGER.debug(
+            "Day %s: %s characters",
+            curr.strftime("%Y-%m-%d"),
+            data.usage[BREAKDOWN_KEY][curr_idx],
+        )
+        characters += data.usage[BREAKDOWN_KEY][curr_idx]
+        curr += timedelta(days=1)
+    return characters
+
+
+def characters_this_month(data: UsageCharactersResponseModel) -> int:
+    """Return the number of characters used this month."""
+    now = datetime.now(UTC)
+    first_day = datetime(now.year, now.month, 1, tzinfo=UTC)
+    return characters_sum_from_timestamp(data, first_day)
+
+
+def characters_7_days(data: UsageCharactersResponseModel) -> int:
+    """Return the number of characters used in the last 7 days."""
+    now = datetime.now(UTC)
+    last_seven = now - timedelta(days=6)  # Last 7 days, including today, so 6 days ago
+    return characters_sum_from_timestamp(data, last_seven)
+
+
+def characters_today(data: UsageCharactersResponseModel) -> int:
+    """Return the number of characters used today."""
+    now = datetime.now(UTC)
+    # ElevenLabs timestamps are 0:00 UTC, so we need to adjust the current time to match
+    today = datetime(now.year, now.month, now.day, tzinfo=UTC)
+    today_unix = int(today.timestamp() * 1_000)
+    today_idx = data.time.index(today_unix)
+    return data.usage[BREAKDOWN_KEY][today_idx]
+
+
+SENSORS: tuple[ElevenLabsSensorEntityDescription, ...] = (
+    ElevenLabsSensorEntityDescription(
+        key="total_characters",
+        translation_key="total_characters",
+        value_fn=lambda data: sum(data.usage[BREAKDOWN_KEY]),
+    ),
+    ElevenLabsSensorEntityDescription(
+        key="characters_today",
+        translation_key="characters_today",
+        value_fn=characters_today,
+    ),
+    ElevenLabsSensorEntityDescription(
+        key="characters_7_days",
+        translation_key="characters_7_days",
+        value_fn=characters_7_days,
+    ),
+    ElevenLabsSensorEntityDescription(
+        key="characters_this_month",
+        translation_key="characters_this_month",
+        value_fn=characters_this_month,
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ElevenLabsConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up ElevenLabs sensors based on a config entry."""
+    coordinator = entry.runtime_data.coordinator
+    async_add_entities(
+        ElevenLabsUsageEntity(
+            coordinator=coordinator,
+            description=description,
+            entry_id=f"{entry.entry_id}",
+        )
+        for description in SENSORS
+    )
+
+
+class ElevenLabsUsageEntity(
+    CoordinatorEntity[ElevenLabsDataUpdateCoordinator], SensorEntity
+):
+    """ElevenLabs usage entity for getting usage metrics."""
+
+    _attr_state_class = SensorStateClass.TOTAL_INCREASING
+
+    def __init__(
+        self,
+        *,
+        coordinator: ElevenLabsDataUpdateCoordinator,
+        description: ElevenLabsSensorEntityDescription,
+        entry_id: str,
+    ) -> None:
+        """Initialize the ElevenLabs usage entity."""
+        super().__init__(coordinator)
+        self.entity_description: ElevenLabsSensorEntityDescription = description
+        self._attr_unique_id = f"{entry_id}_{description.key}"
+
+    @cached_property
+    def native_value(self) -> float | None:
+        """Return the state of the entity."""
+        # Report the value from the description's value_fn
+        return self.entity_description.value_fn(self.coordinator.data)

--- a/homeassistant/components/elevenlabs/strings.json
+++ b/homeassistant/components/elevenlabs/strings.json
@@ -45,5 +45,21 @@
         }
       }
     }
+  },
+  "entity": {
+    "sensor": {
+      "total_characters": {
+        "name": "Total characters"
+      },
+      "characters_today": {
+        "name": "Characters today"
+      },
+      "characters_7_days": {
+        "name": "Characters last 7 days"
+      },
+      "characters_this_month": {
+        "name": "Characters this month"
+      }
+    }
   }
 }

--- a/homeassistant/components/elevenlabs/tts.py
+++ b/homeassistant/components/elevenlabs/tts.py
@@ -21,7 +21,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import EleventLabsConfigEntry
+from . import ElevenLabsConfigEntry
 from .const import (
     CONF_OPTIMIZE_LATENCY,
     CONF_SIMILARITY,
@@ -54,7 +54,7 @@ def to_voice_settings(options: MappingProxyType[str, Any]) -> VoiceSettings:
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: EleventLabsConfigEntry,
+    config_entry: ElevenLabsConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up ElevenLabs tts platform via config entry."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
This remains a draft until I have thoroughly tested parts of this via pytest (it is tested locally). This is mostly a draft to maybe discuss design decisions such as which time windows to expose as sensors. Currently, this is i) the current month ii) the last 7 days iii) today iiii) total. I am happy to have different recommendations.
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change

Adds SensorEntities to the elevenlabs integration, tracking the character usage over multiple different time horizons.
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
This is a feature that was requested for the custom elevenlabs integration a while ago: https://github.com/carleeno/elevenlabs_tts/issues/97

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
