### PR TITLE
Use climate's standard names for fan speeds in coolmaster

### DIFF
--- a/homeassistant/components/coolmaster/climate.py
+++ b/homeassistant/components/coolmaster/climate.py
@@ -11,6 +11,11 @@ from homeassistant.components.climate import (
     ClimateEntity,
     ClimateEntityFeature,
     HVACMode,
+
+    FAN_LOW,
+    FAN_MEDIUM,
+    FAN_HIGH,
+    FAN_AUTO,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
@@ -31,7 +36,16 @@ CM_TO_HA_STATE = {
 
 HA_STATE_TO_CM = {value: key for key, value in CM_TO_HA_STATE.items()}
 
-FAN_MODES = ["low", "med", "high", "auto"]
+CM_TO_HA_FAN = {
+    "low": FAN_LOW,
+    "med": FAN_MEDIUM,
+    "high": FAN_HIGH,
+    "auto": FAN_AUTO,
+}
+
+HA_FAN_TO_CM = {value: key for key, value in CM_TO_HA_FAN.items()}
+
+FAN_MODES = [FAN_LOW, FAN_MEDIUM, FAN_HIGH, FAN_AUTO]
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -105,7 +119,9 @@ class CoolmasterClimate(CoolmasterEntity, ClimateEntity):
     @property
     def fan_mode(self):
         """Return the fan setting."""
-        return self._unit.fan_speed
+        # In principle, there might be a fan speed that isn't in our list.
+        # If so, report it verbatim instead of raising an exception.
+        return CM_TO_HA_FAN.get(self._unit.fan_speed, self._unit.fan_speed)
 
     @property
     def fan_modes(self):
@@ -132,7 +148,7 @@ class CoolmasterClimate(CoolmasterEntity, ClimateEntity):
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set new fan mode."""
         _LOGGER.debug("Setting fan mode of %s to %s", self.unique_id, fan_mode)
-        self._unit = await self._unit.set_fan_speed(fan_mode)
+        self._unit = await self._unit.set_fan_speed(HA_FAN_TO_CM[fan_mode])
         self.async_write_ha_state()
 
     async def async_set_swing_mode(self, swing_mode: str) -> None:


### PR DESCRIPTION
Coolmaster currently reports the fan speeds "low", "med", "high" and "auto". While this is technically valid (the spec says "you're also allowed to use custom fan modes"), it's a bit silly.  The standard fan modes include all of these, except that FAN_MEDIUM is spelled "medium", not "med".

Remap the fan dpeeds to use the defined constants.  This causes the card to display the correct icon for the medium speed.

See #133068.

## Breaking change

The climate entities provided by the coolmaster integration now uses the standard spelling "medium" (matching the FAN_MEDIUM constant) for the medium fan_mode; before this change, it was spelled "med".


## Proposed change

This fixes an oddity in the climate entities from the coolmaster integration.  Without this fix, the entity card doesn't pick up the right icon for the medium fan speed, and other components won't understand that "med" actually means FAN_MEDIUM.  Note that, while this should improve the behavior of homekit on these entities, they're still quite broken -- see #133068.

## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is related to issue: #133068


## Checklist

- [X] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass** [I'll work on this in a bit once I set up the right environment.]
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works. [I don't think this is applicable]

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.


To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
