### PR TITLE
Simplify query to find oldest state

### DIFF
--- a/homeassistant/components/recorder/queries.py
+++ b/homeassistant/components/recorder/queries.py
@@ -640,9 +640,9 @@ def find_states_to_purge(
 def find_oldest_state() -> StatementLambdaElement:
     """Find the last_updated_ts of the oldest state."""
     return lambda_stmt(
-        lambda: select(States.last_updated_ts).where(
-            States.state_id.in_(select(func.min(States.state_id)))
-        )
+        lambda: select(States.last_updated_ts)
+        .order_by(States.last_updated_ts.asc())
+        .limit(1)
     )
 
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
We added this query back in #133561 original PR https://github.com/home-assistant/core/pull/131702
 
While I was looking at log and checking startup times, I noticed it could be optimized a bit more

#### Before

sqlite
```
sqlite> explain query plan  select last_updated_ts from states where state_id in (select min(state_id) from states);
QUERY PLAN
|--SEARCH states USING INTEGER PRIMARY KEY (rowid=?)
`--LIST SUBQUERY 1
   `--SEARCH states
```
PostgreSQL
```
explain  select last_updated_ts from states where state_id in (select min(state_id) from states);
---------------------------------------------------------------------------------------------------------------------------
 Nested Loop  (cost=1.25..9.29 rows=1 width=8)
   ->  Result  (cost=0.68..0.69 rows=1 width=8)
         InitPlan 1 (returns $0)
           ->  Limit  (cost=0.57..0.68 rows=1 width=8)
                 ->  Index Only Scan using states_pkey on states states_1  (cost=0.57..40114313.23 rows=367289903 width=8)
                       Index Cond: (state_id IS NOT NULL)
   ->  Index Scan using states_pkey on states  (cost=0.57..8.59 rows=1 width=16)
         Index Cond: (state_id = ($0))
(8 rows)
```
MariaDB
```
> explain  select last_updated_ts from states where state_id in (select min(state_id) from states);
+------+--------------+-------------+--------+---------------+---------+---------+-------+------+------------------------------+
| id   | select_type  | table       | type   | possible_keys | key     | key_len | ref   | rows | Extra                        |
+------+--------------+-------------+--------+---------------+---------+---------+-------+------+------------------------------+
|    1 | PRIMARY      | <subquery2> | system | NULL          | NULL    | NULL    | NULL  | 0    |                              |
|    1 | PRIMARY      | states      | const  | PRIMARY       | PRIMARY | 8       | const | 1    |                              |
|    2 | MATERIALIZED | NULL        | NULL   | NULL          | NULL    | NULL    | NULL  | NULL | Select tables optimized away |
+------+--------------+-------------+--------+---------------+---------+---------+-------+------+------------------------------+
```

#### After

sqlite
```
sqlite> explain query plan select last_updated_ts from states order by last_updated_ts asc limit 1;
QUERY PLAN
`--SCAN states USING COVERING INDEX ix_states_last_updated_ts
```
PostgreSQL
```
explain select last_updated_ts from states order by last_updated_ts asc limit 1
 Limit  (cost=0.57..0.68 rows=1 width=8)
   ->  Index Only Scan using ix_states_last_updated_ts on states  (cost=0.57..39202480.27 rows=367289903 width=8)
```
MariaDB
```
> explain select last_updated_ts from states order by last_updated_ts asc limit 1;
+------+-------------+--------+-------+---------------+---------------------------+---------+------+------+-------------+
| id   | select_type | table  | type  | possible_keys | key                       | key_len | ref  | rows | Extra       |
+------+-------------+--------+-------+---------------+---------------------------+---------+------+------+-------------+
|    1 | SIMPLE      | states | index | NULL          | ix_states_last_updated_ts | 9       | NULL | 1    | Using index |
+------+-------------+--------+-------+---------------+---------------------------+---------+------+------+-------------+
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
