### PR TITLE
TotalConnect improved config flow and test before setup

### DIFF
--- a/homeassistant/components/totalconnect/quality_scale.yaml
+++ b/homeassistant/components/totalconnect/quality_scale.yaml
@@ -1,11 +1,11 @@
 rules:
   # Bronze
-  config-flow: todo
+  config-flow: done
   test-before-configure: done
   unique-config-entry: done
   config-flow-test-coverage: todo
   runtime-data: done
-  test-before-setup: todo
+  test-before-setup: done
   appropriate-polling: done
   entity-unique-id: done
   has-entity-name: done

--- a/homeassistant/components/totalconnect/strings.json
+++ b/homeassistant/components/totalconnect/strings.json
@@ -2,16 +2,25 @@
   "config": {
     "step": {
       "user": {
+        "title": "Total Connect 2.0 Account Credentials",
+        "description": "It is highly recommended to use a 'standard' Total Connect user account with Home Assistant.  The account should not have full administrative privileges.",
         "data": {
           "username": "[%key:common::config_flow::data::username%]",
           "password": "[%key:common::config_flow::data::password%]"
+        },
+        "data_description": {
+          "username": "The Total Connect username",
+          "password": "The Total Connect password"
         }
       },
       "locations": {
         "title": "Location Usercodes",
         "description": "Enter the usercode for this user at location {location_id}",
         "data": {
-          "usercode": "Usercode"
+          "usercodes": "Usercode"
+        },
+        "data_description": {
+          "usercodes": "The usercode is usually a 4 digit number"
         }
       },
       "reauth_confirm": {
@@ -36,6 +45,10 @@
         "data": {
           "auto_bypass_low_battery": "Auto bypass low battery",
           "code_required": "Require user to enter code for alarm actions"
+        },
+        "data_description": {
+          "auto_bypass_low_battery": "If enabled, Total Connect zones will immediately be bypassed when they report low battery. This option helps because zones tend to report low battery in the middle of the night. The downside of this option is that when the alarm system is armed, the bypassed zone will not be monitored.",
+          "code_required": "If enabled, you must enter the user code to arm or disarm the alarm"
         }
       }
     }

--- a/homeassistant/components/totalconnect/strings.json
+++ b/homeassistant/components/totalconnect/strings.json
@@ -25,7 +25,13 @@
       },
       "reauth_confirm": {
         "title": "[%key:common::config_flow::title::reauth%]",
-        "description": "Total Connect needs to re-authenticate your account"
+        "description": "Total Connect needs to re-authenticate your account",
+        "data": {
+          "password": "[%key:common::config_flow::data::password%]"
+        },
+        "data_description": {
+          "password": "The Total Connect password"
+        }
       }
     },
     "error": {

--- a/homeassistant/components/totalconnect/strings.json
+++ b/homeassistant/components/totalconnect/strings.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "title": "Total Connect 2.0 Account Credentials",
-        "description": "It is highly recommended to use a 'standard' Total Connect user account with Home Assistant.  The account should not have full administrative privileges.",
+        "description": "It is highly recommended to use a 'standard' Total Connect user account with Home Assistant. The account should not have full administrative privileges.",
         "data": {
           "username": "[%key:common::config_flow::data::username%]",
           "password": "[%key:common::config_flow::data::password%]"
@@ -30,7 +30,7 @@
           "password": "[%key:common::config_flow::data::password%]"
         },
         "data_description": {
-          "password": "The Total Connect password"
+          "password": "[%key:component::totalconnect::config::step::user::data_description::password%]"
         }
       }
     },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
Improves config flow user experience by using data_description in strings.json

Marks config-flow and test-before-setup as done in quality_scale.yaml.  Test-before-setup was already handled in the Coordinator.

This does NOT address the lack of proper config flow strings for re-auth as noted from https://github.com/home-assistant/core/pull/132012#discussion_r1865602718.  I plan to tackle that in another PR later (working toward Bronze first).

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [todo] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
