### PR TITLE
Add config flow data description to swiss public transport

### DIFF
--- a/homeassistant/components/swiss_public_transport/quality_scale.yaml
+++ b/homeassistant/components/swiss_public_transport/quality_scale.yaml
@@ -9,7 +9,7 @@ rules:
   brands: done
   common-modules: done
   config-flow-test-coverage: done
-  config-flow: todo
+  config-flow: done
   dependency-transparency: todo
   docs-actions: done
   docs-high-level-description: done

--- a/homeassistant/components/swiss_public_transport/strings.json
+++ b/homeassistant/components/swiss_public_transport/strings.json
@@ -22,9 +22,9 @@
           "time_mode": "Select a time mode"
         },
         "data_description": {
-          "from": "The departure station for the start of the connection.",
-          "to": "The arrival station for the end of the connection.",
-          "via": "List of up to 5 via stations",
+          "from": "The station where the connection starts",
+          "to": "The station where the connection ends",
+          "via": "List of up to 5 stations the route must go through",
           "time_station": "Usually the departure time of a connection when it leaves the start station is tracked. Alternatively, track the time when the connection arrives at its end station.",
           "time_mode": "Time mode lets you change the departure timing and fix it to a specific time (e.g. 7:12:00 AM every morning) or add a moving offset (e.g. +00:05:00 taking into account the time to walk to the station)."
         },

--- a/homeassistant/components/swiss_public_transport/strings.json
+++ b/homeassistant/components/swiss_public_transport/strings.json
@@ -17,11 +17,14 @@
         "data": {
           "from": "Start station",
           "to": "End station",
-          "via": "List of up to 5 via stations",
+          "via": "Via stations",
           "time_station": "Select the relevant station",
           "time_mode": "Select a time mode"
         },
         "data_description": {
+          "from": "The departure station for the start of the connection.",
+          "to": "The arrival station for the end of the connection.",
+          "via": "List of up to 5 via stations",
           "time_station": "Usually the departure time of a connection when it leaves the start station is tracked. Alternatively, track the time when the connection arrives at its end station.",
           "time_mode": "Time mode lets you change the departure timing and fix it to a specific time (e.g. 7:12:00 AM every morning) or add a moving offset (e.g. +00:05:00 taking into account the time to walk to the station)."
         },
@@ -32,12 +35,18 @@
         "data": {
           "time_fixed": "Time of day"
         },
+        "data_description": {
+          "time_fixed": "The time of day for the connection"
+        },
         "description": "Please select the relevant time for the connection (e.g. 7:12:00 AM every morning).",
         "title": "Swiss Public Transport"
       },
       "time_offset": {
         "data": {
           "time_offset": "Time offset"
+        },
+        "data_description": {
+          "time_offset": "The time offset added to the earliest possible connection"
         },
         "description": "Please select the relevant offset to add to the earliest possible connection (e.g. add +00:05:00 offset, taking into account the time to walk to the station)",
         "title": "Swiss Public Transport"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- [x] `config-flow` - Integration needs to be able to be set up via the UI
    - [x] Uses `data-description` to give context to fields
    - [ ] Uses `ConfigEntry.data` and `ConfigEntry.options` correctly
- [ ] `test-before-configure` - Test a connection in the config flow
- [ ] `unique-config-entry` - Don't allow the same device or service to be able to be set up twice
- [ ] `config-flow-test-coverage` - Full test coverage for the config flow
- [ ] `runtime-data` - Use ConfigEntry.runtime_data to store runtime data
- [ ] `test-before-setup` - Check during integration initialization if we are able to set it up correctly
- [ ] `appropriate-polling` - If it's a polling integration, set an appropriate polling interval
- [ ] `entity-unique-id` - Entities have a unique ID
- [ ] `has-entity-name` - Entities use has_entity_name = True
- [ ] `entity-event-setup` - Entities event setup
- [ ] `dependency-transparency` - Dependency transparency
- [ ] `action-setup` - Service actions are registered in async_setup
- [ ] `common-modules` - Place common patterns in common modules
- [ ] `docs-high-level-description` - The documentation includes a high-level description of the integration brand, product, or service
- [ ] `docs-installation-instructions` - The documentation provides step-by-step installation instructions for the integration, including, if needed, prerequisites
- [ ] `docs-removal-instructions` - The documentation provides removal instructions
- [ ] `docs-actions` - The documentation describes the provided service actions that can be used
- [ ] `brands` - Has branding assets available for the integration

## Silver
- [ ] `config-entry-unloading` - Support config entry unloading
- [ ] `log-when-unavailable` - If internet/device/service is unavailable, log once when unavailable and once when back connected
- [ ] `entity-unavailable` - Mark entity unavailable if appropriate
- [ ] `action-exceptions` - Service actions raise exceptions when encountering failures
- [ ] `reauthentication-flow` - Reauthentication flow
- [ ] `parallel-updates` - Set Parallel updates
- [ ] `test-coverage` - Above 95% test coverage for all integration modules
- [ ] `integration-owner` - Has an integration owner
- [ ] `docs-installation-parameters` - The documentation describes all integration installation parameters
- [ ] `docs-configuration-parameters` - The documentation describes all integration configuration options

## Gold
- [ ] `entity-translations` - Entities have translated names
- [ ] `entity-device-class` - Entities use device classes where possible
- [ ] `devices` - The integration creates devices
- [ ] `entity-category` - Entities are assigned an appropriate EntityCategory
- [ ] `entity-disabled-by-default` - Integration disables less popular (or noisy) entities
- [ ] `discovery` - Can be discovered
- [ ] `stale-devices` - Clean up stale devices
- [ ] `diagnostics` - Implements diagnostics
- [ ] `exception-translations` - Exception messages are translatable
- [ ] `icon-translations` - Icon translations
- [ ] `reconfiguration-flow` - Integrations should have a reconfigure flow
- [ ] `dynamic-devices` - Devices added after integration setup
- [ ] `discovery-update-info` - Integration uses discovery info to update network information
- [ ] `repair-issues` - Repair issues and repair flows are used when user intervention is needed
- [ ] `docs-use-cases` - The documentation describes use cases to illustrate how this integration can be used
- [ ] `docs-supported-devices` - The integration documents known supported / unsupported devices
- [ ] `docs-supported-functions` - The documentation describes the supported functionality, including entities, and platforms
- [ ] `docs-data-update` - The documentation describes how data is updated
- [ ] `docs-known-limitations` - The documentation describes known limitations of the integration (not to be confused with bugs)
- [ ] `docs-troubleshooting` - The documentation provides troubleshooting information
- [ ] `docs-examples` - The documentation provides automation examples the user can use.

## Platinum
- [ ] `async-dependency` - Dependency is async
- [ ] `inject-websession` - The integration dependency supports passing in a websession
- [ ] `strict-typing` - Strict typing

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
