### PR TITLE
Add switch platform to Peblar Rocksolid EV Chargers integration

### DIFF
--- a/homeassistant/components/peblar/__init__.py
+++ b/homeassistant/components/peblar/__init__.py
@@ -32,6 +32,7 @@ PLATFORMS = [
     Platform.NUMBER,
     Platform.SELECT,
     Platform.SENSOR,
+    Platform.SWITCH,
     Platform.UPDATE,
 ]
 

--- a/homeassistant/components/peblar/coordinator.py
+++ b/homeassistant/components/peblar/coordinator.py
@@ -11,6 +11,7 @@ from peblar import (
     PeblarError,
     PeblarEVInterface,
     PeblarMeter,
+    PeblarSystem,
     PeblarUserConfiguration,
     PeblarVersions,
 )
@@ -55,6 +56,7 @@ class PeblarData:
 
     ev: PeblarEVInterface
     meter: PeblarMeter
+    system: PeblarSystem
 
 
 class PeblarVersionDataUpdateCoordinator(
@@ -108,6 +110,7 @@ class PeblarDataUpdateCoordinator(DataUpdateCoordinator[PeblarData]):
             return PeblarData(
                 ev=await self.api.ev_interface(),
                 meter=await self.api.meter(),
+                system=await self.api.system(),
             )
         except PeblarError as err:
             raise UpdateFailed(err) from err

--- a/homeassistant/components/peblar/diagnostics.py
+++ b/homeassistant/components/peblar/diagnostics.py
@@ -18,6 +18,7 @@ async def async_get_config_entry_diagnostics(
         "user_configuration": entry.runtime_data.user_configuraton_coordinator.data.to_dict(),
         "ev": entry.runtime_data.data_coordinator.data.ev.to_dict(),
         "meter": entry.runtime_data.data_coordinator.data.meter.to_dict(),
+        "system": entry.runtime_data.data_coordinator.data.system.to_dict(),
         "versions": {
             "available": entry.runtime_data.version_coordinator.data.available.to_dict(),
             "current": entry.runtime_data.version_coordinator.data.current.to_dict(),

--- a/homeassistant/components/peblar/icons.json
+++ b/homeassistant/components/peblar/icons.json
@@ -16,6 +16,11 @@
         }
       }
     },
+    "switch": {
+      "force_single_phase": {
+        "default": "mdi:power-cycle"
+      }
+    },
     "update": {
       "customization": {
         "default": "mdi:palette"

--- a/homeassistant/components/peblar/strings.json
+++ b/homeassistant/components/peblar/strings.json
@@ -85,6 +85,11 @@
         "name": "Voltage phase 3"
       }
     },
+    "switch": {
+      "force_single_phase": {
+        "name": "Force single phase"
+      }
+    },
     "update": {
       "customization": {
         "name": "Customization"

--- a/homeassistant/components/peblar/switch.py
+++ b/homeassistant/components/peblar/switch.py
@@ -1,0 +1,102 @@
+"""Support for Peblar selects."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any
+
+from peblar import PeblarApi
+
+from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import (
+    PeblarConfigEntry,
+    PeblarData,
+    PeblarDataUpdateCoordinator,
+    PeblarRuntimeData,
+)
+
+
+@dataclass(frozen=True, kw_only=True)
+class PeblarSwitchEntityDescription(SwitchEntityDescription):
+    """Class describing Peblar switch entities."""
+
+    has_fn: Callable[[PeblarRuntimeData], bool] = lambda x: True
+    is_on_fn: Callable[[PeblarData], bool]
+    set_fn: Callable[[PeblarApi, bool], Awaitable[Any]]
+
+
+DESCRIPTIONS = [
+    PeblarSwitchEntityDescription(
+        key="force_single_phase",
+        translation_key="force_single_phase",
+        entity_category=EntityCategory.CONFIG,
+        has_fn=lambda x: (
+            x.data_coordinator.data.system.force_single_phase_allowed
+            and x.user_configuraton_coordinator.data.connected_phases > 1
+        ),
+        is_on_fn=lambda x: x.ev.force_single_phase,
+        set_fn=lambda x, on: x.ev_interface(force_single_phase=on),
+    ),
+]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: PeblarConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Peblar switch based on a config entry."""
+    async_add_entities(
+        PeblarSwitchEntity(
+            entry=entry,
+            description=description,
+        )
+        for description in DESCRIPTIONS
+        if description.has_fn(entry.runtime_data)
+    )
+
+
+class PeblarSwitchEntity(CoordinatorEntity[PeblarDataUpdateCoordinator], SwitchEntity):
+    """Defines a Peblar switch entity."""
+
+    entity_description: PeblarSwitchEntityDescription
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        entry: PeblarConfigEntry,
+        description: PeblarSwitchEntityDescription,
+    ) -> None:
+        """Initialize the select entity."""
+        super().__init__(entry.runtime_data.data_coordinator)
+        self.entity_description = description
+        self._attr_unique_id = f"{entry.unique_id}-{description.key}"
+        self._attr_device_info = DeviceInfo(
+            identifiers={
+                (DOMAIN, entry.runtime_data.system_information.product_serial_number)
+            },
+        )
+
+    @property
+    def is_on(self) -> bool:
+        """Return state of the switch."""
+        return self.entity_description.is_on_fn(self.coordinator.data)
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the entity on."""
+        await self.entity_description.set_fn(self.coordinator.api, True)
+        await self.coordinator.async_request_refresh()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the entity off."""
+        await self.entity_description.set_fn(self.coordinator.api, False)
+        await self.coordinator.async_request_refresh()

--- a/tests/components/peblar/conftest.py
+++ b/tests/components/peblar/conftest.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 from peblar import (
     PeblarEVInterface,
     PeblarMeter,
+    PeblarSystem,
     PeblarSystemInformation,
     PeblarUserConfiguration,
     PeblarVersions,
@@ -70,6 +71,9 @@ def mock_peblar() -> Generator[MagicMock]:
         )
         api.meter.return_value = PeblarMeter.from_json(
             load_fixture("meter.json", DOMAIN)
+        )
+        api.system.return_value = PeblarSystem.from_json(
+            load_fixture("system.json", DOMAIN)
         )
 
         yield peblar

--- a/tests/components/peblar/fixtures/system.json
+++ b/tests/components/peblar/fixtures/system.json
@@ -1,0 +1,12 @@
+{
+  "ActiveErrorCodes": [],
+  "ActiveWarningCodes": [],
+  "CellularSignalStrength": null,
+  "FirmwareVersion": "1.6.1+1+WL-1",
+  "Force1PhaseAllowed": true,
+  "PhaseCount": 3,
+  "ProductPn": "6004-2300-8002",
+  "ProductSn": "23-45-A4O-MOF",
+  "Uptime": 322094,
+  "WlanSignalStrength": null
+}

--- a/tests/components/peblar/snapshots/test_diagnostics.ambr
+++ b/tests/components/peblar/snapshots/test_diagnostics.ambr
@@ -20,6 +20,18 @@
       'PowerTotal': 3185,
       'VoltagePhase1': 223,
     }),
+    'system': dict({
+      'ActiveErrorCodes': list([
+      ]),
+      'ActiveWarningCodes': list([
+      ]),
+      'FirmwareVersion': '1.6.1+1+WL-1',
+      'Force1PhaseAllowed': True,
+      'PhaseCount': 3,
+      'ProductPn': '6004-2300-8002',
+      'ProductSn': '23-45-A4O-MOF',
+      'Uptime': 322094,
+    }),
     'system_information': dict({
       'BopCalIGainA': 264625,
       'BopCalIGainB': 267139,

--- a/tests/components/peblar/snapshots/test_switch.ambr
+++ b/tests/components/peblar/snapshots/test_switch.ambr
@@ -1,0 +1,47 @@
+# serializer version: 1
+# name: test_entities[switch][switch.peblar_ev_charger_force_single_phase-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.peblar_ev_charger_force_single_phase',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Force single phase',
+    'platform': 'peblar',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'force_single_phase',
+    'unique_id': '23-45-A4O-MOF-force_single_phase',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[switch][switch.peblar_ev_charger_force_single_phase-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Peblar EV Charger Force single phase',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.peblar_ev_charger_force_single_phase',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---

--- a/tests/components/peblar/test_switch.py
+++ b/tests/components/peblar/test_switch.py
@@ -1,0 +1,35 @@
+"""Tests for the Peblar switch platform."""
+
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.peblar.const import DOMAIN
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+
+@pytest.mark.parametrize("init_integration", [Platform.SWITCH], indirect=True)
+@pytest.mark.usefixtures("init_integration")
+async def test_entities(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the switch entities."""
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+    # Ensure all entities are correctly assigned to the Peblar device
+    device_entry = device_registry.async_get_device(
+        identifiers={(DOMAIN, "23-45-A4O-MOF")}
+    )
+    assert device_entry
+    entity_entries = er.async_entries_for_config_entry(
+        entity_registry, mock_config_entry.entry_id
+    )
+    for entity_entry in entity_entries:
+        assert entity_entry.device_id == device_entry.id


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR adds the switch platform to the [Peblar Rocksolid EV Chargers](https://www.peblar.com) integration.

![CleanShot 2024-12-21 at 20 15 56](https://github.com/user-attachments/assets/e7c2763c-3bf2-469f-9809-ff5271cac7fe)

The switch allows forcing the use of a single phase for charging (if available).

Basic tests have been added to ensure the entities are created correctly.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
