### PR TITLE
Add support for EvoHomeController in Overkiz

### DIFF
--- a/homeassistant/components/overkiz/climate/__init__.py
+++ b/homeassistant/components/overkiz/climate/__init__.py
@@ -25,6 +25,7 @@ from .atlantic_pass_apc_heat_pump_main_component import (
 from .atlantic_pass_apc_heating_zone import AtlanticPassAPCHeatingZone
 from .atlantic_pass_apc_zone_control import AtlanticPassAPCZoneControl
 from .atlantic_pass_apc_zone_control_zone import AtlanticPassAPCZoneControlZone
+from .evo_home_controller import EvoHomeController
 from .hitachi_air_to_air_heat_pump_hlrrwifi import HitachiAirToAirHeatPumpHLRRWIFI
 from .hitachi_air_to_air_heat_pump_ovp import HitachiAirToAirHeatPumpOVP
 from .hitachi_air_to_water_heating_zone import HitachiAirToWaterHeatingZone
@@ -53,6 +54,7 @@ WIDGET_TO_CLIMATE_ENTITY = {
     UIWidget.ATLANTIC_PASS_APC_HEATING_ZONE: AtlanticPassAPCHeatingZone,
     UIWidget.ATLANTIC_PASS_APC_ZONE_CONTROL: AtlanticPassAPCZoneControl,
     UIWidget.HITACHI_AIR_TO_WATER_HEATING_ZONE: HitachiAirToWaterHeatingZone,
+    UIWidget.EVO_HOME_CONTROLLER: EvoHomeController,
     UIWidget.SOMFY_HEATING_TEMPERATURE_INTERFACE: SomfyHeatingTemperatureInterface,
     UIWidget.SOMFY_THERMOSTAT: SomfyThermostat,
     UIWidget.VALVE_HEATING_TEMPERATURE_INTERFACE: ValveHeatingTemperatureInterface,

--- a/homeassistant/components/overkiz/climate/evo_home_controller.py
+++ b/homeassistant/components/overkiz/climate/evo_home_controller.py
@@ -53,9 +53,8 @@ class EvoHomeController(OverkizEntity, ClimateEntity):
     @property
     def hvac_mode(self) -> HVACMode:
         """Return hvac operation ie. heat, cool mode."""
-        operating_mode = self.executor.select_state(
-            OverkizState.RAMSES_RAMSES_OPERATING_MODE
-        )
+        state = self.device.states[OverkizState.RAMSES_RAMSES_OPERATING_MODE]
+        operating_mode = state.value_as_str
 
         if operating_mode in OVERKIZ_TO_HVAC_MODES:
             return OVERKIZ_TO_HVAC_MODES[operating_mode]

--- a/homeassistant/components/overkiz/climate/evo_home_controller.py
+++ b/homeassistant/components/overkiz/climate/evo_home_controller.py
@@ -53,14 +53,14 @@ class EvoHomeController(OverkizEntity, ClimateEntity):
     @property
     def hvac_mode(self) -> HVACMode:
         """Return hvac operation ie. heat, cool mode."""
-        state = self.device.states[OverkizState.RAMSES_RAMSES_OPERATING_MODE]
-        operating_mode = state.value_as_str
+        if state := self.device.states.get(OverkizState.RAMSES_RAMSES_OPERATING_MODE):
+            operating_mode = state.value_as_str
 
-        if operating_mode in OVERKIZ_TO_HVAC_MODES:
-            return OVERKIZ_TO_HVAC_MODES[operating_mode]
+            if operating_mode in OVERKIZ_TO_HVAC_MODES:
+                return OVERKIZ_TO_HVAC_MODES[operating_mode]
 
-        if operating_mode in OVERKIZ_TO_PRESET_MODES:
-            return HVACMode.OFF
+            if operating_mode in OVERKIZ_TO_PRESET_MODES:
+                return HVACMode.OFF
 
         return HVACMode.OFF
 

--- a/homeassistant/components/overkiz/climate/evo_home_controller.py
+++ b/homeassistant/components/overkiz/climate/evo_home_controller.py
@@ -61,7 +61,7 @@ class EvoHomeController(OverkizEntity, ClimateEntity):
             return OVERKIZ_TO_HVAC_MODES[operating_mode]
 
         if operating_mode in OVERKIZ_TO_PRESET_MODES:
-            return HVACMode.HEAT
+            return HVACMode.OFF
 
         return HVACMode.OFF
 

--- a/homeassistant/components/overkiz/climate/evo_home_controller.py
+++ b/homeassistant/components/overkiz/climate/evo_home_controller.py
@@ -1,0 +1,102 @@
+"""Support for EvoHomeController."""
+
+from datetime import timedelta
+
+from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
+
+from homeassistant.components.climate import (
+    PRESET_NONE,
+    ClimateEntity,
+    ClimateEntityFeature,
+    HVACMode,
+)
+from homeassistant.const import UnitOfTemperature
+import homeassistant.util.dt as dt_util
+
+from ..entity import OverkizDataUpdateCoordinator, OverkizEntity
+
+PRESET_DAY_OFF = "day-off"
+PRESET_HOLIDAYS = "holidays"
+
+OVERKIZ_TO_HVAC_MODES: dict[str, HVACMode] = {
+    OverkizCommandParam.AUTO: HVACMode.AUTO,
+    OverkizCommandParam.OFF: HVACMode.OFF,
+}
+HVAC_MODES_TO_OVERKIZ = {v: k for k, v in OVERKIZ_TO_HVAC_MODES.items()}
+
+OVERKIZ_TO_PRESET_MODES: dict[str, str] = {
+    OverkizCommandParam.DAY_OFF: PRESET_DAY_OFF,
+    OverkizCommandParam.HOLIDAYS: PRESET_HOLIDAYS,
+}
+PRESET_MODES_TO_OVERKIZ = {v: k for k, v in OVERKIZ_TO_PRESET_MODES.items()}
+
+
+class EvoHomeController(OverkizEntity, ClimateEntity):
+    """Representation of EvoHomeController device."""
+
+    _attr_hvac_modes = [*HVAC_MODES_TO_OVERKIZ]
+    _attr_preset_modes = [*PRESET_MODES_TO_OVERKIZ]
+    _attr_supported_features = (
+        ClimateEntityFeature.PRESET_MODE | ClimateEntityFeature.TURN_OFF
+    )
+    _attr_temperature_unit = UnitOfTemperature.CELSIUS
+
+    def __init__(
+        self, device_url: str, coordinator: OverkizDataUpdateCoordinator
+    ) -> None:
+        """Init method."""
+        super().__init__(device_url, coordinator)
+
+        if self._attr_device_info:
+            self._attr_device_info["manufacturer"] = "EvoHome"
+
+    @property
+    def hvac_mode(self) -> HVACMode:
+        """Return hvac operation ie. heat, cool mode."""
+        operating_mode = self.executor.select_state(
+            OverkizState.RAMSES_RAMSES_OPERATING_MODE
+        )
+
+        if operating_mode in OVERKIZ_TO_HVAC_MODES:
+            return OVERKIZ_TO_HVAC_MODES[operating_mode]
+
+        if operating_mode in OVERKIZ_TO_PRESET_MODES:
+            return HVACMode.HEAT
+
+        return HVACMode.OFF
+
+    async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
+        """Set new target hvac mode."""
+        await self.executor.async_execute_command(
+            OverkizCommand.SET_OPERATING_MODE, HVAC_MODES_TO_OVERKIZ[hvac_mode]
+        )
+
+    @property
+    def preset_mode(self) -> str | None:
+        """Return the current preset mode, e.g., home, away, temp."""
+        if (
+            state := self.device.states[OverkizState.RAMSES_RAMSES_OPERATING_MODE]
+        ) and state.value_as_str in OVERKIZ_TO_PRESET_MODES:
+            return OVERKIZ_TO_PRESET_MODES[state.value_as_str]
+
+        return PRESET_NONE
+
+    async def async_set_preset_mode(self, preset_mode: str) -> None:
+        """Set new preset mode."""
+        if preset_mode == PRESET_DAY_OFF:
+            today_end_of_day = dt_util.now().replace(
+                hour=0, minute=0, second=0, microsecond=0
+            ) + timedelta(days=1)
+            time_interval = today_end_of_day
+
+        if preset_mode == PRESET_HOLIDAYS:
+            one_week_from_now = dt_util.now().replace(
+                hour=0, minute=0, second=0, microsecond=0
+            ) + timedelta(days=7)
+            time_interval = one_week_from_now
+
+        await self.executor.async_execute_command(
+            OverkizCommand.SET_OPERATING_MODE,
+            PRESET_MODES_TO_OVERKIZ[preset_mode],
+            time_interval.strftime("%Y/%m/%d %H:%M"),
+        )

--- a/homeassistant/components/overkiz/const.py
+++ b/homeassistant/components/overkiz/const.py
@@ -101,6 +101,7 @@ OVERKIZ_DEVICE_TO_PLATFORM: dict[UIClass | UIWidget, Platform | None] = {
     UIWidget.ATLANTIC_PASS_APC_ZONE_CONTROL: Platform.CLIMATE,  # widgetName, uiClass is HeatingSystem (not supported)
     UIWidget.DOMESTIC_HOT_WATER_PRODUCTION: Platform.WATER_HEATER,  # widgetName, uiClass is WaterHeatingSystem (not supported)
     UIWidget.DOMESTIC_HOT_WATER_TANK: Platform.SWITCH,  # widgetName, uiClass is WaterHeatingSystem (not supported)
+    UIWidget.EVO_HOME_CONTROLLER: Platform.CLIMATE,  # widgetName, uiClass is EvoHome (not supported)
     UIWidget.HITACHI_AIR_TO_AIR_HEAT_PUMP: Platform.CLIMATE,  # widgetName, uiClass is HeatingSystem (not supported)
     UIWidget.HITACHI_AIR_TO_WATER_HEATING_ZONE: Platform.CLIMATE,  # widgetName, uiClass is HeatingSystem (not supported)
     UIWidget.HITACHI_DHW: Platform.WATER_HEATER,  # widgetName, uiClass is HitachiHeatingSystem (not supported)


### PR DESCRIPTION
## Proposed change
Add support for EvoHomeController (ported from ha-tahoma, old custom component).

![image](https://github.com/user-attachments/assets/65e357cd-2e97-4ad1-948a-03b5134d7d78)

The original device has presets for a day off and holidays (7 days); these are mapped 1:1 in the HA implementation.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
