### PR TITLE
Record Knocki quality scale

### DIFF
--- a/homeassistant/components/knocki/quality_scale.yaml
+++ b/homeassistant/components/knocki/quality_scale.yaml
@@ -1,0 +1,84 @@
+rules:
+  # Bronze
+  action-setup:
+    status: exempt
+    comment: |
+      This integration does not provide additional actions.
+  appropriate-polling:
+    status: exempt
+    comment: |
+      This integration is push-based.
+  brands: done
+  common-modules: done
+  config-flow-test-coverage: done
+  config-flow:
+    status: todo
+    comment: data_descriptions are missing
+  dependency-transparency: done
+  docs-actions:
+    status: exempt
+    comment: |
+      This integration does not provide additional actions.
+  docs-high-level-description: todo
+  docs-installation-instructions: todo
+  docs-removal-instructions: todo
+  entity-event-setup: done
+  entity-unique-id: done
+  has-entity-name: done
+  runtime-data: done
+  test-before-configure: done
+  test-before-setup: done
+  unique-config-entry: done
+
+  # Silver
+  action-exceptions:
+    status: exempt
+    comment: |
+      This integration does not provide actions.
+  config-entry-unloading: done
+  docs-configuration-parameters: todo
+  docs-installation-parameters: todo
+  entity-unavailable: done
+  integration-owner: done
+  log-when-unavailable: done
+  parallel-updates: todo
+  reauthentication-flow: todo
+  test-coverage: done
+  # Gold
+  devices: done
+  diagnostics: todo
+  discovery-update-info:
+    status: exempt
+    comment: This is a cloud service and does not benefit from device updates.
+  discovery: todo
+  docs-data-update: todo
+  docs-examples: todo
+  docs-known-limitations: todo
+  docs-supported-devices: todo
+  docs-supported-functions: todo
+  docs-troubleshooting: todo
+  docs-use-cases: todo
+  dynamic-devices: done
+  entity-category: done
+  entity-device-class: done
+  entity-disabled-by-default: done
+  entity-translations:
+    status: done
+    comment: |
+      This integration does not have any entities.
+  exception-translations: todo
+  icon-translations: done
+  reconfiguration-flow: todo
+  repair-issues:
+    status: exempt
+    comment: |
+      This integration doesn't have any cases where raising an issue is needed.
+  stale-devices:
+    status: exempt
+    comment: |
+      This integration has a fixed single device.
+
+  # Platinum
+  async-dependency: done
+  inject-websession: done
+  strict-typing: done

--- a/homeassistant/components/knocki/quality_scale.yaml
+++ b/homeassistant/components/knocki/quality_scale.yaml
@@ -36,7 +36,10 @@ rules:
     comment: |
       This integration does not provide actions.
   config-entry-unloading: done
-  docs-configuration-parameters: todo
+  docs-configuration-parameters:
+    status: exempt
+    comment: |
+      This integration does not have any configuration parameters.
   docs-installation-parameters: todo
   entity-unavailable: todo
   integration-owner: done

--- a/homeassistant/components/knocki/quality_scale.yaml
+++ b/homeassistant/components/knocki/quality_scale.yaml
@@ -19,8 +19,8 @@ rules:
     status: exempt
     comment: |
       This integration does not provide additional actions.
-  docs-high-level-description: todo
-  docs-installation-instructions: todo
+  docs-high-level-description: done
+  docs-installation-instructions: done
   docs-removal-instructions: todo
   entity-event-setup: done
   entity-unique-id: done
@@ -38,9 +38,9 @@ rules:
   config-entry-unloading: done
   docs-configuration-parameters: todo
   docs-installation-parameters: todo
-  entity-unavailable: done
+  entity-unavailable: todo
   integration-owner: done
-  log-when-unavailable: done
+  log-when-unavailable: todo
   parallel-updates: todo
   reauthentication-flow: todo
   test-coverage: done
@@ -59,13 +59,22 @@ rules:
   docs-troubleshooting: todo
   docs-use-cases: todo
   dynamic-devices: done
-  entity-category: done
-  entity-device-class: done
-  entity-disabled-by-default: done
-  entity-translations:
-    status: done
+  entity-category:
+    status: exempt
     comment: |
-      This integration does not have any entities.
+      The default ones are good.
+  entity-device-class:
+    status: exempt
+    comment: |
+      Knocki does not have a device class.
+  entity-disabled-by-default:
+    status: exempt
+    comment: |
+      This integration does not have any entities that are disabled by default.
+  entity-translations:
+    status: exempt
+    comment: |
+      This integration does not have any translatable entities.
   exception-translations: todo
   icon-translations: done
   reconfiguration-flow: todo
@@ -73,11 +82,7 @@ rules:
     status: exempt
     comment: |
       This integration doesn't have any cases where raising an issue is needed.
-  stale-devices:
-    status: exempt
-    comment: |
-      This integration has a fixed single device.
-
+  stale-devices: todo
   # Platinum
   async-dependency: done
   inject-websession: done

--- a/script/hassfest/quality_scale.py
+++ b/script/hassfest/quality_scale.py
@@ -563,7 +563,6 @@ INTEGRATIONS_WITHOUT_QUALITY_SCALE_FILE = [
     "kitchen_sink",
     "kiwi",
     "kmtronic",
-    "knocki",
     "knx",
     "kodi",
     "konnected",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Record Knocki quality scale

## Bronze
- [ ] `config-flow` - Integration needs to be able to be set up via the UI
    - [ ] Uses `data_description` to give context to fields
    - [ ] Uses `ConfigEntry.data` and `ConfigEntry.options` correctly
- [x] `test-before-configure` - Test a connection in the config flow
https://github.com/home-assistant/core/blob/924e767736bb657d092523cc4335485d54960d3e/homeassistant/components/knocki/config_flow.py#L36-L38
- [x] `unique-config-entry` - Don't allow the same device or service to be able to be set up twice
https://github.com/home-assistant/core/blob/924e767736bb657d092523cc4335485d54960d3e/homeassistant/components/knocki/config_flow.py#L39-L40
- [x] `config-flow-test-coverage` - Full test coverage for the config flow
```
homeassistant/components/knocki/config_flow.py      32      0   100%
```
- [x] `runtime-data` - Use ConfigEntry.runtime_data to store runtime data
https://github.com/home-assistant/core/blob/d88f6dc6b96a8624acbacccf58b5832412c16439/homeassistant/components/knocki/__init__.py#L16
- [x] `test-before-setup` - Check during integration initialization if we are able to set it up correctly
https://github.com/home-assistant/core/blob/d88f6dc6b96a8624acbacccf58b5832412c16439/homeassistant/components/knocki/__init__.py#L25-L27
- [ ] `appropriate-polling` - If it's a polling integration, set an appropriate polling interval
- [x] `entity-unique-id` - Entities have a unique ID
https://github.com/home-assistant/core/blob/4f7c6bdce87eb1b501fc83ef1c098f2fa4baa2b1/homeassistant/components/knocki/event.py#L65
- [x] `has-entity-name` - Entities use has_entity_name = True
https://github.com/home-assistant/core/blob/4f7c6bdce87eb1b501fc83ef1c098f2fa4baa2b1/homeassistant/components/knocki/event.py#L50
- [x] `entity-event-setup` - Entities event setup
https://github.com/home-assistant/core/blob/4f7c6bdce87eb1b501fc83ef1c098f2fa4baa2b1/homeassistant/components/knocki/event.py#L67-L72
- [x] `dependency-transparency` - Dependency transparency
https://github.com/swan-solutions/knocki-homeassistant
- [ ] `action-setup` - Service actions are registered in async_setup
- [x] `common-modules` - Place common patterns in common modules
Coordinator -> coordinator.py
- [x] `docs-high-level-description` - The documentation includes a high-level description of the integration brand, product, or service
- [x] `docs-installation-instructions` - The documentation provides step-by-step installation instructions for the integration, including, if needed, prerequisites
- [ ] `docs-removal-instructions` - The documentation provides removal instructions
- [ ] `docs-actions` - The documentation describes the provided service actions that can be used
- [x] `brands` - Has branding assets available for the integration

## Silver
- [x] `config-entry-unloading` - Support config entry unloading
https://github.com/home-assistant/core/blob/d88f6dc6b96a8624acbacccf58b5832412c16439/homeassistant/components/knocki/__init__.py#L49-L52
- [ ] `log-when-unavailable` - If internet/device/service is unavailable, log once when unavailable and once when back connected
- [ ] `entity-unavailable` - Mark entity unavailable if appropriate
- [ ] `action-exceptions` - Service actions raise exceptions when encountering failures
- [ ] `reauthentication-flow` - Reauthentication flow
- [ ] `parallel-updates` - Set Parallel updates
- [x] `test-coverage` - Above 95% test coverage for all integration modules
```
---------- coverage: platform darwin, python 3.12.2-final-0 ----------
Name                                             Stmts   Miss  Cover   Missing
------------------------------------------------------------------------------
homeassistant/components/knocki/__init__.py         24      0   100%
homeassistant/components/knocki/config_flow.py      32      0   100%
homeassistant/components/knocki/const.py             3      0   100%
homeassistant/components/knocki/coordinator.py      32      0   100%
homeassistant/components/knocki/event.py            38      0   100%
------------------------------------------------------------------------------
TOTAL                                              129      0   100%
```

- [x] `integration-owner` - Has an integration owner
Itsa me, and some others
- [ ] `docs-installation-parameters` - The documentation describes all integration installation parameters
- [ ] `docs-configuration-parameters` - The documentation describes all integration configuration options

## Gold
- [ ] `entity-translations` - Entities have translated names
- [ ] `entity-device-class` - Entities use device classes where possible
- [x] `devices` - The integration creates devices
https://github.com/home-assistant/core/blob/4f7c6bdce87eb1b501fc83ef1c098f2fa4baa2b1/homeassistant/components/knocki/event.py#L59-L64
- [ ] `entity-category` - Entities are assigned an appropriate EntityCategory
- [ ] `entity-disabled-by-default` - Integration disables less popular (or noisy) entities
- [ ] `discovery` - Can be discovered
- [ ] `stale-devices` - Clean up stale devices
- [ ] `diagnostics` - Implements diagnostics
- [ ] `exception-translations` - Exception messages are translatable
- [ ] `icon-translations` - Icon translations
- [ ] `reconfiguration-flow` - Integrations should have a reconfigure flow
- [x] `dynamic-devices` - Devices added after integration setup
https://github.com/home-assistant/core/blob/4f7c6bdce87eb1b501fc83ef1c098f2fa4baa2b1/homeassistant/components/knocki/event.py#L24-L33
- [ ] `discovery-update-info` - Integration uses discovery info to update network information
- [ ] `repair-issues` - Repair issues and repair flows are used when user intervention is needed
- [ ] `docs-use-cases` - The documentation describes use cases to illustrate how this integration can be used
- [ ] `docs-supported-devices` - The documentation describes known supported / unsupported devices
- [ ] `docs-supported-functions` - The documentation describes the supported functionality, including entities, and platforms
- [ ] `docs-data-update` - The documentation describes how data is updated
- [ ] `docs-known-limitations` - The documentation describes known limitations of the integration (not to be confused with bugs)
- [ ] `docs-troubleshooting` - The documentation provides troubleshooting information
- [x] `docs-examples` - The documentation provides automation examples the user can use.

## Platinum
- [x] `async-dependency` - Dependency is async
https://github.com/home-assistant/core/blob/bc363c385fb487415ff1bad36e3e297c95984684/homeassistant/components/knocki/coordinator.py#L28
- [x] `inject-websession` - The integration dependency supports passing in a websession
https://github.com/home-assistant/core/blob/d88f6dc6b96a8624acbacccf58b5832412c16439/homeassistant/components/knocki/__init__.py#L21-L23
- [x] `strict-typing` - Strict typing
https://github.com/home-assistant/core/blob/bb2d027532a0b481abf4f3b0536bb8c0d199cafe/.strict-typing#L281


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
