### PR TITLE
Use x,y in roborock action call

### DIFF
--- a/homeassistant/components/roborock/services.yaml
+++ b/homeassistant/components/roborock/services.yaml
@@ -9,13 +9,13 @@ set_vacuum_goto_position:
       integration: roborock
       domain: vacuum
   fields:
-    x_coord:
+    x:
       example: 27500
       required: true
       selector:
         text:
           type: number
-    y_coord:
+    y:
       example: 32000
       required: true
       selector:

--- a/homeassistant/components/roborock/strings.json
+++ b/homeassistant/components/roborock/strings.json
@@ -435,11 +435,11 @@
       "fields": {
         "x": {
           "name": "X-coordinate",
-          "description": ""
+          "description": "Coordinates are relative to the dock. x=25500,y=25500 is the dock position."
         },
         "y": {
           "name": "Y-coordinate",
-          "description": ""
+          "description": "[%key:component::roborock::services::set_vacuum_goto_position::fields::x::description%]"
         }
       }
     },

--- a/homeassistant/components/roborock/strings.json
+++ b/homeassistant/components/roborock/strings.json
@@ -433,11 +433,11 @@
       "name": "Go to position",
       "description": "Send the vacuum to a specific position.",
       "fields": {
-        "x_coord": {
+        "x": {
           "name": "X-coordinate",
           "description": ""
         },
-        "y_coord": {
+        "y": {
           "name": "Y-coordinate",
           "description": ""
         }

--- a/homeassistant/components/roborock/vacuum.py
+++ b/homeassistant/components/roborock/vacuum.py
@@ -88,8 +88,8 @@ async def async_setup_entry(
         SET_VACUUM_GOTO_POSITION_SERVICE_NAME,
         cv.make_entity_service_schema(
             {
-                vol.Required("x_coord"): vol.Coerce(int),
-                vol.Required("y_coord"): vol.Coerce(int),
+                vol.Required("x"): vol.Coerce(int),
+                vol.Required("y"): vol.Coerce(int),
             },
         ),
         RoborockVacuum.async_set_vacuum_goto_position.__name__,
@@ -185,9 +185,9 @@ class RoborockVacuum(RoborockCoordinatedEntityV1, StateVacuumEntity):
             [self._device_status.get_fan_speed_code(fan_speed)],
         )
 
-    async def async_set_vacuum_goto_position(self, x_coord: int, y_coord: int) -> None:
+    async def async_set_vacuum_goto_position(self, x: int, y: int) -> None:
         """Send vacuum to a specific target point."""
-        await self.send(RoborockCommand.APP_GOTO_TARGET, [x_coord, y_coord])
+        await self.send(RoborockCommand.APP_GOTO_TARGET, [x, y])
 
     async def async_send_command(
         self,

--- a/tests/components/roborock/test_vacuum.py
+++ b/tests/components/roborock/test_vacuum.py
@@ -197,7 +197,7 @@ async def test_goto(
     vacuum = hass.states.get(ENTITY_ID)
     assert vacuum
 
-    data = {ATTR_ENTITY_ID: ENTITY_ID, "x_coord": 25500, "y_coord": 25500}
+    data = {ATTR_ENTITY_ID: ENTITY_ID, "x": 25500, "y": 25500}
     with patch(
         "homeassistant.components.roborock.coordinator.RoborockLocalClientV1.send_command"
     ) as mock_send_command:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Rename parameters for `set_vacuum_goto_position` action call in `roborock` (for consistency).
the call has not been released, so not breaking.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 