### PR TITLE
Use standard "entity_registry_enabled_by_default" fixture

### DIFF
--- a/tests/components/freebox/conftest.py
+++ b/tests/components/freebox/conftest.py
@@ -1,7 +1,7 @@
 """Test helpers for Freebox."""
 
 import json
-from unittest.mock import AsyncMock, PropertyMock, patch
+from unittest.mock import AsyncMock, patch
 
 from freebox_api.exceptions import HttpRequestError
 import pytest
@@ -32,16 +32,6 @@ def mock_path():
     with (
         patch("homeassistant.components.freebox.router.Path"),
         patch("homeassistant.components.freebox.router.os.makedirs"),
-    ):
-        yield
-
-
-@pytest.fixture(autouse=True)
-def enable_all_entities():
-    """Make sure all entities are enabled."""
-    with patch(
-        "homeassistant.helpers.entity.Entity.entity_registry_enabled_default",
-        PropertyMock(return_value=True),
     ):
         yield
 

--- a/tests/components/freebox/test_binary_sensor.py
+++ b/tests/components/freebox/test_binary_sensor.py
@@ -4,6 +4,7 @@ from copy import deepcopy
 from unittest.mock import Mock
 
 from freezegun.api import FrozenDateTimeFactory
+import pytest
 
 from homeassistant.components.binary_sensor import (
     DOMAIN as BINARY_SENSOR_DOMAIN,
@@ -45,6 +46,7 @@ async def test_raid_array_degraded(
     )
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_home(
     hass: HomeAssistant, freezer: FrozenDateTimeFactory, router: Mock
 ) -> None:

--- a/tests/components/prusalink/test_binary_sensor.py
+++ b/tests/components/prusalink/test_binary_sensor.py
@@ -1,6 +1,6 @@
 """Test Prusalink sensors."""
 
-from unittest.mock import PropertyMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -12,16 +12,13 @@ from homeassistant.setup import async_setup_component
 @pytest.fixture(autouse=True)
 def setup_binary_sensor_platform_only():
     """Only setup sensor platform."""
-    with (
-        patch("homeassistant.components.prusalink.PLATFORMS", [Platform.BINARY_SENSOR]),
-        patch(
-            "homeassistant.helpers.entity.Entity.entity_registry_enabled_default",
-            PropertyMock(return_value=True),
-        ),
+    with patch(
+        "homeassistant.components.prusalink.PLATFORMS", [Platform.BINARY_SENSOR]
     ):
         yield
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_binary_sensors_no_job(
     hass: HomeAssistant, mock_config_entry, mock_api
 ) -> None:

--- a/tests/components/prusalink/test_sensor.py
+++ b/tests/components/prusalink/test_sensor.py
@@ -1,7 +1,7 @@
 """Test Prusalink sensors."""
 
 from datetime import UTC, datetime
-from unittest.mock import PropertyMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -27,16 +27,11 @@ from homeassistant.setup import async_setup_component
 @pytest.fixture(autouse=True)
 def setup_sensor_platform_only():
     """Only setup sensor platform."""
-    with (
-        patch("homeassistant.components.prusalink.PLATFORMS", [Platform.SENSOR]),
-        patch(
-            "homeassistant.helpers.entity.Entity.entity_registry_enabled_default",
-            PropertyMock(return_value=True),
-        ),
-    ):
+    with patch("homeassistant.components.prusalink.PLATFORMS", [Platform.SENSOR]):
         yield
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_sensors_no_job(hass: HomeAssistant, mock_config_entry, mock_api) -> None:
     """Test sensors while no job active."""
     assert await async_setup_component(hass, "prusalink", {})
@@ -140,6 +135,7 @@ async def test_sensors_no_job(hass: HomeAssistant, mock_config_entry, mock_api) 
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == REVOLUTIONS_PER_MINUTE
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_sensors_idle_job_mk3(
     hass: HomeAssistant,
     mock_config_entry,
@@ -248,6 +244,7 @@ async def test_sensors_idle_job_mk3(
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == REVOLUTIONS_PER_MINUTE
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_sensors_active_job(
     hass: HomeAssistant,
     mock_config_entry,

--- a/tests/components/upnp/conftest.py
+++ b/tests/components/upnp/conftest.py
@@ -7,7 +7,7 @@ import copy
 from datetime import datetime
 import socket
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, PropertyMock, create_autospec, patch
+from unittest.mock import AsyncMock, MagicMock, create_autospec, patch
 from urllib.parse import urlparse
 
 from async_upnp_client.aiohttp import AiohttpNotifyServer
@@ -286,11 +286,8 @@ async def mock_config_entry(
 
     # Load config_entry.
     entry.add_to_hass(hass)
-    with patch(
-        "homeassistant.helpers.entity.Entity.entity_registry_enabled_default",
-        PropertyMock(return_value=True),
-    ):
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
 
     return entry

--- a/tests/components/upnp/test_sensor.py
+++ b/tests/components/upnp/test_sensor.py
@@ -3,6 +3,7 @@
 from datetime import datetime, timedelta
 
 from async_upnp_client.profiles.igd import IgdDevice, IgdState
+import pytest
 
 from homeassistant.components.upnp.const import DEFAULT_SCAN_INTERVAL
 from homeassistant.core import HomeAssistant
@@ -11,6 +12,7 @@ import homeassistant.util.dt as dt_util
 from tests.common import MockConfigEntry, async_fire_time_changed
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_upnp_sensors(
     hass: HomeAssistant, mock_config_entry: MockConfigEntry
 ) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Clean-up custom code from all tests and force usage of common "entity_registry_enabled_by_default" fixture

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
