### PR TITLE
Remove deprecated hdr switch from reolink

### DIFF
--- a/homeassistant/components/reolink/strings.json
+++ b/homeassistant/components/reolink/strings.json
@@ -117,10 +117,6 @@
       "title": "Reolink firmware update required",
       "description": "\"{name}\" with model \"{model}\" and hardware version \"{hw_version}\" is running a old firmware version \"{current_firmware}\", while at least firmware version \"{required_firmware}\" is required for proper operation of the Reolink integration. The firmware can be updated by pressing \"install\" in the more info dialog of the update entity of \"{name}\" from within Home Assistant. Alternatively, the latest firmware can be downloaded from the [Reolink download center]({download_link})."
     },
-    "hdr_switch_deprecated": {
-      "title": "Reolink HDR switch deprecated",
-      "description": "The Reolink HDR switch entity is deprecated and will be removed in HA 2025.2.0. It has been replaced by a HDR select entity offering options `on`, `off` and `auto`. To remove this issue, please adjust automations accordingly and disable the HDR switch entity."
-    },
     "hub_switch_deprecated": {
       "title": "Reolink Home Hub switches deprecated",
       "description": "The redundant 'Record', 'Email on event', 'FTP upload', 'Push notifications', and 'Buzzer on event' switches on the Reolink Home Hub are depricated since the new firmware no longer supports these. Please use the equally named switches under each of the camera devices connected to the Home Hub instead. To remove this issue, please adjust automations accordingly and disable the switch entities mentioned."

--- a/homeassistant/components/reolink/switch.py
+++ b/homeassistant/components/reolink/switch.py
@@ -267,18 +267,6 @@ CHIME_SWITCH_ENTITIES = (
     ),
 )
 
-# Can be removed in HA 2025.2.0
-DEPRECATED_HDR = ReolinkSwitchEntityDescription(
-    key="hdr",
-    cmd_key="GetIsp",
-    translation_key="hdr",
-    entity_category=EntityCategory.CONFIG,
-    entity_registry_enabled_default=False,
-    supported=lambda api, ch: api.supported(ch, "HDR"),
-    value=lambda api, ch: api.HDR_on(ch) is True,
-    method=lambda api, ch, value: api.set_HDR(ch, value),
-)
-
 # Can be removed in HA 2025.4.0
 DEPRECATED_NVR_SWITCHES = [
     ReolinkNVRSwitchEntityDescription(
@@ -367,26 +355,6 @@ async def async_setup_entry(
     entity_reg = er.async_get(hass)
     reg_entities = er.async_entries_for_config_entry(entity_reg, config_entry.entry_id)
     for entity in reg_entities:
-        # Can be removed in HA 2025.2.0
-        if entity.domain == "switch" and entity.unique_id.endswith("_hdr"):
-            if entity.disabled:
-                entity_reg.async_remove(entity.entity_id)
-                continue
-
-            ir.async_create_issue(
-                hass,
-                DOMAIN,
-                "hdr_switch_deprecated",
-                is_fixable=False,
-                severity=ir.IssueSeverity.WARNING,
-                translation_key="hdr_switch_deprecated",
-            )
-            entities.extend(
-                ReolinkSwitchEntity(reolink_data, channel, DEPRECATED_HDR)
-                for channel in reolink_data.host.api.channels
-                if DEPRECATED_HDR.supported(reolink_data.host.api, channel)
-            )
-
         # Can be removed in HA 2025.4.0
         if entity.domain == "switch" and entity.unique_id in depricated_dict:
             if entity.disabled:

--- a/tests/components/reolink/test_switch.py
+++ b/tests/components/reolink/test_switch.py
@@ -29,38 +29,6 @@ from .conftest import TEST_CAM_NAME, TEST_NVR_NAME, TEST_UID
 from tests.common import MockConfigEntry, async_fire_time_changed
 
 
-async def test_cleanup_hdr_switch(
-    hass: HomeAssistant,
-    config_entry: MockConfigEntry,
-    reolink_connect: MagicMock,
-    entity_registry: er.EntityRegistry,
-) -> None:
-    """Test cleanup of the HDR switch entity."""
-    original_id = f"{TEST_UID}_hdr"
-    domain = Platform.SWITCH
-
-    reolink_connect.channels = [0]
-    reolink_connect.supported.return_value = True
-
-    entity_registry.async_get_or_create(
-        domain=domain,
-        platform=DOMAIN,
-        unique_id=original_id,
-        config_entry=config_entry,
-        suggested_object_id=original_id,
-        disabled_by=er.RegistryEntryDisabler.USER,
-    )
-
-    assert entity_registry.async_get_entity_id(domain, DOMAIN, original_id)
-
-    # setup CH 0 and host entities/device
-    with patch("homeassistant.components.reolink.PLATFORMS", [domain]):
-        assert await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    assert entity_registry.async_get_entity_id(domain, DOMAIN, original_id) is None
-
-
 @pytest.mark.parametrize(
     (
         "original_id",
@@ -130,41 +98,6 @@ async def test_cleanup_hub_switches(
 
     reolink_connect.is_hub = False
     reolink_connect.supported.return_value = True
-
-
-async def test_hdr_switch_deprecated_repair_issue(
-    hass: HomeAssistant,
-    config_entry: MockConfigEntry,
-    reolink_connect: MagicMock,
-    entity_registry: er.EntityRegistry,
-    issue_registry: ir.IssueRegistry,
-) -> None:
-    """Test repairs issue is raised when hdr switch entity used."""
-    original_id = f"{TEST_UID}_hdr"
-    domain = Platform.SWITCH
-
-    reolink_connect.channels = [0]
-    reolink_connect.supported.return_value = True
-
-    entity_registry.async_get_or_create(
-        domain=domain,
-        platform=DOMAIN,
-        unique_id=original_id,
-        config_entry=config_entry,
-        suggested_object_id=original_id,
-        disabled_by=None,
-    )
-
-    assert entity_registry.async_get_entity_id(domain, DOMAIN, original_id)
-
-    # setup CH 0 and host entities/device
-    with patch("homeassistant.components.reolink.PLATFORMS", [domain]):
-        assert await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    assert entity_registry.async_get_entity_id(domain, DOMAIN, original_id)
-
-    assert (DOMAIN, "hdr_switch_deprecated") in issue_registry.issues
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Removes the previously deprecated hdr switch from `reolink`

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
See breaking

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr 