### PR TITLE
Deprecate sensors in Habitica integration

### DIFF
--- a/homeassistant/components/habitica/sensor.py
+++ b/homeassistant/components/habitica/sensor.py
@@ -284,6 +284,7 @@ async def async_setup_entry(
                                 entity_entry.name or entity_entry.original_name
                             ),
                             "entity": entity_id,
+                            "breaks_in_ha_version": "2025.8.0",
                         },
                     )
 

--- a/homeassistant/components/habitica/sensor.py
+++ b/homeassistant/components/habitica/sensor.py
@@ -6,7 +6,7 @@ from collections.abc import Callable, Mapping
 from dataclasses import asdict, dataclass
 from enum import StrEnum
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from habiticalib import (
     ContentData,
@@ -18,18 +18,24 @@ from habiticalib import (
 )
 
 from homeassistant.components.sensor import (
+    DOMAIN as SENSOR_DOMAIN,
     SensorDeviceClass,
     SensorEntity,
     SensorEntityDescription,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.issue_registry import (
+    IssueSeverity,
+    async_create_issue,
+    async_delete_issue,
+)
 from homeassistant.helpers.typing import StateType
-
-from .const import ASSETS_URL
+from homeassistant.helpers import entity_registry as er
+from .const import ASSETS_URL, DOMAIN
 from .entity import HabiticaBase
 from .types import HabiticaConfigEntry
-from .util import get_attribute_points, get_attributes_total
+from .util import get_attribute_points, get_attributes_total, entity_used_in
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -217,11 +223,13 @@ TASK_SENSOR_DESCRIPTION: tuple[HabiticaTaskSensorEntityDescription, ...] = (
         key=HabiticaSensorEntity.HABITS,
         translation_key=HabiticaSensorEntity.HABITS,
         value_fn=lambda tasks: [r for r in tasks if r.Type is TaskType.HABIT],
+        entity_registry_enabled_default=False,
     ),
     HabiticaTaskSensorEntityDescription(
         key=HabiticaSensorEntity.REWARDS,
         translation_key=HabiticaSensorEntity.REWARDS,
         value_fn=lambda tasks: [r for r in tasks if r.Type is TaskType.REWARD],
+        entity_registry_enabled_default=False,
     ),
 )
 
@@ -272,6 +280,39 @@ class HabiticaSensor(HabiticaBase, SensorEntity):
             return f"{ASSETS_URL}{entity_picture}"
         return None
 
+    async def async_added_to_hass(self) -> None:
+        """Raise issue when entity is registered and was not disabled."""
+        if TYPE_CHECKING:
+            assert self.unique_id
+        if entity_id := er.async_get(self.hass).async_get_entity_id(
+            SENSOR_DOMAIN, DOMAIN, self.unique_id
+        ):
+            if (
+                self.enabled
+                and self.entity_description.key is HabiticaSensorEntity.HEALTH_MAX
+                and entity_used_in(self.hass, entity_id)
+            ):
+                async_create_issue(
+                    self.hass,
+                    DOMAIN,
+                    f"deprecated_entity_{self.entity_description.key}",
+                    breaks_in_ha_version="2025.8.0",
+                    is_fixable=False,
+                    severity=IssueSeverity.WARNING,
+                    translation_key="deprecated_entity",
+                    translation_placeholders={
+                        "name": str(self.name),
+                        "entity": entity_id,
+                    },
+                )
+            else:
+                async_delete_issue(
+                    self.hass,
+                    DOMAIN,
+                    f"deprecated_entity_{self.entity_description.key}",
+                )
+        await super().async_added_to_hass()
+
 
 class HabiticaTaskSensor(HabiticaBase, SensorEntity):
     """A Habitica task sensor."""
@@ -299,3 +340,37 @@ class HabiticaTaskSensor(HabiticaBase, SensorEntity):
                     task[map_key] = value
             attrs[str(task_id)] = task
         return attrs
+
+    async def async_added_to_hass(self) -> None:
+        """Raise issue when entity is registered and was not disabled."""
+        if TYPE_CHECKING:
+            assert self.unique_id
+        if entity_id := er.async_get(self.hass).async_get_entity_id(
+            SENSOR_DOMAIN, DOMAIN, self.unique_id
+        ):
+            if (
+                self.enabled
+                and self.entity_description.key
+                in (HabiticaSensorEntity.REWARDS, HabiticaSensorEntity.HABITS)
+                and entity_used_in(self.hass, entity_id)
+            ):
+                async_create_issue(
+                    self.hass,
+                    DOMAIN,
+                    f"deprecated_task_entity_{self.entity_description.key}",
+                    breaks_in_ha_version="2025.8.0",
+                    is_fixable=False,
+                    severity=IssueSeverity.WARNING,
+                    translation_key="deprecated_entity",
+                    translation_placeholders={
+                        "name": str(self.name),
+                        "entity": entity_id,
+                    },
+                )
+            else:
+                async_delete_issue(
+                    self.hass,
+                    DOMAIN,
+                    f"deprecated_task_entity_{self.entity_description.key}",
+                )
+        await super().async_added_to_hass()

--- a/homeassistant/components/habitica/strings.json
+++ b/homeassistant/components/habitica/strings.json
@@ -403,11 +403,11 @@
   "issues": {
     "deprecated_entity": {
       "title": "The Habitica {name} entity is deprecated",
-      "description": "The Habitica entity `{entity}` is deprecated and will be removed in version {breaks_in_ha_version}.\nPlease update your automations and scripts, and then disable `{entity}`."
+      "description": "The Habitica entity `{entity}` is deprecated and will be removed in a future release.\nPlease update your automations and scripts, disable `{entity}` and reload the integration/restart Home Assistant to fix this issue."
     },
     "deprecated_api_call": {
       "title": "The Habitica action habitica.api_call is deprecated",
-      "description": "The Habitica action `habitica.api_call` is deprecated and will be removed in Home Assistant 2025.8.0.\n\nPlease update your automations and scripts to use other Habitica actions and entities."
+      "description": "The Habitica action `habitica.api_call` is deprecated and will be removed in Home Assistant 2025.5.0.\n\nPlease update your automations and scripts to use other Habitica actions and entities."
     }
   },
   "services": {

--- a/homeassistant/components/habitica/strings.json
+++ b/homeassistant/components/habitica/strings.json
@@ -401,6 +401,10 @@
     }
   },
   "issues": {
+    "deprecated_entity": {
+      "title": "The Habitica {name} entity is deprecated",
+      "description": "The Habitica entity `{entity}` is deprecated and will be removed in a future release.\nPlease update your automations and scripts, and then disable `{entity}`."
+    },
     "deprecated_api_call": {
       "title": "The Habitica action habitica.api_call is deprecated",
       "description": "The Habitica action `habitica.api_call` is deprecated and will be removed in Home Assistant 2025.5.0.\n\nPlease update your automations and scripts to use other Habitica actions and entities."

--- a/homeassistant/components/habitica/strings.json
+++ b/homeassistant/components/habitica/strings.json
@@ -403,11 +403,11 @@
   "issues": {
     "deprecated_entity": {
       "title": "The Habitica {name} entity is deprecated",
-      "description": "The Habitica entity `{entity}` is deprecated and will be removed in a future release.\nPlease update your automations and scripts, and then disable `{entity}`."
+      "description": "The Habitica entity `{entity}` is deprecated and will be removed in version {breaks_in_ha_version}.\nPlease update your automations and scripts, and then disable `{entity}`."
     },
     "deprecated_api_call": {
       "title": "The Habitica action habitica.api_call is deprecated",
-      "description": "The Habitica action `habitica.api_call` is deprecated and will be removed in Home Assistant 2025.5.0.\n\nPlease update your automations and scripts to use other Habitica actions and entities."
+      "description": "The Habitica action `habitica.api_call` is deprecated and will be removed in Home Assistant 2025.8.0.\n\nPlease update your automations and scripts to use other Habitica actions and entities."
     }
   },
   "services": {

--- a/homeassistant/components/habitica/util.py
+++ b/homeassistant/components/habitica/util.py
@@ -23,9 +23,6 @@ from dateutil.rrule import (
 )
 from habiticalib import ContentData, Frequency, TaskData, UserData
 
-from homeassistant.components.automation import automations_with_entity
-from homeassistant.components.script import scripts_with_entity
-from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
 
 
@@ -55,13 +52,6 @@ def next_due_date(task: TaskData, today: datetime.datetime) -> datetime.date | N
             return dt_util.as_local(task.nextDue[1]).date()
 
     return dt_util.as_local(task.nextDue[0]).date()
-
-
-def entity_used_in(hass: HomeAssistant, entity_id: str) -> list[str]:
-    """Get list of related automations and scripts."""
-    used_in = automations_with_entity(hass, entity_id)
-    used_in += scripts_with_entity(hass, entity_id)
-    return used_in
 
 
 FREQUENCY_MAP = {"daily": DAILY, "weekly": WEEKLY, "monthly": MONTHLY, "yearly": YEARLY}

--- a/tests/components/habitica/snapshots/test_sensor.ambr
+++ b/tests/components/habitica/snapshots/test_sensor.ambr
@@ -564,53 +564,6 @@
     'state': '0.0',
   })
 # ---
-# name: test_sensors[sensor.test_user_health_max-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.test_user_health_max',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'Max. health',
-    'platform': 'habitica',
-    'previous_unique_id': None,
-    'supported_features': 0,
-    'translation_key': <HabiticaSensorEntity.HEALTH_MAX: 'health_max'>,
-    'unique_id': 'a380546a-94be-4b8e-8a0b-23e0d5c03303_health_max',
-    'unit_of_measurement': 'HP',
-  })
-# ---
-# name: test_sensors[sensor.test_user_health_max-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'test-user Max. health',
-      'unit_of_measurement': 'HP',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.test_user_health_max',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '50',
-  })
-# ---
 # name: test_sensors[sensor.test_user_intelligence-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -760,6 +713,53 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '50.9',
+  })
+# ---
+# name: test_sensors[sensor.test_user_max_health-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.test_user_max_health',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Max. health',
+    'platform': 'habitica',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': <HabiticaSensorEntity.HEALTH_MAX: 'health_max'>,
+    'unique_id': 'a380546a-94be-4b8e-8a0b-23e0d5c03303_health_max',
+    'unit_of_measurement': 'HP',
+  })
+# ---
+# name: test_sensors[sensor.test_user_max_health-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'test-user Max. health',
+      'unit_of_measurement': 'HP',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.test_user_max_health',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '50',
   })
 # ---
 # name: test_sensors[sensor.test_user_max_mana-entry]

--- a/tests/components/habitica/snapshots/test_sensor.ambr
+++ b/tests/components/habitica/snapshots/test_sensor.ambr
@@ -564,6 +564,53 @@
     'state': '0.0',
   })
 # ---
+# name: test_sensors[sensor.test_user_health_max-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.test_user_health_max',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Max. health',
+    'platform': 'habitica',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': <HabiticaSensorEntity.HEALTH_MAX: 'health_max'>,
+    'unique_id': 'a380546a-94be-4b8e-8a0b-23e0d5c03303_health_max',
+    'unit_of_measurement': 'HP',
+  })
+# ---
+# name: test_sensors[sensor.test_user_health_max-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'test-user Max. health',
+      'unit_of_measurement': 'HP',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.test_user_health_max',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '50',
+  })
+# ---
 # name: test_sensors[sensor.test_user_intelligence-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -713,53 +760,6 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '50.9',
-  })
-# ---
-# name: test_sensors[sensor.test_user_max_health-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.test_user_max_health',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'Max. health',
-    'platform': 'habitica',
-    'previous_unique_id': None,
-    'supported_features': 0,
-    'translation_key': <HabiticaSensorEntity.HEALTH_MAX: 'health_max'>,
-    'unique_id': 'a380546a-94be-4b8e-8a0b-23e0d5c03303_health_max',
-    'unit_of_measurement': 'HP',
-  })
-# ---
-# name: test_sensors[sensor.test_user_max_health-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'test-user Max. health',
-      'unit_of_measurement': 'HP',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.test_user_max_health',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '50',
   })
 # ---
 # name: test_sensors[sensor.test_user_max_mana-entry]

--- a/tests/components/habitica/test_sensor.py
+++ b/tests/components/habitica/test_sensor.py
@@ -39,7 +39,7 @@ async def test_sensors(
     for entity in (
         ("test_user_habits", "habits"),
         ("test_user_rewards", "rewards"),
-        ("test_user_health_max", "health_max"),
+        ("test_user_max_health", "health_max"),
     ):
         entity_registry.async_get_or_create(
             SENSOR_DOMAIN,
@@ -63,7 +63,7 @@ async def test_sensors(
     [
         ("test_user_habits", HabiticaSensorEntity.HABITS),
         ("test_user_rewards", HabiticaSensorEntity.REWARDS),
-        ("test_user_health_max", HabiticaSensorEntity.HEALTH_MAX),
+        ("test_user_max_health", HabiticaSensorEntity.HEALTH_MAX),
     ],
 )
 @pytest.mark.usefixtures("habitica", "entity_registry_enabled_by_default")
@@ -107,7 +107,7 @@ async def test_sensor_deprecation_issue(
     [
         ("test_user_habits", HabiticaSensorEntity.HABITS),
         ("test_user_rewards", HabiticaSensorEntity.REWARDS),
-        ("test_user_health_max", HabiticaSensorEntity.HEALTH_MAX),
+        ("test_user_max_health", HabiticaSensorEntity.HEALTH_MAX),
     ],
 )
 @pytest.mark.usefixtures("habitica", "entity_registry_enabled_by_default")

--- a/tests/components/habitica/test_sensor.py
+++ b/tests/components/habitica/test_sensor.py
@@ -27,17 +27,16 @@ def sensor_only() -> Generator[None]:
         yield
 
 
-@pytest.fixture
-def inject_deprecated_entities(
+@pytest.mark.usefixtures("habitica", "entity_registry_enabled_by_default")
+async def test_sensors(
     hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    snapshot: SnapshotAssertion,
     entity_registry: er.EntityRegistry,
-) -> Generator[None]:
-    """Inject deprecated entities to entity registry."""
+) -> None:
+    """Test setup of the Habitica sensor platform."""
 
-    entity_registry = er.async_get(hass)
     for entity in (
-        ("test_user_dailies", "dailys"),
-        ("test_user_to_do_s", "todos"),
         ("test_user_habits", "habits"),
         ("test_user_rewards", "rewards"),
         ("test_user_health_max", "health_max"),
@@ -50,18 +49,6 @@ def inject_deprecated_entities(
             disabled_by=None,
         )
 
-
-@pytest.mark.usefixtures(
-    "habitica", "entity_registry_enabled_by_default", "inject_deprecated_entities"
-)
-async def test_sensors(
-    hass: HomeAssistant,
-    config_entry: MockConfigEntry,
-    snapshot: SnapshotAssertion,
-    entity_registry: er.EntityRegistry,
-) -> None:
-    """Test setup of the Habitica sensor platform."""
-
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
@@ -71,16 +58,31 @@ async def test_sensors(
     await snapshot_platform(hass, entity_registry, snapshot, config_entry.entry_id)
 
 
-@pytest.mark.usefixtures(
-    "habitica", "entity_registry_enabled_by_default", "inject_deprecated_entities"
+@pytest.mark.parametrize(
+    ("entity_id", "key"),
+    [
+        ("test_user_habits", HabiticaSensorEntity.HABITS),
+        ("test_user_rewards", HabiticaSensorEntity.REWARDS),
+        ("test_user_health_max", HabiticaSensorEntity.HEALTH_MAX),
+    ],
 )
+@pytest.mark.usefixtures("habitica", "entity_registry_enabled_by_default")
 async def test_sensor_deprecation_issue(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
     issue_registry: ir.IssueRegistry,
     entity_registry: er.EntityRegistry,
+    entity_id: str,
+    key: HabiticaSensorEntity,
 ) -> None:
-    """Test task sensor deprecation issue."""
+    """Test sensor deprecation issue."""
+    entity_registry.async_get_or_create(
+        SENSOR_DOMAIN,
+        DOMAIN,
+        f"a380546a-94be-4b8e-8a0b-23e0d5c03303_{key}",
+        suggested_object_id=entity_id,
+        disabled_by=None,
+    )
 
     assert entity_registry is not None
     with patch(
@@ -93,15 +95,57 @@ async def test_sensor_deprecation_issue(
 
         assert config_entry.state is ConfigEntryState.LOADED
 
+        assert entity_registry.async_get(f"sensor.{entity_id}") is not None
         assert issue_registry.async_get_issue(
             domain=DOMAIN,
-            issue_id=f"deprecated_entity_{HabiticaSensorEntity.HABITS}",
+            issue_id=f"deprecated_entity_{key}",
         )
-        assert issue_registry.async_get_issue(
-            domain=DOMAIN,
-            issue_id=f"deprecated_entity_{HabiticaSensorEntity.REWARDS}",
+
+
+@pytest.mark.parametrize(
+    ("entity_id", "key"),
+    [
+        ("test_user_habits", HabiticaSensorEntity.HABITS),
+        ("test_user_rewards", HabiticaSensorEntity.REWARDS),
+        ("test_user_health_max", HabiticaSensorEntity.HEALTH_MAX),
+    ],
+)
+@pytest.mark.usefixtures("habitica", "entity_registry_enabled_by_default")
+async def test_sensor_deprecation_delete_disabled(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    issue_registry: ir.IssueRegistry,
+    entity_registry: er.EntityRegistry,
+    entity_id: str,
+    key: HabiticaSensorEntity,
+) -> None:
+    """Test sensor deletion ."""
+
+    entity_registry.async_get_or_create(
+        SENSOR_DOMAIN,
+        DOMAIN,
+        f"a380546a-94be-4b8e-8a0b-23e0d5c03303_{key}",
+        suggested_object_id=entity_id,
+        disabled_by=er.RegistryEntryDisabler.USER,
+    )
+
+    assert entity_registry is not None
+    with patch(
+        "homeassistant.components.habitica.sensor.entity_used_in", return_value=True
+    ):
+        config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(config_entry.entry_id)
+
+        await hass.async_block_till_done()
+
+        assert config_entry.state is ConfigEntryState.LOADED
+
+        assert (
+            issue_registry.async_get_issue(
+                domain=DOMAIN,
+                issue_id=f"deprecated_entity_{key}",
+            )
+            is None
         )
-        assert issue_registry.async_get_issue(
-            domain=DOMAIN,
-            issue_id=f"deprecated_entity_{HabiticaSensorEntity.HEALTH_MAX}",
-        )
+
+        assert entity_registry.async_get(f"sensor.{entity_id}") is None

--- a/tests/components/habitica/test_sensor.py
+++ b/tests/components/habitica/test_sensor.py
@@ -6,10 +6,12 @@ from unittest.mock import patch
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
+from homeassistant.components.habitica.const import DOMAIN
+from homeassistant.components.habitica.sensor import HabiticaSensorEntity
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import entity_registry as er, issue_registry as ir
 
 from tests.common import MockConfigEntry, snapshot_platform
 
@@ -40,3 +42,35 @@ async def test_sensors(
     assert config_entry.state is ConfigEntryState.LOADED
 
     await snapshot_platform(hass, entity_registry, snapshot, config_entry.entry_id)
+
+
+@pytest.mark.usefixtures("habitica", "entity_registry_enabled_by_default")
+async def test_sensor_deprecation_issue(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test task sensor deprecation issue."""
+
+    with patch(
+        "homeassistant.components.habitica.sensor.entity_used_in", return_value=True
+    ):
+        config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(config_entry.entry_id)
+
+        await hass.async_block_till_done()
+
+        assert config_entry.state is ConfigEntryState.LOADED
+
+        assert issue_registry.async_get_issue(
+            domain=DOMAIN,
+            issue_id=f"deprecated_task_entity_{HabiticaSensorEntity.HABITS}",
+        )
+        assert issue_registry.async_get_issue(
+            domain=DOMAIN,
+            issue_id=f"deprecated_task_entity_{HabiticaSensorEntity.REWARDS}",
+        )
+        assert issue_registry.async_get_issue(
+            domain=DOMAIN,
+            issue_id=f"deprecated_entity_{HabiticaSensorEntity.HEALTH_MAX}",
+        )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

Breaking change in the future

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Deprecates 3 sensors:

- **Max. Health:**: [The max. health is 50 for all players and cannot be altered.](https://habitica.fandom.com/wiki/Health_Points). 
- **Habits and Rewards**: All rewards and habits are dumped as JSON into the extra state attributes of these sensors, which is considered bad practice. The state of the sensors displays the total count of habits/rewards, but this kind of tasks is set up once and they don't get marked as completed or deleted upon completion, so the total count is almost always unchanged. The action `habitica.get_tasks` can be used to retrieve task data instead.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/36710

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
