### PR TITLE
Bump ZHA to 0.0.45

### DIFF
--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -21,7 +21,7 @@
     "zha",
     "universal_silabs_flasher"
   ],
-  "requirements": ["zha==0.0.44"],
+  "requirements": ["zha==0.0.45"],
   "usb": [
     {
       "vid": "10C4",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3118,7 +3118,7 @@ zeroconf==0.136.2
 zeversolar==0.3.2
 
 # homeassistant.components.zha
-zha==0.0.44
+zha==0.0.45
 
 # homeassistant.components.zhong_hong
 zhong-hong-hvac==1.0.13

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2504,7 +2504,7 @@ zeroconf==0.136.2
 zeversolar==0.3.2
 
 # homeassistant.components.zha
-zha==0.0.44
+zha==0.0.45
 
 # homeassistant.components.zwave_js
 zwave-js-server-python==0.60.0


### PR DESCRIPTION
## Proposed change
This bumps ZHA to [0.0.45](https://github.com/zigpy/zha/releases/tag/0.0.45). These dependency upgrades are bundled with it: 
- `zha-quirks` [0.0.130](https://github.com/zigpy/zha-device-handlers/releases/tag/0.0.130)
- `zigpy` [0.74.0](https://github.com/zigpy/zigpy/releases/tag/0.74.0)

This is a bugfix release to fix an issue with certain Aqara H1 wireless remotes causing issues with ZHA starting.


## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #134686, fixes #134691
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
