### PR TITLE
Fix a history stats bug when window and tracked state change simultaneously

### DIFF
--- a/homeassistant/components/history_stats/data.py
+++ b/homeassistant/components/history_stats/data.py
@@ -131,6 +131,18 @@ class HistoryStats:
             await self._async_history_from_db(
                 current_period_start_timestamp, current_period_end_timestamp
             )
+            if event and (new_state := event.data["new_state"]) is not None:
+                if (
+                    current_period_start_timestamp
+                    <= floored_timestamp(new_state.last_changed)
+                    <= current_period_end_timestamp
+                ):
+                    self._history_current_period.append(
+                        HistoryState(
+                            new_state.state, new_state.last_changed.timestamp()
+                        )
+                    )
+
             self._previous_run_before_start = False
 
         seconds_matched, match_count = self._async_compute_seconds_and_changes(

--- a/homeassistant/components/history_stats/data.py
+++ b/homeassistant/components/history_stats/data.py
@@ -118,9 +118,7 @@ class HistoryStats:
                     <= current_period_end_timestamp
                 ):
                     self._history_current_period.append(
-                        HistoryState(
-                            new_state.state, new_state.last_changed.timestamp()
-                        )
+                        HistoryState(new_state.state, new_state.last_changed_timestamp)
                     )
                     new_data = True
             if not new_data and current_period_end_timestamp < now_timestamp:
@@ -138,9 +136,7 @@ class HistoryStats:
                     <= current_period_end_timestamp
                 ):
                     self._history_current_period.append(
-                        HistoryState(
-                            new_state.state, new_state.last_changed.timestamp()
-                        )
+                        HistoryState(new_state.state, new_state.last_changed_timestamp)
                     )
 
             self._previous_run_before_start = False

--- a/tests/components/history_stats/test_sensor.py
+++ b/tests/components/history_stats/test_sensor.py
@@ -1544,12 +1544,8 @@ async def test_state_change_during_window_rollover(
                 ha.State(
                     "binary_sensor.state",
                     "on",
-                    last_changed=t3.replace(
-                        hours=0, minutes=0, seconds=0, microseconds=0
-                    ),
-                    last_updated=t3.replace(
-                        hours=0, minutes=0, seconds=0, microseconds=0
-                    ),
+                    last_changed=t3.replace(hour=0, minute=0, second=0, microsecond=0),
+                    last_updated=t3.replace(hour=0, minute=0, second=0, microsecond=0),
                 ),
             ]
         }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
This change attempts to fix a bug in history stats which looks like the following:

If the sensor has a tracked window that changes in the same minute as the source sensor changes, it is possible that the sensor will fail to register the state change for future updates until the next time the sensor toggles. 

So if you have a sensor that tracks the on-time of a sensor for the current day (midnight to midnight), and if that sensor changes from on->off in the first minute after the window shift (12:00->12:01am), before the history stats sensor updates, history stats will act as if that sensor never turned off and keep accumulating time until the sensor turns on and back off again.

There is some racyness here so it doesn't always happen, it depends what event happens first after the window reset, the history stats sensor update or the source sensor update.

The update is missed because on the state change event, history stats sees it is a new time window and queries the database for state history, but this query _does not yet include_ the current state change that triggered the update.

Then in the next scheduled update of the history stats sensor, it calculates that it does not need to re-query the database, so it just keeps operating on the previously fetched history, which is missing the latest state change.


To fix this issue, when we query the database in response to a state changed event, push the state change event to the end of the list of recorded state events (this is already done in cases where we don't query the database).

I'm fairly sure this fixes the issue reported here: https://github.com/home-assistant/core/issues/75903#issuecomment-2537311025, and maybe also https://github.com/home-assistant/core/issues/121535, but not sure.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
