### PR TITLE
Add `current_humidity` state attribute to Google Nest climate entity

### DIFF
--- a/homeassistant/components/nest/climate.py
+++ b/homeassistant/components/nest/climate.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, cast
 
 from google_nest_sdm.device import Device
-from google_nest_sdm.device_traits import FanTrait, TemperatureTrait
+from google_nest_sdm.device_traits import FanTrait, HumidityTrait, TemperatureTrait
 from google_nest_sdm.exceptions import ApiException
 from google_nest_sdm.thermostat_traits import (
     ThermostatEcoTrait,
@@ -132,6 +132,14 @@ class ThermostatEntity(ClimateEntity):
             return None
         trait: TemperatureTrait = self._device.traits[TemperatureTrait.NAME]
         return trait.ambient_temperature_celsius
+
+    @property
+    def current_humidity(self) -> float | None:
+        """Return the current humidity."""
+        if HumidityTrait.NAME not in self._device.traits:
+            return None
+        trait: HumidityTrait = self._device.traits[HumidityTrait.NAME]
+        return trait.ambient_humidity_percent
 
     @property
     def target_temperature(self) -> float | None:

--- a/tests/components/nest/test_climate.py
+++ b/tests/components/nest/test_climate.py
@@ -13,6 +13,7 @@ import aiohttp
 import pytest
 
 from homeassistant.components.climate import (
+    ATTR_CURRENT_HUMIDITY,
     ATTR_CURRENT_TEMPERATURE,
     ATTR_FAN_MODE,
     ATTR_FAN_MODES,
@@ -122,6 +123,9 @@ async def test_thermostat_off(
             "sdm.devices.traits.Temperature": {
                 "ambientTemperatureCelsius": 16.2,
             },
+            "sdm.devices.traits.Humidity": {
+                "ambientHumidityPercent": 40.6,
+            },
         },
     )
     await setup_platform()
@@ -131,6 +135,7 @@ async def test_thermostat_off(
     assert thermostat is not None
     assert thermostat.state == HVACMode.OFF
     assert thermostat.attributes[ATTR_HVAC_ACTION] == HVACAction.OFF
+    assert thermostat.attributes[ATTR_CURRENT_HUMIDITY] == 40.6
     assert thermostat.attributes[ATTR_CURRENT_TEMPERATURE] == 16.2
     assert set(thermostat.attributes[ATTR_HVAC_MODES]) == {
         HVACMode.HEAT,
@@ -163,6 +168,9 @@ async def test_thermostat_heat(
             "sdm.devices.traits.Temperature": {
                 "ambientTemperatureCelsius": 16.2,
             },
+            "sdm.devices.traits.Humidity": {
+                "ambientHumidityPercent": 40.6,
+            },
             "sdm.devices.traits.ThermostatTemperatureSetpoint": {
                 "heatCelsius": 22.0,
             },
@@ -175,6 +183,7 @@ async def test_thermostat_heat(
     assert thermostat is not None
     assert thermostat.state == HVACMode.HEAT
     assert thermostat.attributes[ATTR_HVAC_ACTION] == HVACAction.HEATING
+    assert thermostat.attributes[ATTR_CURRENT_HUMIDITY] == 40.6
     assert thermostat.attributes[ATTR_CURRENT_TEMPERATURE] == 16.2
     assert set(thermostat.attributes[ATTR_HVAC_MODES]) == {
         HVACMode.HEAT,
@@ -883,6 +892,9 @@ async def test_thermostat_fan_off(
             "sdm.devices.traits.Temperature": {
                 "ambientTemperatureCelsius": 16.2,
             },
+            "sdm.devices.traits.Humidity": {
+                "ambientHumidityPercent": 40.6,
+            },
         }
     )
     await setup_platform()
@@ -892,6 +904,7 @@ async def test_thermostat_fan_off(
     assert thermostat is not None
     assert thermostat.state == HVACMode.COOL
     assert thermostat.attributes[ATTR_HVAC_ACTION] == HVACAction.IDLE
+    assert thermostat.attributes[ATTR_CURRENT_HUMIDITY] == 40.6
     assert thermostat.attributes[ATTR_CURRENT_TEMPERATURE] == 16.2
     assert set(thermostat.attributes[ATTR_HVAC_MODES]) == {
         HVACMode.HEAT,
@@ -932,6 +945,9 @@ async def test_thermostat_fan_on(
             "sdm.devices.traits.Temperature": {
                 "ambientTemperatureCelsius": 16.2,
             },
+            "sdm.devices.traits.Humidity": {
+                "ambientHumidityPercent": 40.6,
+            },
         }
     )
     await setup_platform()
@@ -941,6 +957,7 @@ async def test_thermostat_fan_on(
     assert thermostat is not None
     assert thermostat.state == HVACMode.COOL
     assert thermostat.attributes[ATTR_HVAC_ACTION] == HVACAction.IDLE
+    assert thermostat.attributes[ATTR_CURRENT_HUMIDITY] == 40.6
     assert thermostat.attributes[ATTR_CURRENT_TEMPERATURE] == 16.2
     assert set(thermostat.attributes[ATTR_HVAC_MODES]) == {
         HVACMode.HEAT,
@@ -1128,6 +1145,9 @@ async def test_thermostat_fan_empty(
             "sdm.devices.traits.Temperature": {
                 "ambientTemperatureCelsius": 16.2,
             },
+            "sdm.devices.traits.Humidity": {
+                "ambientHumidityPercent": 40.6,
+            },
         }
     )
     await setup_platform()
@@ -1137,6 +1157,7 @@ async def test_thermostat_fan_empty(
     assert thermostat is not None
     assert thermostat.state == HVACMode.OFF
     assert thermostat.attributes[ATTR_HVAC_ACTION] == HVACAction.OFF
+    assert thermostat.attributes[ATTR_CURRENT_HUMIDITY] == 40.6
     assert thermostat.attributes[ATTR_CURRENT_TEMPERATURE] == 16.2
     assert set(thermostat.attributes[ATTR_HVAC_MODES]) == {
         HVACMode.HEAT,
@@ -1181,6 +1202,9 @@ async def test_thermostat_invalid_fan_mode(
             "sdm.devices.traits.Temperature": {
                 "ambientTemperatureCelsius": 16.2,
             },
+            "sdm.devices.traits.Humidity": {
+                "ambientHumidityPercent": 40.6,
+            },
         }
     )
     await setup_platform()
@@ -1190,6 +1214,7 @@ async def test_thermostat_invalid_fan_mode(
     assert thermostat is not None
     assert thermostat.state == HVACMode.COOL
     assert thermostat.attributes[ATTR_HVAC_ACTION] == HVACAction.IDLE
+    assert thermostat.attributes[ATTR_CURRENT_HUMIDITY] == 40.6
     assert thermostat.attributes[ATTR_CURRENT_TEMPERATURE] == 16.2
     assert set(thermostat.attributes[ATTR_HVAC_MODES]) == {
         HVACMode.HEAT,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
For climate entities, the "More Info" popup displays the current humidity if the entity includes a `current_humidity` state attribute. Previously, this attribute was missing for entities in the Google Nest integration, causing the humidity information to be absent from the popup. This PR resolves the issue by adding the `current_humidity` state attribute to the entity.

<details><summary>Screenshots</summary>

Before:
![image](https://github.com/user-attachments/assets/9821b74d-aa62-4ae9-aea4-93bfcd72354a)

After:
![image](https://github.com/user-attachments/assets/fba78d3d-4fc0-476b-b1aa-82099d8808c8)

</details>


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
