### PR TITLE
Suez_water: use meter id as unique_id

### DIFF
--- a/homeassistant/components/suez_water/__init__.py
+++ b/homeassistant/components/suez_water/__init__.py
@@ -2,12 +2,18 @@
 
 from __future__ import annotations
 
+import logging
+
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 
+from .config_flow import SuezWaterConfigFlow
+from .const import CONF_COUNTER_ID
 from .coordinator import SuezWaterConfigEntry, SuezWaterCoordinator
 
 PLATFORMS: list[Platform] = [Platform.SENSOR]
+
+_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: SuezWaterConfigEntry) -> bool:
@@ -26,3 +32,47 @@ async def async_setup_entry(hass: HomeAssistant, entry: SuezWaterConfigEntry) ->
 async def async_unload_entry(hass: HomeAssistant, entry: SuezWaterConfigEntry) -> bool:
     """Unload a config entry."""
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+
+
+async def async_migrate_entry(
+    hass: HomeAssistant, config_entry: SuezWaterConfigEntry
+) -> bool:
+    """Migrate old suez water config entry."""
+    _LOGGER.debug(
+        "Migrating configuration from version %s.%s",
+        config_entry.version,
+        config_entry.minor_version,
+    )
+
+    if config_entry.version > SuezWaterConfigFlow.VERSION:
+        _LOGGER.error("Suez_water version downgrade not handled")
+        return False
+    if config_entry.version == 2:
+        _LOGGER.debug("Suez_water no minor changes in version 2.X")
+        return True
+
+    unique_id = config_entry.unique_id
+    if config_entry.version == 1:
+        # Going to 2.X
+        counter_id = config_entry.data.get(CONF_COUNTER_ID)
+        if not counter_id:
+            _LOGGER.error(
+                "Failed to migrate to suez_water because no counter_id was previously defined"
+            )
+            return False
+        unique_id = str(counter_id)
+
+    hass.config_entries.async_update_entry(
+        config_entry,
+        unique_id=unique_id,
+        minor_version=SuezWaterConfigFlow.MINOR_VERSION,
+        version=SuezWaterConfigFlow.VERSION,
+    )
+
+    _LOGGER.debug(
+        "Migration to configuration version %s.%s successful",
+        config_entry.version,
+        config_entry.minor_version,
+    )
+
+    return True

--- a/homeassistant/components/suez_water/__init__.py
+++ b/homeassistant/components/suez_water/__init__.py
@@ -7,7 +7,6 @@ import logging
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 
-from .config_flow import SuezWaterConfigFlow
 from .const import CONF_COUNTER_ID
 from .coordinator import SuezWaterConfigEntry, SuezWaterCoordinator
 
@@ -44,16 +43,12 @@ async def async_migrate_entry(
         config_entry.minor_version,
     )
 
-    if config_entry.version > SuezWaterConfigFlow.VERSION:
+    if config_entry.version > 2:
         _LOGGER.error("Suez_water version downgrade not handled")
         return False
-    if config_entry.version == 2:
-        _LOGGER.debug("Suez_water no minor changes in version 2.X")
-        return True
 
-    unique_id = config_entry.unique_id
     if config_entry.version == 1:
-        # Going to 2.X
+        # Migrate to version 2
         counter_id = config_entry.data.get(CONF_COUNTER_ID)
         if not counter_id:
             _LOGGER.error(
@@ -62,12 +57,11 @@ async def async_migrate_entry(
             return False
         unique_id = str(counter_id)
 
-    hass.config_entries.async_update_entry(
-        config_entry,
-        unique_id=unique_id,
-        minor_version=SuezWaterConfigFlow.MINOR_VERSION,
-        version=SuezWaterConfigFlow.VERSION,
-    )
+        hass.config_entries.async_update_entry(
+            config_entry,
+            unique_id=unique_id,
+            version=2,
+        )
 
     _LOGGER.debug(
         "Migration to configuration version %s.%s successful",

--- a/homeassistant/components/suez_water/__init__.py
+++ b/homeassistant/components/suez_water/__init__.py
@@ -44,7 +44,6 @@ async def async_migrate_entry(
     )
 
     if config_entry.version > 2:
-        _LOGGER.error("Suez_water version downgrade not handled")
         return False
 
     if config_entry.version == 1:

--- a/homeassistant/components/suez_water/__init__.py
+++ b/homeassistant/components/suez_water/__init__.py
@@ -50,11 +50,6 @@ async def async_migrate_entry(
     if config_entry.version == 1:
         # Migrate to version 2
         counter_id = config_entry.data.get(CONF_COUNTER_ID)
-        if not counter_id:
-            _LOGGER.error(
-                "Failed to migrate to suez_water because no counter_id was previously defined"
-            )
-            return False
         unique_id = str(counter_id)
 
         hass.config_entries.async_update_entry(

--- a/homeassistant/components/suez_water/config_flow.py
+++ b/homeassistant/components/suez_water/config_flow.py
@@ -56,12 +56,11 @@ class SuezWaterConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Suez Water."""
 
     VERSION = 2
-    MINOR_VERSION = 0
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Handle initial setup step."""
+        """Handle the initial setup step."""
         errors: dict[str, str] = {}
 
         if user_input is not None:
@@ -77,10 +76,10 @@ class SuezWaterConfigFlow(ConfigFlow, domain=DOMAIN):
                 _LOGGER.exception("Unexpected exception")
                 errors["base"] = "unknown"
             else:
-                meter_id = str(user_input[CONF_COUNTER_ID])
-                await self.async_set_unique_id(meter_id)
+                counter_id = str(user_input[CONF_COUNTER_ID])
+                await self.async_set_unique_id(counter_id)
                 self._abort_if_unique_id_configured()
-                return self.async_create_entry(title=meter_id, data=user_input)
+                return self.async_create_entry(title=counter_id, data=user_input)
 
         return self.async_show_form(
             step_id="user",

--- a/homeassistant/components/suez_water/config_flow.py
+++ b/homeassistant/components/suez_water/config_flow.py
@@ -55,16 +55,16 @@ async def validate_input(data: dict[str, Any]) -> None:
 class SuezWaterConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Suez Water."""
 
-    VERSION = 1
+    VERSION = 2
+    MINOR_VERSION = 0
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Handle the initial step."""
+        """Handle initial setup step."""
         errors: dict[str, str] = {}
+
         if user_input is not None:
-            await self.async_set_unique_id(user_input[CONF_USERNAME])
-            self._abort_if_unique_id_configured()
             try:
                 await validate_input(user_input)
             except CannotConnect:
@@ -77,9 +77,10 @@ class SuezWaterConfigFlow(ConfigFlow, domain=DOMAIN):
                 _LOGGER.exception("Unexpected exception")
                 errors["base"] = "unknown"
             else:
-                return self.async_create_entry(
-                    title=user_input[CONF_USERNAME], data=user_input
-                )
+                meter_id = str(user_input[CONF_COUNTER_ID])
+                await self.async_set_unique_id(meter_id)
+                self._abort_if_unique_id_configured()
+                return self.async_create_entry(title=meter_id, data=user_input)
 
         return self.async_show_form(
             step_id="user",
@@ -98,4 +99,4 @@ class InvalidAuth(HomeAssistantError):
 
 
 class CounterNotFound(HomeAssistantError):
-    """Error to indicate we cannot automatically found the counter id."""
+    """Error to indicate we failed to automatically find the counter id."""

--- a/tests/components/suez_water/conftest.py
+++ b/tests/components/suez_water/conftest.py
@@ -8,14 +8,15 @@ from pysuez import AggregatedData, PriceResult
 from pysuez.const import ATTRIBUTION
 import pytest
 
-from homeassistant.components.suez_water.const import DOMAIN
+from homeassistant.components.suez_water.config_flow import SuezWaterConfigFlow
+from homeassistant.components.suez_water.const import CONF_COUNTER_ID, DOMAIN
 
 from tests.common import MockConfigEntry
 
 MOCK_DATA = {
     "username": "test-username",
     "password": "test-password",
-    "counter_id": "test-counter",
+    CONF_COUNTER_ID: "test-counter",
 }
 
 
@@ -23,10 +24,12 @@ MOCK_DATA = {
 def mock_config_entry() -> MockConfigEntry:
     """Create mock config_entry needed by suez_water integration."""
     return MockConfigEntry(
-        unique_id=MOCK_DATA["username"],
+        unique_id=MOCK_DATA[CONF_COUNTER_ID],
         domain=DOMAIN,
         title="Suez mock device",
         data=MOCK_DATA,
+        version=SuezWaterConfigFlow.VERSION,
+        minor_version=SuezWaterConfigFlow.MINOR_VERSION,
     )
 
 

--- a/tests/components/suez_water/conftest.py
+++ b/tests/components/suez_water/conftest.py
@@ -8,7 +8,6 @@ from pysuez import AggregatedData, PriceResult
 from pysuez.const import ATTRIBUTION
 import pytest
 
-from homeassistant.components.suez_water.config_flow import SuezWaterConfigFlow
 from homeassistant.components.suez_water.const import CONF_COUNTER_ID, DOMAIN
 
 from tests.common import MockConfigEntry
@@ -28,8 +27,7 @@ def mock_config_entry() -> MockConfigEntry:
         domain=DOMAIN,
         title="Suez mock device",
         data=MOCK_DATA,
-        version=SuezWaterConfigFlow.VERSION,
-        minor_version=SuezWaterConfigFlow.MINOR_VERSION,
+        version=2,
     )
 
 

--- a/tests/components/suez_water/test_config_flow.py
+++ b/tests/components/suez_water/test_config_flow.py
@@ -32,8 +32,8 @@ async def test_form(
     await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == "test-username"
-    assert result["result"].unique_id == "test-username"
+    assert result["title"] == MOCK_DATA[CONF_COUNTER_ID]
+    assert result["result"].unique_id == MOCK_DATA[CONF_COUNTER_ID]
     assert result["data"] == MOCK_DATA
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -63,18 +63,20 @@ async def test_form_invalid_auth(
     await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == "test-username"
-    assert result["result"].unique_id == "test-username"
+    assert result["title"] == MOCK_DATA[CONF_COUNTER_ID]
+    assert result["result"].unique_id == MOCK_DATA[CONF_COUNTER_ID]
     assert result["data"] == MOCK_DATA
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_form_already_configured(hass: HomeAssistant) -> None:
+async def test_form_already_configured(
+    hass: HomeAssistant, suez_client: AsyncMock
+) -> None:
     """Test we abort when entry is already configured."""
 
     entry = MockConfigEntry(
         domain=DOMAIN,
-        unique_id="test-username",
+        unique_id=MOCK_DATA[CONF_COUNTER_ID],
         data=MOCK_DATA,
     )
     entry.add_to_hass(hass)
@@ -124,7 +126,7 @@ async def test_form_error(
     )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == "test-username"
+    assert result["title"] == MOCK_DATA[CONF_COUNTER_ID]
     assert result["data"] == MOCK_DATA
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -139,7 +141,7 @@ async def test_form_auto_counter(
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {}
 
-    partial_form = {**MOCK_DATA}
+    partial_form = MOCK_DATA.copy()
     partial_form.pop(CONF_COUNTER_ID)
     suez_client.find_counter.side_effect = PySuezError("test counter not found")
 
@@ -160,7 +162,7 @@ async def test_form_auto_counter(
     await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == "test-username"
-    assert result["result"].unique_id == "test-username"
+    assert result["title"] == MOCK_DATA[CONF_COUNTER_ID]
+    assert result["result"].unique_id == MOCK_DATA[CONF_COUNTER_ID]
     assert result["data"] == MOCK_DATA
     assert len(mock_setup_entry.mock_calls) == 1

--- a/tests/components/suez_water/test_init.py
+++ b/tests/components/suez_water/test_init.py
@@ -84,32 +84,10 @@ async def test_migration_version_1_to_2(
         title=MOCK_DATA[CONF_USERNAME],
         data=MOCK_DATA,
         version=1,
-        minor_version=0,
     )
 
     await setup_integration(hass, past_entry)
     assert past_entry.state is ConfigEntryState.LOADED
     assert past_entry.unique_id == MOCK_DATA[CONF_COUNTER_ID]
     assert past_entry.title == MOCK_DATA[CONF_USERNAME]
-
-
-async def test_migration_version_1_to_2_int_counter(
-    hass: HomeAssistant,
-    suez_client: AsyncMock,
-) -> None:
-    """Test that a migration from 1 to 2 change use int counter_id as str unique_id."""
-    data = MOCK_DATA.copy()
-    data[CONF_COUNTER_ID] = 1234
-    past_entry = MockConfigEntry(
-        unique_id=data[CONF_USERNAME],
-        domain=DOMAIN,
-        title=data[CONF_USERNAME],
-        data=data,
-        version=1,
-        minor_version=0,
-    )
-
-    await setup_integration(hass, past_entry)
-    assert past_entry.state is ConfigEntryState.LOADED
-    assert past_entry.unique_id == str(data[CONF_COUNTER_ID])
-    assert past_entry.title == data[CONF_USERNAME]
+    assert past_entry.version == 2

--- a/tests/components/suez_water/test_init.py
+++ b/tests/components/suez_water/test_init.py
@@ -2,11 +2,15 @@
 
 from unittest.mock import AsyncMock
 
+from homeassistant.components.suez_water.config_flow import SuezWaterConfigFlow
+from homeassistant.components.suez_water.const import CONF_COUNTER_ID, DOMAIN
 from homeassistant.components.suez_water.coordinator import PySuezError
 from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import CONF_USERNAME
 from homeassistant.core import HomeAssistant
 
 from . import setup_integration
+from .conftest import MOCK_DATA
 
 from tests.common import MockConfigEntry
 
@@ -35,3 +39,71 @@ async def test_initialization_setup_api_error(
     await setup_integration(hass, mock_config_entry)
 
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_migration_version_rollback(
+    hass: HomeAssistant,
+    suez_client: AsyncMock,
+) -> None:
+    """Test that a version rollback does not impact config."""
+    future_entry = MockConfigEntry(
+        unique_id=MOCK_DATA[CONF_COUNTER_ID],
+        domain=DOMAIN,
+        title="Suez mock device",
+        data=MOCK_DATA,
+        version=SuezWaterConfigFlow.VERSION + 1,
+    )
+    await setup_integration(hass, future_entry)
+    assert future_entry.state is ConfigEntryState.MIGRATION_ERROR
+
+
+async def test_no_migration_current_version(
+    hass: HomeAssistant,
+    suez_client: AsyncMock,
+) -> None:
+    """Test that a current version does not migrate."""
+    current_entry = MockConfigEntry(
+        unique_id=MOCK_DATA[CONF_COUNTER_ID],
+        domain=DOMAIN,
+        title="Suez mock device",
+        data=MOCK_DATA,
+        version=SuezWaterConfigFlow.VERSION,
+    )
+    await setup_integration(hass, current_entry)
+    assert current_entry.state is ConfigEntryState.LOADED
+    assert current_entry.unique_id == MOCK_DATA[CONF_COUNTER_ID]
+
+
+async def test_migration_version_1_to_2(
+    hass: HomeAssistant,
+    suez_client: AsyncMock,
+) -> None:
+    """Test that a migration from 1 to 2 change unique_id."""
+
+    broken_data = MOCK_DATA.copy()
+    broken_data.pop(CONF_COUNTER_ID)
+
+    past_entry = MockConfigEntry(
+        unique_id=MOCK_DATA[CONF_USERNAME],
+        domain=DOMAIN,
+        title=MOCK_DATA[CONF_USERNAME],
+        data=broken_data,
+        version=1,
+        minor_version=0,
+    )
+    await setup_integration(hass, past_entry)
+    assert past_entry.state is ConfigEntryState.MIGRATION_ERROR
+
+    past_entry = MockConfigEntry(
+        unique_id=MOCK_DATA[CONF_USERNAME],
+        domain=DOMAIN,
+        title=MOCK_DATA[CONF_USERNAME],
+        data=MOCK_DATA,
+        version=1,
+        minor_version=0,
+    )
+
+    await setup_integration(hass, past_entry)
+    assert past_entry.state is ConfigEntryState.LOADED
+    assert past_entry.unique_id == str(MOCK_DATA[CONF_COUNTER_ID])
+    assert past_entry.title == MOCK_DATA[CONF_USERNAME]

--- a/tests/components/suez_water/test_init.py
+++ b/tests/components/suez_water/test_init.py
@@ -78,21 +78,6 @@ async def test_migration_version_1_to_2(
     suez_client: AsyncMock,
 ) -> None:
     """Test that a migration from 1 to 2 change unique_id."""
-
-    broken_data = MOCK_DATA.copy()
-    broken_data.pop(CONF_COUNTER_ID)
-
-    past_entry = MockConfigEntry(
-        unique_id=MOCK_DATA[CONF_USERNAME],
-        domain=DOMAIN,
-        title=MOCK_DATA[CONF_USERNAME],
-        data=broken_data,
-        version=1,
-        minor_version=0,
-    )
-    await setup_integration(hass, past_entry)
-    assert past_entry.state is ConfigEntryState.MIGRATION_ERROR
-
     past_entry = MockConfigEntry(
         unique_id=MOCK_DATA[CONF_USERNAME],
         domain=DOMAIN,

--- a/tests/components/suez_water/test_init.py
+++ b/tests/components/suez_water/test_init.py
@@ -44,7 +44,7 @@ async def test_migration_version_rollback(
     hass: HomeAssistant,
     suez_client: AsyncMock,
 ) -> None:
-    """Test that a version rollback does not impact config."""
+    """Test that downgrading from a future version is not possible."""
     future_entry = MockConfigEntry(
         unique_id=MOCK_DATA[CONF_COUNTER_ID],
         domain=DOMAIN,
@@ -77,7 +77,7 @@ async def test_migration_version_1_to_2(
     hass: HomeAssistant,
     suez_client: AsyncMock,
 ) -> None:
-    """Test that a migration from 1 to 2 change unique_id."""
+    """Test that a migration from 1 to 2 changes the unique_id."""
     past_entry = MockConfigEntry(
         unique_id=MOCK_DATA[CONF_USERNAME],
         domain=DOMAIN,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
<!--
## Breaking change
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Change unique_id for suez_water use meter id instead of username which can be changed.
This change is made in prevision of reauth flow which will allow the user to change it's username.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
