### PR TITLE
Add quality_scale file to onewire

### DIFF
--- a/homeassistant/components/onewire/quality_scale.yaml
+++ b/homeassistant/components/onewire/quality_scale.yaml
@@ -3,21 +3,15 @@ rules:
   config-flow:
     status: todo
     comment: Under review
-  test-before-configure:
-    status: todo
-    comment: Under review
+  test-before-configure: done
   unique-config-entry:
-    status: todo
-    comment: Under review
+    status: done
+    comment: unique ID is not available, but duplicates are prevented based on host/port
   config-flow-test-coverage:
     status: todo
     comment: Under review
-  runtime-data:
-    status: todo
-    comment: Under review
-  test-before-setup:
-    status: todo
-    comment: Under review
+  runtime-data: done
+  test-before-setup: done
   appropriate-polling:
     status: todo
     comment: Under review

--- a/homeassistant/components/onewire/quality_scale.yaml
+++ b/homeassistant/components/onewire/quality_scale.yaml
@@ -1,7 +1,7 @@
 rules:
   ## Bronze
   config-flow:
-    status: done
+    status: todo
     comment: missing data_description on options flow
   test-before-configure: done
   unique-config-entry:

--- a/homeassistant/components/onewire/quality_scale.yaml
+++ b/homeassistant/components/onewire/quality_scale.yaml
@@ -1,0 +1,164 @@
+rules:
+  ## Bronze
+  config-flow:
+    status: todo
+    comment: Under review
+  test-before-configure:
+    status: todo
+    comment: Under review
+  unique-config-entry:
+    status: todo
+    comment: Under review
+  config-flow-test-coverage:
+    status: todo
+    comment: Under review
+  runtime-data:
+    status: todo
+    comment: Under review
+  test-before-setup:
+    status: todo
+    comment: Under review
+  appropriate-polling:
+    status: todo
+    comment: Under review
+  entity-unique-id:
+    status: todo
+    comment: Under review
+  has-entity-name:
+    status: todo
+    comment: Under review
+  entity-event-setup:
+    status: todo
+    comment: Under review
+  dependency-transparency:
+    status: todo
+    comment: Under review
+  action-setup:
+    status: todo
+    comment: Under review
+  common-modules:
+    status: todo
+    comment: Under review
+  docs-high-level-description:
+    status: todo
+    comment: Under review
+  docs-installation-instructions:
+    status: todo
+    comment: Under review
+  docs-removal-instructions:
+    status: todo
+    comment: Under review
+  docs-actions:
+    status: todo
+    comment: Under review
+  brands:
+    status: todo
+    comment: Under review
+
+  ## Silver
+  config-entry-unloading:
+    status: todo
+    comment: Under review
+  log-when-unavailable:
+    status: todo
+    comment: Under review
+  entity-unavailable:
+    status: todo
+    comment: Under review
+  action-exceptions:
+    status: todo
+    comment: Under review
+  reauthentication-flow:
+    status: todo
+    comment: Under review
+  parallel-updates:
+    status: todo
+    comment: Under review
+  test-coverage:
+    status: todo
+    comment: Under review
+  integration-owner:
+    status: todo
+    comment: Under review
+  docs-installation-parameters:
+    status: todo
+    comment: Under review
+  docs-configuration-parameters:
+    status: todo
+    comment: Under review
+
+  ## Gold
+  entity-translations:
+    status: todo
+    comment: Under review
+  entity-device-class:
+    status: todo
+    comment: Under review
+  devices:
+    status: todo
+    comment: Under review
+  entity-category:
+    status: todo
+    comment: Under review
+  entity-disabled-by-default:
+    status: todo
+    comment: Under review
+  discovery:
+    status: todo
+    comment: Under review
+  stale-devices:
+    status: todo
+    comment: Under review
+  diagnostics:
+    status: todo
+    comment: Under review
+  exception-translations:
+    status: todo
+    comment: Under review
+  icon-translations:
+    status: todo
+    comment: Under review
+  reconfiguration-flow:
+    status: todo
+    comment: Under review
+  dynamic-devices:
+    status: todo
+    comment: Under review
+  discovery-update-info:
+    status: todo
+    comment: Under review
+  repair-issues:
+    status: todo
+    comment: Under review
+  docs-use-cases:
+    status: todo
+    comment: Under review
+  docs-supported-devices:
+    status: todo
+    comment: Under review
+  docs-supported-functions:
+    status: todo
+    comment: Under review
+  docs-data-update:
+    status: todo
+    comment: Under review
+  docs-known-limitations:
+    status: todo
+    comment: Under review
+  docs-troubleshooting:
+    status: todo
+    comment: Under review
+  docs-examples:
+    status: todo
+    comment: Under review
+
+  ## Platinum
+  async-dependency:
+    status: todo
+    comment: Under review
+  inject-websession:
+    status: todo
+    comment: Under review
+  strict-typing:
+    status: todo
+    comment: Under review

--- a/homeassistant/components/onewire/quality_scale.yaml
+++ b/homeassistant/components/onewire/quality_scale.yaml
@@ -70,7 +70,9 @@ rules:
     comment: mDNS should be possible - https://owfs.org/index_php_page_avahi-discovery.html
   stale-devices:
     status: done
-    comment: Manual removal
+    comment: >
+      Manual removal, as it is not possible to distinguish
+      between a flaky device and a device that has been removed
   diagnostics:
     status: todo
     comment: config-entry diagnostics level available, might be nice to have device-level diagnostics

--- a/homeassistant/components/onewire/quality_scale.yaml
+++ b/homeassistant/components/onewire/quality_scale.yaml
@@ -14,25 +14,21 @@ rules:
   test-before-setup: done
   appropriate-polling:
     status: todo
-    comment: Under review
-  entity-unique-id:
-    status: todo
-    comment: Under review
-  has-entity-name:
-    status: todo
-    comment: Under review
+    comment: In progress - see PR 134953
+  entity-unique-id: done
+  has-entity-name: done
   entity-event-setup:
-    status: todo
-    comment: Under review
+    status: exempt
+    comment: entities do not subscribe to events
   dependency-transparency:
     status: todo
-    comment: Under review
+    comment: The package is not built and published inside a CI pipeline
   action-setup:
-    status: todo
-    comment: Under review
+    status: exempt
+    comment: No service actions currently available
   common-modules:
-    status: todo
-    comment: Under review
+    status: done
+    comment: base entity available, but no coordinator
   docs-high-level-description:
     status: todo
     comment: Under review
@@ -45,9 +41,7 @@ rules:
   docs-actions:
     status: todo
     comment: Under review
-  brands:
-    status: todo
-    comment: Under review
+  brands: done
 
   ## Silver
   config-entry-unloading:
@@ -67,7 +61,7 @@ rules:
     comment: Under review
   parallel-updates:
     status: todo
-    comment: Under review
+    comment: In progress - see PR 134953
   test-coverage:
     status: todo
     comment: Under review

--- a/homeassistant/components/onewire/quality_scale.yaml
+++ b/homeassistant/components/onewire/quality_scale.yaml
@@ -1,6 +1,8 @@
 rules:
   ## Bronze
-  config-flow: done
+  config-flow:
+    status: done
+    comment: missing data_description on options flow
   test-before-configure: done
   unique-config-entry:
     status: done

--- a/homeassistant/components/onewire/quality_scale.yaml
+++ b/homeassistant/components/onewire/quality_scale.yaml
@@ -1,8 +1,6 @@
 rules:
   ## Bronze
-  config-flow:
-    status: todo
-    comment: Under review
+  config-flow: done
   test-before-configure: done
   unique-config-entry:
     status: done

--- a/homeassistant/components/onewire/quality_scale.yaml
+++ b/homeassistant/components/onewire/quality_scale.yaml
@@ -7,7 +7,9 @@ rules:
     comment: unique ID is not available, but duplicates are prevented based on host/port
   config-flow-test-coverage:
     status: todo
-    comment: Under review
+    comment: >
+      Let's have test_user_options_empty_selection end in CREATE_ENTRY
+      Split the happy flow and the not happy flow in test_user_flow
   runtime-data: done
   test-before-setup: done
   appropriate-polling: done

--- a/homeassistant/components/onewire/quality_scale.yaml
+++ b/homeassistant/components/onewire/quality_scale.yaml
@@ -82,9 +82,7 @@ rules:
   icon-translations:
     status: exempt
     comment: It doesn't make sense to override defaults
-  reconfiguration-flow:
-    status: todo
-    comment: see PR 134996
+  reconfiguration-flow: done
   dynamic-devices:
     status: todo
     comment: Not yet implemented

--- a/homeassistant/components/onewire/quality_scale.yaml
+++ b/homeassistant/components/onewire/quality_scale.yaml
@@ -133,10 +133,10 @@ rules:
   ## Platinum
   async-dependency:
     status: todo
-    comment: Under review
+    comment: The dependency is not async
   inject-websession:
-    status: todo
-    comment: Under review
+    status: exempt
+    comment: No websession
   strict-typing:
     status: todo
-    comment: Under review
+    comment: The dependency is not typed

--- a/homeassistant/components/onewire/quality_scale.yaml
+++ b/homeassistant/components/onewire/quality_scale.yaml
@@ -44,30 +44,20 @@ rules:
   brands: done
 
   ## Silver
-  config-entry-unloading:
-    status: todo
-    comment: Under review
-  log-when-unavailable:
-    status: todo
-    comment: Under review
-  entity-unavailable:
-    status: todo
-    comment: Under review
+  config-entry-unloading: done
+  log-when-unavailable: done
+  entity-unavailable: done
   action-exceptions:
-    status: todo
-    comment: Under review
+    status: exempt
+    comment: No service actions currently available
   reauthentication-flow:
-    status: todo
-    comment: Under review
+    status: exempt
+    comment: Local polling without authentication
   parallel-updates:
     status: todo
     comment: In progress - see PR 134953
-  test-coverage:
-    status: todo
-    comment: Under review
-  integration-owner:
-    status: todo
-    comment: Under review
+  test-coverage: done
+  integration-owner: done
   docs-installation-parameters:
     status: todo
     comment: Under review

--- a/homeassistant/components/onewire/quality_scale.yaml
+++ b/homeassistant/components/onewire/quality_scale.yaml
@@ -12,9 +12,7 @@ rules:
     comment: Under review
   runtime-data: done
   test-before-setup: done
-  appropriate-polling:
-    status: todo
-    comment: In progress - see PR 134953
+  appropriate-polling: done
   entity-unique-id: done
   has-entity-name: done
   entity-event-setup:
@@ -53,9 +51,7 @@ rules:
   reauthentication-flow:
     status: exempt
     comment: Local polling without authentication
-  parallel-updates:
-    status: todo
-    comment: In progress - see PR 134953
+  parallel-updates: done
   test-coverage: done
   integration-owner: done
   docs-installation-parameters:

--- a/homeassistant/components/onewire/quality_scale.yaml
+++ b/homeassistant/components/onewire/quality_scale.yaml
@@ -84,7 +84,7 @@ rules:
     comment: It doesn't make sense to override defaults
   reconfiguration-flow:
     status: todo
-    comment: Not yet implemented
+    comment: see PR 134996
   dynamic-devices:
     status: todo
     comment: Not yet implemented

--- a/homeassistant/components/onewire/quality_scale.yaml
+++ b/homeassistant/components/onewire/quality_scale.yaml
@@ -66,48 +66,38 @@ rules:
     comment: Under review
 
   ## Gold
-  entity-translations:
-    status: todo
-    comment: Under review
-  entity-device-class:
-    status: todo
-    comment: Under review
-  devices:
-    status: todo
-    comment: Under review
-  entity-category:
-    status: todo
-    comment: Under review
-  entity-disabled-by-default:
-    status: todo
-    comment: Under review
+  entity-translations: done
+  entity-device-class: done
+  devices: done
+  entity-category: done
+  entity-disabled-by-default: done
   discovery:
     status: todo
-    comment: Under review
+    comment: mDNS should be possible - https://owfs.org/index_php_page_avahi-discovery.html
   stale-devices:
-    status: todo
-    comment: Under review
+    status: done
+    comment: Manual removal
   diagnostics:
     status: todo
-    comment: Under review
+    comment: config-entry diagnostics level available, might be nice to have device-level diagnostics
   exception-translations:
     status: todo
     comment: Under review
   icon-translations:
-    status: todo
-    comment: Under review
+    status: exempt
+    comment: It doesn't make sense to override defaults
   reconfiguration-flow:
     status: todo
-    comment: Under review
+    comment: Not yet implemented
   dynamic-devices:
     status: todo
-    comment: Under review
+    comment: Not yet implemented
   discovery-update-info:
     status: todo
     comment: Under review
   repair-issues:
-    status: todo
-    comment: Under review
+    status: exempt
+    comment: No repairs available
   docs-use-cases:
     status: todo
     comment: Under review

--- a/script/hassfest/quality_scale.py
+++ b/script/hassfest/quality_scale.py
@@ -742,7 +742,6 @@ INTEGRATIONS_WITHOUT_QUALITY_SCALE_FILE = [
     "omnilogic",
     "oncue",
     "ondilo_ico",
-    "onewire",
     "onvif",
     "open_meteo",
     "openai_conversation",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
## Bronze
- [ ] `config-flow` - Integration needs to be able to be set up via the UI
    - [ ] Uses `data_description` to give context to fields
    - [x] Uses `ConfigEntry.data` and `ConfigEntry.options` correctly
- [x] `test-before-configure` - Test a connection in the config flow
- [x] `unique-config-entry` - Don't allow the same device or service to be able to be set up twice
- [ ] `config-flow-test-coverage` - Full test coverage for the config flow
- [x] `runtime-data` - Use ConfigEntry.runtime_data to store runtime data
- [x] `test-before-setup` - Check during integration initialization if we are able to set it up correctly
- [x] `appropriate-polling` - If it's a polling integration, set an appropriate polling interval
  - #134953
- [x] `entity-unique-id` - Entities have a unique ID
- [x] `has-entity-name` - Entities use has_entity_name = True
- [x] `entity-event-setup` - Entities event setup
- [ ] `dependency-transparency` - Dependency transparency
- [x] `action-setup` - Service actions are registered in async_setup
- [x] `common-modules` - Place common patterns in common modules
- [ ] `docs-high-level-description` - The documentation includes a high-level description of the integration brand, product, or service
- [ ] `docs-installation-instructions` - The documentation provides step-by-step installation instructions for the integration, including, if needed, prerequisites
- [ ] `docs-removal-instructions` - The documentation provides removal instructions
- [ ] `docs-actions` - The documentation describes the provided service actions that can be used
- [x] `brands` - Has branding assets available for the integration

## Silver
- [x] `config-entry-unloading` - Support config entry unloading
- [x] `log-when-unavailable` - If internet/device/service is unavailable, log once when unavailable and once when back connected
- [x] `entity-unavailable` - Mark entity unavailable if appropriate
- [x] `action-exceptions` - Service actions raise exceptions when encountering failures
- [x] `reauthentication-flow` - Reauthentication flow
- [x] `parallel-updates` - Set Parallel updates
  - #134953
- [x] `test-coverage` - Above 95% test coverage for all integration modules
- [x] `integration-owner` - Has an integration owner
- [ ] `docs-installation-parameters` - The documentation describes all integration installation parameters
- [ ] `docs-configuration-parameters` - The documentation describes all integration configuration options

## Gold
- [x] `entity-translations` - Entities have translated names
- [x] `entity-device-class` - Entities use device classes where possible
- [x] `devices` - The integration creates devices
- [x] `entity-category` - Entities are assigned an appropriate EntityCategory
- [x] `entity-disabled-by-default` - Integration disables less popular (or noisy) entities
- [ ] `discovery` - Can be discovered
- [x] `stale-devices` - Clean up stale devices
- [ ] `diagnostics` - Implements diagnostics
- [ ] `exception-translations` - Exception messages are translatable
- [x] `icon-translations` - Icon translations
- [x] `reconfiguration-flow` - Integrations should have a reconfigure flow
  - #134996
- [ ] `dynamic-devices` - Devices added after integration setup
- [ ] `discovery-update-info` - Integration uses discovery info to update network information
- [x] `repair-issues` - Repair issues and repair flows are used when user intervention is needed
- [ ] `docs-use-cases` - The documentation describes use cases to illustrate how this integration can be used
- [ ] `docs-supported-devices` - The documentation describes known supported / unsupported devices
- [ ] `docs-supported-functions` - The documentation describes the supported functionality, including entities, and platforms
- [ ] `docs-data-update` - The documentation describes how data is updated
- [ ] `docs-known-limitations` - The documentation describes known limitations of the integration (not to be confused with bugs)
- [ ] `docs-troubleshooting` - The documentation provides troubleshooting information
- [ ] `docs-examples` - The documentation provides automation examples the user can use.

## Platinum
- [ ] `async-dependency` - Dependency is async
- [x] `inject-websession` - The integration dependency supports passing in a websession
- [ ] `strict-typing` - Strict typing

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
