### PR TITLE
Simplify vesync init loading

### DIFF
--- a/homeassistant/components/vesync/__init__.py
+++ b/homeassistant/components/vesync/__init__.py
@@ -40,8 +40,6 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         _LOGGER.error("Unable to login to the VeSync server")
         return False
 
-    # forward_setups = hass.config_entries.async_forward_entry_setups
-
     hass.data[DOMAIN] = {}
     hass.data[DOMAIN][VS_MANAGER] = manager
 

--- a/homeassistant/components/vesync/__init__.py
+++ b/homeassistant/components/vesync/__init__.py
@@ -9,17 +9,14 @@ from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, Platform
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
-from .common import async_process_devices
+from .common import async_generate_device_list
 from .const import (
     DOMAIN,
     SERVICE_UPDATE_DEVS,
     VS_COORDINATOR,
+    VS_DEVICES,
     VS_DISCOVERY,
-    VS_FANS,
-    VS_LIGHTS,
     VS_MANAGER,
-    VS_SENSORS,
-    VS_SWITCHES,
 )
 from .coordinator import VeSyncDataCoordinator
 
@@ -43,9 +40,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         _LOGGER.error("Unable to login to the VeSync server")
         return False
 
-    device_dict = await async_process_devices(hass, manager)
-
-    forward_setups = hass.config_entries.async_forward_entry_setups
+    # forward_setups = hass.config_entries.async_forward_entry_setups
 
     hass.data[DOMAIN] = {}
     hass.data[DOMAIN][VS_MANAGER] = manager
@@ -55,83 +50,25 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     # Store coordinator at domain level since only single integration instance is permitted.
     hass.data[DOMAIN][VS_COORDINATOR] = coordinator
 
-    switches = hass.data[DOMAIN][VS_SWITCHES] = []
-    fans = hass.data[DOMAIN][VS_FANS] = []
-    lights = hass.data[DOMAIN][VS_LIGHTS] = []
-    sensors = hass.data[DOMAIN][VS_SENSORS] = []
-    platforms = []
+    hass.data[DOMAIN][VS_DEVICES] = await async_generate_device_list(hass, manager)
 
-    if device_dict[VS_SWITCHES]:
-        switches.extend(device_dict[VS_SWITCHES])
-        platforms.append(Platform.SWITCH)
-
-    if device_dict[VS_FANS]:
-        fans.extend(device_dict[VS_FANS])
-        platforms.append(Platform.FAN)
-
-    if device_dict[VS_LIGHTS]:
-        lights.extend(device_dict[VS_LIGHTS])
-        platforms.append(Platform.LIGHT)
-
-    if device_dict[VS_SENSORS]:
-        sensors.extend(device_dict[VS_SENSORS])
-        platforms.append(Platform.SENSOR)
-
-    await hass.config_entries.async_forward_entry_setups(config_entry, platforms)
+    await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
 
     async def async_new_device_discovery(service: ServiceCall) -> None:
         """Discover if new devices should be added."""
         manager = hass.data[DOMAIN][VS_MANAGER]
-        switches = hass.data[DOMAIN][VS_SWITCHES]
-        fans = hass.data[DOMAIN][VS_FANS]
-        lights = hass.data[DOMAIN][VS_LIGHTS]
-        sensors = hass.data[DOMAIN][VS_SENSORS]
+        devices = hass.data[DOMAIN][VS_DEVICES]
 
-        dev_dict = await async_process_devices(hass, manager)
-        switch_devs = dev_dict.get(VS_SWITCHES, [])
-        fan_devs = dev_dict.get(VS_FANS, [])
-        light_devs = dev_dict.get(VS_LIGHTS, [])
-        sensor_devs = dev_dict.get(VS_SENSORS, [])
+        new_devices = await async_generate_device_list(hass, manager)
 
-        switch_set = set(switch_devs)
-        new_switches = list(switch_set.difference(switches))
-        if new_switches and switches:
-            switches.extend(new_switches)
-            async_dispatcher_send(hass, VS_DISCOVERY.format(VS_SWITCHES), new_switches)
+        device_set = set(new_devices)
+        new_devices = list(device_set.difference(devices))
+        if new_devices and devices:
+            devices.extend(new_devices)
+            async_dispatcher_send(hass, VS_DISCOVERY.format(VS_DEVICES), new_devices)
             return
-        if new_switches and not switches:
-            switches.extend(new_switches)
-            hass.async_create_task(forward_setups(config_entry, [Platform.SWITCH]))
-
-        fan_set = set(fan_devs)
-        new_fans = list(fan_set.difference(fans))
-        if new_fans and fans:
-            fans.extend(new_fans)
-            async_dispatcher_send(hass, VS_DISCOVERY.format(VS_FANS), new_fans)
-            return
-        if new_fans and not fans:
-            fans.extend(new_fans)
-            hass.async_create_task(forward_setups(config_entry, [Platform.FAN]))
-
-        light_set = set(light_devs)
-        new_lights = list(light_set.difference(lights))
-        if new_lights and lights:
-            lights.extend(new_lights)
-            async_dispatcher_send(hass, VS_DISCOVERY.format(VS_LIGHTS), new_lights)
-            return
-        if new_lights and not lights:
-            lights.extend(new_lights)
-            hass.async_create_task(forward_setups(config_entry, [Platform.LIGHT]))
-
-        sensor_set = set(sensor_devs)
-        new_sensors = list(sensor_set.difference(sensors))
-        if new_sensors and sensors:
-            sensors.extend(new_sensors)
-            async_dispatcher_send(hass, VS_DISCOVERY.format(VS_SENSORS), new_sensors)
-            return
-        if new_sensors and not sensors:
-            sensors.extend(new_sensors)
-            hass.async_create_task(forward_setups(config_entry, [Platform.SENSOR]))
+        if new_devices and not devices:
+            devices.extend(new_devices)
 
     hass.services.async_register(
         DOMAIN, SERVICE_UPDATE_DEVS, async_new_device_discovery
@@ -142,18 +79,8 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-    in_use_platforms = []
-    if hass.data[DOMAIN][VS_SWITCHES]:
-        in_use_platforms.append(Platform.SWITCH)
-    if hass.data[DOMAIN][VS_FANS]:
-        in_use_platforms.append(Platform.FAN)
-    if hass.data[DOMAIN][VS_LIGHTS]:
-        in_use_platforms.append(Platform.LIGHT)
-    if hass.data[DOMAIN][VS_SENSORS]:
-        in_use_platforms.append(Platform.SENSOR)
-    unload_ok = await hass.config_entries.async_unload_platforms(
-        entry, in_use_platforms
-    )
+
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
         hass.data.pop(DOMAIN)
 

--- a/homeassistant/components/vesync/common.py
+++ b/homeassistant/components/vesync/common.py
@@ -7,45 +7,20 @@ from pyvesync.vesyncbasedevice import VeSyncBaseDevice
 
 from homeassistant.core import HomeAssistant
 
-from .const import VS_FANS, VS_LIGHTS, VS_SENSORS, VS_SWITCHES
-
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_process_devices(
+async def async_generate_device_list(
     hass: HomeAssistant, manager: VeSync
-) -> dict[str, list[VeSyncBaseDevice]]:
+) -> list[VeSyncBaseDevice]:
     """Assign devices to proper component."""
-    devices: dict[str, list[VeSyncBaseDevice]] = {}
-    devices[VS_SWITCHES] = []
-    devices[VS_FANS] = []
-    devices[VS_LIGHTS] = []
-    devices[VS_SENSORS] = []
+    devices: list[VeSyncBaseDevice] = []
 
     await hass.async_add_executor_job(manager.update)
 
-    if manager.fans:
-        devices[VS_FANS].extend(manager.fans)
-        # Expose fan sensors separately
-        devices[VS_SENSORS].extend(manager.fans)
-        _LOGGER.debug("%d VeSync fans found", len(manager.fans))
-
-    if manager.bulbs:
-        devices[VS_LIGHTS].extend(manager.bulbs)
-        _LOGGER.debug("%d VeSync lights found", len(manager.bulbs))
-
-    if manager.outlets:
-        devices[VS_SWITCHES].extend(manager.outlets)
-        # Expose outlets' voltage, power & energy usage as separate sensors
-        devices[VS_SENSORS].extend(manager.outlets)
-        _LOGGER.debug("%d VeSync outlets found", len(manager.outlets))
-
-    if manager.switches:
-        for switch in manager.switches:
-            if not switch.is_dimmable():
-                devices[VS_SWITCHES].append(switch)
-            else:
-                devices[VS_LIGHTS].append(switch)
-        _LOGGER.debug("%d VeSync switches found", len(manager.switches))
+    devices.extend(manager.fans)
+    devices.extend(manager.bulbs)
+    devices.extend(manager.outlets)
+    devices.extend(manager.switches)
 
     return devices

--- a/homeassistant/components/vesync/const.py
+++ b/homeassistant/components/vesync/const.py
@@ -17,11 +17,7 @@ total would be 2880.
 Using 30 seconds interval gives 8640 for 3 devices which
 exceeds the quota of 7700.
 """
-
-VS_SWITCHES = "switches"
-VS_FANS = "fans"
-VS_LIGHTS = "lights"
-VS_SENSORS = "sensors"
+VS_DEVICES = "devices"
 VS_COORDINATOR = "coordinator"
 VS_MANAGER = "manager"
 

--- a/homeassistant/components/vesync/fan.py
+++ b/homeassistant/components/vesync/fan.py
@@ -24,8 +24,8 @@ from .const import (
     DOMAIN,
     SKU_TO_BASE_DEVICE,
     VS_COORDINATOR,
+    VS_DEVICES,
     VS_DISCOVERY,
-    VS_FANS,
 )
 from .coordinator import VeSyncDataCoordinator
 from .entity import VeSyncBaseEntity
@@ -74,10 +74,10 @@ async def async_setup_entry(
         _setup_entities(devices, async_add_entities, coordinator)
 
     config_entry.async_on_unload(
-        async_dispatcher_connect(hass, VS_DISCOVERY.format(VS_FANS), discover)
+        async_dispatcher_connect(hass, VS_DISCOVERY.format(VS_DEVICES), discover)
     )
 
-    _setup_entities(hass.data[DOMAIN][VS_FANS], async_add_entities, coordinator)
+    _setup_entities(hass.data[DOMAIN][VS_DEVICES], async_add_entities, coordinator)
 
 
 @callback

--- a/homeassistant/components/vesync/light.py
+++ b/homeassistant/components/vesync/light.py
@@ -17,7 +17,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util import color as color_util
 
-from .const import DEV_TYPE_TO_HA, DOMAIN, VS_COORDINATOR, VS_DISCOVERY, VS_LIGHTS
+from .const import DEV_TYPE_TO_HA, DOMAIN, VS_COORDINATOR, VS_DEVICES, VS_DISCOVERY
 from .coordinator import VeSyncDataCoordinator
 from .entity import VeSyncBaseEntity
 
@@ -41,10 +41,10 @@ async def async_setup_entry(
         _setup_entities(devices, async_add_entities, coordinator)
 
     config_entry.async_on_unload(
-        async_dispatcher_connect(hass, VS_DISCOVERY.format(VS_LIGHTS), discover)
+        async_dispatcher_connect(hass, VS_DISCOVERY.format(VS_DEVICES), discover)
     )
 
-    _setup_entities(hass.data[DOMAIN][VS_LIGHTS], async_add_entities, coordinator)
+    _setup_entities(hass.data[DOMAIN][VS_DEVICES], async_add_entities, coordinator)
 
 
 @callback

--- a/homeassistant/components/vesync/sensor.py
+++ b/homeassistant/components/vesync/sensor.py
@@ -36,8 +36,8 @@ from .const import (
     DOMAIN,
     SKU_TO_BASE_DEVICE,
     VS_COORDINATOR,
+    VS_DEVICES,
     VS_DISCOVERY,
-    VS_SENSORS,
 )
 from .coordinator import VeSyncDataCoordinator
 from .entity import VeSyncBaseEntity
@@ -204,10 +204,10 @@ async def async_setup_entry(
         _setup_entities(devices, async_add_entities, coordinator)
 
     config_entry.async_on_unload(
-        async_dispatcher_connect(hass, VS_DISCOVERY.format(VS_SENSORS), discover)
+        async_dispatcher_connect(hass, VS_DISCOVERY.format(VS_DEVICES), discover)
     )
 
-    _setup_entities(hass.data[DOMAIN][VS_SENSORS], async_add_entities, coordinator)
+    _setup_entities(hass.data[DOMAIN][VS_DEVICES], async_add_entities, coordinator)
 
 
 @callback

--- a/homeassistant/components/vesync/switch.py
+++ b/homeassistant/components/vesync/switch.py
@@ -11,7 +11,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DEV_TYPE_TO_HA, DOMAIN, VS_COORDINATOR, VS_DISCOVERY, VS_SWITCHES
+from .const import DEV_TYPE_TO_HA, DOMAIN, VS_COORDINATOR, VS_DEVICES, VS_DISCOVERY
 from .coordinator import VeSyncDataCoordinator
 from .entity import VeSyncBaseEntity
 
@@ -33,10 +33,10 @@ async def async_setup_entry(
         _setup_entities(devices, async_add_entities, coordinator)
 
     config_entry.async_on_unload(
-        async_dispatcher_connect(hass, VS_DISCOVERY.format(VS_SWITCHES), discover)
+        async_dispatcher_connect(hass, VS_DISCOVERY.format(VS_DEVICES), discover)
     )
 
-    _setup_entities(hass.data[DOMAIN][VS_SWITCHES], async_add_entities, coordinator)
+    _setup_entities(hass.data[DOMAIN][VS_DEVICES], async_add_entities, coordinator)
 
 
 @callback


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Follow up from feedback here: https://github.com/home-assistant/core/pull/134425  

Attempting to reduce the need for checks on devices in multiple places.   From a experience standpoint mine is unchanged with this code change.  This should allow adding a few other device types easier.  We will also remove the requirement to map SKUs on the constants and shift to a feature focused check. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
