### PR TITLE
Improve Google Tasks coordinator updates behavior

### DIFF
--- a/homeassistant/components/google_tasks/__init__.py
+++ b/homeassistant/components/google_tasks/__init__.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+
 from aiohttp import ClientError, ClientResponseError
 
 from homeassistant.const import Platform
@@ -11,6 +13,7 @@ from homeassistant.helpers import config_entry_oauth2_flow
 
 from . import api
 from .const import DOMAIN
+from .coordinator import TaskUpdateCoordinator
 from .exceptions import GoogleTasksApiError
 from .types import GoogleTasksConfigEntry, GoogleTasksData
 
@@ -46,7 +49,23 @@ async def async_setup_entry(hass: HomeAssistant, entry: GoogleTasksConfigEntry) 
     except GoogleTasksApiError as err:
         raise ConfigEntryNotReady from err
 
-    entry.runtime_data = GoogleTasksData(auth, task_lists)
+    coordinators = {
+        task_list["id"]: TaskUpdateCoordinator(
+            hass,
+            auth,
+            task_list["id"],
+            task_list["title"],
+        )
+        for task_list in task_lists
+    }
+    # Refresh all coordinators in parallel
+    await asyncio.gather(
+        *(
+            coordinator.async_config_entry_first_refresh()
+            for coordinator in coordinators.values()
+        )
+    )
+    entry.runtime_data = GoogleTasksData(coordinators)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/homeassistant/components/google_tasks/__init__.py
+++ b/homeassistant/components/google_tasks/__init__.py
@@ -15,7 +15,7 @@ from . import api
 from .const import DOMAIN
 from .coordinator import TaskUpdateCoordinator
 from .exceptions import GoogleTasksApiError
-from .types import GoogleTasksConfigEntry, GoogleTasksData
+from .types import GoogleTasksConfigEntry
 
 __all__ = [
     "DOMAIN",
@@ -49,23 +49,23 @@ async def async_setup_entry(hass: HomeAssistant, entry: GoogleTasksConfigEntry) 
     except GoogleTasksApiError as err:
         raise ConfigEntryNotReady from err
 
-    coordinators = {
-        task_list["id"]: TaskUpdateCoordinator(
+    coordinators = [
+        TaskUpdateCoordinator(
             hass,
             auth,
             task_list["id"],
             task_list["title"],
         )
         for task_list in task_lists
-    }
+    ]
     # Refresh all coordinators in parallel
     await asyncio.gather(
         *(
             coordinator.async_config_entry_first_refresh()
-            for coordinator in coordinators.values()
+            for coordinator in coordinators
         )
     )
-    entry.runtime_data = GoogleTasksData(coordinators)
+    entry.runtime_data = coordinators
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/homeassistant/components/google_tasks/coordinator.py
+++ b/homeassistant/components/google_tasks/coordinator.py
@@ -20,7 +20,11 @@ class TaskUpdateCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
     """Coordinator for fetching Google Tasks for a Task List form the API."""
 
     def __init__(
-        self, hass: HomeAssistant, api: AsyncConfigEntryAuth, task_list_id: str
+        self,
+        hass: HomeAssistant,
+        api: AsyncConfigEntryAuth,
+        task_list_id: str,
+        task_list_title: str,
     ) -> None:
         """Initialize TaskUpdateCoordinator."""
         super().__init__(
@@ -30,9 +34,10 @@ class TaskUpdateCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
             update_interval=UPDATE_INTERVAL,
         )
         self.api = api
-        self._task_list_id = task_list_id
+        self.task_list_id = task_list_id
+        self.task_list_title = task_list_title
 
     async def _async_update_data(self) -> list[dict[str, Any]]:
         """Fetch tasks from API endpoint."""
         async with asyncio.timeout(TIMEOUT):
-            return await self.api.list_tasks(self._task_list_id)
+            return await self.api.list_tasks(self.task_list_id)

--- a/homeassistant/components/google_tasks/todo.py
+++ b/homeassistant/components/google_tasks/todo.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import UTC, date, datetime, timedelta
+from datetime import UTC, date, datetime
 from typing import Any, cast
 
 from homeassistant.components.todo import (
@@ -20,7 +20,6 @@ from .coordinator import TaskUpdateCoordinator
 from .types import GoogleTasksConfigEntry
 
 PARALLEL_UPDATES = 0
-SCAN_INTERVAL = timedelta(minutes=15)
 
 TODO_STATUS_MAP = {
     "needsAction": TodoItemStatus.NEEDS_ACTION,
@@ -76,14 +75,13 @@ async def async_setup_entry(
     async_add_entities(
         (
             GoogleTaskTodoListEntity(
-                TaskUpdateCoordinator(hass, entry.runtime_data.api, task_list["id"]),
-                task_list["title"],
+                coordinator,
+                coordinator.task_list_title,
                 entry.entry_id,
-                task_list["id"],
+                coordinator.task_list_id,
             )
-            for task_list in entry.runtime_data.task_lists
+            for coordinator in entry.runtime_data.coordinators.values()
         ),
-        True,
     )
 
 
@@ -118,8 +116,6 @@ class GoogleTaskTodoListEntity(
     @property
     def todo_items(self) -> list[TodoItem] | None:
         """Get the current set of To-do items."""
-        if self.coordinator.data is None:
-            return None
         return [_convert_api_item(item) for item in _order_tasks(self.coordinator.data)]
 
     async def async_create_todo_item(self, item: TodoItem) -> None:

--- a/homeassistant/components/google_tasks/todo.py
+++ b/homeassistant/components/google_tasks/todo.py
@@ -80,7 +80,7 @@ async def async_setup_entry(
                 entry.entry_id,
                 coordinator.task_list_id,
             )
-            for coordinator in entry.runtime_data.coordinators.values()
+            for coordinator in entry.runtime_data
         ),
     )
 

--- a/homeassistant/components/google_tasks/types.py
+++ b/homeassistant/components/google_tasks/types.py
@@ -1,19 +1,17 @@
 """Types for the Google Tasks integration."""
 
 from dataclasses import dataclass
-from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
 
-from .api import AsyncConfigEntryAuth
+from .coordinator import TaskUpdateCoordinator
 
 
 @dataclass
 class GoogleTasksData:
     """Class to hold Google Tasks data."""
 
-    api: AsyncConfigEntryAuth
-    task_lists: list[dict[str, Any]]
+    coordinators: dict[str, TaskUpdateCoordinator]
 
 
 type GoogleTasksConfigEntry = ConfigEntry[GoogleTasksData]

--- a/homeassistant/components/google_tasks/types.py
+++ b/homeassistant/components/google_tasks/types.py
@@ -1,17 +1,7 @@
 """Types for the Google Tasks integration."""
 
-from dataclasses import dataclass
-
 from homeassistant.config_entries import ConfigEntry
 
 from .coordinator import TaskUpdateCoordinator
 
-
-@dataclass
-class GoogleTasksData:
-    """Class to hold Google Tasks data."""
-
-    coordinators: dict[str, TaskUpdateCoordinator]
-
-
-type GoogleTasksConfigEntry = ConfigEntry[GoogleTasksData]
+type GoogleTasksConfigEntry = ConfigEntry[list[TaskUpdateCoordinator]]

--- a/tests/components/google_tasks/conftest.py
+++ b/tests/components/google_tasks/conftest.py
@@ -34,6 +34,18 @@ LIST_TASK_LIST_RESPONSE = {
     "items": [TASK_LIST],
 }
 
+LIST_TASKS_RESPONSE_WATER = {
+    "items": [
+        {
+            "id": "some-task-id",
+            "title": "Water",
+            "status": "needsAction",
+            "description": "Any size is ok",
+            "position": "00000000000000000001",
+        },
+    ],
+}
+
 
 @pytest.fixture
 def platforms() -> list[Platform]:
@@ -44,7 +56,7 @@ def platforms() -> list[Platform]:
 @pytest.fixture(name="expires_at")
 def mock_expires_at() -> int:
     """Fixture to set the oauth token expiration time."""
-    return time.time() + 3600
+    return time.time() + 86400
 
 
 @pytest.fixture(name="token_entry")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve Google Tasks coordinator updates behavior. This moves coordinator creation into init, uses `async_config_entry_first_refresh` for performing the first update, always ensuring that data will not be `None` and removes any such checks which also improves typing.

This now tests the state transition between `unavailable` back to available which required using a different OAuth token expiration time of 1 day rather than 1 hour.

The `SCAN_INTERVAL` has been removed  as it is currently unused and now follows the more closely the guidance in `appropriate-polling`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
