### PR TITLE
Add naive rgbww support to wled (#125656)

### DIFF
--- a/tests/components/wled/fixtures/rgbww.json
+++ b/tests/components/wled/fixtures/rgbww.json
@@ -1,0 +1,580 @@
+{
+  "state": {
+    "on": true,
+    "bri": 128,
+    "transition": 7,
+    "ps": -1,
+    "pl": -1,
+    "nl": {
+      "on": false,
+      "dur": 60,
+      "mode": 1,
+      "tbri": 0,
+      "rem": -1
+    },
+    "udpn": {
+      "send": false,
+      "recv": true,
+      "sgrp": 1,
+      "rgrp": 1
+    },
+    "lor": 0,
+    "mainseg": 0,
+    "seg": [
+      {
+        "id": 0,
+        "start": 0,
+        "stop": 30,
+        "len": 30,
+        "grp": 1,
+        "spc": 0,
+        "of": 0,
+        "on": true,
+        "frz": false,
+        "bri": 255,
+        "cct": 197,
+        "set": 0,
+        "col": [
+          [255, 0, 0],
+          [0, 0, 0],
+          [0, 0, 0]
+        ],
+        "fx": 0,
+        "sx": 128,
+        "ix": 128,
+        "pal": 0,
+        "c1": 128,
+        "c2": 128,
+        "c3": 16,
+        "sel": true,
+        "rev": false,
+        "mi": false,
+        "o1": false,
+        "o2": false,
+        "o3": false,
+        "si": 0,
+        "m12": 0
+      }
+    ]
+  },
+  "info": {
+    "ver": "0.99.0b1",
+    "vid": 2405180,
+    "leds": {
+      "count": 30,
+      "pwr": 536,
+      "fps": 5,
+      "maxpwr": 850,
+      "maxseg": 32,
+      "seglc": [5],
+      "lc": 5,
+      "rgbw": false,
+      "wv": 0,
+      "cct": 4
+    },
+    "str": false,
+    "name": "WLED RGBWW Light",
+    "udpport": 21324,
+    "live": false,
+    "liveseg": -1,
+    "lm": "",
+    "lip": "",
+    "ws": 2,
+    "fxcount": 187,
+    "palcount": 71,
+    "cpalcount": 0,
+    "maps": [
+      {
+        "id": 0
+      }
+    ],
+    "wifi": {
+      "bssid": "AA:AA:AA:AA:AA:BB",
+      "rssi": -44,
+      "signal": 100,
+      "channel": 11
+    },
+    "fs": {
+      "u": 12,
+      "t": 983,
+      "pmt": 0
+    },
+    "ndc": 1,
+    "arch": "esp32",
+    "core": "v3.3.6-16-gcc5440f6a2",
+    "lwip": 0,
+    "freeheap": 196960,
+    "uptime": 461,
+    "time": "1970-1-1, 00:07:41",
+    "opt": 79,
+    "brand": "WLED",
+    "product": "FOSS",
+    "mac": "aabbccddeeff",
+    "ip": "127.0.0.1"
+  },
+  "effects": [
+    "Solid",
+    "Blink",
+    "Breathe",
+    "Wipe",
+    "Wipe Random",
+    "Random Colors",
+    "Sweep",
+    "Dynamic",
+    "Colorloop",
+    "Rainbow",
+    "Scan",
+    "Scan Dual",
+    "Fade",
+    "Theater",
+    "Theater Rainbow",
+    "Running",
+    "Saw",
+    "Twinkle",
+    "Dissolve",
+    "Dissolve Rnd",
+    "Sparkle",
+    "Sparkle Dark",
+    "Sparkle+",
+    "Strobe",
+    "Strobe Rainbow",
+    "Strobe Mega",
+    "Blink Rainbow",
+    "Android",
+    "Chase",
+    "Chase Random",
+    "Chase Rainbow",
+    "Chase Flash",
+    "Chase Flash Rnd",
+    "Rainbow Runner",
+    "Colorful",
+    "Traffic Light",
+    "Sweep Random",
+    "Chase 2",
+    "Aurora",
+    "Stream",
+    "Scanner",
+    "Lighthouse",
+    "Fireworks",
+    "Rain",
+    "Tetrix",
+    "Fire Flicker",
+    "Gradient",
+    "Loading",
+    "Rolling Balls",
+    "Fairy",
+    "Two Dots",
+    "Fairytwinkle",
+    "Running Dual",
+    "RSVD",
+    "Chase 3",
+    "Tri Wipe",
+    "Tri Fade",
+    "Lightning",
+    "ICU",
+    "Multi Comet",
+    "Scanner Dual",
+    "Stream 2",
+    "Oscillate",
+    "Pride 2015",
+    "Juggle",
+    "Palette",
+    "Fire 2012",
+    "Colorwaves",
+    "Bpm",
+    "Fill Noise",
+    "Noise 1",
+    "Noise 2",
+    "Noise 3",
+    "Noise 4",
+    "Colortwinkles",
+    "Lake",
+    "Meteor",
+    "Meteor Smooth",
+    "Railway",
+    "Ripple",
+    "Twinklefox",
+    "Twinklecat",
+    "Halloween Eyes",
+    "Solid Pattern",
+    "Solid Pattern Tri",
+    "Spots",
+    "Spots Fade",
+    "Glitter",
+    "Candle",
+    "Fireworks Starburst",
+    "Fireworks 1D",
+    "Bouncing Balls",
+    "Sinelon",
+    "Sinelon Dual",
+    "Sinelon Rainbow",
+    "Popcorn",
+    "Drip",
+    "Plasma",
+    "Percent",
+    "Ripple Rainbow",
+    "Heartbeat",
+    "Pacifica",
+    "Candle Multi",
+    "Solid Glitter",
+    "Sunrise",
+    "Phased",
+    "Twinkleup",
+    "Noise Pal",
+    "Sine",
+    "Phased Noise",
+    "Flow",
+    "Chunchun",
+    "Dancing Shadows",
+    "Washing Machine",
+    "RSVD",
+    "Blends",
+    "TV Simulator",
+    "Dynamic Smooth",
+    "Spaceships",
+    "Crazy Bees",
+    "Ghost Rider",
+    "Blobs",
+    "Scrolling Text",
+    "Drift Rose",
+    "Distortion Waves",
+    "Soap",
+    "Octopus",
+    "Waving Cell",
+    "Pixels",
+    "Pixelwave",
+    "Juggles",
+    "Matripix",
+    "Gravimeter",
+    "Plasmoid",
+    "Puddles",
+    "Midnoise",
+    "Noisemeter",
+    "Freqwave",
+    "Freqmatrix",
+    "GEQ",
+    "Waterfall",
+    "Freqpixels",
+    "RSVD",
+    "Noisefire",
+    "Puddlepeak",
+    "Noisemove",
+    "Noise2D",
+    "Perlin Move",
+    "Ripple Peak",
+    "Firenoise",
+    "Squared Swirl",
+    "RSVD",
+    "DNA",
+    "Matrix",
+    "Metaballs",
+    "Freqmap",
+    "Gravcenter",
+    "Gravcentric",
+    "Gravfreq",
+    "DJ Light",
+    "Funky Plank",
+    "RSVD",
+    "Pulser",
+    "Blurz",
+    "Drift",
+    "Waverly",
+    "Sun Radiation",
+    "Colored Bursts",
+    "Julia",
+    "RSVD",
+    "RSVD",
+    "RSVD",
+    "Game Of Life",
+    "Tartan",
+    "Polar Lights",
+    "Swirl",
+    "Lissajous",
+    "Frizzles",
+    "Plasma Ball",
+    "Flow Stripe",
+    "Hiphotic",
+    "Sindots",
+    "DNA Spiral",
+    "Black Hole",
+    "Wavesins",
+    "Rocktaves",
+    "Akemi"
+  ],
+  "palettes": [
+    "Default",
+    "* Random Cycle",
+    "* Color 1",
+    "* Colors 1&2",
+    "* Color Gradient",
+    "* Colors Only",
+    "Party",
+    "Cloud",
+    "Lava",
+    "Ocean",
+    "Forest",
+    "Rainbow",
+    "Rainbow Bands",
+    "Sunset",
+    "Rivendell",
+    "Breeze",
+    "Red & Blue",
+    "Yellowout",
+    "Analogous",
+    "Splash",
+    "Pastel",
+    "Sunset 2",
+    "Beach",
+    "Vintage",
+    "Departure",
+    "Landscape",
+    "Beech",
+    "Sherbet",
+    "Hult",
+    "Hult 64",
+    "Drywet",
+    "Jul",
+    "Grintage",
+    "Rewhi",
+    "Tertiary",
+    "Fire",
+    "Icefire",
+    "Cyane",
+    "Light Pink",
+    "Autumn",
+    "Magenta",
+    "Magred",
+    "Yelmag",
+    "Yelblu",
+    "Orange & Teal",
+    "Tiamat",
+    "April Night",
+    "Orangery",
+    "C9",
+    "Sakura",
+    "Aurora",
+    "Atlantica",
+    "C9 2",
+    "C9 New",
+    "Temperature",
+    "Aurora 2",
+    "Retro Clown",
+    "Candy",
+    "Toxy Reaf",
+    "Fairy Reaf",
+    "Semi Blue",
+    "Pink Candy",
+    "Red Reaf",
+    "Aqua Flash",
+    "Yelblu Hot",
+    "Lite Light",
+    "Red Flash",
+    "Blink Red",
+    "Red Shift",
+    "Red Tide",
+    "Candy2"
+  ],
+  "presets": {
+    "0": {},
+    "1": {
+      "on": true,
+      "bri": 128,
+      "transition": 7,
+      "mainseg": 0,
+      "seg": [
+        {
+          "id": 0,
+          "start": 0,
+          "stop": 131,
+          "grp": 1,
+          "spc": 0,
+          "of": 0,
+          "on": true,
+          "frz": false,
+          "bri": 255,
+          "cct": 127,
+          "set": 0,
+          "n": "",
+          "col": [
+            [40, 255, 3],
+            [0, 0, 0],
+            [0, 0, 0]
+          ],
+          "fx": 0,
+          "sx": 128,
+          "ix": 128,
+          "pal": 0,
+          "c1": 128,
+          "c2": 128,
+          "c3": 16,
+          "sel": true,
+          "rev": false,
+          "mi": false,
+          "o1": false,
+          "o2": false,
+          "o3": false,
+          "si": 0,
+          "m12": 0
+        },
+        {
+          "stop": 0
+        },
+        {
+          "stop": 0
+        },
+        {
+          "stop": 0
+        },
+        {
+          "stop": 0
+        },
+        {
+          "stop": 0
+        },
+        {
+          "stop": 0
+        },
+        {
+          "stop": 0
+        },
+        {
+          "stop": 0
+        },
+        {
+          "stop": 0
+        },
+        {
+          "stop": 0
+        },
+        {
+          "stop": 0
+        },
+        {
+          "stop": 0
+        },
+        {
+          "stop": 0
+        },
+        {
+          "stop": 0
+        },
+        {
+          "stop": 0
+        }
+      ],
+      "n": "Preset 1"
+    },
+    "2": {
+      "on": true,
+      "bri": 128,
+      "transition": 7,
+      "mainseg": 0,
+      "seg": [
+        {
+          "id": 0,
+          "start": 0,
+          "stop": 131,
+          "grp": 1,
+          "spc": 0,
+          "of": 0,
+          "on": true,
+          "frz": false,
+          "bri": 255,
+          "cct": 127,
+          "set": 0,
+          "n": "",
+          "col": [
+            [51, 88, 255],
+            [0, 0, 0],
+            [0, 0, 0]
+          ],
+          "fx": 0,
+          "sx": 128,
+          "ix": 128,
+          "pal": 0,
+          "c1": 128,
+          "c2": 128,
+          "c3": 16,
+          "sel": true,
+          "rev": false,
+          "mi": false,
+          "o1": false,
+          "o2": false,
+          "o3": false,
+          "si": 0,
+          "m12": 0
+        },
+        {
+          "stop": 0
+        },
+        {
+          "stop": 0
+        },
+        {
+          "stop": 0
+        },
+        {
+          "stop": 0
+        },
+        {
+          "stop": 0
+        },
+        {
+          "stop": 0
+        },
+        {
+          "stop": 0
+        },
+        {
+          "stop": 0
+        },
+        {
+          "stop": 0
+        },
+        {
+          "stop": 0
+        },
+        {
+          "stop": 0
+        },
+        {
+          "stop": 0
+        },
+        {
+          "stop": 0
+        },
+        {
+          "stop": 0
+        },
+        {
+          "stop": 0
+        }
+      ],
+      "n": "Preset 2"
+    },
+    "3": {
+      "playlist": {
+        "ps": [1, 2],
+        "dur": [300, 300],
+        "transition": [7, 7],
+        "repeat": 0,
+        "end": 0,
+        "r": 0
+      },
+      "on": true,
+      "n": "Playlist 1"
+    },
+    "4": {
+      "playlist": {
+        "ps": [2, 0],
+        "dur": [300, 300],
+        "transition": [7, 7],
+        "repeat": 0,
+        "end": 0,
+        "r": 0
+      },
+      "on": true,
+      "n": "Playlist 2"
+    }
+  }
+}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
This is fixing #125656. I ran into the same problem with the following setup. 
I am running wled with WS281x LEDs. These identify themselves like RGB + CCT. This is the relevant part from wled/info:
```
{
  "leds": {
    "count": 63,
    "pwr": 666,
    "fps": 2,
    "maxpwr": 5000,
    "maxseg": 32,
    "bootps": 0,
    "seglc": [
      5
    ],
    "lc": 5,
    "rgbw": false,
    "wv": 0,
    "cct": 4
  }
}
```

According WLED documentation leds.lc being 5 means:
![image](https://github.com/user-attachments/assets/4e52646e-4517-497b-b2eb-e2a0d93197ae)

HomeAssistant currently identifies this as RGBWW and sends the `ATTR_RGBWW_COLOR` which is not recognized by the current code.
WLED currently supports [only triplets and quadruplets to set a color](
https://github.com/frenck/python-wled/blob/e92ce9172dc113ed109b78baf287a3e4d8cf111d/src/wled/wled.py#L312) so I made this naive implementation which translates RGBWW to RGB and back. With these changes:
1. I am able to change the color of my WLED
2. The color is correctly reflected back in the homeassistant UI
 

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
