### PR TITLE
2024.12.5

### DIFF
--- a/homeassistant/components/fjaraskupan/light.py
+++ b/homeassistant/components/fjaraskupan/light.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from typing import Any
 
-from fjaraskupan import COMMAND_LIGHT_ON_OFF
-
 from homeassistant.components.light import ATTR_BRIGHTNESS, ColorMode, LightEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -62,7 +60,6 @@ class Light(CoordinatorEntity[FjaraskupanCoordinator], LightEntity):
         if self.is_on:
             async with self.coordinator.async_connect_and_update() as device:
                 await device.send_dim(0)
-                await device.send_command(COMMAND_LIGHT_ON_OFF)
 
     @property
     def is_on(self) -> bool:

--- a/homeassistant/components/fjaraskupan/manifest.json
+++ b/homeassistant/components/fjaraskupan/manifest.json
@@ -14,5 +14,5 @@
   "documentation": "https://www.home-assistant.io/integrations/fjaraskupan",
   "iot_class": "local_polling",
   "loggers": ["bleak", "fjaraskupan"],
-  "requirements": ["fjaraskupan==2.3.1"]
+  "requirements": ["fjaraskupan==2.3.2"]
 }

--- a/homeassistant/components/fjaraskupan/manifest.json
+++ b/homeassistant/components/fjaraskupan/manifest.json
@@ -14,5 +14,5 @@
   "documentation": "https://www.home-assistant.io/integrations/fjaraskupan",
   "iot_class": "local_polling",
   "loggers": ["bleak", "fjaraskupan"],
-  "requirements": ["fjaraskupan==2.3.0"]
+  "requirements": ["fjaraskupan==2.3.1"]
 }

--- a/homeassistant/components/freebox/manifest.json
+++ b/homeassistant/components/freebox/manifest.json
@@ -7,6 +7,6 @@
   "documentation": "https://www.home-assistant.io/integrations/freebox",
   "iot_class": "local_polling",
   "loggers": ["freebox_api"],
-  "requirements": ["freebox-api==1.1.0"],
+  "requirements": ["freebox-api==1.2.1"],
   "zeroconf": ["_fbx-api._tcp.local."]
 }

--- a/homeassistant/components/gardena_bluetooth/manifest.json
+++ b/homeassistant/components/gardena_bluetooth/manifest.json
@@ -14,5 +14,5 @@
   "documentation": "https://www.home-assistant.io/integrations/gardena_bluetooth",
   "iot_class": "local_polling",
   "loggers": ["bleak", "bleak_esphome", "gardena_bluetooth"],
-  "requirements": ["gardena-bluetooth==1.4.4"]
+  "requirements": ["gardena-bluetooth==1.5.0"]
 }

--- a/homeassistant/components/integration/sensor.py
+++ b/homeassistant/components/integration/sensor.py
@@ -576,7 +576,7 @@ class IntegrationSensor(RestoreSensor):
         if (
             self._max_sub_interval is not None
             and source_state is not None
-            and (source_state_dec := _decimal_state(source_state.state))
+            and (source_state_dec := _decimal_state(source_state.state)) is not None
         ):
 
             @callback

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -661,7 +661,7 @@ class MQTT:
                     self.conf.get(CONF_PORT, DEFAULT_PORT),
                     self.conf.get(CONF_KEEPALIVE, DEFAULT_KEEPALIVE),
                 )
-        except OSError as err:
+        except (OSError, mqtt.WebsocketConnectionError) as err:
             _LOGGER.error("Failed to connect to MQTT server due to exception: %s", err)
             self._async_connection_result(False)
         finally:

--- a/homeassistant/components/music_assistant/media_player.py
+++ b/homeassistant/components/music_assistant/media_player.py
@@ -566,17 +566,13 @@ class MusicAssistantPlayer(MusicAssistantEntity, MediaPlayerEntity):
             # shuffle and repeat are not (yet) supported for external sources
             self._attr_shuffle = None
             self._attr_repeat = None
-            if TYPE_CHECKING:
-                assert player.elapsed_time is not None
-            self._attr_media_position = int(player.elapsed_time)
+            self._attr_media_position = int(player.elapsed_time or 0)
             self._attr_media_position_updated_at = (
                 utc_from_timestamp(player.elapsed_time_last_updated)
                 if player.elapsed_time_last_updated
                 else None
             )
-            if TYPE_CHECKING:
-                assert player.elapsed_time is not None
-            self._prev_time = player.elapsed_time
+            self._prev_time = player.elapsed_time or 0
             return
 
         if queue is None:

--- a/homeassistant/components/nice_go/const.py
+++ b/homeassistant/components/nice_go/const.py
@@ -15,8 +15,8 @@ CONF_REFRESH_TOKEN_CREATION_TIME = "refresh_token_creation_time"
 REFRESH_TOKEN_EXPIRY_TIME = timedelta(days=30)
 
 SUPPORTED_DEVICE_TYPES = {
-    Platform.LIGHT: ["WallStation"],
-    Platform.SWITCH: ["WallStation"],
+    Platform.LIGHT: ["WallStation", "WallStation_ESP32"],
+    Platform.SWITCH: ["WallStation", "WallStation_ESP32"],
 }
 KNOWN_UNSUPPORTED_DEVICE_TYPES = {
     Platform.LIGHT: ["Mms100"],

--- a/homeassistant/components/nice_go/coordinator.py
+++ b/homeassistant/components/nice_go/coordinator.py
@@ -239,7 +239,6 @@ class NiceGOUpdateCoordinator(DataUpdateCoordinator[dict[str, NiceGODevice]]):
             ].type,  # Device type is not sent in device state update, and it can't change, so we just reuse the existing one
             BarrierState(
                 deviceId=raw_data["deviceId"],
-                desired=json.loads(raw_data["desired"]),
                 reported=json.loads(raw_data["reported"]),
                 connectionState=ConnectionState(
                     connected=raw_data["connectionState"]["connected"],

--- a/homeassistant/components/nice_go/cover.py
+++ b/homeassistant/components/nice_go/cover.py
@@ -21,6 +21,7 @@ from .entity import NiceGOEntity
 DEVICE_CLASSES = {
     "WallStation": CoverDeviceClass.GARAGE,
     "Mms100": CoverDeviceClass.GATE,
+    "WallStation_ESP32": CoverDeviceClass.GARAGE,
 }
 PARALLEL_UPDATES = 1
 

--- a/homeassistant/components/nice_go/manifest.json
+++ b/homeassistant/components/nice_go/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "hub",
   "iot_class": "cloud_push",
   "loggers": ["nice_go"],
-  "requirements": ["nice-go==0.3.10"]
+  "requirements": ["nice-go==1.0.0"]
 }

--- a/homeassistant/components/overkiz/config_flow.py
+++ b/homeassistant/components/overkiz/config_flow.py
@@ -76,7 +76,7 @@ class OverkizConfigFlow(ConfigFlow, domain=DOMAIN):
             for gateway in gateways:
                 if is_overkiz_gateway(gateway.id):
                     gateway_id = gateway.id
-                    await self.async_set_unique_id(gateway_id)
+                    await self.async_set_unique_id(gateway_id, raise_on_progress=False)
 
         return user_input
 

--- a/homeassistant/components/overkiz/manifest.json
+++ b/homeassistant/components/overkiz/manifest.json
@@ -20,7 +20,7 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "loggers": ["boto3", "botocore", "pyhumps", "pyoverkiz", "s3transfer"],
-  "requirements": ["pyoverkiz==1.15.0"],
+  "requirements": ["pyoverkiz==1.15.3"],
   "zeroconf": [
     {
       "type": "_kizbox._tcp.local.",

--- a/homeassistant/components/roborock/manifest.json
+++ b/homeassistant/components/roborock/manifest.json
@@ -7,7 +7,7 @@
   "iot_class": "local_polling",
   "loggers": ["roborock"],
   "requirements": [
-    "python-roborock==2.7.2",
+    "python-roborock==2.8.1",
     "vacuum-map-parser-roborock==0.1.2"
   ]
 }

--- a/homeassistant/components/screenlogic/__init__.py
+++ b/homeassistant/components/screenlogic/__init__.py
@@ -4,6 +4,7 @@ import logging
 from typing import Any
 
 from screenlogicpy import ScreenLogicError, ScreenLogicGateway
+from screenlogicpy.const.common import ScreenLogicConnectionError
 from screenlogicpy.const.data import SHARED_VALUES
 
 from homeassistant.config_entries import ConfigEntry
@@ -64,7 +65,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ScreenLogicConfigEntry) 
     try:
         await gateway.async_connect(**connect_info)
         await gateway.async_update()
-    except ScreenLogicError as ex:
+    except (ScreenLogicConnectionError, ScreenLogicError) as ex:
         raise ConfigEntryNotReady(ex.msg) from ex
 
     coordinator = ScreenlogicDataUpdateCoordinator(

--- a/homeassistant/components/twinkly/config_flow.py
+++ b/homeassistant/components/twinkly/config_flow.py
@@ -45,7 +45,9 @@ class TwinklyConfigFlow(ConfigFlow, domain=DOMAIN):
             except (TimeoutError, ClientError):
                 errors[CONF_HOST] = "cannot_connect"
             else:
-                await self.async_set_unique_id(device_info[DEV_ID])
+                await self.async_set_unique_id(
+                    device_info[DEV_ID], raise_on_progress=False
+                )
                 self._abort_if_unique_id_configured()
 
                 return self._create_entry_from_device(device_info, host)

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
 APPLICATION_NAME: Final = "HomeAssistant"
 MAJOR_VERSION: Final = 2024
 MINOR_VERSION: Final = 12
-PATCH_VERSION: Final = "4"
+PATCH_VERSION: Final = "5"
 __short_version__: Final = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__: Final = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER: Final[tuple[int, int, int]] = (3, 12, 0)

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -5,7 +5,7 @@ aiodiscover==2.1.0
 aiodns==3.2.0
 aiohasupervisor==0.2.1
 aiohttp-fast-zlib==0.2.0
-aiohttp==3.11.10
+aiohttp==3.11.11
 aiohttp_cors==0.7.0
 aiozoneinfo==0.2.1
 astral==2.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name        = "homeassistant"
-version     = "2024.12.4"
+version     = "2024.12.5"
 license     = {text = "Apache-2.0"}
 description = "Open-source home automation platform running on Python 3."
 readme      = "README.rst"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies    = [
     # change behavior based on presence of supervisor. Deprecated with #127228
     # Lib can be removed with 2025.11
     "aiohasupervisor==0.2.1",
-    "aiohttp==3.11.10",
+    "aiohttp==3.11.11",
     "aiohttp_cors==0.7.0",
     "aiohttp-fast-zlib==0.2.0",
     "aiozoneinfo==0.2.1",

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@
 # Home Assistant Core
 aiodns==3.2.0
 aiohasupervisor==0.2.1
-aiohttp==3.11.10
+aiohttp==3.11.11
 aiohttp_cors==0.7.0
 aiohttp-fast-zlib==0.2.0
 aiozoneinfo==0.2.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -912,7 +912,7 @@ fivem-api==0.1.2
 fixerio==1.0.0a0
 
 # homeassistant.components.fjaraskupan
-fjaraskupan==2.3.1
+fjaraskupan==2.3.2
 
 # homeassistant.components.flexit_bacnet
 flexit_bacnet==2.2.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1460,7 +1460,7 @@ nextdns==4.0.0
 nibe==2.13.0
 
 # homeassistant.components.nice_go
-nice-go==0.3.10
+nice-go==1.0.0
 
 # homeassistant.components.niko_home_control
 niko-home-control==0.2.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2402,7 +2402,7 @@ python-rabbitair==0.0.8
 python-ripple-api==0.0.3
 
 # homeassistant.components.roborock
-python-roborock==2.7.2
+python-roborock==2.8.1
 
 # homeassistant.components.smarttub
 python-smarttub==0.0.38

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -937,7 +937,7 @@ forecast-solar==4.0.0
 fortiosapi==1.0.5
 
 # homeassistant.components.freebox
-freebox-api==1.1.0
+freebox-api==1.2.1
 
 # homeassistant.components.free_mobile
 freesms==0.2.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -912,7 +912,7 @@ fivem-api==0.1.2
 fixerio==1.0.0a0
 
 # homeassistant.components.fjaraskupan
-fjaraskupan==2.3.0
+fjaraskupan==2.3.1
 
 # homeassistant.components.flexit_bacnet
 flexit_bacnet==2.2.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2149,7 +2149,7 @@ pyotgw==2.2.2
 pyotp==2.8.0
 
 # homeassistant.components.overkiz
-pyoverkiz==1.15.0
+pyoverkiz==1.15.3
 
 # homeassistant.components.onewire
 pyownet==0.10.0.post1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -953,7 +953,7 @@ fyta_cli==0.7.0
 gTTS==2.2.4
 
 # homeassistant.components.gardena_bluetooth
-gardena-bluetooth==1.4.4
+gardena-bluetooth==1.5.0
 
 # homeassistant.components.google_assistant_sdk
 gassist-text==0.0.11

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1923,7 +1923,7 @@ python-picnic-api==1.1.0
 python-rabbitair==0.0.8
 
 # homeassistant.components.roborock
-python-roborock==2.7.2
+python-roborock==2.8.1
 
 # homeassistant.components.smarttub
 python-smarttub==0.0.38

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1220,7 +1220,7 @@ nextdns==4.0.0
 nibe==2.13.0
 
 # homeassistant.components.nice_go
-nice-go==0.3.10
+nice-go==1.0.0
 
 # homeassistant.components.nfandroidtv
 notifications-android-tv==0.1.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -771,7 +771,7 @@ fitbit==0.3.1
 fivem-api==0.1.2
 
 # homeassistant.components.fjaraskupan
-fjaraskupan==2.3.0
+fjaraskupan==2.3.1
 
 # homeassistant.components.flexit_bacnet
 flexit_bacnet==2.2.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -771,7 +771,7 @@ fitbit==0.3.1
 fivem-api==0.1.2
 
 # homeassistant.components.fjaraskupan
-fjaraskupan==2.3.1
+fjaraskupan==2.3.2
 
 # homeassistant.components.flexit_bacnet
 flexit_bacnet==2.2.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1736,7 +1736,7 @@ pyotgw==2.2.2
 pyotp==2.8.0
 
 # homeassistant.components.overkiz
-pyoverkiz==1.15.0
+pyoverkiz==1.15.3
 
 # homeassistant.components.onewire
 pyownet==0.10.0.post1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -793,7 +793,7 @@ foobot_async==1.0.0
 forecast-solar==4.0.0
 
 # homeassistant.components.freebox
-freebox-api==1.1.0
+freebox-api==1.2.1
 
 # homeassistant.components.fritz
 # homeassistant.components.fritzbox_callmonitor

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -806,7 +806,7 @@ fyta_cli==0.7.0
 gTTS==2.2.4
 
 # homeassistant.components.gardena_bluetooth
-gardena-bluetooth==1.4.4
+gardena-bluetooth==1.5.0
 
 # homeassistant.components.google_assistant_sdk
 gassist-text==0.0.11

--- a/tests/components/integration/test_sensor.py
+++ b/tests/components/integration/test_sensor.py
@@ -843,6 +843,39 @@ async def test_on_valid_source_expect_update_on_time(
         assert float(state.state) < 1.8
 
 
+async def test_on_0_source_expect_0_and_update_when_source_gets_positive(
+    hass: HomeAssistant,
+) -> None:
+    """Test whether time based integration updates the integral on a valid zero source."""
+    start_time = dt_util.utcnow()
+
+    with freeze_time(start_time) as freezer:
+        await _setup_integral_sensor(hass, max_sub_interval=DEFAULT_MAX_SUB_INTERVAL)
+        await _update_source_sensor(hass, 0)
+        await hass.async_block_till_done()
+
+        # wait one minute and one second
+        freezer.tick(61)
+        async_fire_time_changed(hass, dt_util.now())
+        await hass.async_block_till_done()
+
+        state = hass.states.get("sensor.integration")
+
+        assert condition.async_numeric_state(hass, state) is True
+        assert float(state.state) == 0  # integral is 0 after integration of 0
+
+        # wait one second and update state
+        freezer.tick(1)
+        async_fire_time_changed(hass, dt_util.now())
+        await _update_source_sensor(hass, 100)
+        await hass.async_block_till_done()
+
+        state = hass.states.get("sensor.integration")
+
+        # approx 100*1/3600 (right method after 1 second since last integration)
+        assert 0.027 < float(state.state) < 0.029
+
+
 async def test_on_unvailable_source_expect_no_update_on_time(
     hass: HomeAssistant,
 ) -> None:

--- a/tests/components/music_assistant/fixtures/players.json
+++ b/tests/components/music_assistant/fixtures/players.json
@@ -20,7 +20,7 @@
         "power",
         "enqueue"
       ],
-      "elapsed_time": 0,
+      "elapsed_time": null,
       "elapsed_time_last_updated": 0,
       "state": "idle",
       "volume_level": 20,

--- a/tests/components/nice_go/fixtures/get_all_barriers.json
+++ b/tests/components/nice_go/fixtures/get_all_barriers.json
@@ -11,7 +11,6 @@
     ],
     "state": {
       "deviceId": "1",
-      "desired": { "key": "value" },
       "reported": {
         "displayName": "Test Garage 1",
         "autoDisabled": false,
@@ -42,7 +41,6 @@
     ],
     "state": {
       "deviceId": "2",
-      "desired": { "key": "value" },
       "reported": {
         "displayName": "Test Garage 2",
         "autoDisabled": false,
@@ -73,7 +71,6 @@
     ],
     "state": {
       "deviceId": "3",
-      "desired": { "key": "value" },
       "reported": {
         "displayName": "Test Garage 3",
         "autoDisabled": false,
@@ -101,7 +98,6 @@
     ],
     "state": {
       "deviceId": "4",
-      "desired": { "key": "value" },
       "reported": {
         "displayName": "Test Garage 4",
         "autoDisabled": false,

--- a/tests/components/nice_go/test_init.py
+++ b/tests/components/nice_go/test_init.py
@@ -81,7 +81,6 @@ async def test_firmware_update_required(
                     "displayName": "test-display-name",
                     "migrationStatus": "NOT_STARTED",
                 },
-                desired=None,
                 connectionState=None,
                 version=None,
                 timestamp=None,

--- a/tests/components/screenlogic/test_init.py
+++ b/tests/components/screenlogic/test_init.py
@@ -4,12 +4,14 @@ from dataclasses import dataclass
 from unittest.mock import DEFAULT, patch
 
 import pytest
-from screenlogicpy import ScreenLogicGateway
+from screenlogicpy import ScreenLogicError, ScreenLogicGateway
+from screenlogicpy.const.common import ScreenLogicConnectionError
 
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
 from homeassistant.components.number import DOMAIN as NUMBER_DOMAIN
 from homeassistant.components.screenlogic import DOMAIN
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.util import slugify
@@ -284,3 +286,35 @@ async def test_platform_setup(
 
         for entity_id in tested_entity_ids:
             assert hass.states.get(entity_id) is not None
+
+
+@pytest.mark.parametrize(
+    "exception",
+    [ScreenLogicConnectionError, ScreenLogicError],
+)
+async def test_retry_on_connect_exception(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry, exception: Exception
+) -> None:
+    """Test setup retries on expected exceptions."""
+
+    def stub_connect(*args, **kwargs):
+        raise exception
+
+    mock_config_entry.add_to_hass(hass)
+
+    with (
+        patch(
+            GATEWAY_DISCOVERY_IMPORT_PATH,
+            return_value={},
+        ),
+        patch.multiple(
+            ScreenLogicGateway,
+            async_connect=stub_connect,
+            is_connected=False,
+            _async_connected_request=DEFAULT,
+        ),
+    ):
+        assert not await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY


### PR DESCRIPTION
- Bump `nice-go` to 1.0.0 ([@IceBotYT] - [#133185]) ([nice_go docs]) (dependency)
- Add support for Nice G.O. HAE00080 wall station ([@IceBotYT] - [#133186]) ([nice_go docs])
- Bugfix: also schedule time based integration when source is 0 ([@ronweikamp] - [#133438]) ([integration docs])
- Ensure screenlogic retries if the protocol adapter is still booting ([@bdraco] - [#133444]) ([screenlogic docs])
- Bump Freebox to 1.2.1 ([@Quentame] - [#133455]) ([freebox docs]) (dependency)
- Bump pyOverkiz to 1.15.3 ([@iMicknl] - [#133458]) ([overkiz docs]) (dependency)
- Don't raise Overkiz user flow unique_id check ([@iMicknl] - [#133471]) ([overkiz docs])
- Update Roborock to 2.8.1 ([@Lash-L] - [#133492]) ([roborock docs]) (dependency)
- Update fjäråskupan to 2.3.1 ([@elupus] - [#133493]) ([fjaraskupan docs]) (dependency)
- Update fjäråskupan to 2.3.2 ([@elupus] - [#133499]) ([fjaraskupan docs]) (dependency)
- Bump gardena_bluetooth to 1.5.0 ([@elupus] - [#133502]) ([gardena_bluetooth docs]) (dependency)
- Bump aiohttp to 3.11.11 ([@bdraco] - [#133530]) (dependency)
- Handle null value for elapsed time in Music Assistant ([@marcelveldt] - [#133597]) ([music_assistant docs])
- Fix Twinkly raise on progress ([@joostlek] - [#133601]) ([twinkly docs])
- Handle mqtt.WebsocketConnectionError when connecting to the MQTT broker ([@bdraco] - [#133610]) ([mqtt docs])

[#132195]: https://github.com/home-assistant/core/pull/132195
[#132509]: https://github.com/home-assistant/core/pull/132509
[#132846]: https://github.com/home-assistant/core/pull/132846
[#133123]: https://github.com/home-assistant/core/pull/133123
[#133185]: https://github.com/home-assistant/core/pull/133185
[#133186]: https://github.com/home-assistant/core/pull/133186
[#133422]: https://github.com/home-assistant/core/pull/133422
[#133438]: https://github.com/home-assistant/core/pull/133438
[#133444]: https://github.com/home-assistant/core/pull/133444
[#133455]: https://github.com/home-assistant/core/pull/133455
[#133458]: https://github.com/home-assistant/core/pull/133458
[#133471]: https://github.com/home-assistant/core/pull/133471
[#133492]: https://github.com/home-assistant/core/pull/133492
[#133493]: https://github.com/home-assistant/core/pull/133493
[#133499]: https://github.com/home-assistant/core/pull/133499
[#133502]: https://github.com/home-assistant/core/pull/133502
[#133530]: https://github.com/home-assistant/core/pull/133530
[#133597]: https://github.com/home-assistant/core/pull/133597
[#133601]: https://github.com/home-assistant/core/pull/133601
[#133610]: https://github.com/home-assistant/core/pull/133610
[@IceBotYT]: https://github.com/IceBotYT
[@Lash-L]: https://github.com/Lash-L
[@Quentame]: https://github.com/Quentame
[@bdraco]: https://github.com/bdraco
[@elupus]: https://github.com/elupus
[@frenck]: https://github.com/frenck
[@iMicknl]: https://github.com/iMicknl
[@joostlek]: https://github.com/joostlek
[@marcelveldt]: https://github.com/marcelveldt
[@ronweikamp]: https://github.com/ronweikamp
[abode docs]: https://www.home-assistant.io/integrations/abode/
[acaia docs]: https://www.home-assistant.io/integrations/acaia/
[fjaraskupan docs]: https://www.home-assistant.io/integrations/fjaraskupan/
[freebox docs]: https://www.home-assistant.io/integrations/freebox/
[gardena_bluetooth docs]: https://www.home-assistant.io/integrations/gardena_bluetooth/
[integration docs]: https://www.home-assistant.io/integrations/integration/
[mqtt docs]: https://www.home-assistant.io/integrations/mqtt/
[music_assistant docs]: https://www.home-assistant.io/integrations/music_assistant/
[nice_go docs]: https://www.home-assistant.io/integrations/nice_go/
[overkiz docs]: https://www.home-assistant.io/integrations/overkiz/
[roborock docs]: https://www.home-assistant.io/integrations/roborock/
[screenlogic docs]: https://www.home-assistant.io/integrations/screenlogic/
[twinkly docs]: https://www.home-assistant.io/integrations/twinkly/

Release notes: https://github.com/home-assistant/home-assistant.io/pull/36453