### PR TITLE
Improve pandora media_player typing

### DIFF
--- a/homeassistant/components/pandora/media_player.py
+++ b/homeassistant/components/pandora/media_player.py
@@ -174,6 +174,7 @@ class PandoraMediaPlayer(MediaPlayerEntity):
             _LOGGER.warning("Station %s is not in list", source)
             return
         _LOGGER.debug("Setting station %s, %d", source, station_index)
+        assert self._pianobar is not None
         self._send_station_list_command()
         self._pianobar.sendline(f"{station_index}")
         self._pianobar.expect("\r\n")
@@ -181,6 +182,7 @@ class PandoraMediaPlayer(MediaPlayerEntity):
 
     def _send_station_list_command(self) -> None:
         """Send a station list command."""
+        assert self._pianobar is not None
         self._pianobar.send("s")
         try:
             self._pianobar.expect("Select station:", timeout=1)
@@ -201,6 +203,7 @@ class PandoraMediaPlayer(MediaPlayerEntity):
 
     def _query_for_playing_status(self) -> str | None:
         """Query system for info about current track."""
+        assert self._pianobar is not None
         self._clear_buffer()
         self._pianobar.send("i")
         try:
@@ -263,6 +266,7 @@ class PandoraMediaPlayer(MediaPlayerEntity):
         so we have to detect state by checking the ticker.
 
         """
+        assert self._pianobar is not None
         (
             cur_minutes,
             cur_seconds,
@@ -280,6 +284,7 @@ class PandoraMediaPlayer(MediaPlayerEntity):
 
     def _log_match(self) -> None:
         """Log grabbed values from console."""
+        assert self._pianobar is not None
         _LOGGER.debug(
             "Before: %s\nMatch: %s\nAfter: %s",
             repr(self._pianobar.before),
@@ -289,6 +294,7 @@ class PandoraMediaPlayer(MediaPlayerEntity):
 
     def _send_pianobar_command(self, service_cmd: str) -> None:
         """Send a command to Pianobar."""
+        assert self._pianobar is not None
         command = CMD_MAP.get(service_cmd)
         _LOGGER.debug("Sending pinaobar command %s for %s", command, service_cmd)
         if command is None:
@@ -299,6 +305,7 @@ class PandoraMediaPlayer(MediaPlayerEntity):
 
     def _update_stations(self) -> None:
         """List defined Pandora stations."""
+        assert self._pianobar is not None
         self._send_station_list_command()
         station_lines = self._pianobar.before.decode("utf-8")
         _LOGGER.debug("Getting stations: %s", station_lines)
@@ -319,6 +326,7 @@ class PandoraMediaPlayer(MediaPlayerEntity):
         This is necessary because there are a bunch of 00:00 in the buffer
 
         """
+        assert self._pianobar is not None
         try:
             while not self._pianobar.expect(".+", timeout=0.1):
                 pass

--- a/homeassistant/components/pandora/media_player.py
+++ b/homeassistant/components/pandora/media_player.py
@@ -8,6 +8,7 @@ import os
 import re
 import shutil
 import signal
+from typing import cast
 
 import pexpect
 
@@ -26,7 +27,7 @@ from homeassistant.const import (
     SERVICE_VOLUME_DOWN,
     SERVICE_VOLUME_UP,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import Event, HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
@@ -58,7 +59,7 @@ def setup_platform(
 
     # Make sure we end the pandora subprocess on exit in case user doesn't
     # power it down.
-    def _stop_pianobar(_event):
+    def _stop_pianobar(_event: Event) -> None:
         pandora.turn_off()
 
     hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, _stop_pianobar)
@@ -80,7 +81,7 @@ class PandoraMediaPlayer(MediaPlayerEntity):
         | MediaPlayerEntityFeature.PLAY
     )
 
-    def __init__(self, name):
+    def __init__(self, name: str) -> None:
         """Initialize the Pandora device."""
         self._attr_name = name
         self._attr_state = MediaPlayerState.OFF
@@ -91,7 +92,7 @@ class PandoraMediaPlayer(MediaPlayerEntity):
         self._attr_source_list = []
         self._time_remaining = 0
         self._attr_media_duration = 0
-        self._pianobar = None
+        self._pianobar: pexpect.spawn | None = None
 
     def turn_on(self) -> None:
         """Turn the media player on."""
@@ -178,7 +179,7 @@ class PandoraMediaPlayer(MediaPlayerEntity):
         self._pianobar.expect("\r\n")
         self._attr_state = MediaPlayerState.PLAYING
 
-    def _send_station_list_command(self):
+    def _send_station_list_command(self) -> None:
         """Send a station list command."""
         self._pianobar.send("s")
         try:
@@ -189,7 +190,7 @@ class PandoraMediaPlayer(MediaPlayerEntity):
             self._pianobar.send("s")
             self._pianobar.expect("Select station:")
 
-    def update_playing_status(self):
+    def update_playing_status(self) -> None:
         """Query pianobar for info about current media_title, station."""
         response = self._query_for_playing_status()
         if not response:
@@ -198,7 +199,7 @@ class PandoraMediaPlayer(MediaPlayerEntity):
         self._update_current_song(response)
         self._update_song_position()
 
-    def _query_for_playing_status(self):
+    def _query_for_playing_status(self) -> str | None:
         """Query system for info about current track."""
         self._clear_buffer()
         self._pianobar.send("i")
@@ -224,15 +225,17 @@ class PandoraMediaPlayer(MediaPlayerEntity):
             _LOGGER.warning("On unexpected station list page")
             self._pianobar.sendcontrol("m")  # press enter
             self._pianobar.sendcontrol("m")  # do it again b/c an 'i' got in
-            response = self.update_playing_status()
+            self.update_playing_status()
+            response = None
         elif match_idx == 3:
             _LOGGER.debug("Received new playlist list")
-            response = self.update_playing_status()
+            self.update_playing_status()
+            response = None
         else:
             response = self._pianobar.before.decode("utf-8")
         return response
 
-    def _update_current_station(self, response):
+    def _update_current_station(self, response: str) -> None:
         """Update current station."""
         if station_match := re.search(STATION_PATTERN, response):
             self._attr_source = station_match.group(1)
@@ -240,7 +243,7 @@ class PandoraMediaPlayer(MediaPlayerEntity):
         else:
             _LOGGER.warning("No station match")
 
-    def _update_current_song(self, response):
+    def _update_current_song(self, response: str) -> None:
         """Update info about current song."""
         if song_match := re.search(CURRENT_SONG_PATTERN, response):
             (
@@ -253,7 +256,7 @@ class PandoraMediaPlayer(MediaPlayerEntity):
             _LOGGER.warning("No song match")
 
     @util.Throttle(MIN_TIME_BETWEEN_UPDATES)
-    def _update_song_position(self):
+    def _update_song_position(self) -> None:
         """Get the song position and duration.
 
         It's hard to predict whether or not the music will start during init
@@ -265,7 +268,7 @@ class PandoraMediaPlayer(MediaPlayerEntity):
             cur_seconds,
             total_minutes,
             total_seconds,
-        ) = self._pianobar.match.groups()
+        ) = cast(re.Match[str], self._pianobar.match).groups()
         time_remaining = int(cur_minutes) * 60 + int(cur_seconds)
         self._attr_media_duration = int(total_minutes) * 60 + int(total_seconds)
 
@@ -275,7 +278,7 @@ class PandoraMediaPlayer(MediaPlayerEntity):
             self._attr_state = MediaPlayerState.PAUSED
         self._time_remaining = time_remaining
 
-    def _log_match(self):
+    def _log_match(self) -> None:
         """Log grabbed values from console."""
         _LOGGER.debug(
             "Before: %s\nMatch: %s\nAfter: %s",
@@ -284,16 +287,17 @@ class PandoraMediaPlayer(MediaPlayerEntity):
             repr(self._pianobar.after),
         )
 
-    def _send_pianobar_command(self, service_cmd):
+    def _send_pianobar_command(self, service_cmd: str) -> None:
         """Send a command to Pianobar."""
         command = CMD_MAP.get(service_cmd)
         _LOGGER.debug("Sending pinaobar command %s for %s", command, service_cmd)
         if command is None:
             _LOGGER.warning("Command %s not supported yet", service_cmd)
+            return
         self._clear_buffer()
         self._pianobar.sendline(command)
 
-    def _update_stations(self):
+    def _update_stations(self) -> None:
         """List defined Pandora stations."""
         self._send_station_list_command()
         station_lines = self._pianobar.before.decode("utf-8")
@@ -309,7 +313,7 @@ class PandoraMediaPlayer(MediaPlayerEntity):
         self._pianobar.sendcontrol("m")  # press enter with blank line
         self._pianobar.sendcontrol("m")  # do it twice in case an 'i' got in
 
-    def _clear_buffer(self):
+    def _clear_buffer(self) -> None:
         """Clear buffer from pexpect.
 
         This is necessary because there are a bunch of 00:00 in the buffer
@@ -324,7 +328,7 @@ class PandoraMediaPlayer(MediaPlayerEntity):
             pass
 
 
-def _pianobar_exists():
+def _pianobar_exists() -> bool:
     """Verify that Pianobar is properly installed."""
     pianobar_exe = shutil.which("pianobar")
     if pianobar_exe:


### PR DESCRIPTION
## Proposed change
Add more type annotations for pandora. These are in preparation for a followup PR where I plan to add the `types-pexpect` package.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
