### PR TITLE
Revert "Remove deprecated supported features warning in .. (multiple)"

### DIFF
--- a/homeassistant/components/alarm_control_panel/__init__.py
+++ b/homeassistant/components/alarm_control_panel/__init__.py
@@ -355,7 +355,12 @@ class AlarmControlPanelEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_A
     @cached_property
     def supported_features(self) -> AlarmControlPanelEntityFeature:
         """Return the list of supported features."""
-        return self._attr_supported_features
+        features = self._attr_supported_features
+        if type(features) is int:  # noqa: E721
+            new_features = AlarmControlPanelEntityFeature(features)
+            self._report_deprecated_supported_features_values(new_features)
+            return new_features
+        return features
 
     @final
     @property

--- a/homeassistant/components/baf/fan.py
+++ b/homeassistant/components/baf/fan.py
@@ -46,7 +46,7 @@ class BAFFan(BAFEntity, FanEntity):
         | FanEntityFeature.TURN_OFF
         | FanEntityFeature.TURN_ON
     )
-
+    _enable_turn_on_off_backwards_compatibility = False
     _attr_preset_modes = [PRESET_MODE_AUTO]
     _attr_speed_count = SPEED_COUNT
     _attr_name = None

--- a/homeassistant/components/balboa/fan.py
+++ b/homeassistant/components/balboa/fan.py
@@ -38,7 +38,7 @@ class BalboaPumpFanEntity(BalboaEntity, FanEntity):
         | FanEntityFeature.TURN_OFF
         | FanEntityFeature.TURN_ON
     )
-
+    _enable_turn_on_off_backwards_compatibility = False
     _attr_translation_key = "pump"
 
     def __init__(self, control: SpaControl) -> None:

--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -516,6 +516,19 @@ class Camera(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
         """Flag supported features."""
         return self._attr_supported_features
 
+    @property
+    def supported_features_compat(self) -> CameraEntityFeature:
+        """Return the supported features as CameraEntityFeature.
+
+        Remove this compatibility shim in 2025.1 or later.
+        """
+        features = self.supported_features
+        if type(features) is int:  # noqa: E721
+            new_features = CameraEntityFeature(features)
+            self._report_deprecated_supported_features_values(new_features)
+            return new_features
+        return features
+
     @cached_property
     def is_recording(self) -> bool:
         """Return true if the device is recording."""
@@ -569,7 +582,7 @@ class Camera(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
 
                 self._deprecate_attr_frontend_stream_type_logged = True
             return self._attr_frontend_stream_type
-        if CameraEntityFeature.STREAM not in self.supported_features:
+        if CameraEntityFeature.STREAM not in self.supported_features_compat:
             return None
         if (
             self._webrtc_provider
@@ -798,7 +811,9 @@ class Camera(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
     async def async_internal_added_to_hass(self) -> None:
         """Run when entity about to be added to hass."""
         await super().async_internal_added_to_hass()
-        self.__supports_stream = self.supported_features & CameraEntityFeature.STREAM
+        self.__supports_stream = (
+            self.supported_features_compat & CameraEntityFeature.STREAM
+        )
         await self.async_refresh_providers(write_state=False)
 
     async def async_refresh_providers(self, *, write_state: bool = True) -> None:
@@ -838,7 +853,7 @@ class Camera(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
         self, fn: Callable[[HomeAssistant, Camera], Coroutine[None, None, _T | None]]
     ) -> _T | None:
         """Get first provider that supports this camera."""
-        if CameraEntityFeature.STREAM not in self.supported_features:
+        if CameraEntityFeature.STREAM not in self.supported_features_compat:
             return None
 
         return await fn(self.hass, self)
@@ -896,7 +911,7 @@ class Camera(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
     def camera_capabilities(self) -> CameraCapabilities:
         """Return the camera capabilities."""
         frontend_stream_types = set()
-        if CameraEntityFeature.STREAM in self.supported_features:
+        if CameraEntityFeature.STREAM in self.supported_features_compat:
             if self._supports_native_sync_webrtc or self._supports_native_async_webrtc:
                 # The camera has a native WebRTC implementation
                 frontend_stream_types.add(StreamType.WEB_RTC)
@@ -916,7 +931,8 @@ class Camera(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
         """
         super().async_write_ha_state()
         if self.__supports_stream != (
-            supports_stream := self.supported_features & CameraEntityFeature.STREAM
+            supports_stream := self.supported_features_compat
+            & CameraEntityFeature.STREAM
         ):
             self.__supports_stream = supports_stream
             self._invalidate_camera_capabilities_cache()

--- a/homeassistant/components/comfoconnect/fan.py
+++ b/homeassistant/components/comfoconnect/fan.py
@@ -68,7 +68,7 @@ class ComfoConnectFan(FanEntity):
         | FanEntityFeature.TURN_OFF
         | FanEntityFeature.TURN_ON
     )
-
+    _enable_turn_on_off_backwards_compatibility = False
     _attr_preset_modes = PRESET_MODES
     current_speed: float | None = None
 

--- a/homeassistant/components/cover/__init__.py
+++ b/homeassistant/components/cover/__init__.py
@@ -300,6 +300,10 @@ class CoverEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
     def supported_features(self) -> CoverEntityFeature:
         """Flag supported features."""
         if (features := self._attr_supported_features) is not None:
+            if type(features) is int:  # noqa: E721
+                new_features = CoverEntityFeature(features)
+                self._report_deprecated_supported_features_values(new_features)
+                return new_features
             return features
 
         supported_features = (

--- a/homeassistant/components/deconz/fan.py
+++ b/homeassistant/components/deconz/fan.py
@@ -65,6 +65,7 @@ class DeconzFan(DeconzDevice[Light], FanEntity):
         | FanEntityFeature.TURN_ON
         | FanEntityFeature.TURN_OFF
     )
+    _enable_turn_on_off_backwards_compatibility = False
 
     def __init__(self, device: Light, hub: DeconzHub) -> None:
         """Set up fan."""

--- a/homeassistant/components/demo/fan.py
+++ b/homeassistant/components/demo/fan.py
@@ -100,6 +100,7 @@ class BaseDemoFan(FanEntity):
 
     _attr_should_poll = False
     _attr_translation_key = "demo"
+    _enable_turn_on_off_backwards_compatibility = False
 
     def __init__(
         self,

--- a/homeassistant/components/esphome/fan.py
+++ b/homeassistant/components/esphome/fan.py
@@ -45,6 +45,7 @@ class EsphomeFan(EsphomeEntity[FanInfo, FanState], FanEntity):
     """A fan implementation for ESPHome."""
 
     _supports_speed_levels: bool = True
+    _enable_turn_on_off_backwards_compatibility = False
 
     async def async_set_percentage(self, percentage: int) -> None:
         """Set the speed percentage of the fan."""

--- a/homeassistant/components/fan/__init__.py
+++ b/homeassistant/components/fan/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from datetime import timedelta
 from enum import IntFlag
 import functools as ft
@@ -24,6 +25,7 @@ from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity import ToggleEntity, ToggleEntityDescription
 from homeassistant.helpers.entity_component import EntityComponent
+from homeassistant.helpers.entity_platform import EntityPlatform
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.loader import bind_hass
 from homeassistant.util.hass_dict import HassKey
@@ -216,6 +218,99 @@ class FanEntity(ToggleEntity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
     _attr_preset_modes: list[str] | None = None
     _attr_speed_count: int = 100
     _attr_supported_features: FanEntityFeature = FanEntityFeature(0)
+
+    __mod_supported_features: FanEntityFeature = FanEntityFeature(0)
+    # Integrations should set `_enable_turn_on_off_backwards_compatibility` to False
+    # once migrated and set the feature flags TURN_ON/TURN_OFF as needed.
+    _enable_turn_on_off_backwards_compatibility: bool = True
+
+    def __getattribute__(self, name: str, /) -> Any:
+        """Get attribute.
+
+        Modify return of `supported_features` to
+        include `_mod_supported_features` if attribute is set.
+        """
+        if name != "supported_features":
+            return super().__getattribute__(name)
+
+        # Convert the supported features to ClimateEntityFeature.
+        # Remove this compatibility shim in 2025.1 or later.
+        _supported_features: FanEntityFeature = super().__getattribute__(
+            "supported_features"
+        )
+        _mod_supported_features: FanEntityFeature = super().__getattribute__(
+            "_FanEntity__mod_supported_features"
+        )
+        if type(_supported_features) is int:  # noqa: E721
+            _features = FanEntityFeature(_supported_features)
+            self._report_deprecated_supported_features_values(_features)
+        else:
+            _features = _supported_features
+
+        if not _mod_supported_features:
+            return _features
+
+        # Add automatically calculated FanEntityFeature.TURN_OFF/TURN_ON to
+        # supported features and return it
+        return _features | _mod_supported_features
+
+    @callback
+    def add_to_platform_start(
+        self,
+        hass: HomeAssistant,
+        platform: EntityPlatform,
+        parallel_updates: asyncio.Semaphore | None,
+    ) -> None:
+        """Start adding an entity to a platform."""
+        super().add_to_platform_start(hass, platform, parallel_updates)
+
+        def _report_turn_on_off(feature: str, method: str) -> None:
+            """Log warning not implemented turn on/off feature."""
+            report_issue = self._suggest_report_issue()
+            message = (
+                "Entity %s (%s) does not set FanEntityFeature.%s"
+                " but implements the %s method. Please %s"
+            )
+            _LOGGER.warning(
+                message,
+                self.entity_id,
+                type(self),
+                feature,
+                method,
+                report_issue,
+            )
+
+        # Adds FanEntityFeature.TURN_OFF/TURN_ON depending on service calls implemented
+        # This should be removed in 2025.2.
+        if self._enable_turn_on_off_backwards_compatibility is False:
+            # Return if integration has migrated already
+            return
+
+        supported_features = self.supported_features
+        if supported_features & (FanEntityFeature.TURN_ON | FanEntityFeature.TURN_OFF):
+            # The entity supports both turn_on and turn_off, the backwards compatibility
+            # checks are not needed
+            return
+
+        if not supported_features & FanEntityFeature.TURN_OFF and (
+            type(self).async_turn_off is not ToggleEntity.async_turn_off
+            or type(self).turn_off is not ToggleEntity.turn_off
+        ):
+            # turn_off implicitly supported by implementing turn_off method
+            _report_turn_on_off("TURN_OFF", "turn_off")
+            self.__mod_supported_features |= (  # pylint: disable=unused-private-member
+                FanEntityFeature.TURN_OFF
+            )
+
+        if not supported_features & FanEntityFeature.TURN_ON and (
+            type(self).async_turn_on is not FanEntity.async_turn_on
+            or type(self).turn_on is not FanEntity.turn_on
+        ):
+            # turn_on implicitly supported by implementing turn_on method
+            _report_turn_on_off("TURN_ON", "turn_on")
+            self.__mod_supported_features |= (  # pylint: disable=unused-private-member
+                FanEntityFeature.TURN_ON
+            )
 
     def set_percentage(self, percentage: int) -> None:
         """Set the speed of the fan, as a percentage."""

--- a/homeassistant/components/fjaraskupan/fan.py
+++ b/homeassistant/components/fjaraskupan/fan.py
@@ -71,7 +71,7 @@ class Fan(CoordinatorEntity[FjaraskupanCoordinator], FanEntity):
         | FanEntityFeature.TURN_OFF
         | FanEntityFeature.TURN_ON
     )
-
+    _enable_turn_on_off_backwards_compatibility = False
     _attr_has_entity_name = True
     _attr_name = None
 

--- a/homeassistant/components/freedompro/fan.py
+++ b/homeassistant/components/freedompro/fan.py
@@ -40,6 +40,7 @@ class FreedomproFan(CoordinatorEntity[FreedomproDataUpdateCoordinator], FanEntit
     _attr_name = None
     _attr_is_on = False
     _attr_percentage = 0
+    _enable_turn_on_off_backwards_compatibility = False
 
     def __init__(
         self,

--- a/homeassistant/components/group/fan.py
+++ b/homeassistant/components/group/fan.py
@@ -109,6 +109,7 @@ class FanGroup(GroupEntity, FanEntity):
     """Representation of a FanGroup."""
 
     _attr_available: bool = False
+    _enable_turn_on_off_backwards_compatibility = False
 
     def __init__(self, unique_id: str | None, name: str, entities: list[str]) -> None:
         """Initialize a FanGroup entity."""

--- a/homeassistant/components/homekit_controller/fan.py
+++ b/homeassistant/components/homekit_controller/fan.py
@@ -42,6 +42,7 @@ class BaseHomeKitFan(HomeKitEntity, FanEntity):
     # This must be set in subclasses to the name of a boolean characteristic
     # that controls whether the fan is on or off.
     on_characteristic: str
+    _enable_turn_on_off_backwards_compatibility = False
 
     @callback
     def _async_reconfigure(self) -> None:

--- a/homeassistant/components/humidifier/__init__.py
+++ b/homeassistant/components/humidifier/__init__.py
@@ -170,7 +170,7 @@ class HumidifierEntity(ToggleEntity, cached_properties=CACHED_PROPERTIES_WITH_AT
             ATTR_MAX_HUMIDITY: self.max_humidity,
         }
 
-        if HumidifierEntityFeature.MODES in self.supported_features:
+        if HumidifierEntityFeature.MODES in self.supported_features_compat:
             data[ATTR_AVAILABLE_MODES] = self.available_modes
 
         return data
@@ -199,7 +199,7 @@ class HumidifierEntity(ToggleEntity, cached_properties=CACHED_PROPERTIES_WITH_AT
         if self.target_humidity is not None:
             data[ATTR_HUMIDITY] = self.target_humidity
 
-        if HumidifierEntityFeature.MODES in self.supported_features:
+        if HumidifierEntityFeature.MODES in self.supported_features_compat:
             data[ATTR_MODE] = self.mode
 
         return data
@@ -265,6 +265,19 @@ class HumidifierEntity(ToggleEntity, cached_properties=CACHED_PROPERTIES_WITH_AT
     def supported_features(self) -> HumidifierEntityFeature:
         """Return the list of supported features."""
         return self._attr_supported_features
+
+    @property
+    def supported_features_compat(self) -> HumidifierEntityFeature:
+        """Return the supported features as HumidifierEntityFeature.
+
+        Remove this compatibility shim in 2025.1 or later.
+        """
+        features = self.supported_features
+        if type(features) is int:  # noqa: E721
+            new_features = HumidifierEntityFeature(features)
+            self._report_deprecated_supported_features_values(new_features)
+            return new_features
+        return features
 
 
 async def async_service_humidity_set(

--- a/homeassistant/components/insteon/fan.py
+++ b/homeassistant/components/insteon/fan.py
@@ -56,6 +56,7 @@ class InsteonFanEntity(InsteonEntity, FanEntity):
         | FanEntityFeature.TURN_ON
     )
     _attr_speed_count = 3
+    _enable_turn_on_off_backwards_compatibility = False
 
     @property
     def percentage(self) -> int | None:

--- a/homeassistant/components/intellifire/fan.py
+++ b/homeassistant/components/intellifire/fan.py
@@ -81,6 +81,7 @@ class IntellifireFan(IntellifireEntity, FanEntity):
         | FanEntityFeature.TURN_OFF
         | FanEntityFeature.TURN_ON
     )
+    _enable_turn_on_off_backwards_compatibility = False
 
     @property
     def is_on(self) -> bool:

--- a/homeassistant/components/isy994/fan.py
+++ b/homeassistant/components/isy994/fan.py
@@ -53,6 +53,7 @@ class ISYFanEntity(ISYNodeEntity, FanEntity):
         | FanEntityFeature.TURN_OFF
         | FanEntityFeature.TURN_ON
     )
+    _enable_turn_on_off_backwards_compatibility = False
 
     @property
     def percentage(self) -> int | None:

--- a/homeassistant/components/knx/fan.py
+++ b/homeassistant/components/knx/fan.py
@@ -43,6 +43,7 @@ class KNXFan(KnxYamlEntity, FanEntity):
     """Representation of a KNX fan."""
 
     _device: XknxFan
+    _enable_turn_on_off_backwards_compatibility = False
 
     def __init__(self, knx_module: KNXModule, config: ConfigType) -> None:
         """Initialize of KNX fan."""

--- a/homeassistant/components/lock/__init__.py
+++ b/homeassistant/components/lock/__init__.py
@@ -285,7 +285,12 @@ class LockEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
     @cached_property
     def supported_features(self) -> LockEntityFeature:
         """Return the list of supported features."""
-        return self._attr_supported_features
+        features = self._attr_supported_features
+        if type(features) is int:  # noqa: E721
+            new_features = LockEntityFeature(features)
+            self._report_deprecated_supported_features_values(new_features)
+            return new_features
+        return features
 
     async def async_internal_added_to_hass(self) -> None:
         """Call when the sensor entity is added to hass."""

--- a/homeassistant/components/lutron/fan.py
+++ b/homeassistant/components/lutron/fan.py
@@ -51,6 +51,7 @@ class LutronFan(LutronDevice, FanEntity):
     )
     _lutron_device: Output
     _prev_percentage: int | None = None
+    _enable_turn_on_off_backwards_compatibility = False
 
     def set_percentage(self, percentage: int) -> None:
         """Set the speed of the fan, as a percentage."""

--- a/homeassistant/components/lutron_caseta/fan.py
+++ b/homeassistant/components/lutron_caseta/fan.py
@@ -50,6 +50,7 @@ class LutronCasetaFan(LutronCasetaUpdatableEntity, FanEntity):
         | FanEntityFeature.TURN_ON
     )
     _attr_speed_count = len(ORDERED_NAMED_FAN_SPEEDS)
+    _enable_turn_on_off_backwards_compatibility = False
 
     @property
     def percentage(self) -> int | None:

--- a/homeassistant/components/matter/fan.py
+++ b/homeassistant/components/matter/fan.py
@@ -58,7 +58,7 @@ class MatterFan(MatterEntity, FanEntity):
 
     _last_known_preset_mode: str | None = None
     _last_known_percentage: int = 0
-
+    _enable_turn_on_off_backwards_compatibility = False
     _feature_map: int | None = None
     _platform_translation_key = "fan"
 

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -773,6 +773,19 @@ class MediaPlayerEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
         """Flag media player features that are supported."""
         return self._attr_supported_features
 
+    @property
+    def supported_features_compat(self) -> MediaPlayerEntityFeature:
+        """Return the supported features as MediaPlayerEntityFeature.
+
+        Remove this compatibility shim in 2025.1 or later.
+        """
+        features = self.supported_features
+        if type(features) is int:  # noqa: E721
+            new_features = MediaPlayerEntityFeature(features)
+            self._report_deprecated_supported_features_values(new_features)
+            return new_features
+        return features
+
     def turn_on(self) -> None:
         """Turn the media player on."""
         raise NotImplementedError
@@ -912,85 +925,87 @@ class MediaPlayerEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
     @property
     def support_play(self) -> bool:
         """Boolean if play is supported."""
-        return MediaPlayerEntityFeature.PLAY in self.supported_features
+        return MediaPlayerEntityFeature.PLAY in self.supported_features_compat
 
     @final
     @property
     def support_pause(self) -> bool:
         """Boolean if pause is supported."""
-        return MediaPlayerEntityFeature.PAUSE in self.supported_features
+        return MediaPlayerEntityFeature.PAUSE in self.supported_features_compat
 
     @final
     @property
     def support_stop(self) -> bool:
         """Boolean if stop is supported."""
-        return MediaPlayerEntityFeature.STOP in self.supported_features
+        return MediaPlayerEntityFeature.STOP in self.supported_features_compat
 
     @final
     @property
     def support_seek(self) -> bool:
         """Boolean if seek is supported."""
-        return MediaPlayerEntityFeature.SEEK in self.supported_features
+        return MediaPlayerEntityFeature.SEEK in self.supported_features_compat
 
     @final
     @property
     def support_volume_set(self) -> bool:
         """Boolean if setting volume is supported."""
-        return MediaPlayerEntityFeature.VOLUME_SET in self.supported_features
+        return MediaPlayerEntityFeature.VOLUME_SET in self.supported_features_compat
 
     @final
     @property
     def support_volume_mute(self) -> bool:
         """Boolean if muting volume is supported."""
-        return MediaPlayerEntityFeature.VOLUME_MUTE in self.supported_features
+        return MediaPlayerEntityFeature.VOLUME_MUTE in self.supported_features_compat
 
     @final
     @property
     def support_previous_track(self) -> bool:
         """Boolean if previous track command supported."""
-        return MediaPlayerEntityFeature.PREVIOUS_TRACK in self.supported_features
+        return MediaPlayerEntityFeature.PREVIOUS_TRACK in self.supported_features_compat
 
     @final
     @property
     def support_next_track(self) -> bool:
         """Boolean if next track command supported."""
-        return MediaPlayerEntityFeature.NEXT_TRACK in self.supported_features
+        return MediaPlayerEntityFeature.NEXT_TRACK in self.supported_features_compat
 
     @final
     @property
     def support_play_media(self) -> bool:
         """Boolean if play media command supported."""
-        return MediaPlayerEntityFeature.PLAY_MEDIA in self.supported_features
+        return MediaPlayerEntityFeature.PLAY_MEDIA in self.supported_features_compat
 
     @final
     @property
     def support_select_source(self) -> bool:
         """Boolean if select source command supported."""
-        return MediaPlayerEntityFeature.SELECT_SOURCE in self.supported_features
+        return MediaPlayerEntityFeature.SELECT_SOURCE in self.supported_features_compat
 
     @final
     @property
     def support_select_sound_mode(self) -> bool:
         """Boolean if select sound mode command supported."""
-        return MediaPlayerEntityFeature.SELECT_SOUND_MODE in self.supported_features
+        return (
+            MediaPlayerEntityFeature.SELECT_SOUND_MODE in self.supported_features_compat
+        )
 
     @final
     @property
     def support_clear_playlist(self) -> bool:
         """Boolean if clear playlist command supported."""
-        return MediaPlayerEntityFeature.CLEAR_PLAYLIST in self.supported_features
+        return MediaPlayerEntityFeature.CLEAR_PLAYLIST in self.supported_features_compat
 
     @final
     @property
     def support_shuffle_set(self) -> bool:
         """Boolean if shuffle is supported."""
-        return MediaPlayerEntityFeature.SHUFFLE_SET in self.supported_features
+        return MediaPlayerEntityFeature.SHUFFLE_SET in self.supported_features_compat
 
     @final
     @property
     def support_grouping(self) -> bool:
         """Boolean if player grouping is supported."""
-        return MediaPlayerEntityFeature.GROUPING in self.supported_features
+        return MediaPlayerEntityFeature.GROUPING in self.supported_features_compat
 
     async def async_toggle(self) -> None:
         """Toggle the power on the media player."""
@@ -1019,7 +1034,7 @@ class MediaPlayerEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
         if (
             self.volume_level is not None
             and self.volume_level < 1
-            and MediaPlayerEntityFeature.VOLUME_SET in self.supported_features
+            and MediaPlayerEntityFeature.VOLUME_SET in self.supported_features_compat
         ):
             await self.async_set_volume_level(
                 min(1, self.volume_level + self.volume_step)
@@ -1037,7 +1052,7 @@ class MediaPlayerEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
         if (
             self.volume_level is not None
             and self.volume_level > 0
-            and MediaPlayerEntityFeature.VOLUME_SET in self.supported_features
+            and MediaPlayerEntityFeature.VOLUME_SET in self.supported_features_compat
         ):
             await self.async_set_volume_level(
                 max(0, self.volume_level - self.volume_step)
@@ -1080,7 +1095,7 @@ class MediaPlayerEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
     def capability_attributes(self) -> dict[str, Any]:
         """Return capability attributes."""
         data: dict[str, Any] = {}
-        supported_features = self.supported_features
+        supported_features = self.supported_features_compat
 
         if (
             source_list := self.source_list
@@ -1286,7 +1301,7 @@ async def websocket_browse_media(
         connection.send_error(msg["id"], "entity_not_found", "Entity not found")
         return
 
-    if MediaPlayerEntityFeature.BROWSE_MEDIA not in player.supported_features:
+    if MediaPlayerEntityFeature.BROWSE_MEDIA not in player.supported_features_compat:
         connection.send_message(
             websocket_api.error_message(
                 msg["id"], ERR_NOT_SUPPORTED, "Player does not support browsing media"

--- a/homeassistant/components/modbus/fan.py
+++ b/homeassistant/components/modbus/fan.py
@@ -38,6 +38,8 @@ async def async_setup_platform(
 class ModbusFan(BaseSwitch, FanEntity):
     """Class representing a Modbus fan."""
 
+    _enable_turn_on_off_backwards_compatibility = False
+
     def __init__(
         self, hass: HomeAssistant, hub: ModbusHub, config: dict[str, Any]
     ) -> None:

--- a/homeassistant/components/modern_forms/fan.py
+++ b/homeassistant/components/modern_forms/fan.py
@@ -78,6 +78,7 @@ class ModernFormsFanEntity(FanEntity, ModernFormsDeviceEntity):
         | FanEntityFeature.TURN_ON
     )
     _attr_translation_key = "fan"
+    _enable_turn_on_off_backwards_compatibility = False
 
     def __init__(
         self, entry_id: str, coordinator: ModernFormsDataUpdateCoordinator

--- a/homeassistant/components/mqtt/fan.py
+++ b/homeassistant/components/mqtt/fan.py
@@ -226,6 +226,7 @@ class MqttFan(MqttEntity, FanEntity):
     _optimistic_preset_mode: bool
     _payload: dict[str, Any]
     _speed_range: tuple[int, int]
+    _enable_turn_on_off_backwards_compatibility = False
 
     @staticmethod
     def config_schema() -> VolSchemaType:

--- a/homeassistant/components/netatmo/fan.py
+++ b/homeassistant/components/netatmo/fan.py
@@ -51,6 +51,7 @@ class NetatmoFan(NetatmoModuleEntity, FanEntity):
     _attr_configuration_url = CONF_URL_CONTROL
     _attr_name = None
     device: NaModules.Fan
+    _enable_turn_on_off_backwards_compatibility = False
 
     def __init__(self, netatmo_device: NetatmoDevice) -> None:
         """Initialize of Netatmo fan."""

--- a/homeassistant/components/rabbitair/fan.py
+++ b/homeassistant/components/rabbitair/fan.py
@@ -55,6 +55,7 @@ class RabbitAirFanEntity(RabbitAirBaseEntity, FanEntity):
         | FanEntityFeature.TURN_ON
         | FanEntityFeature.TURN_OFF
     )
+    _enable_turn_on_off_backwards_compatibility = False
 
     def __init__(
         self,

--- a/homeassistant/components/remote/__init__.py
+++ b/homeassistant/components/remote/__init__.py
@@ -170,6 +170,19 @@ class RemoteEntity(ToggleEntity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_)
         """Flag supported features."""
         return self._attr_supported_features
 
+    @property
+    def supported_features_compat(self) -> RemoteEntityFeature:
+        """Return the supported features as RemoteEntityFeature.
+
+        Remove this compatibility shim in 2025.1 or later.
+        """
+        features = self.supported_features
+        if type(features) is int:  # noqa: E721
+            new_features = RemoteEntityFeature(features)
+            self._report_deprecated_supported_features_values(new_features)
+            return new_features
+        return features
+
     @cached_property
     def current_activity(self) -> str | None:
         """Active activity."""
@@ -184,7 +197,7 @@ class RemoteEntity(ToggleEntity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_)
     @property
     def state_attributes(self) -> dict[str, Any] | None:
         """Return optional state attributes."""
-        if RemoteEntityFeature.ACTIVITY not in self.supported_features:
+        if RemoteEntityFeature.ACTIVITY not in self.supported_features_compat:
             return None
 
         return {

--- a/homeassistant/components/renson/fan.py
+++ b/homeassistant/components/renson/fan.py
@@ -127,6 +127,7 @@ class RensonFan(RensonEntity, FanEntity):
         | FanEntityFeature.TURN_OFF
         | FanEntityFeature.TURN_ON
     )
+    _enable_turn_on_off_backwards_compatibility = False
 
     def __init__(self, api: RensonVentilation, coordinator: RensonCoordinator) -> None:
         """Initialize the Renson fan."""

--- a/homeassistant/components/siren/__init__.py
+++ b/homeassistant/components/siren/__init__.py
@@ -191,4 +191,9 @@ class SirenEntity(ToggleEntity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
     @cached_property
     def supported_features(self) -> SirenEntityFeature:
         """Return the list of supported features."""
-        return self._attr_supported_features
+        features = self._attr_supported_features
+        if type(features) is int:  # noqa: E721
+            new_features = SirenEntityFeature(features)
+            self._report_deprecated_supported_features_values(new_features)
+            return new_features
+        return features

--- a/homeassistant/components/smartthings/fan.py
+++ b/homeassistant/components/smartthings/fan.py
@@ -70,6 +70,7 @@ class SmartThingsFan(SmartThingsEntity, FanEntity):
     """Define a SmartThings Fan."""
 
     _attr_speed_count = int_states_in_range(SPEED_RANGE)
+    _enable_turn_on_off_backwards_compatibility = False
 
     def __init__(self, device):
         """Init the class."""

--- a/homeassistant/components/smarty/fan.py
+++ b/homeassistant/components/smarty/fan.py
@@ -48,6 +48,7 @@ class SmartyFan(SmartyEntity, FanEntity):
         | FanEntityFeature.TURN_OFF
         | FanEntityFeature.TURN_ON
     )
+    _enable_turn_on_off_backwards_compatibility = False
 
     def __init__(self, coordinator: SmartyCoordinator) -> None:
         """Initialize the entity."""

--- a/homeassistant/components/snooz/fan.py
+++ b/homeassistant/components/snooz/fan.py
@@ -83,6 +83,7 @@ class SnoozFan(FanEntity, RestoreEntity):
     _attr_should_poll = False
     _is_on: bool | None = None
     _percentage: int | None = None
+    _enable_turn_on_off_backwards_compatibility = False
 
     def __init__(self, data: SnoozConfigurationData) -> None:
         """Initialize a Snooz fan entity."""

--- a/homeassistant/components/switch_as_x/fan.py
+++ b/homeassistant/components/switch_as_x/fan.py
@@ -46,6 +46,7 @@ class FanSwitch(BaseToggleEntity, FanEntity):
     """Represents a Switch as a Fan."""
 
     _attr_supported_features = FanEntityFeature.TURN_OFF | FanEntityFeature.TURN_ON
+    _enable_turn_on_off_backwards_compatibility = False
 
     @property
     def is_on(self) -> bool | None:

--- a/homeassistant/components/tasmota/fan.py
+++ b/homeassistant/components/tasmota/fan.py
@@ -72,6 +72,7 @@ class TasmotaFan(
     )
     _fan_speed = tasmota_const.FAN_SPEED_MEDIUM
     _tasmota_entity: tasmota_fan.TasmotaFan
+    _enable_turn_on_off_backwards_compatibility = False
 
     def __init__(self, **kwds: Any) -> None:
         """Initialize the Tasmota fan."""

--- a/homeassistant/components/template/fan.py
+++ b/homeassistant/components/template/fan.py
@@ -124,6 +124,7 @@ class TemplateFan(TemplateEntity, FanEntity):
     """A template fan component."""
 
     _attr_should_poll = False
+    _enable_turn_on_off_backwards_compatibility = False
 
     def __init__(
         self,

--- a/homeassistant/components/tolo/fan.py
+++ b/homeassistant/components/tolo/fan.py
@@ -29,6 +29,7 @@ class ToloFan(ToloSaunaCoordinatorEntity, FanEntity):
 
     _attr_translation_key = "fan"
     _attr_supported_features = FanEntityFeature.TURN_OFF | FanEntityFeature.TURN_ON
+    _enable_turn_on_off_backwards_compatibility = False
 
     def __init__(
         self, coordinator: ToloSaunaUpdateCoordinator, entry: ConfigEntry

--- a/homeassistant/components/tplink/fan.py
+++ b/homeassistant/components/tplink/fan.py
@@ -64,6 +64,7 @@ class TPLinkFanEntity(CoordinatedTPLinkEntity, FanEntity):
         | FanEntityFeature.TURN_OFF
         | FanEntityFeature.TURN_ON
     )
+    _enable_turn_on_off_backwards_compatibility = False
 
     def __init__(
         self,

--- a/homeassistant/components/tradfri/fan.py
+++ b/homeassistant/components/tradfri/fan.py
@@ -69,6 +69,7 @@ class TradfriAirPurifierFan(TradfriBaseEntity, FanEntity):
     # ... with step size 1
     # 50 = Max
     _attr_speed_count = ATTR_MAX_FAN_STEPS
+    _enable_turn_on_off_backwards_compatibility = False
 
     def __init__(
         self,

--- a/homeassistant/components/tuya/fan.py
+++ b/homeassistant/components/tuya/fan.py
@@ -66,6 +66,7 @@ class TuyaFanEntity(TuyaEntity, FanEntity):
     _speeds: EnumTypeData | None = None
     _switch: DPCode | None = None
     _attr_name = None
+    _enable_turn_on_off_backwards_compatibility = False
 
     def __init__(
         self,

--- a/homeassistant/components/update/__init__.py
+++ b/homeassistant/components/update/__init__.py
@@ -136,7 +136,7 @@ async def async_install(entity: UpdateEntity, service_call: ServiceCall) -> None
     # If version is specified, but not supported by the entity.
     if (
         version is not None
-        and UpdateEntityFeature.SPECIFIC_VERSION not in entity.supported_features
+        and UpdateEntityFeature.SPECIFIC_VERSION not in entity.supported_features_compat
     ):
         raise HomeAssistantError(
             f"Installing a specific version is not supported for {entity.entity_id}"
@@ -145,7 +145,7 @@ async def async_install(entity: UpdateEntity, service_call: ServiceCall) -> None
     # If backup is requested, but not supported by the entity.
     if (
         backup := service_call.data[ATTR_BACKUP]
-    ) and UpdateEntityFeature.BACKUP not in entity.supported_features:
+    ) and UpdateEntityFeature.BACKUP not in entity.supported_features_compat:
         raise HomeAssistantError(f"Backup is not supported for {entity.entity_id}")
 
     # Update is already in progress.
@@ -279,7 +279,7 @@ class UpdateEntity(
             return self._attr_entity_category
         if hasattr(self, "entity_description"):
             return self.entity_description.entity_category
-        if UpdateEntityFeature.INSTALL in self.supported_features:
+        if UpdateEntityFeature.INSTALL in self.supported_features_compat:
             return EntityCategory.CONFIG
         return EntityCategory.DIAGNOSTIC
 
@@ -336,6 +336,19 @@ class UpdateEntity(
         versus the title of the software installed.
         """
         return self._attr_title
+
+    @property
+    def supported_features_compat(self) -> UpdateEntityFeature:
+        """Return the supported features as UpdateEntityFeature.
+
+        Remove this compatibility shim in 2025.1 or later.
+        """
+        features = self.supported_features
+        if type(features) is int:  # noqa: E721
+            new_features = UpdateEntityFeature(features)
+            self._report_deprecated_supported_features_values(new_features)
+            return new_features
+        return features
 
     @cached_property
     def update_percentage(self) -> int | float | None:
@@ -438,7 +451,7 @@ class UpdateEntity(
 
         # If entity supports progress, return the in_progress value.
         # Otherwise, we use the internal progress value.
-        if UpdateEntityFeature.PROGRESS in self.supported_features:
+        if UpdateEntityFeature.PROGRESS in self.supported_features_compat:
             in_progress = self.in_progress
             update_percentage = self.update_percentage if in_progress else None
             if type(in_progress) is not bool and isinstance(in_progress, int):
@@ -481,7 +494,7 @@ class UpdateEntity(
         Handles setting the in_progress state in case the entity doesn't
         support it natively.
         """
-        if UpdateEntityFeature.PROGRESS not in self.supported_features:
+        if UpdateEntityFeature.PROGRESS not in self.supported_features_compat:
             self.__in_progress = True
             self.async_write_ha_state()
 
@@ -526,7 +539,7 @@ async def websocket_release_notes(
         )
         return
 
-    if UpdateEntityFeature.RELEASE_NOTES not in entity.supported_features:
+    if UpdateEntityFeature.RELEASE_NOTES not in entity.supported_features_compat:
         connection.send_error(
             msg["id"],
             websocket_api.ERR_NOT_SUPPORTED,

--- a/homeassistant/components/vacuum/__init__.py
+++ b/homeassistant/components/vacuum/__init__.py
@@ -312,7 +312,7 @@ class StateVacuumEntity(
     @property
     def capability_attributes(self) -> dict[str, Any] | None:
         """Return capability attributes."""
-        if VacuumEntityFeature.FAN_SPEED in self.supported_features:
+        if VacuumEntityFeature.FAN_SPEED in self.supported_features_compat:
             return {ATTR_FAN_SPEED_LIST: self.fan_speed_list}
         return None
 
@@ -330,7 +330,7 @@ class StateVacuumEntity(
     def state_attributes(self) -> dict[str, Any]:
         """Return the state attributes of the vacuum cleaner."""
         data: dict[str, Any] = {}
-        supported_features = self.supported_features
+        supported_features = self.supported_features_compat
 
         if VacuumEntityFeature.BATTERY in supported_features:
             data[ATTR_BATTERY_LEVEL] = self.battery_level
@@ -368,6 +368,19 @@ class StateVacuumEntity(
     def supported_features(self) -> VacuumEntityFeature:
         """Flag vacuum cleaner features that are supported."""
         return self._attr_supported_features
+
+    @property
+    def supported_features_compat(self) -> VacuumEntityFeature:
+        """Return the supported features as VacuumEntityFeature.
+
+        Remove this compatibility shim in 2025.1 or later.
+        """
+        features = self.supported_features
+        if type(features) is int:  # noqa: E721
+            new_features = VacuumEntityFeature(features)
+            self._report_deprecated_supported_features_values(new_features)
+            return new_features
+        return features
 
     def stop(self, **kwargs: Any) -> None:
         """Stop the vacuum cleaner."""

--- a/homeassistant/components/vallox/fan.py
+++ b/homeassistant/components/vallox/fan.py
@@ -83,6 +83,7 @@ class ValloxFanEntity(ValloxEntity, FanEntity):
         | FanEntityFeature.TURN_OFF
         | FanEntityFeature.TURN_ON
     )
+    _enable_turn_on_off_backwards_compatibility = False
 
     def __init__(
         self,

--- a/homeassistant/components/vesync/fan.py
+++ b/homeassistant/components/vesync/fan.py
@@ -111,6 +111,7 @@ class VeSyncFanHA(VeSyncBaseEntity, FanEntity):
     )
     _attr_name = None
     _attr_translation_key = "vesync"
+    _enable_turn_on_off_backwards_compatibility = False
 
     def __init__(
         self, fan: VeSyncBaseDevice, coordinator: VeSyncDataCoordinator

--- a/homeassistant/components/vicare/fan.py
+++ b/homeassistant/components/vicare/fan.py
@@ -120,6 +120,7 @@ class ViCareFan(ViCareEntity, FanEntity):
     _attr_speed_count = len(ORDERED_NAMED_FAN_SPEEDS)
     _attr_supported_features = FanEntityFeature.SET_SPEED
     _attr_translation_key = "ventilation"
+    _enable_turn_on_off_backwards_compatibility = False
 
     def __init__(
         self,

--- a/homeassistant/components/wemo/fan.py
+++ b/homeassistant/components/wemo/fan.py
@@ -81,6 +81,7 @@ class WemoHumidifier(WemoBinaryStateEntity, FanEntity):
     )
     wemo: Humidifier
     _last_fan_on_mode: FanMode
+    _enable_turn_on_off_backwards_compatibility = False
 
     def __init__(self, coordinator: DeviceCoordinator) -> None:
         """Initialize the WeMo switch."""

--- a/homeassistant/components/wilight/fan.py
+++ b/homeassistant/components/wilight/fan.py
@@ -64,6 +64,7 @@ class WiLightFan(WiLightDevice, FanEntity):
         | FanEntityFeature.TURN_ON
         | FanEntityFeature.TURN_OFF
     )
+    _enable_turn_on_off_backwards_compatibility = False
 
     def __init__(self, api_device: PyWiLightDevice, index: str, item_name: str) -> None:
         """Initialize the device."""

--- a/homeassistant/components/xiaomi_miio/fan.py
+++ b/homeassistant/components/xiaomi_miio/fan.py
@@ -300,6 +300,7 @@ class XiaomiGenericDevice(XiaomiCoordinatedMiioEntity, FanEntity):
     """Representation of a generic Xiaomi device."""
 
     _attr_name = None
+    _enable_turn_on_off_backwards_compatibility = False
 
     def __init__(self, device, entry, unique_id, coordinator):
         """Initialize the generic Xiaomi device."""

--- a/homeassistant/components/zha/fan.py
+++ b/homeassistant/components/zha/fan.py
@@ -47,6 +47,7 @@ class ZhaFan(FanEntity, ZHAEntity):
     """Representation of a ZHA fan."""
 
     _attr_translation_key: str = "fan"
+    _enable_turn_on_off_backwards_compatibility = False
 
     def __init__(self, entity_data: EntityData) -> None:
         """Initialize the ZHA fan."""

--- a/homeassistant/components/zwave_js/fan.py
+++ b/homeassistant/components/zwave_js/fan.py
@@ -83,6 +83,7 @@ class ZwaveFan(ZWaveBaseEntity, FanEntity):
         | FanEntityFeature.TURN_OFF
         | FanEntityFeature.TURN_ON
     )
+    _enable_turn_on_off_backwards_compatibility = False
 
     def __init__(
         self, config_entry: ConfigEntry, driver: Driver, info: ZwaveDiscoveryInfo

--- a/homeassistant/components/zwave_me/fan.py
+++ b/homeassistant/components/zwave_me/fan.py
@@ -49,6 +49,7 @@ class ZWaveMeFan(ZWaveMeEntity, FanEntity):
         | FanEntityFeature.TURN_OFF
         | FanEntityFeature.TURN_ON
     )
+    _enable_turn_on_off_backwards_compatibility = False
 
     @property
     def percentage(self) -> int:

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -7,7 +7,7 @@ import asyncio
 from collections import deque
 from collections.abc import Callable, Coroutine, Iterable, Mapping
 import dataclasses
-from enum import Enum, auto
+from enum import Enum, IntFlag, auto
 import functools as ft
 import logging
 import math
@@ -1637,6 +1637,31 @@ class Entity(
         platform_name = self.platform.platform_name if self.platform else None
         return async_suggest_report_issue(
             self.hass, integration_domain=platform_name, module=type(self).__module__
+        )
+
+    @callback
+    def _report_deprecated_supported_features_values(
+        self, replacement: IntFlag
+    ) -> None:
+        """Report deprecated supported features values."""
+        if self._deprecated_supported_features_reported is True:
+            return
+        self._deprecated_supported_features_reported = True
+        report_issue = self._suggest_report_issue()
+        report_issue += (
+            " and reference "
+            "https://developers.home-assistant.io/blog/2023/12/28/support-feature-magic-numbers-deprecation"
+        )
+        _LOGGER.warning(
+            (
+                "Entity %s (%s) is using deprecated supported features"
+                " values which will be removed in HA Core 2025.1. Instead it should use"
+                " %s, please %s"
+            ),
+            self.entity_id,
+            type(self),
+            repr(replacement),
+            report_issue,
         )
 
 

--- a/tests/components/alarm_control_panel/test_init.py
+++ b/tests/components/alarm_control_panel/test_init.py
@@ -54,6 +54,29 @@ async def help_test_async_alarm_control_panel_service(
     await hass.async_block_till_done()
 
 
+def test_deprecated_supported_features_ints(caplog: pytest.LogCaptureFixture) -> None:
+    """Test deprecated supported features ints."""
+
+    class MockAlarmControlPanelEntity(alarm_control_panel.AlarmControlPanelEntity):
+        _attr_supported_features = 1
+
+    entity = MockAlarmControlPanelEntity()
+    assert (
+        entity.supported_features
+        is alarm_control_panel.AlarmControlPanelEntityFeature(1)
+    )
+    assert "MockAlarmControlPanelEntity" in caplog.text
+    assert "is using deprecated supported features values" in caplog.text
+    assert "Instead it should use" in caplog.text
+    assert "AlarmControlPanelEntityFeature.ARM_HOME" in caplog.text
+    caplog.clear()
+    assert (
+        entity.supported_features
+        is alarm_control_panel.AlarmControlPanelEntityFeature(1)
+    )
+    assert "is using deprecated supported features values" not in caplog.text
+
+
 async def test_set_mock_alarm_control_panel_options(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,

--- a/tests/components/camera/test_init.py
+++ b/tests/components/camera/test_init.py
@@ -826,6 +826,26 @@ def test_deprecated_state_constants(
     import_and_test_deprecated_constant_enum(caplog, module, enum, "STATE_", "2025.10")
 
 
+def test_deprecated_supported_features_ints(caplog: pytest.LogCaptureFixture) -> None:
+    """Test deprecated supported features ints."""
+
+    class MockCamera(camera.Camera):
+        @property
+        def supported_features(self) -> int:
+            """Return supported features."""
+            return 1
+
+    entity = MockCamera()
+    assert entity.supported_features_compat is camera.CameraEntityFeature(1)
+    assert "MockCamera" in caplog.text
+    assert "is using deprecated supported features values" in caplog.text
+    assert "Instead it should use" in caplog.text
+    assert "CameraEntityFeature.ON_OFF" in caplog.text
+    caplog.clear()
+    assert entity.supported_features_compat is camera.CameraEntityFeature(1)
+    assert "is using deprecated supported features values" not in caplog.text
+
+
 @pytest.mark.usefixtures("mock_camera")
 async def test_entity_picture_url_changes_on_token_update(hass: HomeAssistant) -> None:
     """Test the token is rotated and entity entity picture cache is cleared."""

--- a/tests/components/cover/test_init.py
+++ b/tests/components/cover/test_init.py
@@ -2,6 +2,8 @@
 
 from enum import Enum
 
+import pytest
+
 from homeassistant.components import cover
 from homeassistant.components.cover import CoverState
 from homeassistant.const import ATTR_ENTITY_ID, CONF_PLATFORM, SERVICE_TOGGLE
@@ -153,3 +155,20 @@ def _create_tuples(enum: type[Enum], constant_prefix: str) -> list[tuple[Enum, s
 def test_all() -> None:
     """Test module.__all__ is correctly set."""
     help_test_all(cover)
+
+
+def test_deprecated_supported_features_ints(caplog: pytest.LogCaptureFixture) -> None:
+    """Test deprecated supported features ints."""
+
+    class MockCoverEntity(cover.CoverEntity):
+        _attr_supported_features = 1
+
+    entity = MockCoverEntity()
+    assert entity.supported_features is cover.CoverEntityFeature(1)
+    assert "MockCoverEntity" in caplog.text
+    assert "is using deprecated supported features values" in caplog.text
+    assert "Instead it should use" in caplog.text
+    assert "CoverEntityFeature.OPEN" in caplog.text
+    caplog.clear()
+    assert entity.supported_features is cover.CoverEntityFeature(1)
+    assert "is using deprecated supported features values" not in caplog.text

--- a/tests/components/fan/test_init.py
+++ b/tests/components/fan/test_init.py
@@ -1,5 +1,7 @@
 """Tests for fan platforms."""
 
+from unittest.mock import patch
+
 import pytest
 
 from homeassistant.components.fan import (
@@ -11,13 +13,23 @@ from homeassistant.components.fan import (
     FanEntityFeature,
     NotValidPresetModeError,
 )
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import SERVICE_TURN_OFF, SERVICE_TURN_ON
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 import homeassistant.helpers.entity_registry as er
 from homeassistant.setup import async_setup_component
 
 from .common import MockFan
 
-from tests.common import setup_test_component_platform
+from tests.common import (
+    MockConfigEntry,
+    MockModule,
+    MockPlatform,
+    mock_integration,
+    mock_platform,
+    setup_test_component_platform,
+)
 
 
 class BaseFan(FanEntity):
@@ -149,3 +161,300 @@ async def test_preset_mode_validation(
     with pytest.raises(NotValidPresetModeError) as exc:
         await test_fan._valid_preset_mode_or_raise("invalid")
     assert exc.value.translation_key == "not_valid_preset_mode"
+
+
+def test_deprecated_supported_features_ints(caplog: pytest.LogCaptureFixture) -> None:
+    """Test deprecated supported features ints."""
+
+    class MockFan(FanEntity):
+        @property
+        def supported_features(self) -> int:
+            """Return supported features."""
+            return 1
+
+    entity = MockFan()
+    assert entity.supported_features is FanEntityFeature(1)
+    assert "MockFan" in caplog.text
+    assert "is using deprecated supported features values" in caplog.text
+    assert "Instead it should use" in caplog.text
+    assert "FanEntityFeature.SET_SPEED" in caplog.text
+    caplog.clear()
+    assert entity.supported_features is FanEntityFeature(1)
+    assert "is using deprecated supported features values" not in caplog.text
+
+
+async def test_warning_not_implemented_turn_on_off_feature(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, config_flow_fixture: None
+) -> None:
+    """Test adding feature flag and warn if missing when methods are set."""
+
+    called = []
+
+    class MockFanEntityTest(MockFan):
+        """Mock Fan device."""
+
+        def turn_on(
+            self,
+            percentage: int | None = None,
+            preset_mode: str | None = None,
+        ) -> None:
+            """Turn on."""
+            called.append("turn_on")
+
+        def turn_off(self) -> None:
+            """Turn off."""
+            called.append("turn_off")
+
+    async def async_setup_entry_init(
+        hass: HomeAssistant, config_entry: ConfigEntry
+    ) -> bool:
+        """Set up test config entry."""
+        await hass.config_entries.async_forward_entry_setups(config_entry, [DOMAIN])
+        return True
+
+    async def async_setup_entry_fan_platform(
+        hass: HomeAssistant,
+        config_entry: ConfigEntry,
+        async_add_entities: AddEntitiesCallback,
+    ) -> None:
+        """Set up test fan platform via config entry."""
+        async_add_entities([MockFanEntityTest(name="test", entity_id="fan.test")])
+
+    mock_integration(
+        hass,
+        MockModule(
+            "test",
+            async_setup_entry=async_setup_entry_init,
+        ),
+        built_in=False,
+    )
+    mock_platform(
+        hass,
+        "test.fan",
+        MockPlatform(async_setup_entry=async_setup_entry_fan_platform),
+    )
+
+    with patch.object(
+        MockFanEntityTest, "__module__", "tests.custom_components.fan.test_init"
+    ):
+        config_entry = MockConfigEntry(domain="test")
+        config_entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    state = hass.states.get("fan.test")
+    assert state is not None
+
+    assert (
+        "Entity fan.test (<class 'tests.custom_components.fan.test_init.test_warning_not_implemented_turn_on_off_feature.<locals>.MockFanEntityTest'>) "
+        "does not set FanEntityFeature.TURN_OFF but implements the turn_off method. Please report it to the author of the 'test' custom integration"
+        in caplog.text
+    )
+    assert (
+        "Entity fan.test (<class 'tests.custom_components.fan.test_init.test_warning_not_implemented_turn_on_off_feature.<locals>.MockFanEntityTest'>) "
+        "does not set FanEntityFeature.TURN_ON but implements the turn_on method. Please report it to the author of the 'test' custom integration"
+        in caplog.text
+    )
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_TURN_ON,
+        {
+            "entity_id": "fan.test",
+        },
+        blocking=True,
+    )
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_TURN_OFF,
+        {
+            "entity_id": "fan.test",
+        },
+        blocking=True,
+    )
+
+    assert len(called) == 2
+    assert "turn_on" in called
+    assert "turn_off" in called
+
+
+async def test_no_warning_implemented_turn_on_off_feature(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, config_flow_fixture: None
+) -> None:
+    """Test no warning when feature flags are set."""
+
+    class MockFanEntityTest(MockFan):
+        """Mock Fan device."""
+
+        _attr_supported_features = (
+            FanEntityFeature.DIRECTION
+            | FanEntityFeature.OSCILLATE
+            | FanEntityFeature.SET_SPEED
+            | FanEntityFeature.PRESET_MODE
+            | FanEntityFeature.TURN_OFF
+            | FanEntityFeature.TURN_ON
+        )
+
+    async def async_setup_entry_init(
+        hass: HomeAssistant, config_entry: ConfigEntry
+    ) -> bool:
+        """Set up test config entry."""
+        await hass.config_entries.async_forward_entry_setups(config_entry, [DOMAIN])
+        return True
+
+    async def async_setup_entry_fan_platform(
+        hass: HomeAssistant,
+        config_entry: ConfigEntry,
+        async_add_entities: AddEntitiesCallback,
+    ) -> None:
+        """Set up test fan platform via config entry."""
+        async_add_entities([MockFanEntityTest(name="test", entity_id="fan.test")])
+
+    mock_integration(
+        hass,
+        MockModule(
+            "test",
+            async_setup_entry=async_setup_entry_init,
+        ),
+        built_in=False,
+    )
+    mock_platform(
+        hass,
+        "test.fan",
+        MockPlatform(async_setup_entry=async_setup_entry_fan_platform),
+    )
+
+    with patch.object(
+        MockFanEntityTest, "__module__", "tests.custom_components.fan.test_init"
+    ):
+        config_entry = MockConfigEntry(domain="test")
+        config_entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    state = hass.states.get("fan.test")
+    assert state is not None
+
+    assert "does not set FanEntityFeature.TURN_OFF" not in caplog.text
+    assert "does not set FanEntityFeature.TURN_ON" not in caplog.text
+
+
+async def test_no_warning_integration_has_migrated(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, config_flow_fixture: None
+) -> None:
+    """Test no warning when integration migrated using `_enable_turn_on_off_backwards_compatibility`."""
+
+    class MockFanEntityTest(MockFan):
+        """Mock Fan device."""
+
+        _enable_turn_on_off_backwards_compatibility = False
+        _attr_supported_features = (
+            FanEntityFeature.DIRECTION
+            | FanEntityFeature.OSCILLATE
+            | FanEntityFeature.SET_SPEED
+            | FanEntityFeature.PRESET_MODE
+        )
+
+    async def async_setup_entry_init(
+        hass: HomeAssistant, config_entry: ConfigEntry
+    ) -> bool:
+        """Set up test config entry."""
+        await hass.config_entries.async_forward_entry_setups(config_entry, [DOMAIN])
+        return True
+
+    async def async_setup_entry_fan_platform(
+        hass: HomeAssistant,
+        config_entry: ConfigEntry,
+        async_add_entities: AddEntitiesCallback,
+    ) -> None:
+        """Set up test fan platform via config entry."""
+        async_add_entities([MockFanEntityTest(name="test", entity_id="fan.test")])
+
+    mock_integration(
+        hass,
+        MockModule(
+            "test",
+            async_setup_entry=async_setup_entry_init,
+        ),
+        built_in=False,
+    )
+    mock_platform(
+        hass,
+        "test.fan",
+        MockPlatform(async_setup_entry=async_setup_entry_fan_platform),
+    )
+
+    with patch.object(
+        MockFanEntityTest, "__module__", "tests.custom_components.fan.test_init"
+    ):
+        config_entry = MockConfigEntry(domain="test")
+        config_entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    state = hass.states.get("fan.test")
+    assert state is not None
+
+    assert "does not set FanEntityFeature.TURN_OFF" not in caplog.text
+    assert "does not set FanEntityFeature.TURN_ON" not in caplog.text
+
+
+async def test_no_warning_integration_implement_feature_flags(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, config_flow_fixture: None
+) -> None:
+    """Test no warning when integration uses the correct feature flags."""
+
+    class MockFanEntityTest(MockFan):
+        """Mock Fan device."""
+
+        _attr_supported_features = (
+            FanEntityFeature.DIRECTION
+            | FanEntityFeature.OSCILLATE
+            | FanEntityFeature.SET_SPEED
+            | FanEntityFeature.PRESET_MODE
+            | FanEntityFeature.TURN_OFF
+            | FanEntityFeature.TURN_ON
+        )
+
+    async def async_setup_entry_init(
+        hass: HomeAssistant, config_entry: ConfigEntry
+    ) -> bool:
+        """Set up test config entry."""
+        await hass.config_entries.async_forward_entry_setups(config_entry, [DOMAIN])
+        return True
+
+    async def async_setup_entry_fan_platform(
+        hass: HomeAssistant,
+        config_entry: ConfigEntry,
+        async_add_entities: AddEntitiesCallback,
+    ) -> None:
+        """Set up test fan platform via config entry."""
+        async_add_entities([MockFanEntityTest(name="test", entity_id="fan.test")])
+
+    mock_integration(
+        hass,
+        MockModule(
+            "test",
+            async_setup_entry=async_setup_entry_init,
+        ),
+        built_in=False,
+    )
+    mock_platform(
+        hass,
+        "test.fan",
+        MockPlatform(async_setup_entry=async_setup_entry_fan_platform),
+    )
+
+    with patch.object(
+        MockFanEntityTest, "__module__", "tests.custom_components.fan.test_init"
+    ):
+        config_entry = MockConfigEntry(domain="test")
+        config_entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    state = hass.states.get("fan.test")
+    assert state is not None
+
+    assert "does not set FanEntityFeature.TURN_OFF" not in caplog.text
+    assert "does not set FanEntityFeature.TURN_ON" not in caplog.text

--- a/tests/components/humidifier/test_init.py
+++ b/tests/components/humidifier/test_init.py
@@ -6,6 +6,7 @@ import pytest
 
 from homeassistant.components.humidifier import (
     ATTR_HUMIDITY,
+    ATTR_MODE,
     DOMAIN as HUMIDIFIER_DOMAIN,
     MODE_ECO,
     MODE_NORMAL,
@@ -48,6 +49,30 @@ async def test_sync_turn_off(hass: HomeAssistant) -> None:
     await humidifier.async_turn_off()
 
     assert humidifier.turn_off.called
+
+
+def test_deprecated_supported_features_ints(caplog: pytest.LogCaptureFixture) -> None:
+    """Test deprecated supported features ints."""
+
+    class MockHumidifierEntity(HumidifierEntity):
+        _attr_mode = "mode1"
+
+        @property
+        def supported_features(self) -> int:
+            """Return supported features."""
+            return 1
+
+    entity = MockHumidifierEntity()
+    assert entity.supported_features_compat is HumidifierEntityFeature(1)
+    assert "MockHumidifierEntity" in caplog.text
+    assert "is using deprecated supported features values" in caplog.text
+    assert "Instead it should use" in caplog.text
+    assert "HumidifierEntityFeature.MODES" in caplog.text
+    caplog.clear()
+    assert entity.supported_features_compat is HumidifierEntityFeature(1)
+    assert "is using deprecated supported features values" not in caplog.text
+
+    assert entity.state_attributes[ATTR_MODE] == "mode1"
 
 
 async def test_humidity_validation(

--- a/tests/components/lock/test_init.py
+++ b/tests/components/lock/test_init.py
@@ -417,3 +417,20 @@ def test_deprecated_constants(
     import_and_test_deprecated_constant_enum(
         caplog, lock, enum, constant_prefix, remove_in_version
     )
+
+
+def test_deprecated_supported_features_ints(caplog: pytest.LogCaptureFixture) -> None:
+    """Test deprecated supported features ints."""
+
+    class MockLockEntity(lock.LockEntity):
+        _attr_supported_features = 1
+
+    entity = MockLockEntity()
+    assert entity.supported_features is lock.LockEntityFeature(1)
+    assert "MockLockEntity" in caplog.text
+    assert "is using deprecated supported features values" in caplog.text
+    assert "Instead it should use" in caplog.text
+    assert "LockEntityFeature.OPEN" in caplog.text
+    caplog.clear()
+    assert entity.supported_features is lock.LockEntityFeature(1)
+    assert "is using deprecated supported features values" not in caplog.text

--- a/tests/components/media_player/test_init.py
+++ b/tests/components/media_player/test_init.py
@@ -129,7 +129,7 @@ def test_support_properties(property_suffix: str) -> None:
     entity3 = MediaPlayerEntity()
     entity3._attr_supported_features = feature
     entity4 = MediaPlayerEntity()
-    entity4._attr_supported_features = all_features & ~feature
+    entity4._attr_supported_features = all_features - feature
 
     assert getattr(entity1, f"support_{property_suffix}") is False
     assert getattr(entity2, f"support_{property_suffix}") is True
@@ -447,3 +447,23 @@ async def test_get_async_get_browse_image_quoting(
         url = player.get_browse_image_url("album", media_content_id)
         await client.get(url)
         mock_browse_image.assert_called_with("album", media_content_id, None)
+
+
+def test_deprecated_supported_features_ints(caplog: pytest.LogCaptureFixture) -> None:
+    """Test deprecated supported features ints."""
+
+    class MockMediaPlayerEntity(MediaPlayerEntity):
+        @property
+        def supported_features(self) -> int:
+            """Return supported features."""
+            return 1
+
+    entity = MockMediaPlayerEntity()
+    assert entity.supported_features_compat is MediaPlayerEntityFeature(1)
+    assert "MockMediaPlayerEntity" in caplog.text
+    assert "is using deprecated supported features values" in caplog.text
+    assert "Instead it should use" in caplog.text
+    assert "MediaPlayerEntityFeature.PAUSE" in caplog.text
+    caplog.clear()
+    assert entity.supported_features_compat is MediaPlayerEntityFeature(1)
+    assert "is using deprecated supported features values" not in caplog.text

--- a/tests/components/remote/test_init.py
+++ b/tests/components/remote/test_init.py
@@ -1,5 +1,7 @@
 """The tests for the Remote component, adapted from Light Test."""
 
+import pytest
+
 from homeassistant.components import remote
 from homeassistant.components.remote import (
     ATTR_ALTERNATIVE,
@@ -140,3 +142,23 @@ async def test_delete_command(hass: HomeAssistant) -> None:
     assert call.domain == remote.DOMAIN
     assert call.service == SERVICE_DELETE_COMMAND
     assert call.data[ATTR_ENTITY_ID] == ENTITY_ID
+
+
+def test_deprecated_supported_features_ints(caplog: pytest.LogCaptureFixture) -> None:
+    """Test deprecated supported features ints."""
+
+    class MockRemote(remote.RemoteEntity):
+        @property
+        def supported_features(self) -> int:
+            """Return supported features."""
+            return 1
+
+    entity = MockRemote()
+    assert entity.supported_features_compat is remote.RemoteEntityFeature(1)
+    assert "MockRemote" in caplog.text
+    assert "is using deprecated supported features values" in caplog.text
+    assert "Instead it should use" in caplog.text
+    assert "RemoteEntityFeature.LEARN_COMMAND" in caplog.text
+    caplog.clear()
+    assert entity.supported_features_compat is remote.RemoteEntityFeature(1)
+    assert "is using deprecated supported features values" not in caplog.text

--- a/tests/components/siren/test_init.py
+++ b/tests/components/siren/test_init.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from homeassistant.components import siren
 from homeassistant.components.siren import (
     SirenEntity,
     SirenEntityDescription,
@@ -105,3 +106,20 @@ async def test_missing_tones_dict(hass: HomeAssistant) -> None:
     siren.hass = hass
     with pytest.raises(ValueError):
         process_turn_on_params(siren, {"tone": 3})
+
+
+def test_deprecated_supported_features_ints(caplog: pytest.LogCaptureFixture) -> None:
+    """Test deprecated supported features ints."""
+
+    class MockSirenEntity(siren.SirenEntity):
+        _attr_supported_features = 1
+
+    entity = MockSirenEntity()
+    assert entity.supported_features is siren.SirenEntityFeature(1)
+    assert "MockSirenEntity" in caplog.text
+    assert "is using deprecated supported features values" in caplog.text
+    assert "Instead it should use" in caplog.text
+    assert "SirenEntityFeature.TURN_ON" in caplog.text
+    caplog.clear()
+    assert entity.supported_features is siren.SirenEntityFeature(1)
+    assert "is using deprecated supported features values" not in caplog.text

--- a/tests/components/update/test_init.py
+++ b/tests/components/update/test_init.py
@@ -896,6 +896,98 @@ async def test_name(hass: HomeAssistant) -> None:
     assert expected.items() <= state.attributes.items()
 
 
+def test_deprecated_supported_features_ints(caplog: pytest.LogCaptureFixture) -> None:
+    """Test deprecated supported features ints."""
+
+    class MockUpdateEntity(UpdateEntity):
+        @property
+        def supported_features(self) -> int:
+            """Return supported features."""
+            return 1
+
+    entity = MockUpdateEntity()
+    assert entity.supported_features_compat is UpdateEntityFeature(1)
+    assert "MockUpdateEntity" in caplog.text
+    assert "is using deprecated supported features values" in caplog.text
+    assert "Instead it should use" in caplog.text
+    assert "UpdateEntityFeature.INSTALL" in caplog.text
+    caplog.clear()
+    assert entity.supported_features_compat is UpdateEntityFeature(1)
+    assert "is using deprecated supported features values" not in caplog.text
+
+
+async def test_deprecated_supported_features_ints_with_service_call(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test deprecated supported features ints with install service."""
+
+    async def async_setup_entry_init(
+        hass: HomeAssistant, config_entry: ConfigEntry
+    ) -> bool:
+        """Set up test config entry."""
+        await hass.config_entries.async_forward_entry_setups(config_entry, [DOMAIN])
+        return True
+
+    mock_platform(hass, f"{TEST_DOMAIN}.config_flow")
+    mock_integration(
+        hass,
+        MockModule(
+            TEST_DOMAIN,
+            async_setup_entry=async_setup_entry_init,
+        ),
+    )
+
+    class MockUpdateEntity(UpdateEntity):
+        _attr_supported_features = 1 | 2
+
+        def install(self, version: str | None = None, backup: bool = False) -> None:
+            """Install an update."""
+
+    entity = MockUpdateEntity()
+    entity.entity_id = (
+        "update.test_deprecated_supported_features_ints_with_service_call"
+    )
+
+    async def async_setup_entry_platform(
+        hass: HomeAssistant,
+        config_entry: ConfigEntry,
+        async_add_entities: AddEntitiesCallback,
+    ) -> None:
+        """Set up test update platform via config entry."""
+        async_add_entities([entity])
+
+    mock_platform(
+        hass,
+        f"{TEST_DOMAIN}.{DOMAIN}",
+        MockPlatform(async_setup_entry=async_setup_entry_platform),
+    )
+
+    config_entry = MockConfigEntry(domain=TEST_DOMAIN)
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert "is using deprecated supported features values" in caplog.text
+
+    assert isinstance(entity.supported_features, int)
+
+    with pytest.raises(
+        HomeAssistantError,
+        match="Backup is not supported for update.test_deprecated_supported_features_ints_with_service_call",
+    ):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_INSTALL,
+            {
+                ATTR_VERSION: "0.9.9",
+                ATTR_BACKUP: True,
+                ATTR_ENTITY_ID: "update.test_deprecated_supported_features_ints_with_service_call",
+            },
+            blocking=True,
+        )
+
+
 async def test_custom_version_is_newer(hass: HomeAssistant) -> None:
     """Test UpdateEntity with overridden version_is_newer method."""
 
@@ -940,7 +1032,7 @@ async def test_custom_version_is_newer(hass: HomeAssistant) -> None:
     ("supported_features", "extra_expected_attributes"),
     [
         (
-            UpdateEntityFeature(0),
+            0,
             [
                 {},
                 {},

--- a/tests/components/vacuum/test_init.py
+++ b/tests/components/vacuum/test_init.py
@@ -272,6 +272,42 @@ async def test_send_command(hass: HomeAssistant, config_flow_fixture: None) -> N
     assert "test" in strings
 
 
+async def test_supported_features_compat(hass: HomeAssistant) -> None:
+    """Test StateVacuumEntity using deprecated feature constants features."""
+
+    features = (
+        VacuumEntityFeature.BATTERY
+        | VacuumEntityFeature.FAN_SPEED
+        | VacuumEntityFeature.START
+        | VacuumEntityFeature.STOP
+        | VacuumEntityFeature.PAUSE
+    )
+
+    class _LegacyConstantsStateVacuum(StateVacuumEntity):
+        _attr_supported_features = int(features)
+        _attr_fan_speed_list = ["silent", "normal", "pet hair"]
+
+    entity = _LegacyConstantsStateVacuum()
+    assert isinstance(entity.supported_features, int)
+    assert entity.supported_features == int(features)
+    assert entity.supported_features_compat is (
+        VacuumEntityFeature.BATTERY
+        | VacuumEntityFeature.FAN_SPEED
+        | VacuumEntityFeature.START
+        | VacuumEntityFeature.STOP
+        | VacuumEntityFeature.PAUSE
+    )
+    assert entity.state_attributes == {
+        "battery_level": None,
+        "battery_icon": "mdi:battery-unknown",
+        "fan_speed": None,
+    }
+    assert entity.capability_attributes == {
+        "fan_speed_list": ["silent", "normal", "pet hair"]
+    }
+    assert entity._deprecated_supported_features_reported
+
+
 async def test_vacuum_not_log_deprecated_state_warning(
     hass: HomeAssistant,
     mock_vacuum_entity: MockVacuum,

--- a/tests/helpers/test_entity.py
+++ b/tests/helpers/test_entity.py
@@ -4,6 +4,7 @@ import asyncio
 from collections.abc import Iterable
 import dataclasses
 from datetime import timedelta
+from enum import IntFlag
 import logging
 import threading
 from typing import Any
@@ -2483,6 +2484,31 @@ async def test_cached_entity_property_override(hass: HomeAssistant) -> None:
         class EntityWithClassAttribute7(entity.Entity):
             def _attr_attribution(self):
                 return "🤡"
+
+
+async def test_entity_report_deprecated_supported_features_values(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test reporting deprecated supported feature values only happens once."""
+    ent = entity.Entity()
+
+    class MockEntityFeatures(IntFlag):
+        VALUE1 = 1
+        VALUE2 = 2
+
+    ent._report_deprecated_supported_features_values(MockEntityFeatures(2))
+    assert (
+        "is using deprecated supported features values which will be removed"
+        in caplog.text
+    )
+    assert "MockEntityFeatures.VALUE2" in caplog.text
+
+    caplog.clear()
+    ent._report_deprecated_supported_features_values(MockEntityFeatures(2))
+    assert (
+        "is using deprecated supported features values which will be removed"
+        not in caplog.text
+    )
 
 
 async def test_remove_entity_registry(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

While these deprecation cleanups have been correct in general (mostly, except for the error in the media player where constants shouldn't have been removed), it does break custom integrations.

These PR removed support for integers as an supported feature value.

The way our constant deprecation works, is by returning the value of an enum... which are integers. So they unintentionally broke custom integrations using those.

Reverting them as the safe way out, let's see how we can fix our deprecation for the next release. 

This PR reverts the following Pull Requests:

- https://github.com/home-assistant/core/pull/132365
- https://github.com/home-assistant/core/pull/132670
- https://github.com/home-assistant/core/pull/132667
- https://github.com/home-assistant/core/pull/132666
- https://github.com/home-assistant/core/pull/132665
- https://github.com/home-assistant/core/pull/132643
- https://github.com/home-assistant/core/pull/132642
- https://github.com/home-assistant/core/pull/132641
- https://github.com/home-assistant/core/pull/132640
- https://github.com/home-assistant/core/pull/132369
- https://github.com/home-assistant/core/pull/132367
- https://github.com/home-assistant/core/pull/132365

These are combined to make a single PR and a single CI.
The following are not reverted in this PR, because they couldn't be done cleanly; they will have their own dedicated PR:

- https://github.com/home-assistant/core/pull/132668
- https://github.com/home-assistant/core/pull/132371


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
