### PR TITLE
Simplify roborock coordinator

### DIFF
--- a/homeassistant/components/roborock/__init__.py
+++ b/homeassistant/components/roborock/__init__.py
@@ -205,14 +205,6 @@ async def setup_device_v1(
     coordinator = RoborockDataUpdateCoordinator(
         hass, device, networking, product_info, mqtt_client, home_data_rooms
     )
-    # Verify we can communicate locally - if we can't, switch to cloud api
-    await coordinator.verify_api()
-    coordinator.api.is_available = True
-    try:
-        await coordinator.get_maps()
-    except RoborockException as err:
-        _LOGGER.warning("Failed to get map data")
-        _LOGGER.debug(err)
     try:
         await coordinator.async_config_entry_first_refresh()
     except ConfigEntryNotReady as ex:

--- a/homeassistant/components/roborock/coordinator.py
+++ b/homeassistant/components/roborock/coordinator.py
@@ -86,9 +86,9 @@ class RoborockDataUpdateCoordinator(DataUpdateCoordinator[DeviceProp]):
         # Rooms names populated later with calls to `set_current_map_rooms` for each map
         self.maps = {
             roborock_map.mapFlag: RoborockMapInfo(
-                    flag=roborock_map.mapFlag,
-                    name=roborock_map.name or f"Map {roborock_map.mapFlag}",
-                    rooms={},
+                flag=roborock_map.mapFlag,
+                name=roborock_map.name or f"Map {roborock_map.mapFlag}",
+                rooms={},
             )
             for roborock_map in (maps.map_info if (maps and maps.map_info) else ())
         }

--- a/homeassistant/components/roborock/coordinator.py
+++ b/homeassistant/components/roborock/coordinator.py
@@ -73,7 +73,27 @@ class RoborockDataUpdateCoordinator(DataUpdateCoordinator[DeviceProp]):
         self.maps: dict[int, RoborockMapInfo] = {}
         self._home_data_rooms = {str(room.id): room.name for room in home_data_rooms}
 
-    async def verify_api(self) -> None:
+    async def _async_setup(self) -> None:
+        """Set up the coordinator."""
+        # Verify we can communicate locally - if we can't, switch to cloud api
+        await self._verify_api()
+        self.api.is_available = True
+
+        try:
+            maps = await self.api.get_multi_maps_list()
+        except RoborockException as err:
+            raise UpdateFailed("Failed to get map data: {err}") from err
+        # Rooms names populated later with calls to `set_current_map_rooms` for each map
+        self.maps = {
+            roborock_map.mapFlag: RoborockMapInfo(
+                    flag=roborock_map.mapFlag,
+                    name=roborock_map.name or f"Map {roborock_map.mapFlag}",
+                    rooms={},
+            )
+            for roborock_map in (maps.map_info if (maps and maps.map_info) else ())
+        }
+
+    async def _verify_api(self) -> None:
         """Verify that the api is reachable. If it is not, switch clients."""
         if isinstance(self.api, RoborockLocalClientV1):
             try:
@@ -96,12 +116,8 @@ class RoborockDataUpdateCoordinator(DataUpdateCoordinator[DeviceProp]):
 
     async def _update_device_prop(self) -> None:
         """Update device properties."""
-        device_prop = await self.api.get_prop()
-        if device_prop:
-            if self.roborock_device_info.props:
-                self.roborock_device_info.props.update(device_prop)
-            else:
-                self.roborock_device_info.props = device_prop
+        if (device_prop := await self.api.get_prop()) is not None:
+            self.roborock_device_info.props.update(device_prop)
 
     async def _async_update_data(self) -> DeviceProp:
         """Update data via library."""
@@ -111,7 +127,7 @@ class RoborockDataUpdateCoordinator(DataUpdateCoordinator[DeviceProp]):
             # Set the new map id from the updated device props
             self._set_current_map()
             # Get the rooms for that map id.
-            await self.get_rooms()
+            await self.set_current_map_rooms()
         except RoborockException as ex:
             raise UpdateFailed(ex) from ex
         return self.roborock_device_info.props
@@ -127,29 +143,18 @@ class RoborockDataUpdateCoordinator(DataUpdateCoordinator[DeviceProp]):
                 self.roborock_device_info.props.status.map_status - 3
             ) // 4
 
-    async def get_maps(self) -> None:
-        """Add a map to the coordinators mapping."""
-        maps = await self.api.get_multi_maps_list()
-        if maps and maps.map_info:
-            for roborock_map in maps.map_info:
-                self.maps[roborock_map.mapFlag] = RoborockMapInfo(
-                    flag=roborock_map.mapFlag,
-                    name=roborock_map.name or f"Map {roborock_map.mapFlag}",
-                    rooms={},
-                )
-
-    async def get_rooms(self) -> None:
-        """Get all of the rooms for the current map."""
+    async def set_current_map_rooms(self) -> None:
+        """Fetch all of the rooms for the current map and set on RoborockMapInfo."""
         # The api is only able to access rooms for the currently selected map
         # So it is important this is only called when you have the map you care
         # about selected.
-        if self.current_map in self.maps:
-            iot_rooms = await self.api.get_room_mapping()
-            if iot_rooms is not None:
-                for room in iot_rooms:
-                    self.maps[self.current_map].rooms[room.segment_id] = (
-                        self._home_data_rooms.get(room.iot_id, "Unknown")
-                    )
+        if self.current_map is None or self.current_map not in self.maps:
+            return
+        room_mapping = await self.api.get_room_mapping()
+        self.maps[self.current_map].rooms = {
+            room.segment_id: self._home_data_rooms.get(room.iot_id, "Unknown")
+            for room in room_mapping or ()
+        }
 
     @cached_property
     def duid(self) -> str:

--- a/homeassistant/components/roborock/image.py
+++ b/homeassistant/components/roborock/image.py
@@ -121,7 +121,10 @@ class RoborockMap(RoborockCoordinatedEntityV1, ImageEntity):
         """Update the image if it is not cached."""
         if self.is_map_valid():
             response = await asyncio.gather(
-                *(self.cloud_api.get_map_v1(), self.coordinator.get_rooms()),
+                *(
+                    self.cloud_api.get_map_v1(),
+                    self.coordinator.set_current_map_rooms(),
+                ),
                 return_exceptions=True,
             )
             if not isinstance(response[0], bytes):
@@ -174,7 +177,8 @@ async def create_coordinator_maps(
             await asyncio.sleep(MAP_SLEEP)
         # Get the map data
         map_update = await asyncio.gather(
-            *[coord.cloud_api.get_map_v1(), coord.get_rooms()], return_exceptions=True
+            *[coord.cloud_api.get_map_v1(), coord.set_current_map_rooms()],
+            return_exceptions=True,
         )
         # If we fail to get the map, we should set it to empty byte,
         # still create it, and set it as unavailable.

--- a/tests/components/roborock/test_init.py
+++ b/tests/components/roborock/test_init.py
@@ -133,20 +133,18 @@ async def test_local_client_fails_props(
         assert mock_roborock_entry.state is ConfigEntryState.SETUP_RETRY
 
 
-async def test_fails_maps_continue(
+async def test_fail_maps(
     hass: HomeAssistant,
     mock_roborock_entry: MockConfigEntry,
     bypass_api_fixture_v1_only,
 ) -> None:
-    """Test that if we fail to get the maps, we still setup."""
+    """Test that the integration fails to load if we fail to get the maps."""
     with patch(
         "homeassistant.components.roborock.coordinator.RoborockLocalClientV1.get_multi_maps_list",
         side_effect=RoborockException(),
     ):
         await async_setup_component(hass, DOMAIN, {})
-        assert mock_roborock_entry.state is ConfigEntryState.LOADED
-        # No map data means no images
-        assert len(hass.states.async_all("image")) == 0
+        assert mock_roborock_entry.state is ConfigEntryState.SETUP_RETRY
 
 
 async def test_reauth_started(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This updates the roborock coordinator with some code/state simplifications:
- Move coordinator initialization into the coordinator `_async_setup` method which is called once on first init
- Require maps always, rather than silently failing. This should be a fairly robust call, and makes things easier to reason about for users and code.
- Rename `get_rooms` to `set_current_map_rooms` to make its side effects clear, similar to `set_current_map`.
- Increase test coverage by simplifying `_update_device_prop` to always merge device properties since it is populated on startup, then merging is always fine
- Build maps and rooms dicts once, rather than updating one key at a time


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
