### PR TITLE
Add LetPot integration

### DIFF
--- a/.strict-typing
+++ b/.strict-typing
@@ -291,6 +291,7 @@ homeassistant.components.lcn.*
 homeassistant.components.ld2410_ble.*
 homeassistant.components.led_ble.*
 homeassistant.components.lektrico.*
+homeassistant.components.letpot.*
 homeassistant.components.lidarr.*
 homeassistant.components.lifx.*
 homeassistant.components.light.*

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -831,6 +831,8 @@ build.json @home-assistant/supervisor
 /tests/components/led_ble/ @bdraco
 /homeassistant/components/lektrico/ @lektrico
 /tests/components/lektrico/ @lektrico
+/homeassistant/components/letpot/ @jpelgrom
+/tests/components/letpot/ @jpelgrom
 /homeassistant/components/lg_netcast/ @Drafteed @splinter98
 /tests/components/lg_netcast/ @Drafteed @splinter98
 /homeassistant/components/lg_thinq/ @LG-ThinQ-Integration

--- a/homeassistant/components/letpot/__init__.py
+++ b/homeassistant/components/letpot/__init__.py
@@ -66,14 +66,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: LetPotConfigEntry) -> bo
     except LetPotException as exc:
         raise ConfigEntryNotReady from exc
 
-    supported_devices = [
-        device
+    coordinators: list[LetPotDeviceCoordinator] = [
+        LetPotDeviceCoordinator(hass, auth, device)
         for device in devices
         if any(converter.supports_type(device.device_type) for converter in CONVERTERS)
-    ]
-
-    coordinators: list[LetPotDeviceCoordinator] = [
-        LetPotDeviceCoordinator(hass, auth, device) for device in supported_devices
     ]
 
     await asyncio.gather(
@@ -94,5 +90,5 @@ async def async_unload_entry(hass: HomeAssistant, entry: LetPotConfigEntry) -> b
     """Unload a config entry."""
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         for coordinator in entry.runtime_data:
-            coordinator.deviceclient.disconnect()
+            coordinator.device_client.disconnect()
     return unload_ok

--- a/homeassistant/components/letpot/__init__.py
+++ b/homeassistant/components/letpot/__init__.py
@@ -1,0 +1,95 @@
+"""The LetPot integration."""
+
+from __future__ import annotations
+
+import asyncio
+
+from letpot.client import LetPotClient
+from letpot.converters import CONVERTERS
+from letpot.exceptions import LetPotAuthenticationException, LetPotException
+from letpot.models import AuthenticationInfo
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_ACCESS_TOKEN, CONF_EMAIL, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+from .const import (
+    CONF_ACCESS_TOKEN_EXPIRES,
+    CONF_REFRESH_TOKEN,
+    CONF_REFRESH_TOKEN_EXPIRES,
+    CONF_USER_ID,
+)
+from .coordinator import LetPotDeviceCoordinator
+
+PLATFORMS: list[Platform] = [Platform.TIME]
+
+type LetPotConfigEntry = ConfigEntry[list[LetPotDeviceCoordinator]]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: LetPotConfigEntry) -> bool:
+    """Set up LetPot from a config entry."""
+
+    auth = AuthenticationInfo(
+        access_token=entry.data[CONF_ACCESS_TOKEN],
+        access_token_expires=entry.data[CONF_ACCESS_TOKEN_EXPIRES],
+        refresh_token=entry.data[CONF_REFRESH_TOKEN],
+        refresh_token_expires=entry.data[CONF_REFRESH_TOKEN_EXPIRES],
+        user_id=entry.data[CONF_USER_ID],
+        email=entry.data[CONF_EMAIL],
+    )
+    websession = async_get_clientsession(hass)
+    client = LetPotClient(websession, auth)
+
+    if not auth.is_valid:
+        try:
+            auth = await client.refresh_token()
+            hass.config_entries.async_update_entry(
+                entry,
+                data={
+                    CONF_ACCESS_TOKEN: auth.access_token,
+                    CONF_ACCESS_TOKEN_EXPIRES: auth.access_token_expires,
+                    CONF_REFRESH_TOKEN: auth.refresh_token,
+                    CONF_REFRESH_TOKEN_EXPIRES: auth.refresh_token_expires,
+                    CONF_USER_ID: auth.user_id,
+                    CONF_EMAIL: auth.email,
+                },
+            )
+        except LetPotAuthenticationException as exc:
+            raise ConfigEntryAuthFailed from exc
+
+    try:
+        devices = await client.get_devices()
+    except LetPotAuthenticationException as exc:
+        raise ConfigEntryAuthFailed from exc
+    except LetPotException as exc:
+        raise ConfigEntryNotReady from exc
+
+    supported_devices = [
+        device
+        for device in devices
+        if any(converter.supports_type(device.device_type) for converter in CONVERTERS)
+    ]
+
+    coordinators: list[LetPotDeviceCoordinator] = [
+        LetPotDeviceCoordinator(hass, auth, device) for device in supported_devices
+    ]
+
+    await asyncio.gather(
+        *[
+            coordinator.async_config_entry_first_refresh()
+            for coordinator in coordinators
+        ]
+    )
+
+    entry.runtime_data = coordinators
+
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: LetPotConfigEntry) -> bool:
+    """Unload a config entry."""
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/letpot/__init__.py
+++ b/homeassistant/components/letpot/__init__.py
@@ -92,4 +92,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: LetPotConfigEntry) -> bo
 
 async def async_unload_entry(hass: HomeAssistant, entry: LetPotConfigEntry) -> bool:
     """Unload a config entry."""
-    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
+        for coordinator in entry.runtime_data:
+            coordinator.deviceclient.disconnect()
+    return unload_ok

--- a/homeassistant/components/letpot/__init__.py
+++ b/homeassistant/components/letpot/__init__.py
@@ -12,7 +12,7 @@ from letpot.models import AuthenticationInfo
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ACCESS_TOKEN, CONF_EMAIL, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+from homeassistant.exceptions import ConfigEntryError, ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import (
@@ -57,12 +57,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: LetPotConfigEntry) -> bo
                 },
             )
         except LetPotAuthenticationException as exc:
-            raise ConfigEntryAuthFailed from exc
+            raise ConfigEntryError from exc
 
     try:
         devices = await client.get_devices()
     except LetPotAuthenticationException as exc:
-        raise ConfigEntryAuthFailed from exc
+        raise ConfigEntryError from exc
     except LetPotException as exc:
         raise ConfigEntryNotReady from exc
 

--- a/homeassistant/components/letpot/config_flow.py
+++ b/homeassistant/components/letpot/config_flow.py
@@ -1,0 +1,92 @@
+"""Config flow for the LetPot integration."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from letpot.client import LetPotClient
+from letpot.exceptions import LetPotAuthenticationException, LetPotConnectionException
+import voluptuous as vol
+
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.const import CONF_ACCESS_TOKEN, CONF_EMAIL, CONF_PASSWORD
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.selector import (
+    TextSelector,
+    TextSelectorConfig,
+    TextSelectorType,
+)
+
+from .const import (
+    CONF_ACCESS_TOKEN_EXPIRES,
+    CONF_REFRESH_TOKEN,
+    CONF_REFRESH_TOKEN_EXPIRES,
+    CONF_USER_ID,
+    DOMAIN,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+STEP_USER_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_EMAIL): TextSelector(
+            TextSelectorConfig(
+                type=TextSelectorType.EMAIL,
+            ),
+        ),
+        vol.Required(CONF_PASSWORD): TextSelector(
+            TextSelectorConfig(
+                type=TextSelectorType.PASSWORD,
+            ),
+        ),
+    }
+)
+
+
+class LetPotConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for LetPot."""
+
+    VERSION = 1
+
+    async def _async_validate_credentials(
+        self, email: str, password: str
+    ) -> dict[str, Any]:
+        websession = async_get_clientsession(self.hass)
+        client = LetPotClient(websession)
+        auth = await client.login(email, password)
+        return {
+            CONF_ACCESS_TOKEN: auth.access_token,
+            CONF_ACCESS_TOKEN_EXPIRES: auth.access_token_expires,
+            CONF_REFRESH_TOKEN: auth.refresh_token,
+            CONF_REFRESH_TOKEN_EXPIRES: auth.refresh_token_expires,
+            CONF_USER_ID: auth.user_id,
+            CONF_EMAIL: auth.email,
+        }
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle a flow initialized by the user."""
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            try:
+                data_dict = await self._async_validate_credentials(
+                    user_input[CONF_EMAIL], user_input[CONF_PASSWORD]
+                )
+            except LetPotConnectionException:
+                errors["base"] = "cannot_connect"
+            except LetPotAuthenticationException:
+                errors["base"] = "invalid_auth"
+            except Exception:  # noqa: BLE001
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+            else:
+                await self.async_set_unique_id(data_dict[CONF_USER_ID])
+                self._abort_if_unique_id_configured()
+                return self.async_create_entry(
+                    title=str(data_dict[CONF_EMAIL]), data=data_dict
+                )
+        return self.async_show_form(
+            step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
+        )

--- a/homeassistant/components/letpot/config_flow.py
+++ b/homeassistant/components/letpot/config_flow.py
@@ -85,7 +85,7 @@ class LetPotConfigFlow(ConfigFlow, domain=DOMAIN):
                 await self.async_set_unique_id(data_dict[CONF_USER_ID])
                 self._abort_if_unique_id_configured()
                 return self.async_create_entry(
-                    title=str(data_dict[CONF_EMAIL]), data=data_dict
+                    title=data_dict[CONF_EMAIL], data=data_dict
                 )
         return self.async_show_form(
             step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors

--- a/homeassistant/components/letpot/const.py
+++ b/homeassistant/components/letpot/const.py
@@ -1,0 +1,10 @@
+"""Constants for the LetPot integration."""
+
+DOMAIN = "letpot"
+
+CONF_ACCESS_TOKEN_EXPIRES = "access_token_expires"
+CONF_REFRESH_TOKEN = "refresh_token"
+CONF_REFRESH_TOKEN_EXPIRES = "refresh_token_expires"
+CONF_USER_ID = "user_id"
+
+REQUEST_UPDATE_TIMEOUT = 10

--- a/homeassistant/components/letpot/coordinator.py
+++ b/homeassistant/components/letpot/coordinator.py
@@ -28,7 +28,7 @@ class LetPotDeviceCoordinator(DataUpdateCoordinator[LetPotDeviceStatus]):
     config_entry: LetPotConfigEntry
 
     device: LetPotDevice
-    deviceclient: LetPotDeviceClient
+    device_client: LetPotDeviceClient
 
     def __init__(
         self, hass: HomeAssistant, info: AuthenticationInfo, device: LetPotDevice
@@ -41,7 +41,7 @@ class LetPotDeviceCoordinator(DataUpdateCoordinator[LetPotDeviceStatus]):
         )
         self._info = info
         self.device = device
-        self.deviceclient = LetPotDeviceClient(info, device.serial_number)
+        self.device_client = LetPotDeviceClient(info, device.serial_number)
 
     def _handle_status_update(self, status: LetPotDeviceStatus) -> None:
         """Distribute status update to entities."""
@@ -50,7 +50,7 @@ class LetPotDeviceCoordinator(DataUpdateCoordinator[LetPotDeviceStatus]):
     async def _async_setup(self) -> None:
         """Set up subscription for coordinator."""
         try:
-            await self.deviceclient.subscribe(self._handle_status_update)
+            await self.device_client.subscribe(self._handle_status_update)
         except LetPotAuthenticationException as exc:
             raise ConfigEntryError from exc
 
@@ -58,7 +58,7 @@ class LetPotDeviceCoordinator(DataUpdateCoordinator[LetPotDeviceStatus]):
         """Request an update from the device and wait for a status update or timeout."""
         try:
             async with asyncio.timeout(REQUEST_UPDATE_TIMEOUT):
-                await self.deviceclient.get_current_status()
+                await self.device_client.get_current_status()
         except LetPotException as exc:
             raise UpdateFailed(exc) from exc
 

--- a/homeassistant/components/letpot/coordinator.py
+++ b/homeassistant/components/letpot/coordinator.py
@@ -42,7 +42,7 @@ class LetPotDeviceCoordinator(DataUpdateCoordinator[LetPotDeviceStatus]):
         )
         self._info = info
         self.device = device
-        self.deviceclient = LetPotDeviceClient(self._info, self.device.serial_number)
+        self.deviceclient = LetPotDeviceClient(info, device.serial_number)
 
     def _handle_status_update(self, status: LetPotDeviceStatus) -> None:
         """Distribute status update to entities."""

--- a/homeassistant/components/letpot/coordinator.py
+++ b/homeassistant/components/letpot/coordinator.py
@@ -1,0 +1,76 @@
+"""Coordinator for the LetPot integration."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING
+
+from letpot.deviceclient import LetPotDeviceClient
+from letpot.exceptions import LetPotException
+from letpot.models import AuthenticationInfo, LetPotDevice, LetPotDeviceStatus
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import REQUEST_UPDATE_TIMEOUT
+
+if TYPE_CHECKING:
+    from . import LetPotConfigEntry
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class LetPotDeviceCoordinator(DataUpdateCoordinator[LetPotDeviceStatus]):
+    """Class to handle data updates for a specific garden."""
+
+    config_entry: LetPotConfigEntry
+
+    device: LetPotDevice
+    deviceclient: LetPotDeviceClient
+    _update_event: asyncio.Event | None = None
+    _subscription: asyncio.Task | None = None
+
+    def __init__(
+        self, hass: HomeAssistant, info: AuthenticationInfo, device: LetPotDevice
+    ) -> None:
+        """Initialize coordinator."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=f"LetPot {device.serial_number}",
+        )
+        self._info = info
+        self.device = device
+        self.deviceclient = LetPotDeviceClient(self._info, self.device.serial_number)
+
+    def _handle_status_update(self, status: LetPotDeviceStatus) -> None:
+        """Distribute status update to entities."""
+        self.async_set_updated_data(data=status)
+        if self._update_event is not None and not self._update_event.is_set():
+            self._update_event.set()
+
+    async def _async_update_data(self) -> LetPotDeviceStatus:
+        """Request an update from the device and wait for a status update or timeout."""
+        self._update_event = asyncio.Event()
+
+        try:
+            async with asyncio.timeout(REQUEST_UPDATE_TIMEOUT):
+                if self._subscription is None or self._subscription.done():
+                    # Set up the subscription, which will request a status update when connected
+                    self._subscription = self.config_entry.async_create_background_task(
+                        hass=self.hass,
+                        target=self.deviceclient.subscribe(self._handle_status_update),
+                        name=f"{self.device.serial_number}_subscription_task",
+                    )
+                else:
+                    # Request an update, existing subscription will receive status update
+                    await self.deviceclient.request_status_update()
+
+                await self._update_event.wait()
+        except LetPotException as exc:
+            raise UpdateFailed(exc) from exc
+
+        # The subscription task will have updated coordinator.data, so return that data.
+        # If we don't return anything here, coordinator.data will be set to None.
+        return self.data

--- a/homeassistant/components/letpot/entity.py
+++ b/homeassistant/components/letpot/entity.py
@@ -1,0 +1,25 @@
+"""Base class for LetPot entities."""
+
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import LetPotDeviceCoordinator
+
+
+class LetPotEntity(CoordinatorEntity[LetPotDeviceCoordinator]):
+    """Defines a base LetPot entity."""
+
+    _attr_has_entity_name = True
+
+    def __init__(self, coordinator: LetPotDeviceCoordinator) -> None:
+        """Initialize a LetPot entity."""
+        super().__init__(coordinator)
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, coordinator.device.serial_number)},
+            name=coordinator.device.name,
+            manufacturer="LetPot",
+            model=coordinator.deviceclient.device_model_name,
+            model_id=coordinator.deviceclient.device_model_code,
+            serial_number=coordinator.device.serial_number,
+        )

--- a/homeassistant/components/letpot/entity.py
+++ b/homeassistant/components/letpot/entity.py
@@ -19,7 +19,7 @@ class LetPotEntity(CoordinatorEntity[LetPotDeviceCoordinator]):
             identifiers={(DOMAIN, coordinator.device.serial_number)},
             name=coordinator.device.name,
             manufacturer="LetPot",
-            model=coordinator.deviceclient.device_model_name,
-            model_id=coordinator.deviceclient.device_model_code,
+            model=coordinator.device_client.device_model_name,
+            model_id=coordinator.device_client.device_model_code,
             serial_number=coordinator.device.serial_number,
         )

--- a/homeassistant/components/letpot/manifest.json
+++ b/homeassistant/components/letpot/manifest.json
@@ -1,0 +1,11 @@
+{
+  "domain": "letpot",
+  "name": "LetPot",
+  "codeowners": ["@jpelgrom"],
+  "config_flow": true,
+  "documentation": "https://www.home-assistant.io/integrations/letpot",
+  "integration_type": "hub",
+  "iot_class": "cloud_push",
+  "quality_scale": "bronze",
+  "requirements": ["letpot==0.1.2"]
+}

--- a/homeassistant/components/letpot/manifest.json
+++ b/homeassistant/components/letpot/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "hub",
   "iot_class": "cloud_push",
   "quality_scale": "bronze",
-  "requirements": ["letpot==0.1.3"]
+  "requirements": ["letpot==0.2.0"]
 }

--- a/homeassistant/components/letpot/manifest.json
+++ b/homeassistant/components/letpot/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "hub",
   "iot_class": "cloud_push",
   "quality_scale": "bronze",
-  "requirements": ["letpot==0.1.2"]
+  "requirements": ["letpot==0.1.3"]
 }

--- a/homeassistant/components/letpot/quality_scale.yaml
+++ b/homeassistant/components/letpot/quality_scale.yaml
@@ -33,7 +33,7 @@ rules:
   config-entry-unloading:
     status: done
     comment: |
-      Coordinator uses config_entry.async_create_background_task for push connection.
+      Push connection connects in coordinator _async_setup, disconnects in init async_unload_entry.
   docs-configuration-parameters:
     status: exempt
     comment: |

--- a/homeassistant/components/letpot/quality_scale.yaml
+++ b/homeassistant/components/letpot/quality_scale.yaml
@@ -1,0 +1,75 @@
+rules:
+  # Bronze
+  action-setup:
+    status: exempt
+    comment: |
+      This integration does not provide additional actions.
+  appropriate-polling:
+    status: exempt
+    comment: |
+      This integration only receives push-based updates.
+  brands: done
+  common-modules: done
+  config-flow-test-coverage: done
+  config-flow: done
+  dependency-transparency: done
+  docs-actions:
+    status: exempt
+    comment: |
+      This integration does not provide additional actions.
+  docs-high-level-description: done
+  docs-installation-instructions: done
+  docs-removal-instructions: done
+  entity-event-setup: done
+  entity-unique-id: done
+  has-entity-name: done
+  runtime-data: done
+  test-before-configure: done
+  test-before-setup: done
+  unique-config-entry: done
+
+  # Silver
+  action-exceptions: todo
+  config-entry-unloading:
+    status: done
+    comment: |
+      Coordinator uses config_entry.async_create_background_task for push connection.
+  docs-configuration-parameters:
+    status: exempt
+    comment: |
+      The integration does not have configuration options.
+  docs-installation-parameters: done
+  entity-unavailable: todo
+  integration-owner: done
+  log-when-unavailable: todo
+  parallel-updates: done
+  reauthentication-flow: todo
+  test-coverage: todo
+
+  # Gold
+  devices: done
+  diagnostics: todo
+  discovery-update-info: todo
+  discovery: todo
+  docs-data-update: done
+  docs-examples: todo
+  docs-known-limitations: todo
+  docs-supported-devices: done
+  docs-supported-functions: todo
+  docs-troubleshooting: todo
+  docs-use-cases: todo
+  dynamic-devices: todo
+  entity-category: todo
+  entity-device-class: todo
+  entity-disabled-by-default: todo
+  entity-translations: done
+  exception-translations: todo
+  icon-translations: todo
+  reconfiguration-flow: todo
+  repair-issues: todo
+  stale-devices: todo
+
+  # Platinum
+  async-dependency: done
+  inject-websession: done
+  strict-typing: done

--- a/homeassistant/components/letpot/strings.json
+++ b/homeassistant/components/letpot/strings.json
@@ -1,0 +1,34 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "email": "[%key:common::config_flow::data::email%]",
+          "password": "[%key:common::config_flow::data::password%]"
+        },
+        "data_description": {
+          "email": "The email address of your LetPot account.",
+          "password": "The password of your LetPot account."
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_account%]"
+    }
+  },
+  "entity": {
+    "time": {
+      "light_schedule_end": {
+        "name": "Light off"
+      },
+      "light_schedule_start": {
+        "name": "Light on"
+      }
+    }
+  }
+}

--- a/homeassistant/components/letpot/time.py
+++ b/homeassistant/components/letpot/time.py
@@ -58,7 +58,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up LetPot time entities based on a config entry."""
-    coordinators: list[LetPotDeviceCoordinator] = entry.runtime_data
+    coordinators = entry.runtime_data
     async_add_entities(
         LetPotTimeEntity(coordinator, description)
         for description in TIME_SENSORS

--- a/homeassistant/components/letpot/time.py
+++ b/homeassistant/components/letpot/time.py
@@ -88,4 +88,6 @@ class LetPotTimeEntity(LetPotEntity, TimeEntity):
 
     async def async_set_value(self, value: time) -> None:
         """Set the time."""
-        await self.entity_description.set_value_fn(self.coordinator.deviceclient, value)
+        await self.entity_description.set_value_fn(
+            self.coordinator.device_client, value
+        )

--- a/homeassistant/components/letpot/time.py
+++ b/homeassistant/components/letpot/time.py
@@ -1,0 +1,91 @@
+"""Support for LetPot time entities."""
+
+from collections.abc import Callable, Coroutine
+from dataclasses import dataclass
+from datetime import time
+from typing import Any
+
+from letpot.deviceclient import LetPotDeviceClient
+from letpot.models import LetPotDeviceStatus
+
+from homeassistant.components.time import TimeEntity, TimeEntityDescription
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import LetPotConfigEntry
+from .coordinator import LetPotDeviceCoordinator
+from .entity import LetPotEntity
+
+# Each change pushes a 'full' device status with the change. The library will cache
+# pending changes to avoid overwriting, but try to avoid a lot of parallelism.
+PARALLEL_UPDATES = 1
+
+
+@dataclass(frozen=True, kw_only=True)
+class LetPotTimeEntityDescription(TimeEntityDescription):
+    """Describes a LetPot time entity."""
+
+    value_fn: Callable[[LetPotDeviceStatus], time | None]
+    set_value_fn: Callable[[LetPotDeviceClient, time], Coroutine[Any, Any, None]]
+
+
+TIME_SENSORS: tuple[LetPotTimeEntityDescription, ...] = (
+    LetPotTimeEntityDescription(
+        key="light_schedule_end",
+        translation_key="light_schedule_end",
+        value_fn=lambda status: None if status is None else status.light_schedule_end,
+        set_value_fn=lambda deviceclient, value: deviceclient.set_light_schedule(
+            start=None, end=value
+        ),
+        entity_category=EntityCategory.CONFIG,
+    ),
+    LetPotTimeEntityDescription(
+        key="light_schedule_start",
+        translation_key="light_schedule_start",
+        value_fn=lambda status: None if status is None else status.light_schedule_start,
+        set_value_fn=lambda deviceclient, value: deviceclient.set_light_schedule(
+            start=value, end=None
+        ),
+        entity_category=EntityCategory.CONFIG,
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: LetPotConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up LetPot time entities based on a config entry."""
+    coordinators: list[LetPotDeviceCoordinator] = entry.runtime_data
+    async_add_entities(
+        LetPotTimeEntity(coordinator, description)
+        for description in TIME_SENSORS
+        for coordinator in coordinators
+    )
+
+
+class LetPotTimeEntity(LetPotEntity, TimeEntity):
+    """Defines a LetPot time entity."""
+
+    entity_description: LetPotTimeEntityDescription
+
+    def __init__(
+        self,
+        coordinator: LetPotDeviceCoordinator,
+        description: LetPotTimeEntityDescription,
+    ) -> None:
+        """Initialize LetPot time entity."""
+        super().__init__(coordinator)
+        self.entity_description = description
+        self._attr_unique_id = f"{coordinator.config_entry.unique_id}_{coordinator.device.serial_number}_{description.key}"
+
+    @property
+    def native_value(self) -> time | None:
+        """Return the time."""
+        return self.entity_description.value_fn(self.coordinator.data)
+
+    async def async_set_value(self, value: time) -> None:
+        """Set the time."""
+        await self.entity_description.set_value_fn(self.coordinator.deviceclient, value)

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -331,6 +331,7 @@ FLOWS = {
         "leaone",
         "led_ble",
         "lektrico",
+        "letpot",
         "lg_netcast",
         "lg_soundbar",
         "lg_thinq",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -3303,6 +3303,12 @@
       "config_flow": true,
       "iot_class": "local_polling"
     },
+    "letpot": {
+      "name": "LetPot",
+      "integration_type": "hub",
+      "config_flow": true,
+      "iot_class": "cloud_push"
+    },
     "leviton": {
       "name": "Leviton",
       "iot_standards": [

--- a/mypy.ini
+++ b/mypy.ini
@@ -2666,6 +2666,16 @@ disallow_untyped_defs = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.letpot.*]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-homeassistant.components.lidarr.*]
 check_untyped_defs = true
 disallow_incomplete_defs = true

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1302,7 +1302,7 @@ led-ble==1.1.1
 lektricowifi==0.0.43
 
 # homeassistant.components.letpot
-letpot==0.1.2
+letpot==0.1.3
 
 # homeassistant.components.foscam
 libpyfoscam==1.2.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1301,6 +1301,9 @@ led-ble==1.1.1
 # homeassistant.components.lektrico
 lektricowifi==0.0.43
 
+# homeassistant.components.letpot
+letpot==0.1.2
+
 # homeassistant.components.foscam
 libpyfoscam==1.2.2
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1302,7 +1302,7 @@ led-ble==1.1.1
 lektricowifi==0.0.43
 
 # homeassistant.components.letpot
-letpot==0.1.3
+letpot==0.2.0
 
 # homeassistant.components.foscam
 libpyfoscam==1.2.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1101,7 +1101,7 @@ led-ble==1.1.1
 lektricowifi==0.0.43
 
 # homeassistant.components.letpot
-letpot==0.1.2
+letpot==0.1.3
 
 # homeassistant.components.foscam
 libpyfoscam==1.2.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1101,7 +1101,7 @@ led-ble==1.1.1
 lektricowifi==0.0.43
 
 # homeassistant.components.letpot
-letpot==0.1.3
+letpot==0.2.0
 
 # homeassistant.components.foscam
 libpyfoscam==1.2.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1100,6 +1100,9 @@ led-ble==1.1.1
 # homeassistant.components.lektrico
 lektricowifi==0.0.43
 
+# homeassistant.components.letpot
+letpot==0.1.2
+
 # homeassistant.components.foscam
 libpyfoscam==1.2.2
 

--- a/tests/components/letpot/__init__.py
+++ b/tests/components/letpot/__init__.py
@@ -1,0 +1,12 @@
+"""Tests for the LetPot integration."""
+
+from letpot.models import AuthenticationInfo
+
+AUTHENTICATION = AuthenticationInfo(
+    access_token="access_token",
+    access_token_expires=0,
+    refresh_token="refresh_token",
+    refresh_token_expires=0,
+    user_id="a1b2c3d4e5f6a1b2c3d4e5f6",
+    email="email@example.com",
+)

--- a/tests/components/letpot/conftest.py
+++ b/tests/components/letpot/conftest.py
@@ -1,0 +1,46 @@
+"""Common fixtures for the LetPot tests."""
+
+from collections.abc import Generator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from homeassistant.components.letpot.const import (
+    CONF_ACCESS_TOKEN_EXPIRES,
+    CONF_REFRESH_TOKEN,
+    CONF_REFRESH_TOKEN_EXPIRES,
+    CONF_USER_ID,
+    DOMAIN,
+)
+from homeassistant.const import CONF_ACCESS_TOKEN, CONF_EMAIL
+
+from . import AUTHENTICATION
+
+from tests.common import MockConfigEntry
+
+
+@pytest.fixture
+def mock_setup_entry() -> Generator[AsyncMock]:
+    """Override async_setup_entry."""
+    with patch(
+        "homeassistant.components.letpot.async_setup_entry", return_value=True
+    ) as mock_setup_entry:
+        yield mock_setup_entry
+
+
+@pytest.fixture
+def mock_config_entry() -> MockConfigEntry:
+    """Mock a config entry."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        title=AUTHENTICATION.email,
+        data={
+            CONF_ACCESS_TOKEN: AUTHENTICATION.access_token,
+            CONF_ACCESS_TOKEN_EXPIRES: AUTHENTICATION.access_token_expires,
+            CONF_REFRESH_TOKEN: AUTHENTICATION.refresh_token,
+            CONF_REFRESH_TOKEN_EXPIRES: AUTHENTICATION.refresh_token_expires,
+            CONF_USER_ID: AUTHENTICATION.user_id,
+            CONF_EMAIL: AUTHENTICATION.email,
+        },
+        unique_id=AUTHENTICATION.user_id,
+    )

--- a/tests/components/letpot/test_config_flow.py
+++ b/tests/components/letpot/test_config_flow.py
@@ -1,0 +1,147 @@
+"""Test the LetPot config flow."""
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+from letpot.exceptions import LetPotAuthenticationException, LetPotConnectionException
+import pytest
+
+from homeassistant.components.letpot.const import (
+    CONF_ACCESS_TOKEN_EXPIRES,
+    CONF_REFRESH_TOKEN,
+    CONF_REFRESH_TOKEN_EXPIRES,
+    CONF_USER_ID,
+    DOMAIN,
+)
+from homeassistant.config_entries import SOURCE_USER
+from homeassistant.const import CONF_ACCESS_TOKEN, CONF_EMAIL, CONF_PASSWORD
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+from . import AUTHENTICATION
+
+from tests.common import MockConfigEntry
+
+
+def _assert_result_success(result: Any) -> None:
+    """Assert successful end of flow result, creating an entry."""
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == AUTHENTICATION.email
+    assert result["data"] == {
+        CONF_ACCESS_TOKEN: AUTHENTICATION.access_token,
+        CONF_ACCESS_TOKEN_EXPIRES: AUTHENTICATION.access_token_expires,
+        CONF_REFRESH_TOKEN: AUTHENTICATION.refresh_token,
+        CONF_REFRESH_TOKEN_EXPIRES: AUTHENTICATION.refresh_token_expires,
+        CONF_USER_ID: AUTHENTICATION.user_id,
+        CONF_EMAIL: AUTHENTICATION.email,
+    }
+    assert result["result"].unique_id == AUTHENTICATION.user_id
+
+
+async def test_full_flow(hass: HomeAssistant, mock_setup_entry: AsyncMock) -> None:
+    """Test full flow with success."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"] == {}
+
+    with patch(
+        "homeassistant.components.letpot.config_flow.LetPotClient.login",
+        return_value=AUTHENTICATION,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_EMAIL: "email@example.com",
+                CONF_PASSWORD: "test-password",
+            },
+        )
+        await hass.async_block_till_done()
+
+    _assert_result_success(result)
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+@pytest.mark.parametrize(
+    ("exception", "error"),
+    [
+        (LetPotAuthenticationException, "invalid_auth"),
+        (LetPotConnectionException, "cannot_connect"),
+        (Exception, "unknown"),
+    ],
+)
+async def test_flow_exceptions(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    exception: Exception,
+    error: str,
+) -> None:
+    """Test flow with exception during login and recovery."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.letpot.config_flow.LetPotClient.login",
+        side_effect=exception,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_EMAIL: "email@example.com",
+                CONF_PASSWORD: "test-password",
+            },
+        )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"] == {"base": error}
+
+    # Retry to show recovery.
+    with patch(
+        "homeassistant.components.letpot.config_flow.LetPotClient.login",
+        return_value=AUTHENTICATION,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_EMAIL: "email@example.com",
+                CONF_PASSWORD: "test-password",
+            },
+        )
+        await hass.async_block_till_done()
+
+    _assert_result_success(result)
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_flow_duplicate(
+    hass: HomeAssistant, mock_setup_entry: AsyncMock, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test flow aborts when trying to add a previously added account."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {}
+
+    with patch(
+        "homeassistant.components.letpot.config_flow.LetPotClient.login",
+        return_value=AUTHENTICATION,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_EMAIL: "email@example.com",
+                CONF_PASSWORD: "test-password",
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+    assert len(mock_setup_entry.mock_calls) == 0

--- a/tests/components/letpot/test_config_flow.py
+++ b/tests/components/letpot/test_config_flow.py
@@ -25,7 +25,7 @@ from tests.common import MockConfigEntry
 
 def _assert_result_success(result: Any) -> None:
     """Assert successful end of flow result, creating an entry."""
-    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == AUTHENTICATION.email
     assert result["data"] == {
         CONF_ACCESS_TOKEN: AUTHENTICATION.access_token,
@@ -43,7 +43,7 @@ async def test_full_flow(hass: HomeAssistant, mock_setup_entry: AsyncMock) -> No
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {}
 
     with patch(
@@ -94,7 +94,7 @@ async def test_flow_exceptions(
             },
         )
 
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": error}
 
     # Retry to show recovery.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add a new integration for [LetPot](https://letpot.com/) hydroponic gardens/systems. You can control the light (and in the future more, and view state info like whether the pump is running or if there are any issues).

As the initial platform you might expect _light_, but the device actually doesn't let you toggle the light directly but only via the light schedule (when should the light turn on or turn off). As a result I've chosen _time_ as the platform for this PR.

|![Dialog titled 'LetPot', with inputs for Email (The email address of your LetPot account.) and Password (The password of your LetPot account.)](https://github.com/user-attachments/assets/22c66326-0b52-4988-9987-6dcd7c3bdcda)|>|![Dialog titled 'Success!' showing 1 device discovered.](https://github.com/user-attachments/assets/af43fcab-e9d8-40f1-93c0-b0f97e9c0035)|
|---|---|---|

![Config entry showing 'Hubs', with the user's email address as the title and 1 device, 2 entities](https://github.com/user-attachments/assets/0d28f97b-0b1f-4409-91bd-185ea56ff954)

![Device page showing some basic device info (model name, model ID, manufacturer, serial number) and two entities: Light off (18:00 set) and Light on (8:00 set)](https://github.com/user-attachments/assets/c8a1121e-bc63-4024-bd97-a96f91f830af)

## Bronze
- [x] `config-flow` - Integration needs to be able to be set up via the UI - *see config_flow.py and [manifest.json L5](https://github.com/home-assistant/core/blob/e9ca3486f3df4355e682a0c800c1047d6a4b59f1/homeassistant/components/letpot/manifest.json#L5)*
    - [x] Uses `data_description` to give context to fields - *see [strings.json L9-L12](https://github.com/home-assistant/core/blob/e9ca3486f3df4355e682a0c800c1047d6a4b59f1/homeassistant/components/letpot/strings.json#L9)*
    - [x] Uses `ConfigEntry.data` and `ConfigEntry.options` correctly - *all stored data is used for authentication so in ConfigEntry.data*
- [x] `test-before-configure` - Test a connection in the config flow - *see [config_flow.py L74](https://github.com/home-assistant/core/blob/e9ca3486f3df4355e682a0c800c1047d6a4b59f1/homeassistant/components/letpot/config_flow.py#L74)*
- [x] `unique-config-entry` - Don't allow the same device or service to be able to be set up twice - *see [config_flow.py L85-L86](https://github.com/home-assistant/core/blob/e9ca3486f3df4355e682a0c800c1047d6a4b59f1/homeassistant/components/letpot/config_flow.py#L74)*
- [x] `config-flow-test-coverage` - Full test coverage for the config flow - *see:*
![pytest output showing 100% coverage for config_flow.py](https://github.com/user-attachments/assets/60be234d-2934-46b3-b104-c25a6a8deb51)
- [x] `runtime-data` - Use ConfigEntry.runtime_data to store runtime data - *see [\_\_init\_\_.py L86](https://github.com/home-assistant/core/blob/e9ca3486f3df4355e682a0c800c1047d6a4b59f1/homeassistant/components/letpot/__init__.py#L86)*
- [x] `test-before-setup` - Check during integration initialization if we are able to set it up correctly - *see [\_\_init\_\_.py L60, L65, L67](https://github.com/home-assistant/core/blob/e9ca3486f3df4355e682a0c800c1047d6a4b59f1/homeassistant/components/letpot/__init__.py#L60)*
- [E] `appropriate-polling` - If it's a polling integration, set an appropriate polling interval - *exempt: this integration only receives push-based updates*
- [x] `entity-unique-id` - Entities have a unique ID - *see [time.py L82](https://github.com/home-assistant/core/blob/e9ca3486f3df4355e682a0c800c1047d6a4b59f1/homeassistant/components/letpot/time.py#L82)*
- [x] `has-entity-name` - Entities use has_entity_name = True - *see [entity.py L13](https://github.com/home-assistant/core/blob/e9ca3486f3df4355e682a0c800c1047d6a4b59f1/homeassistant/components/letpot/entity.py#L13)*
- [x] `entity-event-setup` - Entities event setup - *see [entity.py L10](https://github.com/home-assistant/core/blob/e9ca3486f3df4355e682a0c800c1047d6a4b59f1/homeassistant/components/letpot/entity.py#L10): using CoordinatorEntity as base with push updates, no other events*
- [x] `dependency-transparency` - Dependency transparency - *see library https://github.com/jpelgrom/python-letpot: MIT licensed, published to PyPI using CI action triggered by GitHub releases*
- [E] `action-setup` - Service actions are registered in async_setup - *exempt: this integration does not provide additional actions*
- [x] `common-modules` - Place common patterns in common modules - *see file names*
- [x] `docs-high-level-description` - The documentation includes a high-level description of the integration brand, product, or service - *see docs PR*
- [x] `docs-installation-instructions` - The documentation provides step-by-step installation instructions for the integration, including, if needed, prerequisites - *see docs PR*
- [x] `docs-removal-instructions` - The documentation provides removal instructions - *see docs PR*
- [E] `docs-actions` - The documentation describes the provided service actions that can be used - *exempt: this integration does not provide additional actions*
- [x] `brands` - Has branding assets available for the integration - *see brands PR*

## Silver
- [x] `config-entry-unloading` - Support config entry unloading - *push connection connects in [coordinator.py _async_setup](https://github.com/home-assistant/core/blob/a1b1082ff669b3521548fa902604f7d11d998bec/homeassistant/components/letpot/coordinator.py#L53), disconnects in [\_\_init\_\_.py async_unload_entry](https://github.com/home-assistant/core/blob/a1b1082ff669b3521548fa902604f7d11d998bec/homeassistant/components/letpot/__init__.py#L97)*
- [ ] `log-when-unavailable` - If internet/device/service is unavailable, log once when unavailable and once when back connected
- [ ] `entity-unavailable` - Mark entity unavailable if appropriate
- [ ] `action-exceptions` - Service actions raise exceptions when encountering failures
- [ ] `reauthentication-flow` - Reauthentication flow
- [x] `parallel-updates` - Set Parallel updates - *see [time.py L22](https://github.com/home-assistant/core/blob/e9ca3486f3df4355e682a0c800c1047d6a4b59f1/homeassistant/components/letpot/time.py#L22)*
- [ ] `test-coverage` - Above 95% test coverage for all integration modules
- [x] `integration-owner` - Has an integration owner - *see updated CODEOWNERS and [manifest.json L4](https://github.com/home-assistant/core/blob/e9ca3486f3df4355e682a0c800c1047d6a4b59f1/homeassistant/components/letpot/manifest.json#L4)*
- [x] `docs-installation-parameters` - The documentation describes all integration installation parameters - *see docs PR*
- [E] `docs-configuration-parameters` - The documentation describes all integration configuration options - *exempt: the integration does not have configuration options*

## Gold
- [x] `entity-translations` - Entities have translated names - *see [time.py L36, L45](https://github.com/home-assistant/core/blob/e9ca3486f3df4355e682a0c800c1047d6a4b59f1/homeassistant/components/letpot/time.py#L36)*
- [ ] `entity-device-class` - Entities use device classes where possible
- [x] `devices` - The integration creates devices - *see [entity.py L18-L25](https://github.com/home-assistant/core/blob/e9ca3486f3df4355e682a0c800c1047d6a4b59f1/homeassistant/components/letpot/entity.py#L18-L25)*
- [ ] `entity-category` - Entities are assigned an appropriate EntityCategory
- [ ] `entity-disabled-by-default` - Integration disables less popular (or noisy) entities
- [ ] `discovery` - Can be discovered
- [ ] `stale-devices` - Clean up stale devices
- [ ] `diagnostics` - Implements diagnostics
- [ ] `exception-translations` - Exception messages are translatable
- [ ] `icon-translations` - Icon translations
- [ ] `reconfiguration-flow` - Integrations should have a reconfigure flow
- [ ] `dynamic-devices` - Devices added after integration setup
- [ ] `discovery-update-info` - Integration uses discovery info to update network information
- [ ] `repair-issues` - Repair issues and repair flows are used when user intervention is needed
- [ ] `docs-use-cases` - The documentation describes use cases to illustrate how this integration can be used
- [x] `docs-supported-devices` - The documentation describes known supported / unsupported devices - *see docs PR*
- [ ] `docs-supported-functions` - The documentation describes the supported functionality, including entities, and platforms
- [x] `docs-data-update` - The documentation describes how data is updated - *see docs PR*
- [ ] `docs-known-limitations` - The documentation describes known limitations of the integration (not to be confused with bugs)
- [ ] `docs-troubleshooting` - The documentation provides troubleshooting information
- [ ] `docs-examples` - The documentation provides automation examples the user can use.

## Platinum
- [x] `async-dependency` - Dependency is async - *see async/await everywhere and library*
- [x] `inject-websession` - The integration dependency supports passing in a websession - *see [\_\_init.py\_\_.py L42-L43](https://github.com/home-assistant/core/blob/e9ca3486f3df4355e682a0c800c1047d6a4b59f1/homeassistant/components/letpot/__init__.py#L42-L43), [config_flow.py L55-L56](https://github.com/home-assistant/core/blob/e9ca3486f3df4355e682a0c800c1047d6a4b59f1/homeassistant/components/letpot/config_flow.py#L55-L56) which is used by [the library client's \_\_init\_\_](https://github.com/jpelgrom/python-letpot/blob/0a974bee037ee81ce651cfa5c1be1431325f80db/letpot/client.py#L29)*
- [x] `strict-typing` - Strict typing - _see [.strict-typing L294](https://github.com/home-assistant/core/blob/e9ca3486f3df4355e682a0c800c1047d6a4b59f1/.strict-typing#L294)_

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: home-assistant/home-assistant.io#36770

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
