### PR TITLE
Add radioactivity concentration units

### DIFF
--- a/homeassistant/components/sensor/const.py
+++ b/homeassistant/components/sensor/const.py
@@ -31,6 +31,7 @@ from homeassistant.const import (
     UnitOfPower,
     UnitOfPrecipitationDepth,
     UnitOfPressure,
+    UnitOfRadioactivityConcentration,
     UnitOfReactivePower,
     UnitOfSoundPressure,
     UnitOfSpeed,
@@ -55,6 +56,7 @@ from homeassistant.util.unit_conversion import (
     MassConverter,
     PowerConverter,
     PressureConverter,
+    RadioactivityConcentrationConverter,
     SpeedConverter,
     TemperatureConverter,
     UnitlessRatioConverter,
@@ -337,6 +339,17 @@ class SensorDeviceClass(StrEnum):
     - `psi`
     """
 
+    RADIOACTIVITY_CONCENTRATION = "radioactivity_concentration"
+    """Radioactivity concentration.
+
+    Use this device class for sensors measuring the the amount of radioactive decay
+    in a specific volume of air. For example, sensors measuring radon.
+
+    Unit of measurement:
+    - SI /metric: `Bq/m³`
+    - USCS / imperial: `pCi/L`
+    """
+
     REACTIVE_POWER = "reactive_power"
     """Reactive power.
 
@@ -507,6 +520,7 @@ UNIT_CONVERTERS: dict[SensorDeviceClass | str | None, type[BaseUnitConverter]] =
     SensorDeviceClass.PRECIPITATION: DistanceConverter,
     SensorDeviceClass.PRECIPITATION_INTENSITY: SpeedConverter,
     SensorDeviceClass.PRESSURE: PressureConverter,
+    SensorDeviceClass.RADIOACTIVITY_CONCENTRATION: RadioactivityConcentrationConverter,
     SensorDeviceClass.SPEED: SpeedConverter,
     SensorDeviceClass.TEMPERATURE: TemperatureConverter,
     SensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS_PARTS: UnitlessRatioConverter,
@@ -571,6 +585,9 @@ DEVICE_CLASS_UNITS: dict[SensorDeviceClass, set[type[StrEnum] | str | None]] = {
     SensorDeviceClass.PRECIPITATION: set(UnitOfPrecipitationDepth),
     SensorDeviceClass.PRECIPITATION_INTENSITY: set(UnitOfVolumetricFlux),
     SensorDeviceClass.PRESSURE: set(UnitOfPressure),
+    SensorDeviceClass.RADIOACTIVITY_CONCENTRATION: set(
+        UnitOfRadioactivityConcentration
+    ),
     SensorDeviceClass.REACTIVE_POWER: {UnitOfReactivePower.VOLT_AMPERE_REACTIVE},
     SensorDeviceClass.SIGNAL_STRENGTH: {
         SIGNAL_STRENGTH_DECIBELS,
@@ -644,6 +661,7 @@ DEVICE_CLASS_STATE_CLASSES: dict[SensorDeviceClass, set[SensorStateClass]] = {
     SensorDeviceClass.PRECIPITATION: set(SensorStateClass),
     SensorDeviceClass.PRECIPITATION_INTENSITY: {SensorStateClass.MEASUREMENT},
     SensorDeviceClass.PRESSURE: {SensorStateClass.MEASUREMENT},
+    SensorDeviceClass.RADIOACTIVITY_CONCENTRATION: {SensorStateClass.MEASUREMENT},
     SensorDeviceClass.REACTIVE_POWER: {SensorStateClass.MEASUREMENT},
     SensorDeviceClass.SIGNAL_STRENGTH: {SensorStateClass.MEASUREMENT},
     SensorDeviceClass.SOUND_PRESSURE: {SensorStateClass.MEASUREMENT},

--- a/homeassistant/components/sensor/device_condition.py
+++ b/homeassistant/components/sensor/device_condition.py
@@ -69,6 +69,7 @@ CONF_IS_PRECIPITATION = "is_precipitation"
 CONF_IS_PRECIPITATION_INTENSITY = "is_precipitation_intensity"
 CONF_IS_PRESSURE = "is_pressure"
 CONF_IS_SPEED = "is_speed"
+CONF_IS_RADIOACTIVITY_CONCENTRATION = "is_radioactivity_concentration"
 CONF_IS_REACTIVE_POWER = "is_reactive_power"
 CONF_IS_SIGNAL_STRENGTH = "is_signal_strength"
 CONF_IS_SOUND_PRESSURE = "is_sound_pressure"
@@ -125,6 +126,9 @@ ENTITY_CONDITIONS = {
         {CONF_TYPE: CONF_IS_PRECIPITATION_INTENSITY}
     ],
     SensorDeviceClass.PRESSURE: [{CONF_TYPE: CONF_IS_PRESSURE}],
+    SensorDeviceClass.RADIOACTIVITY_CONCENTRATION: [
+        {CONF_TYPE: CONF_IS_RADIOACTIVITY_CONCENTRATION}
+    ],
     SensorDeviceClass.REACTIVE_POWER: [{CONF_TYPE: CONF_IS_REACTIVE_POWER}],
     SensorDeviceClass.SIGNAL_STRENGTH: [{CONF_TYPE: CONF_IS_SIGNAL_STRENGTH}],
     SensorDeviceClass.SOUND_PRESSURE: [{CONF_TYPE: CONF_IS_SOUND_PRESSURE}],
@@ -188,6 +192,7 @@ CONDITION_SCHEMA = vol.All(
                     CONF_IS_PRECIPITATION,
                     CONF_IS_PRECIPITATION_INTENSITY,
                     CONF_IS_PRESSURE,
+                    CONF_IS_RADIOACTIVITY_CONCENTRATION,
                     CONF_IS_REACTIVE_POWER,
                     CONF_IS_SIGNAL_STRENGTH,
                     CONF_IS_SOUND_PRESSURE,

--- a/homeassistant/components/sensor/strings.json
+++ b/homeassistant/components/sensor/strings.json
@@ -37,6 +37,7 @@
       "is_precipitation": "Current {entity_name} precipitation",
       "is_precipitation_intensity": "Current {entity_name} precipitation intensity",
       "is_pressure": "Current {entity_name} pressure",
+      "is_radioactivity_concentration": "Current {entity_name} radioactivity concentration",
       "is_reactive_power": "Current {entity_name} reactive power",
       "is_signal_strength": "Current {entity_name} signal strength",
       "is_sound_pressure": "Current {entity_name} sound pressure",
@@ -89,6 +90,7 @@
       "precipitation": "{entity_name} precipitation changes",
       "precipitation_intensity": "{entity_name} precipitation intensity changes",
       "pressure": "{entity_name} pressure changes",
+      "radioactivity_concentration": "{entity_name} radioactivity concentration changes",
       "reactive_power": "{entity_name} reactive power changes",
       "signal_strength": "{entity_name} signal strength changes",
       "sound_pressure": "{entity_name} sound pressure changes",
@@ -251,6 +253,9 @@
     },
     "reactive_power": {
       "name": "Reactive power"
+    },
+    "radioactivity_concentration": {
+      "name": "Radioactivity concentration"
     },
     "signal_strength": {
       "name": "Signal strength"

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -962,6 +962,14 @@ class UnitOfDataRate(StrEnum):
     GIBIBYTES_PER_SECOND = "GiB/s"
 
 
+# Radioactivity concentration units
+class UnitOfRadioactivityConcentration(StrEnum):
+    """Radioactivity concentration units."""
+
+    BECQUERELS_PER_CUBIC_METER = "Bq/m³"
+    PICOCURIES_PER_LITER = "pCi/L"
+
+
 # States
 COMPRESSED_STATE_STATE: Final = "s"
 COMPRESSED_STATE_ATTRIBUTES: Final = "a"
@@ -1066,6 +1074,7 @@ SPEED: Final = "speed"
 WIND_SPEED: Final = "wind_speed"
 ILLUMINANCE: Final = "illuminance"
 ACCUMULATED_PRECIPITATION: Final = "accumulated_precipitation"
+RADIOACTIVITY_CONCENTRATION: Final = "radioactivity_concentration"
 
 WEEKDAYS: Final[list[str]] = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"]
 

--- a/homeassistant/util/unit_conversion.py
+++ b/homeassistant/util/unit_conversion.py
@@ -22,6 +22,7 @@ from homeassistant.const import (
     UnitOfMass,
     UnitOfPower,
     UnitOfPressure,
+    UnitOfRadioactivityConcentration,
     UnitOfSpeed,
     UnitOfTemperature,
     UnitOfTime,
@@ -81,6 +82,9 @@ _ML_TO_CUBIC_METER = 0.001 * _L_TO_CUBIC_METER  # 1 mL = 0.001 L
 _GALLON_TO_CUBIC_METER = 231 * pow(_IN_TO_M, 3)  # US gallon is 231 cubic inches
 _FLUID_OUNCE_TO_CUBIC_METER = _GALLON_TO_CUBIC_METER / 128  # 128 fl. oz. in a US gallon
 _CUBIC_FOOT_TO_CUBIC_METER = pow(_FOOT_TO_M, 3)
+
+# Radioactivity concentration conversion constants
+_BQ_PER_CUBIC_METER_TO_PCI_PER_LITER = 2.7027027e-2  # 100 Bq/m³ = 2.7027 pCi/L
 
 
 class BaseUnitConverter:
@@ -702,4 +706,19 @@ class DurationConverter(BaseUnitConverter):
         UnitOfTime.HOURS,
         UnitOfTime.DAYS,
         UnitOfTime.WEEKS,
+    }
+
+
+class RadioactivityConcentrationConverter(BaseUnitConverter):
+    """Utility to convert radioactivity concentration values."""
+
+    UNIT_CLASS = "radioactivity_concentration"
+    # units in terms of Bq/m³
+    _UNIT_CONVERSION: dict[str | None, float] = {
+        UnitOfRadioactivityConcentration.BECQUERELS_PER_CUBIC_METER: 1,
+        UnitOfRadioactivityConcentration.PICOCURIES_PER_LITER: _BQ_PER_CUBIC_METER_TO_PCI_PER_LITER,
+    }
+    VALID_UNITS = {
+        UnitOfRadioactivityConcentration.BECQUERELS_PER_CUBIC_METER,
+        UnitOfRadioactivityConcentration.PICOCURIES_PER_LITER,
     }

--- a/homeassistant/util/unit_system.py
+++ b/homeassistant/util/unit_system.py
@@ -13,6 +13,7 @@ from homeassistant.const import (
     LENGTH,
     MASS,
     PRESSURE,
+    RADIOACTIVITY_CONCENTRATION,
     TEMPERATURE,
     UNIT_NOT_RECOGNIZED_TEMPLATE,
     VOLUME,
@@ -22,6 +23,7 @@ from homeassistant.const import (
     UnitOfMass,
     UnitOfPrecipitationDepth,
     UnitOfPressure,
+    UnitOfRadioactivityConcentration,
     UnitOfSpeed,
     UnitOfTemperature,
     UnitOfVolume,
@@ -32,6 +34,7 @@ from .unit_conversion import (
     AreaConverter,
     DistanceConverter,
     PressureConverter,
+    RadioactivityConcentrationConverter,
     SpeedConverter,
     TemperatureConverter,
     VolumeConverter,
@@ -57,6 +60,8 @@ MASS_UNITS: set[str] = {
 
 PRESSURE_UNITS = PressureConverter.VALID_UNITS
 
+RADIOACTIVITY_CONCENTRATION_UNITS = RadioactivityConcentrationConverter.VALID_UNITS
+
 VOLUME_UNITS = VolumeConverter.VALID_UNITS
 
 WIND_SPEED_UNITS = SpeedConverter.VALID_UNITS
@@ -72,6 +77,7 @@ _VALID_BY_TYPE: dict[str, set[str] | set[str | None]] = {
     VOLUME: VOLUME_UNITS,
     PRESSURE: PRESSURE_UNITS,
     AREA: AREA_UNITS,
+    RADIOACTIVITY_CONCENTRATION: RADIOACTIVITY_CONCENTRATION_UNITS,
 }
 
 
@@ -95,6 +101,7 @@ class UnitSystem:
         length: UnitOfLength,
         mass: UnitOfMass,
         pressure: UnitOfPressure,
+        radioactivity_concentration: UnitOfRadioactivityConcentration,
         temperature: UnitOfTemperature,
         volume: UnitOfVolume,
         wind_speed: UnitOfSpeed,
@@ -111,6 +118,7 @@ class UnitSystem:
                 (volume, VOLUME),
                 (mass, MASS),
                 (pressure, PRESSURE),
+                (radioactivity_concentration, RADIOACTIVITY_CONCENTRATION),
             )
             if not _is_valid_unit(unit, unit_type)
         )
@@ -124,6 +132,7 @@ class UnitSystem:
         self.length_unit = length
         self.mass_unit = mass
         self.pressure_unit = pressure
+        self.radioactivity_concentration_unit = radioactivity_concentration
         self.temperature_unit = temperature
         self.volume_unit = volume
         self.wind_speed_unit = wind_speed
@@ -198,6 +207,20 @@ class UnitSystem:
             volume, from_unit, self.volume_unit
         )
 
+    def radioactivity_concentration(
+        self, radioactivity_concentration: float | None, from_unit: str
+    ) -> float:
+        """Convert the given radioactivity_concentration to this unit system."""
+        if not isinstance(radioactivity_concentration, Number):
+            raise TypeError(f"{radioactivity_concentration!s} is not a numeric value")
+
+        # type ignore: https://github.com/python/mypy/issues/7207
+        return RadioactivityConcentrationConverter.convert(  # type: ignore[unreachable]
+            radioactivity_concentration,
+            from_unit,
+            self.radioactivity_concentration_unit,
+        )
+
     def as_dict(self) -> dict[str, str]:
         """Convert the unit system to a dictionary."""
         return {
@@ -206,6 +229,7 @@ class UnitSystem:
             AREA: self.area_unit,
             MASS: self.mass_unit,
             PRESSURE: self.pressure_unit,
+            RADIOACTIVITY_CONCENTRATION: self.radioactivity_concentration_unit,
             TEMPERATURE: self.temperature_unit,
             VOLUME: self.volume_unit,
             WIND_SPEED: self.wind_speed_unit,
@@ -314,6 +338,7 @@ METRIC_SYSTEM = UnitSystem(
     length=UnitOfLength.KILOMETERS,
     mass=UnitOfMass.GRAMS,
     pressure=UnitOfPressure.PA,
+    radioactivity_concentration=UnitOfRadioactivityConcentration.BECQUERELS_PER_CUBIC_METER,
     temperature=UnitOfTemperature.CELSIUS,
     volume=UnitOfVolume.LITERS,
     wind_speed=UnitOfSpeed.METERS_PER_SECOND,
@@ -362,6 +387,11 @@ US_CUSTOMARY_SYSTEM = UnitSystem(
         ("pressure", UnitOfPressure.HPA): UnitOfPressure.PSI,
         ("pressure", UnitOfPressure.KPA): UnitOfPressure.PSI,
         ("pressure", UnitOfPressure.MMHG): UnitOfPressure.INHG,
+        # Convert non-USCS radioactivity concentration
+        (
+            "radioactivity concentration",
+            UnitOfRadioactivityConcentration.BECQUERELS_PER_CUBIC_METER,
+        ): UnitOfRadioactivityConcentration.PICOCURIES_PER_LITER,
         # Convert non-USCS speeds, except knots, to mph
         ("speed", UnitOfSpeed.METERS_PER_SECOND): UnitOfSpeed.MILES_PER_HOUR,
         ("speed", UnitOfSpeed.MILLIMETERS_PER_SECOND): UnitOfSpeed.INCHES_PER_SECOND,
@@ -392,6 +422,7 @@ US_CUSTOMARY_SYSTEM = UnitSystem(
     length=UnitOfLength.MILES,
     mass=UnitOfMass.POUNDS,
     pressure=UnitOfPressure.PSI,
+    radioactivity_concentration=UnitOfRadioactivityConcentration.PICOCURIES_PER_LITER,
     temperature=UnitOfTemperature.FAHRENHEIT,
     volume=UnitOfVolume.GALLONS,
     wind_speed=UnitOfSpeed.MILES_PER_HOUR,

--- a/tests/components/sensor/common.py
+++ b/tests/components/sensor/common.py
@@ -14,6 +14,7 @@ from homeassistant.const import (
     UnitOfApparentPower,
     UnitOfFrequency,
     UnitOfPressure,
+    UnitOfRadioactivityConcentration,
     UnitOfReactivePower,
     UnitOfVolume,
 )
@@ -48,6 +49,7 @@ UNITS_OF_MEASUREMENT = {
     SensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS: CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,  # µg/m³ of vocs
     SensorDeviceClass.VOLTAGE: "V",  # voltage (V)
     SensorDeviceClass.GAS: UnitOfVolume.CUBIC_METERS,  # gas (m³)
+    SensorDeviceClass.RADIOACTIVITY_CONCENTRATION: UnitOfRadioactivityConcentration.BECQUERELS_PER_CUBIC_METER,  # radioactivity concentration (Bq/m³)
 }
 
 

--- a/tests/components/sensor/test_device_condition.py
+++ b/tests/components/sensor/test_device_condition.py
@@ -53,6 +53,7 @@ def test_matches_device_classes(device_class: SensorDeviceClass) -> None:
         SensorDeviceClass.CO2: "CONF_IS_CO2",
         SensorDeviceClass.ENERGY_STORAGE: "CONF_IS_ENERGY",
         SensorDeviceClass.VOLUME_STORAGE: "CONF_IS_VOLUME",
+        SensorDeviceClass.RADIOACTIVITY_CONCENTRATION: "CONF_IS_RADIOACTIVITY_CONCENTRATION",
     }.get(device_class, f"CONF_IS_{device_class.value.upper()}")
     assert hasattr(device_condition, constant_name), f"Missing constant {constant_name}"
 
@@ -61,6 +62,7 @@ def test_matches_device_classes(device_class: SensorDeviceClass) -> None:
         SensorDeviceClass.BATTERY: "is_battery_level",
         SensorDeviceClass.ENERGY_STORAGE: "is_energy",
         SensorDeviceClass.VOLUME_STORAGE: "is_volume",
+        SensorDeviceClass.RADIOACTIVITY_CONCENTRATION: "is_radioactivity_concentration",
     }.get(device_class, f"is_{device_class.value}")
     assert getattr(device_condition, constant_name) == constant_value
 
@@ -119,7 +121,7 @@ async def test_get_conditions(
     conditions = await async_get_device_automations(
         hass, DeviceAutomationType.CONDITION, device_entry.id
     )
-    assert len(conditions) == 27
+    assert len(conditions) == 28
     assert conditions == unordered(expected_conditions)
 
 

--- a/tests/util/test_unit_conversion.py
+++ b/tests/util/test_unit_conversion.py
@@ -23,6 +23,7 @@ from homeassistant.const import (
     UnitOfMass,
     UnitOfPower,
     UnitOfPressure,
+    UnitOfRadioactivityConcentration,
     UnitOfSpeed,
     UnitOfTemperature,
     UnitOfTime,
@@ -47,6 +48,7 @@ from homeassistant.util.unit_conversion import (
     MassConverter,
     PowerConverter,
     PressureConverter,
+    RadioactivityConcentrationConverter,
     SpeedConverter,
     TemperatureConverter,
     UnitlessRatioConverter,
@@ -76,6 +78,7 @@ _ALL_CONVERTERS: dict[type[BaseUnitConverter], list[str | None]] = {
         MassConverter,
         PowerConverter,
         PressureConverter,
+        RadioactivityConcentrationConverter,
         SpeedConverter,
         TemperatureConverter,
         UnitlessRatioConverter,
@@ -119,6 +122,11 @@ _GET_UNIT_RATIO: dict[type[BaseUnitConverter], tuple[str | None, str | None, flo
     MassConverter: (UnitOfMass.STONES, UnitOfMass.KILOGRAMS, 0.157473),
     PowerConverter: (UnitOfPower.WATT, UnitOfPower.KILO_WATT, 1000),
     PressureConverter: (UnitOfPressure.HPA, UnitOfPressure.INHG, 33.86389),
+    RadioactivityConcentrationConverter: (
+        UnitOfRadioactivityConcentration.BECQUERELS_PER_CUBIC_METER,
+        UnitOfRadioactivityConcentration.PICOCURIES_PER_LITER,
+        37,
+    ),
     SpeedConverter: (
         UnitOfSpeed.KILOMETERS_PER_HOUR,
         UnitOfSpeed.MILES_PER_HOUR,
@@ -567,6 +575,32 @@ _CONVERTED_VALUE: dict[
         (30, UnitOfPressure.MMHG, 3.99967, UnitOfPressure.CBAR),
         (30, UnitOfPressure.MMHG, 1.181102, UnitOfPressure.INHG),
         (5, UnitOfPressure.BAR, 72.51887, UnitOfPressure.PSI),
+    ],
+    RadioactivityConcentrationConverter: [
+        (
+            37,
+            UnitOfRadioactivityConcentration.BECQUERELS_PER_CUBIC_METER,
+            1,
+            UnitOfRadioactivityConcentration.PICOCURIES_PER_LITER,
+        ),
+        (
+            1,
+            UnitOfRadioactivityConcentration.PICOCURIES_PER_LITER,
+            37,
+            UnitOfRadioactivityConcentration.BECQUERELS_PER_CUBIC_METER,
+        ),
+        (
+            100,
+            UnitOfRadioactivityConcentration.BECQUERELS_PER_CUBIC_METER,
+            2.7027,
+            UnitOfRadioactivityConcentration.PICOCURIES_PER_LITER,
+        ),
+        (
+            4,
+            UnitOfRadioactivityConcentration.PICOCURIES_PER_LITER,
+            148,
+            UnitOfRadioactivityConcentration.BECQUERELS_PER_CUBIC_METER,
+        ),
     ],
     SpeedConverter: [
         # 5 km/h / 1.609 km/mi = 3.10686 mi/h

--- a/tests/util/test_unit_system.py
+++ b/tests/util/test_unit_system.py
@@ -11,6 +11,7 @@ from homeassistant.const import (
     LENGTH,
     MASS,
     PRESSURE,
+    RADIOACTIVITY_CONCENTRATION,
     TEMPERATURE,
     VOLUME,
     WIND_SPEED,
@@ -19,6 +20,7 @@ from homeassistant.const import (
     UnitOfMass,
     UnitOfPrecipitationDepth,
     UnitOfPressure,
+    UnitOfRadioactivityConcentration,
     UnitOfSpeed,
     UnitOfTemperature,
     UnitOfVolume,
@@ -53,6 +55,7 @@ def test_invalid_units() -> None:
             length=UnitOfLength.METERS,
             mass=UnitOfMass.GRAMS,
             pressure=UnitOfPressure.PA,
+            radioactivity_concentration=UnitOfRadioactivityConcentration.BECQUERELS_PER_CUBIC_METER,
             temperature=INVALID_UNIT,
             volume=UnitOfVolume.LITERS,
             wind_speed=UnitOfSpeed.METERS_PER_SECOND,
@@ -67,6 +70,7 @@ def test_invalid_units() -> None:
             length=INVALID_UNIT,
             mass=UnitOfMass.GRAMS,
             pressure=UnitOfPressure.PA,
+            radioactivity_concentration=UnitOfRadioactivityConcentration.BECQUERELS_PER_CUBIC_METER,
             temperature=UnitOfTemperature.CELSIUS,
             volume=UnitOfVolume.LITERS,
             wind_speed=UnitOfSpeed.METERS_PER_SECOND,
@@ -81,6 +85,7 @@ def test_invalid_units() -> None:
             length=UnitOfLength.METERS,
             mass=UnitOfMass.GRAMS,
             pressure=UnitOfPressure.PA,
+            radioactivity_concentration=UnitOfRadioactivityConcentration.BECQUERELS_PER_CUBIC_METER,
             temperature=UnitOfTemperature.CELSIUS,
             volume=UnitOfVolume.LITERS,
             wind_speed=INVALID_UNIT,
@@ -95,6 +100,7 @@ def test_invalid_units() -> None:
             length=UnitOfLength.METERS,
             mass=UnitOfMass.GRAMS,
             pressure=UnitOfPressure.PA,
+            radioactivity_concentration=UnitOfRadioactivityConcentration.BECQUERELS_PER_CUBIC_METER,
             temperature=UnitOfTemperature.CELSIUS,
             volume=INVALID_UNIT,
             wind_speed=UnitOfSpeed.METERS_PER_SECOND,
@@ -109,6 +115,7 @@ def test_invalid_units() -> None:
             length=UnitOfLength.METERS,
             mass=INVALID_UNIT,
             pressure=UnitOfPressure.PA,
+            radioactivity_concentration=UnitOfRadioactivityConcentration.BECQUERELS_PER_CUBIC_METER,
             temperature=UnitOfTemperature.CELSIUS,
             volume=UnitOfVolume.LITERS,
             wind_speed=UnitOfSpeed.METERS_PER_SECOND,
@@ -123,6 +130,7 @@ def test_invalid_units() -> None:
             length=UnitOfLength.METERS,
             mass=UnitOfMass.GRAMS,
             pressure=INVALID_UNIT,
+            radioactivity_concentration=UnitOfRadioactivityConcentration.BECQUERELS_PER_CUBIC_METER,
             temperature=UnitOfTemperature.CELSIUS,
             volume=UnitOfVolume.LITERS,
             wind_speed=UnitOfSpeed.METERS_PER_SECOND,
@@ -137,6 +145,7 @@ def test_invalid_units() -> None:
             length=UnitOfLength.METERS,
             mass=UnitOfMass.GRAMS,
             pressure=UnitOfPressure.PA,
+            radioactivity_concentration=UnitOfRadioactivityConcentration.BECQUERELS_PER_CUBIC_METER,
             temperature=UnitOfTemperature.CELSIUS,
             volume=UnitOfVolume.LITERS,
             wind_speed=UnitOfSpeed.METERS_PER_SECOND,
@@ -151,6 +160,22 @@ def test_invalid_units() -> None:
             length=UnitOfLength.METERS,
             mass=UnitOfMass.GRAMS,
             pressure=UnitOfPressure.PA,
+            radioactivity_concentration=UnitOfRadioactivityConcentration.BECQUERELS_PER_CUBIC_METER,
+            temperature=UnitOfTemperature.CELSIUS,
+            volume=UnitOfVolume.LITERS,
+            wind_speed=UnitOfSpeed.METERS_PER_SECOND,
+        )
+
+    with pytest.raises(ValueError):
+        UnitSystem(
+            SYSTEM_NAME,
+            accumulated_precipitation=UnitOfPrecipitationDepth.MILLIMETERS,
+            area=UnitOfArea.SQUARE_METERS,
+            conversions={},
+            length=UnitOfLength.METERS,
+            mass=UnitOfMass.GRAMS,
+            pressure=UnitOfPressure.PA,
+            radioactivity_concentration=INVALID_UNIT,
             temperature=UnitOfTemperature.CELSIUS,
             volume=UnitOfVolume.LITERS,
             wind_speed=UnitOfSpeed.METERS_PER_SECOND,
@@ -173,6 +198,10 @@ def test_invalid_value() -> None:
         METRIC_SYSTEM.accumulated_precipitation("50mm", UnitOfLength.MILLIMETERS)
     with pytest.raises(TypeError):
         METRIC_SYSTEM.area("2m²", UnitOfArea.SQUARE_METERS)
+    with pytest.raises(TypeError):
+        METRIC_SYSTEM.radioactivity_concentration(
+            "2m²", UnitOfRadioactivityConcentration.BECQUERELS_PER_CUBIC_METER
+        )
 
 
 def test_as_dict() -> None:
@@ -186,6 +215,7 @@ def test_as_dict() -> None:
         PRESSURE: UnitOfPressure.PA,
         ACCUMULATED_PRECIPITATION: UnitOfLength.MILLIMETERS,
         AREA: UnitOfArea.SQUARE_METERS,
+        RADIOACTIVITY_CONCENTRATION: UnitOfRadioactivityConcentration.BECQUERELS_PER_CUBIC_METER,
     }
 
     assert expected == METRIC_SYSTEM.as_dict()
@@ -354,6 +384,60 @@ def test_area_to_imperial() -> None:
     assert IMPERIAL_SYSTEM.area(25, METRIC_SYSTEM.area_unit) == 269.09776041774313
 
 
+def test_radioactivity_concentration_same_unit() -> None:
+    """Test no conversion happens if to unit is same as from unit."""
+    assert (
+        METRIC_SYSTEM.radioactivity_concentration(
+            5, METRIC_SYSTEM.radioactivity_concentration_unit
+        )
+        == 5
+    )
+
+
+def test_radioactivity_concentration_unknown_unit() -> None:
+    """Test no conversion happens if unknown unit."""
+    with pytest.raises(HomeAssistantError, match="is not a recognized .* unit"):
+        METRIC_SYSTEM.radioactivity_concentration(5, "abc")
+
+
+def test_radioactivity_concentration_to_metric() -> None:
+    """Test temperature conversion to metric system."""
+    assert (
+        METRIC_SYSTEM.radioactivity_concentration(
+            25, METRIC_SYSTEM.radioactivity_concentration_unit
+        )
+        == 25
+    )
+    assert (
+        round(
+            METRIC_SYSTEM.radioactivity_concentration(
+                1, IMPERIAL_SYSTEM.radioactivity_concentration_unit
+            ),
+            1,
+        )
+        == 37.0
+    )
+
+
+def test_radioactivity_concentration_to_imperial() -> None:
+    """Test temperature conversion to imperial system."""
+    assert (
+        IMPERIAL_SYSTEM.radioactivity_concentration(
+            77, IMPERIAL_SYSTEM.radioactivity_concentration_unit
+        )
+        == 77
+    )
+    assert (
+        round(
+            IMPERIAL_SYSTEM.radioactivity_concentration(
+                148, METRIC_SYSTEM.radioactivity_concentration_unit
+            ),
+            0,
+        )
+        == 4
+    )
+
+
 def test_properties() -> None:
     """Test the unit properties are returned as expected."""
     assert METRIC_SYSTEM.length_unit == UnitOfLength.KILOMETERS
@@ -364,6 +448,10 @@ def test_properties() -> None:
     assert METRIC_SYSTEM.pressure_unit == UnitOfPressure.PA
     assert METRIC_SYSTEM.accumulated_precipitation_unit == UnitOfLength.MILLIMETERS
     assert METRIC_SYSTEM.area_unit == UnitOfArea.SQUARE_METERS
+    assert (
+        METRIC_SYSTEM.radioactivity_concentration_unit
+        == UnitOfRadioactivityConcentration.BECQUERELS_PER_CUBIC_METER
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds radioactivity concentration units of measure to support radon sensors and conversion between Metric and USCS measures. These are changes to core that will enable feature requests like [this](https://community.home-assistant.io/t/add-unit-conversion-for-radon-measurement/410807) and [this](https://community.home-assistant.io/t/add-radon-device-class/786304)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: [Documentation PR](https://github.com/home-assistant/home-assistant.io/pull/36641)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
