### PR TITLE
Bugfix: also schedule time based integration when source is 0

### DIFF
--- a/homeassistant/components/integration/sensor.py
+++ b/homeassistant/components/integration/sensor.py
@@ -576,7 +576,7 @@ class IntegrationSensor(RestoreSensor):
         if (
             self._max_sub_interval is not None
             and source_state is not None
-            and (source_state_dec := _decimal_state(source_state.state))
+            and (source_state_dec := _decimal_state(source_state.state)) is not None
         ):
 
             @callback

--- a/tests/components/integration/test_sensor.py
+++ b/tests/components/integration/test_sensor.py
@@ -843,6 +843,40 @@ async def test_on_valid_source_expect_update_on_time(
         assert float(state.state) < 1.8
 
 
+async def test_on_0_source_expect_0_and_update_when_source_gets_positive(
+    hass: HomeAssistant,
+) -> None:
+    """Test whether time based integration updates the integral on a valid zero source."""
+    start_time = dt_util.utcnow()
+
+    with freeze_time(start_time) as freezer:
+        await _setup_integral_sensor(hass, max_sub_interval=DEFAULT_MAX_SUB_INTERVAL)
+        await _update_source_sensor(hass, 0)
+        await hass.async_block_till_done()
+
+        # wait one minute
+        freezer.tick(61)
+        async_fire_time_changed(hass, dt_util.now())
+        await hass.async_block_till_done()
+
+        state = hass.states.get("sensor.integration")
+
+        assert condition.async_numeric_state(hass, state) is True
+        assert float(state.state) == 0  # integral is 0 after integration of 0
+
+        # wait 1 second and update state
+        freezer.tick(1)
+        async_fire_time_changed(hass, dt_util.now())
+        await _update_source_sensor(hass, 100)
+        await hass.async_block_till_done()
+
+        state = hass.states.get("sensor.integration")
+
+        # approx 100*1/3600 (right method after 1 second since last integration)
+        assert float(state.state) > 0.027
+        assert float(state.state) < 0.029
+
+
 async def test_on_unvailable_source_expect_no_update_on_time(
     hass: HomeAssistant,
 ) -> None:

--- a/tests/components/integration/test_sensor.py
+++ b/tests/components/integration/test_sensor.py
@@ -873,7 +873,7 @@ async def test_on_0_source_expect_0_and_update_when_source_gets_positive(
         state = hass.states.get("sensor.integration")
 
         # approx 100*1/3600 (right method after 1 second since last integration)
-        assert float(state.state) > 0.027
+        assert 0.027 < float(state.state) < 0.029
         assert float(state.state) < 0.029
 
 

--- a/tests/components/integration/test_sensor.py
+++ b/tests/components/integration/test_sensor.py
@@ -854,7 +854,7 @@ async def test_on_0_source_expect_0_and_update_when_source_gets_positive(
         await _update_source_sensor(hass, 0)
         await hass.async_block_till_done()
 
-        # wait one minute
+        # wait one minute and one second
         freezer.tick(61)
         async_fire_time_changed(hass, dt_util.now())
         await hass.async_block_till_done()
@@ -864,7 +864,7 @@ async def test_on_0_source_expect_0_and_update_when_source_gets_positive(
         assert condition.async_numeric_state(hass, state) is True
         assert float(state.state) == 0  # integral is 0 after integration of 0
 
-        # wait 1 second and update state
+        # wait one second and update state
         freezer.tick(1)
         async_fire_time_changed(hass, dt_util.now())
         await _update_source_sensor(hass, 100)
@@ -874,7 +874,6 @@ async def test_on_0_source_expect_0_and_update_when_source_gets_positive(
 
         # approx 100*1/3600 (right method after 1 second since last integration)
         assert 0.027 < float(state.state) < 0.029
-        assert float(state.state) < 0.029
 
 
 async def test_on_unvailable_source_expect_no_update_on_time(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Also schedule time based integration when source is 0. The assignment expression evaluated to falsy for a Decimal of 0, as a consequence no new time based integration was scheduled and the next integration is the new state change with a too large time interval. We now also check for not None return value of `_decimal_state`.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #133375
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
