### PR TITLE
Add binary sensor platform to Peblar Rocksolid EV Chargers integration

### DIFF
--- a/homeassistant/components/peblar/__init__.py
+++ b/homeassistant/components/peblar/__init__.py
@@ -29,6 +29,7 @@ from .coordinator import (
 )
 
 PLATFORMS = [
+    Platform.BINARY_SENSOR,
     Platform.NUMBER,
     Platform.SELECT,
     Platform.SENSOR,

--- a/homeassistant/components/peblar/binary_sensor.py
+++ b/homeassistant/components/peblar/binary_sensor.py
@@ -1,0 +1,89 @@
+"""Support for Peblar binary sensors."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+    BinarySensorEntityDescription,
+)
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import PeblarConfigEntry, PeblarData, PeblarDataUpdateCoordinator
+
+
+@dataclass(frozen=True, kw_only=True)
+class PeblarBinarySensorEntityDescription(BinarySensorEntityDescription):
+    """Class describing Peblar binary sensor entities."""
+
+    is_on_fn: Callable[[PeblarData], bool]
+
+
+DESCRIPTIONS = [
+    PeblarBinarySensorEntityDescription(
+        key="active_error_codes",
+        translation_key="active_error_codes",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        is_on_fn=lambda x: bool(x.system.active_error_codes),
+    ),
+    PeblarBinarySensorEntityDescription(
+        key="active_warning_codes",
+        translation_key="active_warning_codes",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        is_on_fn=lambda x: bool(x.system.active_warning_codes),
+    ),
+]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: PeblarConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Peblar binary sensor based on a config entry."""
+    async_add_entities(
+        PeblarBinarySensorEntity(entry=entry, description=description)
+        for description in DESCRIPTIONS
+    )
+
+
+class PeblarBinarySensorEntity(
+    CoordinatorEntity[PeblarDataUpdateCoordinator], BinarySensorEntity
+):
+    """Defines a Peblar binary sensor entity."""
+
+    entity_description: PeblarBinarySensorEntityDescription
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        entry: PeblarConfigEntry,
+        description: PeblarBinarySensorEntityDescription,
+    ) -> None:
+        """Initialize the binary sensor entity."""
+        super().__init__(entry.runtime_data.data_coordinator)
+        self.entity_description = description
+        self._attr_unique_id = f"{entry.unique_id}-{description.key}"
+        self._attr_device_info = DeviceInfo(
+            identifiers={
+                (DOMAIN, entry.runtime_data.system_information.product_serial_number)
+            },
+        )
+
+    @property
+    def is_on(self) -> bool:
+        """Return state of the binary sensor."""
+        return self.entity_description.is_on_fn(self.coordinator.data)

--- a/homeassistant/components/peblar/icons.json
+++ b/homeassistant/components/peblar/icons.json
@@ -1,5 +1,13 @@
 {
   "entity": {
+    "binary_sensor": {
+      "active_error_codes": {
+        "default": "mdi:alert"
+      },
+      "active_warning_codes": {
+        "default": "mdi:alert"
+      }
+    },
     "number": {
       "charge_current_limit": {
         "default": "mdi:speedometer"

--- a/homeassistant/components/peblar/strings.json
+++ b/homeassistant/components/peblar/strings.json
@@ -33,6 +33,14 @@
     }
   },
   "entity": {
+    "binary_sensor": {
+      "active_error_codes": {
+        "name": "Active errors"
+      },
+      "active_warning_codes": {
+        "name": "Active warnings"
+      }
+    },
     "number": {
       "charge_current_limit": {
         "name": "Charge limit"

--- a/tests/components/peblar/snapshots/test_binary_sensor.ambr
+++ b/tests/components/peblar/snapshots/test_binary_sensor.ambr
@@ -1,0 +1,95 @@
+# serializer version: 1
+# name: test_entities[binary_sensor][binary_sensor.peblar_ev_charger_active_errors-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.peblar_ev_charger_active_errors',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': None,
+    'original_name': 'Active errors',
+    'platform': 'peblar',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'active_error_codes',
+    'unique_id': '23-45-A4O-MOF-active_error_codes',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[binary_sensor][binary_sensor.peblar_ev_charger_active_errors-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'Peblar EV Charger Active errors',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.peblar_ev_charger_active_errors',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_entities[binary_sensor][binary_sensor.peblar_ev_charger_active_warnings-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.peblar_ev_charger_active_warnings',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': None,
+    'original_name': 'Active warnings',
+    'platform': 'peblar',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'active_warning_codes',
+    'unique_id': '23-45-A4O-MOF-active_warning_codes',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[binary_sensor][binary_sensor.peblar_ev_charger_active_warnings-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'Peblar EV Charger Active warnings',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.peblar_ev_charger_active_warnings',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---

--- a/tests/components/peblar/test_binary_sensor.py
+++ b/tests/components/peblar/test_binary_sensor.py
@@ -1,0 +1,35 @@
+"""Tests for the Peblar binary sensor platform."""
+
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.peblar.const import DOMAIN
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+
+@pytest.mark.parametrize("init_integration", [Platform.BINARY_SENSOR], indirect=True)
+@pytest.mark.usefixtures("entity_registry_enabled_by_default", "init_integration")
+async def test_entities(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the binary sensors entities."""
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+    # Ensure all entities are correctly assigned to the Peblar device
+    device_entry = device_registry.async_get_device(
+        identifiers={(DOMAIN, "23-45-A4O-MOF")}
+    )
+    assert device_entry
+    entity_entries = er.async_entries_for_config_entry(
+        entity_registry, mock_config_entry.entry_id
+    )
+    for entity_entry in entity_entries:
+        assert entity_entry.device_id == device_entry.id


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR adds the binary sensor platform to the [Peblar Rocksolid EV Chargers](https://www.peblar.com) integration.

![CleanShot 2024-12-21 at 22 15 00](https://github.com/user-attachments/assets/a3a83872-d4e5-40c7-ab86-83d5b38d1f5e)

Two binary sensors that indicate the charger has errors or warnings. Both are disabled by default.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
