### PR TITLE
IQS completion of documentation for Plugwise

### DIFF
--- a/homeassistant/components/plugwise/manifest.json
+++ b/homeassistant/components/plugwise/manifest.json
@@ -7,6 +7,7 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "loggers": ["plugwise"],
+  "quality_scale": "platinum",
   "requirements": ["plugwise==1.6.4"],
   "zeroconf": ["_plugwise._tcp.local."]
 }

--- a/homeassistant/components/plugwise/quality_scale.yaml
+++ b/homeassistant/components/plugwise/quality_scale.yaml
@@ -52,17 +52,13 @@ rules:
   repair-issues:
     status: exempt
     comment: This integration does not have repairs
-  docs-use-cases:
-    status: todo
-    comment: Docs PR 36518
+  docs-use-cases: done
   docs-supported-devices: done
   docs-supported-functions: done
   docs-data-update: done
   docs-known-limitations: done
   docs-troubleshooting: done
-  docs-examples:
-    status: todo
-    comment: Docs PR 36518
+  docs-examples: done
   ## Platinum
   async-dependency: done
   inject-websession: done

--- a/homeassistant/components/plugwise/quality_scale.yaml
+++ b/homeassistant/components/plugwise/quality_scale.yaml
@@ -60,9 +60,7 @@ rules:
   docs-supported-devices:
     status: todo
     comment: Docs PR 36500
-  docs-supported-functions:
-    status: todo
-    comment: Docs PR 36515
+  docs-supported-functions: done
   docs-data-update: done
   docs-known-limitations: done
   docs-troubleshooting: done

--- a/homeassistant/components/plugwise/quality_scale.yaml
+++ b/homeassistant/components/plugwise/quality_scale.yaml
@@ -17,10 +17,8 @@ rules:
   common-modules: done
   docs-high-level-description:
     status: todo
-    comment: Rewrite top section, docs PR prepared waiting for 36087 merge
-  docs-installation-instructions:
-    status: todo
-    comment: Docs PR 36087
+    comment: Partial in Docs PR 36087 - further work in 36500
+  docs-installation-instructions: done
   docs-removal-instructions: done
   docs-actions: done
   brands: done
@@ -35,9 +33,7 @@ rules:
   parallel-updates: done
   test-coverage: done
   integration-owner: done
-  docs-installation-parameters:
-    status: todo
-    comment: Docs PR 36087 (partial) + todo rewrite generically (PR prepared)
+  docs-installation-parameters: done
   docs-configuration-parameters:
     status: exempt
     comment: Plugwise has no options flow
@@ -60,23 +56,19 @@ rules:
     comment: This integration does not have repairs
   docs-use-cases:
     status: todo
-    comment: Check for completeness, PR prepared waiting for 36087 merge
+    comment: Docs PR 36518
   docs-supported-devices:
     status: todo
-    comment: The list is there but could be improved for readability, PR prepared waiting for 36087 merge
+    comment: Docs PR 36500
   docs-supported-functions:
     status: todo
-    comment: Check for completeness, PR prepared waiting for 36087 merge
+    comment: Docs PR 36515
   docs-data-update: done
-  docs-known-limitations:
-    status: todo
-    comment: Partial in 36087 but could be more elaborate
-  docs-troubleshooting:
-    status: todo
-    comment: Check for completeness, PR prepared waiting for 36087 merge
+  docs-known-limitations: done
+  docs-troubleshooting: done
   docs-examples:
     status: todo
-    comment: Check for completeness, PR prepared waiting for 36087 merge
+    comment: Docs PR 36518
   ## Platinum
   async-dependency: done
   inject-websession: done

--- a/homeassistant/components/plugwise/quality_scale.yaml
+++ b/homeassistant/components/plugwise/quality_scale.yaml
@@ -15,9 +15,7 @@ rules:
     status: exempt
     comment: Plugwise integration has no custom actions
   common-modules: done
-  docs-high-level-description:
-    status: todo
-    comment: Partial in Docs PR 36087 - further work in 36500
+  docs-high-level-description: done
   docs-installation-instructions: done
   docs-removal-instructions: done
   docs-actions: done
@@ -57,9 +55,7 @@ rules:
   docs-use-cases:
     status: todo
     comment: Docs PR 36518
-  docs-supported-devices:
-    status: todo
-    comment: Docs PR 36500
+  docs-supported-devices: done
   docs-supported-functions: done
   docs-data-update: done
   docs-known-limitations: done

--- a/script/hassfest/quality_scale.py
+++ b/script/hassfest/quality_scale.py
@@ -1873,7 +1873,6 @@ INTEGRATIONS_WITHOUT_SCALE = [
     "pioneer",
     "pjlink",
     "plaato",
-    "plugwise",
     "plant",
     "plex",
     "plum_lightpad",


### PR DESCRIPTION
## Proposed change
Checklist Plugwise docs for IQS: (replacing Core PR 133151)

Overview as per requested changes from the initial benchmark by @joostlek and most kudos to @bouwew for all the improvements (typing comes to mind :)).

- [x] docs-high-level-description via https://github.com/home-assistant/home-assistant.io/pull/36500 (from https://github.com/home-assistant/core/pull/131888#discussion_r1865806781) - Improved introduction tekst and restructured/reordered accordingly for improved approach (by aligning with comparable integrations)

Multiple docs related (from https://github.com/home-assistant/core/pull/131888#discussion_r1865818063)
- [x] docs-use-cases - https://github.com/home-assistant/home-assistant.io/pull/36518 - added through various sections and examples (and included gas explicitely)
- [x] docs-supported-devices - https://github.com/home-assistant/home-assistant.io/pull/36500 - reworked this section for improved reading including the top section to exclude formerly sold USB (directly)
- [x] docs-supported-functions - https://github.com/home-assistant/home-assistant.io/pull/36515 - reworked by platform section for clear structure
- [x] docs-data-update - https://github.com/home-assistant/home-assistant.io/pull/36500 - was already adjusted in earlier version, though reworked to include gas
- [x] docs-known-limitations - https://github.com/home-assistant/home-assistant.io/pull/36504- added as a section, ingesting existing remarks and added new
- [x] docs-troubleshooting - https://github.com/home-assistant/home-assistant.io/pull/36504- added as a section, ingesting existing
- [x] docs-examples - https://github.com/home-assistant/home-assistant.io/pull/36518 - the existing sample actions have been assigned to their respective platform sections, generally added more use-case directives

This continues on from https://github.com/home-assistant/home-assistant.io/pull/36087 effort on:

- [x] docs-installation-instructions (from https://github.com/home-assistant/core/pull/131888#discussion_r1865811660) - implemented in https://github.com/home-assistant/home-assistant.io/pull/36087
- [x] docs-removal-instructions (from https://github.com/home-assistant/core/pull/131888#discussion_r1865811759) - implemented in https://github.com/home-assistant/home-assistant.io/pull/36087
- [x] docs-installation-parameters (from https://github.com/home-assistant/core/pull/131888#discussion_r1865813463) - implemented in https://github.com/home-assistant/home-assistant.io/pull/36087


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
