### PR TITLE
Change Reolink test switch entity ID

### DIFF
--- a/tests/components/reolink/test_switch.py
+++ b/tests/components/reolink/test_switch.py
@@ -248,16 +248,17 @@ async def test_switch(
 ) -> None:
     """Test switch entity."""
     reolink_connect.camera_name.return_value = TEST_CAM_NAME
+    reolink_connect.audio_record.return_value = True
 
     with patch("homeassistant.components.reolink.PLATFORMS", [Platform.SWITCH]):
         assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
     assert config_entry.state is ConfigEntryState.LOADED
 
-    entity_id = f"{Platform.SWITCH}.{TEST_CAM_NAME}_record"
+    entity_id = f"{Platform.SWITCH}.{TEST_CAM_NAME}_record_audio"
     assert hass.states.get(entity_id).state == STATE_ON
 
-    reolink_connect.recording_enabled.return_value = False
+    reolink_connect.audio_record.return_value = False
     freezer.tick(DEVICE_UPDATE_INTERVAL)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
@@ -271,9 +272,9 @@ async def test_switch(
         {ATTR_ENTITY_ID: entity_id},
         blocking=True,
     )
-    reolink_connect.set_recording.assert_called_with(0, True)
+    reolink_connect.set_audio.assert_called_with(0, True)
 
-    reolink_connect.set_recording.side_effect = ReolinkError("Test error")
+    reolink_connect.set_audio.side_effect = ReolinkError("Test error")
     with pytest.raises(HomeAssistantError):
         await hass.services.async_call(
             SWITCH_DOMAIN,
@@ -283,16 +284,16 @@ async def test_switch(
         )
 
     # test switch turn off
-    reolink_connect.set_recording.reset_mock(side_effect=True)
+    reolink_connect.set_audio.reset_mock(side_effect=True)
     await hass.services.async_call(
         SWITCH_DOMAIN,
         SERVICE_TURN_OFF,
         {ATTR_ENTITY_ID: entity_id},
         blocking=True,
     )
-    reolink_connect.set_recording.assert_called_with(0, False)
+    reolink_connect.set_audio.assert_called_with(0, False)
 
-    reolink_connect.set_recording.side_effect = ReolinkError("Test error")
+    reolink_connect.set_audio.side_effect = ReolinkError("Test error")
     with pytest.raises(HomeAssistantError):
         await hass.services.async_call(
             SWITCH_DOMAIN,
@@ -301,7 +302,7 @@ async def test_switch(
             blocking=True,
         )
 
-    reolink_connect.set_recording.reset_mock(side_effect=True)
+    reolink_connect.set_audio.reset_mock(side_effect=True)
 
     reolink_connect.camera_online.return_value = False
     freezer.tick(DEVICE_UPDATE_INTERVAL)
@@ -321,17 +322,17 @@ async def test_host_switch(
 ) -> None:
     """Test host switch entity."""
     reolink_connect.camera_name.return_value = TEST_CAM_NAME
-    reolink_connect.recording_enabled.return_value = True
+    reolink_connect.email_enabled.return_value = True
 
     with patch("homeassistant.components.reolink.PLATFORMS", [Platform.SWITCH]):
         assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
     assert config_entry.state is ConfigEntryState.LOADED
 
-    entity_id = f"{Platform.SWITCH}.{TEST_NVR_NAME}_record"
+    entity_id = f"{Platform.SWITCH}.{TEST_NVR_NAME}_email_on_event"
     assert hass.states.get(entity_id).state == STATE_ON
 
-    reolink_connect.recording_enabled.return_value = False
+    reolink_connect.email_enabled.return_value = False
     freezer.tick(DEVICE_UPDATE_INTERVAL)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
@@ -345,9 +346,9 @@ async def test_host_switch(
         {ATTR_ENTITY_ID: entity_id},
         blocking=True,
     )
-    reolink_connect.set_recording.assert_called_with(None, True)
+    reolink_connect.set_email.assert_called_with(None, True)
 
-    reolink_connect.set_recording.side_effect = ReolinkError("Test error")
+    reolink_connect.set_email.side_effect = ReolinkError("Test error")
     with pytest.raises(HomeAssistantError):
         await hass.services.async_call(
             SWITCH_DOMAIN,
@@ -357,16 +358,16 @@ async def test_host_switch(
         )
 
     # test switch turn off
-    reolink_connect.set_recording.reset_mock(side_effect=True)
+    reolink_connect.set_email.reset_mock(side_effect=True)
     await hass.services.async_call(
         SWITCH_DOMAIN,
         SERVICE_TURN_OFF,
         {ATTR_ENTITY_ID: entity_id},
         blocking=True,
     )
-    reolink_connect.set_recording.assert_called_with(None, False)
+    reolink_connect.set_email.assert_called_with(None, False)
 
-    reolink_connect.set_recording.side_effect = ReolinkError("Test error")
+    reolink_connect.set_email.side_effect = ReolinkError("Test error")
     with pytest.raises(HomeAssistantError):
         await hass.services.async_call(
             SWITCH_DOMAIN,
@@ -375,7 +376,7 @@ async def test_host_switch(
             blocking=True,
         )
 
-    reolink_connect.set_recording.reset_mock(side_effect=True)
+    reolink_connect.set_email.reset_mock(side_effect=True)
 
 
 async def test_chime_switch(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Change switch entity ID in the Reolink tests.
On rare ocasions the tests would fail becuase the entity was not set up yet.
No idea how this is possible since I would expect `await hass.async_block_till_done()` would actually wait untill all entities would be setup. But this changes the entity_ID to the one which is much further up in the list of entities, so which is setup first.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
