### PR TITLE
Bump reolink-aio to 0.11.6

### DIFF
--- a/homeassistant/components/reolink/camera.py
+++ b/homeassistant/components/reolink/camera.py
@@ -100,7 +100,7 @@ async def async_setup_entry(
             if not entity_description.supported(reolink_data.host.api, channel):
                 continue
             stream_url = await reolink_data.host.api.get_stream_source(
-                channel, entity_description.stream
+                channel, entity_description.stream, False
             )
             if stream_url is None and "snapshots" not in entity_description.stream:
                 continue

--- a/homeassistant/components/reolink/manifest.json
+++ b/homeassistant/components/reolink/manifest.json
@@ -19,5 +19,5 @@
   "iot_class": "local_push",
   "loggers": ["reolink_aio"],
   "quality_scale": "platinum",
-  "requirements": ["reolink-aio==0.11.5"]
+  "requirements": ["reolink-aio==0.11.6"]
 }

--- a/homeassistant/components/reolink/media_source.py
+++ b/homeassistant/components/reolink/media_source.py
@@ -81,6 +81,8 @@ class ReolinkVODMediaSource(MediaSource):
 
         def get_vod_type() -> VodRequestType:
             if filename.endswith(".mp4"):
+                if host.api.is_nvr:
+                    return VodRequestType.DOWNLOAD
                 return VodRequestType.PLAYBACK
             if host.api.is_nvr:
                 return VodRequestType.FLV

--- a/homeassistant/components/reolink/strings.json
+++ b/homeassistant/components/reolink/strings.json
@@ -567,7 +567,7 @@
           "stayoff": "Stay off",
           "auto": "[%key:component::reolink::entity::select::day_night_mode::state::auto%]",
           "alwaysonatnight": "Auto & always on at night",
-          "always": "Always on"
+          "always": "Always on",
           "alwayson": "Always on"
         }
       },

--- a/homeassistant/components/reolink/strings.json
+++ b/homeassistant/components/reolink/strings.json
@@ -567,6 +567,7 @@
           "stayoff": "Stay off",
           "auto": "[%key:component::reolink::entity::select::day_night_mode::state::auto%]",
           "alwaysonatnight": "Auto & always on at night",
+          "always": "Always on"
           "alwayson": "Always on"
         }
       },

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2575,7 +2575,7 @@ renault-api==0.2.8
 renson-endura-delta==1.7.2
 
 # homeassistant.components.reolink
-reolink-aio==0.11.5
+reolink-aio==0.11.6
 
 # homeassistant.components.idteck_prox
 rfk101py==0.0.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2075,7 +2075,7 @@ renault-api==0.2.8
 renson-endura-delta==1.7.2
 
 # homeassistant.components.reolink
-reolink-aio==0.11.5
+reolink-aio==0.11.6
 
 # homeassistant.components.rflink
 rflink==0.0.66

--- a/tests/components/reolink/test_media_source.py
+++ b/tests/components/reolink/test_media_source.py
@@ -109,11 +109,17 @@ async def test_resolve(
     )
     assert play_media.mime_type == TEST_MIME_TYPE_MP4
 
+    reolink_connect.is_nvr = False
+
+    play_media = await async_resolve_media(
+        hass, f"{URI_SCHEME}{DOMAIN}/{file_id}", None
+    )
+    assert play_media.mime_type == TEST_MIME_TYPE_MP4
+
     file_id = (
         f"FILE|{config_entry.entry_id}|{TEST_CHANNEL}|{TEST_STREAM}|{TEST_FILE_NAME}"
     )
     reolink_connect.get_vod_source.return_value = (TEST_MIME_TYPE, TEST_URL)
-    reolink_connect.is_nvr = False
 
     play_media = await async_resolve_media(
         hass, f"{URI_SCHEME}{DOMAIN}/{file_id}", None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump reolink-aio to 0.11.6:
**Additions:**
- [Add Download VodRequestType](https://github.com/starkillerOG/reolink_aio/commit/7b1b36b1ec76d925f1f5c4a2a51abd2d6688d480)
- [Add cry detection support](https://github.com/starkillerOG/reolink_aio/commit/8205713ab73d7145204ff1637593112ee00a165d)

**Bug fixes:**
- [Add GetPerformance as waking command](https://github.com/starkillerOG/reolink_aio/commit/b39b74bc61aa429f2dfc66224da79fe084eca2b4)
- [Prevent keepalive loop watchdog from triggering when protocol is None due to connection errors](https://github.com/starkillerOG/reolink_aio/commit/31f75f890f5276a06f6685a3608a6095937929ba)
- [Fix "Always On" doorbell led option for latest NVR firmware, changed from "Always" to "KeepOn"](https://github.com/starkillerOG/reolink_aio/commit/781c713d6118a0b66a68acd95e207fe4b1680633)
- [Check for baichuan protocol is None](https://github.com/starkillerOG/reolink_aio/commit/bfb318c614c6951eb0ac317b50e9b468c73eeb2d)
- [Baichuan check for future done before calling set_exception](https://github.com/starkillerOG/reolink_aio/commit/c6b32f7e7f2d6267d159566a6d9c2a98faf150f6)
- [Fix KeyError when None not in ch_list of check_new_firmware](https://github.com/starkillerOG/reolink_aio/commit/75fda9d2b31fb5e63845a51b1af45a4ae8277bd1)

**Optimizations:**
- [Make hide_password available](https://github.com/starkillerOG/reolink_aio/commit/f24085ddc749cb8a02f24a5b384c0f122d612740)
- [Prevent multiple lost subscription error logs](https://github.com/starkillerOG/reolink_aio/commit/1f73b8a49b54ed96e5d35ae1939a0e7b9e2d4f68)
- [Also check RTSP stream of Battery cameras, but not on startup](https://github.com/starkillerOG/reolink_aio/commit/4f4ff133d173f41774d747156c447cdb1196aa63)
- [Also set aiohttp sock_read timeout](https://github.com/starkillerOG/reolink_aio/commit/ef9171626ce9fffa78693fe5326b93b0337bfb06)

**Full Changelog**: https://github.com/starkillerOG/reolink_aio/compare/0.11.5...0.11.6

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/132857 https://github.com/starkillerOG/reolink_aio/issues/95 https://github.com/home-assistant/core/issues/133836
- This PR is related to issue: https://github.com/home-assistant/home-assistant.io/issues/36276 https://github.com/home-assistant/core/issues/110939 https://github.com/home-assistant/core/issues/133463
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
