### PR TITLE
Add types package for pexpect

### DIFF
--- a/homeassistant/components/aruba/device_tracker.py
+++ b/homeassistant/components/aruba/device_tracker.py
@@ -90,7 +90,7 @@ class ArubaDeviceScanner(DeviceScanner):
         """Retrieve data from Aruba Access Point and return parsed result."""
 
         connect = f"ssh {self.username}@{self.host} -o HostKeyAlgorithms=ssh-rsa"
-        ssh = pexpect.spawn(connect)
+        ssh: pexpect.spawn[str] = pexpect.spawn(connect, encoding="utf-8")
         query = ssh.expect(
             [
                 "password:",
@@ -125,12 +125,12 @@ class ArubaDeviceScanner(DeviceScanner):
         ssh.expect("#")
         ssh.sendline("show clients")
         ssh.expect("#")
-        devices_result = ssh.before.split(b"\r\n")
+        devices_result = (ssh.before or "").splitlines()
         ssh.sendline("exit")
 
         devices: dict[str, dict[str, str]] = {}
         for device in devices_result:
-            if match := _DEVICES_REGEX.search(device.decode("utf-8")):
+            if match := _DEVICES_REGEX.search(device):
                 devices[match.group("ip")] = {
                     "ip": match.group("ip"),
                     "mac": match.group("mac").upper(),

--- a/homeassistant/components/pandora/media_player.py
+++ b/homeassistant/components/pandora/media_player.py
@@ -92,13 +92,13 @@ class PandoraMediaPlayer(MediaPlayerEntity):
         self._attr_source_list = []
         self._time_remaining = 0
         self._attr_media_duration = 0
-        self._pianobar: pexpect.spawn | None = None
+        self._pianobar: pexpect.spawn[str] | None = None
 
     def turn_on(self) -> None:
         """Turn the media player on."""
         if self.state != MediaPlayerState.OFF:
             return
-        self._pianobar = pexpect.spawn("pianobar")
+        self._pianobar = pexpect.spawn("pianobar", encoding="utf-8")
         _LOGGER.debug("Started pianobar subprocess")
         mode = self._pianobar.expect(
             ["Receiving new playlist", "Select station:", "Email:"]
@@ -135,8 +135,9 @@ class PandoraMediaPlayer(MediaPlayerEntity):
             self._pianobar.terminate()
         except pexpect.exceptions.TIMEOUT:
             # kill the process group
-            os.killpg(os.getpgid(self._pianobar.pid), signal.SIGTERM)
-            _LOGGER.debug("Killed Pianobar subprocess")
+            if (pid := self._pianobar.pid) is not None:
+                os.killpg(os.getpgid(pid), signal.SIGTERM)
+                _LOGGER.debug("Killed Pianobar subprocess")
         self._pianobar = None
         self._attr_state = MediaPlayerState.OFF
         self.schedule_update_ha_state()
@@ -209,7 +210,7 @@ class PandoraMediaPlayer(MediaPlayerEntity):
         try:
             match_idx = self._pianobar.expect(
                 [
-                    rb"(\d\d):(\d\d)/(\d\d):(\d\d)",
+                    r"(\d\d):(\d\d)/(\d\d):(\d\d)",
                     "No song playing",
                     "Select station",
                     "Receiving new playlist",
@@ -222,21 +223,20 @@ class PandoraMediaPlayer(MediaPlayerEntity):
         self._log_match()
         if match_idx == 1:
             # idle.
-            response = None
-        elif match_idx == 2:
+            return None
+        if match_idx == 2:
             # stuck on a station selection dialog. Clear it.
             _LOGGER.warning("On unexpected station list page")
             self._pianobar.sendcontrol("m")  # press enter
             self._pianobar.sendcontrol("m")  # do it again b/c an 'i' got in
             self.update_playing_status()
-            response = None
-        elif match_idx == 3:
+            return None
+        if match_idx == 3:
             _LOGGER.debug("Received new playlist list")
             self.update_playing_status()
-            response = None
-        else:
-            response = self._pianobar.before.decode("utf-8")
-        return response
+            return None
+
+        return self._pianobar.before
 
     def _update_current_station(self, response: str) -> None:
         """Update current station."""
@@ -307,7 +307,7 @@ class PandoraMediaPlayer(MediaPlayerEntity):
         """List defined Pandora stations."""
         assert self._pianobar is not None
         self._send_station_list_command()
-        station_lines = self._pianobar.before.decode("utf-8")
+        station_lines = self._pianobar.before or ""
         _LOGGER.debug("Getting stations: %s", station_lines)
         self._attr_source_list = []
         for line in station_lines.split("\r\n"):

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -42,6 +42,7 @@ types-caldav==1.3.0.20241107
 types-chardet==0.1.5
 types-decorator==5.1.8.20240310
 types-paho-mqtt==1.6.0.20240321
+types-pexpect==4.9.0.20241208
 types-pillow==10.2.0.20240822
 types-protobuf==5.29.1.20241207
 types-psutil==6.1.0.20241221


### PR DESCRIPTION
## Proposed change
`pexpect` is a requirement for multiple integrations.
https://github.com/home-assistant/core/blob/3b5455bc4960ce60cd958d93a72b4a4939adb2ac/requirements_all.txt#L1629-L1632

The types package is part of the `typeshed` project: https://pypi.org/project/types-pexpect/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
