### PR TITLE
Test color_temp updates are processed when an mqtt json light is turned off

### DIFF
--- a/tests/components/mqtt/test_light_json.py
+++ b/tests/components/mqtt/test_light_json.py
@@ -727,7 +727,6 @@ async def test_controlling_state_via_topic(
     async_fire_mqtt_message(hass, "test_light_rgb", '{"state":"ON", "color_temp":155}')
 
     light_state = hass.states.get("light.test")
-
     assert light_state.attributes.get("color_temp_kelvin") == 6451  # 155 mired
 
     async_fire_mqtt_message(hass, "test_light_rgb", '{"state":"ON", "color_temp":null}')

--- a/tests/components/mqtt/test_light_json.py
+++ b/tests/components/mqtt/test_light_json.py
@@ -763,11 +763,26 @@ async def test_controlling_state_via_topic(
     assert light_state.state == STATE_OFF
     assert light_state.attributes.get("brightness") is None
 
+    # Simulate the lights color temp has been changed
+    # while it was switched off
+    async_fire_mqtt_message(
+        hass,
+        "test_light_rgb",
+        '{"state":"OFF","color_temp":201}',
+    )
+    light_state = hass.states.get("light.test")
+    assert light_state.state == STATE_OFF
+    # Color temp attribute is not exposed while the lamp is off
+    assert light_state.attributes.get("color_temp") is None
+
     # test previous zero brightness received was ignored and brightness is restored
+    # see if the latest color_temp value received is restored
     async_fire_mqtt_message(hass, "test_light_rgb", '{"state":"ON"}')
     light_state = hass.states.get("light.test")
     assert light_state.attributes.get("brightness") == 128
+    assert light_state.attributes.get("color_temp") == 201
 
+    # A `0` brightness value is ignored when a light is turned on
     async_fire_mqtt_message(hass, "test_light_rgb", '{"state":"ON","brightness":0}')
     light_state = hass.states.get("light.test")
     assert light_state.attributes.get("brightness") == 128

--- a/tests/components/mqtt/test_light_json.py
+++ b/tests/components/mqtt/test_light_json.py
@@ -727,12 +727,13 @@ async def test_controlling_state_via_topic(
     async_fire_mqtt_message(hass, "test_light_rgb", '{"state":"ON", "color_temp":155}')
 
     light_state = hass.states.get("light.test")
-    assert light_state.attributes.get("color_temp") == 155
+
+    assert light_state.attributes.get("color_temp_kelvin") == 6451  # 155 mired
 
     async_fire_mqtt_message(hass, "test_light_rgb", '{"state":"ON", "color_temp":null}')
 
     light_state = hass.states.get("light.test")
-    assert light_state.attributes.get("color_temp") is None
+    assert light_state.attributes.get("color_temp_kelvin") is None
 
     async_fire_mqtt_message(
         hass, "test_light_rgb", '{"state":"ON", "effect":"colorloop"}'
@@ -773,14 +774,14 @@ async def test_controlling_state_via_topic(
     light_state = hass.states.get("light.test")
     assert light_state.state == STATE_OFF
     # Color temp attribute is not exposed while the lamp is off
-    assert light_state.attributes.get("color_temp") is None
+    assert light_state.attributes.get("color_temp_kelvin") is None
 
     # test previous zero brightness received was ignored and brightness is restored
     # see if the latest color_temp value received is restored
     async_fire_mqtt_message(hass, "test_light_rgb", '{"state":"ON"}')
     light_state = hass.states.get("light.test")
     assert light_state.attributes.get("brightness") == 128
-    assert light_state.attributes.get("color_temp") == 201
+    assert light_state.attributes.get("color_temp_kelvin") == 4975  # 201 mired
 
     # A `0` brightness value is ignored when a light is turned on
     async_fire_mqtt_message(hass, "test_light_rgb", '{"state":"ON","brightness":0}')


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Additional test to assert state updates for `color_temp` are processed when an MQTT json light is turned off.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #121347
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
