### PR TITLE
Add missing asserts to enphase_envoy config flow test

### DIFF
--- a/homeassistant/components/enphase_envoy/quality_scale.yaml
+++ b/homeassistant/components/enphase_envoy/quality_scale.yaml
@@ -11,13 +11,10 @@ rules:
   config-flow-test-coverage:
     status: todo
     comment: |
-      - test_form is missing an assertion for the unique id of the resulting entry
-      - Let's also have test_user_no_serial_number assert the unique_id (as in, it can't be set to the serial_number since we dont have one, so let's assert what it will result in)
       - Let's have every test result in either CREATE_ENTRY or ABORT (like test_form_invalid_auth or test_form_cannot_connect, they can be parametrized)
       - test_zeroconf_token_firmware and test_zeroconf_pre_token_firmware can also be parametrized I think
       - test_zero_conf_malformed_serial_property - with pytest.raises(KeyError) as ex::
       I don't believe this should be able to raise a KeyError Shouldn't we abort the flow?
-      test_reauth -> Let's also assert result before we start with the async_configure part
   config-flow:
     status: todo
     comment: |

--- a/tests/components/enphase_envoy/test_config_flow.py
+++ b/tests/components/enphase_envoy/test_config_flow.py
@@ -49,6 +49,7 @@ async def test_form(
     )
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == "Envoy 1234"
+    assert result["result"].unique_id == "1234"
     assert result["data"] == {
         CONF_HOST: "1.1.1.1",
         CONF_NAME: "Envoy 1234",
@@ -80,6 +81,7 @@ async def test_user_no_serial_number(
     )
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == "Envoy"
+    assert result["result"].unique_id is None
     assert result["data"] == {
         CONF_HOST: "1.1.1.1",
         CONF_NAME: "Envoy",
@@ -100,6 +102,8 @@ async def test_form_invalid_auth(
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
+    assert result["type"] is FlowResultType.FORM
+
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {
@@ -131,6 +135,8 @@ async def test_form_cannot_connect(
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
+    assert result["type"] is FlowResultType.FORM
+
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {
@@ -634,6 +640,8 @@ async def test_reauth(
     """Test we reauth auth."""
     await setup_integration(hass, config_entry)
     result = await config_entry.start_reauth_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
Improve integration quality scale by resolving quality_scale review feedback.

Feedback resolved:

- _test_form is missing an assertion for the unique id of the resulting entry_
- _Let's also have test_user_no_serial_number assert the unique_id (as in, it can't be set to the serial_number since we dont have one, so let's assert what it will result in)_
- _test_reauth -> Let's also assert result before we start with the async_configure part_

This PR adds missing asserts for unique_id and flow results.


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
