### PR TITLE
Bump bleak-esphome to 2.0.0

### DIFF
--- a/homeassistant/components/eq3btsmart/manifest.json
+++ b/homeassistant/components/eq3btsmart/manifest.json
@@ -22,5 +22,5 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "loggers": ["eq3btsmart"],
-  "requirements": ["eq3btsmart==1.4.1", "bleak-esphome==1.1.0"]
+  "requirements": ["eq3btsmart==1.4.1", "bleak-esphome==2.0.0"]
 }

--- a/homeassistant/components/esphome/bluetooth.py
+++ b/homeassistant/components/esphome/bluetooth.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING
 
 from aioesphomeapi import APIClient, DeviceInfo
 from bleak_esphome import connect_scanner
-from bleak_esphome.backend.cache import ESPHomeBluetoothCache
 
 from homeassistant.components.bluetooth import async_register_scanner
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback as hass_callback
@@ -28,10 +27,9 @@ def async_connect_scanner(
     entry_data: RuntimeEntryData,
     cli: APIClient,
     device_info: DeviceInfo,
-    cache: ESPHomeBluetoothCache,
 ) -> CALLBACK_TYPE:
     """Connect scanner."""
-    client_data = connect_scanner(cli, device_info, cache, entry_data.available)
+    client_data = connect_scanner(cli, device_info, entry_data.available)
     entry_data.bluetooth_device = client_data.bluetooth_device
     client_data.disconnect_callbacks = entry_data.disconnect_callbacks
     scanner = client_data.scanner

--- a/homeassistant/components/esphome/domain_data.py
+++ b/homeassistant/components/esphome/domain_data.py
@@ -6,8 +6,6 @@ from dataclasses import dataclass, field
 from functools import cache
 from typing import Self
 
-from bleak_esphome.backend.cache import ESPHomeBluetoothCache
-
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.json import JSONEncoder
 
@@ -22,9 +20,6 @@ class DomainData:
     """Define a class that stores global esphome data in hass.data[DOMAIN]."""
 
     _stores: dict[str, ESPHomeStorage] = field(default_factory=dict)
-    bluetooth_cache: ESPHomeBluetoothCache = field(
-        default_factory=ESPHomeBluetoothCache
-    )
 
     def get_entry_data(self, entry: ESPHomeConfigEntry) -> RuntimeEntryData:
         """Return the runtime entry data associated with this config entry.

--- a/homeassistant/components/esphome/manager.py
+++ b/homeassistant/components/esphome/manager.py
@@ -423,9 +423,7 @@ class ESPHomeManager:
 
         if device_info.bluetooth_proxy_feature_flags_compat(api_version):
             entry_data.disconnect_callbacks.add(
-                async_connect_scanner(
-                    hass, entry_data, cli, device_info, self.domain_data.bluetooth_cache
-                )
+                async_connect_scanner(hass, entry_data, cli, device_info)
             )
 
         if device_info.voice_assistant_feature_flags_compat(api_version) and (

--- a/homeassistant/components/esphome/manifest.json
+++ b/homeassistant/components/esphome/manifest.json
@@ -18,7 +18,7 @@
   "requirements": [
     "aioesphomeapi==28.0.0",
     "esphome-dashboard-api==1.2.3",
-    "bleak-esphome==1.1.0"
+    "bleak-esphome==2.0.0"
   ],
   "zeroconf": ["_esphomelib._tcp.local."]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -590,8 +590,6 @@ bimmer-connected[china]==0.17.2
 bizkaibus==0.1.1
 
 # homeassistant.components.eq3btsmart
-bleak-esphome==1.1.0
-
 # homeassistant.components.esphome
 bleak-esphome==2.0.0
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -590,8 +590,10 @@ bimmer-connected[china]==0.17.2
 bizkaibus==0.1.1
 
 # homeassistant.components.eq3btsmart
-# homeassistant.components.esphome
 bleak-esphome==1.1.0
+
+# homeassistant.components.esphome
+bleak-esphome==2.0.0
 
 # homeassistant.components.bluetooth
 bleak-retry-connector==3.6.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -521,8 +521,10 @@ beautifulsoup4==4.12.3
 bimmer-connected[china]==0.17.2
 
 # homeassistant.components.eq3btsmart
-# homeassistant.components.esphome
 bleak-esphome==1.1.0
+
+# homeassistant.components.esphome
+bleak-esphome==2.0.0
 
 # homeassistant.components.bluetooth
 bleak-retry-connector==3.6.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -521,8 +521,6 @@ beautifulsoup4==4.12.3
 bimmer-connected[china]==0.17.2
 
 # homeassistant.components.eq3btsmart
-bleak-esphome==1.1.0
-
 # homeassistant.components.esphome
 bleak-esphome==2.0.0
 

--- a/tests/components/esphome/bluetooth/test_client.py
+++ b/tests/components/esphome/bluetooth/test_client.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from aioesphomeapi import APIClient, APIVersion, BluetoothProxyFeature, DeviceInfo
 from bleak.exc import BleakError
-from bleak_esphome.backend.cache import ESPHomeBluetoothCache
 from bleak_esphome.backend.client import ESPHomeClient, ESPHomeClientData
 from bleak_esphome.backend.device import ESPHomeBluetoothDevice
 from bleak_esphome.backend.scanner import ESPHomeScanner
@@ -27,7 +26,6 @@ async def client_data_fixture(
     connector = HaBluetoothConnector(ESPHomeClientData, ESP_MAC_ADDRESS, lambda: True)
     return ESPHomeClientData(
         bluetooth_device=ESPHomeBluetoothDevice(ESP_NAME, ESP_MAC_ADDRESS),
-        cache=ESPHomeBluetoothCache(),
         client=mock_client,
         device_info=DeviceInfo(
             mac_address=ESP_MAC_ADDRESS,


### PR DESCRIPTION



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
There is a fix to move the caching to be per ESP device since different ESP chips/major versions can generate different services for the same device. Previously we had a global cache that was shared between all ESPHome Bluetooth proxies which could result in writing to the wrong handle if all the ESPs were not the same

changelog: https://github.com/Bluetooth-Devices/bleak-esphome/compare/v1.1.0...v2.0.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
