### PR TITLE
Add button to move netatmo cover to preferred position

### DIFF
--- a/homeassistant/components/netatmo/button.py
+++ b/homeassistant/components/netatmo/button.py
@@ -1,0 +1,73 @@
+"""Support for Netatmo/Bubendorff button."""
+
+from __future__ import annotations
+
+import logging
+
+from pyatmo import modules as NaModules
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import CONF_URL_CONTROL, NETATMO_CREATE_BUTTON
+from .data_handler import HOME, SIGNAL_NAME, NetatmoDevice
+from .entity import NetatmoModuleEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the Netatmo button platform."""
+
+    @callback
+    def _create_entity(netatmo_device: NetatmoDevice) -> None:
+        entity = NetatmoCoverPreferredPositionButton(netatmo_device)
+        _LOGGER.debug("Adding button %s", entity)
+        async_add_entities([entity])
+
+    entry.async_on_unload(
+        async_dispatcher_connect(hass, NETATMO_CREATE_BUTTON, _create_entity)
+    )
+
+
+class NetatmoCoverPreferredPositionButton(NetatmoModuleEntity, ButtonEntity):
+    """Representation of a Netatmo cover preferred position button device."""
+
+    _attr_configuration_url = CONF_URL_CONTROL
+    _attr_entity_registry_enabled_default = False
+    _attr_translation_key = "preferred_position"
+    device: NaModules.Shutter
+
+    def __init__(self, netatmo_device: NetatmoDevice) -> None:
+        """Initialize the Netatmo device."""
+        super().__init__(netatmo_device)
+
+        self._publishers.extend(
+            [
+                {
+                    "name": HOME,
+                    "home_id": self.home.entity_id,
+                    SIGNAL_NAME: f"{HOME}-{self.home.entity_id}",
+                },
+            ]
+        )
+        self._attr_unique_id = (
+            f"{self.device.entity_id}-{self.device_type}-preferred_position"
+        )
+
+    @callback
+    def async_update_callback(self) -> None:
+        """Update the entity's state."""
+        # No state to update for button
+
+    async def async_press(self) -> None:
+        """Handle button press to move the cover to a preferred position."""
+        _LOGGER.debug("Moving %s to a preferred position", self.device.entity_id)
+        await self.device.async_move_to_preferred_position()

--- a/homeassistant/components/netatmo/const.py
+++ b/homeassistant/components/netatmo/const.py
@@ -10,6 +10,7 @@ DEFAULT_ATTRIBUTION = f"Data provided by {MANUFACTURER}"
 
 PLATFORMS = [
     Platform.BINARY_SENSOR,
+    Platform.BUTTON,
     Platform.CAMERA,
     Platform.CLIMATE,
     Platform.COVER,
@@ -45,6 +46,7 @@ NETATMO_CREATE_CAMERA = "netatmo_create_camera"
 NETATMO_CREATE_CAMERA_LIGHT = "netatmo_create_camera_light"
 NETATMO_CREATE_CLIMATE = "netatmo_create_climate"
 NETATMO_CREATE_COVER = "netatmo_create_cover"
+NETATMO_CREATE_BUTTON = "netatmo_create_button"
 NETATMO_CREATE_FAN = "netatmo_create_fan"
 NETATMO_CREATE_LIGHT = "netatmo_create_light"
 NETATMO_CREATE_ROOM_SENSOR = "netatmo_create_room_sensor"

--- a/homeassistant/components/netatmo/data_handler.py
+++ b/homeassistant/components/netatmo/data_handler.py
@@ -33,6 +33,7 @@ from .const import (
     DOMAIN,
     MANUFACTURER,
     NETATMO_CREATE_BATTERY,
+    NETATMO_CREATE_BUTTON,
     NETATMO_CREATE_CAMERA,
     NETATMO_CREATE_CAMERA_LIGHT,
     NETATMO_CREATE_CLIMATE,
@@ -350,7 +351,10 @@ class NetatmoDataHandler:
                 NETATMO_CREATE_CAMERA_LIGHT,
             ],
             NetatmoDeviceCategory.dimmer: [NETATMO_CREATE_LIGHT],
-            NetatmoDeviceCategory.shutter: [NETATMO_CREATE_COVER],
+            NetatmoDeviceCategory.shutter: [
+                NETATMO_CREATE_COVER,
+                NETATMO_CREATE_BUTTON,
+            ],
             NetatmoDeviceCategory.switch: [
                 NETATMO_CREATE_LIGHT,
                 NETATMO_CREATE_SWITCH,

--- a/homeassistant/components/netatmo/icons.json
+++ b/homeassistant/components/netatmo/icons.json
@@ -13,6 +13,11 @@
         }
       }
     },
+    "button": {
+      "preferred_position": {
+        "default": "mdi:window-shutter-auto"
+      }
+    },
     "sensor": {
       "temp_trend": {
         "default": "mdi:trending-up"

--- a/homeassistant/components/netatmo/strings.json
+++ b/homeassistant/components/netatmo/strings.json
@@ -181,6 +181,11 @@
         }
       }
     },
+    "button": {
+      "preferred_position": {
+        "name": "Preferred position"
+      }
+    },
     "sensor": {
       "temp_trend": {
         "name": "Temperature trend"

--- a/tests/components/netatmo/snapshots/test_button.ambr
+++ b/tests/components/netatmo/snapshots/test_button.ambr
@@ -1,0 +1,95 @@
+# serializer version: 1
+# name: test_entity[button.bubendorff_blind_preferred_position-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': None,
+    'entity_id': 'button.bubendorff_blind_preferred_position',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Preferred position',
+    'platform': 'netatmo',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'preferred_position',
+    'unique_id': '0009999993-DeviceType.NBO-preferred_position',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entity[button.bubendorff_blind_preferred_position-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by Netatmo',
+      'friendly_name': 'Bubendorff blind Preferred position',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.bubendorff_blind_preferred_position',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_entity[button.entrance_blinds_preferred_position-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': None,
+    'entity_id': 'button.entrance_blinds_preferred_position',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Preferred position',
+    'platform': 'netatmo',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'preferred_position',
+    'unique_id': '0009999992-DeviceType.NBR-preferred_position',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entity[button.entrance_blinds_preferred_position-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by Netatmo',
+      'friendly_name': 'Entrance Blinds Preferred position',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.entrance_blinds_preferred_position',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---

--- a/tests/components/netatmo/test_button.py
+++ b/tests/components/netatmo/test_button.py
@@ -1,0 +1,72 @@
+"""The tests for Netatmo button."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from syrupy import SnapshotAssertion
+
+from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
+from homeassistant.const import ATTR_ENTITY_ID, STATE_UNKNOWN, Platform
+from homeassistant.core import HomeAssistant
+import homeassistant.helpers.entity_registry as er
+
+from .common import selected_platforms, snapshot_platform_entities
+
+from tests.common import MockConfigEntry
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_entity(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    netatmo_auth: AsyncMock,
+    snapshot: SnapshotAssertion,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test entities."""
+    await snapshot_platform_entities(
+        hass,
+        config_entry,
+        Platform.BUTTON,
+        entity_registry,
+        snapshot,
+    )
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_button_setup_and_services(
+    hass: HomeAssistant, config_entry: MockConfigEntry, netatmo_auth: AsyncMock
+) -> None:
+    """Test setup and services."""
+    with selected_platforms([Platform.BUTTON]):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+
+        await hass.async_block_till_done()
+
+    button_entity = "button.entrance_blinds_preferred_position"
+
+    assert hass.states.get(button_entity).state == STATE_UNKNOWN
+
+    # Test button press
+    with patch("pyatmo.home.Home.async_set_state") as mock_set_state:
+        await hass.services.async_call(
+            BUTTON_DOMAIN,
+            SERVICE_PRESS,
+            {ATTR_ENTITY_ID: button_entity},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        mock_set_state.assert_called_once_with(
+            {
+                "modules": [
+                    {
+                        "id": "0009999992",
+                        "target_position": -2,
+                        "bridge": "12:34:56:30:d5:d4",
+                    }
+                ]
+            }
+        )
+
+    assert (state := hass.states.get(button_entity))
+    assert state.state != STATE_UNKNOWN


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add a button to move a netatmo compatible cover to a preferred position.
The position is setted locally on the remote, this button will only move to the position

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/36723

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
