### PR TITLE
Add uuid as unique_id to config entries for Cookidoo

### DIFF
--- a/homeassistant/components/cookidoo/__init__.py
+++ b/homeassistant/components/cookidoo/__init__.py
@@ -2,41 +2,27 @@
 
 from __future__ import annotations
 
-from cookidoo_api import Cookidoo, CookidooConfig, get_localization_options
+import logging
 
-from homeassistant.const import (
-    CONF_COUNTRY,
-    CONF_EMAIL,
-    CONF_LANGUAGE,
-    CONF_PASSWORD,
-    Platform,
-)
+from cookidoo_api import CookidooAuthException, CookidooRequestException
+
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .coordinator import CookidooConfigEntry, CookidooDataUpdateCoordinator
+from .helpers import cookidoo_from_config_entry
 
 PLATFORMS: list[Platform] = [Platform.BUTTON, Platform.TODO]
+
+_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: CookidooConfigEntry) -> bool:
     """Set up Cookidoo from a config entry."""
 
-    localizations = await get_localization_options(
-        country=entry.data[CONF_COUNTRY].lower(),
-        language=entry.data[CONF_LANGUAGE],
+    coordinator = CookidooDataUpdateCoordinator(
+        hass, await cookidoo_from_config_entry(hass, entry), entry
     )
-
-    cookidoo = Cookidoo(
-        async_get_clientsession(hass),
-        CookidooConfig(
-            email=entry.data[CONF_EMAIL],
-            password=entry.data[CONF_PASSWORD],
-            localization=localizations[0],
-        ),
-    )
-
-    coordinator = CookidooDataUpdateCoordinator(hass, cookidoo, entry)
     await coordinator.async_config_entry_first_refresh()
 
     entry.runtime_data = coordinator
@@ -49,3 +35,39 @@ async def async_setup_entry(hass: HomeAssistant, entry: CookidooConfigEntry) -> 
 async def async_unload_entry(hass: HomeAssistant, entry: CookidooConfigEntry) -> bool:
     """Unload a config entry."""
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+
+
+async def async_migrate_entry(
+    hass: HomeAssistant, config_entry: CookidooConfigEntry
+) -> bool:
+    """Migrate config entry."""
+    _LOGGER.debug("Migrating from version %s", config_entry.version)
+
+    if config_entry.version > 1:
+        # This means the user has downgraded from a future version
+        return False
+
+    if config_entry.version == 1 and config_entry.minor_version == 1:
+        # Add the unique uuid
+        cookidoo = await cookidoo_from_config_entry(hass, config_entry)
+
+        try:
+            auth_data = await cookidoo.login()
+        except (CookidooRequestException, CookidooAuthException) as e:
+            _LOGGER.error(
+                "Could not migrate config config_entry: %s",
+                str(e),
+            )
+            return False
+
+        hass.config_entries.async_update_entry(
+            config_entry, unique_id=auth_data.sub, minor_version=2
+        )
+
+    _LOGGER.debug(
+        "Migration to version %s.%s successful",
+        config_entry.version,
+        config_entry.minor_version,
+    )
+
+    return True

--- a/homeassistant/components/cookidoo/button.py
+++ b/homeassistant/components/cookidoo/button.py
@@ -56,7 +56,8 @@ class CookidooButton(CookidooBaseEntity, ButtonEntity):
         """Initialize cookidoo button."""
         super().__init__(coordinator)
         self.entity_description = description
-        self._attr_unique_id = f"{coordinator.config_entry.entry_id}_{description.key}"
+        assert coordinator.config_entry.unique_id
+        self._attr_unique_id = f"{coordinator.config_entry.unique_id}_{description.key}"
 
     async def async_press(self) -> None:
         """Press the button."""

--- a/homeassistant/components/cookidoo/entity.py
+++ b/homeassistant/components/cookidoo/entity.py
@@ -21,10 +21,12 @@ class CookidooBaseEntity(CoordinatorEntity[CookidooDataUpdateCoordinator]):
         """Initialize the entity."""
         super().__init__(coordinator)
 
+        assert coordinator.config_entry.unique_id
+
         self.device_info = DeviceInfo(
             entry_type=DeviceEntryType.SERVICE,
             name="Cookidoo",
-            identifiers={(DOMAIN, coordinator.config_entry.entry_id)},
+            identifiers={(DOMAIN, coordinator.config_entry.unique_id)},
             manufacturer="Vorwerk International & Co. KmG",
             model="Cookidoo - Thermomix® recipe portal",
         )

--- a/homeassistant/components/cookidoo/helpers.py
+++ b/homeassistant/components/cookidoo/helpers.py
@@ -1,0 +1,37 @@
+"""Helpers for cookidoo."""
+
+from typing import Any
+
+from cookidoo_api import Cookidoo, CookidooConfig, get_localization_options
+
+from homeassistant.const import CONF_COUNTRY, CONF_EMAIL, CONF_LANGUAGE, CONF_PASSWORD
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+from .coordinator import CookidooConfigEntry
+
+
+async def cookidoo_from_config_data(
+    hass: HomeAssistant, data: dict[str, Any]
+) -> Cookidoo:
+    """Build cookidoo from config data."""
+    localizations = await get_localization_options(
+        country=data[CONF_COUNTRY].lower(),
+        language=data[CONF_LANGUAGE],
+    )
+
+    return Cookidoo(
+        async_get_clientsession(hass),
+        CookidooConfig(
+            email=data[CONF_EMAIL],
+            password=data[CONF_PASSWORD],
+            localization=localizations[0],
+        ),
+    )
+
+
+async def cookidoo_from_config_entry(
+    hass: HomeAssistant, entry: CookidooConfigEntry
+) -> Cookidoo:
+    """Build cookidoo from config entry."""
+    return await cookidoo_from_config_data(hass, dict(entry.data))

--- a/homeassistant/components/cookidoo/manifest.json
+++ b/homeassistant/components/cookidoo/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "loggers": ["cookidoo_api"],
   "quality_scale": "silver",
-  "requirements": ["cookidoo-api==0.12.0"]
+  "requirements": ["cookidoo-api==0.12.1"]
 }

--- a/homeassistant/components/cookidoo/manifest.json
+++ b/homeassistant/components/cookidoo/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "loggers": ["cookidoo_api"],
   "quality_scale": "silver",
-  "requirements": ["cookidoo-api==0.12.1"]
+  "requirements": ["cookidoo-api==0.12.2"]
 }

--- a/homeassistant/components/cookidoo/manifest.json
+++ b/homeassistant/components/cookidoo/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "loggers": ["cookidoo_api"],
   "quality_scale": "silver",
-  "requirements": ["cookidoo-api==0.11.2"]
+  "requirements": ["cookidoo-api==0.12.0"]
 }

--- a/homeassistant/components/cookidoo/strings.json
+++ b/homeassistant/components/cookidoo/strings.json
@@ -44,7 +44,8 @@
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
-      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]",
+      "unique_id_mismatch": "The user identifier does not match the previous identifier"
     }
   },
   "entity": {

--- a/homeassistant/components/cookidoo/todo.py
+++ b/homeassistant/components/cookidoo/todo.py
@@ -52,7 +52,8 @@ class CookidooIngredientsTodoListEntity(CookidooBaseEntity, TodoListEntity):
     def __init__(self, coordinator: CookidooDataUpdateCoordinator) -> None:
         """Initialize the entity."""
         super().__init__(coordinator)
-        self._attr_unique_id = f"{coordinator.config_entry.entry_id}_ingredients"
+        assert coordinator.config_entry.unique_id
+        self._attr_unique_id = f"{coordinator.config_entry.unique_id}_ingredients"
 
     @property
     def todo_items(self) -> list[TodoItem]:
@@ -112,7 +113,8 @@ class CookidooAdditionalItemTodoListEntity(CookidooBaseEntity, TodoListEntity):
     def __init__(self, coordinator: CookidooDataUpdateCoordinator) -> None:
         """Initialize the entity."""
         super().__init__(coordinator)
-        self._attr_unique_id = f"{coordinator.config_entry.entry_id}_additional_items"
+        assert coordinator.config_entry.unique_id
+        self._attr_unique_id = f"{coordinator.config_entry.unique_id}_additional_items"
 
     @property
     def todo_items(self) -> list[TodoItem]:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -710,7 +710,7 @@ connect-box==0.3.1
 construct==2.10.68
 
 # homeassistant.components.cookidoo
-cookidoo-api==0.11.2
+cookidoo-api==0.12.0
 
 # homeassistant.components.backup
 # homeassistant.components.utility_meter

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -710,7 +710,7 @@ connect-box==0.3.1
 construct==2.10.68
 
 # homeassistant.components.cookidoo
-cookidoo-api==0.12.0
+cookidoo-api==0.12.1
 
 # homeassistant.components.backup
 # homeassistant.components.utility_meter

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -710,7 +710,7 @@ connect-box==0.3.1
 construct==2.10.68
 
 # homeassistant.components.cookidoo
-cookidoo-api==0.12.1
+cookidoo-api==0.12.2
 
 # homeassistant.components.backup
 # homeassistant.components.utility_meter

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -606,7 +606,7 @@ colorthief==0.2.1
 construct==2.10.68
 
 # homeassistant.components.cookidoo
-cookidoo-api==0.12.1
+cookidoo-api==0.12.2
 
 # homeassistant.components.backup
 # homeassistant.components.utility_meter

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -606,7 +606,7 @@ colorthief==0.2.1
 construct==2.10.68
 
 # homeassistant.components.cookidoo
-cookidoo-api==0.11.2
+cookidoo-api==0.12.0
 
 # homeassistant.components.backup
 # homeassistant.components.utility_meter

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -606,7 +606,7 @@ colorthief==0.2.1
 construct==2.10.68
 
 # homeassistant.components.cookidoo
-cookidoo-api==0.12.0
+cookidoo-api==0.12.1
 
 # homeassistant.components.backup
 # homeassistant.components.utility_meter

--- a/tests/components/cookidoo/conftest.py
+++ b/tests/components/cookidoo/conftest.py
@@ -21,6 +21,8 @@ PASSWORD = "test-password"
 COUNTRY = "CH"
 LANGUAGE = "de-CH"
 
+TEST_UUID = "sub_uuid"
+
 
 @pytest.fixture
 def mock_setup_entry() -> Generator[AsyncMock]:
@@ -34,16 +36,10 @@ def mock_setup_entry() -> Generator[AsyncMock]:
 @pytest.fixture
 def mock_cookidoo_client() -> Generator[AsyncMock]:
     """Mock a Cookidoo client."""
-    with (
-        patch(
-            "homeassistant.components.cookidoo.Cookidoo",
-            autospec=True,
-        ) as mock_client,
-        patch(
-            "homeassistant.components.cookidoo.config_flow.Cookidoo",
-            new=mock_client,
-        ),
-    ):
+    with patch(
+        "homeassistant.components.cookidoo.helpers.Cookidoo",
+        autospec=True,
+    ) as mock_client:
         client = mock_client.return_value
         client.login.return_value = cast(CookidooAuthResponse, {"name": "Cookidoo"})
         client.get_ingredient_items.return_value = [
@@ -58,7 +54,9 @@ def mock_cookidoo_client() -> Generator[AsyncMock]:
                 "data"
             ]
         ]
-        client.login.return_value = None
+        client.login.return_value = CookidooAuthResponse(
+            **load_json_object_fixture("login.json", DOMAIN)
+        )
         yield client
 
 
@@ -67,6 +65,8 @@ def mock_cookidoo_config_entry() -> MockConfigEntry:
     """Mock cookidoo configuration entry."""
     return MockConfigEntry(
         domain=DOMAIN,
+        version=1,
+        minor_version=2,
         data={
             CONF_EMAIL: EMAIL,
             CONF_PASSWORD: PASSWORD,
@@ -74,4 +74,5 @@ def mock_cookidoo_config_entry() -> MockConfigEntry:
             CONF_LANGUAGE: LANGUAGE,
         },
         entry_id="01JBVVVJ87F6G5V0QJX6HBC94T",
+        unique_id=TEST_UUID,
     )

--- a/tests/components/cookidoo/fixtures/login.json
+++ b/tests/components/cookidoo/fixtures/login.json
@@ -1,0 +1,7 @@
+{
+  "access_token": "eyJhbGci<redacted>",
+  "expires_in": 43199,
+  "refresh_token": "eyJhbGciOiJSUzI1NiI<redacted>",
+  "token_type": "bearer",
+  "sub": "sub_uuid"
+}

--- a/tests/components/cookidoo/snapshots/test_button.ambr
+++ b/tests/components/cookidoo/snapshots/test_button.ambr
@@ -28,7 +28,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'todo_clear',
-    'unique_id': '01JBVVVJ87F6G5V0QJX6HBC94T_todo_clear',
+    'unique_id': 'sub_uuid_todo_clear',
     'unit_of_measurement': None,
   })
 # ---

--- a/tests/components/cookidoo/snapshots/test_todo.ambr
+++ b/tests/components/cookidoo/snapshots/test_todo.ambr
@@ -28,7 +28,7 @@
     'previous_unique_id': None,
     'supported_features': <TodoListEntityFeature: 7>,
     'translation_key': 'additional_item_list',
-    'unique_id': '01JBVVVJ87F6G5V0QJX6HBC94T_additional_items',
+    'unique_id': 'sub_uuid_additional_items',
     'unit_of_measurement': None,
   })
 # ---
@@ -75,7 +75,7 @@
     'previous_unique_id': None,
     'supported_features': <TodoListEntityFeature: 4>,
     'translation_key': 'ingredient_list',
-    'unique_id': '01JBVVVJ87F6G5V0QJX6HBC94T_ingredients',
+    'unique_id': 'sub_uuid_ingredients',
     'unit_of_measurement': None,
   })
 # ---

--- a/tests/components/cookidoo/test_init.py
+++ b/tests/components/cookidoo/test_init.py
@@ -127,6 +127,111 @@ OLD_ENTRY_ID = "OLD_OLD_ENTRY_ID"
         "from_minor_version",
         "config_data",
         "unique_id",
+    ),
+    [
+        (
+            1,
+            1,
+            MOCK_CONFIG_ENTRY_MIGRATION,
+            None,
+        ),
+        (1, 2, MOCK_CONFIG_ENTRY_MIGRATION, TEST_UUID),
+    ],
+)
+async def test_migration_from(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    from_version,
+    from_minor_version,
+    config_data,
+    unique_id,
+    mock_cookidoo_client: AsyncMock,
+) -> None:
+    """Test different expected migration paths."""
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=config_data,
+        title=f"MIGRATION_TEST from {from_version}.{from_minor_version}",
+        version=from_version,
+        minor_version=from_minor_version,
+        unique_id=unique_id,
+        entry_id=OLD_ENTRY_ID,
+    )
+    config_entry.add_to_hass(hass)
+
+    device = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={(DOMAIN, OLD_ENTRY_ID)},
+        entry_type=dr.DeviceEntryType.SERVICE,
+    )
+    entity_registry.async_get_or_create(
+        config_entry=config_entry,
+        platform=DOMAIN,
+        domain="todo",
+        unique_id=f"{OLD_ENTRY_ID}_ingredients",
+        device_id=device.id,
+    )
+    entity_registry.async_get_or_create(
+        config_entry=config_entry,
+        platform=DOMAIN,
+        domain="todo",
+        unique_id=f"{OLD_ENTRY_ID}_additional_items",
+        device_id=device.id,
+    )
+    entity_registry.async_get_or_create(
+        config_entry=config_entry,
+        platform=DOMAIN,
+        domain="button",
+        unique_id=f"{OLD_ENTRY_ID}_todo_clear",
+        device_id=device.id,
+    )
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    # Check change in config entry and verify most recent version
+    assert config_entry.version == 1
+    assert config_entry.minor_version == 2
+    assert config_entry.unique_id == TEST_UUID
+
+    assert entity_registry.async_is_registered(
+        entity_registry.entities.get_entity_id(
+            (
+                Platform.TODO,
+                DOMAIN,
+                f"{TEST_UUID}_ingredients",
+            )
+        )
+    )
+    assert entity_registry.async_is_registered(
+        entity_registry.entities.get_entity_id(
+            (
+                Platform.TODO,
+                DOMAIN,
+                f"{TEST_UUID}_additional_items",
+            )
+        )
+    )
+    assert entity_registry.async_is_registered(
+        entity_registry.entities.get_entity_id(
+            (
+                Platform.BUTTON,
+                DOMAIN,
+                f"{TEST_UUID}_todo_clear",
+            )
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    (
+        "from_version",
+        "from_minor_version",
+        "config_data",
+        "unique_id",
         "login_exception",
         "result",
     ),
@@ -139,11 +244,17 @@ OLD_ENTRY_ID = "OLD_OLD_ENTRY_ID"
             CookidooRequestException,
             ConfigEntryState.MIGRATION_ERROR,
         ),
-        (1, 1, MOCK_CONFIG_ENTRY_MIGRATION, None, None, ConfigEntryState.LOADED),
-        (1, 2, MOCK_CONFIG_ENTRY_MIGRATION, TEST_UUID, None, ConfigEntryState.LOADED),
+        (
+            1,
+            1,
+            MOCK_CONFIG_ENTRY_MIGRATION,
+            None,
+            CookidooAuthException,
+            ConfigEntryState.MIGRATION_ERROR,
+        ),
     ],
 )
-async def test_migration_from(
+async def test_migration_from_with_error(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
@@ -155,10 +266,9 @@ async def test_migration_from(
     result: ConfigEntryState,
     mock_cookidoo_client: AsyncMock,
 ) -> None:
-    """Test different expected migration paths."""
+    """Test different expected migration paths but with connection issues."""
     # Migration can fail due to connection issues as we have to fetch the uuid
-    if login_exception:
-        mock_cookidoo_client.login.side_effect = login_exception
+    mock_cookidoo_client.login.side_effect = login_exception
 
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -201,37 +311,3 @@ async def test_migration_from(
     await hass.config_entries.async_setup(config_entry.entry_id)
 
     assert config_entry.state is result
-
-    if result == ConfigEntryState.LOADED:
-        # Check change in config entry and verify most recent version
-        assert config_entry.version == 1
-        assert config_entry.minor_version == 2
-        assert config_entry.unique_id == TEST_UUID
-
-        assert entity_registry.async_is_registered(
-            entity_registry.entities.get_entity_id(
-                (
-                    Platform.TODO,
-                    DOMAIN,
-                    f"{TEST_UUID}_ingredients",
-                )
-            )
-        )
-        assert entity_registry.async_is_registered(
-            entity_registry.entities.get_entity_id(
-                (
-                    Platform.TODO,
-                    DOMAIN,
-                    f"{TEST_UUID}_additional_items",
-                )
-            )
-        )
-        assert entity_registry.async_is_registered(
-            entity_registry.entities.get_entity_id(
-                (
-                    Platform.BUTTON,
-                    DOMAIN,
-                    f"{TEST_UUID}_todo_clear",
-                )
-            )
-        )

--- a/tests/components/cookidoo/test_init.py
+++ b/tests/components/cookidoo/test_init.py
@@ -233,7 +233,6 @@ async def test_migration_from(
         "config_data",
         "unique_id",
         "login_exception",
-        "result",
     ),
     [
         (
@@ -242,7 +241,6 @@ async def test_migration_from(
             MOCK_CONFIG_ENTRY_MIGRATION,
             None,
             CookidooRequestException,
-            ConfigEntryState.MIGRATION_ERROR,
         ),
         (
             1,
@@ -250,7 +248,6 @@ async def test_migration_from(
             MOCK_CONFIG_ENTRY_MIGRATION,
             None,
             CookidooAuthException,
-            ConfigEntryState.MIGRATION_ERROR,
         ),
     ],
 )
@@ -263,7 +260,6 @@ async def test_migration_from_with_error(
     config_data,
     unique_id,
     login_exception: Exception,
-    result: ConfigEntryState,
     mock_cookidoo_client: AsyncMock,
 ) -> None:
     """Test different expected migration paths but with connection issues."""
@@ -273,7 +269,7 @@ async def test_migration_from_with_error(
     config_entry = MockConfigEntry(
         domain=DOMAIN,
         data=config_data,
-        title=f"MIGRATION_TEST from {from_version}.{from_minor_version} with login exception '{login_exception}' expecting result '{result}'",
+        title=f"MIGRATION_TEST from {from_version}.{from_minor_version} with login exception '{login_exception}'",
         version=from_version,
         minor_version=from_minor_version,
         unique_id=unique_id,
@@ -310,4 +306,32 @@ async def test_migration_from_with_error(
 
     await hass.config_entries.async_setup(config_entry.entry_id)
 
-    assert config_entry.state is result
+    assert config_entry.state is ConfigEntryState.MIGRATION_ERROR
+
+    assert entity_registry.async_is_registered(
+        entity_registry.entities.get_entity_id(
+            (
+                Platform.TODO,
+                DOMAIN,
+                f"{OLD_ENTRY_ID}_ingredients",
+            )
+        )
+    )
+    assert entity_registry.async_is_registered(
+        entity_registry.entities.get_entity_id(
+            (
+                Platform.TODO,
+                DOMAIN,
+                f"{OLD_ENTRY_ID}_additional_items",
+            )
+        )
+    )
+    assert entity_registry.async_is_registered(
+        entity_registry.entities.get_entity_id(
+            (
+                Platform.BUTTON,
+                DOMAIN,
+                f"{OLD_ENTRY_ID}_todo_clear",
+            )
+        )
+    )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
There has been a change in the auth for the cookidoo and we now get consistent jwt data. In there is a `sub` field with a uuid which can be used as `unique_id` for the config entry. This enforces the same account per config entry, regardless of any email changes. This PR migrates also existing config entries and adds the `unique_id`. Noteworthy, the migration might fail, when connection issues are present.

Version 0.12.0 for `cookidoo-api`:

https://github.com/miaucl/cookidoo-api/blob/master/CHANGELOG.md
https://github.com/miaucl/cookidoo-api/releases/tag/0.12.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
