### PR TITLE
Record NYT Games quality scale

### DIFF
--- a/homeassistant/components/nyt_games/quality_scale.yaml
+++ b/homeassistant/components/nyt_games/quality_scale.yaml
@@ -42,7 +42,7 @@ rules:
       This is handled by the coordinator.
   integration-owner: done
   log-when-unavailable:
-    status: exempt
+    status: done
     comment: |
       This is handled by the coordinator.
   parallel-updates: todo
@@ -67,7 +67,10 @@ rules:
   docs-troubleshooting: todo
   docs-use-cases: todo
   dynamic-devices: todo
-  entity-category: done
+  entity-category:
+    status: done
+    comment: |
+      The entities are categorized well by using default category.
   entity-device-class: done
   entity-disabled-by-default: done
   entity-translations: done

--- a/homeassistant/components/nyt_games/quality_scale.yaml
+++ b/homeassistant/components/nyt_games/quality_scale.yaml
@@ -66,10 +66,7 @@ rules:
   docs-supported-functions: todo
   docs-troubleshooting: todo
   docs-use-cases: todo
-  dynamic-devices:
-    status: exempt
-    comment: |
-      This integration has a fixed device per game type.
+  dynamic-devices: todo
   entity-category: done
   entity-device-class: done
   entity-disabled-by-default: done
@@ -84,7 +81,7 @@ rules:
   stale-devices:
     status: exempt
     comment: |
-      This integration has a fixed device per game type.
+      Games can't be "unplayed".
 
   # Platinum
   async-dependency: done

--- a/homeassistant/components/nyt_games/quality_scale.yaml
+++ b/homeassistant/components/nyt_games/quality_scale.yaml
@@ -1,0 +1,92 @@
+rules:
+  # Bronze
+  action-setup:
+    status: exempt
+    comment: |
+      This integration does not provide additional actions.
+  appropriate-polling: done
+  brands: done
+  common-modules: done
+  config-flow-test-coverage: done
+  config-flow: done
+  dependency-transparency: done
+  docs-actions:
+    status: exempt
+    comment: |
+      This integration does not provide additional actions.
+  docs-high-level-description: todo
+  docs-installation-instructions: todo
+  docs-removal-instructions: todo
+  entity-event-setup:
+    status: exempt
+    comment: |
+      Entities of this integration does not explicitly subscribe to events.
+  entity-unique-id: done
+  has-entity-name: done
+  runtime-data: done
+  test-before-configure: done
+  test-before-setup: done
+  unique-config-entry: done
+
+  # Silver
+  action-exceptions:
+    status: exempt
+    comment: |
+      This integration does not provide additional actions.
+  config-entry-unloading: done
+  docs-configuration-parameters: todo
+  docs-installation-parameters: todo
+  entity-unavailable:
+    status: exempt
+    comment: |
+      This is handled by the coordinator.
+  integration-owner: done
+  log-when-unavailable:
+    status: exempt
+    comment: |
+      This is handled by the coordinator.
+  parallel-updates: todo
+  reauthentication-flow: todo
+  test-coverage: done
+  # Gold
+  devices: done
+  diagnostics: todo
+  discovery-update-info:
+    status: exempt
+    comment: |
+      This integration is a service and not discoverable.
+  discovery:
+    status: exempt
+    comment: |
+      This integration is a service and not discoverable.
+  docs-data-update: todo
+  docs-examples: todo
+  docs-known-limitations: todo
+  docs-supported-devices: todo
+  docs-supported-functions: todo
+  docs-troubleshooting: todo
+  docs-use-cases: todo
+  dynamic-devices:
+    status: exempt
+    comment: |
+      This integration has a fixed device per game type.
+  entity-category: done
+  entity-device-class: done
+  entity-disabled-by-default: done
+  entity-translations: done
+  exception-translations: todo
+  icon-translations: done
+  reconfiguration-flow: todo
+  repair-issues:
+    status: exempt
+    comment: |
+      This integration doesn't have any cases where raising an issue is needed.
+  stale-devices:
+    status: exempt
+    comment: |
+      This integration has a fixed device per game type.
+
+  # Platinum
+  async-dependency: done
+  inject-websession: done
+  strict-typing: todo

--- a/script/hassfest/quality_scale.py
+++ b/script/hassfest/quality_scale.py
@@ -735,7 +735,6 @@ INTEGRATIONS_WITHOUT_QUALITY_SCALE_FILE = [
     "nut",
     "nws",
     "nx584",
-    "nyt_games",
     "nzbget",
     "oasa_telematics",
     "obihai",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Record NYT Games quality scale

## Bronze
- [x] `config-flow` - Integration needs to be able to be set up via the UI
    - [x] Uses `data_description` to give context to fields
    - [x] Uses `ConfigEntry.data` and `ConfigEntry.options` correctly
- [x] `test-before-configure` - Test a connection in the config flow
https://github.com/home-assistant/core/blob/ebfa2fb1d0dda7480b6898e432c6a0e5001d0c4b/homeassistant/components/nyt_games/config_flow.py#L28
- [x] `unique-config-entry` - Don't allow the same device or service to be able to be set up twice
https://github.com/home-assistant/core/blob/ebfa2fb1d0dda7480b6898e432c6a0e5001d0c4b/homeassistant/components/nyt_games/config_flow.py#L37-L38
- [x] `config-flow-test-coverage` - Full test coverage for the config flow
```
homeassistant/components/nyt_games/config_flow.py      27      0   100%
```
- [x] `runtime-data` - Use ConfigEntry.runtime_data to store runtime data
https://github.com/home-assistant/core/blob/ae8219dc9742b1718938cfb1adee4b0286a6a04b/homeassistant/components/nyt_games/__init__.py#L19
- [x] `test-before-setup` - Check during integration initialization if we are able to set it up correctly
https://github.com/home-assistant/core/blob/ebfa2fb1d0dda7480b6898e432c6a0e5001d0c4b/homeassistant/components/nyt_games/config_flow.py#L28
- [x] `appropriate-polling` - If it's a polling integration, set an appropriate polling interval
https://github.com/home-assistant/core/blob/32570c59c8ac787a5d0c65fb657a3ecf73536ea8/homeassistant/components/nyt_games/coordinator.py#L40
- [x] `entity-unique-id` - Entities have a unique ID
https://github.com/home-assistant/core/blob/fbe35e6e6bd7c48e207abaa122a6ba09fc079a9c/homeassistant/components/nyt_games/sensor.py#L187
https://github.com/home-assistant/core/blob/fbe35e6e6bd7c48e207abaa122a6ba09fc079a9c/homeassistant/components/nyt_games/sensor.py#L210
https://github.com/home-assistant/core/blob/fbe35e6e6bd7c48e207abaa122a6ba09fc079a9c/homeassistant/components/nyt_games/sensor.py#L234
- [x] `has-entity-name` - Entities use has_entity_name = True
https://github.com/home-assistant/core/blob/c5d562a56fbb89287732b584bae3ca445ef99c2e/homeassistant/components/nyt_games/entity.py#L10-L13
- [ ] `entity-event-setup` - Entities event setup
- [x] `dependency-transparency` - Dependency transparency
https://github.com/joostlek/python-nyt-games
- [ ] `action-setup` - Service actions are registered in async_setup
- [x] `common-modules` - Place common patterns in common modules
Coordinator in coordinator.py and entity in entity.py
- [ ] `docs-high-level-description` - The documentation includes a high-level description of the integration brand, product, or service
- [ ] `docs-installation-instructions` - The documentation provides step-by-step installation instructions for the integration, including, if needed, prerequisites
- [ ] `docs-removal-instructions` - The documentation provides removal instructions
- [ ] `docs-actions` - The documentation describes the provided service actions that can be used
- [x] `brands` - Has branding assets available for the integration

## Silver
- [x] `config-entry-unloading` - Support config entry unloading
https://github.com/home-assistant/core/blob/ae8219dc9742b1718938cfb1adee4b0286a6a04b/homeassistant/components/nyt_games/__init__.py#L40-L42
- [ ] `log-when-unavailable` - If internet/device/service is unavailable, log once when unavailable and once when back connected
- [ ] `entity-unavailable` - Mark entity unavailable if appropriate
- [ ] `action-exceptions` - Service actions raise exceptions when encountering failures
- [ ] `reauthentication-flow` - Reauthentication flow
- [ ] `parallel-updates` - Set Parallel updates
- [x] `test-coverage` - Above 95% test coverage for all integration modules
```
---------- coverage: platform darwin, python 3.12.2-final-0 ----------
Name                                                Stmts   Miss  Cover   Missing
---------------------------------------------------------------------------------
homeassistant/components/nyt_games/__init__.py         18      0   100%
homeassistant/components/nyt_games/config_flow.py      27      0   100%
homeassistant/components/nyt_games/const.py             3      0   100%
homeassistant/components/nyt_games/coordinator.py      25      0   100%
homeassistant/components/nyt_games/entity.py           24      0   100%
homeassistant/components/nyt_games/sensor.py           61      0   100%
---------------------------------------------------------------------------------
TOTAL                                                 158      0   100%
```
- [x] `integration-owner` - Has an integration owner
Itsa me
- [ ] `docs-installation-parameters` - The documentation describes all integration installation parameters
- [ ] `docs-configuration-parameters` - The documentation describes all integration configuration options

## Gold
- [x] `entity-translations` - Entities have translated names
https://github.com/home-assistant/core/blob/c5d562a56fbb89287732b584bae3ca445ef99c2e/homeassistant/components/nyt_games/strings.json#L21-L52
- [x] `entity-device-class` - Entities use device classes where possible
https://github.com/home-assistant/core/blob/fbe35e6e6bd7c48e207abaa122a6ba09fc079a9c/homeassistant/components/nyt_games/sensor.py#L125-L141
- [x] `devices` - The integration creates devices
https://github.com/home-assistant/core/blob/c5d562a56fbb89287732b584bae3ca445ef99c2e/homeassistant/components/nyt_games/entity.py#L24-L61
- [x] `entity-category` - Entities are assigned an appropriate EntityCategory
- [x] `entity-disabled-by-default` - Integration disables less popular (or noisy) entities
- [ ] `discovery` - Can be discovered
- [ ] `stale-devices` - Clean up stale devices
- [ ] `diagnostics` - Implements diagnostics
- [ ] `exception-translations` - Exception messages are translatable
- [x] `icon-translations` - Icon translations
https://github.com/home-assistant/core/blob/2a0ad201883b5a2a7a548e1e165457975e7961b8/homeassistant/components/nyt_games/icons.json#L1-L33
- [ ] `reconfiguration-flow` - Integrations should have a reconfigure flow
- [ ] `dynamic-devices` - Devices added after integration setup
- [ ] `discovery-update-info` - Integration uses discovery info to update network information
- [ ] `repair-issues` - Repair issues and repair flows are used when user intervention is needed
- [ ] `docs-use-cases` - The documentation describes use cases to illustrate how this integration can be used
- [ ] `docs-supported-devices` - The documentation describes known supported / unsupported devices
- [ ] `docs-supported-functions` - The documentation describes the supported functionality, including entities, and platforms
- [ ] `docs-data-update` - The documentation describes how data is updated
- [ ] `docs-known-limitations` - The documentation describes known limitations of the integration (not to be confused with bugs)
- [ ] `docs-troubleshooting` - The documentation provides troubleshooting information
- [ ] `docs-examples` - The documentation provides automation examples the user can use.

## Platinum
- [x] `async-dependency` - Dependency is async
https://github.com/home-assistant/core/blob/32570c59c8ac787a5d0c65fb657a3ecf73536ea8/homeassistant/components/nyt_games/coordinator.py#L46-L47
- [x] `inject-websession` - The integration dependency supports passing in a websession
https://github.com/home-assistant/core/blob/ae8219dc9742b1718938cfb1adee4b0286a6a04b/homeassistant/components/nyt_games/__init__.py#L25-L27
- [ ] `strict-typing` - Strict typing



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
