### PR TITLE
Make elevenlabs recoverable

### DIFF
--- a/homeassistant/components/elevenlabs/__init__.py
+++ b/homeassistant/components/elevenlabs/__init__.py
@@ -6,11 +6,16 @@ from dataclasses import dataclass
 
 from elevenlabs import AsyncElevenLabs, Model
 from elevenlabs.core import ApiError
+from httpx import ConnectError
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_API_KEY, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryError
+from homeassistant.exceptions import (
+    ConfigEntryAuthFailed,
+    ConfigEntryError,
+    ConfigEntryNotReady,
+)
 from homeassistant.helpers.httpx_client import get_async_client
 
 from .const import CONF_MODEL
@@ -48,6 +53,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ElevenLabsConfigEntry) -
     model_id = entry.options[CONF_MODEL]
     try:
         model = await get_model_by_id(client, model_id)
+    except ConnectError as err:
+        raise ConfigEntryNotReady("Failed to connect") from err
     except ApiError as err:
         raise ConfigEntryAuthFailed("Auth failed") from err
 

--- a/tests/components/elevenlabs/conftest.py
+++ b/tests/components/elevenlabs/conftest.py
@@ -42,7 +42,7 @@ def mock_async_client() -> Generator[AsyncMock]:
 
 
 @pytest.fixture
-def mock_async_client_fail() -> Generator[AsyncMock]:
+def mock_async_client_api_error() -> Generator[AsyncMock]:
     """Override async ElevenLabs client."""
     with patch(
         "homeassistant.components.elevenlabs.config_flow.AsyncElevenLabs",

--- a/tests/components/elevenlabs/conftest.py
+++ b/tests/components/elevenlabs/conftest.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, patch
 
 from elevenlabs.core import ApiError
 from elevenlabs.types import GetVoicesResponse
+from httpx import ConnectError
 import pytest
 
 from homeassistant.components.elevenlabs.const import CONF_MODEL, CONF_VOICE
@@ -34,21 +35,55 @@ def _client_mock():
 @pytest.fixture
 def mock_async_client() -> Generator[AsyncMock]:
     """Override async ElevenLabs client."""
-    with patch(
-        "homeassistant.components.elevenlabs.config_flow.AsyncElevenLabs",
-        return_value=_client_mock(),
-    ) as mock_async_client:
+    with (
+        patch(
+            "homeassistant.components.elevenlabs.AsyncElevenLabs",
+            return_value=_client_mock(),
+        ) as mock_async_client,
+        patch(
+            "homeassistant.components.elevenlabs.config_flow.AsyncElevenLabs",
+            new=mock_async_client,
+        ),
+    ):
         yield mock_async_client
 
 
 @pytest.fixture
 def mock_async_client_api_error() -> Generator[AsyncMock]:
+    """Override async ElevenLabs client with ApiError side effect."""
+    client_mock = _client_mock()
+    client_mock.models.get_all.side_effect = ApiError
+    client_mock.voices.get_all.side_effect = ApiError
+
+    with (
+        patch(
+            "homeassistant.components.elevenlabs.AsyncElevenLabs",
+            return_value=client_mock,
+        ) as mock_async_client,
+        patch(
+            "homeassistant.components.elevenlabs.config_flow.AsyncElevenLabs",
+            new=mock_async_client,
+        ),
+    ):
+        yield mock_async_client
+
+
+@pytest.fixture
+def mock_async_client_connect_error() -> Generator[AsyncMock]:
     """Override async ElevenLabs client."""
-    with patch(
-        "homeassistant.components.elevenlabs.config_flow.AsyncElevenLabs",
-        return_value=_client_mock(),
-    ) as mock_async_client:
-        mock_async_client.side_effect = ApiError
+    client_mock = _client_mock()
+    client_mock.models.get_all.side_effect = ConnectError("Unknown")
+    client_mock.voices.get_all.side_effect = ConnectError("Unknown")
+    with (
+        patch(
+            "homeassistant.components.elevenlabs.AsyncElevenLabs",
+            return_value=client_mock,
+        ) as mock_async_client,
+        patch(
+            "homeassistant.components.elevenlabs.config_flow.AsyncElevenLabs",
+            new=mock_async_client,
+        ),
+    ):
         yield mock_async_client
 
 

--- a/tests/components/elevenlabs/test_config_flow.py
+++ b/tests/components/elevenlabs/test_config_flow.py
@@ -56,7 +56,9 @@ async def test_user_step(
 
 
 async def test_invalid_api_key(
-    hass: HomeAssistant, mock_setup_entry: AsyncMock, mock_async_client_fail: AsyncMock
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_async_client_api_error: AsyncMock,
 ) -> None:
     """Test user step with invalid api key."""
 
@@ -78,7 +80,7 @@ async def test_invalid_api_key(
     mock_setup_entry.assert_not_called()
 
     # Reset the side effect
-    mock_async_client_fail.side_effect = None
+    mock_async_client_api_error.side_effect = None
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],

--- a/tests/components/elevenlabs/test_config_flow.py
+++ b/tests/components/elevenlabs/test_config_flow.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import AsyncMock
 
+import pytest
+
 from homeassistant.components.elevenlabs.const import (
     CONF_CONFIGURE_VOICE,
     CONF_MODEL,
@@ -59,6 +61,7 @@ async def test_invalid_api_key(
     hass: HomeAssistant,
     mock_setup_entry: AsyncMock,
     mock_async_client_api_error: AsyncMock,
+    request: pytest.FixtureRequest,
 ) -> None:
     """Test user step with invalid api key."""
 
@@ -79,8 +82,8 @@ async def test_invalid_api_key(
 
     mock_setup_entry.assert_not_called()
 
-    # Reset the side effect
-    mock_async_client_api_error.side_effect = None
+    # Use a working client
+    request.getfixturevalue("mock_async_client")
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],

--- a/tests/components/elevenlabs/test_setup.py
+++ b/tests/components/elevenlabs/test_setup.py
@@ -1,0 +1,60 @@
+"""Tests for the ElevenLabs TTS entity."""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from httpx import ConnectError
+import pytest
+
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+
+from .conftest import _client_mock
+
+from tests.common import MockConfigEntry
+
+
+@pytest.fixture
+def mock_setup_async_client() -> Generator[AsyncMock]:
+    """Override async ElevenLabs client."""
+    with patch(
+        "homeassistant.components.elevenlabs.AsyncElevenLabs",
+        return_value=_client_mock(),
+    ) as mock_async_client:
+        yield mock_async_client
+
+
+@pytest.fixture
+def mock_setup_async_client_connect_error() -> Generator[AsyncMock]:
+    """Override async ElevenLabs client."""
+    client_mock = _client_mock()
+    client_mock.models.get_all.side_effect = ConnectError("Unknown")
+    with patch(
+        "homeassistant.components.elevenlabs.AsyncElevenLabs", return_value=client_mock
+    ) as mock_async_client:
+        yield mock_async_client
+
+
+async def test_setup(
+    hass: HomeAssistant,
+    mock_setup_async_client: MagicMock,
+    mock_entry: MockConfigEntry,
+) -> None:
+    """Test entry setup without any exceptions."""
+    mock_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_entry.entry_id)
+    assert mock_entry.state == ConfigEntryState.LOADED
+
+
+async def test_setup_connect_error(
+    hass: HomeAssistant,
+    mock_setup_async_client_connect_error: MagicMock,
+    mock_entry: MockConfigEntry,
+) -> None:
+    """Test entry setup with a connection error."""
+    mock_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_entry.entry_id)
+    # Ensure is not ready
+    assert mock_entry.state == ConfigEntryState.SETUP_RETRY

--- a/tests/components/elevenlabs/test_setup.py
+++ b/tests/components/elevenlabs/test_setup.py
@@ -19,6 +19,9 @@ async def test_setup(
     mock_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(mock_entry.entry_id)
     assert mock_entry.state == ConfigEntryState.LOADED
+    # Unload
+    await hass.config_entries.async_unload(mock_entry.entry_id)
+    assert mock_entry.state == ConfigEntryState.NOT_LOADED
 
 
 async def test_setup_connect_error(

--- a/tests/components/elevenlabs/test_setup.py
+++ b/tests/components/elevenlabs/test_setup.py
@@ -2,44 +2,17 @@
 
 from __future__ import annotations
 
-from collections.abc import Generator
-from unittest.mock import AsyncMock, MagicMock, patch
-
-from httpx import ConnectError
-import pytest
+from unittest.mock import MagicMock
 
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 
-from .conftest import _client_mock
-
 from tests.common import MockConfigEntry
-
-
-@pytest.fixture
-def mock_setup_async_client() -> Generator[AsyncMock]:
-    """Override async ElevenLabs client."""
-    with patch(
-        "homeassistant.components.elevenlabs.AsyncElevenLabs",
-        return_value=_client_mock(),
-    ) as mock_async_client:
-        yield mock_async_client
-
-
-@pytest.fixture
-def mock_setup_async_client_connect_error() -> Generator[AsyncMock]:
-    """Override async ElevenLabs client."""
-    client_mock = _client_mock()
-    client_mock.models.get_all.side_effect = ConnectError("Unknown")
-    with patch(
-        "homeassistant.components.elevenlabs.AsyncElevenLabs", return_value=client_mock
-    ) as mock_async_client:
-        yield mock_async_client
 
 
 async def test_setup(
     hass: HomeAssistant,
-    mock_setup_async_client: MagicMock,
+    mock_async_client: MagicMock,
     mock_entry: MockConfigEntry,
 ) -> None:
     """Test entry setup without any exceptions."""
@@ -50,7 +23,7 @@ async def test_setup(
 
 async def test_setup_connect_error(
     hass: HomeAssistant,
-    mock_setup_async_client_connect_error: MagicMock,
+    mock_async_client_connect_error: MagicMock,
     mock_entry: MockConfigEntry,
 ) -> None:
     """Test entry setup with a connection error."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Make elevenlabs recoverable

So last night the power went out in my building, and it got restored an hour later. The main internet switch did not restore right away. This of course causes HA to still try to connect to the internet, but it can't resolve DNS.

```
2024-12-26 19:12:00.682 ERROR (MainThread) [homeassistant.config_entries] Error setting up entry ElevenLabs for elevenlabs
Traceback (most recent call last):
  File "/usr/local/lib/python3.13/site-packages/httpx/_transports/default.py", line 72, in map_httpcore_exceptions
    yield
  File "/usr/local/lib/python3.13/site-packages/httpx/_transports/default.py", line 377, in handle_async_request
    resp = await self._pool.handle_async_request(req)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/httpcore/_async/connection_pool.py", line 216, in handle_async_request
    raise exc from None
  File "/usr/local/lib/python3.13/site-packages/httpcore/_async/connection_pool.py", line 196, in handle_async_request
    response = await connection.handle_async_request(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        pool_request.request
        ^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/usr/local/lib/python3.13/site-packages/httpcore/_async/connection.py", line 99, in handle_async_request
    raise exc
  File "/usr/local/lib/python3.13/site-packages/httpcore/_async/connection.py", line 76, in handle_async_request
    stream = await self._connect(request)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/httpcore/_async/connection.py", line 122, in _connect
    stream = await self._network_backend.connect_tcp(**kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/httpcore/_backends/auto.py", line 30, in connect_tcp
    return await self._backend.connect_tcp(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<5 lines>...
    )
    ^
  File "/usr/local/lib/python3.13/site-packages/httpcore/_backends/anyio.py", line 114, in connect_tcp
    with map_exceptions(exc_map):
         ~~~~~~~~~~~~~~^^^^^^^^^
  File "/usr/local/lib/python3.13/contextlib.py", line 162, in __exit__
    self.gen.throw(value)
    ~~~~~~~~~~~~~~^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
    raise to_exc(exc) from exc
httpcore.ConnectError: [Errno -3] Try again

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/config_entries.py", line 640, in __async_setup_with_context
    result = await component.async_setup_entry(hass, self)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/elevenlabs/__init__.py", line 50, in async_setup_entry
    model = await get_model_by_id(client, model_id)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/elevenlabs/__init__.py", line 23, in get_model_by_id
    models = await client.models.get_all()
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/elevenlabs/models/client.py", line 107, in get_all
    _response = await self._client_wrapper.httpx_client.request(
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<3 lines>...
    )
    ^
  File "/usr/local/lib/python3.13/site-packages/elevenlabs/core/http_client.py", line 361, in request
    response = await self.httpx_client.request(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<33 lines>...
    )
    ^
  File "/usr/local/lib/python3.13/site-packages/httpx/_client.py", line 1585, in request
    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/httpx/_client.py", line 1674, in send
    response = await self._send_handling_auth(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<4 lines>...
    )
    ^
  File "/usr/local/lib/python3.13/site-packages/httpx/_client.py", line 1702, in _send_handling_auth
    response = await self._send_handling_redirects(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<3 lines>...
    )
    ^
  File "/usr/local/lib/python3.13/site-packages/httpx/_client.py", line 1739, in _send_handling_redirects
    response = await self._send_single_request(request)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/httpx/_client.py", line 1776, in _send_single_request
    response = await transport.handle_async_request(request)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/httpx/_transports/default.py", line 376, in handle_async_request
    with map_httpcore_exceptions():
         ~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/local/lib/python3.13/contextlib.py", line 162, in __exit__
    self.gen.throw(value)
    ~~~~~~~~~~~~~~^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/httpx/_transports/default.py", line 89, in map_httpcore_exceptions
    raise mapped_exc(message) from exc
httpx.ConnectError: [Errno -3] Try again
```

After this, the integration did not reload anymore. This PR is making sure we catch this exception so we can retry again later

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
