### PR TITLE
Replace climate fan speed 'silent' with a button

### DIFF
--- a/homeassistant/components/palazzetti/__init__.py
+++ b/homeassistant/components/palazzetti/__init__.py
@@ -7,7 +7,12 @@ from homeassistant.core import HomeAssistant
 
 from .coordinator import PalazzettiConfigEntry, PalazzettiDataUpdateCoordinator
 
-PLATFORMS: list[Platform] = [Platform.CLIMATE, Platform.NUMBER, Platform.SENSOR]
+PLATFORMS: list[Platform] = [
+    Platform.BUTTON,
+    Platform.CLIMATE,
+    Platform.NUMBER,
+    Platform.SENSOR,
+]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: PalazzettiConfigEntry) -> bool:

--- a/homeassistant/components/palazzetti/button.py
+++ b/homeassistant/components/palazzetti/button.py
@@ -1,0 +1,53 @@
+"""Support for Palazzetti buttons."""
+
+from __future__ import annotations
+
+from pypalazzetti.exceptions import CommunicationError
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import PalazzettiConfigEntry
+from .const import DOMAIN
+from .coordinator import PalazzettiDataUpdateCoordinator
+from .entity import PalazzettiEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: PalazzettiConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Palazzetti button platform."""
+
+    coordinator = config_entry.runtime_data
+    if coordinator.client.has_fan_silent:
+        async_add_entities([PalazzettiSilentButtonEntity(coordinator)])
+
+
+class PalazzettiSilentButtonEntity(PalazzettiEntity, ButtonEntity):
+    """Representation of a Palazzetti Silent button."""
+
+    _attr_translation_key = "silent"
+    _attr_icon = "mdi:volume-mute"
+
+    def __init__(
+        self,
+        coordinator: PalazzettiDataUpdateCoordinator,
+    ) -> None:
+        """Initialize a Palazzetti Silent button."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.config_entry.unique_id}-silent"
+
+    async def async_press(self) -> None:
+        """Press the button."""
+        try:
+            await self.coordinator.client.set_fan_silent()
+        except CommunicationError as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN, translation_key="cannot_connect"
+            ) from err
+
+        await self.coordinator.async_request_refresh()

--- a/homeassistant/components/palazzetti/button.py
+++ b/homeassistant/components/palazzetti/button.py
@@ -31,7 +31,6 @@ class PalazzettiSilentButtonEntity(PalazzettiEntity, ButtonEntity):
     """Representation of a Palazzetti Silent button."""
 
     _attr_translation_key = "silent"
-    _attr_icon = "mdi:volume-mute"
 
     def __init__(
         self,

--- a/homeassistant/components/palazzetti/climate.py
+++ b/homeassistant/components/palazzetti/climate.py
@@ -16,7 +16,7 @@ from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import PalazzettiConfigEntry
-from .const import DOMAIN, FAN_AUTO, FAN_HIGH, FAN_MODES, FAN_SILENT
+from .const import DOMAIN, FAN_AUTO, FAN_HIGH, FAN_MODES
 from .coordinator import PalazzettiDataUpdateCoordinator
 from .entity import PalazzettiEntity
 
@@ -57,8 +57,6 @@ class PalazzettiClimateEntity(PalazzettiEntity, ClimateEntity):
         self._attr_fan_modes = list(
             map(str, range(client.fan_speed_min, client.fan_speed_max + 1))
         )
-        if client.has_fan_silent:
-            self._attr_fan_modes.insert(0, FAN_SILENT)
         if client.has_fan_high:
             self._attr_fan_modes.append(FAN_HIGH)
         if client.has_fan_auto:
@@ -130,9 +128,7 @@ class PalazzettiClimateEntity(PalazzettiEntity, ClimateEntity):
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set new fan mode."""
         try:
-            if fan_mode == FAN_SILENT:
-                await self.coordinator.client.set_fan_silent()
-            elif fan_mode == FAN_HIGH:
+            if fan_mode == FAN_HIGH:
                 await self.coordinator.client.set_fan_high()
             elif fan_mode == FAN_AUTO:
                 await self.coordinator.client.set_fan_auto()

--- a/homeassistant/components/palazzetti/const.py
+++ b/homeassistant/components/palazzetti/const.py
@@ -18,7 +18,7 @@ ERROR_CANNOT_CONNECT = "cannot_connect"
 FAN_SILENT: Final = "silent"
 FAN_HIGH: Final = "high"
 FAN_AUTO: Final = "auto"
-FAN_MODES: Final = [FAN_SILENT, "1", "2", "3", "4", "5", FAN_HIGH, FAN_AUTO]
+FAN_MODES: Final = ["0", "1", "2", "3", "4", "5", FAN_HIGH, FAN_AUTO]
 
 STATUS_TO_HA: Final[dict[StateType, str]] = {
     0: "off",

--- a/homeassistant/components/palazzetti/icons.json
+++ b/homeassistant/components/palazzetti/icons.json
@@ -1,0 +1,9 @@
+{
+  "entity": {
+    "button": {
+      "silent": {
+        "default": "mdi:volume-mute"
+      }
+    }
+  }
+}

--- a/homeassistant/components/palazzetti/quality_scale.yaml
+++ b/homeassistant/components/palazzetti/quality_scale.yaml
@@ -67,9 +67,7 @@ rules:
   entity-translations: done
   exception-translations: done
   icon-translations:
-    status: exempt
-    comment: |
-      This integration does not have custom icons.
+    status: done
   reconfiguration-flow: todo
   repair-issues:
     status: exempt

--- a/homeassistant/components/palazzetti/strings.json
+++ b/homeassistant/components/palazzetti/strings.json
@@ -38,6 +38,11 @@
     }
   },
   "entity": {
+    "button": {
+      "silent": {
+        "name": "Silent"
+      }
+    },
     "climate": {
       "palazzetti": {
         "state_attributes": {

--- a/tests/components/palazzetti/snapshots/test_button.ambr
+++ b/tests/components/palazzetti/snapshots/test_button.ambr
@@ -22,7 +22,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:volume-mute',
+    'original_icon': None,
     'original_name': 'Silent',
     'platform': 'palazzetti',
     'previous_unique_id': None,
@@ -36,7 +36,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Stove Silent',
-      'icon': 'mdi:volume-mute',
     }),
     'context': <ANY>,
     'entity_id': 'button.stove_silent',

--- a/tests/components/palazzetti/snapshots/test_button.ambr
+++ b/tests/components/palazzetti/snapshots/test_button.ambr
@@ -1,0 +1,48 @@
+# serializer version: 1
+# name: test_all_entities[button.stove_silent-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': None,
+    'entity_id': 'button.stove_silent',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:volume-mute',
+    'original_name': 'Silent',
+    'platform': 'palazzetti',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'silent',
+    'unique_id': '11:22:33:44:55:66-silent',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[button.stove_silent-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Stove Silent',
+      'icon': 'mdi:volume-mute',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.stove_silent',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---

--- a/tests/components/palazzetti/snapshots/test_climate.ambr
+++ b/tests/components/palazzetti/snapshots/test_climate.ambr
@@ -6,7 +6,6 @@
     'area_id': None,
     'capabilities': dict({
       'fan_modes': list([
-        'silent',
         '1',
         '2',
         '3',
@@ -56,7 +55,6 @@
       'current_temperature': 18,
       'fan_mode': '3',
       'fan_modes': list([
-        'silent',
         '1',
         '2',
         '3',

--- a/tests/components/palazzetti/test_button.py
+++ b/tests/components/palazzetti/test_button.py
@@ -1,0 +1,68 @@
+"""Tests for the Palazzetti button platform."""
+
+from unittest.mock import AsyncMock, patch
+
+from pypalazzetti.exceptions import CommunicationError
+import pytest
+from syrupy import SnapshotAssertion
+
+from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
+from homeassistant.const import ATTR_ENTITY_ID, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry as er
+
+from . import setup_integration
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+ENTITY_ID = "button.stove_silent"
+
+
+async def test_all_entities(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    mock_palazzetti_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test all entities."""
+    with patch("homeassistant.components.palazzetti.PLATFORMS", [Platform.BUTTON]):
+        await setup_integration(hass, mock_config_entry)
+
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+async def test_async_press(
+    hass: HomeAssistant,
+    mock_palazzetti_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test pressing via service call."""
+    await setup_integration(hass, mock_config_entry)
+
+    await hass.services.async_call(
+        BUTTON_DOMAIN,
+        SERVICE_PRESS,
+        {ATTR_ENTITY_ID: ENTITY_ID},
+        blocking=True,
+    )
+    mock_palazzetti_client.set_fan_silent.assert_called_once()
+
+
+async def test_async_press_error(
+    hass: HomeAssistant,
+    mock_palazzetti_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test pressing with error via service call."""
+    await setup_integration(hass, mock_config_entry)
+
+    mock_palazzetti_client.set_fan_silent.side_effect = CommunicationError()
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            BUTTON_DOMAIN,
+            SERVICE_PRESS,
+            {ATTR_ENTITY_ID: ENTITY_ID},
+            blocking=True,
+        )

--- a/tests/components/palazzetti/test_button.py
+++ b/tests/components/palazzetti/test_button.py
@@ -59,7 +59,8 @@ async def test_async_press_error(
     await setup_integration(hass, mock_config_entry)
 
     mock_palazzetti_client.set_fan_silent.side_effect = CommunicationError()
-    with pytest.raises(HomeAssistantError):
+    error_message = "Could not connect to the device"
+    with pytest.raises(HomeAssistantError, match=error_message):
         await hass.services.async_call(
             BUTTON_DOMAIN,
             SERVICE_PRESS,

--- a/tests/components/palazzetti/test_climate.py
+++ b/tests/components/palazzetti/test_climate.py
@@ -15,7 +15,7 @@ from homeassistant.components.climate import (
     SERVICE_SET_TEMPERATURE,
     HVACMode,
 )
-from homeassistant.components.palazzetti.const import FAN_AUTO, FAN_HIGH, FAN_SILENT
+from homeassistant.components.palazzetti.const import FAN_AUTO, FAN_HIGH
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_TEMPERATURE, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
@@ -118,15 +118,6 @@ async def test_async_set_data(
         )
 
     # Set Fan Mode: Success
-    await hass.services.async_call(
-        CLIMATE_DOMAIN,
-        SERVICE_SET_FAN_MODE,
-        {ATTR_ENTITY_ID: ENTITY_ID, ATTR_FAN_MODE: FAN_SILENT},
-        blocking=True,
-    )
-    mock_palazzetti_client.set_fan_silent.assert_called_once()
-    mock_palazzetti_client.set_fan_silent.reset_mock()
-
     await hass.services.async_call(
         CLIMATE_DOMAIN,
         SERVICE_SET_FAN_MODE,

--- a/tests/components/palazzetti/test_number.py
+++ b/tests/components/palazzetti/test_number.py
@@ -49,7 +49,7 @@ async def test_async_set_data(
         blocking=True,
     )
     mock_palazzetti_client.set_power_mode.assert_called_once_with(1)
-    mock_palazzetti_client.set_on.reset_mock()
+    mock_palazzetti_client.set_power_mode.reset_mock()
 
     # Set value: Error
     mock_palazzetti_client.set_power_mode.side_effect = CommunicationError()
@@ -60,7 +60,7 @@ async def test_async_set_data(
             {ATTR_ENTITY_ID: ENTITY_ID, "value": 1},
             blocking=True,
         )
-    mock_palazzetti_client.set_on.reset_mock()
+    mock_palazzetti_client.set_power_mode.reset_mock()
 
     mock_palazzetti_client.set_power_mode.side_effect = ValidationError()
     with pytest.raises(ServiceValidationError):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Upon talking with users and studying the existing API, we found that 'silent' is not an actual fan speed for the stove. The models that have a 'silent' mode are setting the main + secondary fans speed to 0 and combustion power to 3. Silent is more a shortcut than a state.

This PR creates a button to trigger the silent mode, removes the fan_mode 'silent', and fixes a bug where it was not possible to change the fan_mode to '0'.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: 
- This PR is related to issue: 
- Link to documentation pull request: [TBD](https://github.com/home-assistant/home-assistant.io/pull/36826)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]
https://github.com/home-assistant/home-assistant.io/pull/36826

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
