### PR TITLE
Add HEOS options flow for optional authentication

### DIFF
--- a/homeassistant/components/heos/__init__.py
+++ b/homeassistant/components/heos/__init__.py
@@ -109,11 +109,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: HeosConfigEntry) -> bool
             favorites = await controller.get_favorites()
         else:
             _LOGGER.warning(
-                (
-                    "%s is not logged in to a HEOS account and will be unable to"
-                    " retrieve HEOS favorites: Use the 'heos.sign_in' service to"
-                    " sign-in to a HEOS account"
-                ),
+                "HEOS System (via %s) is not logged in: enter credentials in the integration options to access favorites and streaming services",
                 host,
             )
         inputs = await controller.get_input_sources()

--- a/homeassistant/components/heos/__init__.py
+++ b/homeassistant/components/heos/__init__.py
@@ -70,7 +70,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: HeosConfigEntry) -> bool
 
     host = entry.data[CONF_HOST]
     credentials: Credentials | None = None
-    if CONF_USERNAME in entry.options and CONF_PASSWORD in entry.options:
+    if entry.options:
         credentials = Credentials(
             entry.options[CONF_USERNAME], entry.options[CONF_PASSWORD]
         )
@@ -108,9 +108,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: HeosConfigEntry) -> bool
         if controller.is_signed_in:
             favorites = await controller.get_favorites()
         else:
-            _LOGGER.warning(
-                "HEOS System (via %s) is not logged in: enter credentials in the integration options to access favorites and streaming services",
-                host,
+            _LOGGER.info(
+                "The HEOS System is not logged in: Enter credentials in the integration options to access favorites and streaming services"
             )
         inputs = await controller.get_input_sources()
     except HeosError as error:

--- a/homeassistant/components/heos/__init__.py
+++ b/homeassistant/components/heos/__init__.py
@@ -108,7 +108,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: HeosConfigEntry) -> bool
         if controller.is_signed_in:
             favorites = await controller.get_favorites()
         else:
-            _LOGGER.info(
+            _LOGGER.warning(
                 "The HEOS System is not logged in: Enter credentials in the integration options to access favorites and streaming services"
             )
         inputs = await controller.get_input_sources()

--- a/homeassistant/components/heos/config_flow.py
+++ b/homeassistant/components/heos/config_flow.py
@@ -139,9 +139,9 @@ class HeosOptionsFlowHandler(OptionsFlow):
         if user_input is not None:
             authentication = CONF_USERNAME in user_input or CONF_PASSWORD in user_input
             if authentication and CONF_USERNAME not in user_input:
-                errors["username"] = "username_missing"
+                errors[CONF_USERNAME] = "username_missing"
             if authentication and CONF_PASSWORD not in user_input:
-                errors["password"] = "password_missing"
+                errors[CONF_PASSWORD] = "password_missing"
 
             if not errors:
                 heos = cast(
@@ -160,12 +160,12 @@ class HeosOptionsFlowHandler(OptionsFlow):
                                 heos.signed_in_username,
                             )
                         except CommandFailedError as err:
-                            log_level = logging.INFO
+                            errors["base"] = "unknown"
+                            log_level = logging.ERROR
+
                             if err.error_id in (6, 8, 10):
                                 errors["base"] = "invalid_auth"
-                            else:
-                                errors["base"] = "unknown"
-                                log_level = logging.ERROR
+                                log_level = logging.INFO
 
                             _LOGGER.log(
                                 log_level, "Failed to sign-in to HEOS Account: %s", err
@@ -175,8 +175,8 @@ class HeosOptionsFlowHandler(OptionsFlow):
                         await heos.sign_out()
                         _LOGGER.info("Successfully signed-out of HEOS Account")
                 except HeosError:
-                    _LOGGER.exception("Unexpected error occurred during sign-in/out")
                     errors["base"] = "unknown"
+                    _LOGGER.exception("Unexpected error occurred during sign-in/out")
 
             if not errors:
                 return self.async_create_entry(data=user_input)

--- a/homeassistant/components/heos/config_flow.py
+++ b/homeassistant/components/heos/config_flow.py
@@ -160,16 +160,13 @@ class HeosOptionsFlowHandler(OptionsFlow):
                                 heos.signed_in_username,
                             )
                         except CommandFailedError as err:
-                            errors["base"] = "unknown"
-                            log_level = logging.ERROR
-
-                            if err.error_id in (6, 8, 10):
+                            if err.error_id in (6, 8, 10):  # Auth-specific errors
                                 errors["base"] = "invalid_auth"
-                                log_level = logging.INFO
-
-                            _LOGGER.log(
-                                log_level, "Failed to sign-in to HEOS Account: %s", err
-                            )
+                                _LOGGER.info(
+                                    "Failed to sign-in to HEOS Account: %s", err
+                                )
+                            else:
+                                raise  # Re-raise unexpected error
                     else:
                         # Log out
                         await heos.sign_out()

--- a/homeassistant/components/heos/config_flow.py
+++ b/homeassistant/components/heos/config_flow.py
@@ -149,7 +149,7 @@ class HeosOptionsFlowHandler(OptionsFlow):
                 )
 
                 try:
-                    if authentication:
+                    if user_input:
                         # Attempt to login
                         try:
                             await heos.sign_in(

--- a/homeassistant/components/heos/config_flow.py
+++ b/homeassistant/components/heos/config_flow.py
@@ -154,10 +154,6 @@ class HeosOptionsFlowHandler(OptionsFlow):
                         await heos.sign_in(
                             user_input[CONF_USERNAME], user_input[CONF_PASSWORD]
                         )
-                        _LOGGER.debug(
-                            "Successfully signed-in to HEOS Account: %s",
-                            heos.signed_in_username,
-                        )
                     except CommandFailedError as err:
                         if err.error_id in (6, 8, 10):  # Auth-specific errors
                             errors["base"] = "invalid_auth"
@@ -172,14 +168,20 @@ class HeosOptionsFlowHandler(OptionsFlow):
                     except HeosError:
                         errors["base"] = "unknown"
                         _LOGGER.exception("Unexpected error occurred during sign-in")
+                    else:
+                        _LOGGER.debug(
+                            "Successfully signed-in to HEOS Account: %s",
+                            heos.signed_in_username,
+                        )
                 else:
                     # Log out
                     try:
                         await heos.sign_out()
-                        _LOGGER.debug("Successfully signed-out of HEOS Account")
                     except HeosError:
                         errors["base"] = "unknown"
                         _LOGGER.exception("Unexpected error occurred during sign-out")
+                    else:
+                        _LOGGER.debug("Successfully signed-out of HEOS Account")
 
             if not errors:
                 return self.async_create_entry(data=user_input)

--- a/homeassistant/components/heos/config_flow.py
+++ b/homeassistant/components/heos/config_flow.py
@@ -148,32 +148,38 @@ class HeosOptionsFlowHandler(OptionsFlow):
                     Heos, self.config_entry.runtime_data.controller_manager.controller
                 )
 
-                try:
-                    if user_input:
-                        # Attempt to login
-                        try:
-                            await heos.sign_in(
-                                user_input[CONF_USERNAME], user_input[CONF_PASSWORD]
+                if user_input:
+                    # Attempt to login
+                    try:
+                        await heos.sign_in(
+                            user_input[CONF_USERNAME], user_input[CONF_PASSWORD]
+                        )
+                        _LOGGER.debug(
+                            "Successfully signed-in to HEOS Account: %s",
+                            heos.signed_in_username,
+                        )
+                    except CommandFailedError as err:
+                        if err.error_id in (6, 8, 10):  # Auth-specific errors
+                            errors["base"] = "invalid_auth"
+                            _LOGGER.warning(
+                                "Failed to sign-in to HEOS Account: %s", err
                             )
-                            _LOGGER.info(
-                                "Successfully signed-in to HEOS Account: %s",
-                                heos.signed_in_username,
+                        else:
+                            errors["base"] = "unknown"
+                            _LOGGER.exception(
+                                "Unexpected error occurred during sign-in"
                             )
-                        except CommandFailedError as err:
-                            if err.error_id in (6, 8, 10):  # Auth-specific errors
-                                errors["base"] = "invalid_auth"
-                                _LOGGER.info(
-                                    "Failed to sign-in to HEOS Account: %s", err
-                                )
-                            else:
-                                raise  # Re-raise unexpected error
-                    else:
-                        # Log out
+                    except HeosError:
+                        errors["base"] = "unknown"
+                        _LOGGER.exception("Unexpected error occurred during sign-in")
+                else:
+                    # Log out
+                    try:
                         await heos.sign_out()
-                        _LOGGER.info("Successfully signed-out of HEOS Account")
-                except HeosError:
-                    errors["base"] = "unknown"
-                    _LOGGER.exception("Unexpected error occurred during sign-in/out")
+                        _LOGGER.debug("Successfully signed-out of HEOS Account")
+                    except HeosError:
+                        errors["base"] = "unknown"
+                        _LOGGER.exception("Unexpected error occurred during sign-out")
 
             if not errors:
                 return self.async_create_entry(data=user_input)

--- a/homeassistant/components/heos/quality_scale.yaml
+++ b/homeassistant/components/heos/quality_scale.yaml
@@ -33,10 +33,7 @@ rules:
     status: todo
     comment: Actions currently only log and instead should raise exceptions.
   config-entry-unloading: done
-  docs-configuration-parameters:
-    status: done
-    comment: |
-      The integration doesn't provide any additional configuration parameters.
+  docs-configuration-parameters: done
   docs-installation-parameters: done
   entity-unavailable: done
   integration-owner: done

--- a/homeassistant/components/heos/strings.json
+++ b/homeassistant/components/heos/strings.json
@@ -31,6 +31,27 @@
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
     }
   },
+  "options": {
+    "step": {
+      "init": {
+        "description": "You can sign-in to your HEOS Account to access favorites, streaming services, and other features. Clearing the credentials will sign-out of your account.",
+        "data": {
+          "username": "[%key:common::config_flow::data::username%]",
+          "password": "[%key:common::config_flow::data::password%]"
+        },
+        "data_description": {
+          "username": "The username or e-mail address of your HEOS Account.",
+          "password": "The password to your HEOS Account."
+        }
+      }
+    },
+    "error": {
+      "username_missing": "Username is missing",
+      "password_missing": "Password is missing",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
+    }
+  },
   "services": {
     "sign_in": {
       "name": "Sign in",

--- a/homeassistant/components/heos/strings.json
+++ b/homeassistant/components/heos/strings.json
@@ -34,6 +34,7 @@
   "options": {
     "step": {
       "init": {
+        "title": "HEOS Options",
         "description": "You can sign-in to your HEOS Account to access favorites, streaming services, and other features. Clearing the credentials will sign-out of your account.",
         "data": {
           "username": "[%key:common::config_flow::data::username%]",

--- a/homeassistant/components/heos/strings.json
+++ b/homeassistant/components/heos/strings.json
@@ -41,7 +41,7 @@
           "password": "[%key:common::config_flow::data::password%]"
         },
         "data_description": {
-          "username": "The username or e-mail address of your HEOS Account.",
+          "username": "The username or email address of your HEOS Account.",
           "password": "The password to your HEOS Account."
         }
       }

--- a/tests/components/heos/conftest.py
+++ b/tests/components/heos/conftest.py
@@ -18,21 +18,45 @@ import pytest
 import pytest_asyncio
 
 from homeassistant.components import ssdp
-from homeassistant.components.heos import DOMAIN
+from homeassistant.components.heos import (
+    DOMAIN,
+    ControllerManager,
+    GroupManager,
+    HeosRuntimeData,
+    SourceManager,
+)
 from homeassistant.const import CONF_HOST
 
 from tests.common import MockConfigEntry
 
 
 @pytest.fixture(name="config_entry")
-def config_entry_fixture():
+def config_entry_fixture(heos_runtime_data):
     """Create a mock HEOS config entry."""
-    return MockConfigEntry(
+    entry = MockConfigEntry(
         domain=DOMAIN,
         data={CONF_HOST: "127.0.0.1"},
         title="HEOS System (via 127.0.0.1)",
         unique_id=DOMAIN,
     )
+    entry.runtime_data = heos_runtime_data
+    return entry
+
+
+@pytest.fixture(name="heos_runtime_data")
+def heos_runtime_data_fixture(controller_manager, players):
+    """Create a mock HeosRuntimeData fixture."""
+    return HeosRuntimeData(
+        controller_manager, Mock(GroupManager), Mock(SourceManager), players
+    )
+
+
+@pytest.fixture(name="controller_manager")
+def controller_manager_fixture(controller):
+    """Create a mock controller manager fixture."""
+    mock_controller_manager = Mock(ControllerManager)
+    mock_controller_manager.controller = controller
+    return mock_controller_manager
 
 
 @pytest.fixture(name="controller")

--- a/tests/components/heos/test_config_flow.py
+++ b/tests/components/heos/test_config_flow.py
@@ -225,6 +225,18 @@ async def test_options_flow_signs_in(
         assert result["errors"] == {"base": "invalid_auth"}
         assert result["type"] is FlowResultType.FORM
 
+    # Unknown command error validating credentials shows error
+    controller.sign_in.reset_mock()
+    controller.sign_in.side_effect = CommandFailedError("sign_in", "System error", 12)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input
+    )
+    assert controller.sign_in.call_count == 1
+    assert controller.sign_out.call_count == 0
+    assert result["step_id"] == "init"
+    assert result["errors"] == {"base": "unknown"}
+    assert result["type"] is FlowResultType.FORM
+
     # Unknown error validating credentials shows error
     controller.sign_in.reset_mock()
     controller.sign_in.side_effect = HeosError()

--- a/tests/components/heos/test_config_flow.py
+++ b/tests/components/heos/test_config_flow.py
@@ -261,8 +261,21 @@ async def test_options_flow_signs_out(
     assert result["errors"] == {}
     assert result["type"] is FlowResultType.FORM
 
-    # Clear credentials
+    # Fail to sign-out, show error
     user_input = {}
+    controller.sign_out.side_effect = HeosError()
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input
+    )
+    assert controller.sign_in.call_count == 0
+    assert controller.sign_out.call_count == 1
+    assert result["step_id"] == "init"
+    assert result["errors"] == {"base": "unknown"}
+    assert result["type"] is FlowResultType.FORM
+
+    # Clear credentials
+    controller.sign_out.reset_mock()
+    controller.sign_out.side_effect = None
     result = await hass.config_entries.options.async_configure(
         result["flow_id"], user_input
     )

--- a/tests/components/heos/test_init.py
+++ b/tests/components/heos/test_init.py
@@ -8,7 +8,6 @@ from pyheos import CommandFailedError, HeosError, const
 import pytest
 
 from homeassistant.components.heos import (
-    CONF_PASSWORD,
     ControllerManager,
     HeosOptions,
     HeosRuntimeData,
@@ -17,7 +16,7 @@ from homeassistant.components.heos import (
 )
 from homeassistant.components.heos.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import CONF_HOST, CONF_USERNAME
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.setup import async_setup_component

--- a/tests/components/heos/test_init.py
+++ b/tests/components/heos/test_init.py
@@ -85,8 +85,7 @@ async def test_async_setup_entry_not_signed_in_loads_platforms(
         assert controller.get_input_sources.call_count == 1
         controller.disconnect.assert_not_called()
     assert (
-        "127.0.0.1 is not logged in to a HEOS account and will be unable to retrieve "
-        "HEOS favorites: Use the 'heos.sign_in' service to sign-in to a HEOS account"
+        "HEOS System (via 127.0.0.1) is not logged in: enter credentials in the integration options to access favorites and streaming services"
         in caplog.text
     )
 

--- a/tests/components/heos/test_init.py
+++ b/tests/components/heos/test_init.py
@@ -1,18 +1,23 @@
 """Tests for the init module."""
 
 import asyncio
+from typing import cast
 from unittest.mock import Mock, patch
 
 from pyheos import CommandFailedError, HeosError, const
 import pytest
 
 from homeassistant.components.heos import (
+    CONF_PASSWORD,
     ControllerManager,
+    HeosOptions,
     HeosRuntimeData,
     async_setup_entry,
     async_unload_entry,
 )
 from homeassistant.components.heos.const import DOMAIN
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import CONF_HOST, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.setup import async_setup_component
@@ -59,6 +64,32 @@ async def test_async_setup_entry_loads_platforms(
         assert controller.get_favorites.call_count == 1
         assert controller.get_input_sources.call_count == 1
         controller.disconnect.assert_not_called()
+
+
+async def test_async_setup_entry_with_options_loads_platforms(
+    hass: HomeAssistant,
+    config_entry_options,
+    config,
+    controller,
+    input_sources,
+    favorites,
+) -> None:
+    """Test load connects to heos with options, retrieves players, and loads platforms."""
+    config_entry_options.add_to_hass(hass)
+    assert await async_setup_component(hass, DOMAIN, config)
+    await hass.async_block_till_done()
+
+    # Assert options passed and methods called
+    assert config_entry_options.state is ConfigEntryState.LOADED
+    options = cast(HeosOptions, controller.call_args[0][0])
+    assert options.host == config_entry_options.data[CONF_HOST]
+    assert options.credentials.username == config_entry_options.options[CONF_USERNAME]
+    assert options.credentials.password == config_entry_options.options[CONF_PASSWORD]
+    assert controller.connect.call_count == 1
+    assert controller.get_players.call_count == 1
+    assert controller.get_favorites.call_count == 1
+    assert controller.get_input_sources.call_count == 1
+    controller.disconnect.assert_not_called()
 
 
 async def test_async_setup_entry_not_signed_in_loads_platforms(

--- a/tests/components/heos/test_init.py
+++ b/tests/components/heos/test_init.py
@@ -115,7 +115,7 @@ async def test_async_setup_entry_not_signed_in_loads_platforms(
         assert controller.get_input_sources.call_count == 1
         controller.disconnect.assert_not_called()
     assert (
-        "HEOS System (via 127.0.0.1) is not logged in: enter credentials in the integration options to access favorites and streaming services"
+        "The HEOS System is not logged in: Enter credentials in the integration options to access favorites and streaming services"
         in caplog.text
     )
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds options flow for the user to enter their HEOS Account credentials used to access their favorites, playlists, and streaming services. The integration uses the stored credentials to ensure the HEOS System is logged in. When the credentials are cleared from the options flow, it will explicitly sign out of the HEOS Account. Previously, users were automating calls to the sign-in custom service action. This removes the need call the service actions directly.

Future enhancements:
- Add re-auth flow for when an invalid credentials callback event received from HEOS
- Deprecate `sign_in` and `sign_out` actions.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository] https://github.com/home-assistant/home-assistant.io/pull/36583

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
