### PR TITLE
Define setpoints as constants in flexit_bacnet

### DIFF
--- a/homeassistant/components/flexit_bacnet/number.py
+++ b/homeassistant/components/flexit_bacnet/number.py
@@ -29,30 +29,29 @@ _MIN_FAN_SETPOINT = 30
 
 @dataclass(kw_only=True, frozen=True)
 class FlexitNumberEntityDescription(NumberEntityDescription):
-    """Describes a Flexit number entity.
-
-    Setpoints for Away, Home and High are dependent of each other. Fireplace and Cooker Hood
-    have setpoints between 0 (MIN_FAN_SETPOINT) and 100 (MAX_FAN_SETPOINT).
-    See the table below for all the setpoints.
-
-    | Mode        | Setpoint | Min                   | Max                   |
-    |:------------|----------|:----------------------|:----------------------|
-    | HOME        | Supply   | AWAY Supply setpoint  | 100                   |
-    | HOME        | Extract  | AWAY Extract setpoint | 100                   |
-    | AWAY        | Supply   | 30                    | HOME Supply setpoint  |
-    | AWAY        | Extract  | 30                    | HOME Extract setpoint |
-    | HIGH        | Supply   | HOME Supply setpoint  | 100                   |
-    | HIGH        | Extract  | HOME Extract setpoint | 100                   |
-    | COOKER_HOOD | Supply   | 30                    | 100                   |
-    | COOKER_HOOD | Extract  | 30                    | 100                   |
-    | FIREPLACE   | Supply   | 30                    | 100                   |
-    | FIREPLACE   | Extract  | 30                    | 100                   |
-    """
+    """Describes a Flexit number entity."""
 
     native_value_fn: Callable[[FlexitBACnet], float]
     native_max_value_fn: Callable[[FlexitBACnet], int]
     native_min_value_fn: Callable[[FlexitBACnet], int]
     set_native_value_fn: Callable[[FlexitBACnet], Callable[[int], Awaitable[None]]]
+
+    # Setpoints for Away, Home and High are dependent of each other. Fireplace and Cooker Hood
+    # have setpoints between 0 (MIN_FAN_SETPOINT) and 100 (MAX_FAN_SETPOINT).
+    # See the table below for all the setpoints.
+    #
+    # | Mode        | Setpoint | Min                   | Max                   |
+    # |:------------|----------|:----------------------|:----------------------|
+    # | HOME        | Supply   | AWAY Supply setpoint  | 100                   |
+    # | HOME        | Extract  | AWAY Extract setpoint | 100                   |
+    # | AWAY        | Supply   | 30                    | HOME Supply setpoint  |
+    # | AWAY        | Extract  | 30                    | HOME Extract setpoint |
+    # | HIGH        | Supply   | HOME Supply setpoint  | 100                   |
+    # | HIGH        | Extract  | HOME Extract setpoint | 100                   |
+    # | COOKER_HOOD | Supply   | 30                    | 100                   |
+    # | COOKER_HOOD | Extract  | 30                    | 100                   |
+    # | FIREPLACE   | Supply   | 30                    | 100                   |
+    # | FIREPLACE   | Extract  | 30                    | 100                   |
 
 
 NUMBERS: tuple[FlexitNumberEntityDescription, ...] = (

--- a/homeassistant/components/flexit_bacnet/number.py
+++ b/homeassistant/components/flexit_bacnet/number.py
@@ -36,22 +36,23 @@ class FlexitNumberEntityDescription(NumberEntityDescription):
     native_min_value_fn: Callable[[FlexitBACnet], int]
     set_native_value_fn: Callable[[FlexitBACnet], Callable[[int], Awaitable[None]]]
 
-    # Setpoints for Away, Home and High are dependent of each other. Fireplace and Cooker Hood
-    # have setpoints between 0 (MIN_FAN_SETPOINT) and 100 (MAX_FAN_SETPOINT).
-    # See the table below for all the setpoints.
-    #
-    # | Mode        | Setpoint | Min                   | Max                   |
-    # |:------------|----------|:----------------------|:----------------------|
-    # | HOME        | Supply   | AWAY Supply setpoint  | 100                   |
-    # | HOME        | Extract  | AWAY Extract setpoint | 100                   |
-    # | AWAY        | Supply   | 30                    | HOME Supply setpoint  |
-    # | AWAY        | Extract  | 30                    | HOME Extract setpoint |
-    # | HIGH        | Supply   | HOME Supply setpoint  | 100                   |
-    # | HIGH        | Extract  | HOME Extract setpoint | 100                   |
-    # | COOKER_HOOD | Supply   | 30                    | 100                   |
-    # | COOKER_HOOD | Extract  | 30                    | 100                   |
-    # | FIREPLACE   | Supply   | 30                    | 100                   |
-    # | FIREPLACE   | Extract  | 30                    | 100                   |
+
+# Setpoints for Away, Home and High are dependent of each other. Fireplace and Cooker Hood
+# have setpoints between 0 (MIN_FAN_SETPOINT) and 100 (MAX_FAN_SETPOINT).
+# See the table below for all the setpoints.
+#
+# | Mode        | Setpoint | Min                   | Max                   |
+# |:------------|----------|:----------------------|:----------------------|
+# | HOME        | Supply   | AWAY Supply setpoint  | 100                   |
+# | HOME        | Extract  | AWAY Extract setpoint | 100                   |
+# | AWAY        | Supply   | 30                    | HOME Supply setpoint  |
+# | AWAY        | Extract  | 30                    | HOME Extract setpoint |
+# | HIGH        | Supply   | HOME Supply setpoint  | 100                   |
+# | HIGH        | Extract  | HOME Extract setpoint | 100                   |
+# | COOKER_HOOD | Supply   | 30                    | 100                   |
+# | COOKER_HOOD | Extract  | 30                    | 100                   |
+# | FIREPLACE   | Supply   | 30                    | 100                   |
+# | FIREPLACE   | Extract  | 30                    | 100                   |
 
 
 NUMBERS: tuple[FlexitNumberEntityDescription, ...] = (

--- a/homeassistant/components/flexit_bacnet/number.py
+++ b/homeassistant/components/flexit_bacnet/number.py
@@ -23,10 +23,31 @@ from . import FlexitCoordinator
 from .const import DOMAIN
 from .entity import FlexitEntity
 
+_MAX_FAN_SETPOINT = 100
+_MIN_FAN_SETPOINT = 30
+
 
 @dataclass(kw_only=True, frozen=True)
 class FlexitNumberEntityDescription(NumberEntityDescription):
-    """Describes a Flexit number entity."""
+    """Describes a Flexit number entity.
+
+    Setpoints for Away, Home and High are dependent of each other. Fireplace and Cooker Hood
+    have setpoints between 0 (MIN_FAN_SETPOINT) and 100 (MAX_FAN_SETPOINT).
+    See the table below for all the setpoints.
+
+    | Mode        | Setpoint | Min                   | Max                   |
+    |:------------|----------|:----------------------|:----------------------|
+    | HOME        | Supply   | AWAY Supply setpoint  | 100                   |
+    | HOME        | Extract  | AWAY Extract setpoint | 100                   |
+    | AWAY        | Supply   | 30                    | HOME Supply setpoint  |
+    | AWAY        | Extract  | 30                    | HOME Extract setpoint |
+    | HIGH        | Supply   | HOME Supply setpoint  | 100                   |
+    | HIGH        | Extract  | HOME Extract setpoint | 100                   |
+    | COOKER_HOOD | Supply   | 30                    | 100                   |
+    | COOKER_HOOD | Extract  | 30                    | 100                   |
+    | FIREPLACE   | Supply   | 30                    | 100                   |
+    | FIREPLACE   | Extract  | 30                    | 100                   |
+    """
 
     native_value_fn: Callable[[FlexitBACnet], float]
     native_max_value_fn: Callable[[FlexitBACnet], int]
@@ -45,7 +66,7 @@ NUMBERS: tuple[FlexitNumberEntityDescription, ...] = (
         set_native_value_fn=lambda device: device.set_fan_setpoint_extract_air_away,
         native_unit_of_measurement=PERCENTAGE,
         native_max_value_fn=lambda device: int(device.fan_setpoint_extract_air_home),
-        native_min_value_fn=lambda _: 30,
+        native_min_value_fn=lambda _: _MIN_FAN_SETPOINT,
     ),
     FlexitNumberEntityDescription(
         key="away_supply_fan_setpoint",
@@ -57,7 +78,7 @@ NUMBERS: tuple[FlexitNumberEntityDescription, ...] = (
         set_native_value_fn=lambda device: device.set_fan_setpoint_supply_air_away,
         native_unit_of_measurement=PERCENTAGE,
         native_max_value_fn=lambda device: int(device.fan_setpoint_supply_air_home),
-        native_min_value_fn=lambda _: 30,
+        native_min_value_fn=lambda _: _MIN_FAN_SETPOINT,
     ),
     FlexitNumberEntityDescription(
         key="cooker_hood_extract_fan_setpoint",
@@ -68,8 +89,8 @@ NUMBERS: tuple[FlexitNumberEntityDescription, ...] = (
         native_value_fn=lambda device: device.fan_setpoint_extract_air_cooker,
         set_native_value_fn=lambda device: device.set_fan_setpoint_extract_air_cooker,
         native_unit_of_measurement=PERCENTAGE,
-        native_max_value_fn=lambda _: 100,
-        native_min_value_fn=lambda _: 30,
+        native_max_value_fn=lambda _: _MAX_FAN_SETPOINT,
+        native_min_value_fn=lambda _: _MIN_FAN_SETPOINT,
     ),
     FlexitNumberEntityDescription(
         key="cooker_hood_supply_fan_setpoint",
@@ -80,8 +101,8 @@ NUMBERS: tuple[FlexitNumberEntityDescription, ...] = (
         native_value_fn=lambda device: device.fan_setpoint_supply_air_cooker,
         set_native_value_fn=lambda device: device.set_fan_setpoint_supply_air_cooker,
         native_unit_of_measurement=PERCENTAGE,
-        native_max_value_fn=lambda _: 100,
-        native_min_value_fn=lambda _: 30,
+        native_max_value_fn=lambda _: _MAX_FAN_SETPOINT,
+        native_min_value_fn=lambda _: _MIN_FAN_SETPOINT,
     ),
     FlexitNumberEntityDescription(
         key="fireplace_extract_fan_setpoint",
@@ -92,8 +113,8 @@ NUMBERS: tuple[FlexitNumberEntityDescription, ...] = (
         native_value_fn=lambda device: device.fan_setpoint_extract_air_fire,
         set_native_value_fn=lambda device: device.set_fan_setpoint_extract_air_fire,
         native_unit_of_measurement=PERCENTAGE,
-        native_max_value_fn=lambda _: 100,
-        native_min_value_fn=lambda _: 30,
+        native_max_value_fn=lambda _: _MAX_FAN_SETPOINT,
+        native_min_value_fn=lambda _: _MIN_FAN_SETPOINT,
     ),
     FlexitNumberEntityDescription(
         key="fireplace_supply_fan_setpoint",
@@ -104,8 +125,8 @@ NUMBERS: tuple[FlexitNumberEntityDescription, ...] = (
         native_value_fn=lambda device: device.fan_setpoint_supply_air_fire,
         set_native_value_fn=lambda device: device.set_fan_setpoint_supply_air_fire,
         native_unit_of_measurement=PERCENTAGE,
-        native_max_value_fn=lambda _: 100,
-        native_min_value_fn=lambda _: 30,
+        native_max_value_fn=lambda _: _MAX_FAN_SETPOINT,
+        native_min_value_fn=lambda _: _MIN_FAN_SETPOINT,
     ),
     FlexitNumberEntityDescription(
         key="high_extract_fan_setpoint",
@@ -116,7 +137,7 @@ NUMBERS: tuple[FlexitNumberEntityDescription, ...] = (
         native_value_fn=lambda device: device.fan_setpoint_extract_air_high,
         set_native_value_fn=lambda device: device.set_fan_setpoint_extract_air_high,
         native_unit_of_measurement=PERCENTAGE,
-        native_max_value_fn=lambda _: 100,
+        native_max_value_fn=lambda _: _MAX_FAN_SETPOINT,
         native_min_value_fn=lambda device: int(device.fan_setpoint_extract_air_home),
     ),
     FlexitNumberEntityDescription(
@@ -128,7 +149,7 @@ NUMBERS: tuple[FlexitNumberEntityDescription, ...] = (
         native_value_fn=lambda device: device.fan_setpoint_supply_air_high,
         set_native_value_fn=lambda device: device.set_fan_setpoint_supply_air_high,
         native_unit_of_measurement=PERCENTAGE,
-        native_max_value_fn=lambda _: 100,
+        native_max_value_fn=lambda _: _MAX_FAN_SETPOINT,
         native_min_value_fn=lambda device: int(device.fan_setpoint_supply_air_home),
     ),
     FlexitNumberEntityDescription(
@@ -140,7 +161,7 @@ NUMBERS: tuple[FlexitNumberEntityDescription, ...] = (
         native_value_fn=lambda device: device.fan_setpoint_extract_air_home,
         set_native_value_fn=lambda device: device.set_fan_setpoint_extract_air_home,
         native_unit_of_measurement=PERCENTAGE,
-        native_max_value_fn=lambda _: 100,
+        native_max_value_fn=lambda _: _MAX_FAN_SETPOINT,
         native_min_value_fn=lambda device: int(device.fan_setpoint_extract_air_away),
     ),
     FlexitNumberEntityDescription(
@@ -152,7 +173,7 @@ NUMBERS: tuple[FlexitNumberEntityDescription, ...] = (
         native_value_fn=lambda device: device.fan_setpoint_supply_air_home,
         set_native_value_fn=lambda device: device.set_fan_setpoint_supply_air_home,
         native_unit_of_measurement=PERCENTAGE,
-        native_max_value_fn=lambda _: 100,
+        native_max_value_fn=lambda _: _MAX_FAN_SETPOINT,
         native_min_value_fn=lambda device: int(device.fan_setpoint_supply_air_away),
     ),
 )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

Define max and min values as constants. Add inline comment with explanation for fan setpoint dependencies.


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
