### PR TITLE
Add support for HitachiAirToWaterHeatingZone in Overkiz

### DIFF
--- a/homeassistant/components/overkiz/climate/__init__.py
+++ b/homeassistant/components/overkiz/climate/__init__.py
@@ -29,6 +29,7 @@ from .atlantic_pass_apc_zone_control import AtlanticPassAPCZoneControl
 from .atlantic_pass_apc_zone_control_zone import AtlanticPassAPCZoneControlZone
 from .hitachi_air_to_air_heat_pump_hlrrwifi import HitachiAirToAirHeatPumpHLRRWIFI
 from .hitachi_air_to_air_heat_pump_ovp import HitachiAirToAirHeatPumpOVP
+from .hitachi_air_to_water_heating_zone import HitachiAirToWaterHeatingZone
 from .somfy_heating_temperature_interface import SomfyHeatingTemperatureInterface
 from .somfy_thermostat import SomfyThermostat
 from .valve_heating_temperature_interface import ValveHeatingTemperatureInterface
@@ -53,6 +54,7 @@ WIDGET_TO_CLIMATE_ENTITY = {
     UIWidget.ATLANTIC_HEAT_RECOVERY_VENTILATION: AtlanticHeatRecoveryVentilation,
     UIWidget.ATLANTIC_PASS_APC_HEATING_ZONE: AtlanticPassAPCHeatingZone,
     UIWidget.ATLANTIC_PASS_APC_ZONE_CONTROL: AtlanticPassAPCZoneControl,
+    UIWidget.HITACHI_AIR_TO_WATER_HEATING_ZONE: HitachiAirToWaterHeatingZone,
     UIWidget.SOMFY_HEATING_TEMPERATURE_INTERFACE: SomfyHeatingTemperatureInterface,
     UIWidget.SOMFY_THERMOSTAT: SomfyThermostat,
     UIWidget.VALVE_HEATING_TEMPERATURE_INTERFACE: ValveHeatingTemperatureInterface,

--- a/homeassistant/components/overkiz/climate/hitachi_air_to_water_heating_zone.py
+++ b/homeassistant/components/overkiz/climate/hitachi_air_to_water_heating_zone.py
@@ -9,6 +9,7 @@ from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
 from homeassistant.components.climate import (
     PRESET_COMFORT,
     PRESET_ECO,
+    PRESET_NONE,
     ClimateEntity,
     ClimateEntityFeature,
     HVACMode,
@@ -63,9 +64,12 @@ class HitachiAirToWaterHeatingZone(OverkizEntity, ClimateEntity):
     @property
     def hvac_mode(self) -> HVACMode:
         """Return hvac operation ie. heat, cool mode."""
-        return OVERKIZ_TO_HVAC_MODE[
-            self.executor.select_state(OverkizState.MODBUS_AUTO_MANU_MODE_ZONE_1_STATE)
-        ]
+        if (
+            state := self.device.states[OverkizState.MODBUS_AUTO_MANU_MODE_ZONE_1_STATE]
+        ) and state.value_as_str:
+            return OVERKIZ_TO_HVAC_MODE[state.value_as_str]
+
+        return HVACMode.OFF
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
@@ -76,9 +80,12 @@ class HitachiAirToWaterHeatingZone(OverkizEntity, ClimateEntity):
     @property
     def preset_mode(self) -> str | None:
         """Return the current preset mode, e.g., home, away, temp."""
-        return OVERKIZ_TO_PRESET_MODE[
-            self.executor.select_state(OverkizState.MODBUS_YUTAKI_TARGET_MODE_STATE)
-        ]
+        if (
+            state := self.device.states[OverkizState.MODBUS_YUTAKI_TARGET_MODE_STATE]
+        ) and state.value_as_str:
+            return OVERKIZ_TO_PRESET_MODE[state.value_as_str]
+
+        return PRESET_NONE
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set new preset mode."""

--- a/homeassistant/components/overkiz/climate/hitachi_air_to_water_heating_zone.py
+++ b/homeassistant/components/overkiz/climate/hitachi_air_to_water_heating_zone.py
@@ -21,14 +21,14 @@ from ..entity import OverkizDataUpdateCoordinator, OverkizEntity
 PRESET_STATE_ECO = "eco"
 PRESET_STATE_COMFORT = "comfort"
 
-OVERKIZ_TO_HVAC_MODE = {
+OVERKIZ_TO_HVAC_MODE: dict[str, str] = {
     OverkizCommandParam.MANU: HVACMode.HEAT,
     OverkizCommandParam.AUTO: HVACMode.AUTO,
 }
 
 HVAC_MODE_TO_OVERKIZ = {v: k for k, v in OVERKIZ_TO_HVAC_MODE.items()}
 
-OVERKIZ_TO_PRESET_MODE = {
+OVERKIZ_TO_PRESET_MODE: dict[str, str] = {
     PRESET_STATE_COMFORT: PRESET_COMFORT,
     PRESET_STATE_ECO: PRESET_ECO,
 }

--- a/homeassistant/components/overkiz/climate/hitachi_air_to_water_heating_zone.py
+++ b/homeassistant/components/overkiz/climate/hitachi_air_to_water_heating_zone.py
@@ -1,0 +1,134 @@
+"""Support for HitachiAirToWaterHeatingZone."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pyoverkiz.enums import OverkizCommand, OverkizState
+
+from homeassistant.components.climate import (
+    PRESET_COMFORT,
+    PRESET_ECO,
+    ClimateEntity,
+    ClimateEntityFeature,
+    HVACMode,
+)
+from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
+
+from ..const import DOMAIN
+from ..entity import OverkizDataUpdateCoordinator, OverkizEntity
+
+MODBUS_YUTAKI_TARGET_MODE_STATE = "modbus:YutakiTargetModeState"
+MODBUS_ROOM_AMBIENT_TEMPERATURE_STATUS_ZONE_1_STATE = (
+    "modbus:RoomAmbientTemperatureStatusZone1State"
+)
+MODBUS_THERMOSTAT_SETTING_STATUS_ZONE_1_STATE = (
+    "modbus:ThermostatSettingStatusZone1State"
+)
+MODBUS_AUTO_MANU_MODE_ZONE_1_STATE = "modbus:AutoManuModeZone1State"
+MODBUS_THERMOSTAT_SETTING_CONTROL_ZONE_1_STATE = (
+    "modbus:ThermostatSettingControlZone1State"
+)
+
+HVAC_STATE_MANU = "manu"
+HVAC_STATE_AUTO = "auto"
+
+PRESET_STATE_ECO = "eco"
+PRESET_STATE_COMFORT = "comfort"
+
+OVERKIZ_TO_HVAC_MODE = {
+    HVAC_STATE_MANU: HVACMode.HEAT,
+    HVAC_STATE_AUTO: HVACMode.AUTO,
+}
+
+HVAC_MODE_TO_OVERKIZ = {v: k for k, v in OVERKIZ_TO_HVAC_MODE.items()}
+
+OVERKIZ_TO_PRESET_MODE = {
+    PRESET_STATE_COMFORT: PRESET_COMFORT,
+    PRESET_STATE_ECO: PRESET_ECO,
+}
+
+PRESET_MODE_TO_OVERKIZ = {v: k for k, v in OVERKIZ_TO_PRESET_MODE.items()}
+
+
+class HitachiAirToWaterHeatingZone(OverkizEntity, ClimateEntity):
+    """Representation of HitachiAirToWaterHeatingZone."""
+
+    _attr_hvac_modes = [*HVAC_MODE_TO_OVERKIZ]
+    _attr_preset_modes = [*PRESET_MODE_TO_OVERKIZ]
+    _attr_supported_features = (
+        ClimateEntityFeature.PRESET_MODE | ClimateEntityFeature.TARGET_TEMPERATURE
+    )
+    _attr_min_temp = 5.0
+    _attr_max_temp = 35.0
+    _attr_precision = 0.1
+    _attr_target_temperature_step = 0.5
+    _attr_temperature_unit = UnitOfTemperature.CELSIUS
+    _attr_translation_key = DOMAIN
+
+    def __init__(
+        self, device_url: str, coordinator: OverkizDataUpdateCoordinator
+    ) -> None:
+        """Init method."""
+        super().__init__(device_url, coordinator)
+
+        if self._attr_device_info:
+            self._attr_device_info["manufacturer"] = "Hitachi"
+
+    @property
+    def hvac_mode(self) -> HVACMode:
+        """Return hvac operation ie. heat, cool mode."""
+        return OVERKIZ_TO_HVAC_MODE[
+            self.executor.select_state(OverkizState.MODBUS_AUTO_MANU_MODE_ZONE_1_STATE)
+        ]
+
+    async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
+        """Set new target hvac mode."""
+        await self.executor.async_execute_command(
+            OverkizCommand.SET_AUTO_MANU_MODE, HVAC_MODE_TO_OVERKIZ[hvac_mode]
+        )
+
+    @property
+    def preset_mode(self) -> str | None:
+        """Return the current preset mode, e.g., home, away, temp."""
+        return OVERKIZ_TO_PRESET_MODE[
+            self.executor.select_state(OverkizState.MODBUS_YUTAKI_TARGET_MODE_STATE)
+        ]
+
+    async def async_set_preset_mode(self, preset_mode: str) -> None:
+        """Set new preset mode."""
+        await self.executor.async_execute_command(
+            OverkizCommand.SET_TARGET_MODE, PRESET_MODE_TO_OVERKIZ[preset_mode]
+        )
+
+    @property
+    def current_temperature(self) -> float | None:
+        """Return the current temperature."""
+        current_temperature = self.device.states[
+            OverkizState.MODBUS_ROOM_AMBIENT_TEMPERATURE_STATUS_ZONE_1_STATE
+        ]
+
+        if current_temperature:
+            return current_temperature.value_as_float
+
+        return None
+
+    @property
+    def target_temperature(self) -> float | None:
+        """Return the temperature we try to reach."""
+        target_temperature = self.device.states[
+            OverkizState.MODBUS_THERMOSTAT_SETTING_CONTROL_ZONE_1_STATE
+        ]
+
+        if target_temperature:
+            return target_temperature.value_as_float
+
+        return None
+
+    async def async_set_temperature(self, **kwargs: Any) -> None:
+        """Set new target temperature."""
+        temperature = kwargs.get(ATTR_TEMPERATURE)
+
+        await self.executor.async_execute_command(
+            OverkizCommand.SET_THERMOSTAT_SETTING_CONTROL_ZONE_1, int(temperature)
+        )

--- a/homeassistant/components/overkiz/climate/hitachi_air_to_water_heating_zone.py
+++ b/homeassistant/components/overkiz/climate/hitachi_air_to_water_heating_zone.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
-from pyoverkiz.enums import OverkizCommand, OverkizState
+from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
 
 from homeassistant.components.climate import (
     PRESET_COMFORT,
@@ -18,27 +18,12 @@ from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
 from ..const import DOMAIN
 from ..entity import OverkizDataUpdateCoordinator, OverkizEntity
 
-MODBUS_YUTAKI_TARGET_MODE_STATE = "modbus:YutakiTargetModeState"
-MODBUS_ROOM_AMBIENT_TEMPERATURE_STATUS_ZONE_1_STATE = (
-    "modbus:RoomAmbientTemperatureStatusZone1State"
-)
-MODBUS_THERMOSTAT_SETTING_STATUS_ZONE_1_STATE = (
-    "modbus:ThermostatSettingStatusZone1State"
-)
-MODBUS_AUTO_MANU_MODE_ZONE_1_STATE = "modbus:AutoManuModeZone1State"
-MODBUS_THERMOSTAT_SETTING_CONTROL_ZONE_1_STATE = (
-    "modbus:ThermostatSettingControlZone1State"
-)
-
-HVAC_STATE_MANU = "manu"
-HVAC_STATE_AUTO = "auto"
-
 PRESET_STATE_ECO = "eco"
 PRESET_STATE_COMFORT = "comfort"
 
 OVERKIZ_TO_HVAC_MODE = {
-    HVAC_STATE_MANU: HVACMode.HEAT,
-    HVAC_STATE_AUTO: HVACMode.AUTO,
+    OverkizCommandParam.MANU: HVACMode.HEAT,
+    OverkizCommandParam.AUTO: HVACMode.AUTO,
 }
 
 HVAC_MODE_TO_OVERKIZ = {v: k for k, v in OVERKIZ_TO_HVAC_MODE.items()}
@@ -127,7 +112,7 @@ class HitachiAirToWaterHeatingZone(OverkizEntity, ClimateEntity):
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
-        temperature = kwargs.get(ATTR_TEMPERATURE)
+        temperature = cast(float, kwargs.get(ATTR_TEMPERATURE))
 
         await self.executor.async_execute_command(
             OverkizCommand.SET_THERMOSTAT_SETTING_CONTROL_ZONE_1, int(temperature)

--- a/homeassistant/components/overkiz/climate/hitachi_air_to_water_heating_zone.py
+++ b/homeassistant/components/overkiz/climate/hitachi_air_to_water_heating_zone.py
@@ -19,9 +19,6 @@ from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
 from ..const import DOMAIN
 from ..entity import OverkizDataUpdateCoordinator, OverkizEntity
 
-PRESET_STATE_ECO = "eco"
-PRESET_STATE_COMFORT = "comfort"
-
 OVERKIZ_TO_HVAC_MODE: dict[str, HVACMode] = {
     OverkizCommandParam.MANU: HVACMode.HEAT,
     OverkizCommandParam.AUTO: HVACMode.AUTO,
@@ -30,8 +27,8 @@ OVERKIZ_TO_HVAC_MODE: dict[str, HVACMode] = {
 HVAC_MODE_TO_OVERKIZ = {v: k for k, v in OVERKIZ_TO_HVAC_MODE.items()}
 
 OVERKIZ_TO_PRESET_MODE: dict[str, str] = {
-    PRESET_STATE_COMFORT: PRESET_COMFORT,
-    PRESET_STATE_ECO: PRESET_ECO,
+    OverkizCommandParam.COMFORT: PRESET_COMFORT,
+    OverkizCommandParam.ECO: PRESET_ECO,
 }
 
 PRESET_MODE_TO_OVERKIZ = {v: k for k, v in OVERKIZ_TO_PRESET_MODE.items()}
@@ -65,7 +62,7 @@ class HitachiAirToWaterHeatingZone(OverkizEntity, ClimateEntity):
     def hvac_mode(self) -> HVACMode:
         """Return hvac operation ie. heat, cool mode."""
         if (
-            state := self.device.states[OverkizState.MODBUS_AUTO_MANU_MODE_ZONE_1_STATE]
+            state := self.device.states[OverkizState.MODBUS_AUTO_MANU_MODE_ZONE_1]
         ) and state.value_as_str:
             return OVERKIZ_TO_HVAC_MODE[state.value_as_str]
 
@@ -81,7 +78,7 @@ class HitachiAirToWaterHeatingZone(OverkizEntity, ClimateEntity):
     def preset_mode(self) -> str | None:
         """Return the current preset mode, e.g., home, away, temp."""
         if (
-            state := self.device.states[OverkizState.MODBUS_YUTAKI_TARGET_MODE_STATE]
+            state := self.device.states[OverkizState.MODBUS_YUTAKI_TARGET_MODE]
         ) and state.value_as_str:
             return OVERKIZ_TO_PRESET_MODE[state.value_as_str]
 
@@ -97,7 +94,7 @@ class HitachiAirToWaterHeatingZone(OverkizEntity, ClimateEntity):
     def current_temperature(self) -> float | None:
         """Return the current temperature."""
         current_temperature = self.device.states[
-            OverkizState.MODBUS_ROOM_AMBIENT_TEMPERATURE_STATUS_ZONE_1_STATE
+            OverkizState.MODBUS_ROOM_AMBIENT_TEMPERATURE_STATUS_ZONE_1
         ]
 
         if current_temperature:
@@ -109,7 +106,7 @@ class HitachiAirToWaterHeatingZone(OverkizEntity, ClimateEntity):
     def target_temperature(self) -> float | None:
         """Return the temperature we try to reach."""
         target_temperature = self.device.states[
-            OverkizState.MODBUS_THERMOSTAT_SETTING_CONTROL_ZONE_1_STATE
+            OverkizState.MODBUS_THERMOSTAT_SETTING_CONTROL_ZONE_1
         ]
 
         if target_temperature:

--- a/homeassistant/components/overkiz/climate/hitachi_air_to_water_heating_zone.py
+++ b/homeassistant/components/overkiz/climate/hitachi_air_to_water_heating_zone.py
@@ -21,7 +21,7 @@ from ..entity import OverkizDataUpdateCoordinator, OverkizEntity
 PRESET_STATE_ECO = "eco"
 PRESET_STATE_COMFORT = "comfort"
 
-OVERKIZ_TO_HVAC_MODE: dict[str, str] = {
+OVERKIZ_TO_HVAC_MODE: dict[str, HVACMode] = {
     OverkizCommandParam.MANU: HVACMode.HEAT,
     OverkizCommandParam.AUTO: HVACMode.AUTO,
 }

--- a/homeassistant/components/overkiz/const.py
+++ b/homeassistant/components/overkiz/const.py
@@ -102,6 +102,7 @@ OVERKIZ_DEVICE_TO_PLATFORM: dict[UIClass | UIWidget, Platform | None] = {
     UIWidget.DOMESTIC_HOT_WATER_PRODUCTION: Platform.WATER_HEATER,  # widgetName, uiClass is WaterHeatingSystem (not supported)
     UIWidget.DOMESTIC_HOT_WATER_TANK: Platform.SWITCH,  # widgetName, uiClass is WaterHeatingSystem (not supported)
     UIWidget.HITACHI_AIR_TO_AIR_HEAT_PUMP: Platform.CLIMATE,  # widgetName, uiClass is HeatingSystem (not supported)
+    UIWidget.HITACHI_AIR_TO_WATER_HEATING_ZONE: Platform.CLIMATE,  # widgetName, uiClass is HeatingSystem (not supported)
     UIWidget.HITACHI_DHW: Platform.WATER_HEATER,  # widgetName, uiClass is HitachiHeatingSystem (not supported)
     UIWidget.MY_FOX_ALARM_CONTROLLER: Platform.ALARM_CONTROL_PANEL,  # widgetName, uiClass is Alarm (not supported)
     UIWidget.MY_FOX_SECURITY_CAMERA: Platform.SWITCH,  # widgetName, uiClass is Camera (not supported)


### PR DESCRIPTION
## Proposed change
Add support for HitachiAirToWaterHeatingZone (ported from ha-tahoma, old custom component). 

Fixes #98939

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #98939
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
