### PR TITLE
Remove timeout from Russound RIO initialization

### DIFF
--- a/homeassistant/components/russound_rio/__init__.py
+++ b/homeassistant/components/russound_rio/__init__.py
@@ -1,6 +1,5 @@
 """The russound_rio component."""
 
-import asyncio
 import logging
 
 from aiorussound import RussoundClient, RussoundTcpConnectionHandler
@@ -11,7 +10,7 @@ from homeassistant.const import CONF_HOST, CONF_PORT, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 
-from .const import CONNECT_TIMEOUT, DOMAIN, RUSSOUND_RIO_EXCEPTIONS
+from .const import DOMAIN, RUSSOUND_RIO_EXCEPTIONS
 
 PLATFORMS = [Platform.MEDIA_PLAYER]
 
@@ -40,8 +39,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: RussoundConfigEntry) -> 
     await client.register_state_update_callbacks(_connection_update_callback)
 
     try:
-        async with asyncio.timeout(CONNECT_TIMEOUT):
-            await client.connect()
+        await client.connect()
     except RUSSOUND_RIO_EXCEPTIONS as err:
         raise ConfigEntryNotReady(
             translation_domain=DOMAIN,

--- a/homeassistant/components/russound_rio/config_flow.py
+++ b/homeassistant/components/russound_rio/config_flow.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
 from typing import Any
 
@@ -17,7 +16,7 @@ from homeassistant.config_entries import (
 from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.helpers import config_validation as cv
 
-from .const import CONNECT_TIMEOUT, DOMAIN, RUSSOUND_RIO_EXCEPTIONS
+from .const import DOMAIN, RUSSOUND_RIO_EXCEPTIONS
 
 DATA_SCHEMA = vol.Schema(
     {
@@ -45,10 +44,9 @@ class FlowHandler(ConfigFlow, domain=DOMAIN):
 
             client = RussoundClient(RussoundTcpConnectionHandler(host, port))
             try:
-                async with asyncio.timeout(CONNECT_TIMEOUT):
-                    await client.connect()
-                    controller = client.controllers[1]
-                    await client.disconnect()
+                await client.connect()
+                controller = client.controllers[1]
+                await client.disconnect()
             except RUSSOUND_RIO_EXCEPTIONS:
                 _LOGGER.exception("Could not connect to Russound RIO")
                 errors["base"] = "cannot_connect"
@@ -90,10 +88,9 @@ class FlowHandler(ConfigFlow, domain=DOMAIN):
         # Connection logic is repeated here since this method will be removed in future releases
         client = RussoundClient(RussoundTcpConnectionHandler(host, port))
         try:
-            async with asyncio.timeout(CONNECT_TIMEOUT):
-                await client.connect()
-                controller = client.controllers[1]
-                await client.disconnect()
+            await client.connect()
+            controller = client.controllers[1]
+            await client.disconnect()
         except RUSSOUND_RIO_EXCEPTIONS:
             _LOGGER.exception("Could not connect to Russound RIO")
             return self.async_abort(

--- a/homeassistant/components/russound_rio/const.py
+++ b/homeassistant/components/russound_rio/const.py
@@ -16,9 +16,6 @@ RUSSOUND_RIO_EXCEPTIONS = (
     asyncio.CancelledError,
 )
 
-
-CONNECT_TIMEOUT = 15
-
 MP_FEATURES_BY_FLAG = {
     FeatureFlag.COMMANDS_ZONE_MUTE_OFF_ON: MediaPlayerEntityFeature.VOLUME_MUTE
 }


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
**⚠️ Please add to 2025.1 milestone. Resolves a crucial issue preventing users with 3+ controllers from connecting**

Timeouts have been removed from the integration as they have been implemented in the upstream library.
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/issues/133787
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
