### PR TITLE
Update enphase_envoy test_init to use str for unique_id and test for loaded config entry

### DIFF
--- a/homeassistant/components/enphase_envoy/quality_scale.yaml
+++ b/homeassistant/components/enphase_envoy/quality_scale.yaml
@@ -67,7 +67,6 @@ rules:
   test-coverage:
     status: todo
     comment: |
-      - test_config_different_unique_id -> unique_id set to the mock config entry is an int, not a str
       - Apart from the coverage, test_option_change_reload does not verify that the config entry is reloaded
 
   # Gold

--- a/homeassistant/components/enphase_envoy/quality_scale.yaml
+++ b/homeassistant/components/enphase_envoy/quality_scale.yaml
@@ -64,10 +64,7 @@ rules:
     status: done
     comment: pending https://github.com/home-assistant/core/pull/132373
   reauthentication-flow: done
-  test-coverage:
-    status: todo
-    comment: |
-      - Apart from the coverage, test_option_change_reload does not verify that the config entry is reloaded
+  test-coverage: done
 
   # Gold
   devices: done

--- a/tests/components/enphase_envoy/test_init.py
+++ b/tests/components/enphase_envoy/test_init.py
@@ -346,8 +346,10 @@ async def test_option_change_reload(
     await setup_integration(hass, config_entry)
     await hass.async_block_till_done(wait_background_tasks=True)
     assert config_entry.state is ConfigEntryState.LOADED
+    # By default neither option is available
+    assert config_entry.options == {}
 
-    # option change will take care of COV of init::async_reload_entry
+    # option change will also take care of COV of init::async_reload_entry
     hass.config_entries.async_update_entry(
         config_entry,
         options={
@@ -355,8 +357,23 @@ async def test_option_change_reload(
             OPTION_DISABLE_KEEP_ALIVE: True,
         },
     )
-    await hass.async_block_till_done()
+    await hass.async_block_till_done(wait_background_tasks=True)
+    assert config_entry.state is ConfigEntryState.LOADED
     assert config_entry.options == {
         OPTION_DIAGNOSTICS_INCLUDE_FIXTURES: False,
         OPTION_DISABLE_KEEP_ALIVE: True,
+    }
+    # flip em
+    hass.config_entries.async_update_entry(
+        config_entry,
+        options={
+            OPTION_DIAGNOSTICS_INCLUDE_FIXTURES: True,
+            OPTION_DISABLE_KEEP_ALIVE: False,
+        },
+    )
+    await hass.async_block_till_done(wait_background_tasks=True)
+    assert config_entry.state is ConfigEntryState.LOADED
+    assert config_entry.options == {
+        OPTION_DIAGNOSTICS_INCLUDE_FIXTURES: True,
+        OPTION_DISABLE_KEEP_ALIVE: False,
     }

--- a/tests/components/enphase_envoy/test_init.py
+++ b/tests/components/enphase_envoy/test_init.py
@@ -263,7 +263,7 @@ async def test_config_different_unique_id(
         domain=DOMAIN,
         entry_id="45a36e55aaddb2007c5f6602e0c38e72",
         title="Envoy 1234",
-        unique_id=4321,
+        unique_id="4321",
         data={
             CONF_HOST: "1.1.1.1",
             CONF_NAME: "Envoy 1234",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Feedback in the first review of enphase_envoy quality_scale.yaml (#132489) included comments for the test-coverage topic.

_- test_config_different_unique_id -> unique_id set to the mock config entry is an int, not a str_
_- Apart from the coverage, test_option_change_reload does not verify that the config entry is reloaded_

This PR addresses these comments and set the status to done by:

- Changing test test_config_different_unique_id to use str for unique_id
- Update test test_option_change_reload
  - to test for no options at setup
  - Test for  ConfigEntryState.LOADED after async_update_entry
  - Add additional test step to also test setting of OPTION_DIAGNOSTICS_INCLUDE_FIXTURES
- Set the state of test-coverage in quality_scale.yaml to done

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
