### PR TITLE
Remove deprecated binary sensor battery charging from technove

### DIFF
--- a/homeassistant/components/technove/binary_sensor.py
+++ b/homeassistant/components/technove/binary_sensor.py
@@ -4,28 +4,19 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
 
 from technove import Station as TechnoVEStation
 
 from homeassistant.components.binary_sensor import (
-    DOMAIN as BINARY_SENSOR_DOMAIN,
     BinarySensorDeviceClass,
     BinarySensorEntity,
     BinarySensorEntityDescription,
 )
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.issue_registry import (
-    IssueSeverity,
-    async_create_issue,
-    async_delete_issue,
-)
 
 from . import TechnoVEConfigEntry
-from .const import DOMAIN
 from .coordinator import TechnoVEDataUpdateCoordinator
 from .entity import TechnoVEEntity
 
@@ -34,7 +25,6 @@ from .entity import TechnoVEEntity
 class TechnoVEBinarySensorDescription(BinarySensorEntityDescription):
     """Describes TechnoVE binary sensor entity."""
 
-    deprecated_version: str | None = None
     value_fn: Callable[[TechnoVEStation], bool | None]
 
 
@@ -56,15 +46,6 @@ BINARY_SENSORS = [
         translation_key="is_battery_protected",
         entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=lambda station: station.info.is_battery_protected,
-    ),
-    TechnoVEBinarySensorDescription(
-        key="is_session_active",
-        entity_category=EntityCategory.DIAGNOSTIC,
-        device_class=BinarySensorDeviceClass.BATTERY_CHARGING,
-        value_fn=lambda station: station.info.is_session_active,
-        deprecated_version="2025.2.0",
-        # Disabled by default, as this entity is deprecated
-        entity_registry_enabled_default=False,
     ),
     TechnoVEBinarySensorDescription(
         key="is_static_ip",
@@ -113,34 +94,3 @@ class TechnoVEBinarySensorEntity(TechnoVEEntity, BinarySensorEntity):
         """Return the state of the sensor."""
 
         return self.entity_description.value_fn(self.coordinator.data)
-
-    async def async_added_to_hass(self) -> None:
-        """Raise issue when entity is registered and was not disabled."""
-        if TYPE_CHECKING:
-            assert self.unique_id
-        if entity_id := er.async_get(self.hass).async_get_entity_id(
-            BINARY_SENSOR_DOMAIN, DOMAIN, self.unique_id
-        ):
-            if self.enabled and self.entity_description.deprecated_version:
-                async_create_issue(
-                    self.hass,
-                    DOMAIN,
-                    f"deprecated_entity_{self.entity_description.key}",
-                    breaks_in_ha_version=self.entity_description.deprecated_version,
-                    is_fixable=False,
-                    severity=IssueSeverity.WARNING,
-                    translation_key=f"deprecated_entity_{self.entity_description.key}",
-                    translation_placeholders={
-                        "sensor_name": self.name
-                        if isinstance(self.name, str)
-                        else entity_id,
-                        "entity": entity_id,
-                    },
-                )
-            else:
-                async_delete_issue(
-                    self.hass,
-                    DOMAIN,
-                    f"deprecated_entity_{self.entity_description.key}",
-                )
-        await super().async_added_to_hass()

--- a/homeassistant/components/technove/strings.json
+++ b/homeassistant/components/technove/strings.json
@@ -90,11 +90,5 @@
     "set_charging_enabled_on_auto_charge": {
       "message": "Cannot enable or disable charging when auto-charge is enabled. Try disabling auto-charge first."
     }
-  },
-  "issues": {
-    "deprecated_entity_is_session_active": {
-      "title": "The TechnoVE {sensor_name} binary sensor is deprecated",
-      "description": "`{entity}` is deprecated.\nPlease update your automations and scripts to replace the binary sensor entity with the newly added switch entity.\nWhen you are done migrating you can disable `{entity}`."
-    }
   }
 }

--- a/tests/components/technove/snapshots/test_binary_sensor.ambr
+++ b/tests/components/technove/snapshots/test_binary_sensor.ambr
@@ -45,53 +45,6 @@
     'state': 'off',
   })
 # ---
-# name: test_sensors[binary_sensor.technove_station_charging-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'binary_sensor',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'binary_sensor.technove_station_charging',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': <BinarySensorDeviceClass.BATTERY_CHARGING: 'battery_charging'>,
-    'original_icon': None,
-    'original_name': 'Charging',
-    'platform': 'technove',
-    'previous_unique_id': None,
-    'supported_features': 0,
-    'translation_key': None,
-    'unique_id': 'AA:AA:AA:AA:AA:BB_is_session_active',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_sensors[binary_sensor.technove_station_charging-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'battery_charging',
-      'friendly_name': 'TechnoVE Station Charging',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.technove_station_charging',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'on',
-  })
-# ---
 # name: test_sensors[binary_sensor.technove_station_conflict_with_power_sharing_mode-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({

--- a/tests/components/technove/test_binary_sensor.py
+++ b/tests/components/technove/test_binary_sensor.py
@@ -45,7 +45,6 @@ async def test_sensors(
     "entity_id",
     [
         "binary_sensor.technove_station_static_ip",
-        "binary_sensor.technove_station_charging",
     ],
 )
 @pytest.mark.usefixtures("init_integration")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Binary sensors has been previously deprecated and is now removed

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
See breaking

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 