### PR TITLE
Remove deprecated uptime sensor from qnap_qsw

### DIFF
--- a/homeassistant/components/qnap_qsw/sensor.py
+++ b/homeassistant/components/qnap_qsw/sensor.py
@@ -27,12 +27,9 @@ from aioqsw.const import (
     QSD_TEMP_MAX,
     QSD_TX_OCTETS,
     QSD_TX_SPEED,
-    QSD_UPTIME_SECONDS,
     QSD_UPTIME_TIMESTAMP,
 )
 
-from homeassistant.components.automation import automations_with_entity
-from homeassistant.components.script import scripts_with_entity
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
@@ -45,10 +42,8 @@ from homeassistant.const import (
     UnitOfDataRate,
     UnitOfInformation,
     UnitOfTemperature,
-    UnitOfTime,
 )
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import entity_registry as er, issue_registry as ir
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import UNDEFINED, StateType
 from homeassistant.util import dt as dt_util
@@ -66,16 +61,6 @@ class QswSensorEntityDescription(SensorEntityDescription, QswEntityDescription):
     qsw_type: QswEntityType | None = None
     sep_key: str = "_"
     value_fn: Callable[[str], datetime | StateType] = lambda value: value
-
-
-DEPRECATED_UPTIME_SECONDS = QswSensorEntityDescription(
-    translation_key="uptime",
-    key=QSD_SYSTEM_TIME,
-    entity_category=EntityCategory.DIAGNOSTIC,
-    native_unit_of_measurement=UnitOfTime.SECONDS,
-    state_class=SensorStateClass.TOTAL_INCREASING,
-    subkey=QSD_UPTIME_SECONDS,
-)
 
 
 SENSOR_TYPES: Final[tuple[QswSensorEntityDescription, ...]] = (
@@ -354,46 +339,6 @@ async def async_setup_entry(
                 name=f"Port {port_id} {description.name}",
             )
             entities.append(QswSensor(coordinator, _desc, entry, port_id))
-
-    # Can be removed in HA 2025.5.0
-    entity_reg = er.async_get(hass)
-    reg_entities = er.async_entries_for_config_entry(entity_reg, entry.entry_id)
-    for entity in reg_entities:
-        if entity.domain == "sensor" and entity.unique_id.endswith(
-            ("_uptime", "_uptime_seconds")
-        ):
-            entity_id = entity.entity_id
-
-            if entity.disabled:
-                entity_reg.async_remove(entity_id)
-                continue
-
-            if (
-                DEPRECATED_UPTIME_SECONDS.key in coordinator.data
-                and DEPRECATED_UPTIME_SECONDS.subkey
-                in coordinator.data[DEPRECATED_UPTIME_SECONDS.key]
-            ):
-                entities.append(
-                    QswSensor(coordinator, DEPRECATED_UPTIME_SECONDS, entry)
-                )
-
-                entity_automations = automations_with_entity(hass, entity_id)
-                entity_scripts = scripts_with_entity(hass, entity_id)
-
-                for item in entity_automations + entity_scripts:
-                    ir.async_create_issue(
-                        hass,
-                        DOMAIN,
-                        f"uptime_seconds_deprecated_{entity_id}_{item}",
-                        breaks_in_ha_version="2025.5.0",
-                        is_fixable=False,
-                        severity=ir.IssueSeverity.WARNING,
-                        translation_key="uptime_seconds_deprecated",
-                        translation_placeholders={
-                            "entity": entity_id,
-                            "info": item,
-                        },
-                    )
 
     async_add_entities(entities)
 

--- a/homeassistant/components/qnap_qsw/strings.json
+++ b/homeassistant/components/qnap_qsw/strings.json
@@ -57,11 +57,5 @@
         "name": "Uptime timestamp"
       }
     }
-  },
-  "issues": {
-    "uptime_seconds_deprecated": {
-      "title": "QNAP QSW uptime seconds sensor deprecated",
-      "description": "The QNAP QSW uptime seconds sensor entity is deprecated and will be removed in HA 2025.2.0.\nHome Assistant detected that entity `{entity}` is being used in `{info}`\n\nYou should remove the uptime seconds entity from `{info}` then click submit to fix this issue."
-    }
   }
 }

--- a/tests/components/qnap_qsw/test_sensor.py
+++ b/tests/components/qnap_qsw/test_sensor.py
@@ -1,14 +1,12 @@
 """The sensor tests for the QNAP QSW platform."""
 
-from unittest.mock import patch
-
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 
 from homeassistant.components.qnap_qsw.const import ATTR_MAX, DOMAIN
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er, issue_registry as ir
+from homeassistant.helpers import entity_registry as er
 
 from .util import async_init_integration, init_config_entry
 
@@ -381,39 +379,6 @@ async def test_qnap_qsw_create_sensors(
 
     state = hass.states.get("sensor.qsw_m408_4c_port_12_tx_speed")
     assert state.state == "0"
-
-
-@pytest.mark.usefixtures("entity_registry_enabled_by_default")
-async def test_deprecated_uptime_seconds(
-    hass: HomeAssistant,
-    entity_registry: er.EntityRegistry,
-    issue_registry: ir.IssueRegistry,
-) -> None:
-    """Test deprecation warning of the Uptime seconds sensor entity."""
-    original_id = "sensor.qsw_m408_4c_uptime"
-    domain = Platform.SENSOR
-
-    config_entry = init_config_entry(hass)
-
-    entity = entity_registry.async_get_or_create(
-        domain=domain,
-        platform=DOMAIN,
-        unique_id=original_id,
-        config_entry=config_entry,
-        suggested_object_id=original_id,
-        disabled_by=None,
-    )
-
-    assert entity_registry.async_get_entity_id(domain, DOMAIN, original_id)
-
-    with patch(
-        "homeassistant.components.qnap_qsw.sensor.automations_with_entity",
-        return_value=["item"],
-    ):
-        await async_init_integration(hass, config_entry=config_entry)
-        assert issue_registry.async_get_issue(
-            DOMAIN, f"uptime_seconds_deprecated_{entity.entity_id}_item"
-        )
 
 
 async def test_cleanup_deprecated_uptime_seconds(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The uptime sensor was previously deprecated and has now been removed.
https://github.com/home-assistant/core/pull/122589

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 