### PR TITLE
ElevenLabs invalid api key config flow testing

### DIFF
--- a/homeassistant/components/elevenlabs/quality_scale.yaml
+++ b/homeassistant/components/elevenlabs/quality_scale.yaml
@@ -7,11 +7,7 @@ rules:
   appropriate-polling: done
   brands: done
   common-modules: done
-  config-flow-test-coverage:
-    status: todo
-    comment: >
-      We should have every test end in either ABORT or CREATE_ENTRY.
-      test_invalid_api_key should assert the kind of error that is raised.
+  config-flow-test-coverage: done
   config-flow: done
   dependency-transparency: done
   docs-actions: done

--- a/tests/components/elevenlabs/conftest.py
+++ b/tests/components/elevenlabs/conftest.py
@@ -24,14 +24,18 @@ def mock_setup_entry() -> Generator[AsyncMock]:
         yield mock_setup_entry
 
 
-@pytest.fixture
-def mock_async_client() -> Generator[AsyncMock]:
-    """Override async ElevenLabs client."""
+def _client_mock():
     client_mock = AsyncMock()
     client_mock.voices.get_all.return_value = GetVoicesResponse(voices=MOCK_VOICES)
     client_mock.models.get_all.return_value = MOCK_MODELS
+    return client_mock
+
+
+@pytest.fixture
+def mock_async_client() -> Generator[AsyncMock]:
+    """Override async ElevenLabs client."""
     with patch(
-        "elevenlabs.AsyncElevenLabs", return_value=client_mock
+        "elevenlabs.AsyncElevenLabs", return_value=_client_mock()
     ) as mock_async_client:
         yield mock_async_client
 
@@ -41,7 +45,7 @@ def mock_async_client_fail() -> Generator[AsyncMock]:
     """Override async ElevenLabs client."""
     with patch(
         "homeassistant.components.elevenlabs.config_flow.AsyncElevenLabs",
-        return_value=AsyncMock(),
+        return_value=_client_mock(),
     ) as mock_async_client:
         mock_async_client.side_effect = ApiError
         yield mock_async_client

--- a/tests/components/elevenlabs/conftest.py
+++ b/tests/components/elevenlabs/conftest.py
@@ -35,7 +35,8 @@ def _client_mock():
 def mock_async_client() -> Generator[AsyncMock]:
     """Override async ElevenLabs client."""
     with patch(
-        "elevenlabs.AsyncElevenLabs", return_value=_client_mock()
+        "homeassistant.components.elevenlabs.config_flow.AsyncElevenLabs",
+        return_value=_client_mock(),
     ) as mock_async_client:
         yield mock_async_client
 

--- a/tests/components/elevenlabs/test_config_flow.py
+++ b/tests/components/elevenlabs/test_config_flow.py
@@ -73,9 +73,27 @@ async def test_invalid_api_key(
         },
     )
     assert result["type"] is FlowResultType.FORM
-    assert result["errors"]
+    assert result["errors"] == {"base": "invalid_api_key"}
 
     mock_setup_entry.assert_not_called()
+
+    # Reset the side effect
+    mock_async_client_fail.side_effect = None
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_API_KEY: "api_key",
+        },
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "ElevenLabs"
+    assert result["data"] == {
+        "api_key": "api_key",
+    }
+    assert result["options"] == {CONF_MODEL: DEFAULT_MODEL, CONF_VOICE: "voice1"}
+
+    mock_setup_entry.assert_called_once()
 
 
 async def test_options_flow_init(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Reworks the invalid api key test for the ElevenLabs integration

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR relates to discussions in #133276

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
