### PR TITLE
Improve support for Aprilaire S86WMUPR

### DIFF
--- a/homeassistant/components/aprilaire/coordinator.py
+++ b/homeassistant/components/aprilaire/coordinator.py
@@ -120,6 +120,8 @@ class AprilaireCoordinator(BaseDataUpdateCoordinatorProtocol):
         """Wait for the client to be ready."""
 
         if not self.data or Attribute.MAC_ADDRESS not in self.data:
+            await self.client.read_mac_address()
+
             data = await self.client.wait_for_response(
                 FunctionalDomain.IDENTIFICATION, 2, WAIT_TIMEOUT
             )
@@ -130,12 +132,9 @@ class AprilaireCoordinator(BaseDataUpdateCoordinatorProtocol):
 
                 return False
 
-        if not self.data or Attribute.NAME not in self.data:
-            await self.client.wait_for_response(
-                FunctionalDomain.IDENTIFICATION, 4, WAIT_TIMEOUT
-            )
-
         if not self.data or Attribute.THERMOSTAT_MODES not in self.data:
+            await self.client.read_thermostat_iaq_available()
+
             await self.client.wait_for_response(
                 FunctionalDomain.CONTROL, 7, WAIT_TIMEOUT
             )
@@ -144,9 +143,15 @@ class AprilaireCoordinator(BaseDataUpdateCoordinatorProtocol):
             not self.data
             or Attribute.INDOOR_TEMPERATURE_CONTROLLING_SENSOR_STATUS not in self.data
         ):
+            await self.client.read_sensors()
+
             await self.client.wait_for_response(
                 FunctionalDomain.SENSORS, 2, WAIT_TIMEOUT
             )
+
+        await self.client.read_thermostat_status()
+
+        await self.client.read_iaq_status()
 
         await ready_callback(True)
 

--- a/homeassistant/components/aprilaire/manifest.json
+++ b/homeassistant/components/aprilaire/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "device",
   "iot_class": "local_push",
   "loggers": ["pyaprilaire"],
-  "requirements": ["pyaprilaire==0.7.4"]
+  "requirements": ["pyaprilaire==0.7.7"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1779,7 +1779,7 @@ pyairnow==1.2.1
 pyairvisual==2023.08.1
 
 # homeassistant.components.aprilaire
-pyaprilaire==0.7.4
+pyaprilaire==0.7.7
 
 # homeassistant.components.asuswrt
 pyasuswrt==0.1.21

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1459,7 +1459,7 @@ pyairnow==1.2.1
 pyairvisual==2023.08.1
 
 # homeassistant.components.aprilaire
-pyaprilaire==0.7.4
+pyaprilaire==0.7.7
 
 # homeassistant.components.asuswrt
 pyasuswrt==0.1.21

--- a/tests/components/aprilaire/test_config_flow.py
+++ b/tests/components/aprilaire/test_config_flow.py
@@ -95,7 +95,6 @@ async def test_config_flow_data(client: AprilaireClient, hass: HomeAssistant) ->
         )
 
     client.start_listen.assert_called_once()
-    client.wait_for_response.assert_any_call(FunctionalDomain.IDENTIFICATION, 4, 30)
     client.wait_for_response.assert_any_call(FunctionalDomain.CONTROL, 7, 30)
     client.wait_for_response.assert_any_call(FunctionalDomain.SENSORS, 2, 30)
     client.stop_listen.assert_called_once()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add additional reads and remove name lookup to improve support for AprilAire S86WMUPR

pyaprilaire changelog: https://github.com/chamberlain2007/pyaprilaire/compare/0.7.4...0.7.7

- Add reading of additional statuses
- Add writing outdoor temperature

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
