### PR TITLE
Check if requirement is typed in strict_typing IQS validation

### DIFF
--- a/homeassistant/components/fritz/quality_scale.yaml
+++ b/homeassistant/components/fritz/quality_scale.yaml
@@ -95,4 +95,7 @@ rules:
     comment: |
       the fritzconnection lib is not async and relies on requests
       changing this might need a bit more efforts to be spent
-  strict-typing: done
+  strict-typing:
+    status: todo
+    comment: |
+      Requirement 'xmltodict==0.13.0' appears untyped

--- a/homeassistant/components/fritz/quality_scale.yaml
+++ b/homeassistant/components/fritz/quality_scale.yaml
@@ -98,4 +98,4 @@ rules:
   strict-typing:
     status: todo
     comment: |
-      Requirement 'xmltodict==0.13.0' appears untyped
+      Requirements 'fritzconnection==1.14.0' and 'xmltodict==0.13.0' appear untyped

--- a/homeassistant/components/imap/quality_scale.yaml
+++ b/homeassistant/components/imap/quality_scale.yaml
@@ -94,4 +94,7 @@ rules:
     status: exempt
     comment: |
       This integration does not use web sessions.
-  strict-typing: done
+  strict-typing:
+    status: todo
+    comment: |
+      Requirement 'aioimaplib==1.1.0' appears untyped

--- a/homeassistant/components/mastodon/quality_scale.yaml
+++ b/homeassistant/components/mastodon/quality_scale.yaml
@@ -93,4 +93,7 @@ rules:
   # Platinum
   async-dependency: todo
   inject-websession: todo
-  strict-typing: done
+  strict-typing:
+    status: todo
+    comment: |
+      Requirement 'Mastodon.py==1.8.1' appears untyped

--- a/homeassistant/components/mqtt/quality_scale.yaml
+++ b/homeassistant/components/mqtt/quality_scale.yaml
@@ -125,4 +125,7 @@ rules:
     status: exempt
     comment: |
       This integration does not use web sessions.
-  strict-typing: done
+  strict-typing:
+    status: todo
+    comment: |
+      Requirement 'paho-mqtt==1.6.1' appears untyped

--- a/homeassistant/components/stookwijzer/quality_scale.yaml
+++ b/homeassistant/components/stookwijzer/quality_scale.yaml
@@ -86,4 +86,7 @@ rules:
   # Platinum
   async-dependency: done
   inject-websession: done
-  strict-typing: done
+  strict-typing:
+    status: todo
+    comment: |
+      Requirement 'stookwijzer==1.5.1' appears untyped

--- a/script/hassfest/quality_scale_validation/strict_typing.py
+++ b/script/hassfest/quality_scale_validation/strict_typing.py
@@ -30,6 +30,8 @@ def _check_requirements_are_typed(integration: Integration) -> list[str]:
     invalid_requirements = []
     for requirement in integration.requirements:
         requirement_name, requirement_version = requirement.split("==")
+        # Remove any extras
+        requirement_name = requirement_name.split("[")[0]
         try:
             distribution = metadata.distribution(requirement_name)
         except metadata.PackageNotFoundError:

--- a/script/hassfest/quality_scale_validation/strict_typing.py
+++ b/script/hassfest/quality_scale_validation/strict_typing.py
@@ -59,6 +59,7 @@ def validate(
         ]
     if untyped_requirements := _check_requirements_are_typed(integration):
         return [
-            f"Requirements {untyped_requirements} appears untyped (missing py.typed)"
+            f"Requirements {untyped_requirements} do not conform PEP 561 (https://peps.python.org/pep-0561/)",
+            "They should be typed and have a 'py.typed' file",
         ]
     return None

--- a/script/hassfest/quality_scale_validation/strict_typing.py
+++ b/script/hassfest/quality_scale_validation/strict_typing.py
@@ -41,7 +41,7 @@ def _check_requirements_are_typed(integration: Integration) -> str | None:
         if not any(file for file in distribution.files if file.name == "py.typed"):
             # no py.typed file
             return requirement
-        return None
+        continue
     return None
 
 

--- a/script/hassfest/quality_scale_validation/strict_typing.py
+++ b/script/hassfest/quality_scale_validation/strict_typing.py
@@ -25,8 +25,9 @@ def _strict_typing_components(strict_typing_file: Path) -> set[str]:
     )
 
 
-def _check_requirements_are_typed(integration: Integration) -> str | None:
+def _check_requirements_are_typed(integration: Integration) -> list[str]:
     """Check if all requirements are typed."""
+    invalid_requirements = []
     for requirement in integration.requirements:
         requirement_name, requirement_version = requirement.split("==")
         try:
@@ -40,8 +41,9 @@ def _check_requirements_are_typed(integration: Integration) -> str | None:
 
         if not any(file for file in distribution.files if file.name == "py.typed"):
             # no py.typed file
-            return requirement
-    return None
+            invalid_requirements.append(requirement)
+
+    return invalid_requirements
 
 
 def validate(
@@ -55,8 +57,8 @@ def validate(
             "Integration does not have strict typing enabled "
             "(is missing from .strict-typing)"
         ]
-    if untyped_requirement := _check_requirements_are_typed(integration):
+    if untyped_requirements := _check_requirements_are_typed(integration):
         return [
-            f"Requirement '{untyped_requirement}' appears untyped (missing py.typed)"
+            f"Requirements {untyped_requirements} appears untyped (missing py.typed)"
         ]
     return None

--- a/script/hassfest/quality_scale_validation/strict_typing.py
+++ b/script/hassfest/quality_scale_validation/strict_typing.py
@@ -41,7 +41,6 @@ def _check_requirements_are_typed(integration: Integration) -> str | None:
         if not any(file for file in distribution.files if file.name == "py.typed"):
             # no py.typed file
             return requirement
-        continue
     return None
 
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Per https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/strict-typing/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
