### PR TITLE
Bump ZHA to 0.0.43

### DIFF
--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -21,7 +21,7 @@
     "zha",
     "universal_silabs_flasher"
   ],
-  "requirements": ["universal-silabs-flasher==0.0.25", "zha==0.0.42"],
+  "requirements": ["universal-silabs-flasher==0.0.25", "zha==0.0.43"],
   "usb": [
     {
       "vid": "10C4",

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -586,6 +586,12 @@
       },
       "preheat_status": {
         "name": "Pre-heat status"
+      },
+      "open_window_detection_status": {
+        "name": "Open window detection status"
+      },
+      "window_detection": {
+        "name": "Open window detection"
       }
     },
     "button": {
@@ -822,6 +828,57 @@
       },
       "approach_distance": {
         "name": "Approach distance"
+      },
+      "fixed_load_demand": {
+        "name": "Fixed load demand"
+      },
+      "display_brightness": {
+        "name": "Display brightness"
+      },
+      "display_inactive_brightness": {
+        "name": "Display inactive brightness"
+      },
+      "display_activity_timeout": {
+        "name": "Display activity timeout"
+      },
+      "open_window_detection_threshold": {
+        "name": "Open window detection threshold"
+      },
+      "open_window_event_duration": {
+        "name": "Open window event duration"
+      },
+      "open_window_detection_guard_period": {
+        "name": "Open window detection guard period"
+      },
+      "fallback_timeout": {
+        "name": "Fallback timeout"
+      },
+      "boost_amount": {
+        "name": "Boost amount"
+      },
+      "ambient_sensor_correction": {
+        "name": "Ambient sensor correction"
+      },
+      "external_sensor_correction": {
+        "name": "External sensor correction"
+      },
+      "move_sensitivity": {
+        "name": "Motion sensitivity"
+      },
+      "detection_distance_min": {
+        "name": "Minimum range"
+      },
+      "detection_distance_max": {
+        "name": "Maximum range"
+      },
+      "presence_sensitivity": {
+        "name": "Presence sensitivity"
+      },
+      "presence_timeout": {
+        "name": "Fade time"
+      },
+      "regulator_set_point": {
+        "name": "Regulator set point"
       }
     },
     "select": {
@@ -926,6 +983,45 @@
       },
       "external_trigger_mode": {
         "name": "External trigger mode"
+      },
+      "local_temperature_source": {
+        "name": "Local temperature source"
+      },
+      "control_type": {
+        "name": "Control type"
+      },
+      "thermostat_application": {
+        "name": "Thermostat application"
+      },
+      "heating_fuel": {
+        "name": "Heating fuel"
+      },
+      "heat_transfer_medium": {
+        "name": "Heat transfer medium"
+      },
+      "heating_emitter_type": {
+        "name": "Heating emitter type"
+      },
+      "external_temperature_sensor_type": {
+        "name": "External temperature sensor type"
+      },
+      "preset_mode": {
+        "name": "Preset mode"
+      },
+      "sensor_mode": {
+        "name": "Sensor mode"
+      },
+      "thermostat_mode": {
+        "name": "Thermostat mode"
+      },
+      "regulator_period": {
+        "name": "Regulator period"
+      },
+      "click_mode": {
+        "name": "Click mode"
+      },
+      "operation_mode": {
+        "name": "Operation mode"
       }
     },
     "sensor": {
@@ -1132,6 +1228,15 @@
       },
       "motion_distance": {
         "name": "Motion distance"
+      },
+      "control_status": {
+        "name": "Control status"
+      },
+      "distance": {
+        "name": "Target distance"
+      },
+      "local_temperature_floor": {
+        "name": "Floor temperature"
       }
     },
     "switch": {
@@ -1257,6 +1362,9 @@
       },
       "enable_siren": {
         "name": "Enable siren"
+      },
+      "find_switch": {
+        "name": "Distance switch"
       }
     }
   }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3097,7 +3097,7 @@ zeroconf==0.136.2
 zeversolar==0.3.2
 
 # homeassistant.components.zha
-zha==0.0.42
+zha==0.0.43
 
 # homeassistant.components.zhong_hong
 zhong-hong-hvac==1.0.13

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2486,7 +2486,7 @@ zeroconf==0.136.2
 zeversolar==0.3.2
 
 # homeassistant.components.zha
-zha==0.0.42
+zha==0.0.43
 
 # homeassistant.components.zwave_js
 zwave-js-server-python==0.60.0


### PR DESCRIPTION
## Proposed change
This bumps ZHA to [0.0.43](https://github.com/zigpy/zha/releases/tag/0.0.43) (full diff: https://github.com/zigpy/zha/compare/0.0.42...0.0.43). These dependency upgrades are bundled with it: 
- `bellows` [0.42.6](https://github.com/zigpy/bellows/releases/tag/0.42.6)
full diff: https://github.com/zigpy/bellows/compare/0.42.5...0.42.6

- `zha-quirks` [0.0.128](https://github.com/zigpy/zha-device-handlers/releases/tag/0.0.128) (including [0.0.127](https://github.com/zigpy/zha-device-handlers/releases/tag/0.0.127) and [0.0.126](https://github.com/zigpy/zha-device-handlers/releases/tag/0.0.126) changes)
full diff: https://github.com/zigpy/zha-device-handlers/compare/0.0.125...0.0.128

- `zigpy` [0.73.3](https://github.com/zigpy/zigpy/releases/tag/0.73.3) (including [0.73.2](https://github.com/zigpy/zigpy/releases/tag/0.73.2) changes)
full diff: https://github.com/zigpy/zigpy/compare/0.73.1...0.73.3

This zha-quirks release also adds a few entities via the quirks v2 API. The entity names are added to `strings.json`.


## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #132669
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
