### PR TITLE
Increase Squeezebox config_flow test coverage to 100%

### DIFF
--- a/tests/components/squeezebox/test_config_flow.py
+++ b/tests/components/squeezebox/test_config_flow.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 
 from pysqueezebox import Server
 
-from homeassistant import config_entries, exceptions
+from homeassistant import config_entries
 from homeassistant.components import dhcp
 from homeassistant.components.squeezebox.const import CONF_HTTPS, DOMAIN
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME
@@ -169,10 +169,13 @@ async def test_form_invalid_auth(hass: HomeAssistant) -> None:
 async def test_form_validate_exception(hass: HomeAssistant) -> None:
     """Test we handle exception."""
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": "edit"}
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    with patch("homeassistant.components.squeezebox.config_flow.Server.async_query", side_effect=Exception):
+    with patch(
+        "homeassistant.components.squeezebox.config_flow.Server.async_query",
+        side_effect=Exception,
+    ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {

--- a/tests/components/squeezebox/test_config_flow.py
+++ b/tests/components/squeezebox/test_config_flow.py
@@ -188,10 +188,6 @@ async def test_form_validate_exception(hass: HomeAssistant) -> None:
         )
         assert result["type"] is FlowResultType.FORM
         assert result["step_id"] == "edit"
-        assert CONF_HOST in result["data_schema"].schema
-        for key in result["data_schema"].schema:
-            if key == CONF_HOST:
-                assert key.description == {"suggested_value": HOST}
 
         with patch(
             "homeassistant.components.squeezebox.config_flow.Server.async_query",
@@ -210,29 +206,25 @@ async def test_form_validate_exception(hass: HomeAssistant) -> None:
             assert result["type"] is FlowResultType.FORM
             assert result["errors"] == {"base": "unknown"}
 
-        with patch(
-            "homeassistant.components.squeezebox.async_setup_entry",
-            return_value=True,
-        ):
-            result = await hass.config_entries.flow.async_configure(
-                result["flow_id"],
-                {
-                    CONF_HOST: HOST,
-                    CONF_PORT: PORT,
-                    CONF_USERNAME: "",
-                    CONF_PASSWORD: "",
-                    CONF_HTTPS: False,
-                },
-            )
-            assert result["type"] is FlowResultType.CREATE_ENTRY
-            assert result["title"] == HOST
-            assert result["data"] == {
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
                 CONF_HOST: HOST,
                 CONF_PORT: PORT,
                 CONF_USERNAME: "",
                 CONF_PASSWORD: "",
                 CONF_HTTPS: False,
-            }
+            },
+        )
+        assert result["type"] is FlowResultType.CREATE_ENTRY
+        assert result["title"] == HOST
+        assert result["data"] == {
+            CONF_HOST: HOST,
+            CONF_PORT: PORT,
+            CONF_USERNAME: "",
+            CONF_PASSWORD: "",
+            CONF_HTTPS: False,
+        }
 
 
 async def test_form_cannot_connect(hass: HomeAssistant) -> None:

--- a/tests/components/squeezebox/test_config_flow.py
+++ b/tests/components/squeezebox/test_config_flow.py
@@ -169,7 +169,7 @@ async def test_form_invalid_auth(hass: HomeAssistant) -> None:
 async def test_form_validate_exception(hass: HomeAssistant) -> None:
     """Test we handle exception."""
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
+        DOMAIN, context={"source": "edit"}
     )
 
     with patch(
@@ -188,6 +188,8 @@ async def test_form_validate_exception(hass: HomeAssistant) -> None:
 
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": "unknown"}
+
+    await test_user_form(hass)
 
 
 async def test_form_cannot_connect(hass: HomeAssistant) -> None:

--- a/tests/components/squeezebox/test_config_flow.py
+++ b/tests/components/squeezebox/test_config_flow.py
@@ -172,13 +172,7 @@ async def test_form_validate_exception(hass: HomeAssistant) -> None:
         DOMAIN, context={"source": "edit"}
     )
 
-    class FakeError(exceptions.HomeAssistantError):
-        """Error."""
-
-    async def patch_async_query(self, *args):
-        raise FakeError
-
-    with patch("pysqueezebox.Server.async_query", new=patch_async_query):
+    with patch("homeassistant.components.squeezebox.config_flow.Server.async_query", side_effect=Exception):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
Small PR to add a test for 1 missing segment to increase test coverage of config_flow to 100%
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
