### PR TITLE
Record Mealie quality scale

### DIFF
--- a/homeassistant/components/mealie/quality_scale.yaml
+++ b/homeassistant/components/mealie/quality_scale.yaml
@@ -45,11 +45,11 @@ rules:
     status: exempt
     comment: This is a self-hosted service without a way to discover.
   discovery: todo
-  docs-data-update: todo
+  docs-data-update: done
   docs-examples: done
   docs-known-limitations: todo
   docs-supported-devices: todo
-  docs-supported-functions: todo
+  docs-supported-functions: done
   docs-troubleshooting: todo
   docs-use-cases: todo
   dynamic-devices:

--- a/homeassistant/components/mealie/quality_scale.yaml
+++ b/homeassistant/components/mealie/quality_scale.yaml
@@ -5,7 +5,7 @@ rules:
   brands: done
   common-modules: done
   config-flow-test-coverage: done
-  config-flow: todo
+  config-flow: done
   dependency-transparency: done
   docs-actions: done
   docs-high-level-description: todo

--- a/homeassistant/components/mealie/quality_scale.yaml
+++ b/homeassistant/components/mealie/quality_scale.yaml
@@ -1,0 +1,81 @@
+rules:
+  # Bronze
+  action-setup: done
+  appropriate-polling: done
+  brands: done
+  common-modules: done
+  config-flow-test-coverage: done
+  config-flow: todo
+  dependency-transparency: done
+  docs-actions: done
+  docs-high-level-description: todo
+  docs-installation-instructions: done
+  docs-removal-instructions: done
+  entity-event-setup:
+    status: exempt
+    comment: |
+      Entities of this integration does not explicitly subscribe to events.
+  entity-unique-id: done
+  has-entity-name: done
+  runtime-data: done
+  test-before-configure: done
+  test-before-setup: done
+  unique-config-entry: done
+
+  # Silver
+  action-exceptions: done
+  config-entry-unloading: done
+  docs-configuration-parameters:
+    status: exempt
+    comment: |
+      This integration does not have any configuration parameters.
+  docs-installation-parameters: done
+  entity-unavailable: done
+  integration-owner: done
+  log-when-unavailable: done
+  parallel-updates: todo
+  reauthentication-flow: done
+  test-coverage:
+    status: todo
+    comment: Platform missing tests
+  # Gold
+  devices: done
+  diagnostics: done
+  discovery-update-info:
+    status: exempt
+    comment: This is a self-hosted service without a way to discover.
+  discovery: todo
+  docs-data-update: todo
+  docs-examples: done
+  docs-known-limitations: todo
+  docs-supported-devices: todo
+  docs-supported-functions: todo
+  docs-troubleshooting: todo
+  docs-use-cases: todo
+  dynamic-devices:
+    status: done
+    comment: |
+      The integration adds new todo lists on runtime.
+  entity-category: done
+  entity-device-class: done
+  entity-disabled-by-default:
+    status: exempt
+    comment: |
+      This integration does not have any irrelevant entities.
+  entity-translations: done
+  exception-translations: todo
+  icon-translations: done
+  reconfiguration-flow: done
+  repair-issues:
+    status: exempt
+    comment: |
+      This integration doesn't have any cases where raising an issue is needed.
+  stale-devices:
+    status: done
+    comment: |
+      The integration removes removed todo lists on runtime.
+
+  # Platinum
+  async-dependency: done
+  inject-websession: done
+  strict-typing: todo

--- a/homeassistant/components/mealie/quality_scale.yaml
+++ b/homeassistant/components/mealie/quality_scale.yaml
@@ -41,9 +41,7 @@ rules:
   # Gold
   devices: done
   diagnostics: done
-  discovery-update-info:
-    status: exempt
-    comment: This is a self-hosted service without a way to discover.
+  discovery-update-info: todo
   discovery: todo
   docs-data-update: done
   docs-examples: done

--- a/homeassistant/components/mealie/quality_scale.yaml
+++ b/homeassistant/components/mealie/quality_scale.yaml
@@ -8,7 +8,7 @@ rules:
   config-flow: done
   dependency-transparency: done
   docs-actions: done
-  docs-high-level-description: todo
+  docs-high-level-description: done
   docs-installation-instructions: done
   docs-removal-instructions: done
   entity-event-setup:

--- a/script/hassfest/quality_scale.py
+++ b/script/hassfest/quality_scale.py
@@ -632,7 +632,6 @@ INTEGRATIONS_WITHOUT_QUALITY_SCALE_FILE = [
     "matter",
     "maxcube",
     "mazda",
-    "mealie",
     "meater",
     "medcom_ble",
     "media_extractor",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Record Mealie quality scale

## Bronze
- [ ] `config-flow` - Integration needs to be able to be set up via the UI
    - [ ] Uses `data_description` to give context to fields
    - [ ] Uses `ConfigEntry.data` and `ConfigEntry.options` correctly
- [x] `test-before-configure` - Test a connection in the config flow
https://github.com/home-assistant/core/blob/132a8cc31b4da5ef9bb6926c7c5f97f51c1e960b/homeassistant/components/mealie/config_flow.py#L51-L53
- [x] `unique-config-entry` - Don't allow the same device or service to be able to be set up twice
https://github.com/home-assistant/core/blob/132a8cc31b4da5ef9bb6926c7c5f97f51c1e960b/homeassistant/components/mealie/config_flow.py#L77-L78
- [x] `config-flow-test-coverage` - Full test coverage for the config flow
```
homeassistant/components/mealie/config_flow.py      68      0   100%
```
- [x] `runtime-data` - Use ConfigEntry.runtime_data to store runtime data
https://github.com/home-assistant/core/blob/8d01ad98ebf43054387354878a5ab258059bbd05/homeassistant/components/mealie/coordinator.py#L31-L41
- [x] `test-before-setup` - Check during integration initialization if we are able to set it up correctly
https://github.com/home-assistant/core/blob/adf25b427b972caf6079403c5e1532d854c1c97b/homeassistant/components/mealie/__init__.py#L50-L57
- [x] `appropriate-polling` - If it's a polling integration, set an appropriate polling interval
  - Mealplan is updated every hour
  - Shopping list every 5 minutes
  - Statistics every 15 minutes
- [x] `entity-unique-id` - Entities have a unique ID
https://github.com/home-assistant/core/blob/898803abe9eae9ed24f8024d7226e5a12968a103/homeassistant/components/mealie/entity.py#L20
- [x] `has-entity-name` - Entities use has_entity_name = True
https://github.com/home-assistant/core/blob/898803abe9eae9ed24f8024d7226e5a12968a103/homeassistant/components/mealie/entity.py#L13
- [ ] `entity-event-setup` - Entities event setup
- [x] `dependency-transparency` - Dependency transparency
https://github.com/joostlek/python-mealie
- [x] `action-setup` - Service actions are registered in async_setup
https://github.com/home-assistant/core/blob/adf25b427b972caf6079403c5e1532d854c1c97b/homeassistant/components/mealie/__init__.py#L35-L38
- [x] `common-modules` - Place common patterns in common modules
Entity is in entity.py
Coordinator is in coordinator.py
- [ ] `docs-high-level-description` - The documentation includes a high-level description of the integration brand, product, or service
- [x] `docs-installation-instructions` - The documentation provides step-by-step installation instructions for the integration, including, if needed, prerequisites
- [x] `docs-removal-instructions` - The documentation provides removal instructions
- [x] `docs-actions` - The documentation describes the provided service actions that can be used
- [x] `brands` - Has branding assets available for the integration

## Silver
- [x] `config-entry-unloading` - Support config entry unloading
https://github.com/home-assistant/core/blob/adf25b427b972caf6079403c5e1532d854c1c97b/homeassistant/components/mealie/__init__.py#L100-L102
- [ ] `log-when-unavailable` - If internet/device/service is unavailable, log once when unavailable and once when back connected
- [ ] `entity-unavailable` - Mark entity unavailable if appropriate
- [x] `action-exceptions` - Service actions raise exceptions when encountering failures
https://github.com/home-assistant/core/blob/7ec41275d5b3a6246cdfad062731783eb6eb13ce/homeassistant/components/mealie/services.py#L103-L115
- [x] `reauthentication-flow` - Reauthentication flow
- [ ] `parallel-updates` - Set Parallel updates
- [ ] `test-coverage` - Above 95% test coverage for all integration modules
- [x] `integration-owner` - Has an integration owner
- [x] `docs-installation-parameters` - The documentation describes all integration installation parameters
- [ ] `docs-configuration-parameters` - The documentation describes all integration configuration options

## Gold
- [x] `entity-translations` - Entities have translated names
https://github.com/home-assistant/core/blob/132a8cc31b4da5ef9bb6926c7c5f97f51c1e960b/homeassistant/components/mealie/strings.json#L43-L80
- [ ] `entity-device-class` - Entities use device classes where possible
- [x] `devices` - The integration creates devices
https://github.com/home-assistant/core/blob/adf25b427b972caf6079403c5e1532d854c1c97b/homeassistant/components/mealie/__init__.py#L76-L81
- [x] `entity-category` - Entities are assigned an appropriate EntityCategory
- [ ] `entity-disabled-by-default` - Integration disables less popular (or noisy) entities
- [ ] `discovery` - Can be discovered
- [x] `stale-devices` - Clean up stale devices
https://github.com/home-assistant/core/blob/73475aa6756adcc1c414b5e6ba633d587e7ff481/homeassistant/components/mealie/todo.py#L57-L65
- [x] `diagnostics` - Implements diagnostics
- [x] `exception-translations` - Exception messages are translatable
https://github.com/home-assistant/core/blob/132a8cc31b4da5ef9bb6926c7c5f97f51c1e960b/homeassistant/components/mealie/strings.json#L81-L114
- [x] `icon-translations` - Icon translations
https://github.com/home-assistant/core/blob/cffa8b4febfb39124153d5cac38ed8399a4bd53c/homeassistant/components/mealie/icons.json#L2-L25
- [x] `reconfiguration-flow` - Integrations should have a reconfigure flow
- [x] `dynamic-devices` - Devices added after integration setup
https://github.com/home-assistant/core/blob/73475aa6756adcc1c414b5e6ba633d587e7ff481/homeassistant/components/mealie/todo.py#L67-L79
- [ ] `discovery-update-info` - Integration uses discovery info to update network information
- [ ] `repair-issues` - Repair issues and repair flows are used when user intervention is needed
- [ ] `docs-use-cases` - The documentation describes use cases to illustrate how this integration can be used
- [ ] `docs-supported-devices` - The documentation describes known supported / unsupported devices
- [ ] `docs-supported-functions` - The documentation describes the supported functionality, including entities, and platforms
- [ ] `docs-data-update` - The documentation describes how data is updated
- [ ] `docs-known-limitations` - The documentation describes known limitations of the integration (not to be confused with bugs)
- [ ] `docs-troubleshooting` - The documentation provides troubleshooting information
- [x] `docs-examples` - The documentation provides automation examples the user can use.

## Platinum
- [x] `async-dependency` - Dependency is async
https://github.com/home-assistant/core/blob/adf25b427b972caf6079403c5e1532d854c1c97b/homeassistant/components/mealie/__init__.py#L50-L57
- [x] `inject-websession` - The integration dependency supports passing in a websession
https://github.com/home-assistant/core/blob/adf25b427b972caf6079403c5e1532d854c1c97b/homeassistant/components/mealie/__init__.py#L43-L49
- [ ] `strict-typing` - Strict typing



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
