### PR TITLE
Record Overkiz quality scale

### DIFF
--- a/homeassistant/components/overkiz/quality_scale.yaml
+++ b/homeassistant/components/overkiz/quality_scale.yaml
@@ -24,40 +24,42 @@ rules:
   runtime-data: done
 
   # Silver
-  log-when-unavailable: todo
-  config-entry-unloading: todo
-  reauthentication-flow: todo
+  log-when-unavailable: done
+  config-entry-unloading: done
+  reauthentication-flow: done
   action-exceptions:
     status: exempt
     comment: The integration does not register actions.
-  docs-installation-parameters: todo
+  docs-installation-parameters: done
   integration-owner: done
   parallel-updates: todo
   test-coverage: todo
-  docs-configuration-parameters: todo
-  entity-unavailable: todo
+  docs-configuration-parameters:
+    status: exempt
+    comment: The integration does not provide configuration parameters.
+  entity-unavailable: done
 
   # Gold
   docs-examples: todo
-  discovery-update-info: todo
-  entity-device-class: todo
+  discovery-update-info: done
+  entity-device-class: done
   entity-translations: todo
-  docs-data-update: todo
-  entity-disabled-by-default: todo
-  discovery: todo
+  docs-data-update: done
+  entity-disabled-by-default: done
+  discovery: done
   exception-translations: todo
-  devices: todo
-  docs-supported-devices: todo
+  devices: done
+  docs-supported-devices: done
   icon-translations: todo
-  docs-known-limitations: todo
+  docs-known-limitations: done
   stale-devices: todo
   docs-supported-functions: todo
   repair-issues: todo
   reconfiguration-flow: todo
-  entity-category: todo
+  entity-category: done
   dynamic-devices: todo
   docs-troubleshooting: todo
-  diagnostics: todo
+  diagnostics: done
   docs-use-cases: todo
 
   # Platinum

--- a/homeassistant/components/overkiz/quality_scale.yaml
+++ b/homeassistant/components/overkiz/quality_scale.yaml
@@ -29,9 +29,11 @@ rules:
   log-when-unavailable: todo
   config-entry-unloading: todo
   reauthentication-flow: todo
-  action-exceptions: todo
+  action-exceptions:
+    status: exempt
+    comment: The integration does not register actions.
   docs-installation-parameters: todo
-  integration-owner: todo
+  integration-owner: done
   parallel-updates: todo
   test-coverage: todo
   docs-configuration-parameters: todo

--- a/homeassistant/components/overkiz/quality_scale.yaml
+++ b/homeassistant/components/overkiz/quality_scale.yaml
@@ -23,7 +23,7 @@ rules:
   docs-actions:
     status: exempt
     comment: The integration does not register actions.
-  runtime-data: todo
+  runtime-data: done
 
   # Silver
   log-when-unavailable: todo

--- a/homeassistant/components/overkiz/quality_scale.yaml
+++ b/homeassistant/components/overkiz/quality_scale.yaml
@@ -1,0 +1,64 @@
+rules:
+  # Bronze
+  config-flow: todo
+  brands: todo
+  dependency-transparency: todo
+  common-modules: todo
+  has-entity-name: todo
+  action-setup:
+    status: exempt
+    comment: The integration does not register actions.
+  appropriate-polling: todo
+  test-before-configure: todo
+  entity-event-setup: todo
+  unique-config-entry: todo
+  entity-unique-id: todo
+  docs-installation-instructions: todo
+  docs-removal-instructions: todo
+  test-before-setup: todo
+  docs-high-level-description: todo
+  config-flow-test-coverage: todo
+  docs-actions:
+    status: exempt
+    comment: The integration does not register actions.
+  runtime-data: todo
+
+  # Silver
+  log-when-unavailable: todo
+  config-entry-unloading: todo
+  reauthentication-flow: todo
+  action-exceptions: todo
+  docs-installation-parameters: todo
+  integration-owner: todo
+  parallel-updates: todo
+  test-coverage: todo
+  docs-configuration-parameters: todo
+  entity-unavailable: todo
+
+  # Gold
+  docs-examples: todo
+  discovery-update-info: todo
+  entity-device-class: todo
+  entity-translations: todo
+  docs-data-update: todo
+  entity-disabled-by-default: todo
+  discovery: todo
+  exception-translations: todo
+  devices: todo
+  docs-supported-devices: todo
+  icon-translations: todo
+  docs-known-limitations: todo
+  stale-devices: todo
+  docs-supported-functions: todo
+  repair-issues: todo
+  reconfiguration-flow: todo
+  entity-category: todo
+  dynamic-devices: todo
+  docs-troubleshooting: todo
+  diagnostics: todo
+  docs-use-cases: todo
+
+  # Platinum
+  async-dependency: todo
+  strict-typing: todo
+  inject-websession: todo

--- a/homeassistant/components/overkiz/quality_scale.yaml
+++ b/homeassistant/components/overkiz/quality_scale.yaml
@@ -1,23 +1,25 @@
 rules:
   # Bronze
-  config-flow: todo
-  brands: todo
-  dependency-transparency: todo
-  common-modules: todo
-  has-entity-name: todo
+  config-flow:
+    status: todo
+    comment: Fields are missing a data_description
+  brands: done
+  dependency-transparency: done
+  common-modules: done
+  has-entity-name: done
   action-setup:
     status: exempt
     comment: The integration does not register actions.
-  appropriate-polling: todo
-  test-before-configure: todo
-  entity-event-setup: todo
-  unique-config-entry: todo
-  entity-unique-id: todo
-  docs-installation-instructions: todo
+  appropriate-polling: done
+  test-before-configure: done
+  entity-event-setup: done
+  unique-config-entry: done
+  entity-unique-id: done
+  docs-installation-instructions: done
   docs-removal-instructions: todo
-  test-before-setup: todo
-  docs-high-level-description: todo
-  config-flow-test-coverage: todo
+  test-before-setup: done
+  docs-high-level-description: done
+  config-flow-test-coverage: done
   docs-actions:
     status: exempt
     comment: The integration does not register actions.

--- a/homeassistant/components/overkiz/quality_scale.yaml
+++ b/homeassistant/components/overkiz/quality_scale.yaml
@@ -61,6 +61,6 @@ rules:
   docs-use-cases: todo
 
   # Platinum
-  async-dependency: todo
-  strict-typing: todo
-  inject-websession: todo
+  async-dependency: done
+  strict-typing: done
+  inject-websession: done

--- a/homeassistant/components/overkiz/quality_scale.yaml
+++ b/homeassistant/components/overkiz/quality_scale.yaml
@@ -1,8 +1,6 @@
 rules:
   # Bronze
-  config-flow:
-    status: todo
-    comment: Fields are missing a data_description
+  config-flow: done
   brands: done
   dependency-transparency: done
   common-modules: done

--- a/homeassistant/components/overkiz/quality_scale.yaml
+++ b/homeassistant/components/overkiz/quality_scale.yaml
@@ -14,7 +14,7 @@ rules:
   unique-config-entry: done
   entity-unique-id: done
   docs-installation-instructions: done
-  docs-removal-instructions: todo
+  docs-removal-instructions: done
   test-before-setup: done
   docs-high-level-description: done
   config-flow-test-coverage: done

--- a/script/hassfest/quality_scale.py
+++ b/script/hassfest/quality_scale.py
@@ -1744,7 +1744,6 @@ INTEGRATIONS_WITHOUT_SCALE = [
     "otbr",
     "otp",
     "ourgroceries",
-    "overkiz",
     "ovo_energy",
     "owntracks",
     "p1_monitor",


### PR DESCRIPTION
## Proposed change
## Bronze
- [x] `config-flow` - Integration needs to be able to be set up via the UI
    - [x] Uses `data_description` to give context to fields
    - [x] Uses `ConfigEntry.data` and `ConfigEntry.options` correctly
- [x] `test-before-configure` - Test a connection in the config flow
https://github.com/home-assistant/core/blob/a3febc4449375868c8968350262b8dd84170e76b/homeassistant/components/overkiz/config_flow.py#L64
- [x] `unique-config-entry` - Don't allow the same device or service to be able to be set up twice
https://github.com/home-assistant/core/blob/a3febc4449375868c8968350262b8dd84170e76b/homeassistant/components/overkiz/config_flow.py#L79
https://github.com/home-assistant/core/blob/a3febc4449375868c8968350262b8dd84170e76b/homeassistant/components/overkiz/config_flow.py#L186
- [x] `config-flow-test-coverage` - Full test coverage for the config flow
- [x] `runtime-data` - Use ConfigEntry.runtime_data to store runtime data
https://github.com/home-assistant/core/blob/619aed39b70fb6eb4712cb4fad643e461b16f765/homeassistant/components/overkiz/__init__.py#L129-L131
- [x] `test-before-setup` - Check during integration initialization if we are able to set it up correctly
https://github.com/home-assistant/core/blob/a3febc4449375868c8968350262b8dd84170e76b/homeassistant/components/overkiz/__init__.py#L82-L83
- [x] `appropriate-polling` - If it's a polling integration, set an appropriate polling interval
https://github.com/home-assistant/core/blob/a3febc4449375868c8968350262b8dd84170e76b/homeassistant/components/overkiz/const.py#L46-L47
- [x] `entity-unique-id` - Entities have a unique ID
https://github.com/home-assistant/core/blob/a3febc4449375868c8968350262b8dd84170e76b/homeassistant/components/overkiz/entity.py#L39
- [x] `has-entity-name` - Entities use has_entity_name = True
https://github.com/home-assistant/core/blob/a3febc4449375868c8968350262b8dd84170e76b/homeassistant/components/overkiz/entity.py#L22
- [x] `entity-event-setup` - Entities event setup
Handled in coordinator.py
- [x] `dependency-transparency` - Dependency transparency
https://github.com/iMicknl/python-overkiz-api
- [x] `action-setup` - Service actions are registered in async_setup
- [x] `common-modules` - Place common patterns in common modules
[coordinator.py](https://github.com/home-assistant/core/blob/dev/homeassistant/components/overkiz/coordinator.py), [entity.py](https://github.com/home-assistant/core/blob/dev/homeassistant/components/overkiz/entity.py)
- [x] `docs-high-level-description` - The documentation includes a high-level description of the integration brand, product, or service
https://www.home-assistant.io/integrations/overkiz/
- [x] `docs-installation-instructions` - The documentation provides step-by-step installation instructions for the integration, including, if needed, prerequisites
- [x] `docs-removal-instructions` - The documentation provides removal instructions
https://www.home-assistant.io/integrations/overkiz#removing-the-integration
- [x] `docs-actions` - The documentation describes the provided service actions that can be used
- [x] `brands` - Has branding assets available for the integration

## Silver
- [x] `config-entry-unloading` - Support config entry unloading
https://github.com/home-assistant/core/blob/bbb5f9e7173debcd3b412cef41e09ab8df56369b/homeassistant/components/overkiz/__init__.py#L168
- [x] `log-when-unavailable` - If internet/device/service is unavailable, log once when unavailable and once when back connected
https://github.com/home-assistant/core/blob/bbb5f9e7173debcd3b412cef41e09ab8df56369b/homeassistant/components/overkiz/coordinator.py#L75-L84
- [x] `entity-unavailable` - Mark entity unavailable if appropriate
https://github.com/home-assistant/core/blob/bbb5f9e7173debcd3b412cef41e09ab8df56369b/homeassistant/components/overkiz/coordinator.py#L75-L84
https://github.com/home-assistant/core/blob/bbb5f9e7173debcd3b412cef41e09ab8df56369b/homeassistant/components/overkiz/entity.py#L38
- [x] `action-exceptions` - Service actions raise exceptions when encountering failures
- [x] `reauthentication-flow` - Reauthentication flow
https://github.com/home-assistant/core/blob/bbb5f9e7173debcd3b412cef41e09ab8df56369b/homeassistant/components/overkiz/config_flow.py#L318
- [ ] `parallel-updates` - Set Parallel updates
- [ ] `test-coverage` - Above 95% test coverage for all integration modules
- [x] `integration-owner` - Has an integration owner
- [x] `docs-installation-parameters` - The documentation describes all integration installation parameters
https://www.home-assistant.io/integrations/overkiz#configuration
- [x] `docs-configuration-parameters` - The documentation describes all integration configuration options

## Gold
- [ ] `entity-translations` - Entities have translated names
- [x] `entity-device-class` - Entities use device classes where possible
- [x] `devices` - The integration creates devices
https://github.com/home-assistant/core/blob/bbb5f9e7173debcd3b412cef41e09ab8df56369b/homeassistant/components/overkiz/entity.py#L90
- [x] `entity-category` - Entities are assigned an appropriate EntityCategory
- [x] `entity-disabled-by-default` - Integration disables less popular (or noisy) entities
https://github.com/home-assistant/core/blob/bbb5f9e7173debcd3b412cef41e09ab8df56369b/homeassistant/components/overkiz/sensor.py#L233
- [x] `discovery` - Can be discovered
https://github.com/home-assistant/core/blob/bbb5f9e7173debcd3b412cef41e09ab8df56369b/homeassistant/components/overkiz/config_flow.py#L286
- [ ] `stale-devices` - Clean up stale devices
- [x] `diagnostics` - Implements diagnostics
https://github.com/home-assistant/core/blob/bbb5f9e7173debcd3b412cef41e09ab8df56369b/homeassistant/components/overkiz/diagnostics.py#L17
- [ ] `exception-translations` - Exception messages are translatable
- [ ] `icon-translations` - Icon translations
- [ ] `reconfiguration-flow` - Integrations should have a reconfigure flow
- [ ] `dynamic-devices` - Devices added after integration setup
- [x] `discovery-update-info` - Integration uses discovery info to update network information
https://github.com/home-assistant/core/blob/bbb5f9e7173debcd3b412cef41e09ab8df56369b/homeassistant/components/overkiz/config_flow.py#L290-L292
- [ ] `repair-issues` - Repair issues and repair flows are used when user intervention is needed
- [ ] `docs-use-cases` - The documentation describes use cases to illustrate how this integration can be used
- [x] `docs-supported-devices` - The documentation describes known supported / unsupported devices
- [ ] `docs-supported-functions` - The documentation describes the supported functionality, including entities, and platforms
- [x] `docs-data-update` - The documentation describes how data is updated
- [x] `docs-known-limitations` - The documentation describes known limitations of the integration (not to be confused with bugs)
- [ ] `docs-troubleshooting` - The documentation provides troubleshooting information
- [ ] `docs-examples` - The documentation provides automation examples the user can use.

## Platinum
- [x] `async-dependency` - Dependency is async
https://github.com/home-assistant/core/blob/619aed39b70fb6eb4712cb4fad643e461b16f765/homeassistant/components/overkiz/__init__.py#L86-L87
- [x] `inject-websession` - The integration dependency supports passing in a websession
https://github.com/home-assistant/core/blob/619aed39b70fb6eb4712cb4fad643e461b16f765/homeassistant/components/overkiz/__init__.py#L238
https://github.com/home-assistant/core/blob/619aed39b70fb6eb4712cb4fad643e461b16f765/homeassistant/components/overkiz/__init__.py#L255-L259
- [x] `strict-typing` - Strict typing
https://github.com/home-assistant/core/blob/619aed39b70fb6eb4712cb4fad643e461b16f765/.strict-typing#L364



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
