### PR TITLE
Fix fan setpoints for flexit_bacnet

### DIFF
--- a/homeassistant/components/flexit_bacnet/number.py
+++ b/homeassistant/components/flexit_bacnet/number.py
@@ -29,6 +29,8 @@ class FlexitNumberEntityDescription(NumberEntityDescription):
     """Describes a Flexit number entity."""
 
     native_value_fn: Callable[[FlexitBACnet], float]
+    native_max_value_fn: Callable[[FlexitBACnet], int]
+    native_min_value_fn: Callable[[FlexitBACnet], int]
     set_native_value_fn: Callable[[FlexitBACnet], Callable[[int], Awaitable[None]]]
 
 
@@ -37,121 +39,121 @@ NUMBERS: tuple[FlexitNumberEntityDescription, ...] = (
         key="away_extract_fan_setpoint",
         translation_key="away_extract_fan_setpoint",
         device_class=NumberDeviceClass.POWER_FACTOR,
-        native_min_value=0,
-        native_max_value=100,
         native_step=1,
         mode=NumberMode.SLIDER,
         native_value_fn=lambda device: device.fan_setpoint_extract_air_away,
         set_native_value_fn=lambda device: device.set_fan_setpoint_extract_air_away,
         native_unit_of_measurement=PERCENTAGE,
+        native_max_value_fn=lambda device: int(device.fan_setpoint_extract_air_home),
+        native_min_value_fn=lambda _: 30,
     ),
     FlexitNumberEntityDescription(
         key="away_supply_fan_setpoint",
         translation_key="away_supply_fan_setpoint",
         device_class=NumberDeviceClass.POWER_FACTOR,
-        native_min_value=0,
-        native_max_value=100,
         native_step=1,
         mode=NumberMode.SLIDER,
         native_value_fn=lambda device: device.fan_setpoint_supply_air_away,
         set_native_value_fn=lambda device: device.set_fan_setpoint_supply_air_away,
         native_unit_of_measurement=PERCENTAGE,
+        native_max_value_fn=lambda device: int(device.fan_setpoint_supply_air_home),
+        native_min_value_fn=lambda _: 30,
     ),
     FlexitNumberEntityDescription(
         key="cooker_hood_extract_fan_setpoint",
         translation_key="cooker_hood_extract_fan_setpoint",
         device_class=NumberDeviceClass.POWER_FACTOR,
-        native_min_value=0,
-        native_max_value=100,
         native_step=1,
         mode=NumberMode.SLIDER,
         native_value_fn=lambda device: device.fan_setpoint_extract_air_cooker,
         set_native_value_fn=lambda device: device.set_fan_setpoint_extract_air_cooker,
         native_unit_of_measurement=PERCENTAGE,
+        native_max_value_fn=lambda _: 100,
+        native_min_value_fn=lambda _: 30,
     ),
     FlexitNumberEntityDescription(
         key="cooker_hood_supply_fan_setpoint",
         translation_key="cooker_hood_supply_fan_setpoint",
         device_class=NumberDeviceClass.POWER_FACTOR,
-        native_min_value=0,
-        native_max_value=100,
         native_step=1,
         mode=NumberMode.SLIDER,
         native_value_fn=lambda device: device.fan_setpoint_supply_air_cooker,
         set_native_value_fn=lambda device: device.set_fan_setpoint_supply_air_cooker,
         native_unit_of_measurement=PERCENTAGE,
+        native_max_value_fn=lambda _: 100,
+        native_min_value_fn=lambda _: 30,
     ),
     FlexitNumberEntityDescription(
         key="fireplace_extract_fan_setpoint",
         translation_key="fireplace_extract_fan_setpoint",
         device_class=NumberDeviceClass.POWER_FACTOR,
-        native_min_value=0,
-        native_max_value=100,
         native_step=1,
         mode=NumberMode.SLIDER,
         native_value_fn=lambda device: device.fan_setpoint_extract_air_fire,
         set_native_value_fn=lambda device: device.set_fan_setpoint_extract_air_fire,
         native_unit_of_measurement=PERCENTAGE,
+        native_max_value_fn=lambda _: 100,
+        native_min_value_fn=lambda _: 30,
     ),
     FlexitNumberEntityDescription(
         key="fireplace_supply_fan_setpoint",
         translation_key="fireplace_supply_fan_setpoint",
         device_class=NumberDeviceClass.POWER_FACTOR,
-        native_min_value=0,
-        native_max_value=100,
         native_step=1,
         mode=NumberMode.SLIDER,
         native_value_fn=lambda device: device.fan_setpoint_supply_air_fire,
         set_native_value_fn=lambda device: device.set_fan_setpoint_supply_air_fire,
         native_unit_of_measurement=PERCENTAGE,
+        native_max_value_fn=lambda _: 100,
+        native_min_value_fn=lambda _: 30,
     ),
     FlexitNumberEntityDescription(
         key="high_extract_fan_setpoint",
         translation_key="high_extract_fan_setpoint",
         device_class=NumberDeviceClass.POWER_FACTOR,
-        native_min_value=0,
-        native_max_value=100,
         native_step=1,
         mode=NumberMode.SLIDER,
         native_value_fn=lambda device: device.fan_setpoint_extract_air_high,
         set_native_value_fn=lambda device: device.set_fan_setpoint_extract_air_high,
         native_unit_of_measurement=PERCENTAGE,
+        native_max_value_fn=lambda _: 100,
+        native_min_value_fn=lambda device: int(device.fan_setpoint_extract_air_home),
     ),
     FlexitNumberEntityDescription(
         key="high_supply_fan_setpoint",
         translation_key="high_supply_fan_setpoint",
         device_class=NumberDeviceClass.POWER_FACTOR,
-        native_min_value=0,
-        native_max_value=100,
         native_step=1,
         mode=NumberMode.SLIDER,
         native_value_fn=lambda device: device.fan_setpoint_supply_air_high,
         set_native_value_fn=lambda device: device.set_fan_setpoint_supply_air_high,
         native_unit_of_measurement=PERCENTAGE,
+        native_max_value_fn=lambda _: 100,
+        native_min_value_fn=lambda device: int(device.fan_setpoint_supply_air_home),
     ),
     FlexitNumberEntityDescription(
         key="home_extract_fan_setpoint",
         translation_key="home_extract_fan_setpoint",
         device_class=NumberDeviceClass.POWER_FACTOR,
-        native_min_value=0,
-        native_max_value=100,
         native_step=1,
         mode=NumberMode.SLIDER,
         native_value_fn=lambda device: device.fan_setpoint_extract_air_home,
         set_native_value_fn=lambda device: device.set_fan_setpoint_extract_air_home,
         native_unit_of_measurement=PERCENTAGE,
+        native_max_value_fn=lambda _: 100,
+        native_min_value_fn=lambda device: int(device.fan_setpoint_extract_air_away),
     ),
     FlexitNumberEntityDescription(
         key="home_supply_fan_setpoint",
         translation_key="home_supply_fan_setpoint",
         device_class=NumberDeviceClass.POWER_FACTOR,
-        native_min_value=0,
-        native_max_value=100,
         native_step=1,
         mode=NumberMode.SLIDER,
         native_value_fn=lambda device: device.fan_setpoint_supply_air_home,
         set_native_value_fn=lambda device: device.set_fan_setpoint_supply_air_home,
         native_unit_of_measurement=PERCENTAGE,
+        native_max_value_fn=lambda _: 100,
+        native_min_value_fn=lambda device: int(device.fan_setpoint_supply_air_away),
     ),
 )
 
@@ -191,6 +193,16 @@ class FlexitNumber(FlexitEntity, NumberEntity):
     def native_value(self) -> float:
         """Return the state of the number."""
         return self.entity_description.native_value_fn(self.coordinator.device)
+
+    @property
+    def native_max_value(self) -> float:
+        """Return the native max value of the number."""
+        return self.entity_description.native_max_value_fn(self.coordinator.device)
+
+    @property
+    def native_min_value(self) -> float:
+        """Return the native min value of the number."""
+        return self.entity_description.native_min_value_fn(self.coordinator.device)
 
     async def async_set_native_value(self, value: float) -> None:
         """Update the current value."""

--- a/tests/components/flexit_bacnet/conftest.py
+++ b/tests/components/flexit_bacnet/conftest.py
@@ -69,16 +69,16 @@ def mock_flexit_bacnet() -> Generator[AsyncMock]:
         flexit_bacnet.electric_heater = True
 
         # Mock fan setpoints
-        flexit_bacnet.fan_setpoint_extract_air_fire = 10
-        flexit_bacnet.fan_setpoint_supply_air_fire = 20
-        flexit_bacnet.fan_setpoint_extract_air_away = 30
-        flexit_bacnet.fan_setpoint_supply_air_away = 40
-        flexit_bacnet.fan_setpoint_extract_air_home = 50
-        flexit_bacnet.fan_setpoint_supply_air_home = 60
-        flexit_bacnet.fan_setpoint_extract_air_high = 70
-        flexit_bacnet.fan_setpoint_supply_air_high = 80
-        flexit_bacnet.fan_setpoint_extract_air_cooker = 90
-        flexit_bacnet.fan_setpoint_supply_air_cooker = 100
+        flexit_bacnet.fan_setpoint_extract_air_fire = 56
+        flexit_bacnet.fan_setpoint_supply_air_fire = 77
+        flexit_bacnet.fan_setpoint_extract_air_away = 40
+        flexit_bacnet.fan_setpoint_supply_air_away = 42
+        flexit_bacnet.fan_setpoint_extract_air_home = 70
+        flexit_bacnet.fan_setpoint_supply_air_home = 74
+        flexit_bacnet.fan_setpoint_extract_air_high = 100
+        flexit_bacnet.fan_setpoint_supply_air_high = 100
+        flexit_bacnet.fan_setpoint_extract_air_cooker = 50
+        flexit_bacnet.fan_setpoint_supply_air_cooker = 70
 
         yield flexit_bacnet
 

--- a/tests/components/flexit_bacnet/snapshots/test_number.ambr
+++ b/tests/components/flexit_bacnet/snapshots/test_number.ambr
@@ -5,8 +5,8 @@
     }),
     'area_id': None,
     'capabilities': dict({
-      'max': 100,
-      'min': 0,
+      'max': 70,
+      'min': 30,
       'mode': <NumberMode.SLIDER: 'slider'>,
       'step': 1,
     }),
@@ -42,8 +42,8 @@
     'attributes': ReadOnlyDict({
       'device_class': 'power_factor',
       'friendly_name': 'Device Name Away extract fan setpoint',
-      'max': 100,
-      'min': 0,
+      'max': 70,
+      'min': 30,
       'mode': <NumberMode.SLIDER: 'slider'>,
       'step': 1,
       'unit_of_measurement': '%',
@@ -53,7 +53,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '30',
+    'state': '40',
   })
 # ---
 # name: test_numbers[number.device_name_away_supply_fan_setpoint-entry]
@@ -62,8 +62,8 @@
     }),
     'area_id': None,
     'capabilities': dict({
-      'max': 100,
-      'min': 0,
+      'max': 74,
+      'min': 30,
       'mode': <NumberMode.SLIDER: 'slider'>,
       'step': 1,
     }),
@@ -99,8 +99,8 @@
     'attributes': ReadOnlyDict({
       'device_class': 'power_factor',
       'friendly_name': 'Device Name Away supply fan setpoint',
-      'max': 100,
-      'min': 0,
+      'max': 74,
+      'min': 30,
       'mode': <NumberMode.SLIDER: 'slider'>,
       'step': 1,
       'unit_of_measurement': '%',
@@ -110,7 +110,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '40',
+    'state': '42',
   })
 # ---
 # name: test_numbers[number.device_name_cooker_hood_extract_fan_setpoint-entry]
@@ -120,7 +120,7 @@
     'area_id': None,
     'capabilities': dict({
       'max': 100,
-      'min': 0,
+      'min': 30,
       'mode': <NumberMode.SLIDER: 'slider'>,
       'step': 1,
     }),
@@ -157,7 +157,7 @@
       'device_class': 'power_factor',
       'friendly_name': 'Device Name Cooker hood extract fan setpoint',
       'max': 100,
-      'min': 0,
+      'min': 30,
       'mode': <NumberMode.SLIDER: 'slider'>,
       'step': 1,
       'unit_of_measurement': '%',
@@ -167,7 +167,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '90',
+    'state': '50',
   })
 # ---
 # name: test_numbers[number.device_name_cooker_hood_supply_fan_setpoint-entry]
@@ -177,7 +177,7 @@
     'area_id': None,
     'capabilities': dict({
       'max': 100,
-      'min': 0,
+      'min': 30,
       'mode': <NumberMode.SLIDER: 'slider'>,
       'step': 1,
     }),
@@ -214,7 +214,7 @@
       'device_class': 'power_factor',
       'friendly_name': 'Device Name Cooker hood supply fan setpoint',
       'max': 100,
-      'min': 0,
+      'min': 30,
       'mode': <NumberMode.SLIDER: 'slider'>,
       'step': 1,
       'unit_of_measurement': '%',
@@ -224,7 +224,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '100',
+    'state': '70',
   })
 # ---
 # name: test_numbers[number.device_name_fireplace_extract_fan_setpoint-entry]
@@ -234,7 +234,7 @@
     'area_id': None,
     'capabilities': dict({
       'max': 100,
-      'min': 0,
+      'min': 30,
       'mode': <NumberMode.SLIDER: 'slider'>,
       'step': 1,
     }),
@@ -271,7 +271,7 @@
       'device_class': 'power_factor',
       'friendly_name': 'Device Name Fireplace extract fan setpoint',
       'max': 100,
-      'min': 0,
+      'min': 30,
       'mode': <NumberMode.SLIDER: 'slider'>,
       'step': 1,
       'unit_of_measurement': '%',
@@ -281,7 +281,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '10',
+    'state': '56',
   })
 # ---
 # name: test_numbers[number.device_name_fireplace_supply_fan_setpoint-entry]
@@ -291,7 +291,7 @@
     'area_id': None,
     'capabilities': dict({
       'max': 100,
-      'min': 0,
+      'min': 30,
       'mode': <NumberMode.SLIDER: 'slider'>,
       'step': 1,
     }),
@@ -328,7 +328,7 @@
       'device_class': 'power_factor',
       'friendly_name': 'Device Name Fireplace supply fan setpoint',
       'max': 100,
-      'min': 0,
+      'min': 30,
       'mode': <NumberMode.SLIDER: 'slider'>,
       'step': 1,
       'unit_of_measurement': '%',
@@ -338,7 +338,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '20',
+    'state': '77',
   })
 # ---
 # name: test_numbers[number.device_name_high_extract_fan_setpoint-entry]
@@ -348,7 +348,7 @@
     'area_id': None,
     'capabilities': dict({
       'max': 100,
-      'min': 0,
+      'min': 70,
       'mode': <NumberMode.SLIDER: 'slider'>,
       'step': 1,
     }),
@@ -385,7 +385,7 @@
       'device_class': 'power_factor',
       'friendly_name': 'Device Name High extract fan setpoint',
       'max': 100,
-      'min': 0,
+      'min': 70,
       'mode': <NumberMode.SLIDER: 'slider'>,
       'step': 1,
       'unit_of_measurement': '%',
@@ -395,7 +395,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '70',
+    'state': '100',
   })
 # ---
 # name: test_numbers[number.device_name_high_supply_fan_setpoint-entry]
@@ -405,7 +405,7 @@
     'area_id': None,
     'capabilities': dict({
       'max': 100,
-      'min': 0,
+      'min': 74,
       'mode': <NumberMode.SLIDER: 'slider'>,
       'step': 1,
     }),
@@ -442,7 +442,7 @@
       'device_class': 'power_factor',
       'friendly_name': 'Device Name High supply fan setpoint',
       'max': 100,
-      'min': 0,
+      'min': 74,
       'mode': <NumberMode.SLIDER: 'slider'>,
       'step': 1,
       'unit_of_measurement': '%',
@@ -452,7 +452,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '80',
+    'state': '100',
   })
 # ---
 # name: test_numbers[number.device_name_home_extract_fan_setpoint-entry]
@@ -462,7 +462,7 @@
     'area_id': None,
     'capabilities': dict({
       'max': 100,
-      'min': 0,
+      'min': 40,
       'mode': <NumberMode.SLIDER: 'slider'>,
       'step': 1,
     }),
@@ -499,7 +499,7 @@
       'device_class': 'power_factor',
       'friendly_name': 'Device Name Home extract fan setpoint',
       'max': 100,
-      'min': 0,
+      'min': 40,
       'mode': <NumberMode.SLIDER: 'slider'>,
       'step': 1,
       'unit_of_measurement': '%',
@@ -509,7 +509,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '50',
+    'state': '70',
   })
 # ---
 # name: test_numbers[number.device_name_home_supply_fan_setpoint-entry]
@@ -519,7 +519,7 @@
     'area_id': None,
     'capabilities': dict({
       'max': 100,
-      'min': 0,
+      'min': 42,
       'mode': <NumberMode.SLIDER: 'slider'>,
       'step': 1,
     }),
@@ -556,7 +556,7 @@
       'device_class': 'power_factor',
       'friendly_name': 'Device Name Home supply fan setpoint',
       'max': 100,
-      'min': 0,
+      'min': 42,
       'mode': <NumberMode.SLIDER: 'slider'>,
       'step': 1,
       'unit_of_measurement': '%',
@@ -566,6 +566,6 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '60',
+    'state': '74',
   })
 # ---

--- a/tests/components/flexit_bacnet/test_number.py
+++ b/tests/components/flexit_bacnet/test_number.py
@@ -64,21 +64,21 @@ async def test_numbers_implementation(
     assert len(mocked_method.mock_calls) == 1
     assert hass.states.get(ENTITY_ID).state == "60"
 
-    mock_flexit_bacnet.fan_setpoint_supply_air_fire = 10
+    mock_flexit_bacnet.fan_setpoint_supply_air_fire = 40
 
     await hass.services.async_call(
         NUMBER_DOMAIN,
         SERVICE_SET_VALUE,
         {
             ATTR_ENTITY_ID: ENTITY_ID,
-            ATTR_VALUE: 10,
+            ATTR_VALUE: 40,
         },
         blocking=True,
     )
 
     mocked_method = getattr(mock_flexit_bacnet, "set_fan_setpoint_supply_air_fire")
     assert len(mocked_method.mock_calls) == 2
-    assert hass.states.get(ENTITY_ID).state == "10"
+    assert hass.states.get(ENTITY_ID).state == "40"
 
     # Error recovery, when setting the value
     mock_flexit_bacnet.set_fan_setpoint_supply_air_fire.side_effect = DecodingError
@@ -89,7 +89,7 @@ async def test_numbers_implementation(
             SERVICE_SET_VALUE,
             {
                 ATTR_ENTITY_ID: ENTITY_ID,
-                ATTR_VALUE: 10,
+                ATTR_VALUE: 40,
             },
             blocking=True,
         )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fixes a bug that made the integration break when setting fan setpoints.

The Flexit App works like this: if the Home extract/supply setpoint is 74, then the Away extract/supply setpoint must be 74 or lower i.e., max values for the Away extract/supply setpoints is the setpoints for Home extract/supply.

High setpoints can't be set lower than Home setpoints.

Also for setpoints not depending on other setpoints, the lowest value seems to be 30 (not 0, see screenshots and table below).

| Mode        | Setpoint | Min                   | Max                   |
|-------------|----------|-----------------------|-----------------------|
| HOME        | Supply   | AWAY Supply setpoint  | 100                   |
| HOME        | Extract  | AWAY Extract setpoint | 100                   |
| AWAY        | Supply   | 30                    | HOME Supply setpoint  |
| AWAY        | Extract  | 30                    | HOME Extract setpoint |
| HIGH        | Supply   | HOME Supply setpoint  | 100                   |
| HIGH        | Extract  | HOME Extract setpoint | 100                   |
| COOKER_HOOD | Supply   | 30                    | 100                   |
| COOKER_HOOD | Extract  | 30                    | 100                   |
| FIREPLACE   | Supply   | 30                    | 100                   |
| FIREPLACE   | Extract  | 30                    | 100                   |


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #133378
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

![Screenshot_20241216-215155](https://github.com/user-attachments/assets/474df4c5-0ea0-463a-b0d5-3f06ef26a3e6)

![Screenshot_20241216-215205](https://github.com/user-attachments/assets/921c3432-e2e4-457c-933d-5507b971512f)

![Screenshot_20241216-215217](https://github.com/user-attachments/assets/5a22622d-2a88-45e5-a7d8-506159b8761e)