### PR TITLE
Impove LG webOS TV tests quality

### DIFF
--- a/homeassistant/components/webostv/quality_scale.yaml
+++ b/homeassistant/components/webostv/quality_scale.yaml
@@ -8,9 +8,7 @@ rules:
   common-modules:
     status: exempt
     comment: The integration does not use common patterns.
-  config-flow-test-coverage:
-    status: todo
-    comment: remove duplicated config flow start in tests, make sure tests ends with CREATE_ENTRY or ABORT, use hass.config_entries.async_setup instead of async_setup_component, snapshot in diagnostics (and other tests when possible), test_client_disconnected validate no error in log
+  config-flow-test-coverage: done
   config-flow:
     status: todo
     comment: make reauth flow more graceful
@@ -39,7 +37,7 @@ rules:
   log-when-unavailable: todo
   parallel-updates: todo
   reauthentication-flow: done
-  test-coverage: todo
+  test-coverage: done
 
   # Gold
   devices: done

--- a/tests/components/webostv/__init__.py
+++ b/tests/components/webostv/__init__.py
@@ -3,7 +3,6 @@
 from homeassistant.components.webostv.const import DOMAIN
 from homeassistant.const import CONF_CLIENT_SECRET, CONF_HOST
 from homeassistant.core import HomeAssistant
-from homeassistant.setup import async_setup_component
 
 from .const import CLIENT_KEY, FAKE_UUID, HOST, TV_NAME
 
@@ -25,11 +24,7 @@ async def setup_webostv(
     )
     entry.add_to_hass(hass)
 
-    await async_setup_component(
-        hass,
-        DOMAIN,
-        {DOMAIN: {CONF_HOST: HOST}},
-    )
+    await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
     return entry

--- a/tests/components/webostv/snapshots/test_diagnostics.ambr
+++ b/tests/components/webostv/snapshots/test_diagnostics.ambr
@@ -1,0 +1,66 @@
+# serializer version: 1
+# name: test_diagnostics
+  dict({
+    'client': dict({
+      'apps': dict({
+        'com.webos.app.livetv': dict({
+          'icon': '**REDACTED**',
+          'id': 'com.webos.app.livetv',
+          'largeIcon': '**REDACTED**',
+          'title': 'Live TV',
+        }),
+      }),
+      'current_app_id': 'com.webos.app.livetv',
+      'current_channel': dict({
+        'channelId': 'ch1id',
+        'channelName': 'Channel 1',
+        'channelNumber': '1',
+      }),
+      'hello_info': dict({
+        'deviceUUID': '**REDACTED**',
+      }),
+      'inputs': dict({
+        'in1': dict({
+          'appId': 'app0',
+          'id': 'in1',
+          'label': 'Input01',
+        }),
+        'in2': dict({
+          'appId': 'app1',
+          'id': 'in2',
+          'label': 'Input02',
+        }),
+      }),
+      'is_connected': True,
+      'is_on': True,
+      'is_registered': True,
+      'software_info': dict({
+        'major_ver': 'major',
+        'minor_ver': 'minor',
+      }),
+      'sound_output': 'speaker',
+      'system_info': dict({
+        'modelName': 'MODEL',
+      }),
+    }),
+    'entry': dict({
+      'data': dict({
+        'client_secret': '**REDACTED**',
+        'host': '**REDACTED**',
+      }),
+      'disabled_by': None,
+      'discovery_keys': dict({
+      }),
+      'domain': 'webostv',
+      'minor_version': 1,
+      'options': dict({
+      }),
+      'pref_disable_new_entities': False,
+      'pref_disable_polling': False,
+      'source': 'user',
+      'title': 'LG webOS TV MODEL',
+      'unique_id': '**REDACTED**',
+      'version': 1,
+    }),
+  })
+# ---

--- a/tests/components/webostv/snapshots/test_media_player.ambr
+++ b/tests/components/webostv/snapshots/test_media_player.ambr
@@ -1,0 +1,59 @@
+# serializer version: 1
+# name: test_entity_attributes
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'tv',
+      'friendly_name': 'LG webOS TV MODEL',
+      'is_volume_muted': False,
+      'media_content_type': <MediaType.CHANNEL: 'channel'>,
+      'media_title': 'Channel 1',
+      'sound_output': 'speaker',
+      'source': 'Live TV',
+      'source_list': list([
+        'Input01',
+        'Input02',
+        'Live TV',
+      ]),
+      'supported_features': <MediaPlayerEntityFeature: 24381>,
+      'volume_level': 0.37,
+    }),
+    'context': <ANY>,
+    'entity_id': 'media_player.lg_webos_tv_model',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_entity_attributes.1
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'webostv',
+        'some-fake-uuid',
+      ),
+    }),
+    'is_new': False,
+    'labels': set({
+    }),
+    'manufacturer': 'LG',
+    'model': 'MODEL',
+    'model_id': None,
+    'name': 'LG webOS TV MODEL',
+    'name_by_user': None,
+    'primary_config_entry': <ANY>,
+    'serial_number': None,
+    'suggested_area': None,
+    'sw_version': 'major.minor',
+    'via_device_id': None,
+  })
+# ---

--- a/tests/components/webostv/test_diagnostics.py
+++ b/tests/components/webostv/test_diagnostics.py
@@ -1,6 +1,8 @@
 """Tests for the diagnostics data provided by LG webOS Smart TV."""
 
-from homeassistant.components.diagnostics import REDACTED
+from syrupy.assertion import SnapshotAssertion
+from syrupy.filters import props
+
 from homeassistant.core import HomeAssistant
 
 from . import setup_webostv
@@ -10,56 +12,13 @@ from tests.typing import ClientSessionGenerator
 
 
 async def test_diagnostics(
-    hass: HomeAssistant, hass_client: ClientSessionGenerator, client
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    client,
+    snapshot: SnapshotAssertion,
 ) -> None:
     """Test diagnostics."""
     entry = await setup_webostv(hass)
-    assert await get_diagnostics_for_config_entry(hass, hass_client, entry) == {
-        "client": {
-            "is_registered": True,
-            "is_connected": True,
-            "current_app_id": "com.webos.app.livetv",
-            "current_channel": {
-                "channelId": "ch1id",
-                "channelName": "Channel 1",
-                "channelNumber": "1",
-            },
-            "apps": {
-                "com.webos.app.livetv": {
-                    "icon": REDACTED,
-                    "id": "com.webos.app.livetv",
-                    "largeIcon": REDACTED,
-                    "title": "Live TV",
-                }
-            },
-            "inputs": {
-                "in1": {"appId": "app0", "id": "in1", "label": "Input01"},
-                "in2": {"appId": "app1", "id": "in2", "label": "Input02"},
-            },
-            "system_info": {"modelName": "MODEL"},
-            "software_info": {"major_ver": "major", "minor_ver": "minor"},
-            "hello_info": {"deviceUUID": "**REDACTED**"},
-            "sound_output": "speaker",
-            "is_on": True,
-        },
-        "entry": {
-            "entry_id": entry.entry_id,
-            "version": 1,
-            "minor_version": 1,
-            "domain": "webostv",
-            "title": "LG webOS TV MODEL",
-            "data": {
-                "client_secret": "**REDACTED**",
-                "host": "**REDACTED**",
-            },
-            "options": {},
-            "pref_disable_new_entities": False,
-            "pref_disable_polling": False,
-            "source": "user",
-            "unique_id": REDACTED,
-            "disabled_by": None,
-            "created_at": entry.created_at.isoformat(),
-            "modified_at": entry.modified_at.isoformat(),
-            "discovery_keys": {},
-        },
-    }
+    assert await get_diagnostics_for_config_entry(hass, hass_client, entry) == snapshot(
+        exclude=props("created_at", "modified_at", "entry_id")
+    )

--- a/tests/components/webostv/test_media_player.py
+++ b/tests/components/webostv/test_media_player.py
@@ -5,6 +5,7 @@ from http import HTTPStatus
 from unittest.mock import Mock
 
 from aiowebostv import WebOsTvPairError
+from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy.assertion import SnapshotAssertion
 from syrupy.filters import props
@@ -460,13 +461,15 @@ async def test_client_disconnected(
     client,
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test error not raised when client is disconnected."""
     await setup_webostv(hass)
     monkeypatch.setattr(client, "is_connected", Mock(return_value=False))
     monkeypatch.setattr(client, "connect", Mock(side_effect=TimeoutError))
 
-    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=20))
+    freezer.tick(timedelta(seconds=20))
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
     assert "TimeoutError" not in caplog.text


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow-up for https://github.com/home-assistant/core/pull/133732
- Remove duplicate config flow init in tests
- Make sure tests ends with `CREATE_ENTRY` or `ABORT`
- Use `hass.config_entries.async_setup` instead of `async_setup_component`
- Use snapshots in diagnostics and media player attributes tests
- Fix `test_client_disconnected` test

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
