### PR TITLE
Generate deterministic `unique_id` and `entity_id` for System Bridge entities

### DIFF
--- a/homeassistant/components/system_bridge/binary_sensor.py
+++ b/homeassistant/components/system_bridge/binary_sensor.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 
 from homeassistant.components.binary_sensor import (
+    ENTITY_ID_FORMAT,
     BinarySensorDeviceClass,
     BinarySensorEntity,
     BinarySensorEntityDescription,
@@ -13,7 +14,9 @@ from homeassistant.components.binary_sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PORT
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import async_generate_entity_id
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import UNDEFINED
 
 from .const import DOMAIN
 from .coordinator import SystemBridgeDataUpdateCoordinator
@@ -106,6 +109,9 @@ class SystemBridgeBinarySensor(SystemBridgeEntity, BinarySensorEntity):
             description.key,
         )
         self.entity_description = description
+        self.entity_id = async_generate_entity_id(ENTITY_ID_FORMAT, self.unique_id, hass=coordinator.hass)
+        if description.name != UNDEFINED:
+            self._attr_has_entity_name = False
 
     @property
     def is_on(self) -> bool:

--- a/homeassistant/components/system_bridge/binary_sensor.py
+++ b/homeassistant/components/system_bridge/binary_sensor.py
@@ -109,7 +109,9 @@ class SystemBridgeBinarySensor(SystemBridgeEntity, BinarySensorEntity):
             description.key,
         )
         self.entity_description = description
-        self.entity_id = async_generate_entity_id(ENTITY_ID_FORMAT, self.unique_id, hass=coordinator.hass)
+        self.entity_id = async_generate_entity_id(
+            ENTITY_ID_FORMAT, self.unique_id, hass=coordinator.hass
+        )
         if description.name != UNDEFINED:
             self._attr_has_entity_name = False
 

--- a/homeassistant/components/system_bridge/coordinator.py
+++ b/homeassistant/components/system_bridge/coordinator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from asyncio import Task
+from binascii import crc32
 from collections.abc import Callable
 from datetime import timedelta
 import logging
@@ -61,6 +62,8 @@ class SystemBridgeDataUpdateCoordinator(DataUpdateCoordinator[SystemBridgeData])
         )
 
         self._host = entry.data[CONF_HOST]
+
+        self.host_id = f"{crc32(self._host.encode()):08x}"
 
         super().__init__(
             hass,

--- a/homeassistant/components/system_bridge/entity.py
+++ b/homeassistant/components/system_bridge/entity.py
@@ -1,5 +1,6 @@
 """Base entity for the system bridge integration."""
 
+from propcache import cached_property
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -23,7 +24,7 @@ class SystemBridgeEntity(CoordinatorEntity[SystemBridgeDataUpdateCoordinator]):
         super().__init__(coordinator)
 
         self._hostname = coordinator.data.system.hostname
-        self._key = f"{self._hostname}_{key}"
+        self._key = key
         self._configuration_url = (
             f"http://{self._hostname}:{api_port}/app/settings.html"
         )
@@ -31,12 +32,12 @@ class SystemBridgeEntity(CoordinatorEntity[SystemBridgeDataUpdateCoordinator]):
         self._uuid = coordinator.data.system.uuid
         self._version = coordinator.data.system.version
 
-    @property
+    @cached_property
     def unique_id(self) -> str:
         """Return the unique ID for this entity."""
-        return self._key
+        return f"sbe_{self.coordinator.host_id}_{self._key}"
 
-    @property
+    @cached_property
     def device_info(self) -> DeviceInfo:
         """Return device information about this System Bridge instance."""
         return DeviceInfo(

--- a/homeassistant/components/system_bridge/media_player.py
+++ b/homeassistant/components/system_bridge/media_player.py
@@ -5,9 +5,12 @@ from __future__ import annotations
 import datetime as dt
 from typing import Final
 
+from homeassistant.helpers.entity import async_generate_entity_id
+from homeassistant.helpers.typing import UNDEFINED
 from systembridgemodels.media_control import MediaAction, MediaControl
 
 from homeassistant.components.media_player import (
+    ENTITY_ID_FORMAT,
     MediaPlayerDeviceClass,
     MediaPlayerEntity,
     MediaPlayerEntityDescription,
@@ -102,6 +105,9 @@ class SystemBridgeMediaPlayer(SystemBridgeEntity, MediaPlayerEntity):
             description.key,
         )
         self.entity_description = description
+        self.entity_id = async_generate_entity_id(ENTITY_ID_FORMAT, self.unique_id, hass=coordinator.hass)
+        if description.name != UNDEFINED:
+            self._attr_has_entity_name = False
 
     @property
     def available(self) -> bool:

--- a/homeassistant/components/system_bridge/media_player.py
+++ b/homeassistant/components/system_bridge/media_player.py
@@ -105,7 +105,9 @@ class SystemBridgeMediaPlayer(SystemBridgeEntity, MediaPlayerEntity):
             description.key,
         )
         self.entity_description = description
-        self.entity_id = async_generate_entity_id(ENTITY_ID_FORMAT, self.unique_id, hass=coordinator.hass)
+        self.entity_id = async_generate_entity_id(
+            ENTITY_ID_FORMAT, self.unique_id, hass=coordinator.hass
+        )
         if description.name != UNDEFINED:
             self._attr_has_entity_name = False
 

--- a/homeassistant/components/system_bridge/sensor.py
+++ b/homeassistant/components/system_bridge/sensor.py
@@ -12,6 +12,7 @@ from systembridgemodels.modules.displays import Display
 from systembridgemodels.modules.gpus import GPU
 
 from homeassistant.components.sensor import (
+    ENTITY_ID_FORMAT,
     SensorDeviceClass,
     SensorEntity,
     SensorEntityDescription,
@@ -32,6 +33,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import UNDEFINED, StateType
 from homeassistant.util import dt as dt_util
+from homeassistant.util import slugify
 
 from .const import DOMAIN
 from .coordinator import SystemBridgeDataUpdateCoordinator
@@ -419,12 +421,12 @@ async def async_setup_entry(
 
     if coordinator.data.displays is not None:
         for index, display in enumerate(coordinator.data.displays):
-            entities = [
-                *entities,
+            display_unique_id = slugify(display.id)
+            entities.extend([
                 SystemBridgeSensor(
                     coordinator,
                     SystemBridgeSensorEntityDescription(
-                        key=f"display_{display.id}_resolution_x",
+                        key=f"display_{display_unique_id}_resolution_x",
                         name=f"Display {display.id} resolution x",
                         state_class=SensorStateClass.MEASUREMENT,
                         native_unit_of_measurement=PIXELS,
@@ -438,7 +440,7 @@ async def async_setup_entry(
                 SystemBridgeSensor(
                     coordinator,
                     SystemBridgeSensorEntityDescription(
-                        key=f"display_{display.id}_resolution_y",
+                        key=f"display_{display_unique_id}_resolution_y",
                         name=f"Display {display.id} resolution y",
                         state_class=SensorStateClass.MEASUREMENT,
                         native_unit_of_measurement=PIXELS,
@@ -452,7 +454,7 @@ async def async_setup_entry(
                 SystemBridgeSensor(
                     coordinator,
                     SystemBridgeSensorEntityDescription(
-                        key=f"display_{display.id}_refresh_rate",
+                        key=f"display_{display_unique_id}_refresh_rate",
                         name=f"Display {display.id} refresh rate",
                         state_class=SensorStateClass.MEASUREMENT,
                         native_unit_of_measurement=UnitOfFrequency.HERTZ,
@@ -462,7 +464,7 @@ async def async_setup_entry(
                     ),
                     entry.data[CONF_PORT],
                 ),
-            ]
+            ])
 
     for index, gpu in enumerate(coordinator.data.gpus):
         entities.extend(
@@ -642,6 +644,7 @@ class SystemBridgeSensor(SystemBridgeEntity, SensorEntity):
             description.key,
         )
         self.entity_description = description
+        self.entity_id = async_generate_entity_id(ENTITY_ID_FORMAT, self.unique_id, hass=coordinator.hass)
         if description.name != UNDEFINED:
             self._attr_has_entity_name = False
 

--- a/homeassistant/components/system_bridge/sensor.py
+++ b/homeassistant/components/system_bridge/sensor.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import Final, cast
 
+from homeassistant.helpers.entity import async_generate_entity_id
 from systembridgemodels.modules.cpu import PerCPU
 from systembridgemodels.modules.displays import Display
 from systembridgemodels.modules.gpus import GPU
@@ -422,49 +423,51 @@ async def async_setup_entry(
     if coordinator.data.displays is not None:
         for index, display in enumerate(coordinator.data.displays):
             display_unique_id = slugify(display.id)
-            entities.extend([
-                SystemBridgeSensor(
-                    coordinator,
-                    SystemBridgeSensorEntityDescription(
-                        key=f"display_{display_unique_id}_resolution_x",
-                        name=f"Display {display.id} resolution x",
-                        state_class=SensorStateClass.MEASUREMENT,
-                        native_unit_of_measurement=PIXELS,
-                        icon="mdi:monitor",
-                        value=lambda data, k=index: display_resolution_horizontal(
-                            data, k
+            entities.extend(
+                [
+                    SystemBridgeSensor(
+                        coordinator,
+                        SystemBridgeSensorEntityDescription(
+                            key=f"display_{display_unique_id}_resolution_x",
+                            name=f"Display {display.id} resolution x",
+                            state_class=SensorStateClass.MEASUREMENT,
+                            native_unit_of_measurement=PIXELS,
+                            icon="mdi:monitor",
+                            value=lambda data, k=index: display_resolution_horizontal(
+                                data, k
+                            ),
                         ),
+                        entry.data[CONF_PORT],
                     ),
-                    entry.data[CONF_PORT],
-                ),
-                SystemBridgeSensor(
-                    coordinator,
-                    SystemBridgeSensorEntityDescription(
-                        key=f"display_{display_unique_id}_resolution_y",
-                        name=f"Display {display.id} resolution y",
-                        state_class=SensorStateClass.MEASUREMENT,
-                        native_unit_of_measurement=PIXELS,
-                        icon="mdi:monitor",
-                        value=lambda data, k=index: display_resolution_vertical(
-                            data, k
+                    SystemBridgeSensor(
+                        coordinator,
+                        SystemBridgeSensorEntityDescription(
+                            key=f"display_{display_unique_id}_resolution_y",
+                            name=f"Display {display.id} resolution y",
+                            state_class=SensorStateClass.MEASUREMENT,
+                            native_unit_of_measurement=PIXELS,
+                            icon="mdi:monitor",
+                            value=lambda data, k=index: display_resolution_vertical(
+                                data, k
+                            ),
                         ),
+                        entry.data[CONF_PORT],
                     ),
-                    entry.data[CONF_PORT],
-                ),
-                SystemBridgeSensor(
-                    coordinator,
-                    SystemBridgeSensorEntityDescription(
-                        key=f"display_{display_unique_id}_refresh_rate",
-                        name=f"Display {display.id} refresh rate",
-                        state_class=SensorStateClass.MEASUREMENT,
-                        native_unit_of_measurement=UnitOfFrequency.HERTZ,
-                        device_class=SensorDeviceClass.FREQUENCY,
-                        icon="mdi:monitor",
-                        value=lambda data, k=index: display_refresh_rate(data, k),
+                    SystemBridgeSensor(
+                        coordinator,
+                        SystemBridgeSensorEntityDescription(
+                            key=f"display_{display_unique_id}_refresh_rate",
+                            name=f"Display {display.id} refresh rate",
+                            state_class=SensorStateClass.MEASUREMENT,
+                            native_unit_of_measurement=UnitOfFrequency.HERTZ,
+                            device_class=SensorDeviceClass.FREQUENCY,
+                            icon="mdi:monitor",
+                            value=lambda data, k=index: display_refresh_rate(data, k),
+                        ),
+                        entry.data[CONF_PORT],
                     ),
-                    entry.data[CONF_PORT],
-                ),
-            ])
+                ]
+            )
 
     for index, gpu in enumerate(coordinator.data.gpus):
         entities.extend(
@@ -644,7 +647,9 @@ class SystemBridgeSensor(SystemBridgeEntity, SensorEntity):
             description.key,
         )
         self.entity_description = description
-        self.entity_id = async_generate_entity_id(ENTITY_ID_FORMAT, self.unique_id, hass=coordinator.hass)
+        self.entity_id = async_generate_entity_id(
+            ENTITY_ID_FORMAT, self.unique_id, hass=coordinator.hass
+        )
         if description.name != UNDEFINED:
             self._attr_has_entity_name = False
 

--- a/homeassistant/components/system_bridge/sensor.py
+++ b/homeassistant/components/system_bridge/sensor.py
@@ -7,7 +7,6 @@ from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import Final, cast
 
-from homeassistant.helpers.entity import async_generate_entity_id
 from systembridgemodels.modules.cpu import PerCPU
 from systembridgemodels.modules.displays import Display
 from systembridgemodels.modules.gpus import GPU
@@ -31,10 +30,10 @@ from homeassistant.const import (
     UnitOfTemperature,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import async_generate_entity_id
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import UNDEFINED, StateType
-from homeassistant.util import dt as dt_util
-from homeassistant.util import slugify
+from homeassistant.util import dt as dt_util, slugify
 
 from .const import DOMAIN
 from .coordinator import SystemBridgeDataUpdateCoordinator
@@ -470,12 +469,13 @@ async def async_setup_entry(
             )
 
     for index, gpu in enumerate(coordinator.data.gpus):
+        gpu_unique_id = gpu.id.replace("gpu-", "")
         entities.extend(
             [
                 SystemBridgeSensor(
                     coordinator,
                     SystemBridgeSensorEntityDescription(
-                        key=f"gpu_{gpu.id}_core_clock_speed",
+                        key=f"gpu_{gpu_unique_id}_core_clock_speed",
                         name=f"{gpu.name} clock speed",
                         entity_registry_enabled_default=False,
                         state_class=SensorStateClass.MEASUREMENT,
@@ -489,7 +489,7 @@ async def async_setup_entry(
                 SystemBridgeSensor(
                     coordinator,
                     SystemBridgeSensorEntityDescription(
-                        key=f"gpu_{gpu.id}_memory_clock_speed",
+                        key=f"gpu_{gpu_unique_id}_memory_clock_speed",
                         name=f"{gpu.name} memory clock speed",
                         entity_registry_enabled_default=False,
                         state_class=SensorStateClass.MEASUREMENT,
@@ -503,7 +503,7 @@ async def async_setup_entry(
                 SystemBridgeSensor(
                     coordinator,
                     SystemBridgeSensorEntityDescription(
-                        key=f"gpu_{gpu.id}_memory_free",
+                        key=f"gpu_{gpu_unique_id}_memory_free",
                         name=f"{gpu.name} memory free",
                         state_class=SensorStateClass.MEASUREMENT,
                         native_unit_of_measurement=UnitOfInformation.MEGABYTES,
@@ -516,7 +516,7 @@ async def async_setup_entry(
                 SystemBridgeSensor(
                     coordinator,
                     SystemBridgeSensorEntityDescription(
-                        key=f"gpu_{gpu.id}_memory_used_percentage",
+                        key=f"gpu_{gpu_unique_id}_memory_used_percentage",
                         name=f"{gpu.name} memory used %",
                         state_class=SensorStateClass.MEASUREMENT,
                         native_unit_of_measurement=PERCENTAGE,
@@ -528,7 +528,7 @@ async def async_setup_entry(
                 SystemBridgeSensor(
                     coordinator,
                     SystemBridgeSensorEntityDescription(
-                        key=f"gpu_{gpu.id}_memory_used",
+                        key=f"gpu_{gpu_unique_id}_memory_used",
                         name=f"{gpu.name} memory used",
                         entity_registry_enabled_default=False,
                         state_class=SensorStateClass.MEASUREMENT,
@@ -542,7 +542,7 @@ async def async_setup_entry(
                 SystemBridgeSensor(
                     coordinator,
                     SystemBridgeSensorEntityDescription(
-                        key=f"gpu_{gpu.id}_fan_speed",
+                        key=f"gpu_{gpu_unique_id}_fan_speed",
                         name=f"{gpu.name} fan speed",
                         entity_registry_enabled_default=False,
                         state_class=SensorStateClass.MEASUREMENT,
@@ -555,7 +555,7 @@ async def async_setup_entry(
                 SystemBridgeSensor(
                     coordinator,
                     SystemBridgeSensorEntityDescription(
-                        key=f"gpu_{gpu.id}_power_usage",
+                        key=f"gpu_{gpu_unique_id}_power_usage",
                         name=f"{gpu.name} power usage",
                         entity_registry_enabled_default=False,
                         device_class=SensorDeviceClass.POWER,
@@ -568,7 +568,7 @@ async def async_setup_entry(
                 SystemBridgeSensor(
                     coordinator,
                     SystemBridgeSensorEntityDescription(
-                        key=f"gpu_{gpu.id}_temperature",
+                        key=f"gpu_{gpu_unique_id}_temperature",
                         name=f"{gpu.name} temperature",
                         entity_registry_enabled_default=False,
                         device_class=SensorDeviceClass.TEMPERATURE,
@@ -581,7 +581,7 @@ async def async_setup_entry(
                 SystemBridgeSensor(
                     coordinator,
                     SystemBridgeSensorEntityDescription(
-                        key=f"gpu_{gpu.id}_usage_percentage",
+                        key=f"gpu_{gpu_unique_id}_usage_percentage",
                         name=f"{gpu.name} usage %",
                         state_class=SensorStateClass.MEASUREMENT,
                         native_unit_of_measurement=PERCENTAGE,

--- a/homeassistant/components/system_bridge/update.py
+++ b/homeassistant/components/system_bridge/update.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
-from homeassistant.components.update import UpdateEntity
+from homeassistant.components.update import ENTITY_ID_FORMAT, UpdateEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PORT
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import async_generate_entity_id
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
@@ -49,6 +50,7 @@ class SystemBridgeUpdateEntity(SystemBridgeEntity, UpdateEntity):
             "update",
         )
         self._attr_name = coordinator.data.system.hostname
+        self.entity_id = async_generate_entity_id(ENTITY_ID_FORMAT, self.unique_id, hass=coordinator.hass)
 
     @property
     def installed_version(self) -> str | None:

--- a/homeassistant/components/system_bridge/update.py
+++ b/homeassistant/components/system_bridge/update.py
@@ -50,7 +50,9 @@ class SystemBridgeUpdateEntity(SystemBridgeEntity, UpdateEntity):
             "update",
         )
         self._attr_name = coordinator.data.system.hostname
-        self.entity_id = async_generate_entity_id(ENTITY_ID_FORMAT, self.unique_id, hass=coordinator.hass)
+        self.entity_id = async_generate_entity_id(
+            ENTITY_ID_FORMAT, self.unique_id, hass=coordinator.hass
+        )
 
     @property
     def installed_version(self) -> str | None:


### PR DESCRIPTION

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The `entity_id` and `unique_id` of the entities generated by System Bridge integration **WILL BE CHANGED**.
Your automations and dashboards may be affected.
It's advised to remove all devices and re-add them from the configuration interface.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Modify the `entity_id` of entities to better reflect their uniqueness.

1. `entity_id` is changed from `slugify(friendly_name)` to `f"sbe_{crc32(coordinator._host.encode()):08x}_{slugify(entity.unique_id)}"`, in which `coordinator._host` is the the *Host* field in device configuration (usually IP address).
2. `unique_id` is mostly untouched, except:
    1. sensors from `displays` modules, `display_unique_id` changed from `display.id` (usually 0, 1) to `slugify(display.name)` (e.g. `slugify("\\.\DISPLAY5")=display5`)
    2. sensors from `gpus` module, removed `gpu-` string from `gpu_unique_id`, because otherwise it will generate redundant string like `sensor.xxx_gpu_gpu_amd_0_xxx` in generated IDs.

The reason to use IP address is that the host name used in device name and sensor `friendly_name` is generated from `system` module, which is 
1. not always available on sensor setup, because the sensor name should not depends on a sensor value!
2. prone to change.

Take some examples from my own laptop, in which `desktop_1234567` is my hostname, `0a0b0c0d` is the CRC32'd IP address.

* **Entity name:** CPU temperature
  * **original entity_id:** sensor.desktop_1234567_cpu_temperature
  * **new entity_id:** sensor.sbe_0a0b0c0d_cpu_temperature
* CPU voltage
  * sensor.desktop_1234567_cpu_voltage
  * sensor.sbe_0a0b0c0d_cpu_voltage
* Memory used
  * sensor.desktop_1234567_memory_used
  * sensor.sbe_0a0b0c0d_memory_used
* AMD Radeon 780M Graphics clock speed
  * sensor.amd_radeon_780m_graphics_clock_speed
  * sensor.sbe\_0a0b0c0d\_gpu\_amd\_0\_core\_clock\_speed
* AMD Radeon 780M Graphics temperature
  * sensor.amd_radeon_780m_graphics_temperature
  * sensor.sbe\_0a0b0c0d\_gpu\_amd\_0\_temperature
* NVIDIA GeForce RTX 4060 Laptop GPU memory used
  * sensor.nvidia_geforce_rtx_4060_laptop_gpu_memory_used_2
  * sensor.sbe\_0a0b0c0d\_gpu\_nvidia\_0\_memory\_used
* NVIDIA GeForce RTX 4060 Laptop GPU temperature
  * sensor.nvidia_geforce_rtx_4060_laptop_gpu_temperature
  * sensor.sbe\_0a0b0c0d\_gpu\_nvidia\_0\_temperature
* AMD Radeon 780M Graphics memory used
  * sensor.amd_radeon_780m_graphics_memory_used_2
  * sensor.sbe_0a0b0c0d_gpu_amd_0_memory_used
* NVIDIA GeForce RTX 4060 Laptop GPU memory used
  * sensor.nvidia_geforce_rtx_4060_laptop_gpu_memory_used_2
  * sensor.sbe\_0a0b0c0d\_gpu\_nvidia\_0\_memory\_used
* AMD Radeon 780M Graphics memory used %
  * sensor.amd_radeon_780m_graphics_memory_used
  * sensor.sbe\_0a0b0c0d\_gpu\_amd\_0\_memory\_used
* NVIDIA GeForce RTX 4060 Laptop GPU memory used %
  * sensor.nvidia_geforce_rtx_4060_laptop_gpu_memory_used
  * sensor.sbe\_0a0b0c0d\_gpu\_nvidia\_0\_memory\_used\_percentage
* Load CPU 0
  * sensor.load_cpu_0
  * sensor.sbe\_0a0b0c0d\_processes\_load\_cpu\_0
* CPU Core 0 Power
  * sensor.cpu_core_0_power
  * sensor.sbe\_0a0b0c0d\_cpu\_power\_core\_0
* Load CPU 1
  * sensor.load_cpu_1
  * sensor.sbe\_0a0b0c0d\_processes\_load\_cpu\_1
* CPU Core 1 Power
  * sensor.cpu_core_1_power
  * sensor.sbe\_0a0b0c0d\_cpu\_power\_core\_1
* Memory used
  * sensor.desktop_1234567_memory_used
  * sensor.sbe\_0a0b0c0d\_memory\_used
* DESKTOP-1234567 Memory free
  * sensor.desktop_1234567_memory_free
  * sensor.sbe\_0a0b0c0d\_memory\_free
* DESKTOP-1234567 None
  * sensor.desktop_1234567_none
  * sensor.sbe\_0a0b0c0d\_memory\_used\_percentage
* C:\ space used
  * sensor.c_space_used
  * sensor.sbe\_0a0b0c0d\_filesystem\_c
* D:\ space used
  * sensor.d_space_used
  * sensor.sbe\_0a0b0c0d\_filesystem\_d

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
