### PR TITLE
Improve BMW test quality

### DIFF
--- a/tests/components/bmw_connected_drive/__init__.py
+++ b/tests/components/bmw_connected_drive/__init__.py
@@ -53,6 +53,13 @@ REMOTE_SERVICE_EXC_TRANSLATION = (
     "Error executing remote service on vehicle. HTTPStatusError: 502 Bad Gateway"
 )
 
+BIMMER_CONNECTED_LOGIN_PATCH = (
+    "homeassistant.components.bmw_connected_drive.config_flow.MyBMWAuthentication.login"
+)
+BIMMER_CONNECTED_VEHICLE_PATCH = (
+    "homeassistant.components.bmw_connected_drive.coordinator.MyBMWAccount.get_vehicles"
+)
+
 
 async def setup_mocked_integration(hass: HomeAssistant) -> MockConfigEntry:
     """Mock a fully setup config entry and all components based on fixtures."""

--- a/tests/components/bmw_connected_drive/test_config_flow.py
+++ b/tests/components/bmw_connected_drive/test_config_flow.py
@@ -20,6 +20,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 from . import (
+    BIMMER_CONNECTED_LOGIN_PATCH,
+    BIMMER_CONNECTED_VEHICLE_PATCH,
     FIXTURE_CAPTCHA_INPUT,
     FIXTURE_CONFIG_ENTRY,
     FIXTURE_GCID,
@@ -72,7 +74,7 @@ async def test_connection_error(hass: HomeAssistant) -> None:
     """Test we show user form on MyBMW API error."""
 
     with patch(
-        "bimmer_connected.api.authentication.MyBMWAuthentication.login",
+        BIMMER_CONNECTED_LOGIN_PATCH,
         side_effect=RequestError("Connection reset"),
     ):
         result = await hass.config_entries.flow.async_init(
@@ -163,7 +165,7 @@ async def test_options_flow_implementation(hass: HomeAssistant) -> None:
     """Test config flow options."""
     with (
         patch(
-            "bimmer_connected.account.MyBMWAccount.get_vehicles",
+            BIMMER_CONNECTED_VEHICLE_PATCH,
             return_value=[],
         ),
         patch(
@@ -200,7 +202,7 @@ async def test_reauth(hass: HomeAssistant) -> None:
     """Test the reauth form."""
     with (
         patch(
-            "bimmer_connected.api.authentication.MyBMWAuthentication.login",
+            BIMMER_CONNECTED_LOGIN_PATCH,
             side_effect=login_sideeffect,
             autospec=True,
         ),
@@ -249,7 +251,7 @@ async def test_reauth(hass: HomeAssistant) -> None:
 async def test_reconfigure(hass: HomeAssistant) -> None:
     """Test the reconfiguration form."""
     with patch(
-        "bimmer_connected.api.authentication.MyBMWAuthentication.login",
+        BIMMER_CONNECTED_LOGIN_PATCH,
         side_effect=login_sideeffect,
         autospec=True,
     ):

--- a/tests/components/bmw_connected_drive/test_config_flow.py
+++ b/tests/components/bmw_connected_drive/test_config_flow.py
@@ -15,7 +15,7 @@ from homeassistant.components.bmw_connected_drive.const import (
     CONF_READ_ONLY,
     CONF_REFRESH_TOKEN,
 )
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.const import CONF_PASSWORD, CONF_REGION, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
@@ -42,97 +42,11 @@ def login_sideeffect(self: MyBMWAuthentication):
     self.gcid = FIXTURE_GCID
 
 
-async def test_show_form(hass: HomeAssistant) -> None:
-    """Test that the form is served with no input."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
-
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "user"
-
-
-async def test_authentication_error(hass: HomeAssistant) -> None:
-    """Test we show user form on MyBMW authentication error."""
-
-    with patch(
-        "bimmer_connected.api.authentication.MyBMWAuthentication.login",
-        side_effect=MyBMWAuthError("Login failed"),
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_USER},
-            data=deepcopy(FIXTURE_USER_INPUT_W_CAPTCHA),
-        )
-
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "user"
-    assert result["errors"] == {"base": "invalid_auth"}
-
-
-async def test_connection_error(hass: HomeAssistant) -> None:
-    """Test we show user form on MyBMW API error."""
-
-    with patch(
-        BIMMER_CONNECTED_LOGIN_PATCH,
-        side_effect=RequestError("Connection reset"),
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_USER},
-            data=deepcopy(FIXTURE_USER_INPUT_W_CAPTCHA),
-        )
-
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "user"
-    assert result["errors"] == {"base": "cannot_connect"}
-
-
-async def test_api_error(hass: HomeAssistant) -> None:
-    """Test we show user form on general connection error."""
-
-    with patch(
-        "bimmer_connected.api.authentication.MyBMWAuthentication.login",
-        side_effect=MyBMWAPIError("400 Bad Request"),
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_USER},
-            data=deepcopy(FIXTURE_USER_INPUT_W_CAPTCHA),
-        )
-
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "user"
-    assert result["errors"] == {"base": "cannot_connect"}
-
-
-@pytest.mark.usefixtures("bmw_fixture")
-async def test_captcha_flow_missing_error(hass: HomeAssistant) -> None:
-    """Test the external flow with captcha failing once and succeeding the second time."""
-
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": config_entries.SOURCE_USER},
-        data=deepcopy(FIXTURE_USER_INPUT),
-    )
-
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "captcha"
-
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], {CONF_CAPTCHA_TOKEN: " "}
-    )
-
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "user"
-    assert result["errors"] == {"base": "missing_captcha"}
-
-
 async def test_full_user_flow_implementation(hass: HomeAssistant) -> None:
     """Test registering an integration and finishing flow works."""
     with (
         patch(
-            "bimmer_connected.api.authentication.MyBMWAuthentication.login",
+            BIMMER_CONNECTED_LOGIN_PATCH,
             side_effect=login_sideeffect,
             autospec=True,
         ),
@@ -157,8 +71,118 @@ async def test_full_user_flow_implementation(hass: HomeAssistant) -> None:
         assert result["type"] is FlowResultType.CREATE_ENTRY
         assert result["title"] == FIXTURE_COMPLETE_ENTRY[CONF_USERNAME]
         assert result["data"] == FIXTURE_COMPLETE_ENTRY
+        assert (
+            result["result"].unique_id
+            == f"{FIXTURE_USER_INPUT[CONF_REGION]}-{FIXTURE_USER_INPUT[CONF_USERNAME]}"
+        )
 
         assert len(mock_setup_entry.mock_calls) == 1
+
+
+@pytest.mark.parametrize(
+    ("side_effect", "error"),
+    [
+        (MyBMWAuthError("Login failed"), "invalid_auth"),
+        (RequestError("Connection reset"), "cannot_connect"),
+        (MyBMWAPIError("400 Bad Request"), "cannot_connect"),
+    ],
+)
+async def test_error_display_with_successful_login(
+    hass: HomeAssistant, side_effect: Exception, error: str
+) -> None:
+    """Test we show user form on MyBMW authentication error and are still able to succeed."""
+
+    with patch(
+        BIMMER_CONNECTED_LOGIN_PATCH,
+        side_effect=side_effect,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+            data=deepcopy(FIXTURE_USER_INPUT_W_CAPTCHA),
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {"base": error}
+
+    with (
+        patch(
+            BIMMER_CONNECTED_LOGIN_PATCH,
+            side_effect=login_sideeffect,
+            autospec=True,
+        ),
+        patch(
+            "homeassistant.components.bmw_connected_drive.async_setup_entry",
+            return_value=True,
+        ) as mock_setup_entry,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            deepcopy(FIXTURE_USER_INPUT),
+        )
+
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "captcha"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], FIXTURE_CAPTCHA_INPUT
+        )
+
+        assert result["type"] is FlowResultType.CREATE_ENTRY
+        assert result["title"] == FIXTURE_COMPLETE_ENTRY[CONF_USERNAME]
+        assert result["data"] == FIXTURE_COMPLETE_ENTRY
+        assert (
+            result["result"].unique_id
+            == f"{FIXTURE_USER_INPUT[CONF_REGION]}-{FIXTURE_USER_INPUT[CONF_USERNAME]}"
+        )
+
+        assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_unique_id_existing(hass: HomeAssistant) -> None:
+    """Test registering an integration and when the unique id already exists."""
+
+    mock_config_entry = MockConfigEntry(**FIXTURE_CONFIG_ENTRY)
+    mock_config_entry.add_to_hass(hass)
+
+    with (
+        patch(
+            BIMMER_CONNECTED_LOGIN_PATCH,
+            side_effect=login_sideeffect,
+            autospec=True,
+        ),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+            data=deepcopy(FIXTURE_USER_INPUT),
+        )
+
+        assert result["type"] is FlowResultType.ABORT
+        assert result["reason"] == "already_configured"
+
+
+@pytest.mark.usefixtures("bmw_fixture")
+async def test_captcha_flow_missing_error(hass: HomeAssistant) -> None:
+    """Test the external flow with captcha failing once and succeeding the second time."""
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_USER},
+        data=deepcopy(FIXTURE_USER_INPUT),
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "captcha"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_CAPTCHA_TOKEN: " "}
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {"base": "missing_captcha"}
 
 
 async def test_options_flow_implementation(hass: HomeAssistant) -> None:

--- a/tests/components/bmw_connected_drive/test_coordinator.py
+++ b/tests/components/bmw_connected_drive/test_coordinator.py
@@ -19,7 +19,7 @@ from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.update_coordinator import UpdateFailed
 
-from . import FIXTURE_CONFIG_ENTRY
+from . import BIMMER_CONNECTED_VEHICLE_PATCH, FIXTURE_CONFIG_ENTRY
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
@@ -55,7 +55,7 @@ async def test_update_failed(
     freezer.tick(timedelta(minutes=5, seconds=1))
 
     with patch(
-        "bimmer_connected.account.MyBMWAccount.get_vehicles",
+        BIMMER_CONNECTED_VEHICLE_PATCH,
         side_effect=MyBMWAPIError("Test error"),
     ):
         async_fire_time_changed(hass)
@@ -83,7 +83,7 @@ async def test_update_reauth(
 
     freezer.tick(timedelta(minutes=5, seconds=1))
     with patch(
-        "bimmer_connected.account.MyBMWAccount.get_vehicles",
+        BIMMER_CONNECTED_VEHICLE_PATCH,
         side_effect=MyBMWAuthError("Test error"),
     ):
         async_fire_time_changed(hass)
@@ -94,7 +94,7 @@ async def test_update_reauth(
 
     freezer.tick(timedelta(minutes=5, seconds=1))
     with patch(
-        "bimmer_connected.account.MyBMWAccount.get_vehicles",
+        BIMMER_CONNECTED_VEHICLE_PATCH,
         side_effect=MyBMWAuthError("Test error"),
     ):
         async_fire_time_changed(hass)
@@ -117,7 +117,7 @@ async def test_init_reauth(
     assert len(issue_registry.issues) == 0
 
     with patch(
-        "bimmer_connected.account.MyBMWAccount.get_vehicles",
+        BIMMER_CONNECTED_VEHICLE_PATCH,
         side_effect=MyBMWAuthError("Test error"),
     ):
         await hass.config_entries.async_setup(config_entry.entry_id)
@@ -152,7 +152,7 @@ async def test_captcha_reauth(
 
     freezer.tick(timedelta(minutes=10, seconds=1))
     with patch(
-        "bimmer_connected.account.MyBMWAccount.get_vehicles",
+        BIMMER_CONNECTED_VEHICLE_PATCH,
         side_effect=MyBMWCaptchaMissingError(
             "Missing hCaptcha token for North America login"
         ),

--- a/tests/components/bmw_connected_drive/test_coordinator.py
+++ b/tests/components/bmw_connected_drive/test_coordinator.py
@@ -1,4 +1,4 @@
-"""Test BMW coordinator."""
+"""Test BMW coordinator for general availability/unavailability of entities and raising issues."""
 
 from copy import deepcopy
 from datetime import timedelta
@@ -13,27 +13,51 @@ from freezegun.api import FrozenDateTimeFactory
 import pytest
 
 from homeassistant.components.bmw_connected_drive import DOMAIN as BMW_DOMAIN
-from homeassistant.const import CONF_REGION
+from homeassistant.components.bmw_connected_drive.const import CONF_REFRESH_TOKEN
 from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant
-from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers import issue_registry as ir
-from homeassistant.helpers.update_coordinator import UpdateFailed
 
 from . import BIMMER_CONNECTED_VEHICLE_PATCH, FIXTURE_CONFIG_ENTRY
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
+FIXTURE_ENTITY_STATES = {
+    "binary_sensor.m340i_xdrive_door_lock_state": "off",
+    "lock.m340i_xdrive_lock": "locked",
+    "lock.i3_rex_lock": "unlocked",
+    "number.ix_xdrive50_target_soc": "80",
+    "sensor.ix_xdrive50_rear_left_tire_pressure": "2.61",
+    "sensor.ix_xdrive50_rear_right_tire_pressure": "2.69",
+}
+
 
 @pytest.mark.usefixtures("bmw_fixture")
-async def test_update_success(hass: HomeAssistant) -> None:
-    """Test the reauth form."""
-    config_entry = MockConfigEntry(**FIXTURE_CONFIG_ENTRY)
+async def test_config_entry_update(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test if the coordinator updates the refresh token in config entry."""
+    config_entry_fixure = deepcopy(FIXTURE_CONFIG_ENTRY)
+    config_entry_fixure["data"][CONF_REFRESH_TOKEN] = "old_token"
+    config_entry = MockConfigEntry(**config_entry_fixure)
     config_entry.add_to_hass(hass)
+
+    assert (
+        hass.config_entries.async_get_entry(config_entry.entry_id).data[
+            CONF_REFRESH_TOKEN
+        ]
+        == "old_token"
+    )
 
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert config_entry.runtime_data.last_update_success is True
+    assert (
+        hass.config_entries.async_get_entry(config_entry.entry_id).data[
+            CONF_REFRESH_TOKEN
+        ]
+        == "another_token_string"
+    )
 
 
 @pytest.mark.usefixtures("bmw_fixture")
@@ -41,19 +65,19 @@ async def test_update_failed(
     hass: HomeAssistant,
     freezer: FrozenDateTimeFactory,
 ) -> None:
-    """Test the reauth form."""
+    """Test a failing API call."""
     config_entry = MockConfigEntry(**FIXTURE_CONFIG_ENTRY)
     config_entry.add_to_hass(hass)
 
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    coordinator = config_entry.runtime_data
+    # Test if entities show data correctly
+    for entity_id, state in FIXTURE_ENTITY_STATES.items():
+        assert hass.states.get(entity_id).state == state
 
-    assert coordinator.last_update_success is True
-
+    # On API error, entities should be unavailable
     freezer.tick(timedelta(minutes=5, seconds=1))
-
     with patch(
         BIMMER_CONNECTED_VEHICLE_PATCH,
         side_effect=MyBMWAPIError("Test error"),
@@ -61,26 +85,35 @@ async def test_update_failed(
         async_fire_time_changed(hass)
         await hass.async_block_till_done()
 
-    assert coordinator.last_update_success is False
-    assert isinstance(coordinator.last_exception, UpdateFailed) is True
+    for entity_id in FIXTURE_ENTITY_STATES:
+        assert hass.states.get(entity_id).state == "unavailable"
+
+    # And should recover on next update
+    freezer.tick(timedelta(minutes=5, seconds=1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    for entity_id, state in FIXTURE_ENTITY_STATES.items():
+        assert hass.states.get(entity_id).state == state
 
 
 @pytest.mark.usefixtures("bmw_fixture")
-async def test_update_reauth(
+async def test_auth_failed_as_update_failed(
     hass: HomeAssistant,
     freezer: FrozenDateTimeFactory,
 ) -> None:
-    """Test the reauth form."""
+    """Test a single auth failure not initializing reauth flow."""
     config_entry = MockConfigEntry(**FIXTURE_CONFIG_ENTRY)
     config_entry.add_to_hass(hass)
 
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    coordinator = config_entry.runtime_data
+    # Test if entities show data correctly
+    for entity_id, state in FIXTURE_ENTITY_STATES.items():
+        assert hass.states.get(entity_id).state == state
 
-    assert coordinator.last_update_success is True
-
+    # Due to flaky API, we allow one retry on AuthError and raise as UpdateFailed
     freezer.tick(timedelta(minutes=5, seconds=1))
     with patch(
         BIMMER_CONNECTED_VEHICLE_PATCH,
@@ -89,39 +122,62 @@ async def test_update_reauth(
         async_fire_time_changed(hass)
         await hass.async_block_till_done()
 
-    assert coordinator.last_update_success is False
-    assert isinstance(coordinator.last_exception, UpdateFailed) is True
+    for entity_id in FIXTURE_ENTITY_STATES:
+        assert hass.states.get(entity_id).state == "unavailable"
 
+    # And should recover on next update
     freezer.tick(timedelta(minutes=5, seconds=1))
-    with patch(
-        BIMMER_CONNECTED_VEHICLE_PATCH,
-        side_effect=MyBMWAuthError("Test error"),
-    ):
-        async_fire_time_changed(hass)
-        await hass.async_block_till_done()
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
 
-    assert coordinator.last_update_success is False
-    assert isinstance(coordinator.last_exception, ConfigEntryAuthFailed) is True
+    for entity_id, state in FIXTURE_ENTITY_STATES.items():
+        assert hass.states.get(entity_id).state == state
 
 
 @pytest.mark.usefixtures("bmw_fixture")
-async def test_init_reauth(
+async def test_auth_failed_init_reauth(
     hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
     issue_registry: ir.IssueRegistry,
 ) -> None:
-    """Test the reauth form."""
+    """Test a two subsequent auth failures initializing reauth flow."""
 
     config_entry = MockConfigEntry(**FIXTURE_CONFIG_ENTRY)
     config_entry.add_to_hass(hass)
 
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Test if entities show data correctly
+    for entity_id, state in FIXTURE_ENTITY_STATES.items():
+        assert hass.states.get(entity_id).state == state
     assert len(issue_registry.issues) == 0
 
+    # Due to flaky API, we allow one retry on AuthError and raise as UpdateFailed
+    freezer.tick(timedelta(minutes=5, seconds=1))
     with patch(
         BIMMER_CONNECTED_VEHICLE_PATCH,
         side_effect=MyBMWAuthError("Test error"),
     ):
-        await hass.config_entries.async_setup(config_entry.entry_id)
+        async_fire_time_changed(hass)
         await hass.async_block_till_done()
+
+    for entity_id in FIXTURE_ENTITY_STATES:
+        assert hass.states.get(entity_id).state == "unavailable"
+    assert len(issue_registry.issues) == 0
+
+    # On second failure, we should initialize reauth flow
+    freezer.tick(timedelta(minutes=5, seconds=1))
+    with patch(
+        BIMMER_CONNECTED_VEHICLE_PATCH,
+        side_effect=MyBMWAuthError("Test error"),
+    ):
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+
+    for entity_id in FIXTURE_ENTITY_STATES:
+        assert hass.states.get(entity_id).state == "unavailable"
+    assert len(issue_registry.issues) == 1
 
     reauth_issue = issue_registry.async_get_issue(
         HOMEASSISTANT_DOMAIN,
@@ -134,32 +190,34 @@ async def test_init_reauth(
 async def test_captcha_reauth(
     hass: HomeAssistant,
     freezer: FrozenDateTimeFactory,
+    issue_registry: ir.IssueRegistry,
 ) -> None:
-    """Test the reauth form."""
-    TEST_REGION = "north_america"
-
-    config_entry_fixure = deepcopy(FIXTURE_CONFIG_ENTRY)
-    config_entry_fixure["data"][CONF_REGION] = TEST_REGION
-    config_entry = MockConfigEntry(**config_entry_fixure)
+    """Test a CaptchaError initializing reauth flow."""
+    config_entry = MockConfigEntry(**FIXTURE_CONFIG_ENTRY)
     config_entry.add_to_hass(hass)
 
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    coordinator = config_entry.runtime_data
+    # Test if entities show data correctly
+    for entity_id, state in FIXTURE_ENTITY_STATES.items():
+        assert hass.states.get(entity_id).state == state
 
-    assert coordinator.last_update_success is True
-
-    freezer.tick(timedelta(minutes=10, seconds=1))
+    # If library decides a captcha is needed, we should initialize reauth flow
+    freezer.tick(timedelta(minutes=5, seconds=1))
     with patch(
         BIMMER_CONNECTED_VEHICLE_PATCH,
-        side_effect=MyBMWCaptchaMissingError(
-            "Missing hCaptcha token for North America login"
-        ),
+        side_effect=MyBMWCaptchaMissingError("Missing hCaptcha token"),
     ):
         async_fire_time_changed(hass)
         await hass.async_block_till_done()
 
-    assert coordinator.last_update_success is False
-    assert isinstance(coordinator.last_exception, ConfigEntryAuthFailed) is True
-    assert coordinator.last_exception.translation_key == "missing_captcha"
+    for entity_id in FIXTURE_ENTITY_STATES:
+        assert hass.states.get(entity_id).state == "unavailable"
+    assert len(issue_registry.issues) == 1
+
+    reauth_issue = issue_registry.async_get_issue(
+        HOMEASSISTANT_DOMAIN,
+        f"config_entry_reauth_{BMW_DOMAIN}_{config_entry.entry_id}",
+    )
+    assert reauth_issue.active is True

--- a/tests/components/bmw_connected_drive/test_init.py
+++ b/tests/components/bmw_connected_drive/test_init.py
@@ -14,7 +14,7 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
-from . import FIXTURE_CONFIG_ENTRY
+from . import BIMMER_CONNECTED_VEHICLE_PATCH, FIXTURE_CONFIG_ENTRY
 
 from tests.common import MockConfigEntry
 
@@ -156,7 +156,7 @@ async def test_migrate_unique_ids(
     assert entity.unique_id == old_unique_id
 
     with patch(
-        "bimmer_connected.account.MyBMWAccount.get_vehicles",
+        BIMMER_CONNECTED_VEHICLE_PATCH,
         return_value=[],
     ):
         assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
@@ -212,7 +212,7 @@ async def test_dont_migrate_unique_ids(
     assert entity.unique_id == old_unique_id
 
     with patch(
-        "bimmer_connected.account.MyBMWAccount.get_vehicles",
+        BIMMER_CONNECTED_VEHICLE_PATCH,
         return_value=[],
     ):
         assert await hass.config_entries.async_setup(mock_config_entry.entry_id)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve BMW tests based on finding from quality scale review in #132017.

Changes:
- test_show_form doesn't really add anything
- Patch bimmer_connected imports with homeassistant.components.bmw_connected_drive.bimmer_connected imports
- Ensure that configs flows end in CREATE_ENTRY or ABORT
- Parameterize test_authentication_error, test_api_error and test_connection_error
- test_full_user_flow_implementation doesn't assert unique id of created entry
- test that aborts when a mocked config entry already exists
- don't test on internals (e.g. `coordinator.last_update_success`) but rather on the resulting state (change)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
