### PR TITLE
Remove incorrect device check in LCN events

### DIFF
--- a/homeassistant/components/lcn/__init__.py
+++ b/homeassistant/components/lcn/__init__.py
@@ -230,8 +230,6 @@ def async_host_input_received(
     )
     identifiers = {(DOMAIN, generate_unique_id(config_entry.entry_id, address))}
     device = device_registry.async_get_device(identifiers=identifiers)
-    if device is None:
-        return
 
     if isinstance(inp, pypck.inputs.ModStatusAccessControl):
         _async_fire_access_control_event(hass, device, address, inp)
@@ -240,7 +238,10 @@ def async_host_input_received(
 
 
 def _async_fire_access_control_event(
-    hass: HomeAssistant, device: dr.DeviceEntry, address: AddressType, inp: InputType
+    hass: HomeAssistant,
+    device: dr.DeviceEntry | None,
+    address: AddressType,
+    inp: InputType,
 ) -> None:
     """Fire access control event (transponder, transmitter, fingerprint, codelock)."""
     event_data = {
@@ -262,7 +263,10 @@ def _async_fire_access_control_event(
 
 
 def _async_fire_send_keys_event(
-    hass: HomeAssistant, device: dr.DeviceEntry, address: AddressType, inp: InputType
+    hass: HomeAssistant,
+    device: dr.DeviceEntry | None,
+    address: AddressType,
+    inp: InputType,
 ) -> None:
     """Fire send_keys event."""
     for table, action in enumerate(inp.actions):

--- a/tests/components/lcn/test_events.py
+++ b/tests/components/lcn/test_events.py
@@ -150,19 +150,3 @@ async def test_dont_fire_on_non_module_input(
         await lcn_connection.async_process_input(inp)
         await hass.async_block_till_done()
         assert len(events) == 0
-
-
-async def test_dont_fire_on_unknown_module(
-    hass: HomeAssistant, entry: MockConfigEntry
-) -> None:
-    """Test for no event is fired if an input from an unknown module is received."""
-    lcn_connection = await init_integration(hass, entry)
-    inp = ModStatusAccessControl(
-        LcnAddr(0, 10, False),  # unknown module
-        periphery=AccessControlPeriphery.FINGERPRINT,
-        code="aabbcc",
-    )
-    events = async_capture_events(hass, LCN_FINGERPRINT)
-    await lcn_connection.async_process_input(inp)
-    await hass.async_block_till_done()
-    assert len(events) == 0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Removal of a check in the LCN event logic as to whether the calling devices are known to the integration.
The check is not necessary and might lead to unwanted behaviour when events are called.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
