### PR TITLE
Add button error handling for Peblar Rocksolid EV Chargers

### DIFF
--- a/homeassistant/components/peblar/button.py
+++ b/homeassistant/components/peblar/button.py
@@ -19,6 +19,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .coordinator import PeblarConfigEntry, PeblarUserConfigurationDataUpdateCoordinator
 from .entity import PeblarEntity
+from .helpers import peblar_exception_handler
 
 PARALLEL_UPDATES = 1
 
@@ -72,6 +73,7 @@ class PeblarButtonEntity(
 
     entity_description: PeblarButtonEntityDescription
 
+    @peblar_exception_handler
     async def async_press(self) -> None:
         """Trigger button press on the Peblar device."""
         await self.entity_description.press_fn(self.coordinator.peblar)

--- a/homeassistant/components/peblar/helpers.py
+++ b/homeassistant/components/peblar/helpers.py
@@ -1,0 +1,55 @@
+"""Helpers for Peblar."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Coroutine
+from typing import Any, Concatenate
+
+from peblar import PeblarAuthenticationError, PeblarConnectionError, PeblarError
+
+from homeassistant.exceptions import HomeAssistantError
+
+from .const import DOMAIN
+from .entity import PeblarEntity
+
+
+def peblar_exception_handler[_PeblarEntityT: PeblarEntity, **_P](
+    func: Callable[Concatenate[_PeblarEntityT, _P], Coroutine[Any, Any, Any]],
+) -> Callable[Concatenate[_PeblarEntityT, _P], Coroutine[Any, Any, None]]:
+    """Decorate Peblar calls to handle exceptions.
+
+    A decorator that wraps the passed in function, catches Peblar errors.
+    """
+
+    async def handler(
+        self: _PeblarEntityT, *args: _P.args, **kwargs: _P.kwargs
+    ) -> None:
+        try:
+            await func(self, *args, **kwargs)
+            self.coordinator.async_update_listeners()
+
+        except PeblarAuthenticationError as error:
+            # Reload the config entry to trigger reauth flow
+            self.hass.config_entries.async_schedule_reload(
+                self.coordinator.config_entry.entry_id
+            )
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="authentication_error",
+            ) from error
+
+        except PeblarConnectionError as error:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="communication_error",
+                translation_placeholders={"error": str(error)},
+            ) from error
+
+        except PeblarError as error:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="unknown_error",
+                translation_placeholders={"error": str(error)},
+            ) from error
+
+    return handler

--- a/homeassistant/components/peblar/strings.json
+++ b/homeassistant/components/peblar/strings.json
@@ -161,5 +161,16 @@
         "name": "Customization"
       }
     }
+  },
+  "exceptions": {
+    "authentication_error": {
+      "message": "An authentication failure occurred while communicating with the Peblar device."
+    },
+    "communication_error": {
+      "message": "An error occurred while communicating with the Peblar device: {error}"
+    },
+    "unknown_error": {
+      "message": "An unknown error occurred while communicating with the Peblar device: {error}"
+    }
   }
 }

--- a/tests/components/peblar/test_button.py
+++ b/tests/components/peblar/test_button.py
@@ -1,19 +1,29 @@
 """Tests for the Peblar button platform."""
 
+from unittest.mock import MagicMock
+
+from peblar import PeblarAuthenticationError, PeblarConnectionError, PeblarError
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
+from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
 from homeassistant.components.peblar.const import DOMAIN
-from homeassistant.const import Platform
+from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
+from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from tests.common import MockConfigEntry, snapshot_platform
 
+pytestmark = [
+    pytest.mark.freeze_time("2024-12-21 21:45:00"),
+    pytest.mark.parametrize("init_integration", [Platform.BUTTON], indirect=True),
+    pytest.mark.usefixtures("init_integration"),
+]
 
-@pytest.mark.freeze_time("2024-12-21 21:45:00")
-@pytest.mark.parametrize("init_integration", [Platform.BUTTON], indirect=True)
-@pytest.mark.usefixtures("entity_registry_enabled_by_default", "init_integration")
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_entities(
     hass: HomeAssistant,
     snapshot: SnapshotAssertion,
@@ -34,3 +44,110 @@ async def test_entities(
     )
     for entity_entry in entity_entries:
         assert entity_entry.device_id == device_entry.id
+
+
+@pytest.mark.parametrize(
+    ("entity_id", "method"),
+    [
+        ("button.peblar_ev_charger_identify", "identify"),
+        ("button.peblar_ev_charger_restart", "reboot"),
+    ],
+)
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_buttons(
+    hass: HomeAssistant,
+    mock_peblar: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    entity_id: str,
+    method: str,
+) -> None:
+    """Test the Peblar EV charger buttons."""
+    mocked_method = getattr(mock_peblar, method)
+
+    # Test normal happy path button press
+    await hass.services.async_call(
+        BUTTON_DOMAIN,
+        SERVICE_PRESS,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+
+    assert len(mocked_method.mock_calls) == 1
+    mocked_method.assert_called_with()
+
+    # Test connection error handling
+    mocked_method.side_effect = PeblarConnectionError("Could not connect")
+    with pytest.raises(
+        HomeAssistantError,
+        match=(
+            r"An error occurred while communicating "
+            r"with the Peblar device: Could not connect"
+        ),
+    ) as excinfo:
+        await hass.services.async_call(
+            BUTTON_DOMAIN,
+            SERVICE_PRESS,
+            {ATTR_ENTITY_ID: entity_id},
+            blocking=True,
+        )
+
+    assert excinfo.value.translation_domain == DOMAIN
+    assert excinfo.value.translation_key == "communication_error"
+    assert excinfo.value.translation_placeholders == {"error": "Could not connect"}
+
+    # Test unknown error handling
+    mocked_method.side_effect = PeblarError("Unknown error")
+    with pytest.raises(
+        HomeAssistantError,
+        match=(
+            r"An unknown error occurred while communicating "
+            r"with the Peblar device: Unknown error"
+        ),
+    ) as excinfo:
+        await hass.services.async_call(
+            BUTTON_DOMAIN,
+            SERVICE_PRESS,
+            {ATTR_ENTITY_ID: entity_id},
+            blocking=True,
+        )
+
+    assert excinfo.value.translation_domain == DOMAIN
+    assert excinfo.value.translation_key == "unknown_error"
+    assert excinfo.value.translation_placeholders == {"error": "Unknown error"}
+
+    # Test authentication error handling
+    mocked_method.side_effect = PeblarAuthenticationError("Authentication error")
+    mock_peblar.login.side_effect = PeblarAuthenticationError("Authentication error")
+    with pytest.raises(
+        HomeAssistantError,
+        match=(
+            r"An authentication failure occurred while communicating "
+            r"with the Peblar device"
+        ),
+    ) as excinfo:
+        await hass.services.async_call(
+            BUTTON_DOMAIN,
+            SERVICE_PRESS,
+            {ATTR_ENTITY_ID: entity_id},
+            blocking=True,
+        )
+
+    assert excinfo.value.translation_domain == DOMAIN
+    assert excinfo.value.translation_key == "authentication_error"
+    assert not excinfo.value.translation_placeholders
+
+    # Ensure the device is reloaded on authentication error and triggers
+    # a reauthentication flow.
+    await hass.async_block_till_done()
+    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
+
+    flows = hass.config_entries.flow.async_progress()
+    assert len(flows) == 1
+
+    flow = flows[0]
+    assert flow["step_id"] == "reauth_confirm"
+    assert flow["handler"] == DOMAIN
+
+    assert "context" in flow
+    assert flow["context"].get("source") == SOURCE_REAUTH
+    assert flow["context"].get("entry_id") == mock_config_entry.entry_id


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add error handling for pressing button entities on the [Peblar Rocksolid EV Charger](https://www.peblar.com) integration.

This introduces the helper to handle connection errors, authentication errors, and any unknown other error. I've included tests to verify its working.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
