### PR TITLE
Bump pypck to 0.8.1

### DIFF
--- a/homeassistant/components/lcn/__init__.py
+++ b/homeassistant/components/lcn/__init__.py
@@ -105,7 +105,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
             f"Unable to connect to {config_entry.title}: {ex}"
         ) from ex
 
-    _LOGGER.info('LCN connected to "%s"', config_entry.title)
+    _LOGGER.debug('LCN connected to "%s"', config_entry.title)
     hass.data[DOMAIN][config_entry.entry_id] = {
         CONNECTION: lcn_connection,
         DEVICE_CONNECTIONS: {},

--- a/homeassistant/components/lcn/__init__.py
+++ b/homeassistant/components/lcn/__init__.py
@@ -6,7 +6,14 @@ from functools import partial
 import logging
 
 import pypck
-from pypck.connection import PchkConnectionManager
+from pypck.connection import (
+    PchkAuthenticationError,
+    PchkConnectionFailedError,
+    PchkConnectionManager,
+    PchkConnectionRefusedError,
+    PchkLcnNotConnectedError,
+    PchkLicenseError,
+)
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
@@ -20,6 +27,7 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.helpers.typing import ConfigType
 
@@ -81,31 +89,29 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         settings=settings,
         connection_id=config_entry.entry_id,
     )
+
     try:
         # establish connection to PCHK server
         await lcn_connection.async_connect(timeout=15)
-    except pypck.connection.PchkAuthenticationError:
-        _LOGGER.warning('Authentication on PCHK "%s" failed', config_entry.title)
-        return False
-    except pypck.connection.PchkLicenseError:
-        _LOGGER.warning(
-            (
-                'Maximum number of connections on PCHK "%s" was '
-                "reached. An additional license key is required"
-            ),
-            config_entry.title,
-        )
-        return False
-    except TimeoutError:
-        _LOGGER.warning('Connection to PCHK "%s" failed', config_entry.title)
-        return False
+    except (
+        PchkAuthenticationError,
+        PchkLicenseError,
+        PchkConnectionRefusedError,
+        PchkConnectionFailedError,
+        PchkLcnNotConnectedError,
+    ) as ex:
+        await lcn_connection.async_close()
+        raise ConfigEntryNotReady(
+            f"Unable to connect to {config_entry.title}: {ex}"
+        ) from ex
 
-    _LOGGER.debug('LCN connected to "%s"', config_entry.title)
+    _LOGGER.info('LCN connected to "%s"', config_entry.title)
     hass.data[DOMAIN][config_entry.entry_id] = {
         CONNECTION: lcn_connection,
         DEVICE_CONNECTIONS: {},
         ADD_ENTITIES_CALLBACKS: {},
     }
+
     # Update config_entry with LCN device serials
     await async_update_config_entry(hass, config_entry)
 
@@ -121,6 +127,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     input_received = partial(
         async_host_input_received, hass, config_entry, device_registry
     )
+
     lcn_connection.register_for_inputs(input_received)
 
     return True

--- a/homeassistant/components/lcn/config_flow.py
+++ b/homeassistant/components/lcn/config_flow.py
@@ -96,7 +96,10 @@ async def validate_connection(data: ConfigType) -> str | None:
             host_name,
         )
         error = "license_error"
-    except (TimeoutError, ConnectionRefusedError):
+    except (
+        pypck.connection.PchkConnectionFailedError,
+        pypck.connection.PchkConnectionRefusedError,
+    ):
         _LOGGER.warning('Connection to PCHK "%s" failed', host_name)
         error = "connection_refused"
 

--- a/homeassistant/components/lcn/manifest.json
+++ b/homeassistant/components/lcn/manifest.json
@@ -8,5 +8,5 @@
   "documentation": "https://www.home-assistant.io/integrations/lcn",
   "iot_class": "local_push",
   "loggers": ["pypck"],
-  "requirements": ["pypck==0.7.24", "lcn-frontend==0.2.2"]
+  "requirements": ["pypck==0.8.1", "lcn-frontend==0.2.2"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2177,7 +2177,7 @@ pypalazzetti==0.1.15
 pypca==0.0.7
 
 # homeassistant.components.lcn
-pypck==0.7.24
+pypck==0.8.1
 
 # homeassistant.components.pjlink
 pypjlink2==1.2.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1767,7 +1767,7 @@ pyownet==0.10.0.post1
 pypalazzetti==0.1.15
 
 # homeassistant.components.lcn
-pypck==0.7.24
+pypck==0.8.1
 
 # homeassistant.components.pjlink
 pypjlink2==1.2.1

--- a/tests/components/lcn/test_config_flow.py
+++ b/tests/components/lcn/test_config_flow.py
@@ -2,7 +2,12 @@
 
 from unittest.mock import patch
 
-from pypck.connection import PchkAuthenticationError, PchkLicenseError
+from pypck.connection import (
+    PchkAuthenticationError,
+    PchkConnectionFailedError,
+    PchkConnectionRefusedError,
+    PchkLicenseError,
+)
 import pytest
 
 from homeassistant import config_entries, data_entry_flow
@@ -98,7 +103,8 @@ async def test_step_user_existing_host(
     [
         (PchkAuthenticationError, {CONF_BASE: "authentication_error"}),
         (PchkLicenseError, {CONF_BASE: "license_error"}),
-        (TimeoutError, {CONF_BASE: "connection_refused"}),
+        (PchkConnectionFailedError, {CONF_BASE: "connection_refused"}),
+        (PchkConnectionRefusedError, {CONF_BASE: "connection_refused"}),
     ],
 )
 async def test_step_user_error(
@@ -149,7 +155,8 @@ async def test_step_reconfigure(hass: HomeAssistant, entry: MockConfigEntry) -> 
     [
         (PchkAuthenticationError, {CONF_BASE: "authentication_error"}),
         (PchkLicenseError, {CONF_BASE: "license_error"}),
-        (TimeoutError, {CONF_BASE: "connection_refused"}),
+        (PchkConnectionFailedError, {CONF_BASE: "connection_refused"}),
+        (PchkConnectionRefusedError, {CONF_BASE: "connection_refused"}),
     ],
 )
 async def test_step_reconfigure_error(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
Dependency upgrade for LCN integration.

- More detailed exceptions
- Preparation for event-based handling of disconnections

Release notes: https://github.com/alengwenus/pypck/releases
Code changes: https://github.com/alengwenus/pypck/compare/0.7.24...0.8.1

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
