### PR TITLE
Add more sensors to Peblar Rocksolid EV Chargers integration

### DIFF
--- a/homeassistant/components/peblar/const.py
+++ b/homeassistant/components/peblar/const.py
@@ -5,6 +5,38 @@ from __future__ import annotations
 import logging
 from typing import Final
 
+from peblar import ChargeLimiter, CPState
+
 DOMAIN: Final = "peblar"
 
 LOGGER = logging.getLogger(__package__)
+
+PEBLAR_CHARGE_LIMITER_TO_HOME_ASSISTANT = {
+    ChargeLimiter.CHARGING_CABLE: "charging_cable",
+    ChargeLimiter.CURRENT_LIMITER: "current_limiter",
+    ChargeLimiter.DYNAMIC_LOAD_BALANCING: "dynamic_load_balancing",
+    ChargeLimiter.EXTERNAL_POWER_LIMIT: "external_power_limit",
+    ChargeLimiter.GROUP_LOAD_BALANCING: "group_load_balancing",
+    ChargeLimiter.HARDWARE_LIMITATION: "hardware_limitation",
+    ChargeLimiter.HIGH_TEMPERATURE: "high_temperature",
+    ChargeLimiter.HOUSEHOLD_POWER_LIMIT: "household_power_limit",
+    ChargeLimiter.INSTALLATION_LIMIT: "installation_limit",
+    ChargeLimiter.LOCAL_MODBUS_API: "local_modbus_api",
+    ChargeLimiter.LOCAL_REST_API: "local_rest_api",
+    ChargeLimiter.LOCAL_SCHEDULED: "local_scheduled",
+    ChargeLimiter.OCPP_SMART_CHARGING: "ocpp_smart_charging",
+    ChargeLimiter.OVERCURRENT_PROTECTION: "overcurrent_protection",
+    ChargeLimiter.PHASE_IMBALANCE: "phase_imbalance",
+    ChargeLimiter.POWER_FACTOR: "power_factor",
+    ChargeLimiter.SOLAR_CHARGING: "solar_charging",
+}
+
+PEBLAR_CP_STATE_TO_HOME_ASSISTANT = {
+    CPState.CHARGING_SUSPENDED: "suspended",
+    CPState.CHARGING_VENTILATION: "charging",
+    CPState.CHARGING: "charging",
+    CPState.ERROR: "error",
+    CPState.FAULT: "fault",
+    CPState.INVALID: "invalid",
+    CPState.NO_EV_CONNECTED: "no_ev_connected",
+}

--- a/homeassistant/components/peblar/icons.json
+++ b/homeassistant/components/peblar/icons.json
@@ -16,6 +16,17 @@
         }
       }
     },
+    "sensor": {
+      "cp_state": {
+        "default": "mdi:ev-plug-type2"
+      },
+      "charge_current_limit_source": {
+        "default": "mdi:arrow-collapse-up"
+      },
+      "uptime": {
+        "default": "mdi:timer"
+      }
+    },
     "switch": {
       "force_single_phase": {
         "default": "mdi:power-cycle"

--- a/homeassistant/components/peblar/strings.json
+++ b/homeassistant/components/peblar/strings.json
@@ -75,11 +75,11 @@
       "cp_state": {
         "name": "State",
         "state": {
-          "charging": "Charging",
+          "charging": "[%key:common::action::charging%]",
           "error": "Error",
           "fault": "Fault",
           "invalid": "Invalid",
-          "no_ev_connected": "No EV Connected",
+          "no_ev_connected": "No EV connected",
           "suspended": "Suspended"
         }
       },

--- a/homeassistant/components/peblar/strings.json
+++ b/homeassistant/components/peblar/strings.json
@@ -1,8 +1,16 @@
 {
   "config": {
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "no_serial_number": "The discovered Peblar device did not provide a serial number."
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
+    },
     "step": {
       "user": {
-        "description": "Set up your Peblar EV charger to integrate with Home Assistant.\n\nTo do so, you will need to get the IP address of your Peblar charger and the password you use to log into the Peblar device' web interface.\n\nHome Assistant will automatically configure your Peblar charger for use with Home Assistant.",
         "data": {
           "host": "[%key:common::config_flow::data::host%]",
           "password": "[%key:common::config_flow::data::password%]"
@@ -10,26 +18,18 @@
         "data_description": {
           "host": "The hostname or IP address of your Peblar charger on your home network.",
           "password": "The same password as you use to log in to the Peblar device' local web interface."
-        }
+        },
+        "description": "Set up your Peblar EV charger to integrate with Home Assistant.\n\nTo do so, you will need to get the IP address of your Peblar charger and the password you use to log into the Peblar device' web interface.\n\nHome Assistant will automatically configure your Peblar charger for use with Home Assistant."
       },
       "zeroconf_confirm": {
-        "description": "Set up your Peblar EV charger to integrate with Home Assistant.\n\nTo do so, you will need the password you use to log into the Peblar device' web interface.\n\nHome Assistant will automatically configure your Peblar charger for use with Home Assistant.",
         "data": {
           "password": "[%key:common::config_flow::data::password%]"
         },
         "data_description": {
           "password": "[%key:component::peblar::config::step::user::data_description::password%]"
-        }
+        },
+        "description": "Set up your Peblar EV charger to integrate with Home Assistant.\n\nTo do so, you will need the password you use to log into the Peblar device' web interface.\n\nHome Assistant will automatically configure your Peblar charger for use with Home Assistant."
       }
-    },
-    "error": {
-      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
-      "unknown": "[%key:common::config_flow::error::unknown%]"
-    },
-    "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
-      "no_serial_number": "The discovered Peblar device did not provide a serial number."
     }
   },
   "entity": {
@@ -51,6 +51,38 @@
       }
     },
     "sensor": {
+      "charge_current_limit_source": {
+        "name": "Limit source",
+        "state": {
+          "charging_cable": "Charging cable",
+          "current_limiter": "Current limiter",
+          "dynamic_load_balancing": "Dynamic load balancing",
+          "external_power_limit": "External power limit",
+          "group_load_balancing": "Group load balancing",
+          "hardware_limitation": "Hardware limitation",
+          "high_temperature": "High temperature",
+          "household_power_limit": "Household power limit",
+          "installation_limit": "Installation limit",
+          "local_modbus_api": "Modbus API",
+          "local_rest_api": "REST API",
+          "ocpp_smart_charging": "OCPP smart charging",
+          "overcurrent_protection": "Overcurrent protection",
+          "phase_imbalance": "Phase imbalance",
+          "power_factor": "Power factor",
+          "solar_charging": "Solar charging"
+        }
+      },
+      "cp_state": {
+        "name": "State",
+        "state": {
+          "charging": "Charging",
+          "error": "Error",
+          "fault": "Fault",
+          "invalid": "Invalid",
+          "no_ev_connected": "No EV Connected",
+          "suspended": "Suspended"
+        }
+      },
       "current_phase_1": {
         "name": "Current phase 1"
       },
@@ -74,6 +106,9 @@
       },
       "power_phase_3": {
         "name": "Power phase 3"
+      },
+      "uptime": {
+        "name": "Uptime"
       },
       "voltage_phase_1": {
         "name": "Voltage phase 1"

--- a/homeassistant/components/peblar/strings.json
+++ b/homeassistant/components/peblar/strings.json
@@ -75,7 +75,7 @@
       "cp_state": {
         "name": "State",
         "state": {
-          "charging": "[%key:common::action::charging%]",
+          "charging": "Charging",
           "error": "Error",
           "fault": "Fault",
           "invalid": "Invalid",

--- a/tests/components/peblar/snapshots/test_sensor.ambr
+++ b/tests/components/peblar/snapshots/test_sensor.ambr
@@ -741,7 +741,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '2024-12-18T03:04:54+00:00',
+    'state': '2024-12-18T04:16:46+00:00',
   })
 # ---
 # name: test_entities[sensor][sensor.peblar_ev_charger_voltage_phase_1-entry]

--- a/tests/components/peblar/snapshots/test_sensor.ambr
+++ b/tests/components/peblar/snapshots/test_sensor.ambr
@@ -1,4 +1,61 @@
 # serializer version: 1
+# name: test_entities[sensor][sensor.peblar_ev_charger_current-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.peblar_ev_charger_current',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.CURRENT: 'current'>,
+    'original_icon': None,
+    'original_name': 'Current',
+    'platform': 'peblar',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '23-45-A4O-MOF_current_total',
+    'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+  })
+# ---
+# name: test_entities[sensor][sensor.peblar_ev_charger_current-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'current',
+      'friendly_name': 'Peblar EV Charger Current',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.peblar_ev_charger_current',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '14.242',
+  })
+# ---
 # name: test_entities[sensor][sensor.peblar_ev_charger_current_phase_1-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -225,6 +282,92 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '880.703',
+  })
+# ---
+# name: test_entities[sensor][sensor.peblar_ev_charger_limit_source-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'charging_cable',
+        'current_limiter',
+        'dynamic_load_balancing',
+        'external_power_limit',
+        'group_load_balancing',
+        'hardware_limitation',
+        'high_temperature',
+        'household_power_limit',
+        'installation_limit',
+        'local_modbus_api',
+        'local_rest_api',
+        'local_scheduled',
+        'ocpp_smart_charging',
+        'overcurrent_protection',
+        'phase_imbalance',
+        'power_factor',
+        'solar_charging',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.peblar_ev_charger_limit_source',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': 'Limit source',
+    'platform': 'peblar',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'charge_current_limit_source',
+    'unique_id': '23-45-A4O-MOF_charge_current_limit_source',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[sensor][sensor.peblar_ev_charger_limit_source-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'enum',
+      'friendly_name': 'Peblar EV Charger Limit source',
+      'options': list([
+        'charging_cable',
+        'current_limiter',
+        'dynamic_load_balancing',
+        'external_power_limit',
+        'group_load_balancing',
+        'hardware_limitation',
+        'high_temperature',
+        'household_power_limit',
+        'installation_limit',
+        'local_modbus_api',
+        'local_rest_api',
+        'local_scheduled',
+        'ocpp_smart_charging',
+        'overcurrent_protection',
+        'phase_imbalance',
+        'power_factor',
+        'solar_charging',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.peblar_ev_charger_limit_source',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'current_limiter',
   })
 # ---
 # name: test_entities[sensor][sensor.peblar_ev_charger_power-entry]
@@ -486,6 +629,119 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '0.381',
+  })
+# ---
+# name: test_entities[sensor][sensor.peblar_ev_charger_state-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'suspended',
+        'charging',
+        'charging',
+        'error',
+        'fault',
+        'invalid',
+        'no_ev_connected',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.peblar_ev_charger_state',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': 'State',
+    'platform': 'peblar',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'cp_state',
+    'unique_id': '23-45-A4O-MOF_cp_state',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[sensor][sensor.peblar_ev_charger_state-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'enum',
+      'friendly_name': 'Peblar EV Charger State',
+      'options': list([
+        'suspended',
+        'charging',
+        'charging',
+        'error',
+        'fault',
+        'invalid',
+        'no_ev_connected',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.peblar_ev_charger_state',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'charging',
+  })
+# ---
+# name: test_entities[sensor][sensor.peblar_ev_charger_uptime-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.peblar_ev_charger_uptime',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': None,
+    'original_name': 'Uptime',
+    'platform': 'peblar',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'uptime',
+    'unique_id': '23-45-A4O-MOF_uptime',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[sensor][sensor.peblar_ev_charger_uptime-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'timestamp',
+      'friendly_name': 'Peblar EV Charger Uptime',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.peblar_ev_charger_uptime',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2024-12-18T03:04:54+00:00',
   })
 # ---
 # name: test_entities[sensor][sensor.peblar_ev_charger_voltage_phase_1-entry]

--- a/tests/components/peblar/test_sensor.py
+++ b/tests/components/peblar/test_sensor.py
@@ -11,6 +11,7 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 from tests.common import MockConfigEntry, snapshot_platform
 
 
+@pytest.mark.freeze_time("2024-12-21 21:45:00")
 @pytest.mark.parametrize("init_integration", [Platform.SENSOR], indirect=True)
 @pytest.mark.usefixtures("entity_registry_enabled_by_default", "init_integration")
 async def test_entities(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR adds more sensors to the [Peblar Rocksolid EV Chargers](https://www.peblar.com) integration.

![image](https://github.com/user-attachments/assets/91801209-0fb1-431a-9452-e673efb6be6c)

Adds sensors for:
- The current charging state.
- The uptime of the charger.
- The current limiting charging factor in terms of available current.

Additionally:
- Uses a different source for the current sensor, which can now always be activate and represents a total.
- Sorts a translation file (JSON sorted now).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
