### PR TITLE
Record Analytics Insights quality scale

### DIFF
--- a/homeassistant/components/analytics_insights/config_flow.py
+++ b/homeassistant/components/analytics_insights/config_flow.py
@@ -11,12 +11,7 @@ from python_homeassistant_analytics import (
 from python_homeassistant_analytics.models import IntegrationType
 import voluptuous as vol
 
-from homeassistant.config_entries import (
-    ConfigEntry,
-    ConfigFlow,
-    ConfigFlowResult,
-    OptionsFlow,
-)
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult, OptionsFlow
 from homeassistant.core import callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.selector import (
@@ -25,6 +20,7 @@ from homeassistant.helpers.selector import (
     SelectSelectorConfig,
 )
 
+from . import AnalyticsInsightsConfigEntry
 from .const import (
     CONF_TRACKED_ADDONS,
     CONF_TRACKED_CUSTOM_INTEGRATIONS,
@@ -46,7 +42,7 @@ class HomeassistantAnalyticsConfigFlow(ConfigFlow, domain=DOMAIN):
     @staticmethod
     @callback
     def async_get_options_flow(
-        config_entry: ConfigEntry,
+        config_entry: AnalyticsInsightsConfigEntry,
     ) -> HomeassistantAnalyticsOptionsFlowHandler:
         """Get the options flow for this handler."""
         return HomeassistantAnalyticsOptionsFlowHandler()

--- a/homeassistant/components/analytics_insights/quality_scale.yaml
+++ b/homeassistant/components/analytics_insights/quality_scale.yaml
@@ -68,7 +68,10 @@ rules:
     comment: |
       This integration has a fixed single service.
   entity-category: done
-  entity-device-class: done
+  entity-device-class:
+    status: exempt
+    comment: |
+      This integration does not have entities with device classes.
   entity-disabled-by-default: done
   entity-translations: done
   exception-translations: todo

--- a/homeassistant/components/analytics_insights/quality_scale.yaml
+++ b/homeassistant/components/analytics_insights/quality_scale.yaml
@@ -1,0 +1,89 @@
+rules:
+  # Bronze
+  action-setup:
+    status: exempt
+    comment: |
+      This integration does not provide additional actions.
+  appropriate-polling: done
+  brands: done
+  common-modules: done
+  config-flow-test-coverage: done
+  config-flow: done
+  dependency-transparency: done
+  docs-actions:
+    status: exempt
+    comment: |
+      This integration does not provide additional actions.
+  docs-high-level-description: todo
+  docs-installation-instructions: todo
+  docs-removal-instructions: todo
+  entity-event-setup:
+    status: exempt
+    comment: |
+      Entities of this integration does not explicitly subscribe to events.
+  entity-unique-id: done
+  has-entity-name: done
+  runtime-data: done
+  test-before-configure: done
+  test-before-setup: done
+  unique-config-entry: done
+
+  # Silver
+  action-exceptions:
+    status: exempt
+    comment: |
+      This integration does not provide actions.
+  config-entry-unloading: done
+  docs-configuration-parameters: todo
+  docs-installation-parameters: todo
+  entity-unavailable: done
+  integration-owner: done
+  log-when-unavailable: done
+  parallel-updates: todo
+  reauthentication-flow:
+    status: exempt
+    comment: |
+      This integration does not require authentication.
+  test-coverage: todo
+  # Gold
+  devices: done
+  diagnostics: todo
+  discovery-update-info:
+    status: exempt
+    comment: |
+      This integration is a cloud service and thus does not support discovery.
+  discovery:
+    status: exempt
+    comment: |
+      This integration is a cloud service and thus does not support discovery.
+  docs-data-update: todo
+  docs-examples: todo
+  docs-known-limitations: todo
+  docs-supported-devices: todo
+  docs-supported-functions: todo
+  docs-troubleshooting: todo
+  docs-use-cases: todo
+  dynamic-devices:
+    status: exempt
+    comment: |
+      This integration has a fixed single service.
+  entity-category: done
+  entity-device-class: done
+  entity-disabled-by-default: done
+  entity-translations: done
+  exception-translations: todo
+  icon-translations: done
+  reconfiguration-flow: todo
+  repair-issues:
+    status: exempt
+    comment: |
+      This integration doesn't have any cases where raising an issue is needed.
+  stale-devices:
+    status: exempt
+    comment: |
+      This integration has a fixed single service.
+
+  # Platinum
+  async-dependency: done
+  inject-websession: done
+  strict-typing: done

--- a/homeassistant/components/analytics_insights/quality_scale.yaml
+++ b/homeassistant/components/analytics_insights/quality_scale.yaml
@@ -37,7 +37,7 @@ rules:
   docs-configuration-parameters: todo
   docs-installation-parameters: todo
   entity-unavailable:
-    status: exempt
+    status: done
     comment: |
       The coordinator handles this.
   integration-owner: done

--- a/homeassistant/components/analytics_insights/quality_scale.yaml
+++ b/homeassistant/components/analytics_insights/quality_scale.yaml
@@ -42,7 +42,7 @@ rules:
       The coordinator handles this.
   integration-owner: done
   log-when-unavailable:
-    status: exempt
+    status: done
     comment: |
       The coordinator handles this.
   parallel-updates: todo

--- a/homeassistant/components/analytics_insights/quality_scale.yaml
+++ b/homeassistant/components/analytics_insights/quality_scale.yaml
@@ -36,9 +36,15 @@ rules:
   config-entry-unloading: done
   docs-configuration-parameters: todo
   docs-installation-parameters: todo
-  entity-unavailable: done
+  entity-unavailable:
+    status: exempt
+    comment: |
+      The coordinator handles this.
   integration-owner: done
-  log-when-unavailable: done
+  log-when-unavailable:
+    status: exempt
+    comment: |
+      The coordinator handles this.
   parallel-updates: todo
   reauthentication-flow:
     status: exempt
@@ -76,7 +82,9 @@ rules:
   entity-translations: done
   exception-translations: todo
   icon-translations: done
-  reconfiguration-flow: todo
+  reconfiguration-flow:
+    status: exempt
+    comment: All the options of this integration are managed via the options flow
   repair-issues:
     status: exempt
     comment: |

--- a/script/hassfest/quality_scale.py
+++ b/script/hassfest/quality_scale.py
@@ -151,7 +151,6 @@ INTEGRATIONS_WITHOUT_QUALITY_SCALE_FILE = [
     "amcrest",
     "ampio",
     "analytics",
-    "analytics_insights",
     "android_ip_webcam",
     "androidtv",
     "androidtv_remote",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Record Analytics Insights quality scale

## Bronze
- [x] `config-flow` - Integration needs to be able to be set up via the UI
    - [x] Uses `data_description` to give context to fields
    - [x] Uses `ConfigEntry.data` and `ConfigEntry.options` correctly
- [x] `test-before-configure` - Test a connection in the config flow
https://github.com/home-assistant/core/blob/245d8fff056f7c059b1c6e75bb096beffdb2a5f1/homeassistant/components/analytics_insights/config_flow.py#L79-L85
- [x] `unique-config-entry` - Don't allow the same device or service to be able to be set up twice
https://github.com/home-assistant/core/blob/201b8d9ebf551367d01be2f7bf850ee3de894ad6/homeassistant/components/analytics_insights/manifest.json#L11
- [x] `config-flow-test-coverage` - Full test coverage for the config flow
```
homeassistant/components/analytics_insights/config_flow.py      52      0   100%
```
- [x] `runtime-data` - Use ConfigEntry.runtime_data to store runtime data
https://github.com/home-assistant/core/blob/44049c34f969a79cad7e992e8bc0a386c4e4b902/homeassistant/components/analytics_insights/__init__.py#L25-L35
- [x] `test-before-setup` - Check during integration initialization if we are able to set it up correctly
https://github.com/home-assistant/core/blob/44049c34f969a79cad7e992e8bc0a386c4e4b902/homeassistant/components/analytics_insights/__init__.py#L39-L42
- [x] `appropriate-polling` - If it's a polling integration, set an appropriate polling interval
https://github.com/home-assistant/core/blob/a95c232f11670fe04e0c518feb25e4038db11c94/homeassistant/components/analytics_insights/coordinator.py#L56
- [x] `entity-unique-id` - Entities have a unique ID
https://github.com/home-assistant/core/blob/a95c232f11670fe04e0c518feb25e4038db11c94/homeassistant/components/analytics_insights/sensor.py#L156
- [x] `has-entity-name` - Entities use has_entity_name = True
https://github.com/home-assistant/core/blob/a95c232f11670fe04e0c518feb25e4038db11c94/homeassistant/components/analytics_insights/sensor.py#L143
- [ ] `entity-event-setup` - Entities event setup
- [x] `dependency-transparency` - Dependency transparency
https://github.com/joostlek/python-homeassistant-analytics
- [ ] `action-setup` - Service actions are registered in async_setup
- [x] `common-modules` - Place common patterns in common modules
Coordinator -> coordinator.py
- [ ] `docs-high-level-description` - The documentation includes a high-level description of the integration brand, product, or service
- [ ] `docs-installation-instructions` - The documentation provides step-by-step installation instructions for the integration, including, if needed, prerequisites
- [ ] `docs-removal-instructions` - The documentation provides removal instructions
- [ ] `docs-actions` - The documentation describes the provided service actions that can be used
- [x] `brands` - Has branding assets available for the integration
We have nice icon

## Silver
- [x] `config-entry-unloading` - Support config entry unloading
https://github.com/home-assistant/core/blob/44049c34f969a79cad7e992e8bc0a386c4e4b902/homeassistant/components/analytics_insights/__init__.py#L63-L67
- [x] `log-when-unavailable` - If internet/device/service is unavailable, log once when unavailable and once when back connected
Coordinator
- [x] `entity-unavailable` - Mark entity unavailable if appropriate
Coordinator
- [ ] `action-exceptions` - Service actions raise exceptions when encountering failures
- [ ] `reauthentication-flow` - Reauthentication flow
- [ ] `parallel-updates` - Set Parallel updates
- [ ] `test-coverage` - Above 95% test coverage for all integration modules
- [x] `integration-owner` - Has an integration owner
It'sa me
- [ ] `docs-installation-parameters` - The documentation describes all integration installation parameters
- [ ] `docs-configuration-parameters` - The documentation describes all integration configuration options

## Gold
- [x] `entity-translations` - Entities have translated names
https://github.com/home-assistant/core/blob/a95c232f11670fe04e0c518feb25e4038db11c94/homeassistant/components/analytics_insights/strings.json#L47-L59
- [ ] `entity-device-class` - Entities use device classes where possible
- [x] `devices` - The integration creates devices
https://github.com/home-assistant/core/blob/a95c232f11670fe04e0c518feb25e4038db11c94/homeassistant/components/analytics_insights/sensor.py#L157-L160
- [x] `entity-category` - Entities are assigned an appropriate EntityCategory
https://github.com/home-assistant/core/blob/a95c232f11670fe04e0c518feb25e4038db11c94/homeassistant/components/analytics_insights/sensor.py#L144
- [x] `entity-disabled-by-default` - Integration disables less popular (or noisy) entities
https://github.com/home-assistant/core/blob/a95c232f11670fe04e0c518feb25e4038db11c94/homeassistant/components/analytics_insights/sensor.py#L74-L91
- [ ] `discovery` - Can be discovered
- [ ] `stale-devices` - Clean up stale devices
- [ ] `diagnostics` - Implements diagnostics
- [ ] `exception-translations` - Exception messages are translatable
- [x] `icon-translations` - Icon translations
https://github.com/home-assistant/core/blob/3184951625d14d9be402fbc284a3fbcdba5c6b99/homeassistant/components/analytics_insights/icons.json#L1-L18
- [ ] `reconfiguration-flow` - Integrations should have a reconfigure flow
- [ ] `dynamic-devices` - Devices added after integration setup
- [ ] `discovery-update-info` - Integration uses discovery info to update network information
- [ ] `repair-issues` - Repair issues and repair flows are used when user intervention is needed
- [ ] `docs-use-cases` - The documentation describes use cases to illustrate how this integration can be used
- [ ] `docs-supported-devices` - The documentation describes known supported / unsupported devices
- [ ] `docs-supported-functions` - The documentation describes the supported functionality, including entities, and platforms
- [ ] `docs-data-update` - The documentation describes how data is updated
- [ ] `docs-known-limitations` - The documentation describes known limitations of the integration (not to be confused with bugs)
- [ ] `docs-troubleshooting` - The documentation provides troubleshooting information
- [ ] `docs-examples` - The documentation provides automation examples the user can use.

## Platinum
- [x] `async-dependency` - Dependency is async
https://github.com/home-assistant/core/blob/44049c34f969a79cad7e992e8bc0a386c4e4b902/homeassistant/components/analytics_insights/__init__.py#L40
- [x] `inject-websession` - The integration dependency supports passing in a websession
https://github.com/home-assistant/core/blob/44049c34f969a79cad7e992e8bc0a386c4e4b902/homeassistant/components/analytics_insights/__init__.py#L37
- [x] `strict-typing` - Strict typing
https://github.com/home-assistant/core/blob/bb2d027532a0b481abf4f3b0536bb8c0d199cafe/.strict-typing#L76



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
