### PR TITLE
Add attribute target_temp_step to water_heater

### DIFF
--- a/homeassistant/components/demo/water_heater.py
+++ b/homeassistant/components/demo/water_heater.py
@@ -30,10 +30,15 @@ async def async_setup_entry(
     async_add_entities(
         [
             DemoWaterHeater(
-                "Demo Water Heater", 119, UnitOfTemperature.FAHRENHEIT, False, "eco"
+                "Demo Water Heater", 119, UnitOfTemperature.FAHRENHEIT, False, "eco", 1
             ),
             DemoWaterHeater(
-                "Demo Water Heater Celsius", 45, UnitOfTemperature.CELSIUS, True, "eco"
+                "Demo Water Heater Celsius",
+                45,
+                UnitOfTemperature.CELSIUS,
+                True,
+                "eco",
+                1,
             ),
         ]
     )
@@ -52,6 +57,7 @@ class DemoWaterHeater(WaterHeaterEntity):
         unit_of_measurement: str,
         away: bool,
         current_operation: str,
+        target_temperature_step: float,
     ) -> None:
         """Initialize the water_heater device."""
         self._attr_name = name
@@ -74,6 +80,7 @@ class DemoWaterHeater(WaterHeaterEntity):
             "gas",
             "off",
         ]
+        self._attr_target_temperature_step = target_temperature_step
 
     def set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperatures."""

--- a/homeassistant/components/water_heater/__init__.py
+++ b/homeassistant/components/water_heater/__init__.py
@@ -72,6 +72,7 @@ ATTR_OPERATION_MODE = "operation_mode"
 ATTR_OPERATION_LIST = "operation_list"
 ATTR_TARGET_TEMP_HIGH = "target_temp_high"
 ATTR_TARGET_TEMP_LOW = "target_temp_low"
+ATTR_TARGET_TEMP_STEP = "target_temp_step"
 ATTR_CURRENT_TEMPERATURE = "current_temperature"
 
 CONVERTIBLE_ATTRIBUTE = [ATTR_TEMPERATURE]
@@ -147,6 +148,7 @@ CACHED_PROPERTIES_WITH_ATTR_ = {
     "operation_list",
     "current_temperature",
     "target_temperature",
+    "target_temperature_step",
     "target_temperature_high",
     "target_temperature_low",
     "is_away_mode_on",
@@ -157,7 +159,12 @@ class WaterHeaterEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
     """Base class for water heater entities."""
 
     _entity_component_unrecorded_attributes = frozenset(
-        {ATTR_OPERATION_LIST, ATTR_MIN_TEMP, ATTR_MAX_TEMP}
+        {
+            ATTR_OPERATION_LIST,
+            ATTR_MIN_TEMP,
+            ATTR_MAX_TEMP,
+            ATTR_TARGET_TEMP_STEP,
+        }
     )
 
     entity_description: WaterHeaterEntityDescription
@@ -174,6 +181,7 @@ class WaterHeaterEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
     _attr_target_temperature_low: float | None = None
     _attr_target_temperature: float | None = None
     _attr_temperature_unit: str
+    _attr_target_temperature_step: float | None = None
 
     @final
     @property
@@ -201,6 +209,8 @@ class WaterHeaterEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
                 self.hass, self.max_temp, self.temperature_unit, self.precision
             ),
         }
+        if target_temperature_step := self.target_temperature_step:
+            data[ATTR_TARGET_TEMP_STEP] = target_temperature_step
 
         if WaterHeaterEntityFeature.OPERATION_MODE in self.supported_features:
             data[ATTR_OPERATION_LIST] = self.operation_list
@@ -283,6 +293,11 @@ class WaterHeaterEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
     def target_temperature_low(self) -> float | None:
         """Return the lowbound target temperature we try to reach."""
         return self._attr_target_temperature_low
+
+    @cached_property
+    def target_temperature_step(self) -> float | None:
+        """Return the supported step of target temperature."""
+        return self._attr_target_temperature_step
 
     @cached_property
     def is_away_mode_on(self) -> bool | None:

--- a/tests/components/demo/test_water_heater.py
+++ b/tests/components/demo/test_water_heater.py
@@ -43,6 +43,7 @@ async def test_setup_params(hass: HomeAssistant) -> None:
     assert state.attributes.get("temperature") == 119
     assert state.attributes.get("away_mode") == "off"
     assert state.attributes.get("operation_mode") == "eco"
+    assert state.attributes.get("target_temp_step") == 1
 
 
 async def test_default_setup_params(hass: HomeAssistant) -> None:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add attribute "target_temp_step" to water_heater for customize step in frontend.

- When the temperature is in Celsius, I want to adjust the target temperature to level 1, but there is no attribute, so it operates at 0.5.
- [ha-state-control-water_heater-temperature.ts](https://github.com/home-assistant/frontend/blob/3e1227b064fc6704cba63e8ebf1782c38192e232/src/state-control/water_heater/ha-state-control-water_heater-temperature.ts#L51) needs attr_target_temp_step, but water_heater does not have that.


```
  private get _step() {
    return (
      this.stateObj.attributes.target_temp_step ||
      (this.hass.config.unit_system.temperature === UNIT_F ? 1 : 0.5)
    );
  }
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
