### PR TITLE
Add extra failure exceptions during roborock setup

### DIFF
--- a/homeassistant/components/roborock/__init__.py
+++ b/homeassistant/components/roborock/__init__.py
@@ -9,7 +9,13 @@ from datetime import timedelta
 import logging
 from typing import Any
 
-from roborock import HomeDataRoom, RoborockException, RoborockInvalidCredentials
+from roborock import (
+    HomeDataRoom,
+    RoborockException,
+    RoborockInvalidCredentials,
+    RoborockInvalidUserAgreement,
+    RoborockNoUserAgreement,
+)
 from roborock.containers import DeviceData, HomeDataDevice, HomeDataProduct, UserData
 from roborock.version_1_apis.roborock_mqtt_client_v1 import RoborockMqttClientV1
 from roborock.version_a01_apis import RoborockMqttClientA01
@@ -60,12 +66,25 @@ async def async_setup_entry(hass: HomeAssistant, entry: RoborockConfigEntry) -> 
             translation_domain=DOMAIN,
             translation_key="invalid_credentials",
         ) from err
+    except RoborockInvalidUserAgreement as err:
+        raise ConfigEntryNotReady(
+            "User agreement must be accepted again. Open your Roborock app and accept the agreement.",
+            translation_domain=DOMAIN,
+            translation_key="invalid_user_agreement",
+        ) from err
+    except RoborockNoUserAgreement as err:
+        raise ConfigEntryNotReady(
+            "You have not valid user agreement. Open your Roborock app and accept the agreement.",
+            translation_domain=DOMAIN,
+            translation_key="no_user_agreement",
+        ) from err
     except RoborockException as err:
         raise ConfigEntryNotReady(
             "Failed to get Roborock home data",
             translation_domain=DOMAIN,
             translation_key="home_data_fail",
         ) from err
+
     _LOGGER.debug("Got home data %s", home_data)
     all_devices: list[HomeDataDevice] = home_data.devices + home_data.received_devices
     device_map: dict[str, HomeDataDevice] = {

--- a/homeassistant/components/roborock/__init__.py
+++ b/homeassistant/components/roborock/__init__.py
@@ -68,13 +68,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: RoborockConfigEntry) -> 
         ) from err
     except RoborockInvalidUserAgreement as err:
         raise ConfigEntryNotReady(
-            "User agreement must be accepted again. Open your Roborock app and accept the agreement.",
             translation_domain=DOMAIN,
             translation_key="invalid_user_agreement",
         ) from err
     except RoborockNoUserAgreement as err:
         raise ConfigEntryNotReady(
-            "You have not valid user agreement. Open your Roborock app and accept the agreement.",
             translation_domain=DOMAIN,
             translation_key="no_user_agreement",
         ) from err

--- a/homeassistant/components/roborock/strings.json
+++ b/homeassistant/components/roborock/strings.json
@@ -422,6 +422,12 @@
     },
     "update_options_failed": {
       "message": "Failed to update Roborock options"
+    },
+    "invalid_user_agreement": {
+      "message": "User agreement must be accepted again. Open your Roborock app and accept the agreement."
+    },
+    "no_user_agreement": {
+      "message": "You have not valid user agreement. Open your Roborock app and accept the agreement."
     }
   },
   "services": {

--- a/tests/components/roborock/test_init.py
+++ b/tests/components/roborock/test_init.py
@@ -4,7 +4,12 @@ from copy import deepcopy
 from unittest.mock import patch
 
 import pytest
-from roborock import RoborockException, RoborockInvalidCredentials
+from roborock import (
+    RoborockException,
+    RoborockInvalidCredentials,
+    RoborockInvalidUserAgreement,
+    RoborockNoUserAgreement,
+)
 
 from homeassistant.components.roborock.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
@@ -194,3 +199,37 @@ async def test_not_supported_a01_device(
         await async_setup_component(hass, DOMAIN, {})
         await hass.async_block_till_done()
     assert "The device you added is not yet supported" in caplog.text
+
+
+async def test_invalid_user_agreement(
+    hass: HomeAssistant,
+    bypass_api_fixture,
+    mock_roborock_entry: MockConfigEntry,
+) -> None:
+    """Test that we fail setting up if the user agreement is out of date."""
+    with patch(
+        "homeassistant.components.roborock.RoborockApiClient.get_home_data_v2",
+        side_effect=RoborockInvalidUserAgreement(),
+    ):
+        await async_setup_component(hass, DOMAIN, {})
+        await hass.async_block_till_done()
+        assert mock_roborock_entry.state is ConfigEntryState.SETUP_RETRY
+        assert (
+            mock_roborock_entry.error_reason_translation_key == "invalid_user_agreement"
+        )
+
+
+async def test_no_user_agreement(
+    hass: HomeAssistant,
+    bypass_api_fixture,
+    mock_roborock_entry: MockConfigEntry,
+) -> None:
+    """Test that we fail setting up if the user has no agreement."""
+    with patch(
+        "homeassistant.components.roborock.RoborockApiClient.get_home_data_v2",
+        side_effect=RoborockNoUserAgreement(),
+    ):
+        await async_setup_component(hass, DOMAIN, {})
+        await hass.async_block_till_done()
+        assert mock_roborock_entry.state is ConfigEntryState.SETUP_RETRY
+        assert mock_roborock_entry.error_reason_translation_key == "no_user_agreement"

--- a/tests/components/roborock/test_init.py
+++ b/tests/components/roborock/test_init.py
@@ -211,8 +211,7 @@ async def test_invalid_user_agreement(
         "homeassistant.components.roborock.RoborockApiClient.get_home_data_v2",
         side_effect=RoborockInvalidUserAgreement(),
     ):
-        await async_setup_component(hass, DOMAIN, {})
-        await hass.async_block_till_done()
+        await hass.config_entries.async_setup(mock_roborock_entry.entry_id)
         assert mock_roborock_entry.state is ConfigEntryState.SETUP_RETRY
         assert (
             mock_roborock_entry.error_reason_translation_key == "invalid_user_agreement"
@@ -229,7 +228,6 @@ async def test_no_user_agreement(
         "homeassistant.components.roborock.RoborockApiClient.get_home_data_v2",
         side_effect=RoborockNoUserAgreement(),
     ):
-        await async_setup_component(hass, DOMAIN, {})
-        await hass.async_block_till_done()
+        await hass.config_entries.async_setup(mock_roborock_entry.entry_id)
         assert mock_roborock_entry.state is ConfigEntryState.SETUP_RETRY
         assert mock_roborock_entry.error_reason_translation_key == "no_user_agreement"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This will give the user some better exceptions during setup if there is a failure instead of them having to go to the logs to figure out the cause.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #126288
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
