### PR TITLE
Add option to allow to use setpoint instead of override for legacy incomfort RF gateway

### DIFF
--- a/homeassistant/components/incomfort/__init__.py
+++ b/homeassistant/components/incomfort/__init__.py
@@ -25,7 +25,7 @@ INTEGRATION_TITLE = "Intergas InComfort/Intouch Lan2RF gateway"
 type InComfortConfigEntry = ConfigEntry[InComfortDataCoordinator]
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: InComfortConfigEntry) -> bool:
     """Set up a config entry."""
     try:
         data = await async_connect_gateway(hass, dict(entry.data))

--- a/homeassistant/components/incomfort/climate.py
+++ b/homeassistant/components/incomfort/climate.py
@@ -18,7 +18,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import InComfortConfigEntry
-from .const import DOMAIN
+from .const import CONF_LEGACY_SETPOINT_STATUS, DOMAIN
 from .coordinator import InComfortDataCoordinator
 from .entity import IncomfortEntity
 
@@ -32,9 +32,12 @@ async def async_setup_entry(
 ) -> None:
     """Set up InComfort/InTouch climate devices."""
     incomfort_coordinator = entry.runtime_data
+    legacy_setpoint_status = entry.options.get(CONF_LEGACY_SETPOINT_STATUS, False)
     heaters = incomfort_coordinator.data.heaters
     async_add_entities(
-        InComfortClimate(incomfort_coordinator, h, r) for h in heaters for r in h.rooms
+        InComfortClimate(incomfort_coordinator, h, r, legacy_setpoint_status)
+        for h in heaters
+        for r in h.rooms
     )
 
 
@@ -54,12 +57,14 @@ class InComfortClimate(IncomfortEntity, ClimateEntity):
         coordinator: InComfortDataCoordinator,
         heater: InComfortHeater,
         room: InComfortRoom,
+        legacy_setpoint_status: bool,
     ) -> None:
         """Initialize the climate device."""
         super().__init__(coordinator)
 
         self._heater = heater
         self._room = room
+        self._legacy_setpoint_status = legacy_setpoint_status
 
         self._attr_unique_id = f"{heater.serial_no}_{room.room_no}"
         self._attr_device_info = DeviceInfo(
@@ -91,9 +96,11 @@ class InComfortClimate(IncomfortEntity, ClimateEntity):
 
         As we set the override, we report back the override. The actual set point is
         is returned at a later time.
-        Some older thermostats return 0.0 as override, in that case we fallback to
-        the actual setpoint.
+        Some older thermostats do not clear the override setting in that case, in that case
+        we fallback to the returning actual setpoint.
         """
+        if self._legacy_setpoint_status:
+            return self._room.setpoint
         return self._room.override or self._room.setpoint
 
     async def async_set_temperature(self, **kwargs: Any) -> None:

--- a/homeassistant/components/incomfort/config_flow.py
+++ b/homeassistant/components/incomfort/config_flow.py
@@ -91,10 +91,7 @@ class InComfortOptionsFlowHandler(OptionsFlow):
             self.hass.config_entries.async_update_entry(
                 self.config_entry, options=new_options
             )
-            self.hass.async_create_task(
-                self.hass.config_entries.async_reload(self.config_entry.entry_id),
-                eager_start=False,
-            )
+            self.hass.config_entries.async_schedule_reload(self.config_entry.entry_id)
             return self.async_create_entry(data=new_options)
 
         data_schema = self.add_suggested_values_to_schema(

--- a/homeassistant/components/incomfort/config_flow.py
+++ b/homeassistant/components/incomfort/config_flow.py
@@ -15,6 +15,8 @@ from homeassistant.config_entries import (
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.selector import (
+    BooleanSelector,
+    BooleanSelectorConfig,
     TextSelector,
     TextSelectorConfig,
     TextSelectorType,
@@ -41,7 +43,9 @@ CONFIG_SCHEMA = vol.Schema(
 
 OPTIONS_SCHEMA = vol.Schema(
     {
-        vol.Optional(CONF_LEGACY_SETPOINT_STATUS, default=False): bool,
+        vol.Optional(CONF_LEGACY_SETPOINT_STATUS, default=False): BooleanSelector(
+            BooleanSelectorConfig()
+        )
     }
 )
 

--- a/homeassistant/components/incomfort/config_flow.py
+++ b/homeassistant/components/incomfort/config_flow.py
@@ -1,5 +1,7 @@
 """Config flow support for Intergas InComfort integration."""
 
+from __future__ import annotations
+
 from typing import Any
 
 from aiohttp import ClientResponseError
@@ -78,32 +80,6 @@ async def async_try_connect_gateway(
     return None
 
 
-class InComfortOptionsFlowHandler(OptionsFlow):
-    """Handle InComfort Lan2RF gateway options."""
-
-    async def async_step_init(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
-        """Manage the options."""
-        errors: dict[str, str] | None = None
-        if user_input is not None:
-            new_options: dict[str, Any] = self.config_entry.options | user_input
-            self.hass.config_entries.async_update_entry(
-                self.config_entry, options=new_options
-            )
-            self.hass.config_entries.async_schedule_reload(self.config_entry.entry_id)
-            return self.async_create_entry(data=new_options)
-
-        data_schema = self.add_suggested_values_to_schema(
-            OPTIONS_SCHEMA, self.config_entry.options
-        )
-        return self.async_show_form(
-            step_id="init",
-            data_schema=data_schema,
-            errors=errors,
-        )
-
-
 class InComfortConfigFlow(ConfigFlow, domain=DOMAIN):
     """Config flow to set up an Intergas InComfort boyler and thermostats."""
 
@@ -129,4 +105,30 @@ class InComfortConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="user", data_schema=CONFIG_SCHEMA, errors=errors
+        )
+
+
+class InComfortOptionsFlowHandler(OptionsFlow):
+    """Handle InComfort Lan2RF gateway options."""
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Manage the options."""
+        errors: dict[str, str] | None = None
+        if user_input is not None:
+            new_options: dict[str, Any] = self.config_entry.options | user_input
+            self.hass.config_entries.async_update_entry(
+                self.config_entry, options=new_options
+            )
+            self.hass.config_entries.async_schedule_reload(self.config_entry.entry_id)
+            return self.async_create_entry(data=new_options)
+
+        data_schema = self.add_suggested_values_to_schema(
+            OPTIONS_SCHEMA, self.config_entry.options
+        )
+        return self.async_show_form(
+            step_id="init",
+            data_schema=data_schema,
+            errors=errors,
         )

--- a/homeassistant/components/incomfort/config_flow.py
+++ b/homeassistant/components/incomfort/config_flow.py
@@ -84,23 +84,9 @@ class InComfortOptionsFlowHandler(OptionsFlow):
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Initiate options flow."""
-        return await self.async_step_gateway()
-
-    async def async_step_gateway(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
         """Manage the options."""
         errors: dict[str, str] | None = None
-        if (
-            user_input is not None
-            and (
-                errors := await async_try_connect_gateway(
-                    self.hass, dict(self.config_entry.data)
-                )
-            )
-            is None
-        ):
+        if user_input is not None:
             new_options: dict[str, Any] = self.config_entry.options | user_input
             self.hass.config_entries.async_update_entry(
                 self.config_entry, options=new_options
@@ -115,7 +101,7 @@ class InComfortOptionsFlowHandler(OptionsFlow):
             OPTIONS_SCHEMA, self.config_entry.options
         )
         return self.async_show_form(
-            step_id="gateway",
+            step_id="init",
             data_schema=data_schema,
             errors=errors,
         )

--- a/homeassistant/components/incomfort/const.py
+++ b/homeassistant/components/incomfort/const.py
@@ -1,3 +1,5 @@
 """Constants for Intergas InComfort integration."""
 
 DOMAIN = "incomfort"
+
+CONF_LEGACY_SETPOINT_STATUS = "legacy_setpoint_status"

--- a/homeassistant/components/incomfort/strings.json
+++ b/homeassistant/components/incomfort/strings.json
@@ -31,6 +31,26 @@
       "unknown": "[%key:component::incomfort::config::abort::unknown%]"
     }
   },
+  "options": {
+    "step": {
+      "gateway": {
+        "title": "Intergas InComfort Lan2RF Gateway options",
+        "data": {
+          "legacy_setpoint_status": "Legacy setpoint handling"
+        },
+        "data_description": {
+          "legacy_setpoint_status": "Only enable this option if experience issues in updating the setpoint for your thermostat."
+        }
+      }
+    },
+    "error": {
+      "auth_error": "[%key:component::incomfort::config::abort::auth_error%]",
+      "no_heaters": "[%key:component::incomfort::config::abort::no_heaters%]",
+      "not_found": "[%key:component::incomfort::config::abort::not_found%]",
+      "timeout_error": "[%key:component::incomfort::config::abort::timeout_error%]",
+      "unknown": "[%key:component::incomfort::config::abort::unknown%]"
+    }
+  },
   "issues": {
     "deprecated_yaml_import_issue_unknown": {
       "title": "YAML import failed with unknown error",

--- a/homeassistant/components/incomfort/strings.json
+++ b/homeassistant/components/incomfort/strings.json
@@ -39,7 +39,7 @@
           "legacy_setpoint_status": "Legacy setpoint handling"
         },
         "data_description": {
-          "legacy_setpoint_status": "Only enable this option if experience issues in updating the setpoint for your thermostat."
+          "legacy_setpoint_status": "Only enable this option if you experience issues in updating the setpoint for your thermostat."
         }
       }
     },

--- a/homeassistant/components/incomfort/strings.json
+++ b/homeassistant/components/incomfort/strings.json
@@ -33,7 +33,7 @@
   },
   "options": {
     "step": {
-      "gateway": {
+      "init": {
         "title": "Intergas InComfort Lan2RF Gateway options",
         "data": {
           "legacy_setpoint_status": "Legacy setpoint handling"
@@ -42,13 +42,6 @@
           "legacy_setpoint_status": "Only enable this option if you experience issues in updating the setpoint for your thermostat."
         }
       }
-    },
-    "error": {
-      "auth_error": "[%key:component::incomfort::config::abort::auth_error%]",
-      "no_heaters": "[%key:component::incomfort::config::abort::no_heaters%]",
-      "not_found": "[%key:component::incomfort::config::abort::not_found%]",
-      "timeout_error": "[%key:component::incomfort::config::abort::timeout_error%]",
-      "unknown": "[%key:component::incomfort::config::abort::unknown%]"
     }
   },
   "issues": {

--- a/homeassistant/components/incomfort/strings.json
+++ b/homeassistant/components/incomfort/strings.json
@@ -39,7 +39,7 @@
           "legacy_setpoint_status": "Legacy setpoint handling"
         },
         "data_description": {
-          "legacy_setpoint_status": "Only enable this option if you experience issues in updating the setpoint for your thermostat."
+          "legacy_setpoint_status": "Some older gateway models with an older firmware versions might not update the thermostat setpoint and override settings correctly. Enable this option if you experience issues in updating the setpoint for your thermostat."
         }
       }
     }

--- a/homeassistant/components/incomfort/strings.json
+++ b/homeassistant/components/incomfort/strings.json
@@ -39,7 +39,7 @@
           "legacy_setpoint_status": "Legacy setpoint handling"
         },
         "data_description": {
-          "legacy_setpoint_status": "Some older gateway models with an older firmware versions might not update the thermostat setpoint and override settings correctly. Enable this option if you experience issues in updating the setpoint for your thermostat."
+          "legacy_setpoint_status": "Some older gateway models with an older firmware versions might not update the thermostat setpoint and override settings correctly. Enable this option if you experience issues in updating the setpoint for your thermostat. It will use the actual setpoint of the thermostat instead of the override. As side effect is that it might take a few minutes before the setpoint is updated."
         }
       }
     }

--- a/tests/components/incomfort/conftest.py
+++ b/tests/components/incomfort/conftest.py
@@ -54,11 +54,21 @@ def mock_entry_data() -> dict[str, Any]:
 
 
 @pytest.fixture
+def mock_entry_options() -> dict[str, Any] | None:
+    """Mock config entry options for fixture."""
+    return None
+
+
+@pytest.fixture
 def mock_config_entry(
-    hass: HomeAssistant, mock_entry_data: dict[str, Any]
+    hass: HomeAssistant,
+    mock_entry_data: dict[str, Any],
+    mock_entry_options: dict[str, Any],
 ) -> ConfigEntry:
     """Mock a config entry setup for incomfort integration."""
-    entry = MockConfigEntry(domain=DOMAIN, data=mock_entry_data)
+    entry = MockConfigEntry(
+        domain=DOMAIN, data=mock_entry_data, options=mock_entry_options
+    )
     entry.add_to_hass(hass)
     return entry
 

--- a/tests/components/incomfort/snapshots/test_climate.ambr
+++ b/tests/components/incomfort/snapshots/test_climate.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_setup_platform[legacy_thermostat][climate.thermostat_1-entry]
+# name: test_setup_platform[legacy-override][climate.thermostat_1-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -38,7 +38,73 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_setup_platform[legacy_thermostat][climate.thermostat_1-state]
+# name: test_setup_platform[legacy-override][climate.thermostat_1-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_temperature': 21.4,
+      'friendly_name': 'Thermostat 1',
+      'hvac_action': <HVACAction.IDLE: 'idle'>,
+      'hvac_modes': list([
+        <HVACMode.HEAT: 'heat'>,
+      ]),
+      'max_temp': 30.0,
+      'min_temp': 5.0,
+      'status': dict({
+        'override': 19.0,
+        'room_temp': 21.42,
+        'setpoint': 18.0,
+      }),
+      'supported_features': <ClimateEntityFeature: 1>,
+      'temperature': 18.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.thermostat_1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'heat',
+  })
+# ---
+# name: test_setup_platform[legacy-zero_override][climate.thermostat_1-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'hvac_modes': list([
+        <HVACMode.HEAT: 'heat'>,
+      ]),
+      'max_temp': 30.0,
+      'min_temp': 5.0,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'climate',
+    'entity_category': None,
+    'entity_id': 'climate.thermostat_1',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'incomfort',
+    'previous_unique_id': None,
+    'supported_features': <ClimateEntityFeature: 1>,
+    'translation_key': None,
+    'unique_id': 'c0ffeec0ffee_1',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup_platform[legacy-zero_override][climate.thermostat_1-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 21.4,
@@ -65,7 +131,7 @@
     'state': 'heat',
   })
 # ---
-# name: test_setup_platform[new_thermostat][climate.thermostat_1-entry]
+# name: test_setup_platform[modern-override][climate.thermostat_1-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -104,7 +170,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_setup_platform[new_thermostat][climate.thermostat_1-state]
+# name: test_setup_platform[modern-override][climate.thermostat_1-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': 21.4,
@@ -116,7 +182,73 @@
       'max_temp': 30.0,
       'min_temp': 5.0,
       'status': dict({
-        'override': 18.0,
+        'override': 19.0,
+        'room_temp': 21.42,
+        'setpoint': 18.0,
+      }),
+      'supported_features': <ClimateEntityFeature: 1>,
+      'temperature': 19.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.thermostat_1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'heat',
+  })
+# ---
+# name: test_setup_platform[modern-zero_override][climate.thermostat_1-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'hvac_modes': list([
+        <HVACMode.HEAT: 'heat'>,
+      ]),
+      'max_temp': 30.0,
+      'min_temp': 5.0,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'climate',
+    'entity_category': None,
+    'entity_id': 'climate.thermostat_1',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'incomfort',
+    'previous_unique_id': None,
+    'supported_features': <ClimateEntityFeature: 1>,
+    'translation_key': None,
+    'unique_id': 'c0ffeec0ffee_1',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup_platform[modern-zero_override][climate.thermostat_1-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_temperature': 21.4,
+      'friendly_name': 'Thermostat 1',
+      'hvac_action': <HVACAction.IDLE: 'idle'>,
+      'hvac_modes': list([
+        <HVACMode.HEAT: 'heat'>,
+      ]),
+      'max_temp': 30.0,
+      'min_temp': 5.0,
+      'status': dict({
+        'override': 0.0,
         'room_temp': 21.42,
         'setpoint': 18.0,
       }),

--- a/tests/components/incomfort/test_climate.py
+++ b/tests/components/incomfort/test_climate.py
@@ -17,10 +17,15 @@ from tests.common import snapshot_platform
 @pytest.mark.parametrize(
     "mock_room_status",
     [
-        {"room_temp": 21.42, "setpoint": 18.0, "override": 18.0},
+        {"room_temp": 21.42, "setpoint": 18.0, "override": 19.0},
         {"room_temp": 21.42, "setpoint": 18.0, "override": 0.0},
     ],
-    ids=["new_thermostat", "legacy_thermostat"],
+    ids=["override", "zero_override"],
+)
+@pytest.mark.parametrize(
+    "mock_entry_options",
+    [None, {"legacy_setpoint_status": True}],
+    ids=["modern", "legacy"],
 )
 async def test_setup_platform(
     hass: HomeAssistant,
@@ -31,8 +36,9 @@ async def test_setup_platform(
 ) -> None:
     """Test the incomfort entities are set up correctly.
 
-    Legacy thermostats report 0.0 as override if no override is set,
-    but new thermostat sync the override with the actual setpoint instead.
+    Thermostats report 0.0 as override if no override is set
+    or when the setpoint has been changed manually,
+    Some older thermostats do not reset the override setpoint has been changed manually.
     """
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)

--- a/tests/components/incomfort/test_config_flow.py
+++ b/tests/components/incomfort/test_config_flow.py
@@ -1,6 +1,7 @@
 """Tests for the Intergas InComfort config flow."""
 
-from unittest.mock import AsyncMock, MagicMock
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from aiohttp import ClientResponseError
 from incomfortclient import IncomfortError, InvalidHeaterList
@@ -113,3 +114,69 @@ async def test_form_validation(
     )
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert "errors" not in result
+
+
+@pytest.mark.parametrize(
+    ("user_input", "legacy_setpoint_status"),
+    [
+        ({}, False),
+        ({"legacy_setpoint_status": False}, False),
+        ({"legacy_setpoint_status": True}, True),
+    ],
+)
+async def test_options_flow(
+    hass: HomeAssistant,
+    mock_incomfort: MagicMock,
+    user_input: dict[str, Any],
+    legacy_setpoint_status: bool,
+) -> None:
+    """Test options flow."""
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG)
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "gateway"
+
+    with patch("homeassistant.components.incomfort.async_setup_entry") as restart_mock:
+        result2 = await hass.config_entries.options.async_configure(
+            result["flow_id"], user_input
+        )
+        await hass.async_block_till_done(wait_background_tasks=True)
+        assert restart_mock.call_count == 1
+
+    assert result2["type"] is FlowResultType.CREATE_ENTRY
+    assert result2["data"] == {"legacy_setpoint_status": legacy_setpoint_status}
+    assert entry.options.get("legacy_setpoint_status", False) is legacy_setpoint_status
+
+
+async def test_options_flow_test_fails(
+    hass: HomeAssistant, mock_incomfort: MagicMock
+) -> None:
+    """Test options flow fails because of setup error."""
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG)
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "gateway"
+
+    # Simulate an issue
+    mock_incomfort().heaters.side_effect = InvalidHeaterList
+
+    with patch("homeassistant.components.incomfort.async_setup_entry") as restart_mock:
+        result2 = await hass.config_entries.options.async_configure(
+            result["flow_id"], {"legacy_setpoint_status": True}
+        )
+        await hass.async_block_till_done(wait_background_tasks=True)
+        assert restart_mock.call_count == 0
+
+    assert result2["type"] is FlowResultType.FORM
+    assert result2["errors"] == {"base": "no_heaters"}
+
+    # Entry options were not updated
+    assert entry.options.get("legacy_setpoint_status", False) is False


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Some older InComfort RF Gateways do not reset the override setting after the setpoint of a climate has changed manually. In that case the changed setpoint is not updated in Home Assistant. To work-a-round this issue this PR adds an option that allows to return the setpoint instead of the override. As side effect is though that when the setpoint is changed using the override, it will take some time for the climate to show the correct setpoint as the override attribute will be ignored.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/jbouwh/incomfort-client/issues/40
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/36819

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
