### PR TITLE
Converge stream av open methods, options, and error handling

### DIFF
--- a/homeassistant/components/generic/config_flow.py
+++ b/homeassistant/components/generic/config_flow.py
@@ -255,10 +255,6 @@ async def async_test_and_preview_stream(
     """
     if not (stream_source := info.get(CONF_STREAM_SOURCE)):
         return None
-    # Import from stream.worker as stream cannot reexport from worker
-    # without forcing the av dependency on default_config
-    # pylint: disable-next=import-outside-toplevel
-    from homeassistant.components.stream.worker import StreamWorkerError
 
     if not isinstance(stream_source, template_helper.Template):
         stream_source = template_helper.Template(stream_source, hass)
@@ -294,8 +290,6 @@ async def async_test_and_preview_stream(
             f"{DOMAIN}.test_stream",
         )
         hls_provider = stream.add_provider(HLS_PROVIDER)
-    except StreamWorkerError as err:
-        raise InvalidStreamException("unknown_with_details", str(err)) from err
     except PermissionError as err:
         raise InvalidStreamException("stream_not_permitted") from err
     except OSError as err:

--- a/homeassistant/components/stream/__init__.py
+++ b/homeassistant/components/stream/__init__.py
@@ -155,7 +155,7 @@ def _convert_stream_options(
     try:
         STREAM_OPTIONS_SCHEMA(stream_options)
     except vol.Invalid as exc:
-        raise HomeAssistantError("Invalid stream options") from exc
+        raise HomeAssistantError(f"Invalid stream options: {exc}") from exc
 
     if extra_wait_time := stream_options.get(CONF_EXTRA_PART_WAIT_TIME):
         stream_settings.hls_part_timeout += extra_wait_time

--- a/homeassistant/components/stream/__init__.py
+++ b/homeassistant/components/stream/__init__.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Callable, Mapping
 import copy
-from enum import IntEnum
 import logging
 import secrets
 import threading
@@ -41,12 +40,12 @@ from homeassistant.util.async_ import create_eager_task
 
 from .const import (
     ATTR_ENDPOINTS,
+    ATTR_PREFER_TCP,
     ATTR_SETTINGS,
     ATTR_STREAMS,
     CONF_EXTRA_PART_WAIT_TIME,
     CONF_LL_HLS,
     CONF_PART_DURATION,
-    CONF_PREFER_TCP,
     CONF_RTSP_TRANSPORT,
     CONF_SEGMENT_DURATION,
     CONF_USE_WALLCLOCK_AS_TIMESTAMPS,
@@ -62,6 +61,7 @@ from .const import (
     SOURCE_TIMEOUT,
     STREAM_RESTART_INCREMENT,
     STREAM_RESTART_RESET_TIME,
+    StreamClientError,
 )
 from .core import (
     PROVIDERS,
@@ -73,11 +73,10 @@ from .core import (
     StreamSettings,
 )
 from .diagnostics import Diagnostics
+from .exceptions import StreamOpenClientError, StreamWorkerError
 from .hls import HlsStreamOutput, async_setup_hls
 
 if TYPE_CHECKING:
-    from av.container import InputContainer, OutputContainer
-
     from homeassistant.components.camera import DynamicStreamSettings
 
 __all__ = [
@@ -92,96 +91,13 @@ __all__ = [
     "RTSP_TRANSPORTS",
     "SOURCE_TIMEOUT",
     "Stream",
+    "StreamClientError",
+    "StreamOpenClientError",
     "create_stream",
     "Orientation",
 ]
 
 _LOGGER = logging.getLogger(__name__)
-
-
-class StreamClientError(IntEnum):
-    """Enum for stream client errors."""
-
-    BadRequest = 400
-    Unauthorized = 401
-    Forbidden = 403
-    NotFound = 404
-    Other = 4
-
-
-class StreamOpenClientError(HomeAssistantError):
-    """Raised when client error received when trying to open a stream.
-
-    :param stream_client_error: The type of client error
-    """
-
-    def __init__(
-        self, *args: Any, stream_client_error: StreamClientError, **kwargs: Any
-    ) -> None:
-        self.stream_client_error = stream_client_error
-        super().__init__(*args, **kwargs)
-
-
-async def _async_try_open_stream(
-    hass: HomeAssistant, source: str, pyav_options: dict[str, str] | None = None
-) -> InputContainer | OutputContainer:
-    """Try to open a stream.
-
-    Will raise StreamOpenClientError if an http client error is encountered.
-    """
-    return await hass.loop.run_in_executor(None, _try_open_stream, source, pyav_options)
-
-
-def _try_open_stream(
-    source: str, pyav_options: dict[str, str] | None = None
-) -> InputContainer | OutputContainer:
-    """Try to open a stream.
-
-    Will raise StreamOpenClientError if an http client error is encountered.
-    """
-    import av  # pylint: disable=import-outside-toplevel
-
-    if pyav_options is None:
-        pyav_options = {}
-
-    default_pyav_options = {
-        "rtsp_flags": CONF_PREFER_TCP,
-        "timeout": str(SOURCE_TIMEOUT),
-    }
-
-    pyav_options = {
-        **default_pyav_options,
-        **pyav_options,
-    }
-
-    try:
-        container = av.open(source, options=pyav_options, timeout=5)
-
-    except av.HTTPBadRequestError as ex:
-        raise StreamOpenClientError(
-            stream_client_error=StreamClientError.BadRequest
-        ) from ex
-
-    except av.HTTPUnauthorizedError as ex:
-        raise StreamOpenClientError(
-            stream_client_error=StreamClientError.Unauthorized
-        ) from ex
-
-    except av.HTTPForbiddenError as ex:
-        raise StreamOpenClientError(
-            stream_client_error=StreamClientError.Forbidden
-        ) from ex
-
-    except av.HTTPNotFoundError as ex:
-        raise StreamOpenClientError(
-            stream_client_error=StreamClientError.NotFound
-        ) from ex
-
-    except av.HTTPOtherClientError as ex:
-        raise StreamOpenClientError(stream_client_error=StreamClientError.Other) from ex
-
-    else:
-        return container
 
 
 async def async_check_stream_client_error(
@@ -192,18 +108,24 @@ async def async_check_stream_client_error(
     Raise StreamOpenClientError if an http client error is encountered.
     """
     await hass.loop.run_in_executor(
-        None, _check_stream_client_error, source, pyav_options
+        None, _check_stream_client_error, hass, source, pyav_options
     )
 
 
 def _check_stream_client_error(
-    source: str, pyav_options: dict[str, str] | None = None
+    hass: HomeAssistant, source: str, options: dict[str, str] | None = None
 ) -> None:
     """Check if a stream can be successfully opened.
 
     Raise StreamOpenClientError if an http client error is encountered.
     """
-    _try_open_stream(source, pyav_options).close()
+    from .worker import try_open_stream  # pylint: disable=import-outside-toplevel
+
+    pyav_options, _ = _convert_stream_options(hass, source, options or {})
+    try:
+        try_open_stream(source, pyav_options).close()
+    except StreamWorkerError as err:
+        raise StreamOpenClientError(str(err), err.error_code) from err
 
 
 def redact_credentials(url: str) -> str:
@@ -217,6 +139,42 @@ def redact_credentials(url: str) -> str:
         {"auth", "user", "password"} & yurl.query.keys(), "****"
     )
     return str(yurl.update_query(redacted_query_params))
+
+
+def _convert_stream_options(
+    hass: HomeAssistant,
+    stream_source: str,
+    stream_options: Mapping[str, str | bool | float],
+) -> tuple[dict[str, str], StreamSettings]:
+    """Convert options from stream options into PyAV options and stream settings."""
+    if DOMAIN not in hass.data:
+        raise HomeAssistantError("Stream integration is not set up.")
+
+    stream_settings = copy.copy(hass.data[DOMAIN][ATTR_SETTINGS])
+    pyav_options: dict[str, str] = {}
+    try:
+        STREAM_OPTIONS_SCHEMA(stream_options)
+    except vol.Invalid as exc:
+        raise HomeAssistantError("Invalid stream options") from exc
+
+    if extra_wait_time := stream_options.get(CONF_EXTRA_PART_WAIT_TIME):
+        stream_settings.hls_part_timeout += extra_wait_time
+    if rtsp_transport := stream_options.get(CONF_RTSP_TRANSPORT):
+        assert isinstance(rtsp_transport, str)
+        # The PyAV options currently match the stream CONF constants, but this
+        # will not necessarily always be the case, so they are hard coded here
+        pyav_options["rtsp_transport"] = rtsp_transport
+    if stream_options.get(CONF_USE_WALLCLOCK_AS_TIMESTAMPS):
+        pyav_options["use_wallclock_as_timestamps"] = "1"
+
+    # For RTSP streams, prefer TCP
+    if isinstance(stream_source, str) and stream_source[:7] == "rtsp://":
+        pyav_options = {
+            "rtsp_flags": ATTR_PREFER_TCP,
+            "stimeout": "5000000",
+            **pyav_options,
+        }
+    return pyav_options, stream_settings
 
 
 def create_stream(
@@ -234,41 +192,13 @@ def create_stream(
     The stream_label is a string used as an additional message in logging.
     """
 
-    def convert_stream_options(
-        hass: HomeAssistant, stream_options: Mapping[str, str | bool | float]
-    ) -> tuple[dict[str, str], StreamSettings]:
-        """Convert options from stream options into PyAV options and stream settings."""
-        stream_settings = copy.copy(hass.data[DOMAIN][ATTR_SETTINGS])
-        pyav_options: dict[str, str] = {}
-        try:
-            STREAM_OPTIONS_SCHEMA(stream_options)
-        except vol.Invalid as exc:
-            raise HomeAssistantError("Invalid stream options") from exc
-
-        if extra_wait_time := stream_options.get(CONF_EXTRA_PART_WAIT_TIME):
-            stream_settings.hls_part_timeout += extra_wait_time
-        if rtsp_transport := stream_options.get(CONF_RTSP_TRANSPORT):
-            assert isinstance(rtsp_transport, str)
-            # The PyAV options currently match the stream CONF constants, but this
-            # will not necessarily always be the case, so they are hard coded here
-            pyav_options["rtsp_transport"] = rtsp_transport
-        if stream_options.get(CONF_USE_WALLCLOCK_AS_TIMESTAMPS):
-            pyav_options["use_wallclock_as_timestamps"] = "1"
-
-        return pyav_options, stream_settings
-
     if DOMAIN not in hass.config.components:
         raise HomeAssistantError("Stream integration is not set up.")
 
     # Convert extra stream options into PyAV options and stream settings
-    pyav_options, stream_settings = convert_stream_options(hass, options)
-    # For RTSP streams, prefer TCP
-    if isinstance(stream_source, str) and stream_source[:7] == "rtsp://":
-        pyav_options = {
-            "rtsp_flags": "prefer_tcp",
-            "stimeout": "5000000",
-            **pyav_options,
-        }
+    pyav_options, stream_settings = _convert_stream_options(
+        hass, stream_source, options
+    )
 
     stream = Stream(
         hass,
@@ -531,7 +461,7 @@ class Stream:
         """Handle consuming streams and restart keepalive streams."""
         # Keep import here so that we can import stream integration without installing reqs
         # pylint: disable-next=import-outside-toplevel
-        from .worker import StreamState, StreamWorkerError, stream_worker
+        from .worker import StreamState, stream_worker
 
         stream_state = StreamState(self.hass, self.outputs, self._diagnostics)
         wait_timeout = 0

--- a/homeassistant/components/stream/const.py
+++ b/homeassistant/components/stream/const.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from enum import IntEnum
 from typing import Final
 
 DOMAIN = "stream"
@@ -48,7 +49,7 @@ CONF_LL_HLS = "ll_hls"
 CONF_PART_DURATION = "part_duration"
 CONF_SEGMENT_DURATION = "segment_duration"
 
-CONF_PREFER_TCP = "prefer_tcp"
+ATTR_PREFER_TCP = "prefer_tcp"
 CONF_RTSP_TRANSPORT = "rtsp_transport"
 # The first dict entry below may be used as the default when populating options
 RTSP_TRANSPORTS = {
@@ -59,3 +60,18 @@ RTSP_TRANSPORTS = {
 }
 CONF_USE_WALLCLOCK_AS_TIMESTAMPS = "use_wallclock_as_timestamps"
 CONF_EXTRA_PART_WAIT_TIME = "extra_part_wait_time"
+
+
+class StreamClientError(IntEnum):
+    """Enum for stream client errors.
+
+    These are errors that can be returned by the stream client when trying to
+    open a stream. The caller should not interpret the int values directly, but
+    should use the enum values instead.
+    """
+
+    BadRequest = 400
+    Unauthorized = 401
+    Forbidden = 403
+    NotFound = 404
+    Other = 4

--- a/homeassistant/components/stream/exceptions.py
+++ b/homeassistant/components/stream/exceptions.py
@@ -1,0 +1,32 @@
+"""Stream component exceptions."""
+
+from homeassistant.exceptions import HomeAssistantError
+
+from .const import StreamClientError
+
+
+class StreamOpenClientError(HomeAssistantError):
+    """Raised when client error received when trying to open a stream.
+
+    :param stream_client_error: The type of client error
+    """
+
+    def __init__(self, message: str, error_code: StreamClientError) -> None:
+        """Initialize a stream open client error."""
+        super().__init__(message)
+        self.error_code = error_code
+
+
+class StreamWorkerError(Exception):
+    """An exception thrown while processing a stream."""
+
+    def __init__(
+        self, message: str, error_code: StreamClientError = StreamClientError.Other
+    ) -> None:
+        """Initialize a stream worker error."""
+        super().__init__(message)
+        self.error_code = error_code
+
+
+class StreamEndedError(StreamWorkerError):
+    """Raised when the stream is complete, exposed for facilitating testing."""

--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -15,6 +15,7 @@ from typing import Any, Self, cast
 import av
 import av.audio
 import av.container
+from av.container import InputContainer
 import av.stream
 
 from homeassistant.core import HomeAssistant
@@ -29,6 +30,7 @@ from .const import (
     PACKETS_TO_WAIT_FOR_AUDIO,
     SEGMENT_CONTAINER_FORMAT,
     SOURCE_TIMEOUT,
+    StreamClientError,
 )
 from .core import (
     STREAM_SETTINGS_NON_LL_HLS,
@@ -39,15 +41,12 @@ from .core import (
     StreamSettings,
 )
 from .diagnostics import Diagnostics
+from .exceptions import StreamEndedError, StreamWorkerError
 from .fmp4utils import read_init
 from .hls import HlsStreamOutput
 
 _LOGGER = logging.getLogger(__name__)
 NEGATIVE_INF = float("-inf")
-
-
-class StreamWorkerError(Exception):
-    """An exception thrown while processing a stream."""
 
 
 def redact_av_error_string(err: av.FFmpegError) -> str:
@@ -56,10 +55,6 @@ def redact_av_error_string(err: av.FFmpegError) -> str:
     if err.filename:
         parts.append(redact_credentials(err.filename))
     return ", ".join(parts)
-
-
-class StreamEndedError(StreamWorkerError):
-    """Raised when the stream is complete, exposed for facilitating testing."""
 
 
 class StreamState:
@@ -512,6 +507,47 @@ def get_audio_bitstream_filter(
     return None
 
 
+def try_open_stream(
+    source: str,
+    pyav_options: dict[str, str],
+) -> InputContainer:
+    """Try to open a stream.
+
+    Will raise StreamOpenClientError if an http client error is encountered.
+    """
+
+    try:
+        return av.open(source, options=pyav_options, timeout=SOURCE_TIMEOUT)
+    except av.HTTPBadRequestError as err:
+        raise StreamWorkerError(
+            f"Bad Request Error opening stream ({redact_av_error_string(err)})",
+            error_code=StreamClientError.BadRequest,
+        ) from err
+
+    except av.HTTPUnauthorizedError as err:
+        raise StreamWorkerError(
+            f"Unauthorized error opening stream ({redact_av_error_string(err)})",
+            error_code=StreamClientError.Unauthorized,
+        ) from err
+
+    except av.HTTPForbiddenError as err:
+        raise StreamWorkerError(
+            f"Forbidden error opening stream ({redact_av_error_string(err)})",
+            error_code=StreamClientError.Forbidden,
+        ) from err
+
+    except av.HTTPNotFoundError as err:
+        raise StreamWorkerError(
+            f"Not Found error opening stream ({redact_av_error_string(err)})",
+            error_code=StreamClientError.NotFound,
+        ) from err
+
+    except av.FFmpegError as err:
+        raise StreamWorkerError(
+            f"Error opening stream ({redact_av_error_string(err)})"
+        ) from err
+
+
 def stream_worker(
     source: str,
     pyav_options: dict[str, str],
@@ -526,12 +562,7 @@ def stream_worker(
         # the stimeout option was renamed to timeout as of ffmpeg 5.0
         pyav_options["timeout"] = pyav_options["stimeout"]
         del pyav_options["stimeout"]
-    try:
-        container = av.open(source, options=pyav_options, timeout=SOURCE_TIMEOUT)
-    except av.FFmpegError as err:
-        raise StreamWorkerError(
-            f"Error opening stream ({redact_av_error_string(err)})"
-        ) from err
+    container = try_open_stream(source, pyav_options)
     try:
         video_stream = container.streams.video[0]
     except (KeyError, IndexError) as ex:

--- a/homeassistant/components/tplink/camera.py
+++ b/homeassistant/components/tplink/camera.py
@@ -130,7 +130,7 @@ class TPLinkCameraEntity(CoordinatedTPLinkEntity, Camera):
         try:
             await stream.async_check_stream_client_error(self.hass, video_url)
         except stream.StreamOpenClientError as ex:
-            if ex.stream_client_error is stream.StreamClientError.Unauthorized:
+            if ex.error_code is stream.StreamClientError.Unauthorized:
                 _LOGGER.debug(
                     "Camera stream failed authentication for %s",
                     self._device.host,

--- a/homeassistant/components/tplink/config_flow.py
+++ b/homeassistant/components/tplink/config_flow.py
@@ -468,7 +468,7 @@ class TPLinkConfigFlow(ConfigFlow, domain=DOMAIN):
             try:
                 await stream.async_check_stream_client_error(self.hass, rtsp_url)
             except stream.StreamOpenClientError as ex:
-                if ex.stream_client_error is stream.StreamClientError.Unauthorized:
+                if ex.error_code is stream.StreamClientError.Unauthorized:
                     errors["base"] = "invalid_camera_auth"
                 else:
                     _LOGGER.debug(

--- a/tests/components/stream/test_hls.py
+++ b/tests/components/stream/test_hls.py
@@ -278,8 +278,19 @@ async def test_stream_timeout_after_stop(
     await hass.async_block_till_done()
 
 
+@pytest.mark.parametrize(
+    ("exception"),
+    [
+        # pylint: disable-next=c-extension-no-member
+        (av.error.InvalidDataError(-2, "error")),
+        (av.HTTPBadRequestError(500, "error")),
+    ],
+)
 async def test_stream_retries(
-    hass: HomeAssistant, setup_component, should_retry
+    hass: HomeAssistant,
+    setup_component,
+    should_retry,
+    exception,
 ) -> None:
     """Test hls stream is retried on failure."""
     # Setup demo HLS track
@@ -309,8 +320,7 @@ async def test_stream_retries(
 
     def av_open_side_effect(*args, **kwargs):
         hass.loop.call_soon_threadsafe(futures.pop().set_result, None)
-        # pylint: disable-next=c-extension-no-member
-        raise av.error.InvalidDataError(-2, "error")
+        raise exception
 
     with (
         patch("av.open") as av_open,

--- a/tests/components/stream/test_init.py
+++ b/tests/components/stream/test_init.py
@@ -1,6 +1,7 @@
 """Test stream init."""
 
 import logging
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import av
@@ -12,12 +13,28 @@ from homeassistant.components.stream import (
     StreamOpenClientError,
     __name__ as stream_name,
     async_check_stream_client_error,
+    create_stream,
 )
 from homeassistant.components.stream.const import ATTR_PREFER_TCP
 from homeassistant.const import EVENT_LOGGING_CHANGED
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.setup import async_setup_component
+
+from .common import dynamic_stream_settings
+
+
+async def test_stream_not_setup(hass: HomeAssistant, h264_video) -> None:
+    """Test hls stream.
+
+    Purposefully not mocking anything here to test full
+    integration with the stream component.
+    """
+    with pytest.raises(HomeAssistantError, match="Stream integration is not set up"):
+        create_stream(hass, "rtsp://foobar", {}, dynamic_stream_settings())
+
+    with pytest.raises(HomeAssistantError, match="Stream integration is not set up"):
+        await async_check_stream_client_error(hass, "rtsp://foobar")
 
 
 async def test_log_levels(
@@ -125,3 +142,48 @@ async def test_try_open_stream_error(
     ):
         await async_check_stream_client_error(hass, "rtsp://foobar")
     assert ex.value.error_code is enum_result
+
+
+@pytest.mark.parametrize(
+    ("options", "expected_pyav_options"),
+    [
+        (
+            {},
+            {"rtsp_flags": "prefer_tcp", "stimeout": "5000000"},
+        ),
+        (
+            {"rtsp_transport": "udp"},
+            {
+                "rtsp_flags": "prefer_tcp",
+                "rtsp_transport": "udp",
+                "stimeout": "5000000",
+            },
+        ),
+        (
+            {"use_wallclock_as_timestamps": True},
+            {
+                "rtsp_flags": "prefer_tcp",
+                "stimeout": "5000000",
+                "use_wallclock_as_timestamps": "1",
+            },
+        ),
+    ],
+)
+async def test_convert_stream_options(
+    hass: HomeAssistant,
+    options: dict[str, Any],
+    expected_pyav_options: dict[str, Any],
+) -> None:
+    """Test stream options."""
+    await async_setup_component(hass, "stream", {"stream": {}})
+
+    container_mock = MagicMock()
+    source = "rtsp://foobar"
+
+    with patch("av.open", return_value=container_mock) as open_mock:
+        await async_check_stream_client_error(hass, source, options)
+
+    open_mock.assert_called_once_with(
+        source, options=expected_pyav_options, timeout=SOURCE_TIMEOUT
+    )
+    container_mock.close.assert_called_once()

--- a/tests/components/tplink/test_camera.py
+++ b/tests/components/tplink/test_camera.py
@@ -346,7 +346,8 @@ async def test_camera_image_auth_error(
         patch(
             "homeassistant.components.stream.async_check_stream_client_error",
             side_effect=stream.StreamOpenClientError(
-                stream_client_error=stream.StreamClientError.Unauthorized
+                "Request was unauthorized",
+                error_code=stream.StreamClientError.Unauthorized,
             ),
         ),
         pytest.raises(HomeAssistantError),

--- a/tests/components/tplink/test_config_flow.py
+++ b/tests/components/tplink/test_config_flow.py
@@ -768,7 +768,7 @@ async def test_manual_camera(
         patch(
             "homeassistant.components.stream.async_check_stream_client_error",
             side_effect=stream.StreamOpenClientError(
-                stream_client_error=stream.StreamClientError.NotFound
+                "Stream was not found", error_code=stream.StreamClientError.NotFound
             ),
         ),
     ):
@@ -791,7 +791,8 @@ async def test_manual_camera(
         patch(
             "homeassistant.components.stream.async_check_stream_client_error",
             side_effect=stream.StreamOpenClientError(
-                stream_client_error=stream.StreamClientError.Unauthorized
+                "Request is unauthorized",
+                error_code=stream.StreamClientError.Unauthorized,
             ),
         ),
     ):
@@ -835,7 +836,7 @@ async def test_manual_camera(
     [
         pytest.param(
             stream.StreamOpenClientError(
-                stream_client_error=stream.StreamClientError.NotFound
+                "Stream was not found", error_code=stream.StreamClientError.NotFound
             ),
             id="open_client_error",
         ),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Address proposed improvements in #132866 with related cleanup. This converges:
- use the same exception handling in the stream worker as in the stream test methods, moving the try open code into the worker
- options handling so that all stream options are validated (invalid options are rejected, rather than taking arbitrary dicts) and all defaults are shared
- changes the worker exception and client exception to both attach an error code, making the error code field explicit rather than a part of the string message.
- this prepares for sharing error codes with the `generic` config flow which will happen in follow up steps. Currently the exceptions caught in generic are [not valid](https://github.com/home-assistant/core/pull/122563/files#r1834576454)
- removes some dead code from #132866 that was not used except in tests


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
