### PR TITLE
Add get device capabilities action call for Sensibo

### DIFF
--- a/homeassistant/components/sensibo/icons.json
+++ b/homeassistant/components/sensibo/icons.json
@@ -59,6 +59,9 @@
     },
     "enable_climate_react": {
       "service": "mdi:wizard-hat"
+    },
+    "get_device_capabilities": {
+      "service": "mdi:shape-outline"
     }
   }
 }

--- a/homeassistant/components/sensibo/services.yaml
+++ b/homeassistant/components/sensibo/services.yaml
@@ -159,3 +159,20 @@ enable_climate_react:
             - "feelslike"
             - "humidity"
           translation_key: smart_type
+get_device_capabilities:
+  target:
+    entity:
+      integration: sensibo
+      domain: climate
+  fields:
+    hvac_mode:
+      selector:
+        select:
+          options:
+            - "off"
+            - "auto"
+            - "cool"
+            - "dry"
+            - "fan"
+            - "heat"
+          translation_key: hvac_mode

--- a/homeassistant/components/sensibo/services.yaml
+++ b/homeassistant/components/sensibo/services.yaml
@@ -166,6 +166,8 @@ get_device_capabilities:
       domain: climate
   fields:
     hvac_mode:
+      required: true
+      example: "heat"
       selector:
         select:
           options:

--- a/homeassistant/components/sensibo/services.yaml
+++ b/homeassistant/components/sensibo/services.yaml
@@ -169,7 +169,6 @@ get_device_capabilities:
       selector:
         select:
           options:
-            - "off"
             - "auto"
             - "cool"
             - "dry"

--- a/homeassistant/components/sensibo/strings.json
+++ b/homeassistant/components/sensibo/strings.json
@@ -573,7 +573,7 @@
       "message": "[%key:component::sensibo::config::error::no_devices%]"
     },
     "mode_not_exist": {
-      "message": "The entity does not support the choosen mode"
+      "message": "The entity does not support the chosen mode"
     }
   }
 }

--- a/homeassistant/components/sensibo/strings.json
+++ b/homeassistant/components/sensibo/strings.json
@@ -494,6 +494,16 @@
           "description": "Choose between temperature/feels like/humidity."
         }
       }
+    },
+    "get_device_capabilities": {
+      "name": "Get device mode capabilities",
+      "description": "Retrieve the device capabilities for a specific device according to api requirements.",
+      "fields": {
+        "hvac_mode": {
+          "name": "[%key:component::climate::services::set_hvac_mode::fields::hvac_mode::name%]",
+          "description": "[%key:component::climate::services::set_hvac_mode::fields::hvac_mode::description%]"
+        }
+      }
     }
   },
   "selector": {
@@ -561,6 +571,9 @@
     },
     "no_data": {
       "message": "[%key:component::sensibo::config::error::no_devices%]"
+    },
+    "mode_not_exist": {
+      "message": "The entity does not support the choosen mode"
     }
   }
 }

--- a/tests/components/sensibo/snapshots/test_climate.ambr
+++ b/tests/components/sensibo/snapshots/test_climate.ambr
@@ -227,3 +227,23 @@
     'state': 'off',
   })
 # ---
+# name: test_climate_get_device_capabilities
+  dict({
+    'climate.hallway': dict({
+      'horizontalswing': list([
+        'stopped',
+        'fixedLeft',
+        'fixedCenterLeft',
+      ]),
+      'light': list([
+        'on',
+        'off',
+      ]),
+      'swing': list([
+        'stopped',
+        'fixedTop',
+        'fixedMiddleTop',
+      ]),
+    }),
+  })
+# ---

--- a/tests/components/sensibo/test_climate.py
+++ b/tests/components/sensibo/test_climate.py
@@ -1190,7 +1190,6 @@ async def test_climate_fan_mode_and_swing_mode_not_supported(
     assert state.attributes["swing_mode"] == "stopped"
 
 
-@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_climate_get_device_capabilities(
     hass: HomeAssistant,
     load_int: ConfigEntry,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds new action call `get_device_capabilities` to Sensibo

This responds, for the selected mode, with the correct capabilities to be used with other custom action calls (such as `full_state`)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/36736

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 