### PR TITLE
Fix Mealie test coverage

### DIFF
--- a/homeassistant/components/mealie/quality_scale.yaml
+++ b/homeassistant/components/mealie/quality_scale.yaml
@@ -35,9 +35,7 @@ rules:
   log-when-unavailable: done
   parallel-updates: todo
   reauthentication-flow: done
-  test-coverage:
-    status: todo
-    comment: Platform missing tests
+  test-coverage: done
   # Gold
   devices: done
   diagnostics: done

--- a/homeassistant/components/mealie/todo.py
+++ b/homeassistant/components/mealie/todo.py
@@ -147,29 +147,19 @@ class MealieShoppingListTodoListEntity(MealieEntity, TodoListEntity):
         """Update an item on the list."""
         list_items = self.shopping_items
 
-        for items in list_items:
-            if items.item_id == item.uid:
-                position = items.position
-                break
-
         list_item: ShoppingItem | None = next(
             (x for x in list_items if x.item_id == item.uid), None
         )
+        assert list_item is not None
+        position = list_item.position
 
-        if not list_item:
-            raise HomeAssistantError(
-                translation_domain=DOMAIN,
-                translation_key="item_not_found_error",
-                translation_placeholders={"shopping_list_item": item.uid or ""},
-            )
-
-        udpdate_shopping_item = MutateShoppingItem(
+        update_shopping_item = MutateShoppingItem(
             item_id=list_item.item_id,
             list_id=list_item.list_id,
             note=list_item.note,
             display=list_item.display,
             checked=item.status == TodoItemStatus.COMPLETED,
-            position=list_item.position,
+            position=position,
             is_food=list_item.is_food,
             disable_amount=list_item.disable_amount,
             quantity=list_item.quantity,
@@ -181,16 +171,16 @@ class MealieShoppingListTodoListEntity(MealieEntity, TodoListEntity):
         stripped_item_summary = item.summary.strip() if item.summary else item.summary
 
         if list_item.display.strip() != stripped_item_summary:
-            udpdate_shopping_item.note = stripped_item_summary
-            udpdate_shopping_item.position = position
-            udpdate_shopping_item.is_food = False
-            udpdate_shopping_item.food_id = None
-            udpdate_shopping_item.quantity = 0.0
-            udpdate_shopping_item.checked = item.status == TodoItemStatus.COMPLETED
+            update_shopping_item.note = stripped_item_summary
+            update_shopping_item.position = position
+            update_shopping_item.is_food = False
+            update_shopping_item.food_id = None
+            update_shopping_item.quantity = 0.0
+            update_shopping_item.checked = item.status == TodoItemStatus.COMPLETED
 
         try:
             await self.coordinator.client.update_shopping_item(
-                list_item.item_id, udpdate_shopping_item
+                list_item.item_id, update_shopping_item
             )
         except MealieError as exception:
             raise HomeAssistantError(

--- a/tests/components/mealie/test_calendar.py
+++ b/tests/components/mealie/test_calendar.py
@@ -4,9 +4,10 @@ from datetime import date
 from http import HTTPStatus
 from unittest.mock import AsyncMock, patch
 
+from aiomealie import MealplanResponse
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.const import Platform
+from homeassistant.const import STATE_OFF, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -40,11 +41,26 @@ async def test_entities(
     mock_mealie_client: AsyncMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test the API returns the calendar."""
+    """Test the calendar entities."""
     with patch("homeassistant.components.mealie.PLATFORMS", [Platform.CALENDAR]):
         await setup_integration(hass, mock_config_entry)
 
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+async def test_no_meal_planned(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    entity_registry: er.EntityRegistry,
+    mock_mealie_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the calendar handles no meal planned."""
+    mock_mealie_client.get_mealplans.return_value = MealplanResponse([])
+
+    await setup_integration(hass, mock_config_entry)
+
+    assert hass.states.get("calendar.mealie_dinner").state == STATE_OFF
 
 
 async def test_api_events(

--- a/tests/components/mealie/test_todo.py
+++ b/tests/components/mealie/test_todo.py
@@ -1,9 +1,9 @@
 """Tests for the Mealie todo."""
 
 from datetime import timedelta
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, call, patch
 
-from aiomealie import MealieError, ShoppingListsResponse
+from aiomealie import MealieError, MutateShoppingItem, ShoppingListsResponse
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy.assertion import SnapshotAssertion
@@ -18,7 +18,7 @@ from homeassistant.components.todo import (
 )
 from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import entity_registry as er
 
 from . import setup_integration
@@ -29,6 +29,7 @@ from tests.common import (
     load_fixture,
     snapshot_platform,
 )
+from tests.typing import WebSocketGenerator
 
 
 async def test_entities(
@@ -45,23 +46,38 @@ async def test_entities(
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
 
-async def test_add_todo_list_item(
+@pytest.mark.parametrize(
+    ("service", "data", "method"),
+    [
+        (TodoServices.ADD_ITEM, {ATTR_ITEM: "Soda"}, "add_shopping_item"),
+        (
+            TodoServices.UPDATE_ITEM,
+            {ATTR_ITEM: "aubergine", ATTR_RENAME: "Eggplant", ATTR_STATUS: "completed"},
+            "update_shopping_item",
+        ),
+        (TodoServices.REMOVE_ITEM, {ATTR_ITEM: "aubergine"}, "delete_shopping_item"),
+    ],
+)
+async def test_todo_actions(
     hass: HomeAssistant,
     mock_mealie_client: AsyncMock,
     mock_config_entry: MockConfigEntry,
+    service: str,
+    data: dict[str, str],
+    method: str,
 ) -> None:
-    """Test for adding a To-do Item."""
+    """Test todo actions."""
     await setup_integration(hass, mock_config_entry)
 
     await hass.services.async_call(
         TODO_DOMAIN,
-        TodoServices.ADD_ITEM,
-        {ATTR_ITEM: "Soda"},
+        service,
+        data,
         target={ATTR_ENTITY_ID: "todo.mealie_supermarket"},
         blocking=True,
     )
 
-    mock_mealie_client.add_shopping_item.assert_called_once()
+    getattr(mock_mealie_client, method).assert_called_once()
 
 
 async def test_add_todo_list_item_error(
@@ -74,7 +90,9 @@ async def test_add_todo_list_item_error(
 
     mock_mealie_client.add_shopping_item.side_effect = MealieError
 
-    with pytest.raises(HomeAssistantError):
+    with pytest.raises(
+        HomeAssistantError, match="An error occurred adding an item to Supermarket"
+    ):
         await hass.services.async_call(
             TODO_DOMAIN,
             TodoServices.ADD_ITEM,
@@ -82,25 +100,6 @@ async def test_add_todo_list_item_error(
             target={ATTR_ENTITY_ID: "todo.mealie_supermarket"},
             blocking=True,
         )
-
-
-async def test_update_todo_list_item(
-    hass: HomeAssistant,
-    mock_mealie_client: AsyncMock,
-    mock_config_entry: MockConfigEntry,
-) -> None:
-    """Test for updating a To-do Item."""
-    await setup_integration(hass, mock_config_entry)
-
-    await hass.services.async_call(
-        TODO_DOMAIN,
-        TodoServices.UPDATE_ITEM,
-        {ATTR_ITEM: "aubergine", ATTR_RENAME: "Eggplant", ATTR_STATUS: "completed"},
-        target={ATTR_ENTITY_ID: "todo.mealie_supermarket"},
-        blocking=True,
-    )
-
-    mock_mealie_client.update_shopping_item.assert_called_once()
 
 
 async def test_update_todo_list_item_error(
@@ -113,7 +112,9 @@ async def test_update_todo_list_item_error(
 
     mock_mealie_client.update_shopping_item.side_effect = MealieError
 
-    with pytest.raises(HomeAssistantError):
+    with pytest.raises(
+        HomeAssistantError, match="An error occurred updating an item in Supermarket"
+    ):
         await hass.services.async_call(
             TODO_DOMAIN,
             TodoServices.UPDATE_ITEM,
@@ -123,23 +124,24 @@ async def test_update_todo_list_item_error(
         )
 
 
-async def test_delete_todo_list_item(
+async def test_update_non_existent_item(
     hass: HomeAssistant,
     mock_mealie_client: AsyncMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test for deleting a To-do Item."""
+    """Test for updating a non-existent To-do Item."""
     await setup_integration(hass, mock_config_entry)
 
-    await hass.services.async_call(
-        TODO_DOMAIN,
-        TodoServices.REMOVE_ITEM,
-        {ATTR_ITEM: "aubergine"},
-        target={ATTR_ENTITY_ID: "todo.mealie_supermarket"},
-        blocking=True,
-    )
-
-    mock_mealie_client.delete_shopping_item.assert_called_once()
+    with pytest.raises(
+        ServiceValidationError, match="Unable to find to-do list item: eggplant"
+    ):
+        await hass.services.async_call(
+            TODO_DOMAIN,
+            TodoServices.UPDATE_ITEM,
+            {ATTR_ITEM: "eggplant", ATTR_RENAME: "Aubergine", ATTR_STATUS: "completed"},
+            target={ATTR_ENTITY_ID: "todo.mealie_supermarket"},
+            blocking=True,
+        )
 
 
 async def test_delete_todo_list_item_error(
@@ -153,7 +155,9 @@ async def test_delete_todo_list_item_error(
     mock_mealie_client.delete_shopping_item = AsyncMock()
     mock_mealie_client.delete_shopping_item.side_effect = MealieError
 
-    with pytest.raises(HomeAssistantError):
+    with pytest.raises(
+        HomeAssistantError, match="An error occurred deleting an item in Supermarket"
+    ):
         await hass.services.async_call(
             TODO_DOMAIN,
             TodoServices.REMOVE_ITEM,
@@ -161,6 +165,172 @@ async def test_delete_todo_list_item_error(
             target={ATTR_ENTITY_ID: "todo.mealie_supermarket"},
             blocking=True,
         )
+
+
+async def test_moving_todo_item(
+    hass: HomeAssistant,
+    mock_mealie_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test for moving a To-do Item to place."""
+    await setup_integration(hass, mock_config_entry)
+
+    client = await hass_ws_client()
+    await client.send_json(
+        {
+            "id": 1,
+            "type": "todo/item/move",
+            "entity_id": "todo.mealie_supermarket",
+            "uid": "f45430f7-3edf-45a9-a50f-73bb375090be",
+            "previous_uid": "84d8fd74-8eb0-402e-84b6-71f251bfb7cc",
+        }
+    )
+    resp = await client.receive_json()
+    assert resp.get("id") == 1
+    assert resp.get("success")
+    assert resp.get("result") is None
+
+    assert mock_mealie_client.update_shopping_item.call_count == 3
+    calls = mock_mealie_client.update_shopping_item.mock_calls
+
+    assert calls[0] == call(
+        "84d8fd74-8eb0-402e-84b6-71f251bfb7cc",
+        MutateShoppingItem(
+            item_id="84d8fd74-8eb0-402e-84b6-71f251bfb7cc",
+            list_id="9ce096fe-ded2-4077-877d-78ba450ab13e",
+            note="",
+            display=None,
+            checked=False,
+            position=0,
+            is_food=True,
+            disable_amount=None,
+            quantity=1.0,
+            label_id=None,
+            food_id="09322430-d24c-4b1a-abb6-22b6ed3a88f5",
+            unit_id="7bf539d4-fc78-48bc-b48e-c35ccccec34a",
+        ),
+    )
+
+    assert calls[1] == call(
+        "f45430f7-3edf-45a9-a50f-73bb375090be",
+        MutateShoppingItem(
+            item_id="f45430f7-3edf-45a9-a50f-73bb375090be",
+            list_id="9ce096fe-ded2-4077-877d-78ba450ab13e",
+            note="Apples",
+            display=None,
+            checked=False,
+            position=1,
+            is_food=False,
+            disable_amount=None,
+            quantity=2.0,
+            label_id=None,
+            food_id=None,
+            unit_id=None,
+        ),
+    )
+
+    assert calls[2] == call(
+        "69913b9a-7c75-4935-abec-297cf7483f88",
+        MutateShoppingItem(
+            item_id="69913b9a-7c75-4935-abec-297cf7483f88",
+            list_id="9ce096fe-ded2-4077-877d-78ba450ab13e",
+            note="",
+            display=None,
+            checked=False,
+            position=2,
+            is_food=True,
+            disable_amount=None,
+            quantity=0.0,
+            label_id=None,
+            food_id="96801494-4e26-4148-849a-8155deb76327",
+            unit_id=None,
+        ),
+    )
+
+
+async def test_not_moving_todo_item(
+    hass: HomeAssistant,
+    mock_mealie_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test for moving a To-do Item to the same place."""
+    await setup_integration(hass, mock_config_entry)
+
+    client = await hass_ws_client()
+    await client.send_json(
+        {
+            "id": 1,
+            "type": "todo/item/move",
+            "entity_id": "todo.mealie_supermarket",
+            "uid": "f45430f7-3edf-45a9-a50f-73bb375090be",
+            "previous_uid": "f45430f7-3edf-45a9-a50f-73bb375090be",
+        }
+    )
+    resp = await client.receive_json()
+    assert resp.get("id") == 1
+    assert resp.get("success")
+    assert resp.get("result") is None
+
+    assert mock_mealie_client.update_shopping_item.call_count == 0
+
+
+async def test_moving_todo_item_invalid_uid(
+    hass: HomeAssistant,
+    mock_mealie_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test for moving a To-do Item to place with invalid UID."""
+    await setup_integration(hass, mock_config_entry)
+
+    client = await hass_ws_client()
+    await client.send_json(
+        {
+            "id": 1,
+            "type": "todo/item/move",
+            "entity_id": "todo.mealie_supermarket",
+            "uid": "cheese",
+        }
+    )
+    resp = await client.receive_json()
+    assert resp.get("id") == 1
+    assert resp.get("success") is False
+    assert resp.get("result") is None
+    assert resp["error"]["code"] == "failed"
+    assert resp["error"]["message"] == "Item cheese not found"
+
+    assert mock_mealie_client.update_shopping_item.call_count == 0
+
+
+async def test_moving_todo_item_invalid_previous_uid(
+    hass: HomeAssistant,
+    mock_mealie_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test for moving a To-do Item to place with invalid previous UID."""
+    await setup_integration(hass, mock_config_entry)
+
+    client = await hass_ws_client()
+    await client.send_json(
+        {
+            "id": 1,
+            "type": "todo/item/move",
+            "entity_id": "todo.mealie_supermarket",
+            "uid": "f45430f7-3edf-45a9-a50f-73bb375090be",
+            "previous_uid": "cheese",
+        }
+    )
+    resp = await client.receive_json()
+    assert resp.get("id") == 1
+    assert resp.get("success") is False
+    assert resp.get("result") is None
+    assert resp["error"]["code"] == "failed"
+    assert resp["error"]["message"] == "Item cheese not found"
+
+    assert mock_mealie_client.update_shopping_item.call_count == 0
 
 
 async def test_runtime_management(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix Mealie test coverage
```
---------- coverage: platform darwin, python 3.12.2-final-0 ----------
Name                                             Stmts   Miss  Cover   Missing
------------------------------------------------------------------------------
homeassistant/components/mealie/__init__.py         46      0   100%
homeassistant/components/mealie/calendar.py         33      0   100%
homeassistant/components/mealie/config_flow.py      68      0   100%
homeassistant/components/mealie/const.py            14      0   100%
homeassistant/components/mealie/coordinator.py      67      0   100%
homeassistant/components/mealie/diagnostics.py       9      0   100%
homeassistant/components/mealie/entity.py           12      0   100%
homeassistant/components/mealie/sensor.py           26      0   100%
homeassistant/components/mealie/services.py         95      0   100%
homeassistant/components/mealie/todo.py            121      0   100%
homeassistant/components/mealie/utils.py             4      0   100%
------------------------------------------------------------------------------
TOTAL                                              495      0   100%

```
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
