### PR TITLE
Revert "Remove deprecated supported features warning in LightEntity"

### DIFF
--- a/tests/components/light/common.py
+++ b/tests/components/light/common.py
@@ -26,7 +26,6 @@ from homeassistant.components.light import (
     DOMAIN,
     ColorMode,
     LightEntity,
-    LightEntityFeature,
 )
 from homeassistant.const import (
     ATTR_ENTITY_ID,
@@ -157,7 +156,7 @@ class MockLight(MockToggleEntity, LightEntity):
 
     _attr_max_color_temp_kelvin = DEFAULT_MAX_KELVIN
     _attr_min_color_temp_kelvin = DEFAULT_MIN_KELVIN
-    supported_features = LightEntityFeature(0)
+    supported_features = 0
 
     brightness = None
     color_temp_kelvin = None

--- a/tests/components/light/test_init.py
+++ b/tests/components/light/test_init.py
@@ -1,6 +1,7 @@
 """The tests for the Light component."""
 
 from types import ModuleType
+from typing import Literal
 from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
@@ -137,8 +138,13 @@ async def test_services(
     ent3.supported_color_modes = [light.ColorMode.HS]
     ent1.supported_features = light.LightEntityFeature.TRANSITION
     ent2.supported_features = (
-        light.LightEntityFeature.EFFECT | light.LightEntityFeature.TRANSITION
+        light.SUPPORT_COLOR
+        | light.LightEntityFeature.EFFECT
+        | light.LightEntityFeature.TRANSITION
     )
+    # Set color modes to none to trigger backwards compatibility in LightEntity
+    ent2.supported_color_modes = None
+    ent2.color_mode = None
     ent3.supported_features = (
         light.LightEntityFeature.FLASH | light.LightEntityFeature.TRANSITION
     )
@@ -254,7 +260,10 @@ async def test_services(
     }
 
     _, data = ent2.last_call("turn_on")
-    assert data == {light.ATTR_EFFECT: "fun_effect"}
+    assert data == {
+        light.ATTR_EFFECT: "fun_effect",
+        light.ATTR_HS_COLOR: (0, 0),
+    }
 
     _, data = ent3.last_call("turn_on")
     assert data == {light.ATTR_FLASH: "short", light.ATTR_HS_COLOR: (71.059, 100)}
@@ -338,6 +347,8 @@ async def test_services(
 
     _, data = ent2.last_call("turn_on")
     assert data == {
+        light.ATTR_BRIGHTNESS: 100,
+        light.ATTR_HS_COLOR: profile.hs_color,
         light.ATTR_TRANSITION: 1,
     }
 
@@ -915,12 +926,16 @@ async def test_light_brightness_step(hass: HomeAssistant) -> None:
     setup_test_component_platform(hass, light.DOMAIN, entities)
 
     entity0 = entities[0]
-    entity0.supported_color_modes = {light.ColorMode.BRIGHTNESS}
-    entity0.color_mode = light.ColorMode.BRIGHTNESS
+    entity0.supported_features = light.SUPPORT_BRIGHTNESS
+    # Set color modes to none to trigger backwards compatibility in LightEntity
+    entity0.supported_color_modes = None
+    entity0.color_mode = None
     entity0.brightness = 100
     entity1 = entities[1]
-    entity1.supported_color_modes = {light.ColorMode.BRIGHTNESS}
-    entity1.color_mode = light.ColorMode.BRIGHTNESS
+    entity1.supported_features = light.SUPPORT_BRIGHTNESS
+    # Set color modes to none to trigger backwards compatibility in LightEntity
+    entity1.supported_color_modes = None
+    entity1.color_mode = None
     entity1.brightness = 50
     assert await async_setup_component(hass, "light", {"light": {"platform": "test"}})
     await hass.async_block_till_done()
@@ -981,8 +996,10 @@ async def test_light_brightness_pct_conversion(
     setup_test_component_platform(hass, light.DOMAIN, mock_light_entities)
 
     entity = mock_light_entities[0]
-    entity.supported_color_modes = {light.ColorMode.BRIGHTNESS}
-    entity.color_mode = light.ColorMode.BRIGHTNESS
+    entity.supported_features = light.SUPPORT_BRIGHTNESS
+    # Set color modes to none to trigger backwards compatibility in LightEntity
+    entity.supported_color_modes = None
+    entity.color_mode = None
     entity.brightness = 100
     assert await async_setup_component(hass, "light", {"light": {"platform": "test"}})
     await hass.async_block_till_done()
@@ -1131,6 +1148,167 @@ invalid_no_brightness_no_color_no_transition,,,
         assert invalid_profile_name not in profiles.data
 
 
+@pytest.mark.parametrize("light_state", [STATE_ON, STATE_OFF])
+async def test_light_backwards_compatibility_supported_color_modes(
+    hass: HomeAssistant, light_state: Literal["on", "off"]
+) -> None:
+    """Test supported_color_modes if not implemented by the entity."""
+    entities = [
+        MockLight("Test_0", light_state),
+        MockLight("Test_1", light_state),
+        MockLight("Test_2", light_state),
+        MockLight("Test_3", light_state),
+        MockLight("Test_4", light_state),
+    ]
+
+    entity0 = entities[0]
+
+    entity1 = entities[1]
+    entity1.supported_features = light.SUPPORT_BRIGHTNESS
+    # Set color modes to none to trigger backwards compatibility in LightEntity
+    entity1.supported_color_modes = None
+    entity1.color_mode = None
+
+    entity2 = entities[2]
+    entity2.supported_features = light.SUPPORT_BRIGHTNESS | light.SUPPORT_COLOR_TEMP
+    # Set color modes to none to trigger backwards compatibility in LightEntity
+    entity2.supported_color_modes = None
+    entity2.color_mode = None
+
+    entity3 = entities[3]
+    entity3.supported_features = light.SUPPORT_BRIGHTNESS | light.SUPPORT_COLOR
+    # Set color modes to none to trigger backwards compatibility in LightEntity
+    entity3.supported_color_modes = None
+    entity3.color_mode = None
+
+    entity4 = entities[4]
+    entity4.supported_features = (
+        light.SUPPORT_BRIGHTNESS | light.SUPPORT_COLOR | light.SUPPORT_COLOR_TEMP
+    )
+    # Set color modes to none to trigger backwards compatibility in LightEntity
+    entity4.supported_color_modes = None
+    entity4.color_mode = None
+
+    setup_test_component_platform(hass, light.DOMAIN, entities)
+
+    assert await async_setup_component(hass, "light", {"light": {"platform": "test"}})
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity0.entity_id)
+    assert state.attributes["supported_color_modes"] == [light.ColorMode.ONOFF]
+    if light_state == STATE_OFF:
+        assert state.attributes["color_mode"] is None
+    else:
+        assert state.attributes["color_mode"] == light.ColorMode.ONOFF
+
+    state = hass.states.get(entity1.entity_id)
+    assert state.attributes["supported_color_modes"] == [light.ColorMode.BRIGHTNESS]
+    if light_state == STATE_OFF:
+        assert state.attributes["color_mode"] is None
+    else:
+        assert state.attributes["color_mode"] == light.ColorMode.UNKNOWN
+
+    state = hass.states.get(entity2.entity_id)
+    assert state.attributes["supported_color_modes"] == [light.ColorMode.COLOR_TEMP]
+    if light_state == STATE_OFF:
+        assert state.attributes["color_mode"] is None
+    else:
+        assert state.attributes["color_mode"] == light.ColorMode.UNKNOWN
+
+    state = hass.states.get(entity3.entity_id)
+    assert state.attributes["supported_color_modes"] == [light.ColorMode.HS]
+    if light_state == STATE_OFF:
+        assert state.attributes["color_mode"] is None
+    else:
+        assert state.attributes["color_mode"] == light.ColorMode.UNKNOWN
+
+    state = hass.states.get(entity4.entity_id)
+    assert state.attributes["supported_color_modes"] == [
+        light.ColorMode.COLOR_TEMP,
+        light.ColorMode.HS,
+    ]
+    if light_state == STATE_OFF:
+        assert state.attributes["color_mode"] is None
+    else:
+        assert state.attributes["color_mode"] == light.ColorMode.UNKNOWN
+
+
+async def test_light_backwards_compatibility_color_mode(hass: HomeAssistant) -> None:
+    """Test color_mode if not implemented by the entity."""
+    entities = [
+        MockLight("Test_0", STATE_ON),
+        MockLight("Test_1", STATE_ON),
+        MockLight("Test_2", STATE_ON),
+        MockLight("Test_3", STATE_ON),
+        MockLight("Test_4", STATE_ON),
+    ]
+
+    entity0 = entities[0]
+
+    entity1 = entities[1]
+    entity1.supported_features = light.SUPPORT_BRIGHTNESS
+    # Set color modes to none to trigger backwards compatibility in LightEntity
+    entity1.supported_color_modes = None
+    entity1.color_mode = None
+    entity1.brightness = 100
+
+    entity2 = entities[2]
+    entity2.supported_features = light.SUPPORT_BRIGHTNESS | light.SUPPORT_COLOR_TEMP
+    # Set color modes to none to trigger backwards compatibility in LightEntity
+    entity2.supported_color_modes = None
+    entity2.color_mode = None
+    entity2.color_temp_kelvin = 10000
+
+    entity3 = entities[3]
+    entity3.supported_features = light.SUPPORT_BRIGHTNESS | light.SUPPORT_COLOR
+    # Set color modes to none to trigger backwards compatibility in LightEntity
+    entity3.supported_color_modes = None
+    entity3.color_mode = None
+    entity3.hs_color = (240, 100)
+
+    entity4 = entities[4]
+    entity4.supported_features = (
+        light.SUPPORT_BRIGHTNESS | light.SUPPORT_COLOR | light.SUPPORT_COLOR_TEMP
+    )
+    # Set color modes to none to trigger backwards compatibility in LightEntity
+    entity4.supported_color_modes = None
+    entity4.color_mode = None
+    entity4.hs_color = (240, 100)
+    entity4.color_temp_kelvin = 10000
+
+    setup_test_component_platform(hass, light.DOMAIN, entities)
+
+    assert await async_setup_component(hass, "light", {"light": {"platform": "test"}})
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity0.entity_id)
+    assert state.attributes["supported_color_modes"] == [light.ColorMode.ONOFF]
+    assert state.attributes["color_mode"] == light.ColorMode.ONOFF
+
+    state = hass.states.get(entity1.entity_id)
+    assert state.attributes["supported_color_modes"] == [light.ColorMode.BRIGHTNESS]
+    assert state.attributes["color_mode"] == light.ColorMode.BRIGHTNESS
+
+    state = hass.states.get(entity2.entity_id)
+    assert state.attributes["supported_color_modes"] == [light.ColorMode.COLOR_TEMP]
+    assert state.attributes["color_mode"] == light.ColorMode.COLOR_TEMP
+    assert state.attributes["rgb_color"] == (202, 218, 255)
+    assert state.attributes["hs_color"] == (221.575, 20.9)
+    assert state.attributes["xy_color"] == (0.278, 0.287)
+
+    state = hass.states.get(entity3.entity_id)
+    assert state.attributes["supported_color_modes"] == [light.ColorMode.HS]
+    assert state.attributes["color_mode"] == light.ColorMode.HS
+
+    state = hass.states.get(entity4.entity_id)
+    assert state.attributes["supported_color_modes"] == [
+        light.ColorMode.COLOR_TEMP,
+        light.ColorMode.HS,
+    ]
+    # hs color prioritized over color_temp, light should report mode ColorMode.HS
+    assert state.attributes["color_mode"] == light.ColorMode.HS
+
+
 async def test_light_service_call_rgbw(hass: HomeAssistant) -> None:
     """Test rgbw functionality in service calls."""
     entity0 = MockLight("Test_rgbw", STATE_ON)
@@ -1186,7 +1364,7 @@ async def test_light_state_off(hass: HomeAssistant) -> None:
         "color_mode": None,
         "friendly_name": "Test_onoff",
         "supported_color_modes": [light.ColorMode.ONOFF],
-        "supported_features": light.LightEntityFeature(0),
+        "supported_features": 0,
     }
 
     state = hass.states.get(entity1.entity_id)
@@ -1194,7 +1372,7 @@ async def test_light_state_off(hass: HomeAssistant) -> None:
         "color_mode": None,
         "friendly_name": "Test_brightness",
         "supported_color_modes": [light.ColorMode.BRIGHTNESS],
-        "supported_features": light.LightEntityFeature(0),
+        "supported_features": 0,
         "brightness": None,
     }
 
@@ -1203,7 +1381,7 @@ async def test_light_state_off(hass: HomeAssistant) -> None:
         "color_mode": None,
         "friendly_name": "Test_ct",
         "supported_color_modes": [light.ColorMode.COLOR_TEMP],
-        "supported_features": light.LightEntityFeature(0),
+        "supported_features": 0,
         "brightness": None,
         "color_temp": None,
         "color_temp_kelvin": None,
@@ -1221,7 +1399,7 @@ async def test_light_state_off(hass: HomeAssistant) -> None:
         "color_mode": None,
         "friendly_name": "Test_rgbw",
         "supported_color_modes": [light.ColorMode.RGBW],
-        "supported_features": light.LightEntityFeature(0),
+        "supported_features": 0,
         "brightness": None,
         "rgbw_color": None,
         "hs_color": None,
@@ -1252,7 +1430,7 @@ async def test_light_state_rgbw(hass: HomeAssistant) -> None:
         "color_mode": light.ColorMode.RGBW,
         "friendly_name": "Test_rgbw",
         "supported_color_modes": [light.ColorMode.RGBW],
-        "supported_features": light.LightEntityFeature(0),
+        "supported_features": 0,
         "hs_color": (240.0, 25.0),
         "rgb_color": (3, 3, 4),
         "rgbw_color": (1, 2, 3, 4),
@@ -1283,7 +1461,7 @@ async def test_light_state_rgbww(hass: HomeAssistant) -> None:
         "color_mode": light.ColorMode.RGBWW,
         "friendly_name": "Test_rgbww",
         "supported_color_modes": [light.ColorMode.RGBWW],
-        "supported_features": light.LightEntityFeature(0),
+        "supported_features": 0,
         "hs_color": (60.0, 20.0),
         "rgb_color": (5, 5, 4),
         "rgbww_color": (1, 2, 3, 4, 5),
@@ -1299,6 +1477,7 @@ async def test_light_service_call_color_conversion(hass: HomeAssistant) -> None:
         MockLight("Test_rgb", STATE_ON),
         MockLight("Test_xy", STATE_ON),
         MockLight("Test_all", STATE_ON),
+        MockLight("Test_legacy", STATE_ON),
         MockLight("Test_rgbw", STATE_ON),
         MockLight("Test_rgbww", STATE_ON),
         MockLight("Test_temperature", STATE_ON),
@@ -1322,13 +1501,19 @@ async def test_light_service_call_color_conversion(hass: HomeAssistant) -> None:
     }
 
     entity4 = entities[4]
-    entity4.supported_color_modes = {light.ColorMode.RGBW}
+    entity4.supported_features = light.SUPPORT_COLOR
+    # Set color modes to none to trigger backwards compatibility in LightEntity
+    entity4.supported_color_modes = None
+    entity4.color_mode = None
 
     entity5 = entities[5]
-    entity5.supported_color_modes = {light.ColorMode.RGBWW}
+    entity5.supported_color_modes = {light.ColorMode.RGBW}
 
     entity6 = entities[6]
-    entity6.supported_color_modes = {light.ColorMode.COLOR_TEMP}
+    entity6.supported_color_modes = {light.ColorMode.RGBWW}
+
+    entity7 = entities[7]
+    entity7.supported_color_modes = {light.ColorMode.COLOR_TEMP}
 
     assert await async_setup_component(hass, "light", {"light": {"platform": "test"}})
     await hass.async_block_till_done()
@@ -1350,12 +1535,15 @@ async def test_light_service_call_color_conversion(hass: HomeAssistant) -> None:
     ]
 
     state = hass.states.get(entity4.entity_id)
-    assert state.attributes["supported_color_modes"] == [light.ColorMode.RGBW]
+    assert state.attributes["supported_color_modes"] == [light.ColorMode.HS]
 
     state = hass.states.get(entity5.entity_id)
-    assert state.attributes["supported_color_modes"] == [light.ColorMode.RGBWW]
+    assert state.attributes["supported_color_modes"] == [light.ColorMode.RGBW]
 
     state = hass.states.get(entity6.entity_id)
+    assert state.attributes["supported_color_modes"] == [light.ColorMode.RGBWW]
+
+    state = hass.states.get(entity7.entity_id)
     assert state.attributes["supported_color_modes"] == [light.ColorMode.COLOR_TEMP]
 
     await hass.services.async_call(
@@ -1370,6 +1558,7 @@ async def test_light_service_call_color_conversion(hass: HomeAssistant) -> None:
                 entity4.entity_id,
                 entity5.entity_id,
                 entity6.entity_id,
+                entity7.entity_id,
             ],
             "brightness_pct": 100,
             "hs_color": (240, 100),
@@ -1385,10 +1574,12 @@ async def test_light_service_call_color_conversion(hass: HomeAssistant) -> None:
     _, data = entity3.last_call("turn_on")
     assert data == {"brightness": 255, "hs_color": (240.0, 100.0)}
     _, data = entity4.last_call("turn_on")
-    assert data == {"brightness": 255, "rgbw_color": (0, 0, 255, 0)}
+    assert data == {"brightness": 255, "hs_color": (240.0, 100.0)}
     _, data = entity5.last_call("turn_on")
-    assert data == {"brightness": 255, "rgbww_color": (0, 0, 255, 0, 0)}
+    assert data == {"brightness": 255, "rgbw_color": (0, 0, 255, 0)}
     _, data = entity6.last_call("turn_on")
+    assert data == {"brightness": 255, "rgbww_color": (0, 0, 255, 0, 0)}
+    _, data = entity7.last_call("turn_on")
     assert data == {"brightness": 255, "color_temp_kelvin": 1739, "color_temp": 575}
 
     await hass.services.async_call(
@@ -1403,6 +1594,7 @@ async def test_light_service_call_color_conversion(hass: HomeAssistant) -> None:
                 entity4.entity_id,
                 entity5.entity_id,
                 entity6.entity_id,
+                entity7.entity_id,
             ],
             "brightness_pct": 100,
             "hs_color": (240, 0),
@@ -1418,11 +1610,13 @@ async def test_light_service_call_color_conversion(hass: HomeAssistant) -> None:
     _, data = entity3.last_call("turn_on")
     assert data == {"brightness": 255, "hs_color": (240.0, 0.0)}
     _, data = entity4.last_call("turn_on")
-    assert data == {"brightness": 255, "rgbw_color": (0, 0, 0, 255)}
+    assert data == {"brightness": 255, "hs_color": (240.0, 0.0)}
     _, data = entity5.last_call("turn_on")
+    assert data == {"brightness": 255, "rgbw_color": (0, 0, 0, 255)}
+    _, data = entity6.last_call("turn_on")
     # The midpoint of the white channels is warm, compensated by adding green + blue
     assert data == {"brightness": 255, "rgbww_color": (0, 76, 141, 255, 255)}
-    _, data = entity6.last_call("turn_on")
+    _, data = entity7.last_call("turn_on")
     assert data == {"brightness": 255, "color_temp_kelvin": 5962, "color_temp": 167}
 
     await hass.services.async_call(
@@ -1437,6 +1631,7 @@ async def test_light_service_call_color_conversion(hass: HomeAssistant) -> None:
                 entity4.entity_id,
                 entity5.entity_id,
                 entity6.entity_id,
+                entity7.entity_id,
             ],
             "brightness_pct": 50,
             "rgb_color": (128, 0, 0),
@@ -1451,12 +1646,13 @@ async def test_light_service_call_color_conversion(hass: HomeAssistant) -> None:
     assert data == {"brightness": 128, "xy_color": (0.701, 0.299)}
     _, data = entity3.last_call("turn_on")
     assert data == {"brightness": 128, "rgb_color": (128, 0, 0)}
-
     _, data = entity4.last_call("turn_on")
-    assert data == {"brightness": 128, "rgbw_color": (128, 0, 0, 0)}
+    assert data == {"brightness": 128, "hs_color": (0.0, 100.0)}
     _, data = entity5.last_call("turn_on")
-    assert data == {"brightness": 128, "rgbww_color": (128, 0, 0, 0, 0)}
+    assert data == {"brightness": 128, "rgbw_color": (128, 0, 0, 0)}
     _, data = entity6.last_call("turn_on")
+    assert data == {"brightness": 128, "rgbww_color": (128, 0, 0, 0, 0)}
+    _, data = entity7.last_call("turn_on")
     assert data == {"brightness": 128, "color_temp_kelvin": 6279, "color_temp": 159}
 
     await hass.services.async_call(
@@ -1471,6 +1667,7 @@ async def test_light_service_call_color_conversion(hass: HomeAssistant) -> None:
                 entity4.entity_id,
                 entity5.entity_id,
                 entity6.entity_id,
+                entity7.entity_id,
             ],
             "brightness_pct": 50,
             "rgb_color": (255, 255, 255),
@@ -1486,11 +1683,13 @@ async def test_light_service_call_color_conversion(hass: HomeAssistant) -> None:
     _, data = entity3.last_call("turn_on")
     assert data == {"brightness": 128, "rgb_color": (255, 255, 255)}
     _, data = entity4.last_call("turn_on")
-    assert data == {"brightness": 128, "rgbw_color": (0, 0, 0, 255)}
+    assert data == {"brightness": 128, "hs_color": (0.0, 0.0)}
     _, data = entity5.last_call("turn_on")
+    assert data == {"brightness": 128, "rgbw_color": (0, 0, 0, 255)}
+    _, data = entity6.last_call("turn_on")
     # The midpoint the white channels is warm, compensated by adding green + blue
     assert data == {"brightness": 128, "rgbww_color": (0, 76, 141, 255, 255)}
-    _, data = entity6.last_call("turn_on")
+    _, data = entity7.last_call("turn_on")
     assert data == {"brightness": 128, "color_temp_kelvin": 5962, "color_temp": 167}
 
     await hass.services.async_call(
@@ -1505,6 +1704,7 @@ async def test_light_service_call_color_conversion(hass: HomeAssistant) -> None:
                 entity4.entity_id,
                 entity5.entity_id,
                 entity6.entity_id,
+                entity7.entity_id,
             ],
             "brightness_pct": 50,
             "xy_color": (0.1, 0.8),
@@ -1520,10 +1720,12 @@ async def test_light_service_call_color_conversion(hass: HomeAssistant) -> None:
     _, data = entity3.last_call("turn_on")
     assert data == {"brightness": 128, "xy_color": (0.1, 0.8)}
     _, data = entity4.last_call("turn_on")
-    assert data == {"brightness": 128, "rgbw_color": (0, 255, 22, 0)}
+    assert data == {"brightness": 128, "hs_color": (125.176, 100.0)}
     _, data = entity5.last_call("turn_on")
-    assert data == {"brightness": 128, "rgbww_color": (0, 255, 22, 0, 0)}
+    assert data == {"brightness": 128, "rgbw_color": (0, 255, 22, 0)}
     _, data = entity6.last_call("turn_on")
+    assert data == {"brightness": 128, "rgbww_color": (0, 255, 22, 0, 0)}
+    _, data = entity7.last_call("turn_on")
     assert data == {"brightness": 128, "color_temp_kelvin": 8645, "color_temp": 115}
 
     await hass.services.async_call(
@@ -1538,6 +1740,7 @@ async def test_light_service_call_color_conversion(hass: HomeAssistant) -> None:
                 entity4.entity_id,
                 entity5.entity_id,
                 entity6.entity_id,
+                entity7.entity_id,
             ],
             "brightness_pct": 50,
             "xy_color": (0.323, 0.329),
@@ -1553,11 +1756,13 @@ async def test_light_service_call_color_conversion(hass: HomeAssistant) -> None:
     _, data = entity3.last_call("turn_on")
     assert data == {"brightness": 128, "xy_color": (0.323, 0.329)}
     _, data = entity4.last_call("turn_on")
-    assert data == {"brightness": 128, "rgbw_color": (1, 0, 0, 255)}
+    assert data == {"brightness": 128, "hs_color": (0.0, 0.392)}
     _, data = entity5.last_call("turn_on")
+    assert data == {"brightness": 128, "rgbw_color": (1, 0, 0, 255)}
+    _, data = entity6.last_call("turn_on")
     # The midpoint the white channels is warm, compensated by adding green + blue
     assert data == {"brightness": 128, "rgbww_color": (0, 75, 140, 255, 255)}
-    _, data = entity6.last_call("turn_on")
+    _, data = entity7.last_call("turn_on")
     assert data == {"brightness": 128, "color_temp_kelvin": 5962, "color_temp": 167}
 
     await hass.services.async_call(
@@ -1572,6 +1777,7 @@ async def test_light_service_call_color_conversion(hass: HomeAssistant) -> None:
                 entity4.entity_id,
                 entity5.entity_id,
                 entity6.entity_id,
+                entity7.entity_id,
             ],
             "brightness_pct": 50,
             "rgbw_color": (128, 0, 0, 64),
@@ -1587,11 +1793,13 @@ async def test_light_service_call_color_conversion(hass: HomeAssistant) -> None:
     _, data = entity3.last_call("turn_on")
     assert data == {"brightness": 128, "rgb_color": (128, 43, 43)}
     _, data = entity4.last_call("turn_on")
-    assert data == {"brightness": 128, "rgbw_color": (128, 0, 0, 64)}
+    assert data == {"brightness": 128, "hs_color": (0.0, 66.406)}
     _, data = entity5.last_call("turn_on")
+    assert data == {"brightness": 128, "rgbw_color": (128, 0, 0, 64)}
+    _, data = entity6.last_call("turn_on")
     # The midpoint the white channels is warm, compensated by adding green + blue
     assert data == {"brightness": 128, "rgbww_color": (128, 0, 30, 117, 117)}
-    _, data = entity6.last_call("turn_on")
+    _, data = entity7.last_call("turn_on")
     assert data == {"brightness": 128, "color_temp_kelvin": 3011, "color_temp": 332}
 
     await hass.services.async_call(
@@ -1606,6 +1814,7 @@ async def test_light_service_call_color_conversion(hass: HomeAssistant) -> None:
                 entity4.entity_id,
                 entity5.entity_id,
                 entity6.entity_id,
+                entity7.entity_id,
             ],
             "brightness_pct": 50,
             "rgbw_color": (255, 255, 255, 255),
@@ -1621,11 +1830,13 @@ async def test_light_service_call_color_conversion(hass: HomeAssistant) -> None:
     _, data = entity3.last_call("turn_on")
     assert data == {"brightness": 128, "rgb_color": (255, 255, 255)}
     _, data = entity4.last_call("turn_on")
-    assert data == {"brightness": 128, "rgbw_color": (255, 255, 255, 255)}
+    assert data == {"brightness": 128, "hs_color": (0.0, 0.0)}
     _, data = entity5.last_call("turn_on")
+    assert data == {"brightness": 128, "rgbw_color": (255, 255, 255, 255)}
+    _, data = entity6.last_call("turn_on")
     # The midpoint the white channels is warm, compensated by adding green + blue
     assert data == {"brightness": 128, "rgbww_color": (0, 76, 141, 255, 255)}
-    _, data = entity6.last_call("turn_on")
+    _, data = entity7.last_call("turn_on")
     assert data == {"brightness": 128, "color_temp_kelvin": 5962, "color_temp": 167}
 
     await hass.services.async_call(
@@ -1640,6 +1851,7 @@ async def test_light_service_call_color_conversion(hass: HomeAssistant) -> None:
                 entity4.entity_id,
                 entity5.entity_id,
                 entity6.entity_id,
+                entity7.entity_id,
             ],
             "brightness_pct": 50,
             "rgbww_color": (128, 0, 0, 64, 32),
@@ -1655,10 +1867,12 @@ async def test_light_service_call_color_conversion(hass: HomeAssistant) -> None:
     _, data = entity3.last_call("turn_on")
     assert data == {"brightness": 128, "rgb_color": (128, 33, 26)}
     _, data = entity4.last_call("turn_on")
-    assert data == {"brightness": 128, "rgbw_color": (128, 9, 0, 33)}
+    assert data == {"brightness": 128, "hs_color": (4.118, 79.688)}
     _, data = entity5.last_call("turn_on")
-    assert data == {"brightness": 128, "rgbww_color": (128, 0, 0, 64, 32)}
+    assert data == {"brightness": 128, "rgbw_color": (128, 9, 0, 33)}
     _, data = entity6.last_call("turn_on")
+    assert data == {"brightness": 128, "rgbww_color": (128, 0, 0, 64, 32)}
+    _, data = entity7.last_call("turn_on")
     assert data == {"brightness": 128, "color_temp_kelvin": 3845, "color_temp": 260}
 
     await hass.services.async_call(
@@ -1673,6 +1887,7 @@ async def test_light_service_call_color_conversion(hass: HomeAssistant) -> None:
                 entity4.entity_id,
                 entity5.entity_id,
                 entity6.entity_id,
+                entity7.entity_id,
             ],
             "brightness_pct": 50,
             "rgbww_color": (255, 255, 255, 255, 255),
@@ -1688,11 +1903,13 @@ async def test_light_service_call_color_conversion(hass: HomeAssistant) -> None:
     _, data = entity3.last_call("turn_on")
     assert data == {"brightness": 128, "rgb_color": (255, 217, 185)}
     _, data = entity4.last_call("turn_on")
+    assert data == {"brightness": 128, "hs_color": (27.429, 27.451)}
+    _, data = entity5.last_call("turn_on")
     # The midpoint the white channels is warm, compensated by decreasing green + blue
     assert data == {"brightness": 128, "rgbw_color": (96, 44, 0, 255)}
-    _, data = entity5.last_call("turn_on")
-    assert data == {"brightness": 128, "rgbww_color": (255, 255, 255, 255, 255)}
     _, data = entity6.last_call("turn_on")
+    assert data == {"brightness": 128, "rgbww_color": (255, 255, 255, 255, 255)}
+    _, data = entity7.last_call("turn_on")
     assert data == {"brightness": 128, "color_temp_kelvin": 3451, "color_temp": 289}
 
 
@@ -1705,6 +1922,7 @@ async def test_light_service_call_color_conversion_named_tuple(
         MockLight("Test_rgb", STATE_ON),
         MockLight("Test_xy", STATE_ON),
         MockLight("Test_all", STATE_ON),
+        MockLight("Test_legacy", STATE_ON),
         MockLight("Test_rgbw", STATE_ON),
         MockLight("Test_rgbww", STATE_ON),
     ]
@@ -1727,10 +1945,16 @@ async def test_light_service_call_color_conversion_named_tuple(
     }
 
     entity4 = entities[4]
-    entity4.supported_color_modes = {light.ColorMode.RGBW}
+    entity4.supported_features = light.SUPPORT_COLOR
+    # Set color modes to none to trigger backwards compatibility in LightEntity
+    entity4.supported_color_modes = None
+    entity4.color_mode = None
 
     entity5 = entities[5]
-    entity5.supported_color_modes = {light.ColorMode.RGBWW}
+    entity5.supported_color_modes = {light.ColorMode.RGBW}
+
+    entity6 = entities[6]
+    entity6.supported_color_modes = {light.ColorMode.RGBWW}
 
     assert await async_setup_component(hass, "light", {"light": {"platform": "test"}})
     await hass.async_block_till_done()
@@ -1746,6 +1970,7 @@ async def test_light_service_call_color_conversion_named_tuple(
                 entity3.entity_id,
                 entity4.entity_id,
                 entity5.entity_id,
+                entity6.entity_id,
             ],
             "brightness_pct": 25,
             "rgb_color": color_util.RGBColor(128, 0, 0),
@@ -1761,8 +1986,10 @@ async def test_light_service_call_color_conversion_named_tuple(
     _, data = entity3.last_call("turn_on")
     assert data == {"brightness": 64, "rgb_color": (128, 0, 0)}
     _, data = entity4.last_call("turn_on")
-    assert data == {"brightness": 64, "rgbw_color": (128, 0, 0, 0)}
+    assert data == {"brightness": 64, "hs_color": (0.0, 100.0)}
     _, data = entity5.last_call("turn_on")
+    assert data == {"brightness": 64, "rgbw_color": (128, 0, 0, 0)}
+    _, data = entity6.last_call("turn_on")
     assert data == {"brightness": 64, "rgbww_color": (128, 0, 0, 0, 0)}
 
 
@@ -2131,6 +2358,13 @@ async def test_light_state_color_conversion(hass: HomeAssistant) -> None:
     entity2.rgb_color = "Invalid"  # Should be ignored
     entity2.xy_color = (0.1, 0.8)
 
+    entity3 = entities[3]
+    entity3.hs_color = (240, 100)
+    entity3.supported_features = light.SUPPORT_COLOR
+    # Set color modes to none to trigger backwards compatibility in LightEntity
+    entity3.supported_color_modes = None
+    entity3.color_mode = None
+
     assert await async_setup_component(hass, "light", {"light": {"platform": "test"}})
     await hass.async_block_till_done()
 
@@ -2151,6 +2385,12 @@ async def test_light_state_color_conversion(hass: HomeAssistant) -> None:
     assert state.attributes["hs_color"] == (125.176, 100.0)
     assert state.attributes["rgb_color"] == (0, 255, 22)
     assert state.attributes["xy_color"] == (0.1, 0.8)
+
+    state = hass.states.get(entity3.entity_id)
+    assert state.attributes["color_mode"] == light.ColorMode.HS
+    assert state.attributes["hs_color"] == (240, 100)
+    assert state.attributes["rgb_color"] == (0, 0, 255)
+    assert state.attributes["xy_color"] == (0.136, 0.04)
 
 
 async def test_services_filter_parameters(
@@ -2384,6 +2624,27 @@ def test_filter_supported_color_modes() -> None:
     # ColorMode.BRIGHTNESS has priority over ColorMode.ONOFF
     supported = {light.ColorMode.ONOFF, light.ColorMode.BRIGHTNESS}
     assert light.filter_supported_color_modes(supported) == {light.ColorMode.BRIGHTNESS}
+
+
+def test_deprecated_supported_features_ints(caplog: pytest.LogCaptureFixture) -> None:
+    """Test deprecated supported features ints."""
+
+    class MockLightEntityEntity(light.LightEntity):
+        @property
+        def supported_features(self) -> int:
+            """Return supported features."""
+            return 1
+
+    entity = MockLightEntityEntity()
+    assert entity.supported_features_compat is light.LightEntityFeature(1)
+    assert "MockLightEntityEntity" in caplog.text
+    assert "is using deprecated supported features values" in caplog.text
+    assert "Instead it should use" in caplog.text
+    assert "LightEntityFeature" in caplog.text
+    assert "and color modes" in caplog.text
+    caplog.clear()
+    assert entity.supported_features_compat is light.LightEntityFeature(1)
+    assert "is using deprecated supported features values" not in caplog.text
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This reverts #132371

Context in: https://github.com/home-assistant/core/pull/134933

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
