### PR TITLE
Add coordinator error handling for Peblar Rocksolid EV Chargers

### DIFF
--- a/homeassistant/components/peblar/coordinator.py
+++ b/homeassistant/components/peblar/coordinator.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
 from datetime import timedelta
+from typing import Any, Concatenate
 
 from peblar import (
     Peblar,
     PeblarApi,
+    PeblarAuthenticationError,
+    PeblarConnectionError,
     PeblarError,
     PeblarEVInterface,
     PeblarMeter,
@@ -16,12 +20,13 @@ from peblar import (
     PeblarVersions,
 )
 
-from homeassistant.config_entries import ConfigEntry
+from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from tests.components.peblar.conftest import PeblarSystemInformation
 
-from .const import LOGGER
+from .const import DOMAIN, LOGGER
 
 
 @dataclass(kw_only=True)
@@ -59,6 +64,49 @@ class PeblarData:
     system: PeblarSystem
 
 
+def _coordinator_exception_handler[
+    _DataUpdateCoordinatorT: PeblarDataUpdateCoordinator
+    | PeblarVersionDataUpdateCoordinator
+    | PeblarUserConfigurationDataUpdateCoordinator,
+    **_P,
+](
+    func: Callable[Concatenate[_DataUpdateCoordinatorT, _P], Coroutine[Any, Any, Any]],
+) -> Callable[Concatenate[_DataUpdateCoordinatorT, _P], Coroutine[Any, Any, Any]]:
+    """Handle exceptions within the update handler of a coordinator."""
+
+    async def handler(
+        self: _DataUpdateCoordinatorT, *args: _P.args, **kwargs: _P.kwargs
+    ) -> Any:
+        try:
+            return await func(self, *args, **kwargs)
+        except PeblarAuthenticationError as error:
+            if self.config_entry and self.config_entry.state is ConfigEntryState.LOADED:
+                # This is not the first refresh, so let's reload
+                # the config entry to ensure we trigger a re-authentication
+                # flow (or recover in case of API token changes).
+                self.hass.config_entries.async_schedule_reload(
+                    self.config_entry.entry_id
+                )
+            raise ConfigEntryAuthFailed(
+                translation_domain=DOMAIN,
+                translation_key="authentication_error",
+            ) from error
+        except PeblarConnectionError as error:
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="communication_error",
+                translation_placeholders={"error": str(error)},
+            ) from error
+        except PeblarError as error:
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="unknown_error",
+                translation_placeholders={"error": str(error)},
+            ) from error
+
+    return handler
+
+
 class PeblarVersionDataUpdateCoordinator(
     DataUpdateCoordinator[PeblarVersionInformation]
 ):
@@ -77,15 +125,13 @@ class PeblarVersionDataUpdateCoordinator(
             update_interval=timedelta(hours=2),
         )
 
+    @_coordinator_exception_handler
     async def _async_update_data(self) -> PeblarVersionInformation:
         """Fetch data from the Peblar device."""
-        try:
-            return PeblarVersionInformation(
-                current=await self.peblar.current_versions(),
-                available=await self.peblar.available_versions(),
-            )
-        except PeblarError as err:
-            raise UpdateFailed(err) from err
+        return PeblarVersionInformation(
+            current=await self.peblar.current_versions(),
+            available=await self.peblar.available_versions(),
+        )
 
 
 class PeblarDataUpdateCoordinator(DataUpdateCoordinator[PeblarData]):
@@ -104,16 +150,14 @@ class PeblarDataUpdateCoordinator(DataUpdateCoordinator[PeblarData]):
             update_interval=timedelta(seconds=10),
         )
 
+    @_coordinator_exception_handler
     async def _async_update_data(self) -> PeblarData:
         """Fetch data from the Peblar device."""
-        try:
-            return PeblarData(
-                ev=await self.api.ev_interface(),
-                meter=await self.api.meter(),
-                system=await self.api.system(),
-            )
-        except PeblarError as err:
-            raise UpdateFailed(err) from err
+        return PeblarData(
+            ev=await self.api.ev_interface(),
+            meter=await self.api.meter(),
+            system=await self.api.system(),
+        )
 
 
 class PeblarUserConfigurationDataUpdateCoordinator(
@@ -134,9 +178,7 @@ class PeblarUserConfigurationDataUpdateCoordinator(
             update_interval=timedelta(minutes=5),
         )
 
+    @_coordinator_exception_handler
     async def _async_update_data(self) -> PeblarUserConfiguration:
         """Fetch data from the Peblar device."""
-        try:
-            return await self.peblar.user_configuration()
-        except PeblarError as err:
-            raise UpdateFailed(err) from err
+        return await self.peblar.user_configuration()

--- a/tests/components/peblar/test_coordinator.py
+++ b/tests/components/peblar/test_coordinator.py
@@ -1,0 +1,113 @@
+"""Tests for the Peblar coordinators."""
+
+from datetime import timedelta
+from unittest.mock import MagicMock
+
+from freezegun.api import FrozenDateTimeFactory
+from peblar import PeblarAuthenticationError, PeblarConnectionError, PeblarError
+import pytest
+
+from homeassistant.components.peblar.const import DOMAIN
+from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
+from homeassistant.const import STATE_UNAVAILABLE, Platform
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry, async_fire_time_changed
+
+
+@pytest.mark.parametrize("init_integration", [Platform.SENSOR], indirect=True)
+@pytest.mark.usefixtures("entity_registry_enabled_by_default", "init_integration")
+async def test_coordinator_error_handler(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_peblar: MagicMock,
+    freezer: FrozenDateTimeFactory,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test the coordinators."""
+
+    # Ensure we are set up and the coordinator is working.
+    # Confirming this through a sensor entity, that is available.
+    assert (state := hass.states.get("sensor.peblar_ev_charger_power"))
+    assert state.state != STATE_UNAVAILABLE
+
+    # Mock an error in the coordinator.
+    mock_peblar.rest_api.return_value.meter.side_effect = PeblarConnectionError(
+        "Could not connect"
+    )
+    freezer.tick(timedelta(seconds=15))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # Ensure the sensor entity is now unavailable.
+    assert (state := hass.states.get("sensor.peblar_ev_charger_power"))
+    assert state.state == STATE_UNAVAILABLE
+
+    # Ensure the error is logged
+    assert (
+        "An error occurred while communicating with the Peblar device: "
+        "Could not connect"
+    ) in caplog.text
+
+    # Recover
+    mock_peblar.rest_api.return_value.meter.side_effect = None
+    freezer.tick(timedelta(seconds=15))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # Ensure the sensor entity is now available.
+    assert (state := hass.states.get("sensor.peblar_ev_charger_power"))
+    assert state.state != STATE_UNAVAILABLE
+
+    # Mock an error in the coordinator.
+    mock_peblar.rest_api.return_value.meter.side_effect = PeblarError("Unknown error")
+    freezer.tick(timedelta(seconds=15))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # Ensure the sensor entity is now unavailable.
+    assert (state := hass.states.get("sensor.peblar_ev_charger_power"))
+    assert state.state == STATE_UNAVAILABLE
+
+    # Ensure the error is logged
+    assert (
+        "An unknown error occurred while communicating "
+        "with the Peblar device: Unknown error"
+    ) in caplog.text
+
+    # Recover
+    mock_peblar.rest_api.return_value.meter.side_effect = None
+    freezer.tick(timedelta(seconds=15))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # Ensure the sensor entity is now available.
+    assert (state := hass.states.get("sensor.peblar_ev_charger_power"))
+    assert state.state != STATE_UNAVAILABLE
+
+    # Mock an authentication in the coordinator
+    mock_peblar.rest_api.return_value.meter.side_effect = PeblarAuthenticationError(
+        "Authentication error"
+    )
+    mock_peblar.login.side_effect = PeblarAuthenticationError("Authentication error")
+    freezer.tick(timedelta(seconds=15))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # Ensure the sensor entity is now unavailable.
+    assert (state := hass.states.get("sensor.peblar_ev_charger_power"))
+    assert state.state == STATE_UNAVAILABLE
+
+    # Ensure we have triggered a reauthentication flow
+    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
+
+    flows = hass.config_entries.flow.async_progress()
+    assert len(flows) == 1
+
+    flow = flows[0]
+    assert flow["step_id"] == "reauth_confirm"
+    assert flow["handler"] == DOMAIN
+
+    assert "context" in flow
+    assert flow["context"].get("source") == SOURCE_REAUTH
+    assert flow["context"].get("entry_id") == mock_config_entry.entry_id


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds error handling to the coordinators of the [Peblar Rocksolid EV Chargers](https://www.peblar.com) integration.

This includes translations, tests and the ability to trigger a reload in case an authentication issue occurs during its lifetime.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
