### PR TITLE
Add button platform to Peblar Rocksolid EV Chargers integration

### DIFF
--- a/homeassistant/components/peblar/__init__.py
+++ b/homeassistant/components/peblar/__init__.py
@@ -30,6 +30,7 @@ from .coordinator import (
 
 PLATFORMS = [
     Platform.BINARY_SENSOR,
+    Platform.BUTTON,
     Platform.NUMBER,
     Platform.SELECT,
     Platform.SENSOR,

--- a/homeassistant/components/peblar/button.py
+++ b/homeassistant/components/peblar/button.py
@@ -1,0 +1,92 @@
+"""Support for Peblar button."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any
+
+from peblar import Peblar
+
+from homeassistant.components.button import (
+    ButtonDeviceClass,
+    ButtonEntity,
+    ButtonEntityDescription,
+)
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import PeblarConfigEntry, PeblarUserConfigurationDataUpdateCoordinator
+
+
+@dataclass(frozen=True, kw_only=True)
+class PeblarButtonEntityDescription(ButtonEntityDescription):
+    """Describe a Peblar button."""
+
+    press_fn: Callable[[Peblar], Awaitable[Any]]
+
+
+DESCRIPTIONS = [
+    PeblarButtonEntityDescription(
+        key="identify",
+        device_class=ButtonDeviceClass.IDENTIFY,
+        entity_category=EntityCategory.CONFIG,
+        entity_registry_enabled_default=False,
+        press_fn=lambda x: x.identify(),
+    ),
+    PeblarButtonEntityDescription(
+        key="reboot",
+        device_class=ButtonDeviceClass.RESTART,
+        entity_category=EntityCategory.CONFIG,
+        entity_registry_enabled_default=False,
+        press_fn=lambda x: x.reboot(),
+    ),
+]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: PeblarConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Peblar buttons based on a config entry."""
+    async_add_entities(
+        PeblarButtonEntity(
+            entry=entry,
+            description=description,
+        )
+        for description in DESCRIPTIONS
+    )
+
+
+class PeblarButtonEntity(
+    CoordinatorEntity[PeblarUserConfigurationDataUpdateCoordinator], ButtonEntity
+):
+    """Defines an Peblar button."""
+
+    entity_description: PeblarButtonEntityDescription
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        entry: PeblarConfigEntry,
+        description: PeblarButtonEntityDescription,
+    ) -> None:
+        """Initialize the button entity."""
+        super().__init__(coordinator=entry.runtime_data.user_configuraton_coordinator)
+        self.entity_description = description
+        self._attr_unique_id = f"{entry.unique_id}_{description.key}"
+        self._attr_device_info = DeviceInfo(
+            identifiers={
+                (DOMAIN, entry.runtime_data.system_information.product_serial_number)
+            },
+        )
+
+    async def async_press(self) -> None:
+        """Trigger button press on the Peblar device."""
+        await self.entity_description.press_fn(self.coordinator.peblar)

--- a/tests/components/peblar/snapshots/test_button.ambr
+++ b/tests/components/peblar/snapshots/test_button.ambr
@@ -1,0 +1,95 @@
+# serializer version: 1
+# name: test_entities[button][button.peblar_ev_charger_identify-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'button.peblar_ev_charger_identify',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
+    'original_icon': None,
+    'original_name': 'Identify',
+    'platform': 'peblar',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '23-45-A4O-MOF_identify',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[button][button.peblar_ev_charger_identify-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'identify',
+      'friendly_name': 'Peblar EV Charger Identify',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.peblar_ev_charger_identify',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_entities[button][button.peblar_ev_charger_restart-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'button.peblar_ev_charger_restart',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <ButtonDeviceClass.RESTART: 'restart'>,
+    'original_icon': None,
+    'original_name': 'Restart',
+    'platform': 'peblar',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '23-45-A4O-MOF_reboot',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[button][button.peblar_ev_charger_restart-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'restart',
+      'friendly_name': 'Peblar EV Charger Restart',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.peblar_ev_charger_restart',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---

--- a/tests/components/peblar/test_button.py
+++ b/tests/components/peblar/test_button.py
@@ -1,0 +1,36 @@
+"""Tests for the Peblar button platform."""
+
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.peblar.const import DOMAIN
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+
+@pytest.mark.freeze_time("2024-12-21 21:45:00")
+@pytest.mark.parametrize("init_integration", [Platform.BUTTON], indirect=True)
+@pytest.mark.usefixtures("entity_registry_enabled_by_default", "init_integration")
+async def test_entities(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the button entities."""
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+    # Ensure all entities are correctly assigned to the Peblar device
+    device_entry = device_registry.async_get_device(
+        identifiers={(DOMAIN, "23-45-A4O-MOF")}
+    )
+    assert device_entry
+    entity_entries = er.async_entries_for_config_entry(
+        entity_registry, mock_config_entry.entry_id
+    )
+    for entity_entry in entity_entries:
+        assert entity_entry.device_id == device_entry.id


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR adds the button platform to the [Peblar Rocksolid EV Chargers](https://www.peblar.com) integration.

![CleanShot 2024-12-22 at 11 20 32](https://github.com/user-attachments/assets/340957bc-e101-453e-8845-cca2865b537f)

Two new buttons: Reboot & Identify. Both are disabled by default, as the general use case for these is very low.

Basic tests have been included to ensure the entities are created with the right properties.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
