### PR TITLE
Handle missing application credentials in Tesla Fleet

### DIFF
--- a/homeassistant/components/tesla_fleet/__init__.py
+++ b/homeassistant/components/tesla_fleet/__init__.py
@@ -66,7 +66,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslaFleetConfigEntry) -
 
     try:
         implementation = await async_get_config_entry_implementation(hass, entry)
-    except (ValueError, KeyError) as e:
+    except ValueError as e:
         # Remove invalid implementation from config entry then raise AuthFailed
         hass.config_entries.async_update_entry(
             entry, data={"auth_implementation": None}

--- a/homeassistant/components/tesla_fleet/__init__.py
+++ b/homeassistant/components/tesla_fleet/__init__.py
@@ -64,6 +64,15 @@ CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 async def async_setup_entry(hass: HomeAssistant, entry: TeslaFleetConfigEntry) -> bool:
     """Set up TeslaFleet config."""
 
+    try:
+        implementation = await async_get_config_entry_implementation(hass, entry)
+    except (ValueError, KeyError) as e:
+        # Remove invalid implementation from config entry then raise AuthFailed
+        hass.config_entries.async_update_entry(
+            entry, data={"auth_implementation": None}
+        )
+        raise ConfigEntryAuthFailed from e
+
     access_token = entry.data[CONF_TOKEN][CONF_ACCESS_TOKEN]
     session = async_get_clientsession(hass)
 
@@ -71,7 +80,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslaFleetConfigEntry) -
     scopes: list[Scope] = [Scope(s) for s in token["scp"]]
     region: str = token["ou_code"].lower()
 
-    implementation = await async_get_config_entry_implementation(hass, entry)
     oauth_session = OAuth2Session(hass, entry, implementation)
     refresh_lock = asyncio.Lock()
 

--- a/tests/components/tesla_fleet/conftest.py
+++ b/tests/components/tesla_fleet/conftest.py
@@ -33,7 +33,9 @@ def mock_expires_at() -> int:
     return time.time() + 3600
 
 
-def create_config_entry(expires_at: int, scopes: list[Scope]) -> MockConfigEntry:
+def create_config_entry(
+    expires_at: int, scopes: list[Scope], implementation: str = DOMAIN
+) -> MockConfigEntry:
     """Create Tesla Fleet entry in Home Assistant."""
     access_token = jwt.encode(
         {
@@ -51,7 +53,7 @@ def create_config_entry(expires_at: int, scopes: list[Scope]) -> MockConfigEntry
         title=UID,
         unique_id=UID,
         data={
-            "auth_implementation": DOMAIN,
+            "auth_implementation": implementation,
             "token": {
                 "status": 0,
                 "userid": UID,
@@ -88,6 +90,12 @@ def readonly_config_entry(expires_at: int) -> MockConfigEntry:
             Scope.ENERGY_DEVICE_DATA,
         ],
     )
+
+
+@pytest.fixture
+def bad_config_entry(expires_at: int) -> MockConfigEntry:
+    """Create Tesla Fleet entry in Home Assistant."""
+    return create_config_entry(expires_at, SCOPES, "bad")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/components/tesla_fleet/test_init.py
+++ b/tests/components/tesla_fleet/test_init.py
@@ -30,6 +30,7 @@ from homeassistant.components.tesla_fleet.coordinator import (
 from homeassistant.components.tesla_fleet.models import TeslaFleetData
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers import device_registry as dr
 
 from . import setup_platform
@@ -434,3 +435,10 @@ async def test_bad_implementation(
 
     await setup_platform(hass, bad_config_entry)
     assert bad_config_entry.state is ConfigEntryState.SETUP_ERROR
+
+    # Ensure reauth flow starts
+    assert any(bad_config_entry.async_get_active_flows(hass, {"reauth"}))
+    result = await bad_config_entry.start_reauth_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+    assert not result["errors"]

--- a/tests/components/tesla_fleet/test_init.py
+++ b/tests/components/tesla_fleet/test_init.py
@@ -424,3 +424,13 @@ async def test_signing(
     ) as mock_get_private_key:
         await setup_platform(hass, normal_config_entry)
         mock_get_private_key.assert_called_once()
+
+
+async def test_bad_implementation(
+    hass: HomeAssistant,
+    bad_config_entry: MockConfigEntry,
+) -> None:
+    """Test handling of a bad authentication implementation."""
+
+    await setup_platform(hass, bad_config_entry)
+    assert bad_config_entry.state is ConfigEntryState.SETUP_ERROR


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes #134064 by handling errors from `async_get_config_entry_implementation` and raising reauth.

Required for 2025.1 so please beta.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #134064
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
