### PR TITLE
Mark Peblar Rocksolid EV Chargers Platinum

### DIFF
--- a/homeassistant/components/peblar/manifest.json
+++ b/homeassistant/components/peblar/manifest.json
@@ -6,7 +6,7 @@
   "documentation": "https://www.home-assistant.io/integrations/peblar",
   "integration_type": "device",
   "iot_class": "local_polling",
-  "quality_scale": "bronze",
+  "quality_scale": "platinum",
   "requirements": ["peblar==0.3.0"],
   "zeroconf": [{ "type": "_http._tcp.local.", "name": "pblr-*" }]
 }

--- a/homeassistant/components/peblar/quality_scale.yaml
+++ b/homeassistant/components/peblar/quality_scale.yaml
@@ -28,7 +28,7 @@ rules:
   unique-config-entry: done
 
   # Silver
-  action-exceptions: todo
+  action-exceptions: done
   config-entry-unloading: done
   docs-configuration-parameters:
     status: exempt
@@ -40,19 +40,19 @@ rules:
   log-when-unavailable: done
   parallel-updates: done
   reauthentication-flow: done
-  test-coverage: todo
+  test-coverage: done
   # Gold
   devices: done
   diagnostics: done
   discovery-update-info: done
   discovery: done
-  docs-data-update: todo
-  docs-examples: todo
-  docs-known-limitations: todo
-  docs-supported-devices: todo
-  docs-supported-functions: todo
-  docs-troubleshooting: todo
-  docs-use-cases: todo
+  docs-data-update: done
+  docs-examples: done
+  docs-known-limitations: done
+  docs-supported-devices: done
+  docs-supported-functions: done
+  docs-troubleshooting: done
+  docs-use-cases: done
   dynamic-devices:
     status: exempt
     comment: |


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Mark the [Peblar Rocksolid EV Chargers](https://www.peblar.com) integration as Platinum on the integration quality scale.

Documentation preview: https://next.home-assistant.io/integrations/peblar

![CleanShot 2024-12-22 at 20 17 58](https://github.com/user-attachments/assets/05b60513-a6cd-495a-b54c-ce1e71261cbd)


![CleanShot 2024-12-22 at 20 16 03@2x](https://github.com/user-attachments/assets/0b8d9798-7d63-4143-a08a-0705e27e63f9)


## Bronze
- [x] `config-flow` - Integration needs to be able to be set up via the UI
    - [x] Uses `data_description` to give context to fields
    - [x] Uses `ConfigEntry.data` and `ConfigEntry.options` correctly
- [x] `test-before-configure` - Test a connection in the config flow
- [x] `unique-config-entry` - Don't allow the same device or service to be able to be set up twice
- [x] `config-flow-test-coverage` - Full test coverage for the config flow
- [x] `runtime-data` - Use ConfigEntry.runtime_data to store runtime data
- [x] `test-before-setup` - Check during integration initialization if we are able to set it up correctly
- [x] `appropriate-polling` - If it's a polling integration, set an appropriate polling interval
- [x] `entity-unique-id` - Entities have a unique ID
- [x] `has-entity-name` - Entities use has_entity_name = True
- [x] `entity-event-setup` - Entities event setup
- [x] `dependency-transparency` - Dependency transparency
- [x] `action-setup` - Service actions are registered in async_setup
- [x] `common-modules` - Place common patterns in common modules
- [x] `docs-high-level-description` - The documentation includes a high-level description of the integration brand, product, or service
- [x] `docs-installation-instructions` - The documentation provides step-by-step installation instructions for the integration, including, if needed, prerequisites
- [x] `docs-removal-instructions` - The documentation provides removal instructions
- [x] `docs-actions` - The documentation describes the provided service actions that can be used
- [x] `brands` - Has branding assets available for the integration

## Silver
- [x] `config-entry-unloading` - Support config entry unloading
- [x] `log-when-unavailable` - If internet/device/service is unavailable, log once when unavailable and once when back connected
- [x] `entity-unavailable` - Mark entity unavailable if appropriate
- [x] `action-exceptions` - Service actions raise exceptions when encountering failures
- [x] `reauthentication-flow` - Reauthentication flow
- [x] `parallel-updates` - Set Parallel updates
- [x] `test-coverage` - Above 95% test coverage for all integration modules
- [x] `integration-owner` - Has an integration owner
- [x] `docs-installation-parameters` - The documentation describes all integration installation parameters
- [x] `docs-configuration-parameters` - The documentation describes all integration configuration options

## Gold
- [x] `entity-translations` - Entities have translated names
- [x] `entity-device-class` - Entities use device classes where possible
- [x] `devices` - The integration creates devices
- [x] `entity-category` - Entities are assigned an appropriate EntityCategory
- [x] `entity-disabled-by-default` - Integration disables less popular (or noisy) entities
- [x] `discovery` - Can be discovered
- [x] `stale-devices` - Clean up stale devices
- [x] `diagnostics` - Implements diagnostics
- [x] `exception-translations` - Exception messages are translatable
- [x] `icon-translations` - Icon translations
- [x] `reconfiguration-flow` - Integrations should have a reconfigure flow
- [x] `dynamic-devices` - Devices added after integration setup
- [x] `discovery-update-info` - Integration uses discovery info to update network information
- [x] `repair-issues` - Repair issues and repair flows are used when user intervention is needed
- [x] `docs-use-cases` - The documentation describes use cases to illustrate how this integration can be used
- [x] `docs-supported-devices` - The documentation describes known supported / unsupported devices
- [x] `docs-supported-functions` - The documentation describes the supported functionality, including entities, and platforms
- [x] `docs-data-update` - The documentation describes how data is updated
- [x] `docs-known-limitations` - The documentation describes known limitations of the integration (not to be confused with bugs)
- [x] `docs-troubleshooting` - The documentation provides troubleshooting information
- [x] `docs-examples` - The documentation provides automation examples the user can use.

## Platinum
- [x] `async-dependency` - Dependency is async
- [x] `inject-websession` - The integration dependency supports passing in a websession
- [x] `strict-typing` - Strict typing

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
