### PR TITLE
Fix typo 'devide_id', use uppercase for abbreviations ID and LED

### DIFF
--- a/homeassistant/components/lcn/strings.json
+++ b/homeassistant/components/lcn/strings.json
@@ -73,7 +73,7 @@
     },
     "deprecated_address_parameter": {
       "title": "Deprecated 'address' parameter",
-      "description": "The 'address' parameter in the LCN service calls is deprecated. The 'device_id' parameter should be used going forward.\n\nPlease adjust your automations or scripts to fix this issue."
+      "description": "The 'address' parameter in the LCN action calls is deprecated. The 'device_id' parameter should be used going forward.\n\nPlease adjust your automations or scripts to fix this issue."
     }
   },
   "services": {

--- a/homeassistant/components/lcn/strings.json
+++ b/homeassistant/components/lcn/strings.json
@@ -179,11 +179,11 @@
         },
         "led": {
           "name": "[%key:component::lcn::services::led::name%]",
-          "description": "LED."
+          "description": "The LED port of the device."
         },
         "state": {
           "name": "State",
-          "description": "LED state."
+          "description": "The LED state to set."
         }
       }
     },

--- a/homeassistant/components/lcn/strings.json
+++ b/homeassistant/components/lcn/strings.json
@@ -73,7 +73,7 @@
     },
     "deprecated_address_parameter": {
       "title": "Deprecated 'address' parameter",
-      "description": "The 'address' parameter in the LCN service calls is deprecated. The 'devide_id' parameter should be used going forward.\n\nPlease adjust your automations or scripts to fix this issue."
+      "description": "The 'address' parameter in the LCN service calls is deprecated. The 'device_id' parameter should be used going forward.\n\nPlease adjust your automations or scripts to fix this issue."
     }
   },
   "services": {
@@ -167,7 +167,7 @@
     },
     "led": {
       "name": "LED",
-      "description": "Sets the led state.",
+      "description": "Sets the LED state.",
       "fields": {
         "device_id": {
           "name": "[%key:common::config_flow::data::device%]",
@@ -179,11 +179,11 @@
         },
         "led": {
           "name": "[%key:component::lcn::services::led::name%]",
-          "description": "Led."
+          "description": "LED."
         },
         "state": {
           "name": "State",
-          "description": "Led state."
+          "description": "LED state."
         }
       }
     },
@@ -384,16 +384,16 @@
       }
     },
     "address_to_device_id": {
-      "name": "Address to device id",
-      "description": "Convert LCN address to device id.",
+      "name": "Address to device ID",
+      "description": "Convert LCN address to device ID.",
       "fields": {
         "id": {
-          "name": "Module or group id",
-          "description": "Target module or group id."
+          "name": "Module or group ID",
+          "description": "Target module or group ID."
         },
         "segment_id": {
-          "name": "Segment id",
-          "description": "Target segment id."
+          "name": "Segment ID",
+          "description": "Target segment ID."
         },
         "type": {
           "name": "Type",
@@ -408,13 +408,13 @@
   },
   "exceptions": {
     "no_device_identifier": {
-      "message": "No device identifier provided. Please provide the device id."
+      "message": "No device identifier provided. Please provide the device ID."
     },
     "invalid_address": {
       "message": "LCN device for given address has not been configured."
     },
     "invalid_device_id": {
-      "message": "LCN device for given device id has not been configured."
+      "message": "LCN device for given device ID has not been configured."
     }
   }
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR fixes the typo 'devide_id' in one string of the LCN integration.

In addition it changes the abbreviations "id" and "led" to use the correct uppercase.

As "services" are called "actions" in HA today this is fixed as well.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
