### PR TITLE
Refactor NUT commands to use objects instead of strings

### DIFF
--- a/homeassistant/components/nut/__init__.py
+++ b/homeassistant/components/nut/__init__.py
@@ -28,7 +28,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 from .const import (
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
-    INTEGRATION_SUPPORTED_COMMANDS,
+    INTEGRATION_SUPPORTED_COMMANDS_DICT,
     PLATFORMS,
 )
 
@@ -114,7 +114,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: NutConfigEntry) -> bool:
         user_available_commands = {
             device_supported_command
             for device_supported_command in await data.async_list_commands() or {}
-            if device_supported_command in INTEGRATION_SUPPORTED_COMMANDS
+            if device_supported_command in INTEGRATION_SUPPORTED_COMMANDS_DICT
         }
     else:
         user_available_commands = set()

--- a/homeassistant/components/nut/const.py
+++ b/homeassistant/components/nut/const.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from homeassistant.const import Platform
 
+from .nut_command import NutCommand
+
 DOMAIN = "nut"
 
 PLATFORMS = [Platform.SENSOR]
@@ -37,34 +39,35 @@ STATE_TYPES = {
     "TEST": "Battery Testing",
 }
 
-COMMAND_BEEPER_DISABLE = "beeper.disable"
-COMMAND_BEEPER_ENABLE = "beeper.enable"
-COMMAND_BEEPER_MUTE = "beeper.mute"
-COMMAND_BEEPER_TOGGLE = "beeper.toggle"
-COMMAND_BYPASS_START = "bypass.start"
-COMMAND_BYPASS_STOP = "bypass.stop"
-COMMAND_CALIBRATE_START = "calibrate.start"
-COMMAND_CALIBRATE_STOP = "calibrate.stop"
-COMMAND_LOAD_OFF = "load.off"
-COMMAND_LOAD_ON = "load.on"
-COMMAND_RESET_INPUT_MINMAX = "reset.input.minmax"
-COMMAND_RESET_WATCHDOG = "reset.watchdog"
-COMMAND_SHUTDOWN_REBOOT = "shutdown.reboot"
-COMMAND_SHUTDOWN_REBOOT_GRACEFUL = "shutdown.reboot.graceful"
-COMMAND_SHUTDOWN_RETURN = "shutdown.return"
-COMMAND_SHUTDOWN_STAYOFF = "shutdown.stayoff"
-COMMAND_SHUTDOWN_STOP = "shutdown.stop"
-COMMAND_TEST_BATTERY_START = "test.battery.start"
-COMMAND_TEST_BATTERY_START_DEEP = "test.battery.start.deep"
-COMMAND_TEST_BATTERY_START_QUICK = "test.battery.start.quick"
-COMMAND_TEST_BATTERY_STOP = "test.battery.stop"
-COMMAND_TEST_FAILURE_START = "test.failure.start"
-COMMAND_TEST_FAILURE_STOP = "test.failure.stop"
-COMMAND_TEST_PANEL_START = "test.panel.start"
-COMMAND_TEST_PANEL_STOP = "test.panel.stop"
-COMMAND_TEST_SYSTEM_START = "test.system.start"
 
-INTEGRATION_SUPPORTED_COMMANDS = {
+COMMAND_BEEPER_DISABLE = NutCommand("beeper.disable")
+COMMAND_BEEPER_ENABLE = NutCommand("beeper.enable")
+COMMAND_BEEPER_MUTE = NutCommand("beeper.mute")
+COMMAND_BEEPER_TOGGLE = NutCommand("beeper.toggle")
+COMMAND_BYPASS_START = NutCommand("bypass.start")
+COMMAND_BYPASS_STOP = NutCommand("bypass.stop")
+COMMAND_CALIBRATE_START = NutCommand("calibrate.start")
+COMMAND_CALIBRATE_STOP = NutCommand("calibrate.stop")
+COMMAND_LOAD_OFF = NutCommand("load.off")
+COMMAND_LOAD_ON = NutCommand("load.on")
+COMMAND_RESET_INPUT_MINMAX = NutCommand("reset.input.minmax")
+COMMAND_RESET_WATCHDOG = NutCommand("reset.watchdog")
+COMMAND_SHUTDOWN_REBOOT = NutCommand("shutdown.reboot")
+COMMAND_SHUTDOWN_REBOOT_GRACEFUL = NutCommand("shutdown.reboot.graceful")
+COMMAND_SHUTDOWN_RETURN = NutCommand("shutdown.return")
+COMMAND_SHUTDOWN_STAYOFF = NutCommand("shutdown.stayoff")
+COMMAND_SHUTDOWN_STOP = NutCommand("shutdown.stop")
+COMMAND_TEST_BATTERY_START = NutCommand("test.battery.start")
+COMMAND_TEST_BATTERY_START_DEEP = NutCommand("test.battery.start.deep")
+COMMAND_TEST_BATTERY_START_QUICK = NutCommand("test.battery.start.quick")
+COMMAND_TEST_BATTERY_STOP = NutCommand("test.battery.stop")
+COMMAND_TEST_FAILURE_START = NutCommand("test.failure.start")
+COMMAND_TEST_FAILURE_STOP = NutCommand("test.failure.stop")
+COMMAND_TEST_PANEL_START = NutCommand("test.panel.start")
+COMMAND_TEST_PANEL_STOP = NutCommand("test.panel.stop")
+COMMAND_TEST_SYSTEM_START = NutCommand("test.system.start")
+
+INTEGRATION_SUPPORTED_COMMANDS = [
     COMMAND_BEEPER_DISABLE,
     COMMAND_BEEPER_ENABLE,
     COMMAND_BEEPER_MUTE,
@@ -91,4 +94,8 @@ INTEGRATION_SUPPORTED_COMMANDS = {
     COMMAND_TEST_PANEL_START,
     COMMAND_TEST_PANEL_STOP,
     COMMAND_TEST_SYSTEM_START,
+]
+
+INTEGRATION_SUPPORTED_COMMANDS_DICT = {
+    cmd.command_string: cmd for cmd in INTEGRATION_SUPPORTED_COMMANDS
 }

--- a/homeassistant/components/nut/device_action.py
+++ b/homeassistant/components/nut/device_action.py
@@ -14,7 +14,9 @@ from homeassistant.helpers.typing import ConfigType, TemplateVarsType
 from . import NutRuntimeData
 from .const import DOMAIN, INTEGRATION_SUPPORTED_COMMANDS
 
-ACTION_TYPES = {cmd.replace(".", "_") for cmd in INTEGRATION_SUPPORTED_COMMANDS}
+ACTION_TYPES = {
+    cmd.command_string.replace(".", "_") for cmd in INTEGRATION_SUPPORTED_COMMANDS
+}
 
 ACTION_SCHEMA = cv.DEVICE_ACTION_BASE_SCHEMA.extend(
     {

--- a/homeassistant/components/nut/nut_command.py
+++ b/homeassistant/components/nut/nut_command.py
@@ -1,0 +1,24 @@
+"""Defines the NutCommand class for representing NUT commands and their parameters."""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+import voluptuous as vol
+
+
+@dataclass
+class NutParameter:
+    """Class for representing NUT command parameters with a name and schema, as well as a method for converting the param into a string."""
+
+    name: str
+    schema: vol.All
+    string_formatting_callback: Callable[[Any], str]
+
+
+@dataclass
+class NutCommand:
+    """Class for representing NUT commands."""
+
+    command_string: str
+    parameter: NutParameter | None = None

--- a/tests/components/nut/test_device_action.py
+++ b/tests/components/nut/test_device_action.py
@@ -29,7 +29,7 @@ async def test_get_all_actions_for_specified_user(
 ) -> None:
     """Test we get all the expected actions from a nut if user is specified."""
     list_commands_return_value = {
-        supported_command: supported_command
+        supported_command.command_string: supported_command.command_string
         for supported_command in INTEGRATION_SUPPORTED_COMMANDS
     }
 
@@ -44,7 +44,7 @@ async def test_get_all_actions_for_specified_user(
     expected_actions = [
         {
             "domain": DOMAIN,
-            "type": action.replace(".", "_"),
+            "type": action.command_string.replace(".", "_"),
             "device_id": device_entry.id,
             "metadata": {},
         }


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is part 1 of a 2 part PR for adding support for NUT commands with parameters.
This PR does the initial work of refactoring the nut commands to be objects with an optional parameter object instead of just strings. The next PR will implement the logic to handle the parameter within Home Assistant. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pull/130731

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
