### PR TITLE
Add number platform to Peblar Rocksolid EV Chargers integration

### DIFF
--- a/homeassistant/components/peblar/__init__.py
+++ b/homeassistant/components/peblar/__init__.py
@@ -22,13 +22,14 @@ from homeassistant.helpers.aiohttp_client import async_create_clientsession
 from .const import DOMAIN
 from .coordinator import (
     PeblarConfigEntry,
-    PeblarMeterDataUpdateCoordinator,
+    PeblarDataUpdateCoordinator,
     PeblarRuntimeData,
     PeblarUserConfigurationDataUpdateCoordinator,
     PeblarVersionDataUpdateCoordinator,
 )
 
 PLATFORMS = [
+    Platform.NUMBER,
     Platform.SELECT,
     Platform.SENSOR,
     Platform.UPDATE,
@@ -57,7 +58,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: PeblarConfigEntry) -> bo
         ) from err
 
     # Setup the data coordinators
-    meter_coordinator = PeblarMeterDataUpdateCoordinator(hass, entry, api)
+    meter_coordinator = PeblarDataUpdateCoordinator(hass, entry, api)
     user_configuration_coordinator = PeblarUserConfigurationDataUpdateCoordinator(
         hass, entry, peblar
     )
@@ -70,7 +71,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: PeblarConfigEntry) -> bo
 
     # Store the runtime data
     entry.runtime_data = PeblarRuntimeData(
-        meter_coordinator=meter_coordinator,
+        data_coordinator=meter_coordinator,
         system_information=system_information,
         user_configuraton_coordinator=user_configuration_coordinator,
         version_coordinator=version_coordinator,

--- a/homeassistant/components/peblar/coordinator.py
+++ b/homeassistant/components/peblar/coordinator.py
@@ -9,6 +9,7 @@ from peblar import (
     Peblar,
     PeblarApi,
     PeblarError,
+    PeblarEVInterface,
     PeblarMeter,
     PeblarUserConfiguration,
     PeblarVersions,
@@ -26,7 +27,7 @@ from .const import LOGGER
 class PeblarRuntimeData:
     """Class to hold runtime data."""
 
-    meter_coordinator: PeblarMeterDataUpdateCoordinator
+    data_coordinator: PeblarDataUpdateCoordinator
     system_information: PeblarSystemInformation
     user_configuraton_coordinator: PeblarUserConfigurationDataUpdateCoordinator
     version_coordinator: PeblarVersionDataUpdateCoordinator
@@ -41,6 +42,19 @@ class PeblarVersionInformation:
 
     current: PeblarVersions
     available: PeblarVersions
+
+
+@dataclass(kw_only=True)
+class PeblarData:
+    """Class to hold active charging related information of Peblar.
+
+    This is data that needs to be polled and updated at a relatively high
+    frequency in order for this integration to function correctly.
+    All this data is updated at the same time by a single coordinator.
+    """
+
+    ev: PeblarEVInterface
+    meter: PeblarMeter
 
 
 class PeblarVersionDataUpdateCoordinator(
@@ -72,8 +86,8 @@ class PeblarVersionDataUpdateCoordinator(
             raise UpdateFailed(err) from err
 
 
-class PeblarMeterDataUpdateCoordinator(DataUpdateCoordinator[PeblarMeter]):
-    """Class to manage fetching Peblar meter data."""
+class PeblarDataUpdateCoordinator(DataUpdateCoordinator[PeblarData]):
+    """Class to manage fetching Peblar active data."""
 
     def __init__(
         self, hass: HomeAssistant, entry: PeblarConfigEntry, api: PeblarApi
@@ -88,10 +102,13 @@ class PeblarMeterDataUpdateCoordinator(DataUpdateCoordinator[PeblarMeter]):
             update_interval=timedelta(seconds=10),
         )
 
-    async def _async_update_data(self) -> PeblarMeter:
+    async def _async_update_data(self) -> PeblarData:
         """Fetch data from the Peblar device."""
         try:
-            return await self.api.meter()
+            return PeblarData(
+                ev=await self.api.ev_interface(),
+                meter=await self.api.meter(),
+            )
         except PeblarError as err:
             raise UpdateFailed(err) from err
 

--- a/homeassistant/components/peblar/diagnostics.py
+++ b/homeassistant/components/peblar/diagnostics.py
@@ -16,7 +16,8 @@ async def async_get_config_entry_diagnostics(
     return {
         "system_information": entry.runtime_data.system_information.to_dict(),
         "user_configuration": entry.runtime_data.user_configuraton_coordinator.data.to_dict(),
-        "meter": entry.runtime_data.meter_coordinator.data.to_dict(),
+        "ev": entry.runtime_data.data_coordinator.data.ev.to_dict(),
+        "meter": entry.runtime_data.data_coordinator.data.meter.to_dict(),
         "versions": {
             "available": entry.runtime_data.version_coordinator.data.available.to_dict(),
             "current": entry.runtime_data.version_coordinator.data.current.to_dict(),

--- a/homeassistant/components/peblar/icons.json
+++ b/homeassistant/components/peblar/icons.json
@@ -1,5 +1,10 @@
 {
   "entity": {
+    "number": {
+      "charge_current_limit": {
+        "default": "mdi:speedometer"
+      }
+    },
     "select": {
       "smart_charging": {
         "default": "mdi:lightning-bolt",

--- a/homeassistant/components/peblar/number.py
+++ b/homeassistant/components/peblar/number.py
@@ -1,0 +1,100 @@
+"""Support for Peblar numbers."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any
+
+from peblar import PeblarApi
+
+from homeassistant.components.number import NumberEntity, NumberEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory, UnitOfElectricCurrent
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import (
+    PeblarConfigEntry,
+    PeblarData,
+    PeblarDataUpdateCoordinator,
+    PeblarRuntimeData,
+)
+
+
+@dataclass(frozen=True, kw_only=True)
+class PeblarNumberEntityDescription(NumberEntityDescription):
+    """Describe a Peblar number."""
+
+    native_max_value_fn: Callable[[PeblarRuntimeData], int]
+    set_value_fn: Callable[[PeblarApi, float], Awaitable[Any]]
+    value_fn: Callable[[PeblarData], int | None]
+
+
+DESCRIPTIONS = [
+    PeblarNumberEntityDescription(
+        key="charge_current_limit",
+        translation_key="charge_current_limit",
+        entity_category=EntityCategory.CONFIG,
+        native_step=1,
+        native_min_value=6,
+        native_max_value_fn=lambda x: x.system_information.hardware_max_current,
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        set_value_fn=lambda x, v: x.ev_interface(charge_current_limit=int(v) * 1000),
+        value_fn=lambda x: round(x.ev.charge_current_limit_actual / 1000),
+    ),
+]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Peblar number based on a config entry."""
+    async_add_entities(
+        PeblarNumberEntity(
+            entry=entry,
+            description=description,
+        )
+        for description in DESCRIPTIONS
+    )
+
+
+class PeblarNumberEntity(CoordinatorEntity[PeblarDataUpdateCoordinator], NumberEntity):
+    """Defines a Peblar number."""
+
+    entity_description: PeblarNumberEntityDescription
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        entry: PeblarConfigEntry,
+        description: PeblarNumberEntityDescription,
+    ) -> None:
+        """Initialize the Peblar entity."""
+        super().__init__(entry.runtime_data.data_coordinator)
+        self.entity_description = description
+        self._attr_unique_id = f"{entry.unique_id}_{description.key}"
+        self._attr_device_info = DeviceInfo(
+            identifiers={
+                (DOMAIN, entry.runtime_data.system_information.product_serial_number)
+            },
+        )
+        self._attr_native_max_value = description.native_max_value_fn(
+            entry.runtime_data
+        )
+
+    @property
+    def native_value(self) -> int | None:
+        """Return the number value."""
+        return self.entity_description.value_fn(self.coordinator.data)
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Change to new number value."""
+        await self.entity_description.set_value_fn(self.coordinator.api, value)
+        await self.coordinator.async_request_refresh()

--- a/homeassistant/components/peblar/number.py
+++ b/homeassistant/components/peblar/number.py
@@ -8,8 +8,11 @@ from typing import Any
 
 from peblar import PeblarApi
 
-from homeassistant.components.number import NumberEntity, NumberEntityDescription
-from homeassistant.config_entries import ConfigEntry
+from homeassistant.components.number import (
+    NumberDeviceClass,
+    NumberEntity,
+    NumberEntityDescription,
+)
 from homeassistant.const import EntityCategory, UnitOfElectricCurrent
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -38,6 +41,7 @@ DESCRIPTIONS = [
     PeblarNumberEntityDescription(
         key="charge_current_limit",
         translation_key="charge_current_limit",
+        device_class=NumberDeviceClass.CURRENT,
         entity_category=EntityCategory.CONFIG,
         native_step=1,
         native_min_value=6,
@@ -51,7 +55,7 @@ DESCRIPTIONS = [
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: PeblarConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Peblar number based on a config entry."""

--- a/homeassistant/components/peblar/sensor.py
+++ b/homeassistant/components/peblar/sensor.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass
 
-from peblar import PeblarMeter, PeblarUserConfiguration
+from peblar import PeblarUserConfiguration
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -26,15 +26,15 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
-from .coordinator import PeblarConfigEntry, PeblarMeterDataUpdateCoordinator
+from .coordinator import PeblarConfigEntry, PeblarData, PeblarDataUpdateCoordinator
 
 
 @dataclass(frozen=True, kw_only=True)
 class PeblarSensorDescription(SensorEntityDescription):
-    """Describe an Peblar sensor."""
+    """Describe a Peblar sensor."""
 
     has_fn: Callable[[PeblarUserConfiguration], bool] = lambda _: True
-    value_fn: Callable[[PeblarMeter], int | None]
+    value_fn: Callable[[PeblarData], int | None]
 
 
 DESCRIPTIONS: tuple[PeblarSensorDescription, ...] = (
@@ -48,7 +48,7 @@ DESCRIPTIONS: tuple[PeblarSensorDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=1,
         suggested_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
-        value_fn=lambda x: x.current_phase_1,
+        value_fn=lambda x: x.meter.current_phase_1,
     ),
     PeblarSensorDescription(
         key="current_phase_1",
@@ -61,7 +61,7 @@ DESCRIPTIONS: tuple[PeblarSensorDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=1,
         suggested_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
-        value_fn=lambda x: x.current_phase_1,
+        value_fn=lambda x: x.meter.current_phase_1,
     ),
     PeblarSensorDescription(
         key="current_phase_2",
@@ -74,7 +74,7 @@ DESCRIPTIONS: tuple[PeblarSensorDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=1,
         suggested_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
-        value_fn=lambda x: x.current_phase_2,
+        value_fn=lambda x: x.meter.current_phase_2,
     ),
     PeblarSensorDescription(
         key="current_phase_3",
@@ -87,7 +87,7 @@ DESCRIPTIONS: tuple[PeblarSensorDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=1,
         suggested_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
-        value_fn=lambda x: x.current_phase_3,
+        value_fn=lambda x: x.meter.current_phase_3,
     ),
     PeblarSensorDescription(
         key="energy_session",
@@ -97,7 +97,7 @@ DESCRIPTIONS: tuple[PeblarSensorDescription, ...] = (
         state_class=SensorStateClass.TOTAL_INCREASING,
         suggested_display_precision=2,
         suggested_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
-        value_fn=lambda x: x.energy_session,
+        value_fn=lambda x: x.meter.energy_session,
     ),
     PeblarSensorDescription(
         key="energy_total",
@@ -108,14 +108,14 @@ DESCRIPTIONS: tuple[PeblarSensorDescription, ...] = (
         state_class=SensorStateClass.TOTAL_INCREASING,
         suggested_display_precision=2,
         suggested_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
-        value_fn=lambda x: x.energy_total,
+        value_fn=lambda x: x.meter.energy_total,
     ),
     PeblarSensorDescription(
         key="power_total",
         device_class=SensorDeviceClass.POWER,
         native_unit_of_measurement=UnitOfPower.WATT,
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda x: x.power_total,
+        value_fn=lambda x: x.meter.power_total,
     ),
     PeblarSensorDescription(
         key="power_phase_1",
@@ -126,7 +126,7 @@ DESCRIPTIONS: tuple[PeblarSensorDescription, ...] = (
         has_fn=lambda x: x.connected_phases >= 2,
         native_unit_of_measurement=UnitOfPower.WATT,
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda x: x.power_phase_1,
+        value_fn=lambda x: x.meter.power_phase_1,
     ),
     PeblarSensorDescription(
         key="power_phase_2",
@@ -137,7 +137,7 @@ DESCRIPTIONS: tuple[PeblarSensorDescription, ...] = (
         has_fn=lambda x: x.connected_phases >= 2,
         native_unit_of_measurement=UnitOfPower.WATT,
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda x: x.power_phase_2,
+        value_fn=lambda x: x.meter.power_phase_2,
     ),
     PeblarSensorDescription(
         key="power_phase_3",
@@ -148,7 +148,7 @@ DESCRIPTIONS: tuple[PeblarSensorDescription, ...] = (
         has_fn=lambda x: x.connected_phases == 3,
         native_unit_of_measurement=UnitOfPower.WATT,
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda x: x.power_phase_3,
+        value_fn=lambda x: x.meter.power_phase_3,
     ),
     PeblarSensorDescription(
         key="voltage",
@@ -158,7 +158,7 @@ DESCRIPTIONS: tuple[PeblarSensorDescription, ...] = (
         has_fn=lambda x: x.connected_phases == 1,
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda x: x.voltage_phase_1,
+        value_fn=lambda x: x.meter.voltage_phase_1,
     ),
     PeblarSensorDescription(
         key="voltage_phase_1",
@@ -169,7 +169,7 @@ DESCRIPTIONS: tuple[PeblarSensorDescription, ...] = (
         has_fn=lambda x: x.connected_phases >= 2,
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda x: x.voltage_phase_1,
+        value_fn=lambda x: x.meter.voltage_phase_1,
     ),
     PeblarSensorDescription(
         key="voltage_phase_2",
@@ -180,7 +180,7 @@ DESCRIPTIONS: tuple[PeblarSensorDescription, ...] = (
         has_fn=lambda x: x.connected_phases >= 2,
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda x: x.voltage_phase_2,
+        value_fn=lambda x: x.meter.voltage_phase_2,
     ),
     PeblarSensorDescription(
         key="voltage_phase_3",
@@ -191,7 +191,7 @@ DESCRIPTIONS: tuple[PeblarSensorDescription, ...] = (
         has_fn=lambda x: x.connected_phases == 3,
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda x: x.voltage_phase_3,
+        value_fn=lambda x: x.meter.voltage_phase_3,
     ),
 )
 
@@ -209,9 +209,7 @@ async def async_setup_entry(
     )
 
 
-class PeblarSensorEntity(
-    CoordinatorEntity[PeblarMeterDataUpdateCoordinator], SensorEntity
-):
+class PeblarSensorEntity(CoordinatorEntity[PeblarDataUpdateCoordinator], SensorEntity):
     """Defines a Peblar sensor."""
 
     entity_description: PeblarSensorDescription
@@ -224,7 +222,7 @@ class PeblarSensorEntity(
         description: PeblarSensorDescription,
     ) -> None:
         """Initialize the Peblar entity."""
-        super().__init__(entry.runtime_data.meter_coordinator)
+        super().__init__(entry.runtime_data.data_coordinator)
         self.entity_description = description
         self._attr_unique_id = f"{entry.unique_id}_{description.key}"
         self._attr_device_info = DeviceInfo(

--- a/homeassistant/components/peblar/strings.json
+++ b/homeassistant/components/peblar/strings.json
@@ -33,6 +33,11 @@
     }
   },
   "entity": {
+    "number": {
+      "charge_current_limit": {
+        "name": "Charge limit"
+      }
+    },
     "select": {
       "smart_charging": {
         "name": "Smart charging",

--- a/tests/components/peblar/conftest.py
+++ b/tests/components/peblar/conftest.py
@@ -7,6 +7,7 @@ from contextlib import nullcontext
 from unittest.mock import MagicMock, patch
 
 from peblar import (
+    PeblarEVInterface,
     PeblarMeter,
     PeblarSystemInformation,
     PeblarUserConfiguration,
@@ -64,6 +65,9 @@ def mock_peblar() -> Generator[MagicMock]:
         )
 
         api = peblar.rest_api.return_value
+        api.ev_interface.return_value = PeblarEVInterface.from_json(
+            load_fixture("ev_interface.json", DOMAIN)
+        )
         api.meter.return_value = PeblarMeter.from_json(
             load_fixture("meter.json", DOMAIN)
         )

--- a/tests/components/peblar/fixtures/ev_interface.json
+++ b/tests/components/peblar/fixtures/ev_interface.json
@@ -1,0 +1,7 @@
+{
+  "ChargeCurrentLimit": 16000,
+  "ChargeCurrentLimitActual": 6000,
+  "ChargeCurrentLimitSource": "Current limiter",
+  "CpState": "State C",
+  "Force1Phase": false
+}

--- a/tests/components/peblar/snapshots/test_diagnostics.ambr
+++ b/tests/components/peblar/snapshots/test_diagnostics.ambr
@@ -1,6 +1,13 @@
 # serializer version: 1
 # name: test_diagnostics
   dict({
+    'ev': dict({
+      'ChargeCurrentLimit': 16000,
+      'ChargeCurrentLimitActual': 6000,
+      'ChargeCurrentLimitSource': 'Current limiter',
+      'CpState': 'State C',
+      'Force1Phase': False,
+    }),
     'meter': dict({
       'CurrentPhase1': 14242,
       'CurrentPhase2': 0,

--- a/tests/components/peblar/snapshots/test_number.ambr
+++ b/tests/components/peblar/snapshots/test_number.ambr
@@ -26,7 +26,7 @@
     'name': None,
     'options': dict({
     }),
-    'original_device_class': None,
+    'original_device_class': <NumberDeviceClass.CURRENT: 'current'>,
     'original_icon': None,
     'original_name': 'Charge limit',
     'platform': 'peblar',
@@ -40,6 +40,7 @@
 # name: test_entities[number][number.peblar_ev_charger_charge_limit-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'device_class': 'current',
       'friendly_name': 'Peblar EV Charger Charge limit',
       'max': 16,
       'min': 6,

--- a/tests/components/peblar/snapshots/test_number.ambr
+++ b/tests/components/peblar/snapshots/test_number.ambr
@@ -1,0 +1,57 @@
+# serializer version: 1
+# name: test_entities[number][number.peblar_ev_charger_charge_limit-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'max': 16,
+      'min': 6,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'number.peblar_ev_charger_charge_limit',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Charge limit',
+    'platform': 'peblar',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'charge_current_limit',
+    'unique_id': '23-45-A4O-MOF_charge_current_limit',
+    'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+  })
+# ---
+# name: test_entities[number][number.peblar_ev_charger_charge_limit-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Peblar EV Charger Charge limit',
+      'max': 16,
+      'min': 6,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1,
+      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.peblar_ev_charger_charge_limit',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '6',
+  })
+# ---

--- a/tests/components/peblar/test_number.py
+++ b/tests/components/peblar/test_number.py
@@ -1,0 +1,35 @@
+"""Tests for the Peblar number platform."""
+
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.peblar.const import DOMAIN
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+
+@pytest.mark.parametrize("init_integration", [Platform.NUMBER], indirect=True)
+@pytest.mark.usefixtures("init_integration")
+async def test_entities(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the number entities."""
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+    # Ensure all entities are correctly assigned to the Peblar device
+    device_entry = device_registry.async_get_device(
+        identifiers={(DOMAIN, "23-45-A4O-MOF")}
+    )
+    assert device_entry
+    entity_entries = er.async_entries_for_config_entry(
+        entity_registry, mock_config_entry.entry_id
+    )
+    for entity_entry in entity_entries:
+        assert entity_entry.device_id == device_entry.id


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR adds the number platform to the [Peblar Rocksolid EV Chargers](https://www.peblar.com) integration.

![CleanShot 2024-12-21 at 19 05 47](https://github.com/user-attachments/assets/98c4006f-d3c9-416d-bee8-b36b9513079d)

The added number entity allows the control/setting of the current charging limit for the Peblar charger using a number entity.

Basic tests have been added to ensure the entities are created correctly.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
