### PR TITLE
Update roborock tests to only load the platform under test

### DIFF
--- a/tests/components/roborock/conftest.py
+++ b/tests/components/roborock/conftest.py
@@ -1,5 +1,6 @@
 """Global fixtures for Roborock integration."""
 
+from collections.abc import Generator
 from copy import deepcopy
 from unittest.mock import patch
 
@@ -14,7 +15,7 @@ from homeassistant.components.roborock.const import (
     CONF_USER_DATA,
     DOMAIN,
 )
-from homeassistant.const import CONF_USERNAME
+from homeassistant.const import CONF_USERNAME, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
@@ -166,13 +167,21 @@ def mock_roborock_entry(hass: HomeAssistant) -> MockConfigEntry:
     return mock_entry
 
 
+@pytest.fixture(name="platforms")
+def mock_platforms() -> list[Platform]:
+    """Fixture to specify platforms to test."""
+    return []
+
+
 @pytest.fixture
 async def setup_entry(
     hass: HomeAssistant,
     bypass_api_fixture,
     mock_roborock_entry: MockConfigEntry,
-) -> MockConfigEntry:
+    platforms: list[Platform],
+) -> Generator[MockConfigEntry]:
     """Set up the Roborock platform."""
-    assert await async_setup_component(hass, DOMAIN, {})
-    await hass.async_block_till_done()
-    return mock_roborock_entry
+    with patch("homeassistant.components.roborock.PLATFORMS", platforms):
+        assert await async_setup_component(hass, DOMAIN, {})
+        await hass.async_block_till_done()
+        yield mock_roborock_entry

--- a/tests/components/roborock/test_binary_sensor.py
+++ b/tests/components/roborock/test_binary_sensor.py
@@ -1,8 +1,17 @@
 """Test Roborock Binary Sensor."""
 
+import pytest
+
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
+
+
+@pytest.fixture
+def platforms() -> list[Platform]:
+    """Fixture to set platforms used in the test."""
+    return [Platform.BINARY_SENSOR]
 
 
 async def test_binary_sensors(

--- a/tests/components/roborock/test_button.py
+++ b/tests/components/roborock/test_button.py
@@ -6,10 +6,17 @@ import pytest
 import roborock
 
 from homeassistant.components.button import SERVICE_PRESS
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 
 from tests.common import MockConfigEntry
+
+
+@pytest.fixture
+def platforms() -> list[Platform]:
+    """Fixture to set platforms used in the test."""
+    return [Platform.BUTTON]
 
 
 @pytest.mark.parametrize(

--- a/tests/components/roborock/test_image.py
+++ b/tests/components/roborock/test_image.py
@@ -5,10 +5,11 @@ from datetime import timedelta
 from http import HTTPStatus
 from unittest.mock import patch
 
+import pytest
 from roborock import RoborockException
 
 from homeassistant.components.roborock import DOMAIN
-from homeassistant.const import STATE_UNAVAILABLE
+from homeassistant.const import STATE_UNAVAILABLE, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
@@ -17,6 +18,12 @@ from .mock_data import MAP_DATA, PROP
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 from tests.typing import ClientSessionGenerator
+
+
+@pytest.fixture
+def platforms() -> list[Platform]:
+    """Fixture to set platforms used in the test."""
+    return [Platform.IMAGE]
 
 
 async def test_floorplan_image(

--- a/tests/components/roborock/test_number.py
+++ b/tests/components/roborock/test_number.py
@@ -6,10 +6,17 @@ import pytest
 import roborock
 
 from homeassistant.components.number import ATTR_VALUE, SERVICE_SET_VALUE
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 
 from tests.common import MockConfigEntry
+
+
+@pytest.fixture
+def platforms() -> list[Platform]:
+    """Fixture to set platforms used in the test."""
+    return [Platform.NUMBER]
 
 
 @pytest.mark.parametrize(

--- a/tests/components/roborock/test_select.py
+++ b/tests/components/roborock/test_select.py
@@ -7,7 +7,7 @@ import pytest
 from roborock.exceptions import RoborockException
 
 from homeassistant.components.roborock import DOMAIN
-from homeassistant.const import SERVICE_SELECT_OPTION, STATE_UNKNOWN
+from homeassistant.const import SERVICE_SELECT_OPTION, STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.setup import async_setup_component
@@ -15,6 +15,12 @@ from homeassistant.setup import async_setup_component
 from .mock_data import PROP
 
 from tests.common import MockConfigEntry
+
+
+@pytest.fixture
+def platforms() -> list[Platform]:
+    """Fixture to set platforms used in the test."""
+    return [Platform.SELECT]
 
 
 @pytest.mark.parametrize(

--- a/tests/components/roborock/test_sensor.py
+++ b/tests/components/roborock/test_sensor.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import patch
 
+import pytest
 from roborock import DeviceData, HomeDataDevice
 from roborock.const import (
     FILTER_REPLACE_TIME,
@@ -12,11 +13,18 @@ from roborock.const import (
 from roborock.roborock_message import RoborockMessage, RoborockMessageProtocol
 from roborock.version_1_apis import RoborockMqttClientV1
 
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 
 from .mock_data import CONSUMABLE, STATUS, USER_DATA
 
 from tests.common import MockConfigEntry
+
+
+@pytest.fixture
+def platforms() -> list[Platform]:
+    """Fixture to set platforms used in the test."""
+    return [Platform.SENSOR]
 
 
 async def test_sensors(hass: HomeAssistant, setup_entry: MockConfigEntry) -> None:

--- a/tests/components/roborock/test_switch.py
+++ b/tests/components/roborock/test_switch.py
@@ -6,10 +6,17 @@ import pytest
 import roborock
 
 from homeassistant.components.switch import SERVICE_TURN_OFF, SERVICE_TURN_ON
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 
 from tests.common import MockConfigEntry
+
+
+@pytest.fixture
+def platforms() -> list[Platform]:
+    """Fixture to set platforms used in the test."""
+    return [Platform.SWITCH]
 
 
 @pytest.mark.parametrize(

--- a/tests/components/roborock/test_time.py
+++ b/tests/components/roborock/test_time.py
@@ -7,10 +7,17 @@ import pytest
 import roborock
 
 from homeassistant.components.time import SERVICE_SET_VALUE
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 
 from tests.common import MockConfigEntry
+
+
+@pytest.fixture
+def platforms() -> list[Platform]:
+    """Fixture to set platforms used in the test."""
+    return [Platform.TIME]
 
 
 @pytest.mark.parametrize(

--- a/tests/components/roborock/test_vacuum.py
+++ b/tests/components/roborock/test_vacuum.py
@@ -40,6 +40,15 @@ ENTITY_ID = "vacuum.roborock_s7_maxv"
 DEVICE_ID = "abc123"
 
 
+@pytest.fixture
+def platforms() -> list[Platform]:
+    """Fixture to set platforms used in the test."""
+    # Note: Currently the Image platform is required to make these tests pass since
+    # some initialization of the coordinator happens as a side effect of loading
+    # image platform. Fix that and remove IMAGE here.
+    return [Platform.VACUUM, Platform.IMAGE]
+
+
 async def test_registry_entries(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update roborock tests to only load the platform under test. This exposes an issue where the vacuum tests require the image platform to pass, which can be fixed in a separate PR. This also has a benefit of making the tests about 30% faster.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
