### PR TITLE
Remove mqtt publish templates after 6 months of deprecation

### DIFF
--- a/homeassistant/components/mqtt/strings.json
+++ b/homeassistant/components/mqtt/strings.json
@@ -11,14 +11,6 @@
     "invalid_platform_config": {
       "title": "Invalid config found for mqtt {domain} item",
       "description": "Home Assistant detected an invalid config for a manually configured item.\n\nPlatform domain: **{domain}**\nConfiguration file: **{config_file}**\nNear line: **{line}**\nConfiguration found:\n```yaml\n{config}\n```\nError: **{error}**.\n\nMake sure the configuration is valid and [reload](/developer-tools/yaml) the manually configured MQTT items or restart Home Assistant to fix this issue."
-    },
-    "payload_template_deprecation": {
-      "title": "Deprecated option used in mqtt publish action call",
-      "description": "Deprecated `payload_template` option used in MQTT publish action call to topic `{topic}` from payload template `{payload_template}`. Use the `payload` option instead. In automations templates are supported natively. Update the automation or script to use the `payload` option instead and restart Home Assistant to fix this issue."
-    },
-    "topic_template_deprecation": {
-      "title": "Deprecated option used in mqtt publish action call",
-      "description": "Deprecated `topic_template` option used in MQTT publish action call to topic `{topic}` from topic template `{topic_template}`. Use the `topic` option instead. In automations templates are supported natively. Update the automation or script to use the `topic` option instead and restart Home Assistant to fix this issue."
     }
   },
   "config": {

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -275,80 +275,6 @@ async def test_service_call_mqtt_entry_does_not_publish(
         )
 
 
-# The use of a topic_template in an mqtt publish action call
-# has been deprecated with HA Core 2024.8.0 and will be removed with HA Core 2025.2.0
-async def test_mqtt_publish_action_call_with_topic_and_topic_template_does_not_publish(
-    hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
-) -> None:
-    """Test the mqtt publish action call with topic/topic template.
-
-    If both 'topic' and 'topic_template' are provided then fail.
-    """
-    mqtt_mock = await mqtt_mock_entry()
-    topic = "test/topic"
-    topic_template = "test/{{ 'topic' }}"
-    with pytest.raises(vol.Invalid):
-        await hass.services.async_call(
-            mqtt.DOMAIN,
-            mqtt.SERVICE_PUBLISH,
-            {
-                mqtt.ATTR_TOPIC: topic,
-                mqtt.ATTR_TOPIC_TEMPLATE: topic_template,
-                mqtt.ATTR_PAYLOAD: "payload",
-            },
-            blocking=True,
-        )
-    assert not mqtt_mock.async_publish.called
-
-
-# The use of a topic_template in an mqtt publish action call
-# has been deprecated with HA Core 2024.8.0 and will be removed with HA Core 2025.2.0
-async def test_mqtt_action_call_with_invalid_topic_template_does_not_publish(
-    hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
-) -> None:
-    """Test the mqtt publish action call with a problematic topic template."""
-    mqtt_mock = await mqtt_mock_entry()
-    with pytest.raises(MqttCommandTemplateException) as exc:
-        await hass.services.async_call(
-            mqtt.DOMAIN,
-            mqtt.SERVICE_PUBLISH,
-            {
-                mqtt.ATTR_TOPIC_TEMPLATE: "test/{{ 1 | no_such_filter }}",
-                mqtt.ATTR_PAYLOAD: "payload",
-            },
-            blocking=True,
-        )
-    assert str(exc.value) == (
-        "TemplateError: TemplateAssertionError: No filter named 'no_such_filter'. "
-        "rendering template, template: "
-        "'test/{{ 1 | no_such_filter }}' and payload: None"
-    )
-    assert not mqtt_mock.async_publish.called
-
-
-# The use of a topic_template in an mqtt publish action call
-# has been deprecated with HA Core 2024.8.0 and will be removed with HA Core 2025.2.0
-async def test_mqtt_publish_action_call_with_template_topic_renders_template(
-    hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
-) -> None:
-    """Test the mqtt publish action call with rendered topic template.
-
-    If 'topic_template' is provided and 'topic' is not, then render it.
-    """
-    mqtt_mock = await mqtt_mock_entry()
-    await hass.services.async_call(
-        mqtt.DOMAIN,
-        mqtt.SERVICE_PUBLISH,
-        {
-            mqtt.ATTR_TOPIC_TEMPLATE: "test/{{ 1+1 }}",
-            mqtt.ATTR_PAYLOAD: "payload",
-        },
-        blocking=True,
-    )
-    assert mqtt_mock.async_publish.called
-    assert mqtt_mock.async_publish.call_args[0][0] == "test/2"
-
-
 async def test_service_call_with_template_topic_renders_invalid_topic(
     hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
 ) -> None:
@@ -357,82 +283,21 @@ async def test_service_call_with_template_topic_renders_invalid_topic(
     If a wildcard topic is rendered, then fail.
     """
     mqtt_mock = await mqtt_mock_entry()
-    with pytest.raises(ServiceValidationError) as exc:
+    with pytest.raises(vol.Invalid) as exc:
         await hass.services.async_call(
             mqtt.DOMAIN,
             mqtt.SERVICE_PUBLISH,
             {
-                mqtt.ATTR_TOPIC_TEMPLATE: "test/{{ '+' if True else 'topic' }}/topic",
+                mqtt.ATTR_TOPIC: "test/{{ '+' if True else 'topic' }}/topic",
                 mqtt.ATTR_PAYLOAD: "payload",
             },
             blocking=True,
         )
-    assert str(exc.value) == (
-        "Unable to publish: topic template `test/{{ '+' if True else 'topic' }}/topic` "
-        "produced an invalid topic `test/+/topic` after rendering "
-        "(Wildcards cannot be used in topic names)"
+    assert (
+        str(exc.value) == "Wildcards cannot be used in topic names "
+        "for dictionary value @ data['topic']"
     )
     assert not mqtt_mock.async_publish.called
-
-
-# The use of a payload_template in an mqtt publish action call
-# has been deprecated with HA Core 2024.8.0 and will be removed with HA Core 2025.2.0
-async def test_action_call_with_invalid_rendered_payload_template_doesnt_render_template(
-    hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
-) -> None:
-    """Test the action call with unrendered payload template.
-
-    If both 'payload' and 'payload_template' are provided then fail.
-    """
-    mqtt_mock = await mqtt_mock_entry()
-    payload = "not a template"
-    payload_template = "a template"
-    with pytest.raises(vol.Invalid):
-        await hass.services.async_call(
-            mqtt.DOMAIN,
-            mqtt.SERVICE_PUBLISH,
-            {
-                mqtt.ATTR_TOPIC: "test/topic",
-                mqtt.ATTR_PAYLOAD: payload,
-                mqtt.ATTR_PAYLOAD_TEMPLATE: payload_template,
-            },
-            blocking=True,
-        )
-    assert not mqtt_mock.async_publish.called
-
-
-# The use of a payload_template in an mqtt publish action call
-# has been deprecated with HA Core 2024.8.0 and will be removed with HA Core 2025.2.0
-async def test_mqtt_publish_action_call_with_template_payload_renders_template(
-    hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
-) -> None:
-    """Test the mqtt publish action call with rendered template.
-
-    If 'payload_template' is provided and 'payload' is not, then render it.
-    """
-    mqtt_mock = await mqtt_mock_entry()
-    await hass.services.async_call(
-        mqtt.DOMAIN,
-        mqtt.SERVICE_PUBLISH,
-        {mqtt.ATTR_TOPIC: "test/topic", mqtt.ATTR_PAYLOAD_TEMPLATE: "{{ 4+4 }}"},
-        blocking=True,
-    )
-    assert mqtt_mock.async_publish.called
-    assert mqtt_mock.async_publish.call_args[0][1] == "8"
-    mqtt_mock.reset_mock()
-
-    await hass.services.async_call(
-        mqtt.DOMAIN,
-        mqtt.SERVICE_PUBLISH,
-        {
-            mqtt.ATTR_TOPIC: "test/topic",
-            mqtt.ATTR_PAYLOAD_TEMPLATE: "{{ (4+4) | pack('B') }}",
-        },
-        blocking=True,
-    )
-    assert mqtt_mock.async_publish.called
-    assert mqtt_mock.async_publish.call_args[0][1] == b"\x08"
-    mqtt_mock.reset_mock()
 
 
 @pytest.mark.parametrize(
@@ -501,56 +366,6 @@ async def test_mqtt_publish_action_call_with_raw_data(
             blocking=True,
         )
         assert len(literal_eval_mock.mock_calls) == literal_eval_calls
-
-
-# The use of a payload_template in an mqtt publish action call
-# has been deprecated with HA Core 2024.8.0 and will be removed with HA Core 2025.2.0
-async def test_publish_action_call_with_bad_payload_template(
-    hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
-) -> None:
-    """Test the mqtt publish action call with a bad template does not publish."""
-    mqtt_mock = await mqtt_mock_entry()
-    with pytest.raises(MqttCommandTemplateException) as exc:
-        await hass.services.async_call(
-            mqtt.DOMAIN,
-            mqtt.SERVICE_PUBLISH,
-            {
-                mqtt.ATTR_TOPIC: "test/topic",
-                mqtt.ATTR_PAYLOAD_TEMPLATE: "{{ 1 | bad }}",
-            },
-            blocking=True,
-        )
-    assert not mqtt_mock.async_publish.called
-    assert str(exc.value) == (
-        "TemplateError: TemplateAssertionError: No filter named 'bad'. "
-        "rendering template, template: '{{ 1 | bad }}' and payload: None"
-    )
-
-
-# The use of a payload_template in an mqtt publish action call
-# has been deprecated with HA Core 2024.8.0 and will be removed with HA Core 2025.2.0
-async def test_action_call_with_payload_doesnt_render_template(
-    hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
-) -> None:
-    """Test the mqtt publish action call with an unrendered template.
-
-    If both 'payload' and 'payload_template' are provided then fail.
-    """
-    mqtt_mock = await mqtt_mock_entry()
-    payload = "not a template"
-    payload_template = "a template"
-    with pytest.raises(vol.Invalid):
-        await hass.services.async_call(
-            mqtt.DOMAIN,
-            mqtt.SERVICE_PUBLISH,
-            {
-                mqtt.ATTR_TOPIC: "test/topic",
-                mqtt.ATTR_PAYLOAD: payload,
-                mqtt.ATTR_PAYLOAD_TEMPLATE: payload_template,
-            },
-            blocking=True,
-        )
-    assert not mqtt_mock.async_publish.called
 
 
 async def test_service_call_with_ascii_qos_retain_flags(
@@ -1719,59 +1534,6 @@ async def test_debug_info_qos_retain(
         "time": start_dt,
         "topic": "sensor/abc",
     } in messages
-
-
-# The use of a payload_template in an mqtt publish action call
-# has been deprecated with HA Core 2024.8.0 and will be removed with HA Core 2025.2.0
-async def test_publish_json_from_template(
-    hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
-) -> None:
-    """Test the publishing of call to mqtt publish action."""
-    mqtt_mock = await mqtt_mock_entry()
-
-    test_str = "{'valid': 'python', 'invalid': 'json'}"
-    test_str_tpl = "{'valid': '{{ \"python\" }}', 'invalid': 'json'}"
-
-    await async_setup_component(
-        hass,
-        "script",
-        {
-            "script": {
-                "test_script_payload": {
-                    "sequence": {
-                        "service": "mqtt.publish",
-                        "data": {"topic": "test-topic", "payload": test_str_tpl},
-                    }
-                },
-                "test_script_payload_template": {
-                    "sequence": {
-                        "service": "mqtt.publish",
-                        "data": {
-                            "topic": "test-topic",
-                            "payload_template": test_str_tpl,
-                        },
-                    }
-                },
-            }
-        },
-    )
-
-    await hass.services.async_call("script", "test_script_payload", blocking=True)
-    await hass.async_block_till_done()
-
-    assert mqtt_mock.async_publish.called
-    assert mqtt_mock.async_publish.call_args[0][1] == test_str
-
-    mqtt_mock.async_publish.reset_mock()
-    assert not mqtt_mock.async_publish.called
-
-    await hass.services.async_call(
-        "script", "test_script_payload_template", blocking=True
-    )
-    await hass.async_block_till_done()
-
-    assert mqtt_mock.async_publish.called
-    assert mqtt_mock.async_publish.call_args[0][1] == test_str
 
 
 async def test_subscribe_connection_status(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The MQTT publish action no longer supports the `topic_template` and `payload_template` attributes. In automation and scripts users can use templates by default. Users were instructed to update their automations with a repair flow when the use of the deprecated action options was detected.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove mqtt publish templates after 6 months of deprecation

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
