### PR TITLE
Revert "Add state_class to EcoWittSensorTypes.DEGREE"

### DIFF
--- a/homeassistant/components/ecowitt/sensor.py
+++ b/homeassistant/components/ecowitt/sensor.py
@@ -65,9 +65,7 @@ ECOWITT_SENSORS_MAPPING: Final = {
         state_class=SensorStateClass.MEASUREMENT,
     ),
     EcoWittSensorTypes.DEGREE: SensorEntityDescription(
-        key="DEGREE",
-        native_unit_of_measurement=DEGREE,
-        state_class=SensorStateClass.MEASUREMENT,
+        key="DEGREE", native_unit_of_measurement=DEGREE
     ),
     EcoWittSensorTypes.WATT_METERS_SQUARED: SensorEntityDescription(
         key="WATT_METERS_SQUARED",


### PR DESCRIPTION
Reverts home-assistant/core#134004

Reverts the addition of the state class. Adding a measurement state class to a non-linear sensor (rotational), doesn't work. 

A simple example: Let's say my wind direction is hovering all day today between 10 and 350 degrees. Do you expect the average to be 180? That isn't right...

It is perfectly fine for an entity not to have a state class.

