### PR TITLE
Update roborock to ensure every room has a name, falling back to a placeholder

### DIFF
--- a/homeassistant/components/roborock/coordinator.py
+++ b/homeassistant/components/roborock/coordinator.py
@@ -134,7 +134,7 @@ class RoborockDataUpdateCoordinator(DataUpdateCoordinator[DeviceProp]):
             for roborock_map in maps.map_info:
                 self.maps[roborock_map.mapFlag] = RoborockMapInfo(
                     flag=roborock_map.mapFlag,
-                    name=roborock_map.name or f"Room {roborock_map.mapFlag}",
+                    name=roborock_map.name or f"Map {roborock_map.mapFlag}",
                     rooms={},
                 )
 

--- a/homeassistant/components/roborock/coordinator.py
+++ b/homeassistant/components/roborock/coordinator.py
@@ -133,7 +133,9 @@ class RoborockDataUpdateCoordinator(DataUpdateCoordinator[DeviceProp]):
         if maps and maps.map_info:
             for roborock_map in maps.map_info:
                 self.maps[roborock_map.mapFlag] = RoborockMapInfo(
-                    flag=roborock_map.mapFlag, name=roborock_map.name, rooms={}
+                    flag=roborock_map.mapFlag,
+                    name=roborock_map.name or f"Room {roborock_map.mapFlag}",
+                    rooms={},
                 )
 
     async def get_rooms(self) -> None:

--- a/tests/components/roborock/test_select.py
+++ b/tests/components/roborock/test_select.py
@@ -12,7 +12,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.setup import async_setup_component
 
-from .mock_data import PROP
+from .mock_data import MULTI_MAP_LIST, PROP
 
 from tests.common import MockConfigEntry
 
@@ -86,3 +86,33 @@ async def test_none_map_select(
         await async_setup_component(hass, DOMAIN, {})
     select_entity = hass.states.get("select.roborock_s7_maxv_selected_map")
     assert select_entity.state == STATE_UNKNOWN
+
+
+async def test_selected_map_name(
+    hass: HomeAssistant,
+    bypass_api_fixture,
+    mock_roborock_entry: MockConfigEntry,
+) -> None:
+    """Test that the selected map is set to the correct map name."""
+    await async_setup_component(hass, DOMAIN, {})
+    select_entity = hass.states.get("select.roborock_s7_maxv_selected_map")
+    assert select_entity.state == "Upstairs"
+
+
+async def test_selected_map_without_name(
+    hass: HomeAssistant,
+    bypass_api_fixture_v1_only,
+    mock_roborock_entry: MockConfigEntry,
+) -> None:
+    """Test that maps without a name are given a placeholder name."""
+    map_list = copy.deepcopy(MULTI_MAP_LIST)
+    map_list.map_info[0].name = ""
+    with patch(
+        "homeassistant.components.roborock.coordinator.RoborockLocalClientV1.get_multi_maps_list",
+        return_value=map_list,
+    ):
+        await async_setup_component(hass, DOMAIN, {})
+
+    select_entity = hass.states.get("select.roborock_s7_maxv_selected_map")
+    assert select_entity
+    assert select_entity.state == "Room 0"

--- a/tests/components/roborock/test_select.py
+++ b/tests/components/roborock/test_select.py
@@ -115,4 +115,4 @@ async def test_selected_map_without_name(
 
     select_entity = hass.states.get("select.roborock_s7_maxv_selected_map")
     assert select_entity
-    assert select_entity.state == "Room 0"
+    assert select_entity.state == "Map 0"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update roborock to ensure every room has a name, falling back to a placeholder when a room name is not present.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
- This PR is related to issue: #134570
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
