### PR TITLE
Reorganize input sources in Onkyo options

### DIFF
--- a/homeassistant/components/onkyo/config_flow.py
+++ b/homeassistant/components/onkyo/config_flow.py
@@ -385,7 +385,7 @@ OPTIONS_STEP_INIT_SCHEMA = vol.Schema(
 class OnkyoOptionsFlowHandler(OptionsFlow):
     """Handle an options flow for Onkyo."""
 
-    _data: dict[str, Any] = {}
+    _data: dict[str, Any]
     _input_sources: dict[InputSource, str]
 
     async def async_step_init(

--- a/homeassistant/components/onkyo/config_flow.py
+++ b/homeassistant/components/onkyo/config_flow.py
@@ -15,6 +15,7 @@ from homeassistant.config_entries import (
 )
 from homeassistant.const import CONF_HOST, CONF_NAME
 from homeassistant.core import callback
+from homeassistant.data_entry_flow import section
 from homeassistant.helpers.selector import (
     NumberSelector,
     NumberSelectorConfig,
@@ -49,9 +50,13 @@ INPUT_SOURCES_ALL_MEANINGS = [
     input_source.value_meaning for input_source in InputSource
 ]
 STEP_MANUAL_SCHEMA = vol.Schema({vol.Required(CONF_HOST): str})
-STEP_CONFIGURE_SCHEMA = vol.Schema(
+STEP_RECONFIGURE_SCHEMA = vol.Schema(
     {
         vol.Required(OPTION_VOLUME_RESOLUTION): vol.In(VOLUME_RESOLUTION_ALLOWED),
+    }
+)
+STEP_CONFIGURE_SCHEMA = STEP_RECONFIGURE_SCHEMA.extend(
+    {
         vol.Required(OPTION_INPUT_SOURCES): SelectSelector(
             SelectSelectorConfig(
                 options=INPUT_SOURCES_ALL_MEANINGS,
@@ -216,55 +221,52 @@ class OnkyoConfigFlow(ConfigFlow, domain=DOMAIN):
         """Handle the configuration of a single receiver."""
         errors = {}
 
-        entry = None
-        entry_options = None
+        reconfigure_entry = None
+        schema = STEP_CONFIGURE_SCHEMA
         if self.source == SOURCE_RECONFIGURE:
-            entry = self._get_reconfigure_entry()
-            entry_options = entry.options
+            schema = STEP_RECONFIGURE_SCHEMA
+            reconfigure_entry = self._get_reconfigure_entry()
 
         if user_input is not None:
-            source_meanings: list[str] = user_input[OPTION_INPUT_SOURCES]
-            if not source_meanings:
+            volume_resolution = user_input[OPTION_VOLUME_RESOLUTION]
+
+            if reconfigure_entry is not None:
+                entry_options = reconfigure_entry.options
+                result = self.async_update_reload_and_abort(
+                    reconfigure_entry,
+                    data={
+                        CONF_HOST: self._receiver_info.host,
+                    },
+                    options={
+                        OPTION_VOLUME_RESOLUTION: volume_resolution,
+                        OPTION_MAX_VOLUME: entry_options[OPTION_MAX_VOLUME],
+                        OPTION_INPUT_SOURCES: entry_options[OPTION_INPUT_SOURCES],
+                    },
+                )
+
+                _LOGGER.debug("Reconfigured receiver, result: %s", result)
+                return result
+
+            input_source_meanings: list[str] = user_input[OPTION_INPUT_SOURCES]
+            if not input_source_meanings:
                 errors[OPTION_INPUT_SOURCES] = "empty_input_source_list"
             else:
-                sources_store: dict[str, str] = {}
-                for source_meaning in source_meanings:
-                    source = InputSource.from_meaning(source_meaning)
+                input_sources_store: dict[str, str] = {}
+                for input_source_meaning in input_source_meanings:
+                    input_source = InputSource.from_meaning(input_source_meaning)
+                    input_sources_store[input_source.value] = input_source_meaning
 
-                    source_name = source_meaning
-                    if entry_options is not None:
-                        source_name = entry_options[OPTION_INPUT_SOURCES].get(
-                            source.value, source_name
-                        )
-                    sources_store[source.value] = source_name
-
-                volume_resolution = user_input[OPTION_VOLUME_RESOLUTION]
-
-                if entry_options is None:
-                    result = self.async_create_entry(
-                        title=self._receiver_info.model_name,
-                        data={
-                            CONF_HOST: self._receiver_info.host,
-                        },
-                        options={
-                            OPTION_VOLUME_RESOLUTION: volume_resolution,
-                            OPTION_MAX_VOLUME: OPTION_MAX_VOLUME_DEFAULT,
-                            OPTION_INPUT_SOURCES: sources_store,
-                        },
-                    )
-                else:
-                    assert entry is not None
-                    result = self.async_update_reload_and_abort(
-                        entry,
-                        data={
-                            CONF_HOST: self._receiver_info.host,
-                        },
-                        options={
-                            OPTION_VOLUME_RESOLUTION: volume_resolution,
-                            OPTION_MAX_VOLUME: entry_options[OPTION_MAX_VOLUME],
-                            OPTION_INPUT_SOURCES: sources_store,
-                        },
-                    )
+                result = self.async_create_entry(
+                    title=self._receiver_info.model_name,
+                    data={
+                        CONF_HOST: self._receiver_info.host,
+                    },
+                    options={
+                        OPTION_VOLUME_RESOLUTION: volume_resolution,
+                        OPTION_MAX_VOLUME: OPTION_MAX_VOLUME_DEFAULT,
+                        OPTION_INPUT_SOURCES: input_sources_store,
+                    },
+                )
 
                 _LOGGER.debug("Configured receiver, result: %s", result)
                 return result
@@ -273,12 +275,13 @@ class OnkyoConfigFlow(ConfigFlow, domain=DOMAIN):
 
         suggested_values = user_input
         if suggested_values is None:
-            if entry_options is None:
+            if reconfigure_entry is None:
                 suggested_values = {
                     OPTION_VOLUME_RESOLUTION: OPTION_VOLUME_RESOLUTION_DEFAULT,
                     OPTION_INPUT_SOURCES: [],
                 }
             else:
+                entry_options = reconfigure_entry.options
                 suggested_values = {
                     OPTION_VOLUME_RESOLUTION: entry_options[OPTION_VOLUME_RESOLUTION],
                     OPTION_INPUT_SOURCES: [
@@ -289,9 +292,7 @@ class OnkyoConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="configure_receiver",
-            data_schema=self.add_suggested_values_to_schema(
-                STEP_CONFIGURE_SCHEMA, suggested_values
-            ),
+            data_schema=self.add_suggested_values_to_schema(schema, suggested_values),
             errors=errors,
             description_placeholders={
                 "name": f"{self._receiver_info.model_name} ({self._receiver_info.host})"
@@ -360,57 +361,107 @@ class OnkyoConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
-    def async_get_options_flow(
-        config_entry: ConfigEntry,
-    ) -> OptionsFlow:
+    def async_get_options_flow(config_entry: ConfigEntry) -> OptionsFlow:
         """Return the options flow."""
-        return OnkyoOptionsFlowHandler(config_entry)
+        return OnkyoOptionsFlowHandler()
+
+
+OPTIONS_STEP_INIT_SCHEMA = vol.Schema(
+    {
+        vol.Required(OPTION_MAX_VOLUME): NumberSelector(
+            NumberSelectorConfig(min=1, max=100, mode=NumberSelectorMode.BOX)
+        ),
+        vol.Required(OPTION_INPUT_SOURCES): SelectSelector(
+            SelectSelectorConfig(
+                options=INPUT_SOURCES_ALL_MEANINGS,
+                multiple=True,
+                mode=SelectSelectorMode.DROPDOWN,
+            )
+        ),
+    }
+)
 
 
 class OnkyoOptionsFlowHandler(OptionsFlow):
     """Handle an options flow for Onkyo."""
 
-    def __init__(self, config_entry: ConfigEntry) -> None:
-        """Initialize options flow."""
-        sources_store: dict[str, str] = config_entry.options[OPTION_INPUT_SOURCES]
-        self._input_sources = {InputSource(k): v for k, v in sources_store.items()}
+    _data: dict[str, Any] = {}
+    _input_sources: dict[InputSource, str]
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Manage the options."""
+        errors = {}
+
+        entry_options = self.config_entry.options
+
         if user_input is not None:
-            sources_store: dict[str, str] = {}
-            for source_meaning, source_name in user_input.items():
-                if source_meaning in INPUT_SOURCES_ALL_MEANINGS:
-                    source = InputSource.from_meaning(source_meaning)
-                    sources_store[source.value] = source_name
+            self._input_sources = {}
+            for input_source_meaning in user_input[OPTION_INPUT_SOURCES]:
+                input_source = InputSource.from_meaning(input_source_meaning)
+                input_source_name = entry_options[OPTION_INPUT_SOURCES].get(
+                    input_source.value, input_source_meaning
+                )
+                self._input_sources[input_source] = input_source_name
+
+            if not self._input_sources:
+                errors[OPTION_INPUT_SOURCES] = "empty_input_source_list"
+            else:
+                self._data = {
+                    OPTION_VOLUME_RESOLUTION: entry_options[OPTION_VOLUME_RESOLUTION],
+                    OPTION_MAX_VOLUME: user_input[OPTION_MAX_VOLUME],
+                }
+
+                return await self.async_step_names()
+
+        suggested_values = user_input
+        if suggested_values is None:
+            suggested_values = {
+                OPTION_MAX_VOLUME: entry_options[OPTION_MAX_VOLUME],
+                OPTION_INPUT_SOURCES: [
+                    InputSource(input_source).value_meaning
+                    for input_source in entry_options[OPTION_INPUT_SOURCES]
+                ],
+            }
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=self.add_suggested_values_to_schema(
+                OPTIONS_STEP_INIT_SCHEMA, suggested_values
+            ),
+            errors=errors,
+        )
+
+    async def async_step_names(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Configure names."""
+        if user_input is not None:
+            input_sources_store: dict[str, str] = {}
+            for input_source_meaning, input_source_name in user_input[
+                "input_sources"
+            ].items():
+                input_source = InputSource.from_meaning(input_source_meaning)
+                input_sources_store[input_source.value] = input_source_name
 
             return self.async_create_entry(
                 data={
-                    OPTION_VOLUME_RESOLUTION: self.config_entry.options[
-                        OPTION_VOLUME_RESOLUTION
-                    ],
-                    OPTION_MAX_VOLUME: user_input[OPTION_MAX_VOLUME],
-                    OPTION_INPUT_SOURCES: sources_store,
+                    **self._data,
+                    OPTION_INPUT_SOURCES: input_sources_store,
                 }
             )
 
         schema_dict: dict[Any, Selector] = {}
 
-        max_volume: float = self.config_entry.options[OPTION_MAX_VOLUME]
-        schema_dict[vol.Required(OPTION_MAX_VOLUME, default=max_volume)] = (
-            NumberSelector(
-                NumberSelectorConfig(min=1, max=100, mode=NumberSelectorMode.BOX)
-            )
-        )
-
-        for source, source_name in self._input_sources.items():
-            schema_dict[vol.Required(source.value_meaning, default=source_name)] = (
-                TextSelector()
-            )
+        for input_source, input_source_name in self._input_sources.items():
+            schema_dict[
+                vol.Required(input_source.value_meaning, default=input_source_name)
+            ] = TextSelector()
 
         return self.async_show_form(
-            step_id="init",
-            data_schema=vol.Schema(schema_dict),
+            step_id="names",
+            data_schema=vol.Schema(
+                {vol.Required("input_sources"): section(vol.Schema(schema_dict))}
+            ),
         )

--- a/homeassistant/components/onkyo/strings.json
+++ b/homeassistant/components/onkyo/strings.json
@@ -27,17 +27,17 @@
         "description": "Configure {name}",
         "data": {
           "volume_resolution": "Volume resolution",
-          "input_sources": "Input sources"
+          "input_sources": "[%key:component::onkyo::options::step::init::data::input_sources%]"
         },
         "data_description": {
           "volume_resolution": "Number of steps it takes for the receiver to go from the lowest to the highest possible volume.",
-          "input_sources": "List of input sources supported by the receiver."
+          "input_sources": "[%key:component::onkyo::options::step::init::data_description::input_sources%]"
         }
       }
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "empty_input_source_list": "Input source list cannot be empty",
+      "empty_input_source_list": "[%key:component::onkyo::options::error::empty_input_source_list%]",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {
@@ -52,12 +52,25 @@
     "step": {
       "init": {
         "data": {
-          "max_volume": "Maximum volume limit (%)"
+          "max_volume": "Maximum volume limit (%)",
+          "input_sources": "Input sources"
         },
         "data_description": {
-          "max_volume": "Maximum volume limit as a percentage. This will associate Home Assistant's maximum volume to this value on the receiver, i.e., if you set this to 50%, then setting the volume to 100% in Home Assistant will cause the volume on the receiver to be set to 50% of its maximum value."
+          "max_volume": "Maximum volume limit as a percentage. This will associate Home Assistant's maximum volume to this value on the receiver, i.e., if you set this to 50%, then setting the volume to 100% in Home Assistant will cause the volume on the receiver to be set to 50% of its maximum value.",
+          "input_sources": "List of input sources supported by the receiver."
+        }
+      },
+      "names": {
+        "sections": {
+          "input_sources": {
+            "name": "Input source names",
+            "description": "Mappings of receiver's input sources to their names."
+          }
         }
       }
+    },
+    "error": {
+      "empty_input_source_list": "Input source list cannot be empty"
     }
   },
   "issues": {

--- a/tests/components/onkyo/test_config_flow.py
+++ b/tests/components/onkyo/test_config_flow.py
@@ -638,6 +638,7 @@ async def test_options_flow(hass: HomeAssistant, config_entry: MockConfigEntry) 
         },
     )
 
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "init"
     assert result["errors"] == {OPTION_INPUT_SOURCES: "empty_input_source_list"}
 
@@ -648,6 +649,9 @@ async def test_options_flow(hass: HomeAssistant, config_entry: MockConfigEntry) 
             OPTION_INPUT_SOURCES: ["TV"],
         },
     )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "names"
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Reorganize input sources in Onkyo options for better user experience.

Move input source selection from reconfigure flow to options flow for better user discoverability.
Group input source name mappings into a separate section, providing better descriptions.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
