### PR TITLE
Add HEOS reconfigure flow

### DIFF
--- a/homeassistant/components/heos/config_flow.py
+++ b/homeassistant/components/heos/config_flow.py
@@ -86,8 +86,6 @@ class HeosFlowHandler(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Allow reconfiguration of entry."""
-        await self.async_set_unique_id(DOMAIN)
-
         entry = self._get_reconfigure_entry()
         host = entry.data[CONF_HOST]  # Get current host value
         errors: dict[str, str] = {}

--- a/homeassistant/components/heos/config_flow.py
+++ b/homeassistant/components/heos/config_flow.py
@@ -87,7 +87,6 @@ class HeosFlowHandler(ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Allow reconfiguration of entry."""
         await self.async_set_unique_id(DOMAIN)
-        self._abort_if_unique_id_mismatch()
 
         entry = self._get_reconfigure_entry()
         host = entry.data[CONF_HOST]  # Get current host value

--- a/homeassistant/components/heos/config_flow.py
+++ b/homeassistant/components/heos/config_flow.py
@@ -15,7 +15,20 @@ from .const import DOMAIN
 
 def format_title(host: str) -> str:
     """Format the title for config entries."""
-    return f"Controller ({host})"
+    return f"HEOS System (via {host})"
+
+
+async def _validate_host(host: str, errors: dict[str, str]) -> bool:
+    """Validate host is reachable, return True, otherwise populate errors and return False."""
+    heos = Heos(host)
+    try:
+        await heos.connect()
+    except HeosError:
+        errors[CONF_HOST] = "cannot_connect"
+        return False
+    finally:
+        await heos.disconnect()
+    return True
 
 
 class HeosFlowHandler(ConfigFlow, domain=DOMAIN):
@@ -47,23 +60,17 @@ class HeosFlowHandler(ConfigFlow, domain=DOMAIN):
         self.hass.data.setdefault(DOMAIN, {})
         await self.async_set_unique_id(DOMAIN)
         # Try connecting to host if provided
-        errors = {}
+        errors: dict[str, str] = {}
         host = None
         if user_input is not None:
             host = user_input[CONF_HOST]
             # Map host from friendly name if in discovered hosts
             host = self.hass.data[DOMAIN].get(host, host)
-            heos = Heos(host)
-            try:
-                await heos.connect()
-                self.hass.data.pop(DOMAIN)
+            if await _validate_host(host, errors):
+                self.hass.data.pop(DOMAIN)  # Remove discovery data
                 return self.async_create_entry(
                     title=format_title(host), data={CONF_HOST: host}
                 )
-            except HeosError:
-                errors[CONF_HOST] = "cannot_connect"
-            finally:
-                await heos.disconnect()
 
         # Return form
         host_type = (
@@ -72,5 +79,27 @@ class HeosFlowHandler(ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="user",
             data_schema=vol.Schema({vol.Required(CONF_HOST, default=host): host_type}),
+            errors=errors,
+        )
+
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Allow reconfiguration of entry."""
+        await self.async_set_unique_id(DOMAIN)
+        self._abort_if_unique_id_mismatch()
+
+        entry = self._get_reconfigure_entry()
+        host = entry.data[CONF_HOST]  # Get current host value
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            host = user_input[CONF_HOST]
+            if await _validate_host(host, errors):
+                return self.async_update_reload_and_abort(
+                    entry, data_updates={CONF_HOST: host}
+                )
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=vol.Schema({vol.Required(CONF_HOST, default=host): str}),
             errors=errors,
         )

--- a/homeassistant/components/heos/quality_scale.yaml
+++ b/homeassistant/components/heos/quality_scale.yaml
@@ -88,7 +88,7 @@ rules:
   entity-translations: done
   exception-translations: todo
   icon-translations: done
-  reconfiguration-flow: todo
+  reconfiguration-flow: done
   repair-issues: todo
   stale-devices: todo
   # Platinum

--- a/homeassistant/components/heos/strings.json
+++ b/homeassistant/components/heos/strings.json
@@ -13,7 +13,7 @@
       },
       "reconfigure": {
         "title": "Reconfigure HEOS",
-        "description": "Complete this form to change the host name or IP address of the HEOS-capable product used to access your HEOS System.",
+        "description": "Change the host name or IP address of the HEOS-capable product used to access your HEOS System.",
         "data": {
           "host": "[%key:common::config_flow::data::host%]"
         },

--- a/homeassistant/components/heos/strings.json
+++ b/homeassistant/components/heos/strings.json
@@ -2,13 +2,23 @@
   "config": {
     "step": {
       "user": {
-        "title": "Connect to Heos",
-        "description": "Please enter the host name or IP address of a Heos device (preferably one connected via wire to the network).",
+        "title": "Connect to HEOS",
+        "description": "Please enter the host name or IP address of a HEOS-capable product to access your HEOS System.",
         "data": {
           "host": "[%key:common::config_flow::data::host%]"
         },
         "data_description": {
-          "host": "The hostname or IP address of your HEOS device."
+          "host": "Host name or IP address of a HEOS-capable product (preferrably one connected via wire to the network)."
+        }
+      },
+      "reconfigure": {
+        "title": "Reconfigure HEOS",
+        "description": "Complete this form to change the host name or IP address of the HEOS-capable product used to access your HEOS System.",
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]"
+        },
+        "data_description": {
+          "host": "[%key:component::heos::config::step::user::data_description::host%]"
         }
       }
     },
@@ -17,13 +27,14 @@
     },
     "abort": {
       "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]",
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
     }
   },
   "services": {
     "sign_in": {
       "name": "Sign in",
-      "description": "Signs the controller in to a HEOS account.",
+      "description": "Signs in to a HEOS account.",
       "fields": {
         "username": {
           "name": "[%key:common::config_flow::data::username%]",
@@ -37,7 +48,7 @@
     },
     "sign_out": {
       "name": "Sign out",
-      "description": "Signs the controller out of the HEOS account."
+      "description": "Signs out of the HEOS account."
     }
   }
 }

--- a/tests/components/heos/conftest.py
+++ b/tests/components/heos/conftest.py
@@ -27,7 +27,10 @@ from tests.common import MockConfigEntry
 def config_entry_fixture():
     """Create a mock HEOS config entry."""
     return MockConfigEntry(
-        domain=DOMAIN, data={CONF_HOST: "127.0.0.1"}, title="Controller (127.0.0.1)"
+        domain=DOMAIN,
+        data={CONF_HOST: "127.0.0.1"},
+        title="HEOS System (via 127.0.0.1)",
+        unique_id=DOMAIN,
     )
 
 

--- a/tests/components/heos/test_config_flow.py
+++ b/tests/components/heos/test_config_flow.py
@@ -152,10 +152,10 @@ async def test_reconfigure_validates_and_updates_config(
     assert result["type"] is FlowResultType.ABORT
 
 
-async def test_reconfigure_cannot_connect_shows_form(
+async def test_reconfigure_cannot_connect_recovers(
     hass: HomeAssistant, config_entry, controller
 ) -> None:
-    """Test reconfigure cannot connect and shows error form with previous user input."""
+    """Test reconfigure cannot connect and recovers."""
     controller.connect.side_effect = HeosError()
     config_entry.add_to_hass(hass)
     result = await config_entry.start_reconfigure_flow(hass)

--- a/tests/components/heos/test_config_flow.py
+++ b/tests/components/heos/test_config_flow.py
@@ -122,21 +122,6 @@ async def test_discovery_flow_aborts_already_setup(
     assert result["reason"] == "single_instance_allowed"
 
 
-async def test_reconfigure_shows_form(hass: HomeAssistant, config_entry) -> None:
-    """Test reconfigure flow shows form with current host value."""
-    config_entry.add_to_hass(hass)
-
-    result = await config_entry.start_reconfigure_flow(hass)
-
-    host = next(
-        key.default() for key in result["data_schema"].schema if key == CONF_HOST
-    )
-    assert host == "127.0.0.1"
-    assert result["errors"] == {}
-    assert result["step_id"] == "reconfigure"
-    assert result["type"] is FlowResultType.FORM
-
-
 async def test_reconfigure_validates_and_updates_config(
     hass: HomeAssistant, config_entry, controller
 ) -> None:
@@ -145,11 +130,20 @@ async def test_reconfigure_validates_and_updates_config(
     result = await config_entry.start_reconfigure_flow(hass)
     assert config_entry.data[CONF_HOST] == "127.0.0.1"
 
+    # Test reconfigure initially shows form with current host value.
+    host = next(
+        key.default() for key in result["data_schema"].schema if key == CONF_HOST
+    )
+    assert host == "127.0.0.1"
+    assert result["errors"] == {}
+    assert result["step_id"] == "reconfigure"
+    assert result["type"] is FlowResultType.FORM
+
+    # Test reconfigure successfully updates.
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         user_input={CONF_HOST: "127.0.0.2"},
     )
-
     assert controller.connect.call_count == 2  # Also called when entry reloaded
     assert controller.disconnect.call_count == 1
     assert config_entry.data == {CONF_HOST: "127.0.0.2"}
@@ -181,3 +175,18 @@ async def test_reconfigure_cannot_connect_shows_form(
     assert result["errors"][CONF_HOST] == "cannot_connect"
     assert result["step_id"] == "reconfigure"
     assert result["type"] is FlowResultType.FORM
+
+    # Test reconfigure recovers and successfully updates.
+    controller.connect.side_effect = None
+    controller.connect.reset_mock()
+    controller.disconnect.reset_mock()
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_HOST: "127.0.0.2"},
+    )
+    assert controller.connect.call_count == 2  # Also called when entry reloaded
+    assert controller.disconnect.call_count == 1
+    assert config_entry.data == {CONF_HOST: "127.0.0.2"}
+    assert config_entry.unique_id == DOMAIN
+    assert result["reason"] == "reconfigure_successful"
+    assert result["type"] is FlowResultType.ABORT


### PR DESCRIPTION
## Proposed change
Adds the ability to change the host used to connect to the HEOS System through a reconfiguration flow.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- Adds reconfiguration flow and marks the related quality-scale item complete
- Cleans up strings for consistency and proper brand and product terminology
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/36384

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
