### PR TITLE
Improve type hints in onewire tests

### DIFF
--- a/tests/components/onewire/conftest.py
+++ b/tests/components/onewire/conftest.py
@@ -7,7 +7,7 @@ from pyownet.protocol import ConnError
 import pytest
 
 from homeassistant.components.onewire.const import DOMAIN
-from homeassistant.config_entries import SOURCE_USER, ConfigEntry
+from homeassistant.config_entries import SOURCE_USER
 from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import HomeAssistant
 
@@ -32,7 +32,7 @@ def get_device_id(request: pytest.FixtureRequest) -> str:
 
 
 @pytest.fixture(name="config_entry")
-def get_config_entry(hass: HomeAssistant) -> ConfigEntry:
+def get_config_entry(hass: HomeAssistant) -> MockConfigEntry:
     """Create and register mock config entry."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -54,14 +54,14 @@ def get_config_entry(hass: HomeAssistant) -> ConfigEntry:
 
 
 @pytest.fixture(name="owproxy")
-def get_owproxy() -> MagicMock:
+def get_owproxy() -> Generator[MagicMock]:
     """Mock owproxy."""
     with patch("homeassistant.components.onewire.onewirehub.protocol.proxy") as owproxy:
         yield owproxy
 
 
 @pytest.fixture(name="owproxy_with_connerror")
-def get_owproxy_with_connerror() -> MagicMock:
+def get_owproxy_with_connerror() -> Generator[MagicMock]:
     """Mock owproxy."""
     with patch(
         "homeassistant.components.onewire.onewirehub.protocol.proxy",

--- a/tests/components/onewire/test_binary_sensor.py
+++ b/tests/components/onewire/test_binary_sensor.py
@@ -6,12 +6,13 @@ from unittest.mock import MagicMock, patch
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from . import setup_owproxy_mock_devices
+
+from tests.common import MockConfigEntry
 
 
 @pytest.fixture(autouse=True)
@@ -23,7 +24,7 @@ def override_platforms() -> Generator[None]:
 
 async def test_binary_sensors(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: MockConfigEntry,
     owproxy: MagicMock,
     device_id: str,
     device_registry: dr.DeviceRegistry,

--- a/tests/components/onewire/test_config_flow.py
+++ b/tests/components/onewire/test_config_flow.py
@@ -11,18 +11,21 @@ from homeassistant.components.onewire.const import (
     INPUT_ENTRY_DEVICE_SELECTION,
     MANUFACTURER_MAXIM,
 )
-from homeassistant.config_entries import SOURCE_USER, ConfigEntry
+from homeassistant.config_entries import SOURCE_USER
 from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers import device_registry as dr
+
+from tests.common import MockConfigEntry
 
 pytestmark = pytest.mark.usefixtures("mock_setup_entry")
 
 
 @pytest.fixture
 async def filled_device_registry(
-    hass: HomeAssistant, config_entry: ConfigEntry, device_registry: dr.DeviceRegistry
+    config_entry: MockConfigEntry,
+    device_registry: dr.DeviceRegistry,
 ) -> dr.DeviceRegistry:
     """Fill device registry with mock devices."""
     for key in ("28.111111111111", "28.222222222222", "28.222222222223"):
@@ -79,7 +82,7 @@ async def test_user_flow(hass: HomeAssistant, mock_setup_entry: AsyncMock) -> No
 
 
 async def test_user_duplicate(
-    hass: HomeAssistant, config_entry: ConfigEntry, mock_setup_entry: AsyncMock
+    hass: HomeAssistant, config_entry: MockConfigEntry, mock_setup_entry: AsyncMock
 ) -> None:
     """Test user duplicate flow."""
     await hass.config_entries.async_setup(config_entry.entry_id)
@@ -104,7 +107,7 @@ async def test_user_duplicate(
 
 @pytest.mark.usefixtures("filled_device_registry")
 async def test_user_options_clear(
-    hass: HomeAssistant, config_entry: ConfigEntry
+    hass: HomeAssistant, config_entry: MockConfigEntry
 ) -> None:
     """Test clearing the options."""
     assert await hass.config_entries.async_setup(config_entry.entry_id)
@@ -128,7 +131,7 @@ async def test_user_options_clear(
 
 @pytest.mark.usefixtures("filled_device_registry")
 async def test_user_options_empty_selection(
-    hass: HomeAssistant, config_entry: ConfigEntry
+    hass: HomeAssistant, config_entry: MockConfigEntry
 ) -> None:
     """Test leaving the selection of devices empty."""
     assert await hass.config_entries.async_setup(config_entry.entry_id)
@@ -153,7 +156,7 @@ async def test_user_options_empty_selection(
 
 @pytest.mark.usefixtures("filled_device_registry")
 async def test_user_options_set_single(
-    hass: HomeAssistant, config_entry: ConfigEntry
+    hass: HomeAssistant, config_entry: MockConfigEntry
 ) -> None:
     """Test configuring a single device."""
     # Clear config options to certify functionality when starting from scratch
@@ -191,7 +194,7 @@ async def test_user_options_set_single(
 
 async def test_user_options_set_multiple(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: MockConfigEntry,
     filled_device_registry: dr.DeviceRegistry,
 ) -> None:
     """Test configuring multiple consecutive devices in a row."""
@@ -254,7 +257,7 @@ async def test_user_options_set_multiple(
 
 
 async def test_user_options_no_devices(
-    hass: HomeAssistant, config_entry: ConfigEntry
+    hass: HomeAssistant, config_entry: MockConfigEntry
 ) -> None:
     """Test that options does not change when no devices are available."""
     assert await hass.config_entries.async_setup(config_entry.entry_id)

--- a/tests/components/onewire/test_diagnostics.py
+++ b/tests/components/onewire/test_diagnostics.py
@@ -6,12 +6,12 @@ from unittest.mock import MagicMock, patch
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 
 from . import setup_owproxy_mock_devices
 
+from tests.common import MockConfigEntry
 from tests.components.diagnostics import get_diagnostics_for_config_entry
 from tests.typing import ClientSessionGenerator
 
@@ -40,7 +40,7 @@ DEVICE_DETAILS = {
 @pytest.mark.parametrize("device_id", ["EF.111111111113"], indirect=True)
 async def test_entry_diagnostics(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: MockConfigEntry,
     hass_client: ClientSessionGenerator,
     owproxy: MagicMock,
     device_id: str,

--- a/tests/components/onewire/test_init.py
+++ b/tests/components/onewire/test_init.py
@@ -7,7 +7,7 @@ from pyownet import protocol
 import pytest
 
 from homeassistant.components.onewire.const import DOMAIN
-from homeassistant.config_entries import ConfigEntry, ConfigEntryState
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
@@ -15,11 +15,14 @@ from homeassistant.setup import async_setup_component
 
 from . import setup_owproxy_mock_devices
 
+from tests.common import MockConfigEntry
 from tests.typing import WebSocketGenerator
 
 
 @pytest.mark.usefixtures("owproxy_with_connerror")
-async def test_connect_failure(hass: HomeAssistant, config_entry: ConfigEntry) -> None:
+async def test_connect_failure(
+    hass: HomeAssistant, config_entry: MockConfigEntry
+) -> None:
     """Test connection failure raises ConfigEntryNotReady."""
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
@@ -29,7 +32,7 @@ async def test_connect_failure(hass: HomeAssistant, config_entry: ConfigEntry) -
 
 
 async def test_listing_failure(
-    hass: HomeAssistant, config_entry: ConfigEntry, owproxy: MagicMock
+    hass: HomeAssistant, config_entry: MockConfigEntry, owproxy: MagicMock
 ) -> None:
     """Test listing failure raises ConfigEntryNotReady."""
     owproxy.return_value.dir.side_effect = protocol.OwnetError()
@@ -42,7 +45,7 @@ async def test_listing_failure(
 
 
 @pytest.mark.usefixtures("owproxy")
-async def test_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> None:
+async def test_unload_entry(hass: HomeAssistant, config_entry: MockConfigEntry) -> None:
     """Test being able to unload an entry."""
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
@@ -57,7 +60,7 @@ async def test_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> N
 
 
 async def test_update_options(
-    hass: HomeAssistant, config_entry: ConfigEntry, owproxy: MagicMock
+    hass: HomeAssistant, config_entry: MockConfigEntry, owproxy: MagicMock
 ) -> None:
     """Test update options triggers reload."""
     await hass.config_entries.async_setup(config_entry.entry_id)
@@ -81,7 +84,7 @@ async def test_update_options(
 async def test_registry_cleanup(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
-    config_entry: ConfigEntry,
+    config_entry: MockConfigEntry,
     owproxy: MagicMock,
     hass_ws_client: WebSocketGenerator,
 ) -> None:

--- a/tests/components/onewire/test_sensor.py
+++ b/tests/components/onewire/test_sensor.py
@@ -9,13 +9,14 @@ from pyownet.protocol import OwnetError
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from . import setup_owproxy_mock_devices
 from .const import ATTR_INJECT_READS, MOCK_OWPROXY_DEVICES
+
+from tests.common import MockConfigEntry
 
 
 @pytest.fixture(autouse=True)
@@ -27,7 +28,7 @@ def override_platforms() -> Generator[None]:
 
 async def test_sensors(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: MockConfigEntry,
     owproxy: MagicMock,
     device_id: str,
     device_registry: dr.DeviceRegistry,
@@ -66,7 +67,7 @@ async def test_sensors(
 @pytest.mark.parametrize("device_id", ["12.111111111111"])
 async def test_tai8570_sensors(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: MockConfigEntry,
     owproxy: MagicMock,
     device_id: str,
     entity_registry: er.EntityRegistry,

--- a/tests/components/onewire/test_switch.py
+++ b/tests/components/onewire/test_switch.py
@@ -7,7 +7,6 @@ import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     SERVICE_TOGGLE,
@@ -20,6 +19,8 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from . import setup_owproxy_mock_devices
 
+from tests.common import MockConfigEntry
+
 
 @pytest.fixture(autouse=True)
 def override_platforms() -> Generator[None]:
@@ -30,7 +31,7 @@ def override_platforms() -> Generator[None]:
 
 async def test_switches(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: MockConfigEntry,
     owproxy: MagicMock,
     device_id: str,
     device_registry: dr.DeviceRegistry,
@@ -70,7 +71,7 @@ async def test_switches(
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_switch_toggle(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: MockConfigEntry,
     owproxy: MagicMock,
     device_id: str,
 ) -> None:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
