### PR TITLE
Add velbus cover platform testcases

### DIFF
--- a/tests/components/velbus/conftest.py
+++ b/tests/components/velbus/conftest.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from velbusaio.channels import (
+    Blind,
     Button,
     ButtonCounter,
     Dimmer,
@@ -38,6 +39,8 @@ def mock_controller(
     mock_dimmer: AsyncMock,
     mock_module_no_subdevices: AsyncMock,
     mock_module_subdevices: AsyncMock,
+    mock_cover: AsyncMock,
+    mock_cover_no_position: AsyncMock,
 ) -> Generator[AsyncMock]:
     """Mock a successful velbus controller."""
     with (
@@ -61,6 +64,7 @@ def mock_controller(
         ]
         cont.get_all_light.return_value = [mock_dimmer]
         cont.get_all_led.return_value = [mock_button]
+        cont.get_all_cover.return_value = [mock_cover, mock_cover_no_position]
         cont.get_modules.return_value = {
             1: mock_module_no_subdevices,
             2: mock_module_no_subdevices,
@@ -248,6 +252,48 @@ def mock_dimmer() -> AsyncMock:
     channel.get_module_serial.return_value = "a1b2c3d4e5f6g7"
     channel.is_on.return_value = False
     channel.get_dimmer_state.return_value = 33
+    return channel
+
+
+@pytest.fixture
+def mock_cover() -> AsyncMock:
+    """Mock a successful velbus channel."""
+    channel = AsyncMock(spec=Blind)
+    channel.get_categories.return_value = ["cover"]
+    channel.get_name.return_value = "CoverName"
+    channel.get_module_address.return_value = 201
+    channel.get_channel_number.return_value = 2
+    channel.get_module_type_name.return_value = "VMB2BLE"
+    channel.get_full_name.return_value = "Full cover name"
+    channel.get_module_sw_version.return_value = "1.0.1"
+    channel.get_module_serial.return_value = "1234"
+    channel.support_position.return_value = True
+    channel.get_position.return_value = 50
+    channel.is_closed.return_value = False
+    channel.is_open.return_value = True
+    channel.is_opening.return_value = False
+    channel.is_closing.return_value = False
+    return channel
+
+
+@pytest.fixture
+def mock_cover_no_position() -> AsyncMock:
+    """Mock a successful velbus channel."""
+    channel = AsyncMock(spec=Blind)
+    channel.get_categories.return_value = ["cover"]
+    channel.get_name.return_value = "CoverNameNoPos"
+    channel.get_module_address.return_value = 200
+    channel.get_channel_number.return_value = 1
+    channel.get_module_type_name.return_value = "VMB2BLE"
+    channel.get_full_name.return_value = "Full cover name no position"
+    channel.get_module_sw_version.return_value = "1.0.1"
+    channel.get_module_serial.return_value = "12345"
+    channel.support_position.return_value = False
+    channel.get_position.return_value = None
+    channel.is_closed.return_value = False
+    channel.is_open.return_value = True
+    channel.is_opening.return_value = True
+    channel.is_closing.return_value = True
     return channel
 
 

--- a/tests/components/velbus/snapshots/test_cover.ambr
+++ b/tests/components/velbus/snapshots/test_cover.ambr
@@ -1,0 +1,97 @@
+# serializer version: 1
+# name: test_entities[cover.covername-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'cover',
+    'entity_category': None,
+    'entity_id': 'cover.covername',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'CoverName',
+    'platform': 'velbus',
+    'previous_unique_id': None,
+    'supported_features': <CoverEntityFeature: 15>,
+    'translation_key': None,
+    'unique_id': '1234-2',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[cover.covername-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_position': 50,
+      'friendly_name': 'CoverName',
+      'supported_features': <CoverEntityFeature: 15>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'cover.covername',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'open',
+  })
+# ---
+# name: test_entities[cover.covernamenopos-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'cover',
+    'entity_category': None,
+    'entity_id': 'cover.covernamenopos',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'CoverNameNoPos',
+    'platform': 'velbus',
+    'previous_unique_id': None,
+    'supported_features': <CoverEntityFeature: 11>,
+    'translation_key': None,
+    'unique_id': '12345-1',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[cover.covernamenopos-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'assumed_state': True,
+      'friendly_name': 'CoverNameNoPos',
+      'supported_features': <CoverEntityFeature: 11>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'cover.covernamenopos',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'opening',
+  })
+# ---

--- a/tests/components/velbus/test_cover.py
+++ b/tests/components/velbus/test_cover.py
@@ -1,0 +1,90 @@
+"""Velbus cover platform tests."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.cover import ATTR_POSITION, DOMAIN as COVER_DOMAIN
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    SERVICE_CLOSE_COVER,
+    SERVICE_OPEN_COVER,
+    SERVICE_SET_COVER_POSITION,
+    SERVICE_STOP_COVER,
+    Platform,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from . import init_integration
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+
+async def test_entities(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test all entities."""
+    with patch("homeassistant.components.velbus.PLATFORMS", [Platform.COVER]):
+        await init_integration(hass, config_entry)
+
+    await snapshot_platform(hass, entity_registry, snapshot, config_entry.entry_id)
+
+
+@pytest.mark.parametrize(
+    ("entity_id", "entity_num"),
+    [
+        ("cover.covername", 0),
+        ("cover.covernamenopos", 1),
+    ],
+)
+async def test_actions(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    entity_id: str,
+    entity_num: int,
+) -> None:
+    """Test the cover actions."""
+    await init_integration(hass, config_entry)
+    entity = config_entry.runtime_data.controller.get_all_cover()[entity_num]
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        SERVICE_CLOSE_COVER,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+    entity.close.assert_called_once()
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        SERVICE_OPEN_COVER,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+    entity.open.assert_called_once()
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        SERVICE_STOP_COVER,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+    entity.stop.assert_called_once()
+
+
+async def test_position(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    mock_cover: AsyncMock,
+) -> None:
+    """Test the set_postion over action."""
+    await init_integration(hass, config_entry)
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        SERVICE_SET_COVER_POSITION,
+        {ATTR_ENTITY_ID: "cover.covername", ATTR_POSITION: 25},
+        blocking=True,
+    )
+    mock_cover.set_position.assert_called_once_with(75)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add testcases for the velbus cover platform

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
