### PR TITLE
SleepIQ add core climate for SleepNumber Climate 360 beds

### DIFF
--- a/homeassistant/components/sleepiq/const.py
+++ b/homeassistant/components/sleepiq/const.py
@@ -4,6 +4,8 @@ DATA_SLEEPIQ = "data_sleepiq"
 DOMAIN = "sleepiq"
 
 ACTUATOR = "actuator"
+CORE_CLIMATE_TIMER = "core_climate_timer"
+CORE_CLIMATE = "core_climate"
 BED = "bed"
 FIRMNESS = "firmness"
 ICON_EMPTY = "mdi:bed-empty"
@@ -15,6 +17,8 @@ FOOT_WARMING_TIMER = "foot_warming_timer"
 FOOT_WARMER = "foot_warmer"
 ENTITY_TYPES = {
     ACTUATOR: "Position",
+    CORE_CLIMATE_TIMER: "Core Climate Timer",
+    CORE_CLIMATE: "Core Climate",
     FIRMNESS: "Firmness",
     PRESSURE: "Pressure",
     IS_IN_BED: "Is In Bed",

--- a/homeassistant/components/sleepiq/number.py
+++ b/homeassistant/components/sleepiq/number.py
@@ -7,20 +7,28 @@ from dataclasses import dataclass
 from typing import Any, cast
 
 from asyncsleepiq import (
+    CoreTemps,
     FootWarmingTemps,
     SleepIQActuator,
     SleepIQBed,
+    SleepIQCoreClimate,
     SleepIQFootWarmer,
     SleepIQSleeper,
 )
 
-from homeassistant.components.number import NumberEntity, NumberEntityDescription
+from homeassistant.components.number import (
+    NumberDeviceClass,
+    NumberEntity,
+    NumberEntityDescription,
+)
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import UnitOfTime
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import (
     ACTUATOR,
+    CORE_CLIMATE_TIMER,
     DOMAIN,
     ENTITY_TYPES,
     FIRMNESS,
@@ -95,6 +103,27 @@ def _get_foot_warming_unique_id(bed: SleepIQBed, foot_warmer: SleepIQFootWarmer)
     return f"{bed.id}_{foot_warmer.side.value}_{FOOT_WARMING_TIMER}"
 
 
+async def _async_set_core_climate_time(
+    core_climate: SleepIQCoreClimate, time: int
+) -> None:
+    temperature = CoreTemps(core_climate.temperature)
+    if temperature != CoreTemps.OFF:
+        await core_climate.turn_on(temperature, time)
+
+    core_climate.timer = time
+
+
+def _get_core_climate_name(bed: SleepIQBed, core_climate: SleepIQCoreClimate) -> str:
+    sleeper = sleeper_for_side(bed, core_climate.side)
+    return f"SleepNumber {bed.name} {sleeper.name} {ENTITY_TYPES[CORE_CLIMATE_TIMER]}"
+
+
+def _get_core_climate_unique_id(
+    bed: SleepIQBed, core_climate: SleepIQCoreClimate
+) -> str:
+    return f"{bed.id}_{core_climate.side.value}_{CORE_CLIMATE_TIMER}"
+
+
 NUMBER_DESCRIPTIONS: dict[str, SleepIQNumberEntityDescription] = {
     FIRMNESS: SleepIQNumberEntityDescription(
         key=FIRMNESS,
@@ -131,6 +160,20 @@ NUMBER_DESCRIPTIONS: dict[str, SleepIQNumberEntityDescription] = {
         set_value_fn=_async_set_foot_warmer_time,
         get_name_fn=_get_foot_warming_name,
         get_unique_id_fn=_get_foot_warming_unique_id,
+    ),
+    CORE_CLIMATE_TIMER: SleepIQNumberEntityDescription(
+        key=CORE_CLIMATE_TIMER,
+        native_min_value=0,
+        native_max_value=600,
+        native_step=30,
+        name=ENTITY_TYPES[CORE_CLIMATE_TIMER],
+        icon="mdi:timer",
+        value_fn=lambda core_climate: core_climate.timer,
+        set_value_fn=_async_set_core_climate_time,
+        get_name_fn=_get_core_climate_name,
+        get_unique_id_fn=_get_core_climate_unique_id,
+        native_unit_of_measurement=UnitOfTime.SECONDS,
+        device_class=NumberDeviceClass.DURATION,
     ),
 }
 
@@ -171,6 +214,15 @@ async def async_setup_entry(
                 NUMBER_DESCRIPTIONS[FOOT_WARMING_TIMER],
             )
             for foot_warmer in bed.foundation.foot_warmers
+        )
+        entities.extend(
+            SleepIQNumberEntity(
+                data.data_coordinator,
+                bed,
+                core_climate,
+                NUMBER_DESCRIPTIONS[CORE_CLIMATE_TIMER],
+            )
+            for core_climate in bed.foundation.core_climates
         )
 
     async_add_entities(entities)

--- a/homeassistant/components/sleepiq/select.py
+++ b/homeassistant/components/sleepiq/select.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 from asyncsleepiq import (
+    CoreTemps,
     FootWarmingTemps,
     Side,
     SleepIQBed,
+    SleepIQCoreClimate,
     SleepIQFootWarmer,
     SleepIQPreset,
 )
@@ -15,7 +17,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN, FOOT_WARMER
+from .const import CORE_CLIMATE, DOMAIN, FOOT_WARMER
 from .coordinator import SleepIQData, SleepIQDataUpdateCoordinator
 from .entity import SleepIQBedEntity, SleepIQSleeperEntity, sleeper_for_side
 
@@ -36,6 +38,10 @@ async def async_setup_entry(
         entities.extend(
             SleepIQFootWarmingTempSelectEntity(data.data_coordinator, bed, foot_warmer)
             for foot_warmer in bed.foundation.foot_warmers
+        )
+        entities.extend(
+            SleepIQCoreTempSelectEntity(data.data_coordinator, bed, core_climate)
+            for core_climate in bed.foundation.core_climates
         )
     async_add_entities(entities)
 
@@ -111,6 +117,49 @@ class SleepIQFootWarmingTempSelectEntity(
             await self.foot_warmer.turn_off()
         else:
             await self.foot_warmer.turn_on(temperature, timer)
+
+        self._attr_current_option = option
+        await self.coordinator.async_request_refresh()
+        self.async_write_ha_state()
+
+
+class SleepIQCoreTempSelectEntity(
+    SleepIQSleeperEntity[SleepIQDataUpdateCoordinator], SelectEntity
+):
+    """Representation of a SleepIQ core climate temperature select entity."""
+
+    _attr_icon = "mdi:heat-wave"
+    _attr_options = [e.name.lower() for e in CoreTemps]
+    _attr_translation_key = "core_temps"
+
+    def __init__(
+        self,
+        coordinator: SleepIQDataUpdateCoordinator,
+        bed: SleepIQBed,
+        core_climate: SleepIQCoreClimate,
+    ) -> None:
+        """Initialize the select entity."""
+        self.core_climate = core_climate
+        sleeper = sleeper_for_side(bed, core_climate.side)
+        super().__init__(coordinator, bed, sleeper, CORE_CLIMATE)
+        self._async_update_attrs()
+
+    @callback
+    def _async_update_attrs(self) -> None:
+        """Update entity attributes."""
+        self._attr_current_option = CoreTemps(
+            self.core_climate.temperature
+        ).name.lower()
+
+    async def async_select_option(self, option: str) -> None:
+        """Change the current preset."""
+        temperature = CoreTemps[option.upper()]
+        timer = self.core_climate.timer or 240
+
+        if temperature == 0:
+            await self.core_climate.turn_off()
+        else:
+            await self.core_climate.turn_on(temperature, timer)
 
         self._attr_current_option = option
         await self.coordinator.async_request_refresh()

--- a/homeassistant/components/sleepiq/strings.json
+++ b/homeassistant/components/sleepiq/strings.json
@@ -33,6 +33,17 @@
           "medium": "[%key:common::state::medium%]",
           "high": "[%key:common::state::high%]"
         }
+      },
+      "core_temps": {
+        "state": {
+          "off": "[%key:common::state::off%]",
+          "heating_push_low": "Heating low",
+          "heating_push_med": "Heating medium",
+          "heating_push_high": "Heating high",
+          "cooling_pull_low": "Cooling low",
+          "cooling_pull_med": "Cooling medium",
+          "cooling_pull_high": "Cooling high"
+        }
       }
     }
   }

--- a/homeassistant/components/sleepiq/strings.json
+++ b/homeassistant/components/sleepiq/strings.json
@@ -37,12 +37,12 @@
       "core_temps": {
         "state": {
           "off": "[%key:common::state::off%]",
-          "heating_push_low": "Heating low",
-          "heating_push_med": "Heating medium",
-          "heating_push_high": "Heating high",
-          "cooling_pull_low": "Cooling low",
-          "cooling_pull_med": "Cooling medium",
-          "cooling_pull_high": "Cooling high"
+          "heating_low": "Heating low",
+          "heating_medium": "Heating medium",
+          "heating_high": "Heating high",
+          "cooling_low": "Cooling low",
+          "cooling_medium": "Cooling medium",
+          "cooling_high": "Cooling high"
         }
       }
     }

--- a/tests/components/sleepiq/conftest.py
+++ b/tests/components/sleepiq/conftest.py
@@ -7,10 +7,12 @@ from unittest.mock import AsyncMock, MagicMock, create_autospec, patch
 
 from asyncsleepiq import (
     BED_PRESETS,
+    CoreTemps,
     FootWarmingTemps,
     Side,
     SleepIQActuator,
     SleepIQBed,
+    SleepIQCoreClimate,
     SleepIQFootWarmer,
     SleepIQFoundation,
     SleepIQLight,
@@ -29,6 +31,7 @@ from tests.common import MockConfigEntry
 BED_ID = "123456"
 BED_NAME = "Test Bed"
 BED_NAME_LOWER = BED_NAME.lower().replace(" ", "_")
+CORE_CLIMATE_TIME = 240
 SLEEPER_L_ID = "98765"
 SLEEPER_R_ID = "43219"
 SLEEPER_L_NAME = "SleeperL"
@@ -91,6 +94,7 @@ def mock_bed() -> MagicMock:
     bed.foundation.lights = [light_1, light_2]
 
     bed.foundation.foot_warmers = []
+    bed.foundation.core_climates = []
     return bed
 
 
@@ -127,6 +131,7 @@ def mock_asyncsleepiq_single_foundation(
         preset.options = BED_PRESETS
 
         mock_bed.foundation.foot_warmers = []
+        mock_bed.foundation.core_climates = []
         yield client
 
 
@@ -184,6 +189,18 @@ def mock_asyncsleepiq(mock_bed: MagicMock) -> Generator[MagicMock]:
         foot_warmer_r.side = Side.RIGHT
         foot_warmer_r.timer = FOOT_WARM_TIME
         foot_warmer_r.temperature = FootWarmingTemps.OFF
+
+        core_climate_l = create_autospec(SleepIQCoreClimate)
+        core_climate_r = create_autospec(SleepIQCoreClimate)
+        mock_bed.foundation.core_climates = [core_climate_l, core_climate_r]
+
+        core_climate_l.side = Side.LEFT
+        core_climate_l.timer = CORE_CLIMATE_TIME
+        core_climate_l.temperature = CoreTemps.COOLING_PULL_MED
+
+        core_climate_r.side = Side.RIGHT
+        core_climate_r.timer = CORE_CLIMATE_TIME
+        core_climate_r.temperature = CoreTemps.OFF
 
         yield client
 

--- a/tests/components/sleepiq/test_number.py
+++ b/tests/components/sleepiq/test_number.py
@@ -198,3 +198,42 @@ async def test_foot_warmer_timer(
     await hass.async_block_till_done()
 
     assert mock_asyncsleepiq.beds[BED_ID].foundation.foot_warmers[0].timer == 300
+
+
+async def test_core_climate_timer(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, mock_asyncsleepiq
+) -> None:
+    """Test the SleepIQ core climate number values for a bed with two sides."""
+    entry = await setup_platform(hass, NUMBER_DOMAIN)
+
+    state = hass.states.get(
+        f"number.sleepnumber_{BED_NAME_LOWER}_{SLEEPER_L_NAME_LOWER}_core_climate_timer"
+    )
+    assert state.state == "240.0"
+    assert state.attributes.get(ATTR_ICON) == "mdi:timer"
+    assert state.attributes.get(ATTR_MIN) == 0
+    assert state.attributes.get(ATTR_MAX) == 600
+    assert state.attributes.get(ATTR_STEP) == 30
+    assert (
+        state.attributes.get(ATTR_FRIENDLY_NAME)
+        == f"SleepNumber {BED_NAME} {SLEEPER_L_NAME} Core Climate Timer"
+    )
+
+    entry = entity_registry.async_get(
+        f"number.sleepnumber_{BED_NAME_LOWER}_{SLEEPER_L_NAME_LOWER}_core_climate_timer"
+    )
+    assert entry
+    assert entry.unique_id == f"{BED_ID}_L_core_climate_timer"
+
+    await hass.services.async_call(
+        NUMBER_DOMAIN,
+        SERVICE_SET_VALUE,
+        {
+            ATTR_ENTITY_ID: f"number.sleepnumber_{BED_NAME_LOWER}_{SLEEPER_L_NAME_LOWER}_core_climate_timer",
+            ATTR_VALUE: 420,
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert mock_asyncsleepiq.beds[BED_ID].foundation.core_climates[0].timer == 420

--- a/tests/components/sleepiq/test_select.py
+++ b/tests/components/sleepiq/test_select.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import MagicMock
 
-from asyncsleepiq import FootWarmingTemps
+from asyncsleepiq import CoreTemps, FootWarmingTemps
 
 from homeassistant.components.select import (
     DOMAIN as SELECT_DOMAIN,
@@ -21,6 +21,7 @@ from .conftest import (
     BED_ID,
     BED_NAME,
     BED_NAME_LOWER,
+    CORE_CLIMATE_TIME,
     FOOT_WARM_TIME,
     PRESET_L_STATE,
     PRESET_R_STATE,
@@ -204,3 +205,77 @@ async def test_foot_warmer(
     mock_asyncsleepiq.beds[BED_ID].foundation.foot_warmers[
         1
     ].turn_on.assert_called_with(FootWarmingTemps.HIGH, FOOT_WARM_TIME)
+
+
+async def test_core_climate(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_asyncsleepiq: MagicMock,
+) -> None:
+    """Test the SleepIQ select entity for core climate."""
+    entry = await setup_platform(hass, SELECT_DOMAIN)
+
+    state = hass.states.get(
+        f"select.sleepnumber_{BED_NAME_LOWER}_{SLEEPER_L_NAME_LOWER}_core_climate"
+    )
+    assert state.state == CoreTemps.COOLING_PULL_MED.name.lower()
+    assert state.attributes.get(ATTR_ICON) == "mdi:heat-wave"
+    assert (
+        state.attributes.get(ATTR_FRIENDLY_NAME)
+        == f"SleepNumber {BED_NAME} {SLEEPER_L_NAME} Core Climate"
+    )
+
+    entry = entity_registry.async_get(
+        f"select.sleepnumber_{BED_NAME_LOWER}_{SLEEPER_L_NAME_LOWER}_core_climate"
+    )
+    assert entry
+    assert entry.unique_id == f"{SLEEPER_L_ID}_core_climate"
+
+    await hass.services.async_call(
+        SELECT_DOMAIN,
+        SERVICE_SELECT_OPTION,
+        {
+            ATTR_ENTITY_ID: f"select.sleepnumber_{BED_NAME_LOWER}_{SLEEPER_L_NAME_LOWER}_core_climate",
+            ATTR_OPTION: "off",
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    mock_asyncsleepiq.beds[BED_ID].foundation.core_climates[
+        0
+    ].turn_off.assert_called_once()
+
+    state = hass.states.get(
+        f"select.sleepnumber_{BED_NAME_LOWER}_{SLEEPER_R_NAME_LOWER}_core_climate"
+    )
+    assert state.state == CoreTemps.OFF.name.lower()
+    assert state.attributes.get(ATTR_ICON) == "mdi:heat-wave"
+    assert (
+        state.attributes.get(ATTR_FRIENDLY_NAME)
+        == f"SleepNumber {BED_NAME} {SLEEPER_R_NAME} Core Climate"
+    )
+
+    entry = entity_registry.async_get(
+        f"select.sleepnumber_{BED_NAME_LOWER}_{SLEEPER_R_NAME_LOWER}_core_climate"
+    )
+    assert entry
+    assert entry.unique_id == f"{SLEEPER_R_ID}_core_climate"
+
+    await hass.services.async_call(
+        SELECT_DOMAIN,
+        SERVICE_SELECT_OPTION,
+        {
+            ATTR_ENTITY_ID: f"select.sleepnumber_{BED_NAME_LOWER}_{SLEEPER_R_NAME_LOWER}_core_climate",
+            ATTR_OPTION: "heating_push_high",
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    mock_asyncsleepiq.beds[BED_ID].foundation.core_climates[
+        1
+    ].turn_on.assert_called_once()
+    mock_asyncsleepiq.beds[BED_ID].foundation.core_climates[
+        1
+    ].turn_on.assert_called_with(CoreTemps.HEATING_PUSH_HIGH, CORE_CLIMATE_TIME)

--- a/tests/components/sleepiq/test_select.py
+++ b/tests/components/sleepiq/test_select.py
@@ -218,7 +218,7 @@ async def test_core_climate(
     state = hass.states.get(
         f"select.sleepnumber_{BED_NAME_LOWER}_{SLEEPER_L_NAME_LOWER}_core_climate"
     )
-    assert state.state == CoreTemps.COOLING_PULL_MED.name.lower()
+    assert state.state == "cooling_medium"
     assert state.attributes.get(ATTR_ICON) == "mdi:heat-wave"
     assert (
         state.attributes.get(ATTR_FRIENDLY_NAME)
@@ -267,7 +267,7 @@ async def test_core_climate(
         SERVICE_SELECT_OPTION,
         {
             ATTR_ENTITY_ID: f"select.sleepnumber_{BED_NAME_LOWER}_{SLEEPER_R_NAME_LOWER}_core_climate",
-            ATTR_OPTION: "heating_push_high",
+            ATTR_OPTION: "heating_high",
         },
         blocking=True,
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adds the capability to control the Core Climate feature of SleepNumber Climate 360 beds. These beds have forced air, configurable on the two sides. The air can be heated or cooled with low / medium / high levels. There is a timer that defaults to 4 hours and maxes out at 10 hours. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/36718

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
