### PR TITLE
Add discovery to Russound RIO

### DIFF
--- a/homeassistant/components/russound_rio/config_flow.py
+++ b/homeassistant/components/russound_rio/config_flow.py
@@ -99,7 +99,9 @@ class FlowHandler(ConfigFlow, domain=DOMAIN):
                 _LOGGER.exception("Could not connect to Russound RIO")
                 errors["base"] = "cannot_connect"
             else:
-                await self.async_set_unique_id(controller.mac_address)
+                await self.async_set_unique_id(
+                    controller.mac_address, raise_on_progress=False
+                )
                 if self.source == SOURCE_RECONFIGURE:
                     self._abort_if_unique_id_mismatch(reason="wrong_device")
                     return self.async_update_reload_and_abort(

--- a/homeassistant/components/russound_rio/config_flow.py
+++ b/homeassistant/components/russound_rio/config_flow.py
@@ -8,12 +8,13 @@ from typing import Any
 from aiorussound import RussoundClient, RussoundTcpConnectionHandler
 import voluptuous as vol
 
+from homeassistant.components import zeroconf
 from homeassistant.config_entries import (
     SOURCE_RECONFIGURE,
     ConfigFlow,
     ConfigFlowResult,
 )
-from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT
 from homeassistant.helpers import config_validation as cv
 
 from .const import DOMAIN, RUSSOUND_RIO_EXCEPTIONS
@@ -32,6 +33,53 @@ class FlowHandler(ConfigFlow, domain=DOMAIN):
     """Russound RIO configuration flow."""
 
     VERSION = 1
+
+    def __init__(self) -> None:
+        """Initialize the config flow."""
+        self.data: dict[str, Any] = {}
+
+    async def async_step_zeroconf(
+        self, discovery_info: zeroconf.ZeroconfServiceInfo
+    ) -> ConfigFlowResult:
+        """Handle zeroconf discovery."""
+        self.data[CONF_HOST] = host = discovery_info.host
+        self.data[CONF_PORT] = port = discovery_info.port or 9621
+
+        client = RussoundClient(RussoundTcpConnectionHandler(host, port))
+        try:
+            await client.connect()
+            controller = client.controllers[1]
+            await client.disconnect()
+        except RUSSOUND_RIO_EXCEPTIONS:
+            return self.async_abort(reason="cannot_connect")
+
+        await self.async_set_unique_id(controller.mac_address)
+        self._abort_if_unique_id_configured(updates={CONF_HOST: host})
+
+        self.data[CONF_NAME] = controller.controller_type
+
+        self.context["title_placeholders"] = {
+            "name": self.data[CONF_NAME],
+        }
+        return await self.async_step_discovery_confirm()
+
+    async def async_step_discovery_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Confirm discovery."""
+        if user_input is not None:
+            return self.async_create_entry(
+                title=self.data[CONF_NAME],
+                data={CONF_HOST: self.data[CONF_HOST], CONF_PORT: self.data[CONF_PORT]},
+            )
+
+        self._set_confirm_only()
+        return self.async_show_form(
+            step_id="discovery_confirm",
+            description_placeholders={
+                "name": self.data[CONF_NAME],
+            },
+        )
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None

--- a/homeassistant/components/russound_rio/manifest.json
+++ b/homeassistant/components/russound_rio/manifest.json
@@ -7,5 +7,6 @@
   "iot_class": "local_push",
   "loggers": ["aiorussound"],
   "quality_scale": "silver",
-  "requirements": ["aiorussound==4.2.0"]
+  "requirements": ["aiorussound==4.2.0"],
+  "zeroconf": ["_rio._tcp.local."]
 }

--- a/homeassistant/components/russound_rio/quality_scale.yaml
+++ b/homeassistant/components/russound_rio/quality_scale.yaml
@@ -57,7 +57,7 @@ rules:
     status: exempt
     comment: |
       This integration doesn't have enough / noisy entities that warrant being disabled by default.
-  discovery: todo
+  discovery: done
   stale-devices: todo
   diagnostics: done
   exception-translations: done
@@ -67,7 +67,7 @@ rules:
       There are no entities that require icons.
   reconfiguration-flow: done
   dynamic-devices: todo
-  discovery-update-info: todo
+  discovery-update-info: done
   repair-issues:
     status: exempt
     comment: |

--- a/homeassistant/components/russound_rio/strings.json
+++ b/homeassistant/components/russound_rio/strings.json
@@ -15,6 +15,9 @@
           "port": "The port of the Russound controller."
         }
       },
+      "discovery_confirm": {
+        "description": "Do you want to setup {name}?"
+      },
       "reconfigure": {
         "description": "Reconfigure your Russound controller.",
         "data": {

--- a/homeassistant/generated/zeroconf.py
+++ b/homeassistant/generated/zeroconf.py
@@ -775,6 +775,11 @@ ZEROCONF = {
             },
         },
     ],
+    "_rio._tcp.local.": [
+        {
+            "domain": "russound_rio",
+        },
+    ],
     "_sideplay._tcp.local.": [
         {
             "domain": "ecobee",

--- a/tests/components/russound_rio/test_config_flow.py
+++ b/tests/components/russound_rio/test_config_flow.py
@@ -1,9 +1,11 @@
 """Test the Russound RIO config flow."""
 
+from ipaddress import ip_address
 from unittest.mock import AsyncMock
 
 from homeassistant.components.russound_rio.const import DOMAIN
-from homeassistant.config_entries import SOURCE_USER, ConfigFlowResult
+from homeassistant.components.zeroconf import ZeroconfServiceInfo
+from homeassistant.config_entries import SOURCE_USER, SOURCE_ZEROCONF, ConfigFlowResult
 from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -11,6 +13,23 @@ from homeassistant.data_entry_flow import FlowResultType
 from .const import MOCK_CONFIG, MOCK_RECONFIGURATION_CONFIG, MODEL
 
 from tests.common import MockConfigEntry
+
+ZEROCONF_DISCOVERY = ZeroconfServiceInfo(
+    ip_address=ip_address("192.168.20.17"),
+    ip_addresses=[ip_address("192.168.20.17")],
+    hostname="controller1.local.",
+    name="controller1._stream-magic._tcp.local.",
+    port=9621,
+    type="_rio._tcp.local.",
+    properties={
+        "txtvers": "0",
+        "productType": "2",
+        "productId": "59",
+        "version": "07.04.00",
+        "buildDate": "Jul 8 2019",
+        "localName": "0",
+    },
+)
 
 
 async def test_form(
@@ -85,6 +104,89 @@ async def test_duplicate(
         MOCK_CONFIG,
     )
 
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_zeroconf_flow(
+    hass: HomeAssistant,
+    mock_russound_client: AsyncMock,
+    mock_setup_entry: AsyncMock,
+) -> None:
+    """Test zeroconf flow."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_ZEROCONF},
+        data=ZEROCONF_DISCOVERY,
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "discovery_confirm"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {},
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "MCA-C5"
+    assert result["data"] == {
+        CONF_HOST: "192.168.20.17",
+        CONF_PORT: 9621,
+    }
+    assert result["result"].unique_id == "00:11:22:33:44:55"
+
+
+async def test_zeroconf_flow_errors(
+    hass: HomeAssistant,
+    mock_russound_client: AsyncMock,
+    mock_setup_entry: AsyncMock,
+) -> None:
+    """Test zeroconf flow."""
+    mock_russound_client.connect.side_effect = TimeoutError
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_ZEROCONF},
+        data=ZEROCONF_DISCOVERY,
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "cannot_connect"
+
+    mock_russound_client.connect.side_effect = None
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_ZEROCONF},
+        data=ZEROCONF_DISCOVERY,
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "discovery_confirm"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {},
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "MCA-C5"
+    assert result["data"] == {
+        CONF_HOST: "192.168.20.17",
+        CONF_PORT: 9621,
+    }
+    assert result["result"].unique_id == "00:11:22:33:44:55"
+
+
+async def test_zeroconf_duplicate(
+    hass: HomeAssistant,
+    mock_russound_client: AsyncMock,
+    mock_setup_entry: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test duplicate flow."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_ZEROCONF},
+        data=ZEROCONF_DISCOVERY,
+    )
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 

--- a/tests/components/russound_rio/test_config_flow.py
+++ b/tests/components/russound_rio/test_config_flow.py
@@ -191,6 +191,34 @@ async def test_zeroconf_duplicate(
     assert result["reason"] == "already_configured"
 
 
+async def test_zeroconf_duplicate_different_ip(
+    hass: HomeAssistant,
+    mock_russound_client: AsyncMock,
+    mock_setup_entry: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test duplicate flow with different IP."""
+    mock_config_entry.add_to_hass(hass)
+
+    ZEROCONF_DISCOVERY.ip_address = (ip_address("192.168.20.18"),)
+    ZEROCONF_DISCOVERY.ip_addresses = [ip_address("192.168.20.18")]
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_ZEROCONF},
+        data=ZEROCONF_DISCOVERY,
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+    entry = hass.config_entries.async_get_entry(mock_config_entry.entry_id)
+    assert entry
+    assert entry.data == {
+        CONF_HOST: "(IPv4Address('192.168.20.18'),)",
+        CONF_PORT: 9621,
+    }
+
+
 async def _start_reconfigure_flow(
     hass: HomeAssistant, mock_config_entry: MockConfigEntry
 ) -> ConfigFlowResult:

--- a/tests/components/russound_rio/test_config_flow.py
+++ b/tests/components/russound_rio/test_config_flow.py
@@ -200,13 +200,27 @@ async def test_zeroconf_duplicate_different_ip(
     """Test duplicate flow with different IP."""
     mock_config_entry.add_to_hass(hass)
 
-    ZEROCONF_DISCOVERY.ip_address = (ip_address("192.168.20.18"),)
-    ZEROCONF_DISCOVERY.ip_addresses = [ip_address("192.168.20.18")]
+    ZEROCONF_DISCOVERY_DIFFERENT_IP = ZeroconfServiceInfo(
+        ip_address=ip_address("192.168.20.18"),
+        ip_addresses=[ip_address("192.168.20.18")],
+        hostname="controller1.local.",
+        name="controller1._stream-magic._tcp.local.",
+        port=9621,
+        type="_rio._tcp.local.",
+        properties={
+            "txtvers": "0",
+            "productType": "2",
+            "productId": "59",
+            "version": "07.04.00",
+            "buildDate": "Jul 8 2019",
+            "localName": "0",
+        },
+    )
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
-        data=ZEROCONF_DISCOVERY,
+        data=ZEROCONF_DISCOVERY_DIFFERENT_IP,
     )
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
@@ -214,7 +228,7 @@ async def test_zeroconf_duplicate_different_ip(
     entry = hass.config_entries.async_get_entry(mock_config_entry.entry_id)
     assert entry
     assert entry.data == {
-        CONF_HOST: "(IPv4Address('192.168.20.18'),)",
+        CONF_HOST: "192.168.20.18",
         CONF_PORT: 9621,
     }
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds zeroconf discovery to Russound RIO. Unfortunately, the unique ID is not a field under the zeroconf entry, so a connection to the client is necessary first to get the unique ID (mac address) then it checks if it already has a config entry with that ID.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
