### PR TITLE
Remove setup entry mock assert from LaMetric config flow

### DIFF
--- a/tests/components/lametric/conftest.py
+++ b/tests/components/lametric/conftest.py
@@ -49,8 +49,8 @@ def mock_setup_entry() -> Generator[AsyncMock]:
     """Mock setting up a config entry."""
     with patch(
         "homeassistant.components.lametric.async_setup_entry", return_value=True
-    ) as mock_setup:
-        yield mock_setup
+    ):
+        yield
 
 
 @pytest.fixture

--- a/tests/components/lametric/test_config_flow.py
+++ b/tests/components/lametric/test_config_flow.py
@@ -41,12 +41,11 @@ SSDP_DISCOVERY_INFO = SsdpServiceInfo(
 )
 
 
-@pytest.mark.usefixtures("current_request_with_host")
+@pytest.mark.usefixtures("current_request_with_host", "mock_setup_entry")
 async def test_full_cloud_import_flow_multiple_devices(
     hass: HomeAssistant,
     hass_client_no_auth: ClientSessionGenerator,
     aioclient_mock: AiohttpClientMocker,
-    mock_setup_entry: MagicMock,
     mock_lametric_cloud: MagicMock,
     mock_lametric: MagicMock,
 ) -> None:
@@ -119,15 +118,13 @@ async def test_full_cloud_import_flow_multiple_devices(
     assert len(mock_lametric_cloud.devices.mock_calls) == 1
     assert len(mock_lametric.device.mock_calls) == 1
     assert len(mock_lametric.notify.mock_calls) == 1
-    assert len(mock_setup_entry.mock_calls) == 1
 
 
-@pytest.mark.usefixtures("current_request_with_host")
+@pytest.mark.usefixtures("current_request_with_host", "mock_setup_entry")
 async def test_full_cloud_import_flow_single_device(
     hass: HomeAssistant,
     hass_client_no_auth: ClientSessionGenerator,
     aioclient_mock: AiohttpClientMocker,
-    mock_setup_entry: MagicMock,
     mock_lametric_cloud: MagicMock,
     mock_lametric: MagicMock,
 ) -> None:
@@ -198,12 +195,11 @@ async def test_full_cloud_import_flow_single_device(
     assert len(mock_lametric_cloud.devices.mock_calls) == 1
     assert len(mock_lametric.device.mock_calls) == 1
     assert len(mock_lametric.notify.mock_calls) == 1
-    assert len(mock_setup_entry.mock_calls) == 1
 
 
+@pytest.mark.usefixtures("mock_setup_entry")
 async def test_full_manual(
     hass: HomeAssistant,
-    mock_setup_entry: MagicMock,
     mock_lametric: MagicMock,
 ) -> None:
     """Check a full flow manual entry."""
@@ -246,15 +242,12 @@ async def test_full_manual(
     notification: Notification = mock_lametric.notify.mock_calls[0][2]["notification"]
     assert notification.model.sound == Sound(sound=NotificationSound.WIN)
 
-    assert len(mock_setup_entry.mock_calls) == 1
 
-
-@pytest.mark.usefixtures("current_request_with_host")
+@pytest.mark.usefixtures("current_request_with_host", "mock_setup_entry")
 async def test_full_ssdp_with_cloud_import(
     hass: HomeAssistant,
     hass_client_no_auth: ClientSessionGenerator,
     aioclient_mock: AiohttpClientMocker,
-    mock_setup_entry: MagicMock,
     mock_lametric_cloud: MagicMock,
     mock_lametric: MagicMock,
 ) -> None:
@@ -319,12 +312,11 @@ async def test_full_ssdp_with_cloud_import(
     assert len(mock_lametric_cloud.devices.mock_calls) == 1
     assert len(mock_lametric.device.mock_calls) == 1
     assert len(mock_lametric.notify.mock_calls) == 1
-    assert len(mock_setup_entry.mock_calls) == 1
 
 
+@pytest.mark.usefixtures("mock_setup_entry")
 async def test_full_ssdp_manual_entry(
     hass: HomeAssistant,
-    mock_setup_entry: MagicMock,
     mock_lametric: MagicMock,
 ) -> None:
     """Check a full flow triggered by SSDP, with manual API key entry."""
@@ -361,7 +353,6 @@ async def test_full_ssdp_manual_entry(
 
     assert len(mock_lametric.device.mock_calls) == 1
     assert len(mock_lametric.notify.mock_calls) == 1
-    assert len(mock_setup_entry.mock_calls) == 1
 
 
 @pytest.mark.parametrize(
@@ -549,6 +540,7 @@ async def test_cloud_abort_no_devices(
     assert len(mock_lametric_cloud.devices.mock_calls) == 1
 
 
+@pytest.mark.usefixtures("mock_setup_entry")
 @pytest.mark.parametrize(
     ("side_effect", "reason"),
     [
@@ -561,7 +553,6 @@ async def test_cloud_abort_no_devices(
 async def test_manual_errors(
     hass: HomeAssistant,
     mock_lametric: MagicMock,
-    mock_setup_entry: MagicMock,
     side_effect: Exception,
     reason: str,
 ) -> None:
@@ -586,7 +577,6 @@ async def test_manual_errors(
 
     assert len(mock_lametric.device.mock_calls) == 1
     assert len(mock_lametric.notify.mock_calls) == 0
-    assert len(mock_setup_entry.mock_calls) == 0
 
     mock_lametric.device.side_effect = None
     result = await hass.config_entries.flow.async_configure(
@@ -608,10 +598,9 @@ async def test_manual_errors(
 
     assert len(mock_lametric.device.mock_calls) == 2
     assert len(mock_lametric.notify.mock_calls) == 1
-    assert len(mock_setup_entry.mock_calls) == 1
 
 
-@pytest.mark.usefixtures("current_request_with_host")
+@pytest.mark.usefixtures("current_request_with_host", "mock_setup_entry")
 @pytest.mark.parametrize(
     ("side_effect", "reason"),
     [
@@ -625,7 +614,6 @@ async def test_cloud_errors(
     hass: HomeAssistant,
     hass_client_no_auth: ClientSessionGenerator,
     aioclient_mock: AiohttpClientMocker,
-    mock_setup_entry: MagicMock,
     mock_lametric_cloud: MagicMock,
     mock_lametric: MagicMock,
     side_effect: Exception,
@@ -672,7 +660,6 @@ async def test_cloud_errors(
     assert len(mock_lametric_cloud.devices.mock_calls) == 1
     assert len(mock_lametric.device.mock_calls) == 1
     assert len(mock_lametric.notify.mock_calls) == 0
-    assert len(mock_setup_entry.mock_calls) == 0
 
     mock_lametric.device.side_effect = None
     result = await hass.config_entries.flow.async_configure(
@@ -694,7 +681,6 @@ async def test_cloud_errors(
     assert len(mock_lametric_cloud.devices.mock_calls) == 1
     assert len(mock_lametric.device.mock_calls) == 2
     assert len(mock_lametric.notify.mock_calls) == 1
-    assert len(mock_setup_entry.mock_calls) == 1
 
 
 async def test_dhcp_discovery_updates_entry(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Remove testing if setup_entry mocking has been called in config flow tests in LaMetric; it really doesn't matter.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
