### PR TITLE
Add velbus switch platform testcases

### DIFF
--- a/tests/components/velbus/conftest.py
+++ b/tests/components/velbus/conftest.py
@@ -4,7 +4,7 @@ from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from velbusaio.channels import Button
+from velbusaio.channels import Button, Relay
 
 from homeassistant.components.velbus import VelbusConfigEntry
 from homeassistant.components.velbus.const import DOMAIN
@@ -17,7 +17,9 @@ from tests.common import MockConfigEntry
 
 
 @pytest.fixture(name="controller")
-def mock_controller(mock_button: AsyncMock) -> Generator[AsyncMock]:
+def mock_controller(
+    mock_button: AsyncMock, mock_relay: AsyncMock
+) -> Generator[AsyncMock]:
     """Mock a successful velbus controller."""
     with (
         patch("homeassistant.components.velbus.Velbus", autospec=True) as controller,
@@ -29,6 +31,7 @@ def mock_controller(mock_button: AsyncMock) -> Generator[AsyncMock]:
         cont = controller.return_value
         cont.get_all_binary_sensor.return_value = [mock_button]
         cont.get_all_button.return_value = [mock_button]
+        cont.get_all_switch.return_value = [mock_relay]
         yield controller
 
 
@@ -45,6 +48,22 @@ def mock_button() -> AsyncMock:
     channel.get_module_sw_version.return_value = "1.0.0"
     channel.get_module_serial.return_value = "a1b2c3d4e5f6"
     channel.is_closed.return_value = True
+    return channel
+
+
+@pytest.fixture
+def mock_relay() -> AsyncMock:
+    """Mock a successful velbus channel."""
+    channel = AsyncMock(spec=Relay)
+    channel.get_categories.return_value = ["switch"]
+    channel.get_name.return_value = "RelayName"
+    channel.get_module_address.return_value = 99
+    channel.get_channel_number.return_value = 55
+    channel.get_module_type_name.return_value = "VMB4RYNO"
+    channel.get_full_name.return_value = "Full relay name"
+    channel.get_module_sw_version.return_value = "1.0.1"
+    channel.get_module_serial.return_value = "qwerty123"
+    channel.is_on.return_value = True
     return channel
 
 

--- a/tests/components/velbus/snapshots/test_switch.ambr
+++ b/tests/components/velbus/snapshots/test_switch.ambr
@@ -1,0 +1,47 @@
+# serializer version: 1
+# name: test_entities[switch.relayname-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.relayname',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'RelayName',
+    'platform': 'velbus',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'qwerty123-55',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[switch.relayname-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'RelayName',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.relayname',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---

--- a/tests/components/velbus/test_switch.py
+++ b/tests/components/velbus/test_switch.py
@@ -1,0 +1,57 @@
+"""Velbus switch platform tests."""
+
+from unittest.mock import AsyncMock, patch
+
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    Platform,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from . import init_integration
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+
+async def test_entities(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test all entities."""
+    with patch("homeassistant.components.velbus.PLATFORMS", [Platform.SWITCH]):
+        await init_integration(hass, config_entry)
+
+    await snapshot_platform(hass, entity_registry, snapshot, config_entry.entry_id)
+
+
+async def test_switch_on_off(
+    hass: HomeAssistant,
+    mock_relay: AsyncMock,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test switching relay on and off press."""
+    await init_integration(hass, config_entry)
+    # turn off
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: "switch.relayname"},
+        blocking=True,
+    )
+    mock_relay.turn_off.assert_called_once_with()
+    # turn on
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: "switch.relayname"},
+        blocking=True,
+    )
+    mock_relay.turn_on.assert_called_once_with()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add testcases for the switch platform

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
