### PR TITLE
Additional optimizations to the start time queries

### DIFF
--- a/homeassistant/components/recorder/history/modern.py
+++ b/homeassistant/components/recorder/history/modern.py
@@ -577,22 +577,19 @@ def _get_start_time_state_for_entities_stmt(
         .select_from(StatesMeta)
         .join(
             States,
-            and_(
-                States.last_updated_ts
-                == (
-                    select(States.last_updated_ts)
-                    .where(
-                        (StatesMeta.metadata_id == States.metadata_id)
-                        & (States.last_updated_ts < epoch_time)
-                        & (States.last_updated_ts >= run_start_ts)
-                    )
-                    .order_by(States.last_updated_ts.desc())
-                    .limit(1)
+            States.state_id
+            == (
+                select(States.state_id)
+                .where(
+                    (StatesMeta.metadata_id == States.metadata_id)
+                    & (States.last_updated_ts < epoch_time)
+                    & (States.last_updated_ts >= run_start_ts)
                 )
-                .scalar_subquery()
-                .correlate(StatesMeta),
-                States.metadata_id == StatesMeta.metadata_id,
-            ),
+                .order_by(States.last_updated_ts.desc())
+                .limit(1)
+            )
+            .scalar_subquery()
+            .correlate(StatesMeta),
         )
         .where(StatesMeta.metadata_id.in_(metadata_ids))
     )

--- a/homeassistant/components/recorder/statistics.py
+++ b/homeassistant/components/recorder/statistics.py
@@ -14,7 +14,7 @@ import re
 from time import time as time_time
 from typing import TYPE_CHECKING, Any, Literal, TypedDict, cast
 
-from sqlalchemy import Select, and_, bindparam, func, lambda_stmt, select, text
+from sqlalchemy import Select, bindparam, func, lambda_stmt, select, text
 from sqlalchemy.engine.row import Row
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm.session import Session
@@ -2047,21 +2047,18 @@ def _generate_statistics_at_time_stmt(
         lambda q: q.select_from(StatisticsMeta)
         .join(
             table,
-            and_(
-                table.start_ts
-                == (
-                    select(table.start_ts)
-                    .where(
-                        (StatisticsMeta.id == table.metadata_id)
-                        & (table.start_ts < start_time_ts)
-                    )
-                    .order_by(table.start_ts.desc())
-                    .limit(1)
+            table.id
+            == (
+                select(table.id)
+                .where(
+                    (StatisticsMeta.id == table.metadata_id)
+                    & (table.start_ts < start_time_ts)
                 )
-                .scalar_subquery()
-                .correlate(StatisticsMeta),
-                table.metadata_id == StatisticsMeta.id,
-            ),
+                .order_by(table.start_ts.desc())
+                .limit(1)
+            )
+            .scalar_subquery()
+            .correlate(StatisticsMeta),
         )
         .where(table.metadata_id.in_(metadata_ids))
     )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Followup to #133553

join on the primary key to avoid having to use secondary indices which avoids the `and` in the join condition

MySQL/MariaDB
before
```
+------+--------------------+------------------+--------+-----------------------------------------------------------------+---------------------------------------+---------+-------------------------------------------+------+--------------------------+
| id   | select_type        | table            | type   | possible_keys                                                   | key                                   | key_len | ref                                       | rows | Extra                    |
+------+--------------------+------------------+--------+-----------------------------------------------------------------+---------------------------------------+---------+-------------------------------------------+------+--------------------------+
|    1 | PRIMARY            | <derived4>       | ALL    | distinct_key                                                    | NULL                                  | NULL    | NULL                                      | 1396 |                          |
|    1 | PRIMARY            | states_meta      | eq_ref | PRIMARY                                                         | PRIMARY                               | 8       | tvc_0._col_1                              | 1    | Using where              |
|    1 | PRIMARY            | states           | ref    | ix_states_last_updated_ts,ix_states_metadata_id_last_updated_ts | ix_states_last_updated_ts             | 9       | func                                      | 1    | Using where              |
|    1 | PRIMARY            | state_attributes | eq_ref | PRIMARY                                                         | PRIMARY                               | 8       | hass_132865_rocky.states.attributes_id    | 1    | Using where              |
|    4 | DERIVED            | NULL             | NULL   | NULL                                                            | NULL                                  | NULL    | NULL                                      | NULL | No tables used           |
|    2 | DEPENDENT SUBQUERY | states           | ref    | ix_states_last_updated_ts,ix_states_metadata_id_last_updated_ts | ix_states_metadata_id_last_updated_ts | 9       | hass_132865_rocky.states_meta.metadata_id | 558  | Using where; Using index |
+------+--------------------+------------------+--------+-----------------------------------------------------------------+---------------------------------------+---------+-------------------------------------------+------+--------------------------+
```

after
```
+------+--------------------+------------------+--------+-----------------------------------------------------------------+---------------------------------------+---------+-------------------------------------------+------+--------------------------+
| id   | select_type        | table            | type   | possible_keys                                                   | key                                   | key_len | ref                                       | rows | Extra                    |
+------+--------------------+------------------+--------+-----------------------------------------------------------------+---------------------------------------+---------+-------------------------------------------+------+--------------------------+
|    1 | PRIMARY            | <derived4>       | ALL    | distinct_key                                                    | NULL                                  | NULL    | NULL                                      | 1396 |                          |
|    1 | PRIMARY            | states_meta      | eq_ref | PRIMARY                                                         | PRIMARY                               | 8       | tvc_0._col_1                              | 1    | Using where              |
|    1 | PRIMARY            | states           | eq_ref | PRIMARY                                                         | PRIMARY                               | 8       | func                                      | 1    | Using where              |
|    1 | PRIMARY            | state_attributes | eq_ref | PRIMARY                                                         | PRIMARY                               | 8       | hass_132865_rocky.states.attributes_id    | 1    | Using where              |
|    4 | DERIVED            | NULL             | NULL   | NULL                                                            | NULL                                  | NULL    | NULL                                      | NULL | No tables used           |
|    2 | DEPENDENT SUBQUERY | states           | ref    | ix_states_last_updated_ts,ix_states_metadata_id_last_updated_ts | ix_states_metadata_id_last_updated_ts | 9       | hass_132865_rocky.states_meta.metadata_id | 558  | Using where; Using index |
+------+--------------------+------------------+--------+-----------------------------------------------------------------+---------------------------------------+---------+-------------------------------------------+------+--------------------------+
6 rows in set (0.003 sec)
```

The change is 
```
| id   | select_type        | table            | type   | possible_keys                                                   | key                                   | key_len | ref                                       | rows | Extra                    |

|    1 | PRIMARY            | states           | ref    | ix_states_last_updated_ts,ix_states_metadata_id_last_updated_ts | ix_states_last_updated_ts             | 9       | func                                      | 1    | Using where              |
```
becomes
```
| id   | select_type        | table            | type   | possible_keys                                                   | key                                   | key_len | ref                                       | rows | Extra                    |

|    1 | PRIMARY            | states           | eq_ref | PRIMARY                                                         | PRIMARY                               | 8       | func                                      | 1    | Using where              |
```


PostgreSQL 

before
```
 Nested Loop  (cost=1.36..460.50 rows=1 width=16)
   ->  Seq Scan on states_meta  (cost=0.18..86.34 rows=71 width=8)
         Filter: (metadata_id = ANY ('{2169,2170,485,661,672,673,753,754,755,756,759,450,463,483,2003,2004,2007,2008,2009,2000,2001,1968,627,569,570,571,572,573,574,591,592,593,634,643,1559,1537,1546,1741,1742,1743,1745,1751,1753,1756,1757,1758,1759,1760,1761,421,2,7,20,12,2118,2120,2135,2137,494,502,511,549,554,561,566,929,935,1313,1314,1315,608}'::bigint[]))
   ->  Index Only Scan using ix_states_metadata_id_last_updated_ts on states  (cost=1.18..5.26 rows=1 width=16)
         Index Cond: ((metadata_id = states_meta.metadata_id) AND (last_updated_ts = (SubPlan 1)))
         SubPlan 1
           ->  Limit  (cost=0.57..0.61 rows=1 width=8)
                 ->  Index Only Scan Backward using ix_states_metadata_id_last_updated_ts on states states_1  (cost=0.57..21402.77 rows=555435 width=8)
                       Index Cond: ((metadata_id = states_meta.metadata_id) AND (last_updated_ts < '1734598401.618183'::double precision) AND (last_updated_ts >= '0'::double precision))
(9 rows)
```

after
```
 Nested Loop  (cost=5.09..1004.54 rows=71 width=18)
   ->  Seq Scan on states_meta  (cost=0.18..86.34 rows=71 width=8)
         Filter: (metadata_id = ANY ('{2169,2170,485,661,672,673,753,754,755,756,759,450,463,483,2003,2004,2007,2008,2009,2000,2001,1968,627,569,570,571,572,573,574,591,592,593,634,643,1559,1537,1546,1741,1742,1743,1745,1751,1753,1756,1757,1758,1759,1760,1761,421,2,7,20,12,2118,2120,2135,2137,494,502,511,549,554,561,566,929,935,1313,1314,1315,608}'::bigint[]))
   ->  Index Scan using states_pkey on states  (cost=4.91..12.93 rows=1 width=22)
         Index Cond: (state_id = (SubPlan 1))
         SubPlan 1
           ->  Limit  (cost=0.57..4.34 rows=1 width=16)
                 ->  Index Scan Backward using ix_states_metadata_id_last_updated_ts on states states_1  (cost=0.57..2093980.69 rows=555437 width=16)
                       Index Cond: ((metadata_id = states_meta.metadata_id) AND (last_updated_ts < '1734606683.144284'::double precision) AND (last_updated_ts >= '0'::double precision))
(9 rows)
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
