### PR TITLE
Set default min/max color temperature in hue lights

### DIFF
--- a/homeassistant/components/hue/v1/light.py
+++ b/homeassistant/components/hue/v1/light.py
@@ -17,6 +17,8 @@ from homeassistant.components.light import (
     ATTR_FLASH,
     ATTR_HS_COLOR,
     ATTR_TRANSITION,
+    DEFAULT_MAX_KELVIN,
+    DEFAULT_MIN_KELVIN,
     EFFECT_COLORLOOP,
     EFFECT_RANDOM,
     FLASH_LONG,
@@ -447,13 +449,13 @@ class HueLight(CoordinatorEntity, LightEntity):
     def max_color_temp_kelvin(self) -> int:
         """Return the coldest color_temp_kelvin that this light supports."""
         if self.is_group:
-            return super().max_color_temp_kelvin
+            return DEFAULT_MAX_KELVIN
 
         min_mireds = self.light.controlcapabilities.get("ct", {}).get("min")
 
         # We filter out '0' too, which can be incorrectly reported by 3rd party buls
         if not min_mireds:
-            return super().max_color_temp_kelvin
+            return DEFAULT_MAX_KELVIN
 
         return color_util.color_temperature_mired_to_kelvin(min_mireds)
 
@@ -461,14 +463,14 @@ class HueLight(CoordinatorEntity, LightEntity):
     def min_color_temp_kelvin(self) -> int:
         """Return the warmest color_temp_kelvin that this light supports."""
         if self.is_group:
-            return super().min_color_temp_kelvin
+            return DEFAULT_MIN_KELVIN
         if self.is_livarno:
-            return 500
+            return 2000  # 500 mireds
 
         max_mireds = self.light.controlcapabilities.get("ct", {}).get("max")
 
         if not max_mireds:
-            return super().min_color_temp_kelvin
+            return DEFAULT_MIN_KELVIN
 
         return color_util.color_temperature_mired_to_kelvin(max_mireds)
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
```
Detected that integration 'hue' is using mireds for warmest light color temperature,
when it should be adjusted to use the kelvin attribute `_attr_min_color_temp_kelvin`
or override the kelvin property `min_color_temp_kelvin`, possibly with default DEFAULT_MIN_KELVIN
(see https://github.com/home-assistant/core/pull/79591) 
at homeassistant/components/hue/v1/light.py, line 471: return super().min_color_temp_kelvin. 
Please create a bug report at 
https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue+label%3A%22integration%3A+hue%22
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
