### PR TITLE
Update mypy-dev to 1.14.0a7

### DIFF
--- a/homeassistant/components/image/__init__.py
+++ b/homeassistant/components/image/__init__.py
@@ -348,7 +348,7 @@ async def async_get_still_stream(
         # While this results in additional bandwidth usage,
         # given the low frequency of image updates, it is acceptable.
         frame.extend(frame)
-        await response.write(frame)
+        await response.write(frame)  # type: ignore[arg-type]
         return True
 
     event = asyncio.Event()

--- a/mypy.ini
+++ b/mypy.ini
@@ -10,6 +10,7 @@ show_error_codes = true
 follow_imports = normal
 local_partial_types = true
 strict_equality = true
+strict_bytes = true
 no_implicit_optional = true
 warn_incomplete_stub = true
 warn_redundant_casts = true

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -12,7 +12,7 @@ coverage==7.6.8
 freezegun==1.5.1
 license-expression==30.4.0
 mock-open==1.4.0
-mypy-dev==1.14.0a6
+mypy-dev==1.14.0a7
 pre-commit==4.0.0
 pydantic==2.10.3
 pylint==3.3.2

--- a/script/hassfest/mypy_config.py
+++ b/script/hassfest/mypy_config.py
@@ -47,6 +47,7 @@ GENERAL_SETTINGS: Final[dict[str, str]] = {
     # Enable some checks globally.
     "local_partial_types": "true",
     "strict_equality": "true",
+    "strict_bytes": "true",
     "no_implicit_optional": "true",
     "warn_incomplete_stub": "true",
     "warn_redundant_casts": "true",


### PR DESCRIPTION
## Proposed change
https://github.com/cdce8p/mypy-dev/releases/tag/1.14.0a7
Compare: https://github.com/python/mypy/compare/71ec4a62f08df4fa28f6b1a9f5bc45c272eaa49f...be87d3dcbdc9eb7e103bc6dc8f347b2ebc82aaff

- New option to no longer treat `bytearray` and `memoryview` as subclasses of `bytes`. This will become the default in mypy `2.0`. Fixed most issues already. Just one `type: ignore` remaining.
https://mypy.readthedocs.io/en/latest/command_line.html#cmdoption-mypy-strict-bytes
- Typeshed updates
- Minor improvements and bug fixes

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
