### PR TITLE
Make pip_kwargs consistent with async_mount_local_lib_path

### DIFF
--- a/homeassistant/requirements.py
+++ b/homeassistant/requirements.py
@@ -85,15 +85,20 @@ def async_clear_install_history(hass: HomeAssistant) -> None:
     _async_get_manager(hass).install_failure_history.clear()
 
 
-def pip_kwargs(config_dir: str | None) -> dict[str, Any]:
-    """Return keyword arguments for PIP install."""
+async def async_pip_kwargs(config_dir: str | None) -> dict[str, Any]:
+    """Return keyword arguments for PIP install.
+
+    This function is a coroutine.
+    """
     is_docker = pkg_util.is_docker_env()
     kwargs = {
         "constraints": os.path.join(os.path.dirname(__file__), CONSTRAINT_FILE),
         "timeout": PIP_TIMEOUT,
     }
     if not (config_dir is None or pkg_util.is_virtual_env()) and not is_docker:
-        kwargs["target"] = os.path.join(config_dir, "deps")
+        kwargs["target"] = await pkg_util.async_get_user_site(
+            os.path.join(config_dir, "deps")
+        )
     return kwargs
 
 
@@ -297,7 +302,7 @@ class RequirementsManager:
         requirements: list[str],
     ) -> None:
         """Install a requirement and save failures."""
-        kwargs = pip_kwargs(self.hass.config.config_dir)
+        kwargs = await async_pip_kwargs(self.hass.config.config_dir)
         installed, failures = await self.hass.async_add_executor_job(
             _install_requirements_if_missing, requirements, kwargs
         )

--- a/homeassistant/requirements.py
+++ b/homeassistant/requirements.py
@@ -86,10 +86,7 @@ def async_clear_install_history(hass: HomeAssistant) -> None:
 
 
 async def async_pip_kwargs(config_dir: str | None) -> dict[str, Any]:
-    """Return keyword arguments for PIP install.
-
-    This function is a coroutine.
-    """
+    """Return keyword arguments for PIP install."""
     is_docker = pkg_util.is_docker_env()
     kwargs = {
         "constraints": os.path.join(os.path.dirname(__file__), CONSTRAINT_FILE),

--- a/homeassistant/requirements.py
+++ b/homeassistant/requirements.py
@@ -85,7 +85,7 @@ def async_clear_install_history(hass: HomeAssistant) -> None:
     _async_get_manager(hass).install_failure_history.clear()
 
 
-async def async_pip_kwargs(config_dir: str | None) -> dict[str, Any]:
+def pip_kwargs(config_dir: str | None) -> dict[str, Any]:
     """Return keyword arguments for PIP install."""
     is_docker = pkg_util.is_docker_env()
     kwargs = {
@@ -93,9 +93,8 @@ async def async_pip_kwargs(config_dir: str | None) -> dict[str, Any]:
         "timeout": PIP_TIMEOUT,
     }
     if not (config_dir is None or pkg_util.is_virtual_env()) and not is_docker:
-        kwargs["target"] = await pkg_util.async_get_user_site(
-            os.path.join(config_dir, "deps")
-        )
+        kwargs["target"] = asyncio.run(pkg_util.async_get_user_site(
+            os.path.join(config_dir, "deps")))
     return kwargs
 
 
@@ -299,7 +298,7 @@ class RequirementsManager:
         requirements: list[str],
     ) -> None:
         """Install a requirement and save failures."""
-        kwargs = await async_pip_kwargs(self.hass.config.config_dir)
+        kwargs = await self.hass.async_add_executor_job(pip_kwargs,self.hass.config.config_dir)
         installed, failures = await self.hass.async_add_executor_job(
             _install_requirements_if_missing, requirements, kwargs
         )

--- a/homeassistant/scripts/__init__.py
+++ b/homeassistant/scripts/__init__.py
@@ -13,7 +13,7 @@ import sys
 from homeassistant import runner
 from homeassistant.bootstrap import async_mount_local_lib_path
 from homeassistant.config import get_default_config_dir
-from homeassistant.requirements import pip_kwargs
+from homeassistant.requirements import async_pip_kwargs
 from homeassistant.util.package import install_package, is_installed, is_virtual_env
 
 # mypy: allow-untyped-defs, disallow-any-generics, no-warn-return-any
@@ -49,7 +49,7 @@ def run(args: list[str]) -> int:
     if not is_virtual_env():
         asyncio.run(async_mount_local_lib_path(config_dir))
 
-    _pip_kwargs = pip_kwargs(config_dir)
+    _pip_kwargs = loop.run_until_complete(async_pip_kwargs(config_dir))
 
     logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 

--- a/homeassistant/scripts/__init__.py
+++ b/homeassistant/scripts/__init__.py
@@ -49,7 +49,7 @@ def run(args: list[str]) -> int:
     if not is_virtual_env():
         asyncio.run(async_mount_local_lib_path(config_dir))
 
-    _pip_kwargs = loop.run_until_complete(async_pip_kwargs(config_dir))
+    _pip_kwargs = asyncio.run(async_pip_kwargs(config_dir))
 
     logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 

--- a/homeassistant/scripts/__init__.py
+++ b/homeassistant/scripts/__init__.py
@@ -13,7 +13,7 @@ import sys
 from homeassistant import runner
 from homeassistant.bootstrap import async_mount_local_lib_path
 from homeassistant.config import get_default_config_dir
-from homeassistant.requirements import async_pip_kwargs
+from homeassistant.requirements import pip_kwargs
 from homeassistant.util.package import install_package, is_installed, is_virtual_env
 
 # mypy: allow-untyped-defs, disallow-any-generics, no-warn-return-any
@@ -49,7 +49,7 @@ def run(args: list[str]) -> int:
     if not is_virtual_env():
         asyncio.run(async_mount_local_lib_path(config_dir))
 
-    _pip_kwargs = asyncio.run(async_pip_kwargs(config_dir))
+    _pip_kwargs = pip_kwargs(config_dir)
 
     logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The existing requirements.pip_kwargs function, seems like it intended, under specific circumstances (not virtualenv and not docker, so CORE installations?), to install additional dependencies into the directory mounted by bootstrap.async_mount_local_lib_path (/config/deps/..).

However, what actually ends up happening is that pip_kwargs sets target=/config/deps while async_mount_local_lib_path mounts /config/deps/python3.13/site-packages into sys.path.

This results in HASS installing packages into a directory it doesn't mount onto sys.path.
Therefore, this PR is to correct that inconsistency by making pip_kwargs determine the target in the same way async_mount_local_lib_path does, ensuring that it will install additional dependencies into the same location it mounts.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/issues/127966
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
