### PR TITLE
Add USB-PD Mode select entity to IronOS integration

### DIFF
--- a/homeassistant/components/iron_os/icons.json
+++ b/homeassistant/components/iron_os/icons.json
@@ -102,6 +102,9 @@
       },
       "logo_duration": {
         "default": "mdi:clock-digital"
+      },
+      "usb_pd_mode": {
+        "default": "mdi:meter-electric-outline"
       }
     },
     "sensor": {

--- a/homeassistant/components/iron_os/select.py
+++ b/homeassistant/components/iron_os/select.py
@@ -19,6 +19,7 @@ from pynecil import (
     ScrollSpeed,
     SettingsDataResponse,
     TempUnit,
+    USBPDMode,
 )
 
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
@@ -55,6 +56,7 @@ class PinecilSelect(StrEnum):
     DESC_SCROLL_SPEED = "desc_scroll_speed"
     LOCKING_MODE = "locking_mode"
     LOGO_DURATION = "logo_duration"
+    USB_PD_MODE = "usb_pd_mode"
 
 
 def enum_to_str(enum: Enum | None) -> str | None:
@@ -137,6 +139,16 @@ PINECIL_SELECT_DESCRIPTIONS: tuple[IronOSSelectEntityDescription, ...] = (
         value_fn=lambda x: enum_to_str(x.get("logo_duration")),
         raw_value_fn=lambda value: LogoDuration[value.upper()],
         options=[x.name.lower() for x in LogoDuration],
+        entity_category=EntityCategory.CONFIG,
+        entity_registry_enabled_default=False,
+    ),
+    IronOSSelectEntityDescription(
+        key=PinecilSelect.USB_PD_MODE,
+        translation_key=PinecilSelect.USB_PD_MODE,
+        characteristic=CharSetting.USB_PD_MODE,
+        value_fn=lambda x: enum_to_str(x.get("usb_pd_mode")),
+        raw_value_fn=lambda value: USBPDMode[value.upper()],
+        options=["off", "on"],
         entity_category=EntityCategory.CONFIG,
         entity_registry_enabled_default=False,
     ),

--- a/homeassistant/components/iron_os/strings.json
+++ b/homeassistant/components/iron_os/strings.json
@@ -166,6 +166,13 @@
           "seconds_5": "5 second",
           "loop": "Loop"
         }
+      },
+      "usb_pd_mode": {
+        "name": "Power Delivery 3.1 EPR",
+        "state": {
+          "off": "[%key:common::state::off%]",
+          "on": "[%key:common::state::on%]"
+        }
       }
     },
     "sensor": {

--- a/tests/components/iron_os/snapshots/test_select.ambr
+++ b/tests/components/iron_os/snapshots/test_select.ambr
@@ -237,6 +237,61 @@
     'state': 'right_handed',
   })
 # ---
+# name: test_state[select.pinecil_power_delivery_3_1_epr-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'off',
+        'on',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'select.pinecil_power_delivery_3_1_epr',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Power Delivery 3.1 EPR',
+    'platform': 'iron_os',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': <PinecilSelect.USB_PD_MODE: 'usb_pd_mode'>,
+    'unique_id': 'c0:ff:ee:c0:ff:ee_usb_pd_mode',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_state[select.pinecil_power_delivery_3_1_epr-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Pinecil Power Delivery 3.1 EPR',
+      'options': list([
+        'off',
+        'on',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.pinecil_power_delivery_3_1_epr',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
 # name: test_state[select.pinecil_power_source-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({

--- a/tests/components/iron_os/test_select.py
+++ b/tests/components/iron_os/test_select.py
@@ -16,6 +16,7 @@ from pynecil import (
     ScreenOrientationMode,
     ScrollSpeed,
     TempUnit,
+    USBPDMode,
 )
 import pytest
 from syrupy.assertion import SnapshotAssertion
@@ -104,6 +105,11 @@ async def test_state(
             "select.pinecil_boot_logo_duration",
             "loop",
             (CharSetting.LOGO_DURATION, LogoDuration.LOOP),
+        ),
+        (
+            "select.pinecil_power_delivery_3_1_epr",
+            "on",
+            (CharSetting.USB_PD_MODE, USBPDMode.ON),
         ),
     ],
 )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


Re-adds the USB-PD Mode entity as select entity that was previously a switch entity. The upcoming IronOS v2.23 adds a third option `safe`, this is already reflected in the pynecil library but the available select options don't include the new option yet.

Updating documentation is not required.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
