### PR TITLE
Fix Watergate Power supply mode description and MQTT/Wifi uptimes

### DIFF
--- a/homeassistant/components/watergate/sensor.py
+++ b/homeassistant/components/watergate/sensor.py
@@ -90,7 +90,7 @@ DESCRIPTIONS: list[WatergateSensorEntityDescription] = [
     WatergateSensorEntityDescription(
         value_fn=lambda data: (
             dt_util.as_utc(
-                dt_util.now() - timedelta(microseconds=data.networking.wifi_uptime)
+                dt_util.now() - timedelta(milliseconds=data.networking.wifi_uptime)
             )
             if data.networking
             else None
@@ -104,7 +104,7 @@ DESCRIPTIONS: list[WatergateSensorEntityDescription] = [
     WatergateSensorEntityDescription(
         value_fn=lambda data: (
             dt_util.as_utc(
-                dt_util.now() - timedelta(microseconds=data.networking.mqtt_uptime)
+                dt_util.now() - timedelta(milliseconds=data.networking.mqtt_uptime)
             )
             if data.networking
             else None
@@ -158,7 +158,11 @@ DESCRIPTIONS: list[WatergateSensorEntityDescription] = [
     ),
     WatergateSensorEntityDescription(
         value_fn=lambda data: (
-            PowerSupplyMode(data.state.power_supply.replace("+", "_"))
+            PowerSupplyMode(
+                data.state.power_supply.replace("+", "_").replace(
+                    "external_battery", "battery_external"
+                )
+            )
             if data.state
             else None
         ),

--- a/tests/components/watergate/snapshots/test_sensor.ambr
+++ b/tests/components/watergate/snapshots/test_sensor.ambr
@@ -43,7 +43,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '2021-01-09T11:59:59+00:00',
+    'state': '2021-01-09T11:59:58+00:00',
   })
 # ---
 # name: test_sensor[sensor.sonic_power_supply_mode-entry]
@@ -501,6 +501,6 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '2021-01-09T11:59:59+00:00',
+    'state': '2021-01-09T11:59:57+00:00',
   })
 # ---

--- a/tests/components/watergate/test_sensor.py
+++ b/tests/components/watergate/test_sensor.py
@@ -140,11 +140,11 @@ async def test_power_supply_webhook(
 
     power_supply_change_data = {
         "type": "power-supply-changed",
-        "data": {"supply": "external"},
+        "data": {"supply": "external_battery"},
     }
     client = await hass_client_no_auth()
     await client.post(f"/api/webhook/{MOCK_WEBHOOK_ID}", json=power_supply_change_data)
 
     await hass.async_block_till_done()
 
-    assert hass.states.get(entity_id).state == "external"
+    assert hass.states.get(entity_id).state == "battery_external"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In recent release MQTT Uptime and Wi-Fi Uptime were based on microseconds whereas API serves miliseconds - that needs to be fixed. Another inconsistency in API vs integration was the name of the Power Supply mode.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #135498
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
