### PR TITLE
Deprecate HEOS sign_in and sign_out actions

### DIFF
--- a/homeassistant/components/heos/__init__.py
+++ b/homeassistant/components/heos/__init__.py
@@ -27,6 +27,7 @@ from homeassistant.const import (
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect,
     async_dispatcher_send,
@@ -46,6 +47,8 @@ from .const import (
 PLATFORMS = [Platform.MEDIA_PLAYER]
 
 MIN_UPDATE_SOURCES = timedelta(seconds=1)
+
+CONFIG_SCHEMA = cv.empty_config_schema(DOMAIN)
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/heos/__init__.py
+++ b/homeassistant/components/heos/__init__.py
@@ -31,6 +31,7 @@ from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect,
     async_dispatcher_send,
 )
+from homeassistant.helpers.typing import ConfigType
 from homeassistant.util import Throttle
 
 from . import services
@@ -60,6 +61,12 @@ class HeosRuntimeData:
 
 
 type HeosConfigEntry = ConfigEntry[HeosRuntimeData]
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up the HEOS component."""
+    services.register(hass)
+    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: HeosConfigEntry) -> bool:
@@ -141,7 +148,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: HeosConfigEntry) -> bool
         controller_manager, group_manager, source_manager, players
     )
 
-    services.register(hass, controller)
     group_manager.connect_update()
     entry.async_on_unload(group_manager.disconnect_update)
 
@@ -153,9 +159,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: HeosConfigEntry) -> bool
 async def async_unload_entry(hass: HomeAssistant, entry: HeosConfigEntry) -> bool:
     """Unload a config entry."""
     await entry.runtime_data.controller_manager.disconnect()
-
-    services.remove(hass)
-
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
 

--- a/homeassistant/components/heos/quality_scale.yaml
+++ b/homeassistant/components/heos/quality_scale.yaml
@@ -1,8 +1,6 @@
 rules:
   # Bronze
-  action-setup:
-    status: todo
-    comment: Future enhancement to move custom actions for login/out into an options flow.
+  action-setup: done
   appropriate-polling:
     status: done
     comment: Integration is a local push integration

--- a/homeassistant/components/heos/services.py
+++ b/homeassistant/components/heos/services.py
@@ -57,8 +57,7 @@ async def _sign_in_handler(service: ServiceCall) -> None:
     """Sign in to the HEOS account."""
 
     _LOGGER.warning(
-        "The service calls 'heos.sign_in' and 'heos.sign_out' are deprecated and will be removed in the 2025.4.0 release; "
-        "enter your HEOS Account credentials in the configuration options and the integration will manage authentication automatically"
+        "Actions 'heos.sign_in' and 'heos.sign_out' are deprecated and will be removed in the 2025.4.0 release"
     )
     ir.async_create_issue(
         service.hass,
@@ -88,8 +87,7 @@ async def _sign_out_handler(service: ServiceCall) -> None:
     """Sign out of the HEOS account."""
 
     _LOGGER.warning(
-        "The service calls 'heos.sign_in' and 'heos.sign_out' are deprecated and will be removed in the 2025.4.0 release; "
-        "enter your HEOS Account credentials in the configuration options and the integration will manage authentication automatically"
+        "Actions 'heos.sign_in' and 'heos.sign_out' are deprecated and will be removed in the 2025.4.0 release"
     )
     ir.async_create_issue(
         service.hass,

--- a/homeassistant/components/heos/services.py
+++ b/homeassistant/components/heos/services.py
@@ -8,7 +8,7 @@ import voluptuous as vol
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import config_validation as cv, issue_registry as ir
 
 from .const import (
     ATTR_PASSWORD,
@@ -47,7 +47,9 @@ def _get_controller(hass: HomeAssistant) -> Heos:
     """Get the HEOS controller instance."""
     entry = hass.config_entries.async_entry_for_domain_unique_id(DOMAIN, DOMAIN)
     if not entry or not entry.state == ConfigEntryState.LOADED:
-        raise HomeAssistantError("The HEOS integration is not loaded")
+        raise HomeAssistantError(
+            translation_domain=DOMAIN, translation_key="integration_not_loaded"
+        )
     return entry.runtime_data.controller_manager.controller
 
 
@@ -55,8 +57,17 @@ async def _sign_in_handler(service: ServiceCall) -> None:
     """Sign in to the HEOS account."""
 
     _LOGGER.warning(
-        "The action 'heos.sign_in' is deprecated and will be removed in the 2025.4 release; "
-        "set the credentials in the configuration options and the integration will sign in automatically"
+        "The service calls 'heos.sign_in' and 'heos.sign_out' are deprecated and will be removed in the 2025.4.0 release; "
+        "enter your HEOS Account credentials in the configuration options and the integration will manage authentication automatically"
+    )
+    ir.async_create_issue(
+        service.hass,
+        DOMAIN,
+        "sign_in_out_deprecated",
+        breaks_in_ha_version="2025.4.0",
+        is_fixable=False,
+        severity=ir.IssueSeverity.WARNING,
+        translation_key="sign_in_out_deprecated",
     )
 
     controller = _get_controller(service.hass)
@@ -77,7 +88,17 @@ async def _sign_out_handler(service: ServiceCall) -> None:
     """Sign out of the HEOS account."""
 
     _LOGGER.warning(
-        "The action 'heos.sign_out' is deprecated and will be removed in the 2025.4 release"
+        "The service calls 'heos.sign_in' and 'heos.sign_out' are deprecated and will be removed in the 2025.4.0 release; "
+        "enter your HEOS Account credentials in the configuration options and the integration will manage authentication automatically"
+    )
+    ir.async_create_issue(
+        service.hass,
+        DOMAIN,
+        "sign_in_out_deprecated",
+        breaks_in_ha_version="2025.4.0",
+        is_fixable=False,
+        severity=ir.IssueSeverity.WARNING,
+        translation_key="sign_in_out_deprecated",
     )
 
     controller = _get_controller(service.hass)

--- a/homeassistant/components/heos/services.py
+++ b/homeassistant/components/heos/services.py
@@ -1,12 +1,13 @@
 """Services for the HEOS integration."""
 
-import functools
 import logging
 
 from pyheos import CommandFailedError, Heos, HeosError, const
 import voluptuous as vol
 
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv
 
 from .const import (
@@ -26,30 +27,39 @@ HEOS_SIGN_IN_SCHEMA = vol.Schema(
 HEOS_SIGN_OUT_SCHEMA = vol.Schema({})
 
 
-def register(hass: HomeAssistant, controller: Heos):
+def register(hass: HomeAssistant):
     """Register HEOS services."""
     hass.services.async_register(
         DOMAIN,
         SERVICE_SIGN_IN,
-        functools.partial(_sign_in_handler, controller),
+        _sign_in_handler,
         schema=HEOS_SIGN_IN_SCHEMA,
     )
     hass.services.async_register(
         DOMAIN,
         SERVICE_SIGN_OUT,
-        functools.partial(_sign_out_handler, controller),
+        _sign_out_handler,
         schema=HEOS_SIGN_OUT_SCHEMA,
     )
 
 
-def remove(hass: HomeAssistant):
-    """Unregister HEOS services."""
-    hass.services.async_remove(DOMAIN, SERVICE_SIGN_IN)
-    hass.services.async_remove(DOMAIN, SERVICE_SIGN_OUT)
+def _get_controller(hass: HomeAssistant) -> Heos:
+    """Get the HEOS controller instance."""
+    entry = hass.config_entries.async_entry_for_domain_unique_id(DOMAIN, DOMAIN)
+    if not entry or not entry.state == ConfigEntryState.LOADED:
+        raise HomeAssistantError("The HEOS integration is not loaded")
+    return entry.runtime_data.controller_manager.controller
 
 
-async def _sign_in_handler(controller: Heos, service: ServiceCall) -> None:
+async def _sign_in_handler(service: ServiceCall) -> None:
     """Sign in to the HEOS account."""
+
+    _LOGGER.warning(
+        "The action 'heos.sign_in' is deprecated and will be removed in the 2025.4 release; "
+        "set the credentials in the configuration options and the integration will sign in automatically"
+    )
+
+    controller = _get_controller(service.hass)
     if controller.connection_state != const.STATE_CONNECTED:
         _LOGGER.error("Unable to sign in because HEOS is not connected")
         return
@@ -63,8 +73,14 @@ async def _sign_in_handler(controller: Heos, service: ServiceCall) -> None:
         _LOGGER.error("Unable to sign in: %s", err)
 
 
-async def _sign_out_handler(controller: Heos, service: ServiceCall) -> None:
+async def _sign_out_handler(service: ServiceCall) -> None:
     """Sign out of the HEOS account."""
+
+    _LOGGER.warning(
+        "The action 'heos.sign_out' is deprecated and will be removed in the 2025.4 release"
+    )
+
+    controller = _get_controller(service.hass)
     if controller.connection_state != const.STATE_CONNECTED:
         _LOGGER.error("Unable to sign out because HEOS is not connected")
         return

--- a/homeassistant/components/heos/services.py
+++ b/homeassistant/components/heos/services.py
@@ -47,13 +47,13 @@ def _get_controller(hass: HomeAssistant) -> Heos:
     """Get the HEOS controller instance."""
 
     _LOGGER.warning(
-        "Actions 'heos.sign_in' and 'heos.sign_out' are deprecated and will be removed in the 2025.5.0 release"
+        "Actions 'heos.sign_in' and 'heos.sign_out' are deprecated and will be removed in the 2025.8.0 release"
     )
     ir.async_create_issue(
         hass,
         DOMAIN,
         "sign_in_out_deprecated",
-        breaks_in_ha_version="2025.5.0",
+        breaks_in_ha_version="2025.8.0",
         is_fixable=False,
         severity=ir.IssueSeverity.WARNING,
         translation_key="sign_in_out_deprecated",

--- a/homeassistant/components/heos/services.py
+++ b/homeassistant/components/heos/services.py
@@ -45,6 +45,20 @@ def register(hass: HomeAssistant):
 
 def _get_controller(hass: HomeAssistant) -> Heos:
     """Get the HEOS controller instance."""
+
+    _LOGGER.warning(
+        "Actions 'heos.sign_in' and 'heos.sign_out' are deprecated and will be removed in the 2025.5.0 release"
+    )
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        "sign_in_out_deprecated",
+        breaks_in_ha_version="2025.5.0",
+        is_fixable=False,
+        severity=ir.IssueSeverity.WARNING,
+        translation_key="sign_in_out_deprecated",
+    )
+
     entry = hass.config_entries.async_entry_for_domain_unique_id(DOMAIN, DOMAIN)
     if not entry or not entry.state == ConfigEntryState.LOADED:
         raise HomeAssistantError(
@@ -55,19 +69,6 @@ def _get_controller(hass: HomeAssistant) -> Heos:
 
 async def _sign_in_handler(service: ServiceCall) -> None:
     """Sign in to the HEOS account."""
-
-    _LOGGER.warning(
-        "Actions 'heos.sign_in' and 'heos.sign_out' are deprecated and will be removed in the 2025.4.0 release"
-    )
-    ir.async_create_issue(
-        service.hass,
-        DOMAIN,
-        "sign_in_out_deprecated",
-        breaks_in_ha_version="2025.4.0",
-        is_fixable=False,
-        severity=ir.IssueSeverity.WARNING,
-        translation_key="sign_in_out_deprecated",
-    )
 
     controller = _get_controller(service.hass)
     if controller.connection_state != const.STATE_CONNECTED:
@@ -85,19 +86,6 @@ async def _sign_in_handler(service: ServiceCall) -> None:
 
 async def _sign_out_handler(service: ServiceCall) -> None:
     """Sign out of the HEOS account."""
-
-    _LOGGER.warning(
-        "Actions 'heos.sign_in' and 'heos.sign_out' are deprecated and will be removed in the 2025.4.0 release"
-    )
-    ir.async_create_issue(
-        service.hass,
-        DOMAIN,
-        "sign_in_out_deprecated",
-        breaks_in_ha_version="2025.4.0",
-        is_fixable=False,
-        severity=ir.IssueSeverity.WARNING,
-        translation_key="sign_in_out_deprecated",
-    )
 
     controller = _get_controller(service.hass)
     if controller.connection_state != const.STATE_CONNECTED:

--- a/homeassistant/components/heos/strings.json
+++ b/homeassistant/components/heos/strings.json
@@ -98,7 +98,7 @@
   "issues": {
     "sign_in_out_deprecated": {
       "title": "HEOS Actions Deprecated",
-      "description": "Actions 'heos.sign_in' and 'heos.sign_out' are deprecated and will be removed in the 2025.5.0 release. Enter your HEOS Account credentials in the configuration options and the integration will manage authentication automatically."
+      "description": "Actions 'heos.sign_in' and 'heos.sign_out' are deprecated and will be removed in the 2025.8.0 release. Enter your HEOS Account credentials in the configuration options and the integration will manage authentication automatically."
     }
   }
 }

--- a/homeassistant/components/heos/strings.json
+++ b/homeassistant/components/heos/strings.json
@@ -89,5 +89,16 @@
       "name": "Sign out",
       "description": "Signs out of the HEOS account."
     }
+  },
+  "exceptions": {
+    "integration_not_loaded": {
+      "message": "The HEOS integration is not loaded"
+    }
+  },
+  "issues": {
+    "sign_in_out_deprecated": {
+      "title": "HEOS Actions Deprecated",
+      "description": "The service calls 'heos.sign_in' and 'heos.sign_out' are deprecated and will be removed in the 2025.4.0 release. Enter your HEOS Account credentials in the configuration options and the integration will manage authentication automatically."
+    }
   }
 }

--- a/homeassistant/components/heos/strings.json
+++ b/homeassistant/components/heos/strings.json
@@ -98,7 +98,7 @@
   "issues": {
     "sign_in_out_deprecated": {
       "title": "HEOS Actions Deprecated",
-      "description": "Actions 'heos.sign_in' and 'heos.sign_out' are deprecated and will be removed in the 2025.4.0 release. Enter your HEOS Account credentials in the configuration options and the integration will manage authentication automatically."
+      "description": "Actions 'heos.sign_in' and 'heos.sign_out' are deprecated and will be removed in the 2025.5.0 release. Enter your HEOS Account credentials in the configuration options and the integration will manage authentication automatically."
     }
   }
 }

--- a/homeassistant/components/heos/strings.json
+++ b/homeassistant/components/heos/strings.json
@@ -98,7 +98,7 @@
   "issues": {
     "sign_in_out_deprecated": {
       "title": "HEOS Actions Deprecated",
-      "description": "The service calls 'heos.sign_in' and 'heos.sign_out' are deprecated and will be removed in the 2025.4.0 release. Enter your HEOS Account credentials in the configuration options and the integration will manage authentication automatically."
+      "description": "Actions 'heos.sign_in' and 'heos.sign_out' are deprecated and will be removed in the 2025.4.0 release. Enter your HEOS Account credentials in the configuration options and the integration will manage authentication automatically."
     }
   }
 }

--- a/tests/components/heos/test_services.py
+++ b/tests/components/heos/test_services.py
@@ -11,6 +11,7 @@ from homeassistant.components.heos.const import (
     SERVICE_SIGN_OUT,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
@@ -91,6 +92,20 @@ async def test_sign_in_unknown_error(
     assert "Unable to sign in" in caplog.text
 
 
+async def test_sign_in_not_loaded_raises(hass: HomeAssistant, config_entry) -> None:
+    """Test the sign-in service when entry not loaded raises exception."""
+    await setup_component(hass, config_entry)
+    await hass.config_entries.async_unload(config_entry.entry_id)
+
+    with pytest.raises(HomeAssistantError, match="The HEOS integration is not loaded"):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SIGN_IN,
+            {ATTR_USERNAME: "test@test.com", ATTR_PASSWORD: "password"},
+            blocking=True,
+        )
+
+
 async def test_sign_out(hass: HomeAssistant, config_entry, controller) -> None:
     """Test the sign-out service."""
     await setup_component(hass, config_entry)
@@ -111,6 +126,15 @@ async def test_sign_out_not_connected(
 
     assert controller.sign_out.call_count == 0
     assert "Unable to sign out because HEOS is not connected" in caplog.text
+
+
+async def test_sign_out_not_loaded_raises(hass: HomeAssistant, config_entry) -> None:
+    """Test the sign-out service when entry not loaded raises exception."""
+    await setup_component(hass, config_entry)
+    await hass.config_entries.async_unload(config_entry.entry_id)
+
+    with pytest.raises(HomeAssistantError, match="The HEOS integration is not loaded"):
+        await hass.services.async_call(DOMAIN, SERVICE_SIGN_OUT, {}, blocking=True)
 
 
 async def test_sign_out_unknown_error(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Deprecates the HEOS sign_in and sign_out actions by creating an issue and logging a warning when called. Target removal for the 2025.8.0 release. These services are no longer needed now that the integration manages authentication automatically when set in the configuration options. 

This change also moves the service registration into `async_setup` per standards so that it addresses reported issue meanwhile.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [X] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
- Moved service registration into `async_setup` instead of `async_setup_entry` and removed service unload call.
- Log warning when actions are called
- Create issue with instructions for the user when actions called

- This PR fixes or closes issue: fixes #128691
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository] https://github.com/home-assistant/home-assistant.io/pull/36724

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
