### PR TITLE
Revert "Update docker base image to 2024.12.1"

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,10 +1,10 @@
 image: ghcr.io/home-assistant/{arch}-homeassistant
 build_from:
-  aarch64: ghcr.io/home-assistant/aarch64-homeassistant-base:2024.12.1
-  armhf: ghcr.io/home-assistant/armhf-homeassistant-base:2024.12.1
-  armv7: ghcr.io/home-assistant/armv7-homeassistant-base:2024.12.1
-  amd64: ghcr.io/home-assistant/amd64-homeassistant-base:2024.12.1
-  i386: ghcr.io/home-assistant/i386-homeassistant-base:2024.12.1
+  aarch64: ghcr.io/home-assistant/aarch64-homeassistant-base:2024.11.0
+  armhf: ghcr.io/home-assistant/armhf-homeassistant-base:2024.11.0
+  armv7: ghcr.io/home-assistant/armv7-homeassistant-base:2024.11.0
+  amd64: ghcr.io/home-assistant/amd64-homeassistant-base:2024.11.0
+  i386: ghcr.io/home-assistant/i386-homeassistant-base:2024.11.0
 codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io


### PR DESCRIPTION
Reverts home-assistant/core#133323

This PR was bumping an incorrect image. Our base images != Home Assistant base image.

PR to bump the Home Assistant base image with the new base image: <https://github.com/home-assistant/docker/pull/340>

Meanwhile, reverting this one.


../Frenck