### PR TITLE
Fix errors in HitachiDHW in Overkiz

### DIFF
--- a/homeassistant/components/overkiz/water_heater/hitachi_dhw.py
+++ b/homeassistant/components/overkiz/water_heater/hitachi_dhw.py
@@ -45,29 +45,28 @@ class HitachiDHW(OverkizEntity, WaterHeaterEntity):
     _attr_operation_list = [*OPERATION_MODE_TO_OVERKIZ]
 
     @property
-    def current_temperature(self) -> int | None:
+    def current_temperature(self) -> float | None:
         """Return the current temperature."""
         current_temperature = self.device.states[OverkizState.CORE_DHW_TEMPERATURE]
 
         if current_temperature:
-            return current_temperature.value_as_int
+            return float(current_temperature.value_as_int)
 
         return None
 
     @property
-    def target_temperature(self) -> int | None:
+    def target_temperature(self) -> float | None:
         """Return the temperature we try to reach."""
         target_temperature = self.device.states[
             OverkizState.MODBUS_CONTROL_DHW_SETTING_TEMPERATURE
         ]
         if target_temperature:
-            return target_temperature.value_as_int
+            return float(target_temperature.value_as_int)
 
         return None
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
-
         await self.executor.async_execute_command(
             OverkizCommand.SET_CONTROL_DHW_SETTING_TEMPERATURE,
             int(kwargs[ATTR_TEMPERATURE]),

--- a/homeassistant/components/overkiz/water_heater/hitachi_dhw.py
+++ b/homeassistant/components/overkiz/water_heater/hitachi_dhw.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import Any
 
 from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
 
@@ -13,7 +13,7 @@ from homeassistant.components.water_heater import (
 )
 from homeassistant.const import (
     ATTR_TEMPERATURE,
-    PRECISION_HALVES,
+    PRECISION_WHOLE,
     STATE_OFF,
     STATE_ON,
     UnitOfTemperature,
@@ -35,7 +35,7 @@ class HitachiDHW(OverkizEntity, WaterHeaterEntity):
 
     _attr_min_temp = 30.0
     _attr_max_temp = 70.0
-    _attr_precision = PRECISION_HALVES
+    _attr_precision = PRECISION_WHOLE
 
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_supported_features = (
@@ -45,23 +45,23 @@ class HitachiDHW(OverkizEntity, WaterHeaterEntity):
     _attr_operation_list = [*OPERATION_MODE_TO_OVERKIZ]
 
     @property
-    def current_temperature(self) -> float | None:
+    def current_temperature(self) -> int | None:
         """Return the current temperature."""
         current_temperature = self.device.states[OverkizState.CORE_DHW_TEMPERATURE]
 
         if current_temperature:
-            return cast(float, current_temperature.value)
+            return current_temperature.value_as_int
 
         return None
 
     @property
-    def target_temperature(self) -> float | None:
+    def target_temperature(self) -> int | None:
         """Return the temperature we try to reach."""
         target_temperature = self.device.states[
             OverkizState.MODBUS_CONTROL_DHW_SETTING_TEMPERATURE
         ]
         if target_temperature:
-            return cast(float, target_temperature.value)
+            return target_temperature.value_as_int
 
         return None
 

--- a/homeassistant/components/overkiz/water_heater/hitachi_dhw.py
+++ b/homeassistant/components/overkiz/water_heater/hitachi_dhw.py
@@ -60,6 +60,7 @@ class HitachiDHW(OverkizEntity, WaterHeaterEntity):
         target_temperature = self.device.states[
             OverkizState.MODBUS_CONTROL_DHW_SETTING_TEMPERATURE
         ]
+
         if target_temperature:
             return float(target_temperature.value_as_int)
 

--- a/homeassistant/components/overkiz/water_heater/hitachi_dhw.py
+++ b/homeassistant/components/overkiz/water_heater/hitachi_dhw.py
@@ -49,7 +49,7 @@ class HitachiDHW(OverkizEntity, WaterHeaterEntity):
         """Return the current temperature."""
         current_temperature = self.device.states[OverkizState.CORE_DHW_TEMPERATURE]
 
-        if current_temperature:
+        if current_temperature and current_temperature.value_as_int:
             return float(current_temperature.value_as_int)
 
         return None
@@ -61,7 +61,7 @@ class HitachiDHW(OverkizEntity, WaterHeaterEntity):
             OverkizState.MODBUS_CONTROL_DHW_SETTING_TEMPERATURE
         ]
 
-        if target_temperature:
+        if target_temperature and target_temperature.value_as_int:
             return float(target_temperature.value_as_int)
 
         return None

--- a/homeassistant/components/overkiz/water_heater/hitachi_dhw.py
+++ b/homeassistant/components/overkiz/water_heater/hitachi_dhw.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
 from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
 
@@ -13,7 +13,7 @@ from homeassistant.components.water_heater import (
 )
 from homeassistant.const import (
     ATTR_TEMPERATURE,
-    PRECISION_WHOLE,
+    PRECISION_HALVES,
     STATE_OFF,
     STATE_ON,
     UnitOfTemperature,
@@ -35,7 +35,7 @@ class HitachiDHW(OverkizEntity, WaterHeaterEntity):
 
     _attr_min_temp = 30.0
     _attr_max_temp = 70.0
-    _attr_precision = PRECISION_WHOLE
+    _attr_precision = PRECISION_HALVES
 
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_supported_features = (
@@ -48,8 +48,10 @@ class HitachiDHW(OverkizEntity, WaterHeaterEntity):
     def current_temperature(self) -> float | None:
         """Return the current temperature."""
         current_temperature = self.device.states[OverkizState.CORE_DHW_TEMPERATURE]
+
         if current_temperature:
-            return current_temperature.value_as_float
+            return cast(float, current_temperature.value)
+
         return None
 
     @property
@@ -59,7 +61,8 @@ class HitachiDHW(OverkizEntity, WaterHeaterEntity):
             OverkizState.MODBUS_CONTROL_DHW_SETTING_TEMPERATURE
         ]
         if target_temperature:
-            return target_temperature.value_as_float
+            return cast(float, target_temperature.value)
+
         return None
 
     async def async_set_temperature(self, **kwargs: Any) -> None:


### PR DESCRIPTION
## Proposed change
Temperature value for HitachiDHW is an int, but we try to retrieve the float value. This will raise errors and make this entity not functional.

Fixes https://github.com/home-assistant/core/issues/116738
Fixes https://github.com/home-assistant/core/issues/123242

Previous error:
```
2024-12-21 23:08:03.764 ERROR (MainThread) [homeassistant.components.water_heater] Error adding entity water_heater.none_modbus_1369107_1_4 for domain water_heater with platform overkiz
Traceback (most recent call last):
  File "/workspaces/home-assistant-core/homeassistant/helpers/entity_platform.py", line 608, in _async_add_entities
    await coro
  File "/workspaces/home-assistant-core/homeassistant/helpers/entity_platform.py", line 927, in _async_add_entity
    await entity.add_to_platform_finish()
  File "/workspaces/home-assistant-core/homeassistant/helpers/entity.py", line 1384, in add_to_platform_finish
    self.async_write_ha_state()
    ~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/workspaces/home-assistant-core/homeassistant/helpers/entity.py", line 1023, in async_write_ha_state
    self._async_write_ha_state()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/workspaces/home-assistant-core/homeassistant/helpers/entity.py", line 1148, in _async_write_ha_state
    self.__async_calculate_state()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/workspaces/home-assistant-core/homeassistant/helpers/entity.py", line 1087, in __async_calculate_state
    if state_attributes := self.state_attributes:
                           ^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/home-assistant-core/homeassistant/components/water_heater/__init__.py", line 209, in state_attributes
    self.current_temperature,
    ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/home-assistant-core/homeassistant/components/overkiz/water_heater/hitachi_dhw.py", line 52, in current_temperature
    return current_temperature.value_as_float
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/home-assistant-core/.venv/lib/python3.13/site-packages/pyoverkiz/models.py", line 334, in value_as_float
    raise TypeError(f"{self.name} is not a float")
TypeError: core:DHWTemperatureState is not a float
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
