### PR TITLE
ping: Suppress ProcessLookupError on timeout

### DIFF
--- a/homeassistant/components/ping/helpers.py
+++ b/homeassistant/components/ping/helpers.py
@@ -160,7 +160,7 @@ class PingDataSubProcess(PingData):
             )
 
             if pinger:
-                with suppress(TypeError):
+                with suppress(TypeError, ProcessLookupError):
                     await pinger.kill()  # type: ignore[func-returns-value]
                 del pinger
 

--- a/tests/components/ping/test_helpers.py
+++ b/tests/components/ping/test_helpers.py
@@ -27,13 +27,17 @@ class MockAsyncSubprocess:
         raise self.killsig
 
 
+@pytest.mark.parametrize("exc", [TypeError, ProcessLookupError])
 async def test_async_ping_expected_exceptions(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
     entity_registry: er.EntityRegistry,
+    exc: Exception,
 ) -> None:
     """Test PingDataSubProcess.async_ping handles expected exceptions."""
-    with patch("asyncio.create_subprocess_exec", return_value=MockAsyncSubprocess()):
+    with patch(
+        "asyncio.create_subprocess_exec", return_value=MockAsyncSubprocess(killsig=exc)
+    ):
         # Actual parameters irrelevant, as subprocess will not be created
         ping = PingDataSubProcess(hass, host="10.10.10.10", count=3, privileged=False)
         assert await ping.async_ping() is None

--- a/tests/components/ping/test_helpers.py
+++ b/tests/components/ping/test_helpers.py
@@ -1,0 +1,55 @@
+"""Test the exception handling in subprocess version of async_ping."""
+
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant.components.ping.helpers import PingDataSubProcess
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from tests.common import MockConfigEntry
+
+
+class MockAsyncSubprocess:
+    """Minimal mock implementation of asyncio.subprocess.Process for exception testing."""
+
+    def __init__(self, killsig=ProcessLookupError, **kwargs) -> None:
+        """Store provided exception type for later."""
+        self.killsig = killsig
+
+    async def communicate(self) -> None:
+        """Fails immediately with a timeout."""
+        raise TimeoutError
+
+    async def kill(self) -> None:
+        """Raise preset exception when called."""
+        raise self.killsig
+
+
+async def test_async_ping_expected_exceptions(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test PingDataSubProcess.async_ping handles expected exceptions."""
+    with patch("asyncio.create_subprocess_exec", return_value=MockAsyncSubprocess()):
+        # Actual parameters irrelevant, as subprocess will not be created
+        ping = PingDataSubProcess(hass, host="10.10.10.10", count=3, privileged=False)
+        assert await ping.async_ping() is None
+
+
+async def test_async_ping_unexpected_exceptions(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test PingDataSubProcess.async_ping does not suppress unexpected exceptions."""
+    with patch(
+        "asyncio.create_subprocess_exec",
+        return_value=MockAsyncSubprocess(killsig=KeyboardInterrupt),
+    ):
+        # Actual parameters irrelevant, as subprocess will not be created
+        ping = PingDataSubProcess(hass, host="10.10.10.10", count=3, privileged=False)
+        with pytest.raises(KeyboardInterrupt):
+            assert await ping.async_ping() is None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Suppress log messages when the ping command exits after the timeout is reached.

If the ping command reaches the timeout while Home Assistant is waiting for data, the command is killed as part of the clean up. In some cases, the command can apparently exit before the clean up code is reached, causing an additional unhandled error to occur.

Suppressing this specific exception prevents the extra error messages being emitted, and allows the remainder of the exception handling to proceed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue: #109988 
  - This may not help the originally reported issue (unwanted notifications), but would have removed the extra log messages.
  - No other relevant issues found

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
  - I'm not sure how to add a test for this case

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]
  - Not applicable 

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
  - Not applicable
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
  - Not applicable
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
  - Not applicable

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
