### PR TITLE
UnifiProtect Refactor light control methods to use new API

### DIFF
--- a/homeassistant/components/unifiprotect/light.py
+++ b/homeassistant/components/unifiprotect/light.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from uiprotect.data import Light, ModelType, ProtectAdoptableDeviceModel
 
-from homeassistant.components.light import ATTR_BRIGHTNESS, ColorMode, LightEntity
+from homeassistant.components.light import ColorMode, LightEntity
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -71,13 +71,10 @@ class ProtectLight(ProtectDeviceEntity, LightEntity):
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the light on."""
-        hass_brightness = kwargs.get(ATTR_BRIGHTNESS, self.brightness)
-        unifi_brightness = hass_to_unifi_brightness(hass_brightness)
-
-        _LOGGER.debug("Turning on light with brightness %s", unifi_brightness)
-        await self.device.set_light(True, unifi_brightness)
+        _LOGGER.debug("Turning on light")
+        await self.device.api.set_light_is_led_force_on(self.device.id, True)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the light off."""
         _LOGGER.debug("Turning off light")
-        await self.device.set_light(False)
+        await self.device.api.set_light_is_led_force_on(self.device.id, False)

--- a/tests/components/unifiprotect/test_light.py
+++ b/tests/components/unifiprotect/test_light.py
@@ -95,42 +95,38 @@ async def test_light_update(
 async def test_light_turn_on(
     hass: HomeAssistant, ufp: MockUFPFixture, light: Light, unadopted_light: Light
 ) -> None:
-    """Test light entity turn off."""
+    """Test light entity turn on."""
+
+    light._api = ufp.api
+    light.api.set_light_is_led_force_on = AsyncMock()
 
     await init_entry(hass, ufp, [light, unadopted_light])
     assert_entity_counts(hass, Platform.LIGHT, 1, 1)
 
     entity_id = "light.test_light"
-    light.__pydantic_fields__["set_light"] = Mock(final=False, frozen=False)
-    light.set_light = AsyncMock()
-
     await hass.services.async_call(
-        "light",
-        "turn_on",
-        {ATTR_ENTITY_ID: entity_id, ATTR_BRIGHTNESS: 128},
-        blocking=True,
+        "light", "turn_on", {ATTR_ENTITY_ID: entity_id}, blocking=True
     )
 
-    light.set_light.assert_called_once_with(True, 3)
+    assert light.api.set_light_is_led_force_on.called
+    assert light.api.set_light_is_led_force_on.call_args == ((light.id, True),)
 
 
 async def test_light_turn_off(
     hass: HomeAssistant, ufp: MockUFPFixture, light: Light, unadopted_light: Light
 ) -> None:
-    """Test light entity turn on."""
+    """Test light entity turn off."""
+
+    light._api = ufp.api
+    light.api.set_light_is_led_force_on = AsyncMock()
 
     await init_entry(hass, ufp, [light, unadopted_light])
     assert_entity_counts(hass, Platform.LIGHT, 1, 1)
 
     entity_id = "light.test_light"
-    light.__pydantic_fields__["set_light"] = Mock(final=False, frozen=False)
-    light.set_light = AsyncMock()
-
     await hass.services.async_call(
-        "light",
-        "turn_off",
-        {ATTR_ENTITY_ID: entity_id},
-        blocking=True,
+        "light", "turn_off", {ATTR_ENTITY_ID: entity_id}, blocking=True
     )
 
-    light.set_light.assert_called_once_with(False)
+    assert light.api.set_light_is_led_force_on.called
+    assert light.api.set_light_is_led_force_on.call_args == ((light.id, False),)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fixes #133872 by using the API used in the ProtectUI

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
