### PR TITLE
Add select error handling for Peblar Rocksolid EV Chargers

### DIFF
--- a/homeassistant/components/peblar/select.py
+++ b/homeassistant/components/peblar/select.py
@@ -15,6 +15,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .coordinator import PeblarConfigEntry, PeblarUserConfigurationDataUpdateCoordinator
 from .entity import PeblarEntity
+from .helpers import peblar_exception_handler
 
 PARALLEL_UPDATES = 1
 
@@ -74,6 +75,7 @@ class PeblarSelectEntity(
         """Return the selected entity option to represent the entity state."""
         return self.entity_description.current_fn(self.coordinator.data)
 
+    @peblar_exception_handler
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
         await self.entity_description.select_fn(self.coordinator.peblar, option)

--- a/tests/components/peblar/test_select.py
+++ b/tests/components/peblar/test_select.py
@@ -1,18 +1,36 @@
 """Tests for the Peblar select platform."""
 
+from unittest.mock import MagicMock
+
+from peblar import (
+    PeblarAuthenticationError,
+    PeblarConnectionError,
+    PeblarError,
+    SmartChargingMode,
+)
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.peblar.const import DOMAIN
-from homeassistant.const import Platform
+from homeassistant.components.select import (
+    ATTR_OPTION,
+    DOMAIN as SELECT_DOMAIN,
+    SERVICE_SELECT_OPTION,
+)
+from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
+from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from tests.common import MockConfigEntry, snapshot_platform
 
+pytestmark = [
+    pytest.mark.parametrize("init_integration", [Platform.SELECT], indirect=True),
+    pytest.mark.usefixtures("init_integration"),
+]
 
-@pytest.mark.parametrize("init_integration", [Platform.SELECT], indirect=True)
-@pytest.mark.usefixtures("init_integration")
+
 async def test_entities(
     hass: HomeAssistant,
     snapshot: SnapshotAssertion,
@@ -33,3 +51,115 @@ async def test_entities(
     )
     for entity_entry in entity_entries:
         assert entity_entry.device_id == device_entry.id
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_select(
+    hass: HomeAssistant,
+    mock_peblar: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the Peblar EV charger selects."""
+    entity_id = "select.peblar_ev_charger_smart_charging"
+    mocked_method = mock_peblar.smart_charging
+    mocked_method.reset_mock()
+
+    # Test normal happy path for changing the select option
+    await hass.services.async_call(
+        SELECT_DOMAIN,
+        SERVICE_SELECT_OPTION,
+        {
+            ATTR_ENTITY_ID: entity_id,
+            ATTR_OPTION: "default",
+        },
+        blocking=True,
+    )
+
+    assert len(mocked_method.mock_calls) == 1
+    mocked_method.assert_called_with(SmartChargingMode.DEFAULT)
+
+    # Test connection error handling
+    mocked_method.side_effect = PeblarConnectionError("Could not connect")
+    with pytest.raises(
+        HomeAssistantError,
+        match=(
+            r"An error occurred while communicating "
+            r"with the Peblar device: Could not connect"
+        ),
+    ) as excinfo:
+        await hass.services.async_call(
+            SELECT_DOMAIN,
+            SERVICE_SELECT_OPTION,
+            {
+                ATTR_ENTITY_ID: entity_id,
+                ATTR_OPTION: "default",
+            },
+            blocking=True,
+        )
+
+    assert excinfo.value.translation_domain == DOMAIN
+    assert excinfo.value.translation_key == "communication_error"
+    assert excinfo.value.translation_placeholders == {"error": "Could not connect"}
+
+    # Test unknown error handling
+    mocked_method.side_effect = PeblarError("Unknown error")
+    with pytest.raises(
+        HomeAssistantError,
+        match=(
+            r"An unknown error occurred while communicating "
+            r"with the Peblar device: Unknown error"
+        ),
+    ) as excinfo:
+        await hass.services.async_call(
+            SELECT_DOMAIN,
+            SERVICE_SELECT_OPTION,
+            {
+                ATTR_ENTITY_ID: entity_id,
+                ATTR_OPTION: "default",
+            },
+            blocking=True,
+        )
+
+    assert excinfo.value.translation_domain == DOMAIN
+    assert excinfo.value.translation_key == "unknown_error"
+    assert excinfo.value.translation_placeholders == {"error": "Unknown error"}
+
+    # Test authentication error handling
+    mocked_method.side_effect = PeblarAuthenticationError("Authentication error")
+    mock_peblar.login.side_effect = PeblarAuthenticationError("Authentication error")
+    with pytest.raises(
+        HomeAssistantError,
+        match=(
+            r"An authentication failure occurred while communicating "
+            r"with the Peblar device"
+        ),
+    ) as excinfo:
+        await hass.services.async_call(
+            SELECT_DOMAIN,
+            SERVICE_SELECT_OPTION,
+            {
+                ATTR_ENTITY_ID: entity_id,
+                ATTR_OPTION: "default",
+            },
+            blocking=True,
+        )
+
+    assert excinfo.value.translation_domain == DOMAIN
+    assert excinfo.value.translation_key == "authentication_error"
+    assert not excinfo.value.translation_placeholders
+
+    # Ensure the device is reloaded on authentication error and triggers
+    # a reauthentication flow.
+    await hass.async_block_till_done()
+    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
+
+    flows = hass.config_entries.flow.async_progress()
+    assert len(flows) == 1
+
+    flow = flows[0]
+    assert flow["step_id"] == "reauth_confirm"
+    assert flow["handler"] == DOMAIN
+
+    assert "context" in flow
+    assert flow["context"].get("source") == SOURCE_REAUTH
+    assert flow["context"].get("entry_id") == mock_config_entry.entry_id


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add error handling for changing select entities on the [Peblar Rocksolid EV Charger](https://www.peblar.com) integration.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
