### PR TITLE
Clean-up HEOS entity event setup

### DIFF
--- a/homeassistant/components/heos/__init__.py
+++ b/homeassistant/components/heos/__init__.py
@@ -168,7 +168,6 @@ class ControllerManager:
         self._device_registry = None
         self._entity_registry = None
         self.controller = controller
-        self._signals = []
 
     async def connect_listeners(self):
         """Subscribe to events of interest."""
@@ -176,23 +175,17 @@ class ControllerManager:
         self._entity_registry = er.async_get(self._hass)
 
         # Handle controller events
-        self._signals.append(
-            self.controller.dispatcher.connect(
-                heos_const.SIGNAL_CONTROLLER_EVENT, self._controller_event
-            )
+        self.controller.dispatcher.connect(
+            heos_const.SIGNAL_CONTROLLER_EVENT, self._controller_event
         )
+
         # Handle connection-related events
-        self._signals.append(
-            self.controller.dispatcher.connect(
-                heos_const.SIGNAL_HEOS_EVENT, self._heos_event
-            )
+        self.controller.dispatcher.connect(
+            heos_const.SIGNAL_HEOS_EVENT, self._heos_event
         )
 
     async def disconnect(self):
         """Disconnect subscriptions."""
-        for signal_remove in self._signals:
-            signal_remove()
-        self._signals.clear()
         self.controller.dispatcher.disconnect_all()
         await self.controller.disconnect()
 

--- a/homeassistant/components/heos/media_player.py
+++ b/homeassistant/components/heos/media_player.py
@@ -123,7 +123,6 @@ class HeosMediaPlayer(MediaPlayerEntity):
         """Initialize."""
         self._media_position_updated_at = None
         self._player = player
-        self._signals: list = []
         self._source_manager = source_manager
         self._group_manager = group_manager
         self._attr_unique_id = str(player.player_id)
@@ -150,13 +149,13 @@ class HeosMediaPlayer(MediaPlayerEntity):
     async def async_added_to_hass(self) -> None:
         """Device added to hass."""
         # Update state when attributes of the player change
-        self._signals.append(
+        self.async_on_remove(
             self._player.heos.dispatcher.connect(
                 heos_const.SIGNAL_PLAYER_EVENT, self._player_update
             )
         )
         # Update state when heos changes
-        self._signals.append(
+        self.async_on_remove(
             async_dispatcher_connect(self.hass, SIGNAL_HEOS_UPDATED, self._heos_updated)
         )
         # Register this player's entity_id so it can be resolved by the group manager
@@ -303,12 +302,6 @@ class HeosMediaPlayer(MediaPlayerEntity):
         await self._group_manager.async_unjoin_player(
             self._player.player_id, self.entity_id
         )
-
-    async def async_will_remove_from_hass(self) -> None:
-        """Disconnect the device when removed."""
-        for signal_remove in self._signals:
-            signal_remove()
-        self._signals.clear()
 
     @property
     def available(self) -> bool:

--- a/homeassistant/components/heos/quality_scale.yaml
+++ b/homeassistant/components/heos/quality_scale.yaml
@@ -17,11 +17,7 @@ rules:
   docs-high-level-description: done
   docs-installation-instructions: done
   docs-removal-instructions: todo
-  entity-event-setup:
-    status: todo
-    comment: |
-      Simplify by using async_on_remove instead of keeping track of listeners to remove
-      later in async_will_remove_from_hass.
+  entity-event-setup: done
   entity-unique-id: done
   has-entity-name: done
   runtime-data: done


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Updates the HEOS media_player entity to use `async_on_remove` instead of keeping track of signals to remove later. Removed redundant signal tracking in the `ControllerManager` as the [call to `disconnect_all`](https://github.com/home-assistant/core/pull/134683/files#diff-6851dfa7ab5be54453af64c0714ae8c1e4cb42b7e912b3b32267d44907755437R189) does the same thing.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
