### PR TITLE
Use snapshot_platform helper in onewire tests

### DIFF
--- a/tests/components/onewire/snapshots/test_binary_sensor.ambr
+++ b/tests/components/onewire/snapshots/test_binary_sensor.ambr
@@ -1,1645 +1,773 @@
 # serializer version: 1
-# name: test_binary_sensors[00.111111111111]
-  list([
-  ])
-# ---
-# name: test_binary_sensors[00.111111111111].1
-  list([
-  ])
-# ---
-# name: test_binary_sensors[00.111111111111].2
-  list([
-  ])
-# ---
-# name: test_binary_sensors[05.111111111111]
-  list([
-    DeviceRegistryEntrySnapshot({
-      'area_id': None,
-      'config_entries': <ANY>,
-      'configuration_url': None,
-      'connections': set({
-      }),
-      'disabled_by': None,
-      'entry_type': None,
-      'hw_version': None,
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'onewire',
-          '05.111111111111',
-        ),
-      }),
-      'is_new': False,
-      'labels': set({
-      }),
-      'manufacturer': 'Maxim Integrated',
-      'model': 'DS2405',
-      'model_id': None,
-      'name': '05.111111111111',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': None,
-      'suggested_area': None,
-      'sw_version': None,
-      'via_device_id': None,
+# name: test_binary_sensors[binary_sensor.12_111111111111_sensed_a-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
     }),
-  ])
-# ---
-# name: test_binary_sensors[05.111111111111].1
-  list([
-  ])
-# ---
-# name: test_binary_sensors[05.111111111111].2
-  list([
-  ])
-# ---
-# name: test_binary_sensors[10.111111111111]
-  list([
-    DeviceRegistryEntrySnapshot({
-      'area_id': None,
-      'config_entries': <ANY>,
-      'configuration_url': None,
-      'connections': set({
-      }),
-      'disabled_by': None,
-      'entry_type': None,
-      'hw_version': None,
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'onewire',
-          '10.111111111111',
-        ),
-      }),
-      'is_new': False,
-      'labels': set({
-      }),
-      'manufacturer': 'Maxim Integrated',
-      'model': 'DS18S20',
-      'model_id': None,
-      'name': '10.111111111111',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': None,
-      'suggested_area': None,
-      'sw_version': None,
-      'via_device_id': None,
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.12_111111111111_sensed_a',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
     }),
-  ])
-# ---
-# name: test_binary_sensors[10.111111111111].1
-  list([
-  ])
-# ---
-# name: test_binary_sensors[10.111111111111].2
-  list([
-  ])
-# ---
-# name: test_binary_sensors[12.111111111111]
-  list([
-    DeviceRegistryEntrySnapshot({
-      'area_id': None,
-      'config_entries': <ANY>,
-      'configuration_url': None,
-      'connections': set({
-      }),
-      'disabled_by': None,
-      'entry_type': None,
-      'hw_version': None,
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'onewire',
-          '12.111111111111',
-        ),
-      }),
-      'is_new': False,
-      'labels': set({
-      }),
-      'manufacturer': 'Maxim Integrated',
-      'model': 'DS2406',
-      'model_id': None,
-      'name': '12.111111111111',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': None,
-      'suggested_area': None,
-      'sw_version': None,
-      'via_device_id': None,
+    'name': None,
+    'options': dict({
     }),
-  ])
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Sensed A',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'sensed_id',
+    'unique_id': '/12.111111111111/sensed.A',
+    'unit_of_measurement': None,
+  })
 # ---
-# name: test_binary_sensors[12.111111111111].1
-  list([
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': None,
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'binary_sensor',
-      'entity_category': None,
-      'entity_id': 'binary_sensor.12_111111111111_sensed_a',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': None,
-      'original_icon': None,
-      'original_name': 'Sensed A',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'sensed_id',
-      'unique_id': '/12.111111111111/sensed.A',
-      'unit_of_measurement': None,
+# name: test_binary_sensors[binary_sensor.12_111111111111_sensed_a-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_file': '/12.111111111111/sensed.A',
+      'friendly_name': '12.111111111111 Sensed A',
+      'raw_value': 1.0,
     }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': None,
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'binary_sensor',
-      'entity_category': None,
-      'entity_id': 'binary_sensor.12_111111111111_sensed_b',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': None,
-      'original_icon': None,
-      'original_name': 'Sensed B',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'sensed_id',
-      'unique_id': '/12.111111111111/sensed.B',
-      'unit_of_measurement': None,
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.12_111111111111_sensed_a',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_binary_sensors[binary_sensor.12_111111111111_sensed_b-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
     }),
-  ])
-# ---
-# name: test_binary_sensors[12.111111111111].2
-  list([
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_file': '/12.111111111111/sensed.A',
-        'friendly_name': '12.111111111111 Sensed A',
-        'raw_value': 1.0,
-      }),
-      'context': <ANY>,
-      'entity_id': 'binary_sensor.12_111111111111_sensed_a',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': 'on',
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.12_111111111111_sensed_b',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
     }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_file': '/12.111111111111/sensed.B',
-        'friendly_name': '12.111111111111 Sensed B',
-        'raw_value': 0.0,
-      }),
-      'context': <ANY>,
-      'entity_id': 'binary_sensor.12_111111111111_sensed_b',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': 'off',
+    'name': None,
+    'options': dict({
     }),
-  ])
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Sensed B',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'sensed_id',
+    'unique_id': '/12.111111111111/sensed.B',
+    'unit_of_measurement': None,
+  })
 # ---
-# name: test_binary_sensors[16.111111111111]
-  list([
-  ])
-# ---
-# name: test_binary_sensors[16.111111111111].1
-  list([
-  ])
-# ---
-# name: test_binary_sensors[16.111111111111].2
-  list([
-  ])
-# ---
-# name: test_binary_sensors[1D.111111111111]
-  list([
-    DeviceRegistryEntrySnapshot({
-      'area_id': None,
-      'config_entries': <ANY>,
-      'configuration_url': None,
-      'connections': set({
-      }),
-      'disabled_by': None,
-      'entry_type': None,
-      'hw_version': None,
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'onewire',
-          '1D.111111111111',
-        ),
-      }),
-      'is_new': False,
-      'labels': set({
-      }),
-      'manufacturer': 'Maxim Integrated',
-      'model': 'DS2423',
-      'model_id': None,
-      'name': '1D.111111111111',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': None,
-      'suggested_area': None,
-      'sw_version': None,
-      'via_device_id': None,
+# name: test_binary_sensors[binary_sensor.12_111111111111_sensed_b-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_file': '/12.111111111111/sensed.B',
+      'friendly_name': '12.111111111111 Sensed B',
+      'raw_value': 0.0,
     }),
-  ])
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.12_111111111111_sensed_b',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
 # ---
-# name: test_binary_sensors[1D.111111111111].1
-  list([
-  ])
-# ---
-# name: test_binary_sensors[1D.111111111111].2
-  list([
-  ])
-# ---
-# name: test_binary_sensors[1F.111111111111]
-  list([
-    DeviceRegistryEntrySnapshot({
-      'area_id': None,
-      'config_entries': <ANY>,
-      'configuration_url': None,
-      'connections': set({
-      }),
-      'disabled_by': None,
-      'entry_type': None,
-      'hw_version': None,
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'onewire',
-          '1F.111111111111',
-        ),
-      }),
-      'is_new': False,
-      'labels': set({
-      }),
-      'manufacturer': 'Maxim Integrated',
-      'model': 'DS2409',
-      'model_id': None,
-      'name': '1F.111111111111',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': None,
-      'suggested_area': None,
-      'sw_version': None,
-      'via_device_id': None,
+# name: test_binary_sensors[binary_sensor.29_111111111111_sensed_0-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
     }),
-    DeviceRegistryEntrySnapshot({
-      'area_id': None,
-      'config_entries': <ANY>,
-      'configuration_url': None,
-      'connections': set({
-      }),
-      'disabled_by': None,
-      'entry_type': None,
-      'hw_version': None,
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'onewire',
-          '1D.111111111111',
-        ),
-      }),
-      'is_new': False,
-      'labels': set({
-      }),
-      'manufacturer': 'Maxim Integrated',
-      'model': 'DS2423',
-      'model_id': None,
-      'name': '1D.111111111111',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': None,
-      'suggested_area': None,
-      'sw_version': None,
-      'via_device_id': <ANY>,
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.29_111111111111_sensed_0',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
     }),
-  ])
-# ---
-# name: test_binary_sensors[1F.111111111111].1
-  list([
-  ])
-# ---
-# name: test_binary_sensors[1F.111111111111].2
-  list([
-  ])
-# ---
-# name: test_binary_sensors[22.111111111111]
-  list([
-    DeviceRegistryEntrySnapshot({
-      'area_id': None,
-      'config_entries': <ANY>,
-      'configuration_url': None,
-      'connections': set({
-      }),
-      'disabled_by': None,
-      'entry_type': None,
-      'hw_version': None,
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'onewire',
-          '22.111111111111',
-        ),
-      }),
-      'is_new': False,
-      'labels': set({
-      }),
-      'manufacturer': 'Maxim Integrated',
-      'model': 'DS1822',
-      'model_id': None,
-      'name': '22.111111111111',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': None,
-      'suggested_area': None,
-      'sw_version': None,
-      'via_device_id': None,
+    'name': None,
+    'options': dict({
     }),
-  ])
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Sensed 0',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'sensed_id',
+    'unique_id': '/29.111111111111/sensed.0',
+    'unit_of_measurement': None,
+  })
 # ---
-# name: test_binary_sensors[22.111111111111].1
-  list([
-  ])
-# ---
-# name: test_binary_sensors[22.111111111111].2
-  list([
-  ])
-# ---
-# name: test_binary_sensors[26.111111111111]
-  list([
-    DeviceRegistryEntrySnapshot({
-      'area_id': None,
-      'config_entries': <ANY>,
-      'configuration_url': None,
-      'connections': set({
-      }),
-      'disabled_by': None,
-      'entry_type': None,
-      'hw_version': None,
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'onewire',
-          '26.111111111111',
-        ),
-      }),
-      'is_new': False,
-      'labels': set({
-      }),
-      'manufacturer': 'Maxim Integrated',
-      'model': 'DS2438',
-      'model_id': None,
-      'name': '26.111111111111',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': None,
-      'suggested_area': None,
-      'sw_version': None,
-      'via_device_id': None,
+# name: test_binary_sensors[binary_sensor.29_111111111111_sensed_0-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_file': '/29.111111111111/sensed.0',
+      'friendly_name': '29.111111111111 Sensed 0',
+      'raw_value': 1.0,
     }),
-  ])
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.29_111111111111_sensed_0',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
 # ---
-# name: test_binary_sensors[26.111111111111].1
-  list([
-  ])
-# ---
-# name: test_binary_sensors[26.111111111111].2
-  list([
-  ])
-# ---
-# name: test_binary_sensors[28.111111111111]
-  list([
-    DeviceRegistryEntrySnapshot({
-      'area_id': None,
-      'config_entries': <ANY>,
-      'configuration_url': None,
-      'connections': set({
-      }),
-      'disabled_by': None,
-      'entry_type': None,
-      'hw_version': None,
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'onewire',
-          '28.111111111111',
-        ),
-      }),
-      'is_new': False,
-      'labels': set({
-      }),
-      'manufacturer': 'Maxim Integrated',
-      'model': 'DS18B20',
-      'model_id': None,
-      'name': '28.111111111111',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': None,
-      'suggested_area': None,
-      'sw_version': None,
-      'via_device_id': None,
+# name: test_binary_sensors[binary_sensor.29_111111111111_sensed_1-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
     }),
-  ])
-# ---
-# name: test_binary_sensors[28.111111111111].1
-  list([
-  ])
-# ---
-# name: test_binary_sensors[28.111111111111].2
-  list([
-  ])
-# ---
-# name: test_binary_sensors[28.222222222222]
-  list([
-    DeviceRegistryEntrySnapshot({
-      'area_id': None,
-      'config_entries': <ANY>,
-      'configuration_url': None,
-      'connections': set({
-      }),
-      'disabled_by': None,
-      'entry_type': None,
-      'hw_version': None,
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'onewire',
-          '28.222222222222',
-        ),
-      }),
-      'is_new': False,
-      'labels': set({
-      }),
-      'manufacturer': 'Maxim Integrated',
-      'model': 'DS18B20',
-      'model_id': None,
-      'name': '28.222222222222',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': None,
-      'suggested_area': None,
-      'sw_version': None,
-      'via_device_id': None,
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.29_111111111111_sensed_1',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
     }),
-  ])
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Sensed 1',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'sensed_id',
+    'unique_id': '/29.111111111111/sensed.1',
+    'unit_of_measurement': None,
+  })
 # ---
-# name: test_binary_sensors[28.222222222222].1
-  list([
-  ])
+# name: test_binary_sensors[binary_sensor.29_111111111111_sensed_1-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_file': '/29.111111111111/sensed.1',
+      'friendly_name': '29.111111111111 Sensed 1',
+      'raw_value': 0.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.29_111111111111_sensed_1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
 # ---
-# name: test_binary_sensors[28.222222222222].2
-  list([
-  ])
+# name: test_binary_sensors[binary_sensor.29_111111111111_sensed_2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.29_111111111111_sensed_2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Sensed 2',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'sensed_id',
+    'unique_id': '/29.111111111111/sensed.2',
+    'unit_of_measurement': None,
+  })
 # ---
-# name: test_binary_sensors[28.222222222223]
-  list([
-    DeviceRegistryEntrySnapshot({
-      'area_id': None,
-      'config_entries': <ANY>,
-      'configuration_url': None,
-      'connections': set({
-      }),
-      'disabled_by': None,
-      'entry_type': None,
-      'hw_version': None,
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'onewire',
-          '28.222222222223',
-        ),
-      }),
-      'is_new': False,
-      'labels': set({
-      }),
-      'manufacturer': 'Maxim Integrated',
-      'model': 'DS18B20',
-      'model_id': None,
-      'name': '28.222222222223',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': None,
-      'suggested_area': None,
-      'sw_version': None,
-      'via_device_id': None,
+# name: test_binary_sensors[binary_sensor.29_111111111111_sensed_2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_file': '/29.111111111111/sensed.2',
+      'friendly_name': '29.111111111111 Sensed 2',
+      'raw_value': 0.0,
     }),
-  ])
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.29_111111111111_sensed_2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
 # ---
-# name: test_binary_sensors[28.222222222223].1
-  list([
-  ])
+# name: test_binary_sensors[binary_sensor.29_111111111111_sensed_3-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.29_111111111111_sensed_3',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Sensed 3',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'sensed_id',
+    'unique_id': '/29.111111111111/sensed.3',
+    'unit_of_measurement': None,
+  })
 # ---
-# name: test_binary_sensors[28.222222222223].2
-  list([
-  ])
+# name: test_binary_sensors[binary_sensor.29_111111111111_sensed_3-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_file': '/29.111111111111/sensed.3',
+      'friendly_name': '29.111111111111 Sensed 3',
+      'raw_value': None,
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.29_111111111111_sensed_3',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
 # ---
-# name: test_binary_sensors[29.111111111111]
-  list([
-    DeviceRegistryEntrySnapshot({
-      'area_id': None,
-      'config_entries': <ANY>,
-      'configuration_url': None,
-      'connections': set({
-      }),
-      'disabled_by': None,
-      'entry_type': None,
-      'hw_version': None,
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'onewire',
-          '29.111111111111',
-        ),
-      }),
-      'is_new': False,
-      'labels': set({
-      }),
-      'manufacturer': 'Maxim Integrated',
-      'model': 'DS2408',
-      'model_id': None,
-      'name': '29.111111111111',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': None,
-      'suggested_area': None,
-      'sw_version': None,
-      'via_device_id': None,
+# name: test_binary_sensors[binary_sensor.29_111111111111_sensed_4-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
     }),
-  ])
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.29_111111111111_sensed_4',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Sensed 4',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'sensed_id',
+    'unique_id': '/29.111111111111/sensed.4',
+    'unit_of_measurement': None,
+  })
 # ---
-# name: test_binary_sensors[29.111111111111].1
-  list([
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': None,
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'binary_sensor',
-      'entity_category': None,
-      'entity_id': 'binary_sensor.29_111111111111_sensed_0',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': None,
-      'original_icon': None,
-      'original_name': 'Sensed 0',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'sensed_id',
-      'unique_id': '/29.111111111111/sensed.0',
-      'unit_of_measurement': None,
+# name: test_binary_sensors[binary_sensor.29_111111111111_sensed_4-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_file': '/29.111111111111/sensed.4',
+      'friendly_name': '29.111111111111 Sensed 4',
+      'raw_value': 0.0,
     }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': None,
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'binary_sensor',
-      'entity_category': None,
-      'entity_id': 'binary_sensor.29_111111111111_sensed_1',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': None,
-      'original_icon': None,
-      'original_name': 'Sensed 1',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'sensed_id',
-      'unique_id': '/29.111111111111/sensed.1',
-      'unit_of_measurement': None,
-    }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': None,
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'binary_sensor',
-      'entity_category': None,
-      'entity_id': 'binary_sensor.29_111111111111_sensed_2',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': None,
-      'original_icon': None,
-      'original_name': 'Sensed 2',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'sensed_id',
-      'unique_id': '/29.111111111111/sensed.2',
-      'unit_of_measurement': None,
-    }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': None,
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'binary_sensor',
-      'entity_category': None,
-      'entity_id': 'binary_sensor.29_111111111111_sensed_3',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': None,
-      'original_icon': None,
-      'original_name': 'Sensed 3',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'sensed_id',
-      'unique_id': '/29.111111111111/sensed.3',
-      'unit_of_measurement': None,
-    }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': None,
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'binary_sensor',
-      'entity_category': None,
-      'entity_id': 'binary_sensor.29_111111111111_sensed_4',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': None,
-      'original_icon': None,
-      'original_name': 'Sensed 4',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'sensed_id',
-      'unique_id': '/29.111111111111/sensed.4',
-      'unit_of_measurement': None,
-    }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': None,
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'binary_sensor',
-      'entity_category': None,
-      'entity_id': 'binary_sensor.29_111111111111_sensed_5',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': None,
-      'original_icon': None,
-      'original_name': 'Sensed 5',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'sensed_id',
-      'unique_id': '/29.111111111111/sensed.5',
-      'unit_of_measurement': None,
-    }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': None,
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'binary_sensor',
-      'entity_category': None,
-      'entity_id': 'binary_sensor.29_111111111111_sensed_6',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': None,
-      'original_icon': None,
-      'original_name': 'Sensed 6',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'sensed_id',
-      'unique_id': '/29.111111111111/sensed.6',
-      'unit_of_measurement': None,
-    }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': None,
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'binary_sensor',
-      'entity_category': None,
-      'entity_id': 'binary_sensor.29_111111111111_sensed_7',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': None,
-      'original_icon': None,
-      'original_name': 'Sensed 7',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'sensed_id',
-      'unique_id': '/29.111111111111/sensed.7',
-      'unit_of_measurement': None,
-    }),
-  ])
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.29_111111111111_sensed_4',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
 # ---
-# name: test_binary_sensors[29.111111111111].2
-  list([
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_file': '/29.111111111111/sensed.0',
-        'friendly_name': '29.111111111111 Sensed 0',
-        'raw_value': 1.0,
-      }),
-      'context': <ANY>,
-      'entity_id': 'binary_sensor.29_111111111111_sensed_0',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': 'on',
+# name: test_binary_sensors[binary_sensor.29_111111111111_sensed_5-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
     }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_file': '/29.111111111111/sensed.1',
-        'friendly_name': '29.111111111111 Sensed 1',
-        'raw_value': 0.0,
-      }),
-      'context': <ANY>,
-      'entity_id': 'binary_sensor.29_111111111111_sensed_1',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': 'off',
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.29_111111111111_sensed_5',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
     }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_file': '/29.111111111111/sensed.2',
-        'friendly_name': '29.111111111111 Sensed 2',
-        'raw_value': 0.0,
-      }),
-      'context': <ANY>,
-      'entity_id': 'binary_sensor.29_111111111111_sensed_2',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': 'off',
+    'name': None,
+    'options': dict({
     }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_file': '/29.111111111111/sensed.3',
-        'friendly_name': '29.111111111111 Sensed 3',
-        'raw_value': None,
-      }),
-      'context': <ANY>,
-      'entity_id': 'binary_sensor.29_111111111111_sensed_3',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': 'unknown',
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Sensed 5',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'sensed_id',
+    'unique_id': '/29.111111111111/sensed.5',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_binary_sensors[binary_sensor.29_111111111111_sensed_5-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_file': '/29.111111111111/sensed.5',
+      'friendly_name': '29.111111111111 Sensed 5',
+      'raw_value': 0.0,
     }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_file': '/29.111111111111/sensed.4',
-        'friendly_name': '29.111111111111 Sensed 4',
-        'raw_value': 0.0,
-      }),
-      'context': <ANY>,
-      'entity_id': 'binary_sensor.29_111111111111_sensed_4',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': 'off',
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.29_111111111111_sensed_5',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_binary_sensors[binary_sensor.29_111111111111_sensed_6-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
     }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_file': '/29.111111111111/sensed.5',
-        'friendly_name': '29.111111111111 Sensed 5',
-        'raw_value': 0.0,
-      }),
-      'context': <ANY>,
-      'entity_id': 'binary_sensor.29_111111111111_sensed_5',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': 'off',
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.29_111111111111_sensed_6',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
     }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_file': '/29.111111111111/sensed.6',
-        'friendly_name': '29.111111111111 Sensed 6',
-        'raw_value': 0.0,
-      }),
-      'context': <ANY>,
-      'entity_id': 'binary_sensor.29_111111111111_sensed_6',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': 'off',
+    'name': None,
+    'options': dict({
     }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_file': '/29.111111111111/sensed.7',
-        'friendly_name': '29.111111111111 Sensed 7',
-        'raw_value': 0.0,
-      }),
-      'context': <ANY>,
-      'entity_id': 'binary_sensor.29_111111111111_sensed_7',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': 'off',
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Sensed 6',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'sensed_id',
+    'unique_id': '/29.111111111111/sensed.6',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_binary_sensors[binary_sensor.29_111111111111_sensed_6-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_file': '/29.111111111111/sensed.6',
+      'friendly_name': '29.111111111111 Sensed 6',
+      'raw_value': 0.0,
     }),
-  ])
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.29_111111111111_sensed_6',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
 # ---
-# name: test_binary_sensors[30.111111111111]
-  list([
-    DeviceRegistryEntrySnapshot({
-      'area_id': None,
-      'config_entries': <ANY>,
-      'configuration_url': None,
-      'connections': set({
-      }),
-      'disabled_by': None,
-      'entry_type': None,
-      'hw_version': None,
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'onewire',
-          '30.111111111111',
-        ),
-      }),
-      'is_new': False,
-      'labels': set({
-      }),
-      'manufacturer': 'Maxim Integrated',
-      'model': 'DS2760',
-      'model_id': None,
-      'name': '30.111111111111',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': None,
-      'suggested_area': None,
-      'sw_version': None,
-      'via_device_id': None,
+# name: test_binary_sensors[binary_sensor.29_111111111111_sensed_7-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
     }),
-  ])
-# ---
-# name: test_binary_sensors[30.111111111111].1
-  list([
-  ])
-# ---
-# name: test_binary_sensors[30.111111111111].2
-  list([
-  ])
-# ---
-# name: test_binary_sensors[3A.111111111111]
-  list([
-    DeviceRegistryEntrySnapshot({
-      'area_id': None,
-      'config_entries': <ANY>,
-      'configuration_url': None,
-      'connections': set({
-      }),
-      'disabled_by': None,
-      'entry_type': None,
-      'hw_version': None,
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'onewire',
-          '3A.111111111111',
-        ),
-      }),
-      'is_new': False,
-      'labels': set({
-      }),
-      'manufacturer': 'Maxim Integrated',
-      'model': 'DS2413',
-      'model_id': None,
-      'name': '3A.111111111111',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': None,
-      'suggested_area': None,
-      'sw_version': None,
-      'via_device_id': None,
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.29_111111111111_sensed_7',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
     }),
-  ])
-# ---
-# name: test_binary_sensors[3A.111111111111].1
-  list([
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': None,
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'binary_sensor',
-      'entity_category': None,
-      'entity_id': 'binary_sensor.3a_111111111111_sensed_a',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': None,
-      'original_icon': None,
-      'original_name': 'Sensed A',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'sensed_id',
-      'unique_id': '/3A.111111111111/sensed.A',
-      'unit_of_measurement': None,
+    'name': None,
+    'options': dict({
     }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': None,
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'binary_sensor',
-      'entity_category': None,
-      'entity_id': 'binary_sensor.3a_111111111111_sensed_b',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': None,
-      'original_icon': None,
-      'original_name': 'Sensed B',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'sensed_id',
-      'unique_id': '/3A.111111111111/sensed.B',
-      'unit_of_measurement': None,
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Sensed 7',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'sensed_id',
+    'unique_id': '/29.111111111111/sensed.7',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_binary_sensors[binary_sensor.29_111111111111_sensed_7-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_file': '/29.111111111111/sensed.7',
+      'friendly_name': '29.111111111111 Sensed 7',
+      'raw_value': 0.0,
     }),
-  ])
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.29_111111111111_sensed_7',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
 # ---
-# name: test_binary_sensors[3A.111111111111].2
-  list([
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_file': '/3A.111111111111/sensed.A',
-        'friendly_name': '3A.111111111111 Sensed A',
-        'raw_value': 1.0,
-      }),
-      'context': <ANY>,
-      'entity_id': 'binary_sensor.3a_111111111111_sensed_a',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': 'on',
+# name: test_binary_sensors[binary_sensor.3a_111111111111_sensed_a-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
     }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_file': '/3A.111111111111/sensed.B',
-        'friendly_name': '3A.111111111111 Sensed B',
-        'raw_value': 0.0,
-      }),
-      'context': <ANY>,
-      'entity_id': 'binary_sensor.3a_111111111111_sensed_b',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': 'off',
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.3a_111111111111_sensed_a',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
     }),
-  ])
-# ---
-# name: test_binary_sensors[3B.111111111111]
-  list([
-    DeviceRegistryEntrySnapshot({
-      'area_id': None,
-      'config_entries': <ANY>,
-      'configuration_url': None,
-      'connections': set({
-      }),
-      'disabled_by': None,
-      'entry_type': None,
-      'hw_version': None,
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'onewire',
-          '3B.111111111111',
-        ),
-      }),
-      'is_new': False,
-      'labels': set({
-      }),
-      'manufacturer': 'Maxim Integrated',
-      'model': 'DS1825',
-      'model_id': None,
-      'name': '3B.111111111111',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': None,
-      'suggested_area': None,
-      'sw_version': None,
-      'via_device_id': None,
+    'name': None,
+    'options': dict({
     }),
-  ])
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Sensed A',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'sensed_id',
+    'unique_id': '/3A.111111111111/sensed.A',
+    'unit_of_measurement': None,
+  })
 # ---
-# name: test_binary_sensors[3B.111111111111].1
-  list([
-  ])
-# ---
-# name: test_binary_sensors[3B.111111111111].2
-  list([
-  ])
-# ---
-# name: test_binary_sensors[42.111111111111]
-  list([
-    DeviceRegistryEntrySnapshot({
-      'area_id': None,
-      'config_entries': <ANY>,
-      'configuration_url': None,
-      'connections': set({
-      }),
-      'disabled_by': None,
-      'entry_type': None,
-      'hw_version': None,
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'onewire',
-          '42.111111111111',
-        ),
-      }),
-      'is_new': False,
-      'labels': set({
-      }),
-      'manufacturer': 'Maxim Integrated',
-      'model': 'DS28EA00',
-      'model_id': None,
-      'name': '42.111111111111',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': None,
-      'suggested_area': None,
-      'sw_version': None,
-      'via_device_id': None,
+# name: test_binary_sensors[binary_sensor.3a_111111111111_sensed_a-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_file': '/3A.111111111111/sensed.A',
+      'friendly_name': '3A.111111111111 Sensed A',
+      'raw_value': 1.0,
     }),
-  ])
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.3a_111111111111_sensed_a',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
 # ---
-# name: test_binary_sensors[42.111111111111].1
-  list([
-  ])
-# ---
-# name: test_binary_sensors[42.111111111111].2
-  list([
-  ])
-# ---
-# name: test_binary_sensors[7E.111111111111]
-  list([
-    DeviceRegistryEntrySnapshot({
-      'area_id': None,
-      'config_entries': <ANY>,
-      'configuration_url': None,
-      'connections': set({
-      }),
-      'disabled_by': None,
-      'entry_type': None,
-      'hw_version': None,
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'onewire',
-          '7E.111111111111',
-        ),
-      }),
-      'is_new': False,
-      'labels': set({
-      }),
-      'manufacturer': 'Embedded Data Systems',
-      'model': 'EDS0068',
-      'model_id': None,
-      'name': '7E.111111111111',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': None,
-      'suggested_area': None,
-      'sw_version': None,
-      'via_device_id': None,
+# name: test_binary_sensors[binary_sensor.3a_111111111111_sensed_b-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
     }),
-  ])
-# ---
-# name: test_binary_sensors[7E.111111111111].1
-  list([
-  ])
-# ---
-# name: test_binary_sensors[7E.111111111111].2
-  list([
-  ])
-# ---
-# name: test_binary_sensors[7E.222222222222]
-  list([
-    DeviceRegistryEntrySnapshot({
-      'area_id': None,
-      'config_entries': <ANY>,
-      'configuration_url': None,
-      'connections': set({
-      }),
-      'disabled_by': None,
-      'entry_type': None,
-      'hw_version': None,
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'onewire',
-          '7E.222222222222',
-        ),
-      }),
-      'is_new': False,
-      'labels': set({
-      }),
-      'manufacturer': 'Embedded Data Systems',
-      'model': 'EDS0066',
-      'model_id': None,
-      'name': '7E.222222222222',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': None,
-      'suggested_area': None,
-      'sw_version': None,
-      'via_device_id': None,
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.3a_111111111111_sensed_b',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
     }),
-  ])
-# ---
-# name: test_binary_sensors[7E.222222222222].1
-  list([
-  ])
-# ---
-# name: test_binary_sensors[7E.222222222222].2
-  list([
-  ])
-# ---
-# name: test_binary_sensors[A6.111111111111]
-  list([
-    DeviceRegistryEntrySnapshot({
-      'area_id': None,
-      'config_entries': <ANY>,
-      'configuration_url': None,
-      'connections': set({
-      }),
-      'disabled_by': None,
-      'entry_type': None,
-      'hw_version': None,
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'onewire',
-          'A6.111111111111',
-        ),
-      }),
-      'is_new': False,
-      'labels': set({
-      }),
-      'manufacturer': 'Maxim Integrated',
-      'model': 'DS2438',
-      'model_id': None,
-      'name': 'A6.111111111111',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': None,
-      'suggested_area': None,
-      'sw_version': None,
-      'via_device_id': None,
+    'name': None,
+    'options': dict({
     }),
-  ])
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Sensed B',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'sensed_id',
+    'unique_id': '/3A.111111111111/sensed.B',
+    'unit_of_measurement': None,
+  })
 # ---
-# name: test_binary_sensors[A6.111111111111].1
-  list([
-  ])
+# name: test_binary_sensors[binary_sensor.3a_111111111111_sensed_b-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_file': '/3A.111111111111/sensed.B',
+      'friendly_name': '3A.111111111111 Sensed B',
+      'raw_value': 0.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.3a_111111111111_sensed_b',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
 # ---
-# name: test_binary_sensors[A6.111111111111].2
-  list([
-  ])
+# name: test_binary_sensors[binary_sensor.ef_111111111113_hub_short_on_branch_0-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.ef_111111111113_hub_short_on_branch_0',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': None,
+    'original_name': 'Hub short on branch 0',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'hub_short_id',
+    'unique_id': '/EF.111111111113/hub/short.0',
+    'unit_of_measurement': None,
+  })
 # ---
-# name: test_binary_sensors[EF.111111111111]
-  list([
-    DeviceRegistryEntrySnapshot({
-      'area_id': None,
-      'config_entries': <ANY>,
-      'configuration_url': None,
-      'connections': set({
-      }),
-      'disabled_by': None,
-      'entry_type': None,
-      'hw_version': None,
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'onewire',
-          'EF.111111111111',
-        ),
-      }),
-      'is_new': False,
-      'labels': set({
-      }),
-      'manufacturer': 'Hobby Boards',
-      'model': 'HobbyBoards_EF',
-      'model_id': None,
-      'name': 'EF.111111111111',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': None,
-      'suggested_area': None,
-      'sw_version': None,
-      'via_device_id': None,
+# name: test_binary_sensors[binary_sensor.ef_111111111113_hub_short_on_branch_0-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'device_file': '/EF.111111111113/hub/short.0',
+      'friendly_name': 'EF.111111111113 Hub short on branch 0',
+      'raw_value': 1.0,
     }),
-  ])
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.ef_111111111113_hub_short_on_branch_0',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
 # ---
-# name: test_binary_sensors[EF.111111111111].1
-  list([
-  ])
+# name: test_binary_sensors[binary_sensor.ef_111111111113_hub_short_on_branch_1-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.ef_111111111113_hub_short_on_branch_1',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': None,
+    'original_name': 'Hub short on branch 1',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'hub_short_id',
+    'unique_id': '/EF.111111111113/hub/short.1',
+    'unit_of_measurement': None,
+  })
 # ---
-# name: test_binary_sensors[EF.111111111111].2
-  list([
-  ])
+# name: test_binary_sensors[binary_sensor.ef_111111111113_hub_short_on_branch_1-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'device_file': '/EF.111111111113/hub/short.1',
+      'friendly_name': 'EF.111111111113 Hub short on branch 1',
+      'raw_value': 0.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.ef_111111111113_hub_short_on_branch_1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
 # ---
-# name: test_binary_sensors[EF.111111111112]
-  list([
-    DeviceRegistryEntrySnapshot({
-      'area_id': None,
-      'config_entries': <ANY>,
-      'configuration_url': None,
-      'connections': set({
-      }),
-      'disabled_by': None,
-      'entry_type': None,
-      'hw_version': None,
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'onewire',
-          'EF.111111111112',
-        ),
-      }),
-      'is_new': False,
-      'labels': set({
-      }),
-      'manufacturer': 'Hobby Boards',
-      'model': 'HB_MOISTURE_METER',
-      'model_id': None,
-      'name': 'EF.111111111112',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': None,
-      'suggested_area': None,
-      'sw_version': None,
-      'via_device_id': None,
+# name: test_binary_sensors[binary_sensor.ef_111111111113_hub_short_on_branch_2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
     }),
-  ])
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.ef_111111111113_hub_short_on_branch_2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': None,
+    'original_name': 'Hub short on branch 2',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'hub_short_id',
+    'unique_id': '/EF.111111111113/hub/short.2',
+    'unit_of_measurement': None,
+  })
 # ---
-# name: test_binary_sensors[EF.111111111112].1
-  list([
-  ])
+# name: test_binary_sensors[binary_sensor.ef_111111111113_hub_short_on_branch_2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'device_file': '/EF.111111111113/hub/short.2',
+      'friendly_name': 'EF.111111111113 Hub short on branch 2',
+      'raw_value': 1.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.ef_111111111113_hub_short_on_branch_2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
 # ---
-# name: test_binary_sensors[EF.111111111112].2
-  list([
-  ])
+# name: test_binary_sensors[binary_sensor.ef_111111111113_hub_short_on_branch_3-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.ef_111111111113_hub_short_on_branch_3',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': None,
+    'original_name': 'Hub short on branch 3',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'hub_short_id',
+    'unique_id': '/EF.111111111113/hub/short.3',
+    'unit_of_measurement': None,
+  })
 # ---
-# name: test_binary_sensors[EF.111111111113]
-  list([
-    DeviceRegistryEntrySnapshot({
-      'area_id': None,
-      'config_entries': <ANY>,
-      'configuration_url': None,
-      'connections': set({
-      }),
-      'disabled_by': None,
-      'entry_type': None,
-      'hw_version': None,
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'onewire',
-          'EF.111111111113',
-        ),
-      }),
-      'is_new': False,
-      'labels': set({
-      }),
-      'manufacturer': 'Hobby Boards',
-      'model': 'HB_HUB',
-      'model_id': None,
-      'name': 'EF.111111111113',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': None,
-      'suggested_area': None,
-      'sw_version': None,
-      'via_device_id': None,
+# name: test_binary_sensors[binary_sensor.ef_111111111113_hub_short_on_branch_3-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'device_file': '/EF.111111111113/hub/short.3',
+      'friendly_name': 'EF.111111111113 Hub short on branch 3',
+      'raw_value': 0.0,
     }),
-  ])
-# ---
-# name: test_binary_sensors[EF.111111111113].1
-  list([
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': None,
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'binary_sensor',
-      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-      'entity_id': 'binary_sensor.ef_111111111113_hub_short_on_branch_0',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
-      'original_icon': None,
-      'original_name': 'Hub short on branch 0',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'hub_short_id',
-      'unique_id': '/EF.111111111113/hub/short.0',
-      'unit_of_measurement': None,
-    }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': None,
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'binary_sensor',
-      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-      'entity_id': 'binary_sensor.ef_111111111113_hub_short_on_branch_1',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
-      'original_icon': None,
-      'original_name': 'Hub short on branch 1',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'hub_short_id',
-      'unique_id': '/EF.111111111113/hub/short.1',
-      'unit_of_measurement': None,
-    }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': None,
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'binary_sensor',
-      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-      'entity_id': 'binary_sensor.ef_111111111113_hub_short_on_branch_2',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
-      'original_icon': None,
-      'original_name': 'Hub short on branch 2',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'hub_short_id',
-      'unique_id': '/EF.111111111113/hub/short.2',
-      'unit_of_measurement': None,
-    }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': None,
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'binary_sensor',
-      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-      'entity_id': 'binary_sensor.ef_111111111113_hub_short_on_branch_3',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
-      'original_icon': None,
-      'original_name': 'Hub short on branch 3',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'hub_short_id',
-      'unique_id': '/EF.111111111113/hub/short.3',
-      'unit_of_measurement': None,
-    }),
-  ])
-# ---
-# name: test_binary_sensors[EF.111111111113].2
-  list([
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_class': 'problem',
-        'device_file': '/EF.111111111113/hub/short.0',
-        'friendly_name': 'EF.111111111113 Hub short on branch 0',
-        'raw_value': 1.0,
-      }),
-      'context': <ANY>,
-      'entity_id': 'binary_sensor.ef_111111111113_hub_short_on_branch_0',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': 'on',
-    }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_class': 'problem',
-        'device_file': '/EF.111111111113/hub/short.1',
-        'friendly_name': 'EF.111111111113 Hub short on branch 1',
-        'raw_value': 0.0,
-      }),
-      'context': <ANY>,
-      'entity_id': 'binary_sensor.ef_111111111113_hub_short_on_branch_1',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': 'off',
-    }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_class': 'problem',
-        'device_file': '/EF.111111111113/hub/short.2',
-        'friendly_name': 'EF.111111111113 Hub short on branch 2',
-        'raw_value': 1.0,
-      }),
-      'context': <ANY>,
-      'entity_id': 'binary_sensor.ef_111111111113_hub_short_on_branch_2',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': 'on',
-    }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_class': 'problem',
-        'device_file': '/EF.111111111113/hub/short.3',
-        'friendly_name': 'EF.111111111113 Hub short on branch 3',
-        'raw_value': 0.0,
-      }),
-      'context': <ANY>,
-      'entity_id': 'binary_sensor.ef_111111111113_hub_short_on_branch_3',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': 'off',
-    }),
-  ])
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.ef_111111111113_hub_short_on_branch_3',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
 # ---

--- a/tests/components/onewire/snapshots/test_init.ambr
+++ b/tests/components/onewire/snapshots/test_init.ambr
@@ -1,0 +1,673 @@
+# serializer version: 1
+# name: test_registry[05.111111111111-entry]
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'onewire',
+        '05.111111111111',
+      ),
+    }),
+    'is_new': False,
+    'labels': set({
+    }),
+    'manufacturer': 'Maxim Integrated',
+    'model': 'DS2405',
+    'model_id': None,
+    'name': '05.111111111111',
+    'name_by_user': None,
+    'primary_config_entry': <ANY>,
+    'serial_number': None,
+    'suggested_area': None,
+    'sw_version': None,
+    'via_device_id': None,
+  })
+# ---
+# name: test_registry[10.111111111111-entry]
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'onewire',
+        '10.111111111111',
+      ),
+    }),
+    'is_new': False,
+    'labels': set({
+    }),
+    'manufacturer': 'Maxim Integrated',
+    'model': 'DS18S20',
+    'model_id': None,
+    'name': '10.111111111111',
+    'name_by_user': None,
+    'primary_config_entry': <ANY>,
+    'serial_number': None,
+    'suggested_area': None,
+    'sw_version': None,
+    'via_device_id': None,
+  })
+# ---
+# name: test_registry[12.111111111111-entry]
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'onewire',
+        '12.111111111111',
+      ),
+    }),
+    'is_new': False,
+    'labels': set({
+    }),
+    'manufacturer': 'Maxim Integrated',
+    'model': 'DS2406',
+    'model_id': None,
+    'name': '12.111111111111',
+    'name_by_user': None,
+    'primary_config_entry': <ANY>,
+    'serial_number': None,
+    'suggested_area': None,
+    'sw_version': None,
+    'via_device_id': None,
+  })
+# ---
+# name: test_registry[1D.111111111111-entry]
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'onewire',
+        '1D.111111111111',
+      ),
+    }),
+    'is_new': False,
+    'labels': set({
+    }),
+    'manufacturer': 'Maxim Integrated',
+    'model': 'DS2423',
+    'model_id': None,
+    'name': '1D.111111111111',
+    'name_by_user': None,
+    'primary_config_entry': <ANY>,
+    'serial_number': None,
+    'suggested_area': None,
+    'sw_version': None,
+    'via_device_id': <ANY>,
+  })
+# ---
+# name: test_registry[1F.111111111111-entry]
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'onewire',
+        '1F.111111111111',
+      ),
+    }),
+    'is_new': False,
+    'labels': set({
+    }),
+    'manufacturer': 'Maxim Integrated',
+    'model': 'DS2409',
+    'model_id': None,
+    'name': '1F.111111111111',
+    'name_by_user': None,
+    'primary_config_entry': <ANY>,
+    'serial_number': None,
+    'suggested_area': None,
+    'sw_version': None,
+    'via_device_id': None,
+  })
+# ---
+# name: test_registry[22.111111111111-entry]
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'onewire',
+        '22.111111111111',
+      ),
+    }),
+    'is_new': False,
+    'labels': set({
+    }),
+    'manufacturer': 'Maxim Integrated',
+    'model': 'DS1822',
+    'model_id': None,
+    'name': '22.111111111111',
+    'name_by_user': None,
+    'primary_config_entry': <ANY>,
+    'serial_number': None,
+    'suggested_area': None,
+    'sw_version': None,
+    'via_device_id': None,
+  })
+# ---
+# name: test_registry[26.111111111111-entry]
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'onewire',
+        '26.111111111111',
+      ),
+    }),
+    'is_new': False,
+    'labels': set({
+    }),
+    'manufacturer': 'Maxim Integrated',
+    'model': 'DS2438',
+    'model_id': None,
+    'name': '26.111111111111',
+    'name_by_user': None,
+    'primary_config_entry': <ANY>,
+    'serial_number': None,
+    'suggested_area': None,
+    'sw_version': None,
+    'via_device_id': None,
+  })
+# ---
+# name: test_registry[28.111111111111-entry]
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'onewire',
+        '28.111111111111',
+      ),
+    }),
+    'is_new': False,
+    'labels': set({
+    }),
+    'manufacturer': 'Maxim Integrated',
+    'model': 'DS18B20',
+    'model_id': None,
+    'name': '28.111111111111',
+    'name_by_user': None,
+    'primary_config_entry': <ANY>,
+    'serial_number': None,
+    'suggested_area': None,
+    'sw_version': None,
+    'via_device_id': None,
+  })
+# ---
+# name: test_registry[28.222222222222-entry]
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'onewire',
+        '28.222222222222',
+      ),
+    }),
+    'is_new': False,
+    'labels': set({
+    }),
+    'manufacturer': 'Maxim Integrated',
+    'model': 'DS18B20',
+    'model_id': None,
+    'name': '28.222222222222',
+    'name_by_user': None,
+    'primary_config_entry': <ANY>,
+    'serial_number': None,
+    'suggested_area': None,
+    'sw_version': None,
+    'via_device_id': None,
+  })
+# ---
+# name: test_registry[28.222222222223-entry]
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'onewire',
+        '28.222222222223',
+      ),
+    }),
+    'is_new': False,
+    'labels': set({
+    }),
+    'manufacturer': 'Maxim Integrated',
+    'model': 'DS18B20',
+    'model_id': None,
+    'name': '28.222222222223',
+    'name_by_user': None,
+    'primary_config_entry': <ANY>,
+    'serial_number': None,
+    'suggested_area': None,
+    'sw_version': None,
+    'via_device_id': None,
+  })
+# ---
+# name: test_registry[29.111111111111-entry]
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'onewire',
+        '29.111111111111',
+      ),
+    }),
+    'is_new': False,
+    'labels': set({
+    }),
+    'manufacturer': 'Maxim Integrated',
+    'model': 'DS2408',
+    'model_id': None,
+    'name': '29.111111111111',
+    'name_by_user': None,
+    'primary_config_entry': <ANY>,
+    'serial_number': None,
+    'suggested_area': None,
+    'sw_version': None,
+    'via_device_id': None,
+  })
+# ---
+# name: test_registry[30.111111111111-entry]
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'onewire',
+        '30.111111111111',
+      ),
+    }),
+    'is_new': False,
+    'labels': set({
+    }),
+    'manufacturer': 'Maxim Integrated',
+    'model': 'DS2760',
+    'model_id': None,
+    'name': '30.111111111111',
+    'name_by_user': None,
+    'primary_config_entry': <ANY>,
+    'serial_number': None,
+    'suggested_area': None,
+    'sw_version': None,
+    'via_device_id': None,
+  })
+# ---
+# name: test_registry[3A.111111111111-entry]
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'onewire',
+        '3A.111111111111',
+      ),
+    }),
+    'is_new': False,
+    'labels': set({
+    }),
+    'manufacturer': 'Maxim Integrated',
+    'model': 'DS2413',
+    'model_id': None,
+    'name': '3A.111111111111',
+    'name_by_user': None,
+    'primary_config_entry': <ANY>,
+    'serial_number': None,
+    'suggested_area': None,
+    'sw_version': None,
+    'via_device_id': None,
+  })
+# ---
+# name: test_registry[3B.111111111111-entry]
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'onewire',
+        '3B.111111111111',
+      ),
+    }),
+    'is_new': False,
+    'labels': set({
+    }),
+    'manufacturer': 'Maxim Integrated',
+    'model': 'DS1825',
+    'model_id': None,
+    'name': '3B.111111111111',
+    'name_by_user': None,
+    'primary_config_entry': <ANY>,
+    'serial_number': None,
+    'suggested_area': None,
+    'sw_version': None,
+    'via_device_id': None,
+  })
+# ---
+# name: test_registry[42.111111111111-entry]
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'onewire',
+        '42.111111111111',
+      ),
+    }),
+    'is_new': False,
+    'labels': set({
+    }),
+    'manufacturer': 'Maxim Integrated',
+    'model': 'DS28EA00',
+    'model_id': None,
+    'name': '42.111111111111',
+    'name_by_user': None,
+    'primary_config_entry': <ANY>,
+    'serial_number': None,
+    'suggested_area': None,
+    'sw_version': None,
+    'via_device_id': None,
+  })
+# ---
+# name: test_registry[7E.111111111111-entry]
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'onewire',
+        '7E.111111111111',
+      ),
+    }),
+    'is_new': False,
+    'labels': set({
+    }),
+    'manufacturer': 'Embedded Data Systems',
+    'model': 'EDS0068',
+    'model_id': None,
+    'name': '7E.111111111111',
+    'name_by_user': None,
+    'primary_config_entry': <ANY>,
+    'serial_number': None,
+    'suggested_area': None,
+    'sw_version': None,
+    'via_device_id': None,
+  })
+# ---
+# name: test_registry[7E.222222222222-entry]
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'onewire',
+        '7E.222222222222',
+      ),
+    }),
+    'is_new': False,
+    'labels': set({
+    }),
+    'manufacturer': 'Embedded Data Systems',
+    'model': 'EDS0066',
+    'model_id': None,
+    'name': '7E.222222222222',
+    'name_by_user': None,
+    'primary_config_entry': <ANY>,
+    'serial_number': None,
+    'suggested_area': None,
+    'sw_version': None,
+    'via_device_id': None,
+  })
+# ---
+# name: test_registry[A6.111111111111-entry]
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'onewire',
+        'A6.111111111111',
+      ),
+    }),
+    'is_new': False,
+    'labels': set({
+    }),
+    'manufacturer': 'Maxim Integrated',
+    'model': 'DS2438',
+    'model_id': None,
+    'name': 'A6.111111111111',
+    'name_by_user': None,
+    'primary_config_entry': <ANY>,
+    'serial_number': None,
+    'suggested_area': None,
+    'sw_version': None,
+    'via_device_id': None,
+  })
+# ---
+# name: test_registry[EF.111111111111-entry]
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'onewire',
+        'EF.111111111111',
+      ),
+    }),
+    'is_new': False,
+    'labels': set({
+    }),
+    'manufacturer': 'Hobby Boards',
+    'model': 'HobbyBoards_EF',
+    'model_id': None,
+    'name': 'EF.111111111111',
+    'name_by_user': None,
+    'primary_config_entry': <ANY>,
+    'serial_number': None,
+    'suggested_area': None,
+    'sw_version': None,
+    'via_device_id': None,
+  })
+# ---
+# name: test_registry[EF.111111111112-entry]
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'onewire',
+        'EF.111111111112',
+      ),
+    }),
+    'is_new': False,
+    'labels': set({
+    }),
+    'manufacturer': 'Hobby Boards',
+    'model': 'HB_MOISTURE_METER',
+    'model_id': None,
+    'name': 'EF.111111111112',
+    'name_by_user': None,
+    'primary_config_entry': <ANY>,
+    'serial_number': None,
+    'suggested_area': None,
+    'sw_version': None,
+    'via_device_id': None,
+  })
+# ---
+# name: test_registry[EF.111111111113-entry]
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'onewire',
+        'EF.111111111113',
+      ),
+    }),
+    'is_new': False,
+    'labels': set({
+    }),
+    'manufacturer': 'Hobby Boards',
+    'model': 'HB_HUB',
+    'model_id': None,
+    'name': 'EF.111111111113',
+    'name_by_user': None,
+    'primary_config_entry': <ANY>,
+    'serial_number': None,
+    'suggested_area': None,
+    'sw_version': None,
+    'via_device_id': None,
+  })
+# ---

--- a/tests/components/onewire/snapshots/test_sensor.ambr
+++ b/tests/components/onewire/snapshots/test_sensor.ambr
@@ -1,3477 +1,2647 @@
 # serializer version: 1
-# name: test_sensors[00.111111111111]
-  list([
-  ])
-# ---
-# name: test_sensors[00.111111111111].1
-  list([
-  ])
-# ---
-# name: test_sensors[00.111111111111].2
-  list([
-  ])
-# ---
-# name: test_sensors[05.111111111111]
-  list([
-    DeviceRegistryEntrySnapshot({
-      'area_id': None,
-      'config_entries': <ANY>,
-      'configuration_url': None,
-      'connections': set({
-      }),
-      'disabled_by': None,
-      'entry_type': None,
-      'hw_version': None,
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'onewire',
-          '05.111111111111',
-        ),
-      }),
-      'is_new': False,
-      'labels': set({
-      }),
-      'manufacturer': 'Maxim Integrated',
-      'model': 'DS2405',
-      'model_id': None,
-      'name': '05.111111111111',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': None,
-      'suggested_area': None,
-      'sw_version': None,
-      'via_device_id': None,
+# name: test_sensors[sensor.10_111111111111_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
     }),
-  ])
-# ---
-# name: test_sensors[05.111111111111].1
-  list([
-  ])
-# ---
-# name: test_sensors[05.111111111111].2
-  list([
-  ])
-# ---
-# name: test_sensors[10.111111111111]
-  list([
-    DeviceRegistryEntrySnapshot({
-      'area_id': None,
-      'config_entries': <ANY>,
-      'configuration_url': None,
-      'connections': set({
-      }),
-      'disabled_by': None,
-      'entry_type': None,
-      'hw_version': None,
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'onewire',
-          '10.111111111111',
-        ),
-      }),
-      'is_new': False,
-      'labels': set({
-      }),
-      'manufacturer': 'Maxim Integrated',
-      'model': 'DS18S20',
-      'model_id': None,
-      'name': '10.111111111111',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': None,
-      'suggested_area': None,
-      'sw_version': None,
-      'via_device_id': None,
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
-  ])
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.10_111111111111_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'Temperature',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '/10.111111111111/temperature',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
 # ---
-# name: test_sensors[10.111111111111].1
-  list([
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': dict({
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      }),
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': None,
-      'domain': 'sensor',
-      'entity_category': None,
-      'entity_id': 'sensor.10_111111111111_temperature',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
-      'original_icon': None,
-      'original_name': 'Temperature',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': None,
-      'unique_id': '/10.111111111111/temperature',
+# name: test_sensors[sensor.10_111111111111_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'device_file': '/10.111111111111/temperature',
+      'friendly_name': '10.111111111111 Temperature',
+      'raw_value': 25.123,
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
     }),
-  ])
+    'context': <ANY>,
+    'entity_id': 'sensor.10_111111111111_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '25.123',
+  })
 # ---
-# name: test_sensors[10.111111111111].2
-  list([
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_class': 'temperature',
-        'device_file': '/10.111111111111/temperature',
-        'friendly_name': '10.111111111111 Temperature',
-        'raw_value': 25.123,
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-        'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
-      }),
-      'context': <ANY>,
-      'entity_id': 'sensor.10_111111111111_temperature',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': '25.123',
+# name: test_sensors[sensor.12_111111111111_pressure-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
     }),
-  ])
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.12_111111111111_pressure',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.PRESSURE: 'pressure'>,
+    'original_icon': None,
+    'original_name': 'Pressure',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '/12.111111111111/TAI8570/pressure',
+    'unit_of_measurement': <UnitOfPressure.MBAR: 'mbar'>,
+  })
 # ---
-# name: test_sensors[12.111111111111]
-  list([
-    DeviceRegistryEntrySnapshot({
-      'area_id': None,
-      'config_entries': <ANY>,
-      'configuration_url': None,
-      'connections': set({
-      }),
-      'disabled_by': None,
-      'entry_type': None,
-      'hw_version': None,
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'onewire',
-          '12.111111111111',
-        ),
-      }),
-      'is_new': False,
-      'labels': set({
-      }),
-      'manufacturer': 'Maxim Integrated',
-      'model': 'DS2406',
-      'model_id': None,
-      'name': '12.111111111111',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': None,
-      'suggested_area': None,
-      'sw_version': None,
-      'via_device_id': None,
-    }),
-  ])
-# ---
-# name: test_sensors[12.111111111111].1
-  list([
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': dict({
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      }),
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'sensor',
-      'entity_category': None,
-      'entity_id': 'sensor.12_111111111111_temperature',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
-      'original_icon': None,
-      'original_name': 'Temperature',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': None,
-      'unique_id': '/12.111111111111/TAI8570/temperature',
-      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
-    }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': dict({
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      }),
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'sensor',
-      'entity_category': None,
-      'entity_id': 'sensor.12_111111111111_pressure',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': <SensorDeviceClass.PRESSURE: 'pressure'>,
-      'original_icon': None,
-      'original_name': 'Pressure',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': None,
-      'unique_id': '/12.111111111111/TAI8570/pressure',
+# name: test_sensors[sensor.12_111111111111_pressure-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'device_file': '/12.111111111111/TAI8570/pressure',
+      'friendly_name': '12.111111111111 Pressure',
+      'raw_value': 1025.123,
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfPressure.MBAR: 'mbar'>,
     }),
-  ])
+    'context': <ANY>,
+    'entity_id': 'sensor.12_111111111111_pressure',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '1025.123',
+  })
 # ---
-# name: test_sensors[12.111111111111].2
-  list([
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_class': 'temperature',
-        'device_file': '/12.111111111111/TAI8570/temperature',
-        'friendly_name': '12.111111111111 Temperature',
-        'raw_value': 25.123,
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-        'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
-      }),
-      'context': <ANY>,
-      'entity_id': 'sensor.12_111111111111_temperature',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': '25.123',
+# name: test_sensors[sensor.12_111111111111_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
     }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_class': 'pressure',
-        'device_file': '/12.111111111111/TAI8570/pressure',
-        'friendly_name': '12.111111111111 Pressure',
-        'raw_value': 1025.123,
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-        'unit_of_measurement': <UnitOfPressure.MBAR: 'mbar'>,
-      }),
-      'context': <ANY>,
-      'entity_id': 'sensor.12_111111111111_pressure',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': '1025.123',
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
-  ])
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.12_111111111111_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'Temperature',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '/12.111111111111/TAI8570/temperature',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
 # ---
-# name: test_sensors[16.111111111111]
-  list([
-  ])
-# ---
-# name: test_sensors[16.111111111111].1
-  list([
-  ])
-# ---
-# name: test_sensors[16.111111111111].2
-  list([
-  ])
-# ---
-# name: test_sensors[1D.111111111111]
-  list([
-    DeviceRegistryEntrySnapshot({
-      'area_id': None,
-      'config_entries': <ANY>,
-      'configuration_url': None,
-      'connections': set({
-      }),
-      'disabled_by': None,
-      'entry_type': None,
-      'hw_version': None,
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'onewire',
-          '1D.111111111111',
-        ),
-      }),
-      'is_new': False,
-      'labels': set({
-      }),
-      'manufacturer': 'Maxim Integrated',
-      'model': 'DS2423',
-      'model_id': None,
-      'name': '1D.111111111111',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': None,
-      'suggested_area': None,
-      'sw_version': None,
-      'via_device_id': None,
-    }),
-  ])
-# ---
-# name: test_sensors[1D.111111111111].1
-  list([
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': dict({
-        'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
-      }),
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': None,
-      'domain': 'sensor',
-      'entity_category': None,
-      'entity_id': 'sensor.1d_111111111111_counter_a',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': None,
-      'original_icon': None,
-      'original_name': 'Counter A',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'counter_id',
-      'unique_id': '/1D.111111111111/counter.A',
-      'unit_of_measurement': None,
-    }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': dict({
-        'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
-      }),
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': None,
-      'domain': 'sensor',
-      'entity_category': None,
-      'entity_id': 'sensor.1d_111111111111_counter_b',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': None,
-      'original_icon': None,
-      'original_name': 'Counter B',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'counter_id',
-      'unique_id': '/1D.111111111111/counter.B',
-      'unit_of_measurement': None,
-    }),
-  ])
-# ---
-# name: test_sensors[1D.111111111111].2
-  list([
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_file': '/1D.111111111111/counter.A',
-        'friendly_name': '1D.111111111111 Counter A',
-        'raw_value': 251123.0,
-        'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
-      }),
-      'context': <ANY>,
-      'entity_id': 'sensor.1d_111111111111_counter_a',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': '251123',
-    }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_file': '/1D.111111111111/counter.B',
-        'friendly_name': '1D.111111111111 Counter B',
-        'raw_value': 248125.0,
-        'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
-      }),
-      'context': <ANY>,
-      'entity_id': 'sensor.1d_111111111111_counter_b',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': '248125',
-    }),
-  ])
-# ---
-# name: test_sensors[1F.111111111111]
-  list([
-    DeviceRegistryEntrySnapshot({
-      'area_id': None,
-      'config_entries': <ANY>,
-      'configuration_url': None,
-      'connections': set({
-      }),
-      'disabled_by': None,
-      'entry_type': None,
-      'hw_version': None,
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'onewire',
-          '1F.111111111111',
-        ),
-      }),
-      'is_new': False,
-      'labels': set({
-      }),
-      'manufacturer': 'Maxim Integrated',
-      'model': 'DS2409',
-      'model_id': None,
-      'name': '1F.111111111111',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': None,
-      'suggested_area': None,
-      'sw_version': None,
-      'via_device_id': None,
-    }),
-    DeviceRegistryEntrySnapshot({
-      'area_id': None,
-      'config_entries': <ANY>,
-      'configuration_url': None,
-      'connections': set({
-      }),
-      'disabled_by': None,
-      'entry_type': None,
-      'hw_version': None,
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'onewire',
-          '1D.111111111111',
-        ),
-      }),
-      'is_new': False,
-      'labels': set({
-      }),
-      'manufacturer': 'Maxim Integrated',
-      'model': 'DS2423',
-      'model_id': None,
-      'name': '1D.111111111111',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': None,
-      'suggested_area': None,
-      'sw_version': None,
-      'via_device_id': <ANY>,
-    }),
-  ])
-# ---
-# name: test_sensors[1F.111111111111].1
-  list([
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': dict({
-        'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
-      }),
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': None,
-      'domain': 'sensor',
-      'entity_category': None,
-      'entity_id': 'sensor.1d_111111111111_counter_a',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': None,
-      'original_icon': None,
-      'original_name': 'Counter A',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'counter_id',
-      'unique_id': '/1D.111111111111/counter.A',
-      'unit_of_measurement': None,
-    }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': dict({
-        'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
-      }),
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': None,
-      'domain': 'sensor',
-      'entity_category': None,
-      'entity_id': 'sensor.1d_111111111111_counter_b',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': None,
-      'original_icon': None,
-      'original_name': 'Counter B',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'counter_id',
-      'unique_id': '/1D.111111111111/counter.B',
-      'unit_of_measurement': None,
-    }),
-  ])
-# ---
-# name: test_sensors[1F.111111111111].2
-  list([
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_file': '/1F.111111111111/main/1D.111111111111/counter.A',
-        'friendly_name': '1D.111111111111 Counter A',
-        'raw_value': 251123.0,
-        'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
-      }),
-      'context': <ANY>,
-      'entity_id': 'sensor.1d_111111111111_counter_a',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': '251123',
-    }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_file': '/1F.111111111111/main/1D.111111111111/counter.B',
-        'friendly_name': '1D.111111111111 Counter B',
-        'raw_value': 248125.0,
-        'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
-      }),
-      'context': <ANY>,
-      'entity_id': 'sensor.1d_111111111111_counter_b',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': '248125',
-    }),
-  ])
-# ---
-# name: test_sensors[22.111111111111]
-  list([
-    DeviceRegistryEntrySnapshot({
-      'area_id': None,
-      'config_entries': <ANY>,
-      'configuration_url': None,
-      'connections': set({
-      }),
-      'disabled_by': None,
-      'entry_type': None,
-      'hw_version': None,
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'onewire',
-          '22.111111111111',
-        ),
-      }),
-      'is_new': False,
-      'labels': set({
-      }),
-      'manufacturer': 'Maxim Integrated',
-      'model': 'DS1822',
-      'model_id': None,
-      'name': '22.111111111111',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': None,
-      'suggested_area': None,
-      'sw_version': None,
-      'via_device_id': None,
-    }),
-  ])
-# ---
-# name: test_sensors[22.111111111111].1
-  list([
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': dict({
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      }),
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': None,
-      'domain': 'sensor',
-      'entity_category': None,
-      'entity_id': 'sensor.22_111111111111_temperature',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
-      'original_icon': None,
-      'original_name': 'Temperature',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': None,
-      'unique_id': '/22.111111111111/temperature',
+# name: test_sensors[sensor.12_111111111111_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'device_file': '/12.111111111111/TAI8570/temperature',
+      'friendly_name': '12.111111111111 Temperature',
+      'raw_value': 25.123,
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
     }),
-  ])
+    'context': <ANY>,
+    'entity_id': 'sensor.12_111111111111_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '25.123',
+  })
 # ---
-# name: test_sensors[22.111111111111].2
-  list([
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_class': 'temperature',
-        'device_file': '/22.111111111111/temperature',
-        'friendly_name': '22.111111111111 Temperature',
-        'raw_value': None,
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-        'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
-      }),
-      'context': <ANY>,
-      'entity_id': 'sensor.22_111111111111_temperature',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': 'unknown',
+# name: test_sensors[sensor.1d_111111111111_counter_a-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
     }),
-  ])
-# ---
-# name: test_sensors[26.111111111111]
-  list([
-    DeviceRegistryEntrySnapshot({
-      'area_id': None,
-      'config_entries': <ANY>,
-      'configuration_url': None,
-      'connections': set({
-      }),
-      'disabled_by': None,
-      'entry_type': None,
-      'hw_version': None,
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'onewire',
-          '26.111111111111',
-        ),
-      }),
-      'is_new': False,
-      'labels': set({
-      }),
-      'manufacturer': 'Maxim Integrated',
-      'model': 'DS2438',
-      'model_id': None,
-      'name': '26.111111111111',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': None,
-      'suggested_area': None,
-      'sw_version': None,
-      'via_device_id': None,
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
     }),
-  ])
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.1d_111111111111_counter_a',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Counter A',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'counter_id',
+    'unique_id': '/1D.111111111111/counter.A',
+    'unit_of_measurement': None,
+  })
 # ---
-# name: test_sensors[26.111111111111].1
-  list([
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': dict({
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      }),
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': None,
-      'domain': 'sensor',
-      'entity_category': None,
-      'entity_id': 'sensor.26_111111111111_temperature',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
-      'original_icon': None,
-      'original_name': 'Temperature',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': None,
-      'unique_id': '/26.111111111111/temperature',
+# name: test_sensors[sensor.1d_111111111111_counter_a-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_file': '/1D.111111111111/counter.A',
+      'friendly_name': '1D.111111111111 Counter A',
+      'raw_value': 251123.0,
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.1d_111111111111_counter_a',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '251123',
+  })
+# ---
+# name: test_sensors[sensor.1d_111111111111_counter_b-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.1d_111111111111_counter_b',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Counter B',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'counter_id',
+    'unique_id': '/1D.111111111111/counter.B',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor.1d_111111111111_counter_b-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_file': '/1D.111111111111/counter.B',
+      'friendly_name': '1D.111111111111 Counter B',
+      'raw_value': 248125.0,
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.1d_111111111111_counter_b',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '248125',
+  })
+# ---
+# name: test_sensors[sensor.22_111111111111_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.22_111111111111_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'Temperature',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '/22.111111111111/temperature',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_sensors[sensor.22_111111111111_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'device_file': '/22.111111111111/temperature',
+      'friendly_name': '22.111111111111 Temperature',
+      'raw_value': None,
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
     }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': dict({
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      }),
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'sensor',
-      'entity_category': None,
-      'entity_id': 'sensor.26_111111111111_humidity',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': <SensorDeviceClass.HUMIDITY: 'humidity'>,
-      'original_icon': None,
-      'original_name': 'Humidity',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': None,
-      'unique_id': '/26.111111111111/humidity',
+    'context': <ANY>,
+    'entity_id': 'sensor.22_111111111111_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_sensors[sensor.26_111111111111_hih3600_humidity-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.26_111111111111_hih3600_humidity',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.HUMIDITY: 'humidity'>,
+    'original_icon': None,
+    'original_name': 'HIH3600 humidity',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'humidity_hih3600',
+    'unique_id': '/26.111111111111/HIH3600/humidity',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_sensors[sensor.26_111111111111_hih3600_humidity-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'humidity',
+      'device_file': '/26.111111111111/HIH3600/humidity',
+      'friendly_name': '26.111111111111 HIH3600 humidity',
+      'raw_value': 73.7563,
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': '%',
     }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': dict({
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      }),
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'sensor',
-      'entity_category': None,
-      'entity_id': 'sensor.26_111111111111_hih3600_humidity',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': <SensorDeviceClass.HUMIDITY: 'humidity'>,
-      'original_icon': None,
-      'original_name': 'HIH3600 humidity',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'humidity_hih3600',
-      'unique_id': '/26.111111111111/HIH3600/humidity',
+    'context': <ANY>,
+    'entity_id': 'sensor.26_111111111111_hih3600_humidity',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '73.7563',
+  })
+# ---
+# name: test_sensors[sensor.26_111111111111_hih4000_humidity-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.26_111111111111_hih4000_humidity',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.HUMIDITY: 'humidity'>,
+    'original_icon': None,
+    'original_name': 'HIH4000 humidity',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'humidity_hih4000',
+    'unique_id': '/26.111111111111/HIH4000/humidity',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_sensors[sensor.26_111111111111_hih4000_humidity-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'humidity',
+      'device_file': '/26.111111111111/HIH4000/humidity',
+      'friendly_name': '26.111111111111 HIH4000 humidity',
+      'raw_value': 74.7563,
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': '%',
     }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': dict({
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      }),
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'sensor',
-      'entity_category': None,
-      'entity_id': 'sensor.26_111111111111_hih4000_humidity',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': <SensorDeviceClass.HUMIDITY: 'humidity'>,
-      'original_icon': None,
-      'original_name': 'HIH4000 humidity',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'humidity_hih4000',
-      'unique_id': '/26.111111111111/HIH4000/humidity',
+    'context': <ANY>,
+    'entity_id': 'sensor.26_111111111111_hih4000_humidity',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '74.7563',
+  })
+# ---
+# name: test_sensors[sensor.26_111111111111_hih5030_humidity-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.26_111111111111_hih5030_humidity',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.HUMIDITY: 'humidity'>,
+    'original_icon': None,
+    'original_name': 'HIH5030 humidity',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'humidity_hih5030',
+    'unique_id': '/26.111111111111/HIH5030/humidity',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_sensors[sensor.26_111111111111_hih5030_humidity-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'humidity',
+      'device_file': '/26.111111111111/HIH5030/humidity',
+      'friendly_name': '26.111111111111 HIH5030 humidity',
+      'raw_value': 75.7563,
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': '%',
     }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': dict({
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      }),
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'sensor',
-      'entity_category': None,
-      'entity_id': 'sensor.26_111111111111_hih5030_humidity',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': <SensorDeviceClass.HUMIDITY: 'humidity'>,
-      'original_icon': None,
-      'original_name': 'HIH5030 humidity',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'humidity_hih5030',
-      'unique_id': '/26.111111111111/HIH5030/humidity',
+    'context': <ANY>,
+    'entity_id': 'sensor.26_111111111111_hih5030_humidity',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '75.7563',
+  })
+# ---
+# name: test_sensors[sensor.26_111111111111_htm1735_humidity-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.26_111111111111_htm1735_humidity',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.HUMIDITY: 'humidity'>,
+    'original_icon': None,
+    'original_name': 'HTM1735 humidity',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'humidity_htm1735',
+    'unique_id': '/26.111111111111/HTM1735/humidity',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_sensors[sensor.26_111111111111_htm1735_humidity-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'humidity',
+      'device_file': '/26.111111111111/HTM1735/humidity',
+      'friendly_name': '26.111111111111 HTM1735 humidity',
+      'raw_value': None,
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': '%',
     }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': dict({
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      }),
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'sensor',
-      'entity_category': None,
-      'entity_id': 'sensor.26_111111111111_htm1735_humidity',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': <SensorDeviceClass.HUMIDITY: 'humidity'>,
-      'original_icon': None,
-      'original_name': 'HTM1735 humidity',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'humidity_htm1735',
-      'unique_id': '/26.111111111111/HTM1735/humidity',
+    'context': <ANY>,
+    'entity_id': 'sensor.26_111111111111_htm1735_humidity',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_sensors[sensor.26_111111111111_humidity-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.26_111111111111_humidity',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.HUMIDITY: 'humidity'>,
+    'original_icon': None,
+    'original_name': 'Humidity',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '/26.111111111111/humidity',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_sensors[sensor.26_111111111111_humidity-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'humidity',
+      'device_file': '/26.111111111111/humidity',
+      'friendly_name': '26.111111111111 Humidity',
+      'raw_value': 72.7563,
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': '%',
     }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': dict({
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      }),
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'sensor',
-      'entity_category': None,
-      'entity_id': 'sensor.26_111111111111_pressure',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': <SensorDeviceClass.PRESSURE: 'pressure'>,
-      'original_icon': None,
-      'original_name': 'Pressure',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': None,
-      'unique_id': '/26.111111111111/B1-R1-A/pressure',
-      'unit_of_measurement': <UnitOfPressure.MBAR: 'mbar'>,
+    'context': <ANY>,
+    'entity_id': 'sensor.26_111111111111_humidity',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '72.7563',
+  })
+# ---
+# name: test_sensors[sensor.26_111111111111_illuminance-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
     }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': dict({
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      }),
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'sensor',
-      'entity_category': None,
-      'entity_id': 'sensor.26_111111111111_illuminance',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': <SensorDeviceClass.ILLUMINANCE: 'illuminance'>,
-      'original_icon': None,
-      'original_name': 'Illuminance',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': None,
-      'unique_id': '/26.111111111111/S3-R1-A/illuminance',
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.26_111111111111_illuminance',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ILLUMINANCE: 'illuminance'>,
+    'original_icon': None,
+    'original_name': 'Illuminance',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '/26.111111111111/S3-R1-A/illuminance',
+    'unit_of_measurement': 'lx',
+  })
+# ---
+# name: test_sensors[sensor.26_111111111111_illuminance-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'illuminance',
+      'device_file': '/26.111111111111/S3-R1-A/illuminance',
+      'friendly_name': '26.111111111111 Illuminance',
+      'raw_value': 65.8839,
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': 'lx',
     }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': dict({
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      }),
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'sensor',
-      'entity_category': None,
-      'entity_id': 'sensor.26_111111111111_vad_voltage',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': <SensorDeviceClass.VOLTAGE: 'voltage'>,
-      'original_icon': None,
-      'original_name': 'VAD voltage',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'voltage_vad',
-      'unique_id': '/26.111111111111/VAD',
-      'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
-    }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': dict({
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      }),
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'sensor',
-      'entity_category': None,
-      'entity_id': 'sensor.26_111111111111_vdd_voltage',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': <SensorDeviceClass.VOLTAGE: 'voltage'>,
-      'original_icon': None,
-      'original_name': 'VDD voltage',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'voltage_vdd',
-      'unique_id': '/26.111111111111/VDD',
-      'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
-    }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': dict({
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      }),
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'sensor',
-      'entity_category': None,
-      'entity_id': 'sensor.26_111111111111_vis_voltage_difference',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': <SensorDeviceClass.VOLTAGE: 'voltage'>,
-      'original_icon': None,
-      'original_name': 'VIS voltage difference',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'voltage_vis',
-      'unique_id': '/26.111111111111/vis',
-      'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
-    }),
-  ])
+    'context': <ANY>,
+    'entity_id': 'sensor.26_111111111111_illuminance',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '65.8839',
+  })
 # ---
-# name: test_sensors[26.111111111111].2
-  list([
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_class': 'temperature',
-        'device_file': '/26.111111111111/temperature',
-        'friendly_name': '26.111111111111 Temperature',
-        'raw_value': 25.123,
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-        'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
-      }),
-      'context': <ANY>,
-      'entity_id': 'sensor.26_111111111111_temperature',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': '25.123',
+# name: test_sensors[sensor.26_111111111111_pressure-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
     }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_class': 'humidity',
-        'device_file': '/26.111111111111/humidity',
-        'friendly_name': '26.111111111111 Humidity',
-        'raw_value': 72.7563,
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-        'unit_of_measurement': '%',
-      }),
-      'context': <ANY>,
-      'entity_id': 'sensor.26_111111111111_humidity',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': '72.7563',
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_class': 'humidity',
-        'device_file': '/26.111111111111/HIH3600/humidity',
-        'friendly_name': '26.111111111111 HIH3600 humidity',
-        'raw_value': 73.7563,
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-        'unit_of_measurement': '%',
-      }),
-      'context': <ANY>,
-      'entity_id': 'sensor.26_111111111111_hih3600_humidity',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': '73.7563',
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.26_111111111111_pressure',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
     }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_class': 'humidity',
-        'device_file': '/26.111111111111/HIH4000/humidity',
-        'friendly_name': '26.111111111111 HIH4000 humidity',
-        'raw_value': 74.7563,
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-        'unit_of_measurement': '%',
-      }),
-      'context': <ANY>,
-      'entity_id': 'sensor.26_111111111111_hih4000_humidity',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': '74.7563',
+    'name': None,
+    'options': dict({
     }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_class': 'humidity',
-        'device_file': '/26.111111111111/HIH5030/humidity',
-        'friendly_name': '26.111111111111 HIH5030 humidity',
-        'raw_value': 75.7563,
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-        'unit_of_measurement': '%',
-      }),
-      'context': <ANY>,
-      'entity_id': 'sensor.26_111111111111_hih5030_humidity',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': '75.7563',
-    }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_class': 'humidity',
-        'device_file': '/26.111111111111/HTM1735/humidity',
-        'friendly_name': '26.111111111111 HTM1735 humidity',
-        'raw_value': None,
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-        'unit_of_measurement': '%',
-      }),
-      'context': <ANY>,
-      'entity_id': 'sensor.26_111111111111_htm1735_humidity',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': 'unknown',
-    }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_class': 'pressure',
-        'device_file': '/26.111111111111/B1-R1-A/pressure',
-        'friendly_name': '26.111111111111 Pressure',
-        'raw_value': 969.265,
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-        'unit_of_measurement': <UnitOfPressure.MBAR: 'mbar'>,
-      }),
-      'context': <ANY>,
-      'entity_id': 'sensor.26_111111111111_pressure',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': '969.265',
-    }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_class': 'illuminance',
-        'device_file': '/26.111111111111/S3-R1-A/illuminance',
-        'friendly_name': '26.111111111111 Illuminance',
-        'raw_value': 65.8839,
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-        'unit_of_measurement': 'lx',
-      }),
-      'context': <ANY>,
-      'entity_id': 'sensor.26_111111111111_illuminance',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': '65.8839',
-    }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_class': 'voltage',
-        'device_file': '/26.111111111111/VAD',
-        'friendly_name': '26.111111111111 VAD voltage',
-        'raw_value': 2.97,
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-        'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
-      }),
-      'context': <ANY>,
-      'entity_id': 'sensor.26_111111111111_vad_voltage',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': '2.97',
-    }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_class': 'voltage',
-        'device_file': '/26.111111111111/VDD',
-        'friendly_name': '26.111111111111 VDD voltage',
-        'raw_value': 4.74,
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-        'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
-      }),
-      'context': <ANY>,
-      'entity_id': 'sensor.26_111111111111_vdd_voltage',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': '4.74',
-    }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_class': 'voltage',
-        'device_file': '/26.111111111111/vis',
-        'friendly_name': '26.111111111111 VIS voltage difference',
-        'raw_value': 0.12,
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-        'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
-      }),
-      'context': <ANY>,
-      'entity_id': 'sensor.26_111111111111_vis_voltage_difference',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': '0.12',
-    }),
-  ])
+    'original_device_class': <SensorDeviceClass.PRESSURE: 'pressure'>,
+    'original_icon': None,
+    'original_name': 'Pressure',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '/26.111111111111/B1-R1-A/pressure',
+    'unit_of_measurement': <UnitOfPressure.MBAR: 'mbar'>,
+  })
 # ---
-# name: test_sensors[28.111111111111]
-  list([
-    DeviceRegistryEntrySnapshot({
-      'area_id': None,
-      'config_entries': <ANY>,
-      'configuration_url': None,
-      'connections': set({
-      }),
-      'disabled_by': None,
-      'entry_type': None,
-      'hw_version': None,
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'onewire',
-          '28.111111111111',
-        ),
-      }),
-      'is_new': False,
-      'labels': set({
-      }),
-      'manufacturer': 'Maxim Integrated',
-      'model': 'DS18B20',
-      'model_id': None,
-      'name': '28.111111111111',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': None,
-      'suggested_area': None,
-      'sw_version': None,
-      'via_device_id': None,
-    }),
-  ])
-# ---
-# name: test_sensors[28.111111111111].1
-  list([
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': dict({
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      }),
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': None,
-      'domain': 'sensor',
-      'entity_category': None,
-      'entity_id': 'sensor.28_111111111111_temperature',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
-      'original_icon': None,
-      'original_name': 'Temperature',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': None,
-      'unique_id': '/28.111111111111/temperature',
-      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
-    }),
-  ])
-# ---
-# name: test_sensors[28.111111111111].2
-  list([
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_class': 'temperature',
-        'device_file': '/28.111111111111/temperature',
-        'friendly_name': '28.111111111111 Temperature',
-        'raw_value': 26.984,
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-        'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
-      }),
-      'context': <ANY>,
-      'entity_id': 'sensor.28_111111111111_temperature',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': '26.984',
-    }),
-  ])
-# ---
-# name: test_sensors[28.222222222222]
-  list([
-    DeviceRegistryEntrySnapshot({
-      'area_id': None,
-      'config_entries': <ANY>,
-      'configuration_url': None,
-      'connections': set({
-      }),
-      'disabled_by': None,
-      'entry_type': None,
-      'hw_version': None,
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'onewire',
-          '28.222222222222',
-        ),
-      }),
-      'is_new': False,
-      'labels': set({
-      }),
-      'manufacturer': 'Maxim Integrated',
-      'model': 'DS18B20',
-      'model_id': None,
-      'name': '28.222222222222',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': None,
-      'suggested_area': None,
-      'sw_version': None,
-      'via_device_id': None,
-    }),
-  ])
-# ---
-# name: test_sensors[28.222222222222].1
-  list([
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': dict({
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      }),
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': None,
-      'domain': 'sensor',
-      'entity_category': None,
-      'entity_id': 'sensor.28_222222222222_temperature',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
-      'original_icon': None,
-      'original_name': 'Temperature',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': None,
-      'unique_id': '/28.222222222222/temperature',
-      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
-    }),
-  ])
-# ---
-# name: test_sensors[28.222222222222].2
-  list([
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_class': 'temperature',
-        'device_file': '/28.222222222222/temperature9',
-        'friendly_name': '28.222222222222 Temperature',
-        'raw_value': 26.984,
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-        'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
-      }),
-      'context': <ANY>,
-      'entity_id': 'sensor.28_222222222222_temperature',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': '26.984',
-    }),
-  ])
-# ---
-# name: test_sensors[28.222222222223]
-  list([
-    DeviceRegistryEntrySnapshot({
-      'area_id': None,
-      'config_entries': <ANY>,
-      'configuration_url': None,
-      'connections': set({
-      }),
-      'disabled_by': None,
-      'entry_type': None,
-      'hw_version': None,
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'onewire',
-          '28.222222222223',
-        ),
-      }),
-      'is_new': False,
-      'labels': set({
-      }),
-      'manufacturer': 'Maxim Integrated',
-      'model': 'DS18B20',
-      'model_id': None,
-      'name': '28.222222222223',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': None,
-      'suggested_area': None,
-      'sw_version': None,
-      'via_device_id': None,
-    }),
-  ])
-# ---
-# name: test_sensors[28.222222222223].1
-  list([
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': dict({
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      }),
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': None,
-      'domain': 'sensor',
-      'entity_category': None,
-      'entity_id': 'sensor.28_222222222223_temperature',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
-      'original_icon': None,
-      'original_name': 'Temperature',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': None,
-      'unique_id': '/28.222222222223/temperature',
-      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
-    }),
-  ])
-# ---
-# name: test_sensors[28.222222222223].2
-  list([
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_class': 'temperature',
-        'device_file': '/28.222222222223/temperature',
-        'friendly_name': '28.222222222223 Temperature',
-        'raw_value': 26.984,
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-        'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
-      }),
-      'context': <ANY>,
-      'entity_id': 'sensor.28_222222222223_temperature',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': '26.984',
-    }),
-  ])
-# ---
-# name: test_sensors[29.111111111111]
-  list([
-    DeviceRegistryEntrySnapshot({
-      'area_id': None,
-      'config_entries': <ANY>,
-      'configuration_url': None,
-      'connections': set({
-      }),
-      'disabled_by': None,
-      'entry_type': None,
-      'hw_version': None,
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'onewire',
-          '29.111111111111',
-        ),
-      }),
-      'is_new': False,
-      'labels': set({
-      }),
-      'manufacturer': 'Maxim Integrated',
-      'model': 'DS2408',
-      'model_id': None,
-      'name': '29.111111111111',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': None,
-      'suggested_area': None,
-      'sw_version': None,
-      'via_device_id': None,
-    }),
-  ])
-# ---
-# name: test_sensors[29.111111111111].1
-  list([
-  ])
-# ---
-# name: test_sensors[29.111111111111].2
-  list([
-  ])
-# ---
-# name: test_sensors[30.111111111111]
-  list([
-    DeviceRegistryEntrySnapshot({
-      'area_id': None,
-      'config_entries': <ANY>,
-      'configuration_url': None,
-      'connections': set({
-      }),
-      'disabled_by': None,
-      'entry_type': None,
-      'hw_version': None,
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'onewire',
-          '30.111111111111',
-        ),
-      }),
-      'is_new': False,
-      'labels': set({
-      }),
-      'manufacturer': 'Maxim Integrated',
-      'model': 'DS2760',
-      'model_id': None,
-      'name': '30.111111111111',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': None,
-      'suggested_area': None,
-      'sw_version': None,
-      'via_device_id': None,
-    }),
-  ])
-# ---
-# name: test_sensors[30.111111111111].1
-  list([
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': dict({
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      }),
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': None,
-      'domain': 'sensor',
-      'entity_category': None,
-      'entity_id': 'sensor.30_111111111111_temperature',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
-      'original_icon': None,
-      'original_name': 'Temperature',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': None,
-      'unique_id': '/30.111111111111/temperature',
-      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
-    }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': dict({
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      }),
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'sensor',
-      'entity_category': None,
-      'entity_id': 'sensor.30_111111111111_thermocouple_k_temperature',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
-      'original_icon': None,
-      'original_name': 'Thermocouple K temperature',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'thermocouple_temperature_k',
-      'unique_id': '/30.111111111111/typeX/temperature',
-      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
-    }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': dict({
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      }),
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'sensor',
-      'entity_category': None,
-      'entity_id': 'sensor.30_111111111111_voltage',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': <SensorDeviceClass.VOLTAGE: 'voltage'>,
-      'original_icon': None,
-      'original_name': 'Voltage',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': None,
-      'unique_id': '/30.111111111111/volt',
-      'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
-    }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': dict({
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      }),
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'sensor',
-      'entity_category': None,
-      'entity_id': 'sensor.30_111111111111_vis_voltage_gradient',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': <SensorDeviceClass.VOLTAGE: 'voltage'>,
-      'original_icon': None,
-      'original_name': 'VIS voltage gradient',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'voltage_vis_gradient',
-      'unique_id': '/30.111111111111/vis',
-      'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
-    }),
-  ])
-# ---
-# name: test_sensors[30.111111111111].2
-  list([
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_class': 'temperature',
-        'device_file': '/30.111111111111/temperature',
-        'friendly_name': '30.111111111111 Temperature',
-        'raw_value': 26.984,
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-        'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
-      }),
-      'context': <ANY>,
-      'entity_id': 'sensor.30_111111111111_temperature',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': '26.984',
-    }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_class': 'temperature',
-        'device_file': '/30.111111111111/typeK/temperature',
-        'friendly_name': '30.111111111111 Thermocouple K temperature',
-        'raw_value': 173.7563,
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-        'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
-      }),
-      'context': <ANY>,
-      'entity_id': 'sensor.30_111111111111_thermocouple_k_temperature',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': '173.7563',
-    }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_class': 'voltage',
-        'device_file': '/30.111111111111/volt',
-        'friendly_name': '30.111111111111 Voltage',
-        'raw_value': 2.97,
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-        'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
-      }),
-      'context': <ANY>,
-      'entity_id': 'sensor.30_111111111111_voltage',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': '2.97',
-    }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_class': 'voltage',
-        'device_file': '/30.111111111111/vis',
-        'friendly_name': '30.111111111111 VIS voltage gradient',
-        'raw_value': 0.12,
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-        'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
-      }),
-      'context': <ANY>,
-      'entity_id': 'sensor.30_111111111111_vis_voltage_gradient',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': '0.12',
-    }),
-  ])
-# ---
-# name: test_sensors[3A.111111111111]
-  list([
-    DeviceRegistryEntrySnapshot({
-      'area_id': None,
-      'config_entries': <ANY>,
-      'configuration_url': None,
-      'connections': set({
-      }),
-      'disabled_by': None,
-      'entry_type': None,
-      'hw_version': None,
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'onewire',
-          '3A.111111111111',
-        ),
-      }),
-      'is_new': False,
-      'labels': set({
-      }),
-      'manufacturer': 'Maxim Integrated',
-      'model': 'DS2413',
-      'model_id': None,
-      'name': '3A.111111111111',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': None,
-      'suggested_area': None,
-      'sw_version': None,
-      'via_device_id': None,
-    }),
-  ])
-# ---
-# name: test_sensors[3A.111111111111].1
-  list([
-  ])
-# ---
-# name: test_sensors[3A.111111111111].2
-  list([
-  ])
-# ---
-# name: test_sensors[3B.111111111111]
-  list([
-    DeviceRegistryEntrySnapshot({
-      'area_id': None,
-      'config_entries': <ANY>,
-      'configuration_url': None,
-      'connections': set({
-      }),
-      'disabled_by': None,
-      'entry_type': None,
-      'hw_version': None,
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'onewire',
-          '3B.111111111111',
-        ),
-      }),
-      'is_new': False,
-      'labels': set({
-      }),
-      'manufacturer': 'Maxim Integrated',
-      'model': 'DS1825',
-      'model_id': None,
-      'name': '3B.111111111111',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': None,
-      'suggested_area': None,
-      'sw_version': None,
-      'via_device_id': None,
-    }),
-  ])
-# ---
-# name: test_sensors[3B.111111111111].1
-  list([
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': dict({
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      }),
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': None,
-      'domain': 'sensor',
-      'entity_category': None,
-      'entity_id': 'sensor.3b_111111111111_temperature',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
-      'original_icon': None,
-      'original_name': 'Temperature',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': None,
-      'unique_id': '/3B.111111111111/temperature',
-      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
-    }),
-  ])
-# ---
-# name: test_sensors[3B.111111111111].2
-  list([
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_class': 'temperature',
-        'device_file': '/3B.111111111111/temperature',
-        'friendly_name': '3B.111111111111 Temperature',
-        'raw_value': 28.243,
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-        'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
-      }),
-      'context': <ANY>,
-      'entity_id': 'sensor.3b_111111111111_temperature',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': '28.243',
-    }),
-  ])
-# ---
-# name: test_sensors[42.111111111111]
-  list([
-    DeviceRegistryEntrySnapshot({
-      'area_id': None,
-      'config_entries': <ANY>,
-      'configuration_url': None,
-      'connections': set({
-      }),
-      'disabled_by': None,
-      'entry_type': None,
-      'hw_version': None,
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'onewire',
-          '42.111111111111',
-        ),
-      }),
-      'is_new': False,
-      'labels': set({
-      }),
-      'manufacturer': 'Maxim Integrated',
-      'model': 'DS28EA00',
-      'model_id': None,
-      'name': '42.111111111111',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': None,
-      'suggested_area': None,
-      'sw_version': None,
-      'via_device_id': None,
-    }),
-  ])
-# ---
-# name: test_sensors[42.111111111111].1
-  list([
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': dict({
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      }),
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': None,
-      'domain': 'sensor',
-      'entity_category': None,
-      'entity_id': 'sensor.42_111111111111_temperature',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
-      'original_icon': None,
-      'original_name': 'Temperature',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': None,
-      'unique_id': '/42.111111111111/temperature',
-      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
-    }),
-  ])
-# ---
-# name: test_sensors[42.111111111111].2
-  list([
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_class': 'temperature',
-        'device_file': '/42.111111111111/temperature',
-        'friendly_name': '42.111111111111 Temperature',
-        'raw_value': 29.123,
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-        'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
-      }),
-      'context': <ANY>,
-      'entity_id': 'sensor.42_111111111111_temperature',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': '29.123',
-    }),
-  ])
-# ---
-# name: test_sensors[7E.111111111111]
-  list([
-    DeviceRegistryEntrySnapshot({
-      'area_id': None,
-      'config_entries': <ANY>,
-      'configuration_url': None,
-      'connections': set({
-      }),
-      'disabled_by': None,
-      'entry_type': None,
-      'hw_version': None,
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'onewire',
-          '7E.111111111111',
-        ),
-      }),
-      'is_new': False,
-      'labels': set({
-      }),
-      'manufacturer': 'Embedded Data Systems',
-      'model': 'EDS0068',
-      'model_id': None,
-      'name': '7E.111111111111',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': None,
-      'suggested_area': None,
-      'sw_version': None,
-      'via_device_id': None,
-    }),
-  ])
-# ---
-# name: test_sensors[7E.111111111111].1
-  list([
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': dict({
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      }),
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': None,
-      'domain': 'sensor',
-      'entity_category': None,
-      'entity_id': 'sensor.7e_111111111111_temperature',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
-      'original_icon': None,
-      'original_name': 'Temperature',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': None,
-      'unique_id': '/7E.111111111111/EDS0068/temperature',
-      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
-    }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': dict({
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      }),
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': None,
-      'domain': 'sensor',
-      'entity_category': None,
-      'entity_id': 'sensor.7e_111111111111_pressure',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': <SensorDeviceClass.PRESSURE: 'pressure'>,
-      'original_icon': None,
-      'original_name': 'Pressure',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': None,
-      'unique_id': '/7E.111111111111/EDS0068/pressure',
+# name: test_sensors[sensor.26_111111111111_pressure-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'device_file': '/26.111111111111/B1-R1-A/pressure',
+      'friendly_name': '26.111111111111 Pressure',
+      'raw_value': 969.265,
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfPressure.MBAR: 'mbar'>,
     }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': dict({
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      }),
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': None,
-      'domain': 'sensor',
-      'entity_category': None,
-      'entity_id': 'sensor.7e_111111111111_illuminance',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': <SensorDeviceClass.ILLUMINANCE: 'illuminance'>,
-      'original_icon': None,
-      'original_name': 'Illuminance',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': None,
-      'unique_id': '/7E.111111111111/EDS0068/light',
+    'context': <ANY>,
+    'entity_id': 'sensor.26_111111111111_pressure',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '969.265',
+  })
+# ---
+# name: test_sensors[sensor.26_111111111111_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.26_111111111111_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'Temperature',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '/26.111111111111/temperature',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_sensors[sensor.26_111111111111_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'device_file': '/26.111111111111/temperature',
+      'friendly_name': '26.111111111111 Temperature',
+      'raw_value': 25.123,
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.26_111111111111_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '25.123',
+  })
+# ---
+# name: test_sensors[sensor.26_111111111111_vad_voltage-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.26_111111111111_vad_voltage',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.VOLTAGE: 'voltage'>,
+    'original_icon': None,
+    'original_name': 'VAD voltage',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'voltage_vad',
+    'unique_id': '/26.111111111111/VAD',
+    'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+  })
+# ---
+# name: test_sensors[sensor.26_111111111111_vad_voltage-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'voltage',
+      'device_file': '/26.111111111111/VAD',
+      'friendly_name': '26.111111111111 VAD voltage',
+      'raw_value': 2.97,
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.26_111111111111_vad_voltage',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2.97',
+  })
+# ---
+# name: test_sensors[sensor.26_111111111111_vdd_voltage-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.26_111111111111_vdd_voltage',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.VOLTAGE: 'voltage'>,
+    'original_icon': None,
+    'original_name': 'VDD voltage',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'voltage_vdd',
+    'unique_id': '/26.111111111111/VDD',
+    'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+  })
+# ---
+# name: test_sensors[sensor.26_111111111111_vdd_voltage-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'voltage',
+      'device_file': '/26.111111111111/VDD',
+      'friendly_name': '26.111111111111 VDD voltage',
+      'raw_value': 4.74,
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.26_111111111111_vdd_voltage',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '4.74',
+  })
+# ---
+# name: test_sensors[sensor.26_111111111111_vis_voltage_difference-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.26_111111111111_vis_voltage_difference',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.VOLTAGE: 'voltage'>,
+    'original_icon': None,
+    'original_name': 'VIS voltage difference',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'voltage_vis',
+    'unique_id': '/26.111111111111/vis',
+    'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+  })
+# ---
+# name: test_sensors[sensor.26_111111111111_vis_voltage_difference-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'voltage',
+      'device_file': '/26.111111111111/vis',
+      'friendly_name': '26.111111111111 VIS voltage difference',
+      'raw_value': 0.12,
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.26_111111111111_vis_voltage_difference',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.12',
+  })
+# ---
+# name: test_sensors[sensor.28_111111111111_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.28_111111111111_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'Temperature',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '/28.111111111111/temperature',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_sensors[sensor.28_111111111111_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'device_file': '/28.111111111111/temperature',
+      'friendly_name': '28.111111111111 Temperature',
+      'raw_value': 26.984,
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.28_111111111111_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '26.984',
+  })
+# ---
+# name: test_sensors[sensor.28_222222222222_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.28_222222222222_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'Temperature',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '/28.222222222222/temperature',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_sensors[sensor.28_222222222222_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'device_file': '/28.222222222222/temperature9',
+      'friendly_name': '28.222222222222 Temperature',
+      'raw_value': 26.984,
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.28_222222222222_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '26.984',
+  })
+# ---
+# name: test_sensors[sensor.28_222222222223_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.28_222222222223_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'Temperature',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '/28.222222222223/temperature',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_sensors[sensor.28_222222222223_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'device_file': '/28.222222222223/temperature',
+      'friendly_name': '28.222222222223 Temperature',
+      'raw_value': 26.984,
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.28_222222222223_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '26.984',
+  })
+# ---
+# name: test_sensors[sensor.30_111111111111_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.30_111111111111_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'Temperature',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '/30.111111111111/temperature',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_sensors[sensor.30_111111111111_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'device_file': '/30.111111111111/temperature',
+      'friendly_name': '30.111111111111 Temperature',
+      'raw_value': 26.984,
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.30_111111111111_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '26.984',
+  })
+# ---
+# name: test_sensors[sensor.30_111111111111_thermocouple_k_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.30_111111111111_thermocouple_k_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'Thermocouple K temperature',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'thermocouple_temperature_k',
+    'unique_id': '/30.111111111111/typeX/temperature',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_sensors[sensor.30_111111111111_thermocouple_k_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'device_file': '/30.111111111111/typeK/temperature',
+      'friendly_name': '30.111111111111 Thermocouple K temperature',
+      'raw_value': 173.7563,
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.30_111111111111_thermocouple_k_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '173.7563',
+  })
+# ---
+# name: test_sensors[sensor.30_111111111111_vis_voltage_gradient-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.30_111111111111_vis_voltage_gradient',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.VOLTAGE: 'voltage'>,
+    'original_icon': None,
+    'original_name': 'VIS voltage gradient',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'voltage_vis_gradient',
+    'unique_id': '/30.111111111111/vis',
+    'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+  })
+# ---
+# name: test_sensors[sensor.30_111111111111_vis_voltage_gradient-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'voltage',
+      'device_file': '/30.111111111111/vis',
+      'friendly_name': '30.111111111111 VIS voltage gradient',
+      'raw_value': 0.12,
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.30_111111111111_vis_voltage_gradient',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.12',
+  })
+# ---
+# name: test_sensors[sensor.30_111111111111_voltage-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.30_111111111111_voltage',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.VOLTAGE: 'voltage'>,
+    'original_icon': None,
+    'original_name': 'Voltage',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '/30.111111111111/volt',
+    'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+  })
+# ---
+# name: test_sensors[sensor.30_111111111111_voltage-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'voltage',
+      'device_file': '/30.111111111111/volt',
+      'friendly_name': '30.111111111111 Voltage',
+      'raw_value': 2.97,
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.30_111111111111_voltage',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2.97',
+  })
+# ---
+# name: test_sensors[sensor.3b_111111111111_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.3b_111111111111_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'Temperature',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '/3B.111111111111/temperature',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_sensors[sensor.3b_111111111111_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'device_file': '/3B.111111111111/temperature',
+      'friendly_name': '3B.111111111111 Temperature',
+      'raw_value': 28.243,
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.3b_111111111111_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '28.243',
+  })
+# ---
+# name: test_sensors[sensor.42_111111111111_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.42_111111111111_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'Temperature',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '/42.111111111111/temperature',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_sensors[sensor.42_111111111111_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'device_file': '/42.111111111111/temperature',
+      'friendly_name': '42.111111111111 Temperature',
+      'raw_value': 29.123,
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.42_111111111111_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '29.123',
+  })
+# ---
+# name: test_sensors[sensor.7e_111111111111_humidity-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.7e_111111111111_humidity',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.HUMIDITY: 'humidity'>,
+    'original_icon': None,
+    'original_name': 'Humidity',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '/7E.111111111111/EDS0068/humidity',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_sensors[sensor.7e_111111111111_humidity-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'humidity',
+      'device_file': '/7E.111111111111/EDS0068/humidity',
+      'friendly_name': '7E.111111111111 Humidity',
+      'raw_value': 41.375,
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.7e_111111111111_humidity',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '41.375',
+  })
+# ---
+# name: test_sensors[sensor.7e_111111111111_illuminance-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.7e_111111111111_illuminance',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ILLUMINANCE: 'illuminance'>,
+    'original_icon': None,
+    'original_name': 'Illuminance',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '/7E.111111111111/EDS0068/light',
+    'unit_of_measurement': 'lx',
+  })
+# ---
+# name: test_sensors[sensor.7e_111111111111_illuminance-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'illuminance',
+      'device_file': '/7E.111111111111/EDS0068/light',
+      'friendly_name': '7E.111111111111 Illuminance',
+      'raw_value': 65.8839,
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': 'lx',
     }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': dict({
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      }),
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': None,
-      'domain': 'sensor',
-      'entity_category': None,
-      'entity_id': 'sensor.7e_111111111111_humidity',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': <SensorDeviceClass.HUMIDITY: 'humidity'>,
-      'original_icon': None,
-      'original_name': 'Humidity',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': None,
-      'unique_id': '/7E.111111111111/EDS0068/humidity',
-      'unit_of_measurement': '%',
-    }),
-  ])
+    'context': <ANY>,
+    'entity_id': 'sensor.7e_111111111111_illuminance',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '65.8839',
+  })
 # ---
-# name: test_sensors[7E.111111111111].2
-  list([
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_class': 'temperature',
-        'device_file': '/7E.111111111111/EDS0068/temperature',
-        'friendly_name': '7E.111111111111 Temperature',
-        'raw_value': 13.9375,
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-        'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
-      }),
-      'context': <ANY>,
-      'entity_id': 'sensor.7e_111111111111_temperature',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': '13.9375',
+# name: test_sensors[sensor.7e_111111111111_pressure-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
     }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_class': 'pressure',
-        'device_file': '/7E.111111111111/EDS0068/pressure',
-        'friendly_name': '7E.111111111111 Pressure',
-        'raw_value': 1012.21,
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-        'unit_of_measurement': <UnitOfPressure.MBAR: 'mbar'>,
-      }),
-      'context': <ANY>,
-      'entity_id': 'sensor.7e_111111111111_pressure',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': '1012.21',
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_class': 'illuminance',
-        'device_file': '/7E.111111111111/EDS0068/light',
-        'friendly_name': '7E.111111111111 Illuminance',
-        'raw_value': 65.8839,
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-        'unit_of_measurement': 'lx',
-      }),
-      'context': <ANY>,
-      'entity_id': 'sensor.7e_111111111111_illuminance',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': '65.8839',
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.7e_111111111111_pressure',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
     }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_class': 'humidity',
-        'device_file': '/7E.111111111111/EDS0068/humidity',
-        'friendly_name': '7E.111111111111 Humidity',
-        'raw_value': 41.375,
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-        'unit_of_measurement': '%',
-      }),
-      'context': <ANY>,
-      'entity_id': 'sensor.7e_111111111111_humidity',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': '41.375',
+    'name': None,
+    'options': dict({
     }),
-  ])
+    'original_device_class': <SensorDeviceClass.PRESSURE: 'pressure'>,
+    'original_icon': None,
+    'original_name': 'Pressure',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '/7E.111111111111/EDS0068/pressure',
+    'unit_of_measurement': <UnitOfPressure.MBAR: 'mbar'>,
+  })
 # ---
-# name: test_sensors[7E.222222222222]
-  list([
-    DeviceRegistryEntrySnapshot({
-      'area_id': None,
-      'config_entries': <ANY>,
-      'configuration_url': None,
-      'connections': set({
-      }),
-      'disabled_by': None,
-      'entry_type': None,
-      'hw_version': None,
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'onewire',
-          '7E.222222222222',
-        ),
-      }),
-      'is_new': False,
-      'labels': set({
-      }),
-      'manufacturer': 'Embedded Data Systems',
-      'model': 'EDS0066',
-      'model_id': None,
-      'name': '7E.222222222222',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': None,
-      'suggested_area': None,
-      'sw_version': None,
-      'via_device_id': None,
-    }),
-  ])
-# ---
-# name: test_sensors[7E.222222222222].1
-  list([
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': dict({
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      }),
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': None,
-      'domain': 'sensor',
-      'entity_category': None,
-      'entity_id': 'sensor.7e_222222222222_temperature',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
-      'original_icon': None,
-      'original_name': 'Temperature',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': None,
-      'unique_id': '/7E.222222222222/EDS0066/temperature',
-      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
-    }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': dict({
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      }),
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': None,
-      'domain': 'sensor',
-      'entity_category': None,
-      'entity_id': 'sensor.7e_222222222222_pressure',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': <SensorDeviceClass.PRESSURE: 'pressure'>,
-      'original_icon': None,
-      'original_name': 'Pressure',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': None,
-      'unique_id': '/7E.222222222222/EDS0066/pressure',
+# name: test_sensors[sensor.7e_111111111111_pressure-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'device_file': '/7E.111111111111/EDS0068/pressure',
+      'friendly_name': '7E.111111111111 Pressure',
+      'raw_value': 1012.21,
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfPressure.MBAR: 'mbar'>,
     }),
-  ])
+    'context': <ANY>,
+    'entity_id': 'sensor.7e_111111111111_pressure',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '1012.21',
+  })
 # ---
-# name: test_sensors[7E.222222222222].2
-  list([
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_class': 'temperature',
-        'device_file': '/7E.222222222222/EDS0066/temperature',
-        'friendly_name': '7E.222222222222 Temperature',
-        'raw_value': 13.9375,
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-        'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
-      }),
-      'context': <ANY>,
-      'entity_id': 'sensor.7e_222222222222_temperature',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': '13.9375',
+# name: test_sensors[sensor.7e_111111111111_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
     }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_class': 'pressure',
-        'device_file': '/7E.222222222222/EDS0066/pressure',
-        'friendly_name': '7E.222222222222 Pressure',
-        'raw_value': 1012.21,
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-        'unit_of_measurement': <UnitOfPressure.MBAR: 'mbar'>,
-      }),
-      'context': <ANY>,
-      'entity_id': 'sensor.7e_222222222222_pressure',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': '1012.21',
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
-  ])
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.7e_111111111111_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'Temperature',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '/7E.111111111111/EDS0068/temperature',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
 # ---
-# name: test_sensors[A6.111111111111]
-  list([
-    DeviceRegistryEntrySnapshot({
-      'area_id': None,
-      'config_entries': <ANY>,
-      'configuration_url': None,
-      'connections': set({
-      }),
-      'disabled_by': None,
-      'entry_type': None,
-      'hw_version': None,
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'onewire',
-          'A6.111111111111',
-        ),
-      }),
-      'is_new': False,
-      'labels': set({
-      }),
-      'manufacturer': 'Maxim Integrated',
-      'model': 'DS2438',
-      'model_id': None,
-      'name': 'A6.111111111111',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': None,
-      'suggested_area': None,
-      'sw_version': None,
-      'via_device_id': None,
-    }),
-  ])
-# ---
-# name: test_sensors[A6.111111111111].1
-  list([
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': dict({
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      }),
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': None,
-      'domain': 'sensor',
-      'entity_category': None,
-      'entity_id': 'sensor.a6_111111111111_temperature',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
-      'original_icon': None,
-      'original_name': 'Temperature',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': None,
-      'unique_id': '/A6.111111111111/temperature',
+# name: test_sensors[sensor.7e_111111111111_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'device_file': '/7E.111111111111/EDS0068/temperature',
+      'friendly_name': '7E.111111111111 Temperature',
+      'raw_value': 13.9375,
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
     }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': dict({
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      }),
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'sensor',
-      'entity_category': None,
-      'entity_id': 'sensor.a6_111111111111_humidity',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': <SensorDeviceClass.HUMIDITY: 'humidity'>,
-      'original_icon': None,
-      'original_name': 'Humidity',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': None,
-      'unique_id': '/A6.111111111111/humidity',
-      'unit_of_measurement': '%',
+    'context': <ANY>,
+    'entity_id': 'sensor.7e_111111111111_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '13.9375',
+  })
+# ---
+# name: test_sensors[sensor.7e_222222222222_pressure-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
     }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': dict({
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      }),
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'sensor',
-      'entity_category': None,
-      'entity_id': 'sensor.a6_111111111111_hih3600_humidity',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': <SensorDeviceClass.HUMIDITY: 'humidity'>,
-      'original_icon': None,
-      'original_name': 'HIH3600 humidity',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'humidity_hih3600',
-      'unique_id': '/A6.111111111111/HIH3600/humidity',
-      'unit_of_measurement': '%',
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': dict({
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      }),
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'sensor',
-      'entity_category': None,
-      'entity_id': 'sensor.a6_111111111111_hih4000_humidity',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': <SensorDeviceClass.HUMIDITY: 'humidity'>,
-      'original_icon': None,
-      'original_name': 'HIH4000 humidity',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'humidity_hih4000',
-      'unique_id': '/A6.111111111111/HIH4000/humidity',
-      'unit_of_measurement': '%',
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.7e_222222222222_pressure',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
     }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': dict({
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      }),
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'sensor',
-      'entity_category': None,
-      'entity_id': 'sensor.a6_111111111111_hih5030_humidity',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': <SensorDeviceClass.HUMIDITY: 'humidity'>,
-      'original_icon': None,
-      'original_name': 'HIH5030 humidity',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'humidity_hih5030',
-      'unique_id': '/A6.111111111111/HIH5030/humidity',
-      'unit_of_measurement': '%',
+    'name': None,
+    'options': dict({
     }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': dict({
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      }),
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'sensor',
-      'entity_category': None,
-      'entity_id': 'sensor.a6_111111111111_htm1735_humidity',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': <SensorDeviceClass.HUMIDITY: 'humidity'>,
-      'original_icon': None,
-      'original_name': 'HTM1735 humidity',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'humidity_htm1735',
-      'unique_id': '/A6.111111111111/HTM1735/humidity',
-      'unit_of_measurement': '%',
-    }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': dict({
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      }),
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'sensor',
-      'entity_category': None,
-      'entity_id': 'sensor.a6_111111111111_pressure',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': <SensorDeviceClass.PRESSURE: 'pressure'>,
-      'original_icon': None,
-      'original_name': 'Pressure',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': None,
-      'unique_id': '/A6.111111111111/B1-R1-A/pressure',
+    'original_device_class': <SensorDeviceClass.PRESSURE: 'pressure'>,
+    'original_icon': None,
+    'original_name': 'Pressure',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '/7E.222222222222/EDS0066/pressure',
+    'unit_of_measurement': <UnitOfPressure.MBAR: 'mbar'>,
+  })
+# ---
+# name: test_sensors[sensor.7e_222222222222_pressure-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'device_file': '/7E.222222222222/EDS0066/pressure',
+      'friendly_name': '7E.222222222222 Pressure',
+      'raw_value': 1012.21,
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfPressure.MBAR: 'mbar'>,
     }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': dict({
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      }),
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'sensor',
-      'entity_category': None,
-      'entity_id': 'sensor.a6_111111111111_illuminance',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': <SensorDeviceClass.ILLUMINANCE: 'illuminance'>,
-      'original_icon': None,
-      'original_name': 'Illuminance',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': None,
-      'unique_id': '/A6.111111111111/S3-R1-A/illuminance',
+    'context': <ANY>,
+    'entity_id': 'sensor.7e_222222222222_pressure',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '1012.21',
+  })
+# ---
+# name: test_sensors[sensor.7e_222222222222_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.7e_222222222222_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'Temperature',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '/7E.222222222222/EDS0066/temperature',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_sensors[sensor.7e_222222222222_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'device_file': '/7E.222222222222/EDS0066/temperature',
+      'friendly_name': '7E.222222222222 Temperature',
+      'raw_value': 13.9375,
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.7e_222222222222_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '13.9375',
+  })
+# ---
+# name: test_sensors[sensor.a6_111111111111_hih3600_humidity-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.a6_111111111111_hih3600_humidity',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.HUMIDITY: 'humidity'>,
+    'original_icon': None,
+    'original_name': 'HIH3600 humidity',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'humidity_hih3600',
+    'unique_id': '/A6.111111111111/HIH3600/humidity',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_sensors[sensor.a6_111111111111_hih3600_humidity-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'humidity',
+      'device_file': '/A6.111111111111/HIH3600/humidity',
+      'friendly_name': 'A6.111111111111 HIH3600 humidity',
+      'raw_value': 73.7563,
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.a6_111111111111_hih3600_humidity',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '73.7563',
+  })
+# ---
+# name: test_sensors[sensor.a6_111111111111_hih4000_humidity-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.a6_111111111111_hih4000_humidity',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.HUMIDITY: 'humidity'>,
+    'original_icon': None,
+    'original_name': 'HIH4000 humidity',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'humidity_hih4000',
+    'unique_id': '/A6.111111111111/HIH4000/humidity',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_sensors[sensor.a6_111111111111_hih4000_humidity-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'humidity',
+      'device_file': '/A6.111111111111/HIH4000/humidity',
+      'friendly_name': 'A6.111111111111 HIH4000 humidity',
+      'raw_value': 74.7563,
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.a6_111111111111_hih4000_humidity',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '74.7563',
+  })
+# ---
+# name: test_sensors[sensor.a6_111111111111_hih5030_humidity-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.a6_111111111111_hih5030_humidity',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.HUMIDITY: 'humidity'>,
+    'original_icon': None,
+    'original_name': 'HIH5030 humidity',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'humidity_hih5030',
+    'unique_id': '/A6.111111111111/HIH5030/humidity',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_sensors[sensor.a6_111111111111_hih5030_humidity-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'humidity',
+      'device_file': '/A6.111111111111/HIH5030/humidity',
+      'friendly_name': 'A6.111111111111 HIH5030 humidity',
+      'raw_value': 75.7563,
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.a6_111111111111_hih5030_humidity',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '75.7563',
+  })
+# ---
+# name: test_sensors[sensor.a6_111111111111_htm1735_humidity-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.a6_111111111111_htm1735_humidity',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.HUMIDITY: 'humidity'>,
+    'original_icon': None,
+    'original_name': 'HTM1735 humidity',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'humidity_htm1735',
+    'unique_id': '/A6.111111111111/HTM1735/humidity',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_sensors[sensor.a6_111111111111_htm1735_humidity-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'humidity',
+      'device_file': '/A6.111111111111/HTM1735/humidity',
+      'friendly_name': 'A6.111111111111 HTM1735 humidity',
+      'raw_value': None,
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.a6_111111111111_htm1735_humidity',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_sensors[sensor.a6_111111111111_humidity-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.a6_111111111111_humidity',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.HUMIDITY: 'humidity'>,
+    'original_icon': None,
+    'original_name': 'Humidity',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '/A6.111111111111/humidity',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_sensors[sensor.a6_111111111111_humidity-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'humidity',
+      'device_file': '/A6.111111111111/humidity',
+      'friendly_name': 'A6.111111111111 Humidity',
+      'raw_value': 72.7563,
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.a6_111111111111_humidity',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '72.7563',
+  })
+# ---
+# name: test_sensors[sensor.a6_111111111111_illuminance-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.a6_111111111111_illuminance',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ILLUMINANCE: 'illuminance'>,
+    'original_icon': None,
+    'original_name': 'Illuminance',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '/A6.111111111111/S3-R1-A/illuminance',
+    'unit_of_measurement': 'lx',
+  })
+# ---
+# name: test_sensors[sensor.a6_111111111111_illuminance-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'illuminance',
+      'device_file': '/A6.111111111111/S3-R1-A/illuminance',
+      'friendly_name': 'A6.111111111111 Illuminance',
+      'raw_value': 65.8839,
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': 'lx',
     }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': dict({
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      }),
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'sensor',
-      'entity_category': None,
-      'entity_id': 'sensor.a6_111111111111_vad_voltage',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': <SensorDeviceClass.VOLTAGE: 'voltage'>,
-      'original_icon': None,
-      'original_name': 'VAD voltage',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'voltage_vad',
-      'unique_id': '/A6.111111111111/VAD',
-      'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
-    }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': dict({
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      }),
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'sensor',
-      'entity_category': None,
-      'entity_id': 'sensor.a6_111111111111_vdd_voltage',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': <SensorDeviceClass.VOLTAGE: 'voltage'>,
-      'original_icon': None,
-      'original_name': 'VDD voltage',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'voltage_vdd',
-      'unique_id': '/A6.111111111111/VDD',
-      'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
-    }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': dict({
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      }),
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'sensor',
-      'entity_category': None,
-      'entity_id': 'sensor.a6_111111111111_vis_voltage_difference',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': <SensorDeviceClass.VOLTAGE: 'voltage'>,
-      'original_icon': None,
-      'original_name': 'VIS voltage difference',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'voltage_vis',
-      'unique_id': '/A6.111111111111/vis',
-      'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
-    }),
-  ])
+    'context': <ANY>,
+    'entity_id': 'sensor.a6_111111111111_illuminance',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '65.8839',
+  })
 # ---
-# name: test_sensors[A6.111111111111].2
-  list([
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_class': 'temperature',
-        'device_file': '/A6.111111111111/temperature',
-        'friendly_name': 'A6.111111111111 Temperature',
-        'raw_value': 25.123,
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-        'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
-      }),
-      'context': <ANY>,
-      'entity_id': 'sensor.a6_111111111111_temperature',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': '25.123',
+# name: test_sensors[sensor.a6_111111111111_pressure-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
     }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_class': 'humidity',
-        'device_file': '/A6.111111111111/humidity',
-        'friendly_name': 'A6.111111111111 Humidity',
-        'raw_value': 72.7563,
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-        'unit_of_measurement': '%',
-      }),
-      'context': <ANY>,
-      'entity_id': 'sensor.a6_111111111111_humidity',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': '72.7563',
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_class': 'humidity',
-        'device_file': '/A6.111111111111/HIH3600/humidity',
-        'friendly_name': 'A6.111111111111 HIH3600 humidity',
-        'raw_value': 73.7563,
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-        'unit_of_measurement': '%',
-      }),
-      'context': <ANY>,
-      'entity_id': 'sensor.a6_111111111111_hih3600_humidity',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': '73.7563',
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.a6_111111111111_pressure',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
     }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_class': 'humidity',
-        'device_file': '/A6.111111111111/HIH4000/humidity',
-        'friendly_name': 'A6.111111111111 HIH4000 humidity',
-        'raw_value': 74.7563,
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-        'unit_of_measurement': '%',
-      }),
-      'context': <ANY>,
-      'entity_id': 'sensor.a6_111111111111_hih4000_humidity',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': '74.7563',
+    'name': None,
+    'options': dict({
     }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_class': 'humidity',
-        'device_file': '/A6.111111111111/HIH5030/humidity',
-        'friendly_name': 'A6.111111111111 HIH5030 humidity',
-        'raw_value': 75.7563,
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-        'unit_of_measurement': '%',
-      }),
-      'context': <ANY>,
-      'entity_id': 'sensor.a6_111111111111_hih5030_humidity',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': '75.7563',
-    }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_class': 'humidity',
-        'device_file': '/A6.111111111111/HTM1735/humidity',
-        'friendly_name': 'A6.111111111111 HTM1735 humidity',
-        'raw_value': None,
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-        'unit_of_measurement': '%',
-      }),
-      'context': <ANY>,
-      'entity_id': 'sensor.a6_111111111111_htm1735_humidity',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': 'unknown',
-    }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_class': 'pressure',
-        'device_file': '/A6.111111111111/B1-R1-A/pressure',
-        'friendly_name': 'A6.111111111111 Pressure',
-        'raw_value': 969.265,
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-        'unit_of_measurement': <UnitOfPressure.MBAR: 'mbar'>,
-      }),
-      'context': <ANY>,
-      'entity_id': 'sensor.a6_111111111111_pressure',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': '969.265',
-    }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_class': 'illuminance',
-        'device_file': '/A6.111111111111/S3-R1-A/illuminance',
-        'friendly_name': 'A6.111111111111 Illuminance',
-        'raw_value': 65.8839,
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-        'unit_of_measurement': 'lx',
-      }),
-      'context': <ANY>,
-      'entity_id': 'sensor.a6_111111111111_illuminance',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': '65.8839',
-    }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_class': 'voltage',
-        'device_file': '/A6.111111111111/VAD',
-        'friendly_name': 'A6.111111111111 VAD voltage',
-        'raw_value': 2.97,
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-        'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
-      }),
-      'context': <ANY>,
-      'entity_id': 'sensor.a6_111111111111_vad_voltage',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': '2.97',
-    }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_class': 'voltage',
-        'device_file': '/A6.111111111111/VDD',
-        'friendly_name': 'A6.111111111111 VDD voltage',
-        'raw_value': 4.74,
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-        'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
-      }),
-      'context': <ANY>,
-      'entity_id': 'sensor.a6_111111111111_vdd_voltage',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': '4.74',
-    }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_class': 'voltage',
-        'device_file': '/A6.111111111111/vis',
-        'friendly_name': 'A6.111111111111 VIS voltage difference',
-        'raw_value': 0.12,
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-        'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
-      }),
-      'context': <ANY>,
-      'entity_id': 'sensor.a6_111111111111_vis_voltage_difference',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': '0.12',
-    }),
-  ])
+    'original_device_class': <SensorDeviceClass.PRESSURE: 'pressure'>,
+    'original_icon': None,
+    'original_name': 'Pressure',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '/A6.111111111111/B1-R1-A/pressure',
+    'unit_of_measurement': <UnitOfPressure.MBAR: 'mbar'>,
+  })
 # ---
-# name: test_sensors[EF.111111111111]
-  list([
-    DeviceRegistryEntrySnapshot({
-      'area_id': None,
-      'config_entries': <ANY>,
-      'configuration_url': None,
-      'connections': set({
-      }),
-      'disabled_by': None,
-      'entry_type': None,
-      'hw_version': None,
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'onewire',
-          'EF.111111111111',
-        ),
-      }),
-      'is_new': False,
-      'labels': set({
-      }),
-      'manufacturer': 'Hobby Boards',
-      'model': 'HobbyBoards_EF',
-      'model_id': None,
-      'name': 'EF.111111111111',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': None,
-      'suggested_area': None,
-      'sw_version': None,
-      'via_device_id': None,
+# name: test_sensors[sensor.a6_111111111111_pressure-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'device_file': '/A6.111111111111/B1-R1-A/pressure',
+      'friendly_name': 'A6.111111111111 Pressure',
+      'raw_value': 969.265,
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.MBAR: 'mbar'>,
     }),
-  ])
+    'context': <ANY>,
+    'entity_id': 'sensor.a6_111111111111_pressure',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '969.265',
+  })
 # ---
-# name: test_sensors[EF.111111111111].1
-  list([
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': dict({
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      }),
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': None,
-      'domain': 'sensor',
-      'entity_category': None,
-      'entity_id': 'sensor.ef_111111111111_humidity',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': <SensorDeviceClass.HUMIDITY: 'humidity'>,
-      'original_icon': None,
-      'original_name': 'Humidity',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': None,
-      'unique_id': '/EF.111111111111/humidity/humidity_corrected',
-      'unit_of_measurement': '%',
+# name: test_sensors[sensor.a6_111111111111_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
     }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': dict({
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      }),
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': None,
-      'domain': 'sensor',
-      'entity_category': None,
-      'entity_id': 'sensor.ef_111111111111_raw_humidity',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': <SensorDeviceClass.HUMIDITY: 'humidity'>,
-      'original_icon': None,
-      'original_name': 'Raw humidity',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'humidity_raw',
-      'unique_id': '/EF.111111111111/humidity/humidity_raw',
-      'unit_of_measurement': '%',
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': dict({
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      }),
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': None,
-      'domain': 'sensor',
-      'entity_category': None,
-      'entity_id': 'sensor.ef_111111111111_temperature',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
-      'original_icon': None,
-      'original_name': 'Temperature',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': None,
-      'unique_id': '/EF.111111111111/humidity/temperature',
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.a6_111111111111_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'Temperature',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '/A6.111111111111/temperature',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_sensors[sensor.a6_111111111111_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'device_file': '/A6.111111111111/temperature',
+      'friendly_name': 'A6.111111111111 Temperature',
+      'raw_value': 25.123,
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
     }),
-  ])
+    'context': <ANY>,
+    'entity_id': 'sensor.a6_111111111111_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '25.123',
+  })
 # ---
-# name: test_sensors[EF.111111111111].2
-  list([
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_class': 'humidity',
-        'device_file': '/EF.111111111111/humidity/humidity_corrected',
-        'friendly_name': 'EF.111111111111 Humidity',
-        'raw_value': 67.745,
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-        'unit_of_measurement': '%',
-      }),
-      'context': <ANY>,
-      'entity_id': 'sensor.ef_111111111111_humidity',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': '67.745',
+# name: test_sensors[sensor.a6_111111111111_vad_voltage-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
     }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_class': 'humidity',
-        'device_file': '/EF.111111111111/humidity/humidity_raw',
-        'friendly_name': 'EF.111111111111 Raw humidity',
-        'raw_value': 65.541,
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-        'unit_of_measurement': '%',
-      }),
-      'context': <ANY>,
-      'entity_id': 'sensor.ef_111111111111_raw_humidity',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': '65.541',
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_class': 'temperature',
-        'device_file': '/EF.111111111111/humidity/temperature',
-        'friendly_name': 'EF.111111111111 Temperature',
-        'raw_value': 25.123,
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-        'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
-      }),
-      'context': <ANY>,
-      'entity_id': 'sensor.ef_111111111111_temperature',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': '25.123',
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.a6_111111111111_vad_voltage',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
     }),
-  ])
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.VOLTAGE: 'voltage'>,
+    'original_icon': None,
+    'original_name': 'VAD voltage',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'voltage_vad',
+    'unique_id': '/A6.111111111111/VAD',
+    'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+  })
 # ---
-# name: test_sensors[EF.111111111112]
-  list([
-    DeviceRegistryEntrySnapshot({
-      'area_id': None,
-      'config_entries': <ANY>,
-      'configuration_url': None,
-      'connections': set({
-      }),
-      'disabled_by': None,
-      'entry_type': None,
-      'hw_version': None,
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'onewire',
-          'EF.111111111112',
-        ),
-      }),
-      'is_new': False,
-      'labels': set({
-      }),
-      'manufacturer': 'Hobby Boards',
-      'model': 'HB_MOISTURE_METER',
-      'model_id': None,
-      'name': 'EF.111111111112',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': None,
-      'suggested_area': None,
-      'sw_version': None,
-      'via_device_id': None,
+# name: test_sensors[sensor.a6_111111111111_vad_voltage-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'voltage',
+      'device_file': '/A6.111111111111/VAD',
+      'friendly_name': 'A6.111111111111 VAD voltage',
+      'raw_value': 2.97,
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
     }),
-  ])
+    'context': <ANY>,
+    'entity_id': 'sensor.a6_111111111111_vad_voltage',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2.97',
+  })
 # ---
-# name: test_sensors[EF.111111111112].1
-  list([
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': dict({
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      }),
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': None,
-      'domain': 'sensor',
-      'entity_category': None,
-      'entity_id': 'sensor.ef_111111111112_wetness_0',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': <SensorDeviceClass.HUMIDITY: 'humidity'>,
-      'original_icon': None,
-      'original_name': 'Wetness 0',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'wetness_id',
-      'unique_id': '/EF.111111111112/moisture/sensor.0',
+# name: test_sensors[sensor.a6_111111111111_vdd_voltage-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.a6_111111111111_vdd_voltage',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.VOLTAGE: 'voltage'>,
+    'original_icon': None,
+    'original_name': 'VDD voltage',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'voltage_vdd',
+    'unique_id': '/A6.111111111111/VDD',
+    'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+  })
+# ---
+# name: test_sensors[sensor.a6_111111111111_vdd_voltage-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'voltage',
+      'device_file': '/A6.111111111111/VDD',
+      'friendly_name': 'A6.111111111111 VDD voltage',
+      'raw_value': 4.74,
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.a6_111111111111_vdd_voltage',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '4.74',
+  })
+# ---
+# name: test_sensors[sensor.a6_111111111111_vis_voltage_difference-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.a6_111111111111_vis_voltage_difference',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.VOLTAGE: 'voltage'>,
+    'original_icon': None,
+    'original_name': 'VIS voltage difference',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'voltage_vis',
+    'unique_id': '/A6.111111111111/vis',
+    'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+  })
+# ---
+# name: test_sensors[sensor.a6_111111111111_vis_voltage_difference-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'voltage',
+      'device_file': '/A6.111111111111/vis',
+      'friendly_name': 'A6.111111111111 VIS voltage difference',
+      'raw_value': 0.12,
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.a6_111111111111_vis_voltage_difference',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.12',
+  })
+# ---
+# name: test_sensors[sensor.ef_111111111111_humidity-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.ef_111111111111_humidity',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.HUMIDITY: 'humidity'>,
+    'original_icon': None,
+    'original_name': 'Humidity',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '/EF.111111111111/humidity/humidity_corrected',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_sensors[sensor.ef_111111111111_humidity-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'humidity',
+      'device_file': '/EF.111111111111/humidity/humidity_corrected',
+      'friendly_name': 'EF.111111111111 Humidity',
+      'raw_value': 67.745,
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': '%',
     }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': dict({
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      }),
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': None,
-      'domain': 'sensor',
-      'entity_category': None,
-      'entity_id': 'sensor.ef_111111111112_wetness_1',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': <SensorDeviceClass.HUMIDITY: 'humidity'>,
-      'original_icon': None,
-      'original_name': 'Wetness 1',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'wetness_id',
-      'unique_id': '/EF.111111111112/moisture/sensor.1',
+    'context': <ANY>,
+    'entity_id': 'sensor.ef_111111111111_humidity',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '67.745',
+  })
+# ---
+# name: test_sensors[sensor.ef_111111111111_raw_humidity-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.ef_111111111111_raw_humidity',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.HUMIDITY: 'humidity'>,
+    'original_icon': None,
+    'original_name': 'Raw humidity',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'humidity_raw',
+    'unique_id': '/EF.111111111111/humidity/humidity_raw',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_sensors[sensor.ef_111111111111_raw_humidity-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'humidity',
+      'device_file': '/EF.111111111111/humidity/humidity_raw',
+      'friendly_name': 'EF.111111111111 Raw humidity',
+      'raw_value': 65.541,
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': '%',
     }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': dict({
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      }),
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': None,
-      'domain': 'sensor',
-      'entity_category': None,
-      'entity_id': 'sensor.ef_111111111112_moisture_2',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': <SensorDeviceClass.PRESSURE: 'pressure'>,
-      'original_icon': None,
-      'original_name': 'Moisture 2',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'moisture_id',
-      'unique_id': '/EF.111111111112/moisture/sensor.2',
+    'context': <ANY>,
+    'entity_id': 'sensor.ef_111111111111_raw_humidity',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '65.541',
+  })
+# ---
+# name: test_sensors[sensor.ef_111111111111_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.ef_111111111111_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'Temperature',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '/EF.111111111111/humidity/temperature',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_sensors[sensor.ef_111111111111_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'device_file': '/EF.111111111111/humidity/temperature',
+      'friendly_name': 'EF.111111111111 Temperature',
+      'raw_value': 25.123,
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.ef_111111111111_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '25.123',
+  })
+# ---
+# name: test_sensors[sensor.ef_111111111112_moisture_2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.ef_111111111112_moisture_2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.PRESSURE: 'pressure'>,
+    'original_icon': None,
+    'original_name': 'Moisture 2',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'moisture_id',
+    'unique_id': '/EF.111111111112/moisture/sensor.2',
+    'unit_of_measurement': <UnitOfPressure.CBAR: 'cbar'>,
+  })
+# ---
+# name: test_sensors[sensor.ef_111111111112_moisture_2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'device_file': '/EF.111111111112/moisture/sensor.2',
+      'friendly_name': 'EF.111111111112 Moisture 2',
+      'raw_value': 43.123,
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfPressure.CBAR: 'cbar'>,
     }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': dict({
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      }),
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': None,
-      'domain': 'sensor',
-      'entity_category': None,
-      'entity_id': 'sensor.ef_111111111112_moisture_3',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': <SensorDeviceClass.PRESSURE: 'pressure'>,
-      'original_icon': None,
-      'original_name': 'Moisture 3',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'moisture_id',
-      'unique_id': '/EF.111111111112/moisture/sensor.3',
+    'context': <ANY>,
+    'entity_id': 'sensor.ef_111111111112_moisture_2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '43.123',
+  })
+# ---
+# name: test_sensors[sensor.ef_111111111112_moisture_3-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.ef_111111111112_moisture_3',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.PRESSURE: 'pressure'>,
+    'original_icon': None,
+    'original_name': 'Moisture 3',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'moisture_id',
+    'unique_id': '/EF.111111111112/moisture/sensor.3',
+    'unit_of_measurement': <UnitOfPressure.CBAR: 'cbar'>,
+  })
+# ---
+# name: test_sensors[sensor.ef_111111111112_moisture_3-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'device_file': '/EF.111111111112/moisture/sensor.3',
+      'friendly_name': 'EF.111111111112 Moisture 3',
+      'raw_value': 44.123,
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfPressure.CBAR: 'cbar'>,
     }),
-  ])
+    'context': <ANY>,
+    'entity_id': 'sensor.ef_111111111112_moisture_3',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '44.123',
+  })
 # ---
-# name: test_sensors[EF.111111111112].2
-  list([
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_class': 'humidity',
-        'device_file': '/EF.111111111112/moisture/sensor.0',
-        'friendly_name': 'EF.111111111112 Wetness 0',
-        'raw_value': 41.745,
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-        'unit_of_measurement': '%',
-      }),
-      'context': <ANY>,
-      'entity_id': 'sensor.ef_111111111112_wetness_0',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': '41.745',
+# name: test_sensors[sensor.ef_111111111112_wetness_0-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
     }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_class': 'humidity',
-        'device_file': '/EF.111111111112/moisture/sensor.1',
-        'friendly_name': 'EF.111111111112 Wetness 1',
-        'raw_value': 42.541,
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-        'unit_of_measurement': '%',
-      }),
-      'context': <ANY>,
-      'entity_id': 'sensor.ef_111111111112_wetness_1',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': '42.541',
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_class': 'pressure',
-        'device_file': '/EF.111111111112/moisture/sensor.2',
-        'friendly_name': 'EF.111111111112 Moisture 2',
-        'raw_value': 43.123,
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-        'unit_of_measurement': <UnitOfPressure.CBAR: 'cbar'>,
-      }),
-      'context': <ANY>,
-      'entity_id': 'sensor.ef_111111111112_moisture_2',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': '43.123',
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.ef_111111111112_wetness_0',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
     }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_class': 'pressure',
-        'device_file': '/EF.111111111112/moisture/sensor.3',
-        'friendly_name': 'EF.111111111112 Moisture 3',
-        'raw_value': 44.123,
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-        'unit_of_measurement': <UnitOfPressure.CBAR: 'cbar'>,
-      }),
-      'context': <ANY>,
-      'entity_id': 'sensor.ef_111111111112_moisture_3',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': '44.123',
+    'name': None,
+    'options': dict({
     }),
-  ])
+    'original_device_class': <SensorDeviceClass.HUMIDITY: 'humidity'>,
+    'original_icon': None,
+    'original_name': 'Wetness 0',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'wetness_id',
+    'unique_id': '/EF.111111111112/moisture/sensor.0',
+    'unit_of_measurement': '%',
+  })
 # ---
-# name: test_sensors[EF.111111111113]
-  list([
-    DeviceRegistryEntrySnapshot({
-      'area_id': None,
-      'config_entries': <ANY>,
-      'configuration_url': None,
-      'connections': set({
-      }),
-      'disabled_by': None,
-      'entry_type': None,
-      'hw_version': None,
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'onewire',
-          'EF.111111111113',
-        ),
-      }),
-      'is_new': False,
-      'labels': set({
-      }),
-      'manufacturer': 'Hobby Boards',
-      'model': 'HB_HUB',
-      'model_id': None,
-      'name': 'EF.111111111113',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': None,
-      'suggested_area': None,
-      'sw_version': None,
-      'via_device_id': None,
+# name: test_sensors[sensor.ef_111111111112_wetness_0-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'humidity',
+      'device_file': '/EF.111111111112/moisture/sensor.0',
+      'friendly_name': 'EF.111111111112 Wetness 0',
+      'raw_value': 41.745,
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
     }),
-  ])
+    'context': <ANY>,
+    'entity_id': 'sensor.ef_111111111112_wetness_0',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '41.745',
+  })
 # ---
-# name: test_sensors[EF.111111111113].1
-  list([
-  ])
+# name: test_sensors[sensor.ef_111111111112_wetness_1-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.ef_111111111112_wetness_1',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.HUMIDITY: 'humidity'>,
+    'original_icon': None,
+    'original_name': 'Wetness 1',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'wetness_id',
+    'unique_id': '/EF.111111111112/moisture/sensor.1',
+    'unit_of_measurement': '%',
+  })
 # ---
-# name: test_sensors[EF.111111111113].2
-  list([
-  ])
+# name: test_sensors[sensor.ef_111111111112_wetness_1-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'humidity',
+      'device_file': '/EF.111111111112/moisture/sensor.1',
+      'friendly_name': 'EF.111111111112 Wetness 1',
+      'raw_value': 42.541,
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.ef_111111111112_wetness_1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '42.541',
+  })
 # ---

--- a/tests/components/onewire/snapshots/test_switch.ambr
+++ b/tests/components/onewire/snapshots/test_switch.ambr
@@ -1,2565 +1,1777 @@
 # serializer version: 1
-# name: test_switches[00.111111111111]
-  list([
-  ])
-# ---
-# name: test_switches[00.111111111111].1
-  list([
-  ])
-# ---
-# name: test_switches[00.111111111111].2
-  list([
-  ])
-# ---
-# name: test_switches[05.111111111111]
-  list([
-    DeviceRegistryEntrySnapshot({
-      'area_id': None,
-      'config_entries': <ANY>,
-      'configuration_url': None,
-      'connections': set({
-      }),
-      'disabled_by': None,
-      'entry_type': None,
-      'hw_version': None,
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'onewire',
-          '05.111111111111',
-        ),
-      }),
-      'is_new': False,
-      'labels': set({
-      }),
-      'manufacturer': 'Maxim Integrated',
-      'model': 'DS2405',
-      'model_id': None,
-      'name': '05.111111111111',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': None,
-      'suggested_area': None,
-      'sw_version': None,
-      'via_device_id': None,
-    }),
-  ])
-# ---
-# name: test_switches[05.111111111111].1
-  list([
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': None,
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'switch',
-      'entity_category': None,
-      'entity_id': 'switch.05_111111111111_programmed_input_output',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': None,
-      'original_icon': None,
-      'original_name': 'Programmed input-output',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'pio',
-      'unique_id': '/05.111111111111/PIO',
-      'unit_of_measurement': None,
-    }),
-  ])
-# ---
-# name: test_switches[05.111111111111].2
-  list([
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_file': '/05.111111111111/PIO',
-        'friendly_name': '05.111111111111 Programmed input-output',
-        'raw_value': 1.0,
-      }),
-      'context': <ANY>,
-      'entity_id': 'switch.05_111111111111_programmed_input_output',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': 'on',
-    }),
-  ])
-# ---
-# name: test_switches[10.111111111111]
-  list([
-    DeviceRegistryEntrySnapshot({
-      'area_id': None,
-      'config_entries': <ANY>,
-      'configuration_url': None,
-      'connections': set({
-      }),
-      'disabled_by': None,
-      'entry_type': None,
-      'hw_version': None,
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'onewire',
-          '10.111111111111',
-        ),
-      }),
-      'is_new': False,
-      'labels': set({
-      }),
-      'manufacturer': 'Maxim Integrated',
-      'model': 'DS18S20',
-      'model_id': None,
-      'name': '10.111111111111',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': None,
-      'suggested_area': None,
-      'sw_version': None,
-      'via_device_id': None,
-    }),
-  ])
-# ---
-# name: test_switches[10.111111111111].1
-  list([
-  ])
-# ---
-# name: test_switches[10.111111111111].2
-  list([
-  ])
-# ---
-# name: test_switches[12.111111111111]
-  list([
-    DeviceRegistryEntrySnapshot({
-      'area_id': None,
-      'config_entries': <ANY>,
-      'configuration_url': None,
-      'connections': set({
-      }),
-      'disabled_by': None,
-      'entry_type': None,
-      'hw_version': None,
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'onewire',
-          '12.111111111111',
-        ),
-      }),
-      'is_new': False,
-      'labels': set({
-      }),
-      'manufacturer': 'Maxim Integrated',
-      'model': 'DS2406',
-      'model_id': None,
-      'name': '12.111111111111',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': None,
-      'suggested_area': None,
-      'sw_version': None,
-      'via_device_id': None,
-    }),
-  ])
-# ---
-# name: test_switches[12.111111111111].1
-  list([
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': None,
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'switch',
-      'entity_category': None,
-      'entity_id': 'switch.12_111111111111_programmed_input_output_a',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': None,
-      'original_icon': None,
-      'original_name': 'Programmed input-output A',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'pio_id',
-      'unique_id': '/12.111111111111/PIO.A',
-      'unit_of_measurement': None,
-    }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': None,
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'switch',
-      'entity_category': None,
-      'entity_id': 'switch.12_111111111111_programmed_input_output_b',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': None,
-      'original_icon': None,
-      'original_name': 'Programmed input-output B',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'pio_id',
-      'unique_id': '/12.111111111111/PIO.B',
-      'unit_of_measurement': None,
-    }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': None,
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'switch',
-      'entity_category': None,
-      'entity_id': 'switch.12_111111111111_latch_a',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': None,
-      'original_icon': None,
-      'original_name': 'Latch A',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'latch_id',
-      'unique_id': '/12.111111111111/latch.A',
-      'unit_of_measurement': None,
-    }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': None,
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'switch',
-      'entity_category': None,
-      'entity_id': 'switch.12_111111111111_latch_b',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': None,
-      'original_icon': None,
-      'original_name': 'Latch B',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'latch_id',
-      'unique_id': '/12.111111111111/latch.B',
-      'unit_of_measurement': None,
-    }),
-  ])
-# ---
-# name: test_switches[12.111111111111].2
-  list([
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_file': '/12.111111111111/PIO.A',
-        'friendly_name': '12.111111111111 Programmed input-output A',
-        'raw_value': 1.0,
-      }),
-      'context': <ANY>,
-      'entity_id': 'switch.12_111111111111_programmed_input_output_a',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': 'on',
-    }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_file': '/12.111111111111/PIO.B',
-        'friendly_name': '12.111111111111 Programmed input-output B',
-        'raw_value': 0.0,
-      }),
-      'context': <ANY>,
-      'entity_id': 'switch.12_111111111111_programmed_input_output_b',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': 'off',
-    }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_file': '/12.111111111111/latch.A',
-        'friendly_name': '12.111111111111 Latch A',
-        'raw_value': 1.0,
-      }),
-      'context': <ANY>,
-      'entity_id': 'switch.12_111111111111_latch_a',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': 'on',
-    }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_file': '/12.111111111111/latch.B',
-        'friendly_name': '12.111111111111 Latch B',
-        'raw_value': 0.0,
-      }),
-      'context': <ANY>,
-      'entity_id': 'switch.12_111111111111_latch_b',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': 'off',
-    }),
-  ])
-# ---
-# name: test_switches[16.111111111111]
-  list([
-  ])
-# ---
-# name: test_switches[16.111111111111].1
-  list([
-  ])
-# ---
-# name: test_switches[16.111111111111].2
-  list([
-  ])
-# ---
-# name: test_switches[1D.111111111111]
-  list([
-    DeviceRegistryEntrySnapshot({
-      'area_id': None,
-      'config_entries': <ANY>,
-      'configuration_url': None,
-      'connections': set({
-      }),
-      'disabled_by': None,
-      'entry_type': None,
-      'hw_version': None,
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'onewire',
-          '1D.111111111111',
-        ),
-      }),
-      'is_new': False,
-      'labels': set({
-      }),
-      'manufacturer': 'Maxim Integrated',
-      'model': 'DS2423',
-      'model_id': None,
-      'name': '1D.111111111111',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': None,
-      'suggested_area': None,
-      'sw_version': None,
-      'via_device_id': None,
-    }),
-  ])
-# ---
-# name: test_switches[1D.111111111111].1
-  list([
-  ])
-# ---
-# name: test_switches[1D.111111111111].2
-  list([
-  ])
-# ---
-# name: test_switches[1F.111111111111]
-  list([
-    DeviceRegistryEntrySnapshot({
-      'area_id': None,
-      'config_entries': <ANY>,
-      'configuration_url': None,
-      'connections': set({
-      }),
-      'disabled_by': None,
-      'entry_type': None,
-      'hw_version': None,
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'onewire',
-          '1F.111111111111',
-        ),
-      }),
-      'is_new': False,
-      'labels': set({
-      }),
-      'manufacturer': 'Maxim Integrated',
-      'model': 'DS2409',
-      'model_id': None,
-      'name': '1F.111111111111',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': None,
-      'suggested_area': None,
-      'sw_version': None,
-      'via_device_id': None,
-    }),
-    DeviceRegistryEntrySnapshot({
-      'area_id': None,
-      'config_entries': <ANY>,
-      'configuration_url': None,
-      'connections': set({
-      }),
-      'disabled_by': None,
-      'entry_type': None,
-      'hw_version': None,
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'onewire',
-          '1D.111111111111',
-        ),
-      }),
-      'is_new': False,
-      'labels': set({
-      }),
-      'manufacturer': 'Maxim Integrated',
-      'model': 'DS2423',
-      'model_id': None,
-      'name': '1D.111111111111',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': None,
-      'suggested_area': None,
-      'sw_version': None,
-      'via_device_id': <ANY>,
-    }),
-  ])
-# ---
-# name: test_switches[1F.111111111111].1
-  list([
-  ])
-# ---
-# name: test_switches[1F.111111111111].2
-  list([
-  ])
-# ---
-# name: test_switches[22.111111111111]
-  list([
-    DeviceRegistryEntrySnapshot({
-      'area_id': None,
-      'config_entries': <ANY>,
-      'configuration_url': None,
-      'connections': set({
-      }),
-      'disabled_by': None,
-      'entry_type': None,
-      'hw_version': None,
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'onewire',
-          '22.111111111111',
-        ),
-      }),
-      'is_new': False,
-      'labels': set({
-      }),
-      'manufacturer': 'Maxim Integrated',
-      'model': 'DS1822',
-      'model_id': None,
-      'name': '22.111111111111',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': None,
-      'suggested_area': None,
-      'sw_version': None,
-      'via_device_id': None,
-    }),
-  ])
-# ---
-# name: test_switches[22.111111111111].1
-  list([
-  ])
-# ---
-# name: test_switches[22.111111111111].2
-  list([
-  ])
-# ---
-# name: test_switches[26.111111111111]
-  list([
-    DeviceRegistryEntrySnapshot({
-      'area_id': None,
-      'config_entries': <ANY>,
-      'configuration_url': None,
-      'connections': set({
-      }),
-      'disabled_by': None,
-      'entry_type': None,
-      'hw_version': None,
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'onewire',
-          '26.111111111111',
-        ),
-      }),
-      'is_new': False,
-      'labels': set({
-      }),
-      'manufacturer': 'Maxim Integrated',
-      'model': 'DS2438',
-      'model_id': None,
-      'name': '26.111111111111',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': None,
-      'suggested_area': None,
-      'sw_version': None,
-      'via_device_id': None,
-    }),
-  ])
-# ---
-# name: test_switches[26.111111111111].1
-  list([
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': None,
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'switch',
-      'entity_category': <EntityCategory.CONFIG: 'config'>,
-      'entity_id': 'switch.26_111111111111_current_a_d_control',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': None,
-      'original_icon': None,
-      'original_name': 'Current A/D control',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'iad',
-      'unique_id': '/26.111111111111/IAD',
-      'unit_of_measurement': None,
-    }),
-  ])
-# ---
-# name: test_switches[26.111111111111].2
-  list([
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_file': '/26.111111111111/IAD',
-        'friendly_name': '26.111111111111 Current A/D control',
-        'raw_value': 1.0,
-      }),
-      'context': <ANY>,
-      'entity_id': 'switch.26_111111111111_current_a_d_control',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': 'on',
-    }),
-  ])
-# ---
-# name: test_switches[28.111111111111]
-  list([
-    DeviceRegistryEntrySnapshot({
-      'area_id': None,
-      'config_entries': <ANY>,
-      'configuration_url': None,
-      'connections': set({
-      }),
-      'disabled_by': None,
-      'entry_type': None,
-      'hw_version': None,
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'onewire',
-          '28.111111111111',
-        ),
-      }),
-      'is_new': False,
-      'labels': set({
-      }),
-      'manufacturer': 'Maxim Integrated',
-      'model': 'DS18B20',
-      'model_id': None,
-      'name': '28.111111111111',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': None,
-      'suggested_area': None,
-      'sw_version': None,
-      'via_device_id': None,
-    }),
-  ])
-# ---
-# name: test_switches[28.111111111111].1
-  list([
-  ])
-# ---
-# name: test_switches[28.111111111111].2
-  list([
-  ])
-# ---
-# name: test_switches[28.222222222222]
-  list([
-    DeviceRegistryEntrySnapshot({
-      'area_id': None,
-      'config_entries': <ANY>,
-      'configuration_url': None,
-      'connections': set({
-      }),
-      'disabled_by': None,
-      'entry_type': None,
-      'hw_version': None,
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'onewire',
-          '28.222222222222',
-        ),
-      }),
-      'is_new': False,
-      'labels': set({
-      }),
-      'manufacturer': 'Maxim Integrated',
-      'model': 'DS18B20',
-      'model_id': None,
-      'name': '28.222222222222',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': None,
-      'suggested_area': None,
-      'sw_version': None,
-      'via_device_id': None,
-    }),
-  ])
-# ---
-# name: test_switches[28.222222222222].1
-  list([
-  ])
-# ---
-# name: test_switches[28.222222222222].2
-  list([
-  ])
-# ---
-# name: test_switches[28.222222222223]
-  list([
-    DeviceRegistryEntrySnapshot({
-      'area_id': None,
-      'config_entries': <ANY>,
-      'configuration_url': None,
-      'connections': set({
-      }),
-      'disabled_by': None,
-      'entry_type': None,
-      'hw_version': None,
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'onewire',
-          '28.222222222223',
-        ),
-      }),
-      'is_new': False,
-      'labels': set({
-      }),
-      'manufacturer': 'Maxim Integrated',
-      'model': 'DS18B20',
-      'model_id': None,
-      'name': '28.222222222223',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': None,
-      'suggested_area': None,
-      'sw_version': None,
-      'via_device_id': None,
-    }),
-  ])
-# ---
-# name: test_switches[28.222222222223].1
-  list([
-  ])
-# ---
-# name: test_switches[28.222222222223].2
-  list([
-  ])
-# ---
-# name: test_switches[29.111111111111]
-  list([
-    DeviceRegistryEntrySnapshot({
-      'area_id': None,
-      'config_entries': <ANY>,
-      'configuration_url': None,
-      'connections': set({
-      }),
-      'disabled_by': None,
-      'entry_type': None,
-      'hw_version': None,
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'onewire',
-          '29.111111111111',
-        ),
-      }),
-      'is_new': False,
-      'labels': set({
-      }),
-      'manufacturer': 'Maxim Integrated',
-      'model': 'DS2408',
-      'model_id': None,
-      'name': '29.111111111111',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': None,
-      'suggested_area': None,
-      'sw_version': None,
-      'via_device_id': None,
-    }),
-  ])
-# ---
-# name: test_switches[29.111111111111].1
-  list([
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': None,
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'switch',
-      'entity_category': None,
-      'entity_id': 'switch.29_111111111111_programmed_input_output_0',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': None,
-      'original_icon': None,
-      'original_name': 'Programmed input-output 0',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'pio_id',
-      'unique_id': '/29.111111111111/PIO.0',
-      'unit_of_measurement': None,
-    }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': None,
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'switch',
-      'entity_category': None,
-      'entity_id': 'switch.29_111111111111_programmed_input_output_1',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': None,
-      'original_icon': None,
-      'original_name': 'Programmed input-output 1',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'pio_id',
-      'unique_id': '/29.111111111111/PIO.1',
-      'unit_of_measurement': None,
-    }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': None,
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'switch',
-      'entity_category': None,
-      'entity_id': 'switch.29_111111111111_programmed_input_output_2',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': None,
-      'original_icon': None,
-      'original_name': 'Programmed input-output 2',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'pio_id',
-      'unique_id': '/29.111111111111/PIO.2',
-      'unit_of_measurement': None,
-    }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': None,
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'switch',
-      'entity_category': None,
-      'entity_id': 'switch.29_111111111111_programmed_input_output_3',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': None,
-      'original_icon': None,
-      'original_name': 'Programmed input-output 3',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'pio_id',
-      'unique_id': '/29.111111111111/PIO.3',
-      'unit_of_measurement': None,
-    }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': None,
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'switch',
-      'entity_category': None,
-      'entity_id': 'switch.29_111111111111_programmed_input_output_4',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': None,
-      'original_icon': None,
-      'original_name': 'Programmed input-output 4',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'pio_id',
-      'unique_id': '/29.111111111111/PIO.4',
-      'unit_of_measurement': None,
-    }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': None,
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'switch',
-      'entity_category': None,
-      'entity_id': 'switch.29_111111111111_programmed_input_output_5',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': None,
-      'original_icon': None,
-      'original_name': 'Programmed input-output 5',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'pio_id',
-      'unique_id': '/29.111111111111/PIO.5',
-      'unit_of_measurement': None,
-    }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': None,
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'switch',
-      'entity_category': None,
-      'entity_id': 'switch.29_111111111111_programmed_input_output_6',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': None,
-      'original_icon': None,
-      'original_name': 'Programmed input-output 6',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'pio_id',
-      'unique_id': '/29.111111111111/PIO.6',
-      'unit_of_measurement': None,
-    }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': None,
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'switch',
-      'entity_category': None,
-      'entity_id': 'switch.29_111111111111_programmed_input_output_7',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': None,
-      'original_icon': None,
-      'original_name': 'Programmed input-output 7',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'pio_id',
-      'unique_id': '/29.111111111111/PIO.7',
-      'unit_of_measurement': None,
-    }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': None,
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'switch',
-      'entity_category': None,
-      'entity_id': 'switch.29_111111111111_latch_0',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': None,
-      'original_icon': None,
-      'original_name': 'Latch 0',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'latch_id',
-      'unique_id': '/29.111111111111/latch.0',
-      'unit_of_measurement': None,
-    }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': None,
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'switch',
-      'entity_category': None,
-      'entity_id': 'switch.29_111111111111_latch_1',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': None,
-      'original_icon': None,
-      'original_name': 'Latch 1',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'latch_id',
-      'unique_id': '/29.111111111111/latch.1',
-      'unit_of_measurement': None,
-    }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': None,
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'switch',
-      'entity_category': None,
-      'entity_id': 'switch.29_111111111111_latch_2',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': None,
-      'original_icon': None,
-      'original_name': 'Latch 2',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'latch_id',
-      'unique_id': '/29.111111111111/latch.2',
-      'unit_of_measurement': None,
-    }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': None,
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'switch',
-      'entity_category': None,
-      'entity_id': 'switch.29_111111111111_latch_3',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': None,
-      'original_icon': None,
-      'original_name': 'Latch 3',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'latch_id',
-      'unique_id': '/29.111111111111/latch.3',
-      'unit_of_measurement': None,
-    }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': None,
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'switch',
-      'entity_category': None,
-      'entity_id': 'switch.29_111111111111_latch_4',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': None,
-      'original_icon': None,
-      'original_name': 'Latch 4',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'latch_id',
-      'unique_id': '/29.111111111111/latch.4',
-      'unit_of_measurement': None,
-    }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': None,
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'switch',
-      'entity_category': None,
-      'entity_id': 'switch.29_111111111111_latch_5',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': None,
-      'original_icon': None,
-      'original_name': 'Latch 5',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'latch_id',
-      'unique_id': '/29.111111111111/latch.5',
-      'unit_of_measurement': None,
-    }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': None,
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'switch',
-      'entity_category': None,
-      'entity_id': 'switch.29_111111111111_latch_6',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': None,
-      'original_icon': None,
-      'original_name': 'Latch 6',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'latch_id',
-      'unique_id': '/29.111111111111/latch.6',
-      'unit_of_measurement': None,
-    }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': None,
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'switch',
-      'entity_category': None,
-      'entity_id': 'switch.29_111111111111_latch_7',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': None,
-      'original_icon': None,
-      'original_name': 'Latch 7',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'latch_id',
-      'unique_id': '/29.111111111111/latch.7',
-      'unit_of_measurement': None,
-    }),
-  ])
-# ---
-# name: test_switches[29.111111111111].2
-  list([
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_file': '/29.111111111111/PIO.0',
-        'friendly_name': '29.111111111111 Programmed input-output 0',
-        'raw_value': 1.0,
-      }),
-      'context': <ANY>,
-      'entity_id': 'switch.29_111111111111_programmed_input_output_0',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': 'on',
-    }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_file': '/29.111111111111/PIO.1',
-        'friendly_name': '29.111111111111 Programmed input-output 1',
-        'raw_value': 0.0,
-      }),
-      'context': <ANY>,
-      'entity_id': 'switch.29_111111111111_programmed_input_output_1',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': 'off',
-    }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_file': '/29.111111111111/PIO.2',
-        'friendly_name': '29.111111111111 Programmed input-output 2',
-        'raw_value': 1.0,
-      }),
-      'context': <ANY>,
-      'entity_id': 'switch.29_111111111111_programmed_input_output_2',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': 'on',
-    }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_file': '/29.111111111111/PIO.3',
-        'friendly_name': '29.111111111111 Programmed input-output 3',
-        'raw_value': None,
-      }),
-      'context': <ANY>,
-      'entity_id': 'switch.29_111111111111_programmed_input_output_3',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': 'unknown',
-    }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_file': '/29.111111111111/PIO.4',
-        'friendly_name': '29.111111111111 Programmed input-output 4',
-        'raw_value': 1.0,
-      }),
-      'context': <ANY>,
-      'entity_id': 'switch.29_111111111111_programmed_input_output_4',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': 'on',
-    }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_file': '/29.111111111111/PIO.5',
-        'friendly_name': '29.111111111111 Programmed input-output 5',
-        'raw_value': 0.0,
-      }),
-      'context': <ANY>,
-      'entity_id': 'switch.29_111111111111_programmed_input_output_5',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': 'off',
-    }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_file': '/29.111111111111/PIO.6',
-        'friendly_name': '29.111111111111 Programmed input-output 6',
-        'raw_value': 1.0,
-      }),
-      'context': <ANY>,
-      'entity_id': 'switch.29_111111111111_programmed_input_output_6',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': 'on',
-    }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_file': '/29.111111111111/PIO.7',
-        'friendly_name': '29.111111111111 Programmed input-output 7',
-        'raw_value': 0.0,
-      }),
-      'context': <ANY>,
-      'entity_id': 'switch.29_111111111111_programmed_input_output_7',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': 'off',
-    }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_file': '/29.111111111111/latch.0',
-        'friendly_name': '29.111111111111 Latch 0',
-        'raw_value': 1.0,
-      }),
-      'context': <ANY>,
-      'entity_id': 'switch.29_111111111111_latch_0',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': 'on',
-    }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_file': '/29.111111111111/latch.1',
-        'friendly_name': '29.111111111111 Latch 1',
-        'raw_value': 0.0,
-      }),
-      'context': <ANY>,
-      'entity_id': 'switch.29_111111111111_latch_1',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': 'off',
-    }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_file': '/29.111111111111/latch.2',
-        'friendly_name': '29.111111111111 Latch 2',
-        'raw_value': 1.0,
-      }),
-      'context': <ANY>,
-      'entity_id': 'switch.29_111111111111_latch_2',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': 'on',
-    }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_file': '/29.111111111111/latch.3',
-        'friendly_name': '29.111111111111 Latch 3',
-        'raw_value': 0.0,
-      }),
-      'context': <ANY>,
-      'entity_id': 'switch.29_111111111111_latch_3',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': 'off',
-    }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_file': '/29.111111111111/latch.4',
-        'friendly_name': '29.111111111111 Latch 4',
-        'raw_value': 1.0,
-      }),
-      'context': <ANY>,
-      'entity_id': 'switch.29_111111111111_latch_4',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': 'on',
-    }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_file': '/29.111111111111/latch.5',
-        'friendly_name': '29.111111111111 Latch 5',
-        'raw_value': 0.0,
-      }),
-      'context': <ANY>,
-      'entity_id': 'switch.29_111111111111_latch_5',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': 'off',
-    }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_file': '/29.111111111111/latch.6',
-        'friendly_name': '29.111111111111 Latch 6',
-        'raw_value': 1.0,
-      }),
-      'context': <ANY>,
-      'entity_id': 'switch.29_111111111111_latch_6',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': 'on',
-    }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_file': '/29.111111111111/latch.7',
-        'friendly_name': '29.111111111111 Latch 7',
-        'raw_value': 0.0,
-      }),
-      'context': <ANY>,
-      'entity_id': 'switch.29_111111111111_latch_7',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': 'off',
-    }),
-  ])
-# ---
-# name: test_switches[30.111111111111]
-  list([
-    DeviceRegistryEntrySnapshot({
-      'area_id': None,
-      'config_entries': <ANY>,
-      'configuration_url': None,
-      'connections': set({
-      }),
-      'disabled_by': None,
-      'entry_type': None,
-      'hw_version': None,
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'onewire',
-          '30.111111111111',
-        ),
-      }),
-      'is_new': False,
-      'labels': set({
-      }),
-      'manufacturer': 'Maxim Integrated',
-      'model': 'DS2760',
-      'model_id': None,
-      'name': '30.111111111111',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': None,
-      'suggested_area': None,
-      'sw_version': None,
-      'via_device_id': None,
-    }),
-  ])
-# ---
-# name: test_switches[30.111111111111].1
-  list([
-  ])
-# ---
-# name: test_switches[30.111111111111].2
-  list([
-  ])
-# ---
-# name: test_switches[3A.111111111111]
-  list([
-    DeviceRegistryEntrySnapshot({
-      'area_id': None,
-      'config_entries': <ANY>,
-      'configuration_url': None,
-      'connections': set({
-      }),
-      'disabled_by': None,
-      'entry_type': None,
-      'hw_version': None,
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'onewire',
-          '3A.111111111111',
-        ),
-      }),
-      'is_new': False,
-      'labels': set({
-      }),
-      'manufacturer': 'Maxim Integrated',
-      'model': 'DS2413',
-      'model_id': None,
-      'name': '3A.111111111111',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': None,
-      'suggested_area': None,
-      'sw_version': None,
-      'via_device_id': None,
-    }),
-  ])
-# ---
-# name: test_switches[3A.111111111111].1
-  list([
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': None,
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'switch',
-      'entity_category': None,
-      'entity_id': 'switch.3a_111111111111_programmed_input_output_a',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': None,
-      'original_icon': None,
-      'original_name': 'Programmed input-output A',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'pio_id',
-      'unique_id': '/3A.111111111111/PIO.A',
-      'unit_of_measurement': None,
-    }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': None,
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'switch',
-      'entity_category': None,
-      'entity_id': 'switch.3a_111111111111_programmed_input_output_b',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': None,
-      'original_icon': None,
-      'original_name': 'Programmed input-output B',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'pio_id',
-      'unique_id': '/3A.111111111111/PIO.B',
-      'unit_of_measurement': None,
-    }),
-  ])
-# ---
-# name: test_switches[3A.111111111111].2
-  list([
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_file': '/3A.111111111111/PIO.A',
-        'friendly_name': '3A.111111111111 Programmed input-output A',
-        'raw_value': 1.0,
-      }),
-      'context': <ANY>,
-      'entity_id': 'switch.3a_111111111111_programmed_input_output_a',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': 'on',
-    }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_file': '/3A.111111111111/PIO.B',
-        'friendly_name': '3A.111111111111 Programmed input-output B',
-        'raw_value': 0.0,
-      }),
-      'context': <ANY>,
-      'entity_id': 'switch.3a_111111111111_programmed_input_output_b',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': 'off',
-    }),
-  ])
-# ---
-# name: test_switches[3B.111111111111]
-  list([
-    DeviceRegistryEntrySnapshot({
-      'area_id': None,
-      'config_entries': <ANY>,
-      'configuration_url': None,
-      'connections': set({
-      }),
-      'disabled_by': None,
-      'entry_type': None,
-      'hw_version': None,
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'onewire',
-          '3B.111111111111',
-        ),
-      }),
-      'is_new': False,
-      'labels': set({
-      }),
-      'manufacturer': 'Maxim Integrated',
-      'model': 'DS1825',
-      'model_id': None,
-      'name': '3B.111111111111',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': None,
-      'suggested_area': None,
-      'sw_version': None,
-      'via_device_id': None,
-    }),
-  ])
-# ---
-# name: test_switches[3B.111111111111].1
-  list([
-  ])
-# ---
-# name: test_switches[3B.111111111111].2
-  list([
-  ])
-# ---
-# name: test_switches[42.111111111111]
-  list([
-    DeviceRegistryEntrySnapshot({
-      'area_id': None,
-      'config_entries': <ANY>,
-      'configuration_url': None,
-      'connections': set({
-      }),
-      'disabled_by': None,
-      'entry_type': None,
-      'hw_version': None,
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'onewire',
-          '42.111111111111',
-        ),
-      }),
-      'is_new': False,
-      'labels': set({
-      }),
-      'manufacturer': 'Maxim Integrated',
-      'model': 'DS28EA00',
-      'model_id': None,
-      'name': '42.111111111111',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': None,
-      'suggested_area': None,
-      'sw_version': None,
-      'via_device_id': None,
-    }),
-  ])
-# ---
-# name: test_switches[42.111111111111].1
-  list([
-  ])
-# ---
-# name: test_switches[42.111111111111].2
-  list([
-  ])
-# ---
-# name: test_switches[7E.111111111111]
-  list([
-    DeviceRegistryEntrySnapshot({
-      'area_id': None,
-      'config_entries': <ANY>,
-      'configuration_url': None,
-      'connections': set({
-      }),
-      'disabled_by': None,
-      'entry_type': None,
-      'hw_version': None,
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'onewire',
-          '7E.111111111111',
-        ),
-      }),
-      'is_new': False,
-      'labels': set({
-      }),
-      'manufacturer': 'Embedded Data Systems',
-      'model': 'EDS0068',
-      'model_id': None,
-      'name': '7E.111111111111',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': None,
-      'suggested_area': None,
-      'sw_version': None,
-      'via_device_id': None,
-    }),
-  ])
-# ---
-# name: test_switches[7E.111111111111].1
-  list([
-  ])
-# ---
-# name: test_switches[7E.111111111111].2
-  list([
-  ])
-# ---
-# name: test_switches[7E.222222222222]
-  list([
-    DeviceRegistryEntrySnapshot({
-      'area_id': None,
-      'config_entries': <ANY>,
-      'configuration_url': None,
-      'connections': set({
-      }),
-      'disabled_by': None,
-      'entry_type': None,
-      'hw_version': None,
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'onewire',
-          '7E.222222222222',
-        ),
-      }),
-      'is_new': False,
-      'labels': set({
-      }),
-      'manufacturer': 'Embedded Data Systems',
-      'model': 'EDS0066',
-      'model_id': None,
-      'name': '7E.222222222222',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': None,
-      'suggested_area': None,
-      'sw_version': None,
-      'via_device_id': None,
-    }),
-  ])
-# ---
-# name: test_switches[7E.222222222222].1
-  list([
-  ])
-# ---
-# name: test_switches[7E.222222222222].2
-  list([
-  ])
-# ---
-# name: test_switches[A6.111111111111]
-  list([
-    DeviceRegistryEntrySnapshot({
-      'area_id': None,
-      'config_entries': <ANY>,
-      'configuration_url': None,
-      'connections': set({
-      }),
-      'disabled_by': None,
-      'entry_type': None,
-      'hw_version': None,
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'onewire',
-          'A6.111111111111',
-        ),
-      }),
-      'is_new': False,
-      'labels': set({
-      }),
-      'manufacturer': 'Maxim Integrated',
-      'model': 'DS2438',
-      'model_id': None,
-      'name': 'A6.111111111111',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': None,
-      'suggested_area': None,
-      'sw_version': None,
-      'via_device_id': None,
-    }),
-  ])
-# ---
-# name: test_switches[A6.111111111111].1
-  list([
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': None,
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'switch',
-      'entity_category': <EntityCategory.CONFIG: 'config'>,
-      'entity_id': 'switch.a6_111111111111_current_a_d_control',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': None,
-      'original_icon': None,
-      'original_name': 'Current A/D control',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'iad',
-      'unique_id': '/A6.111111111111/IAD',
-      'unit_of_measurement': None,
-    }),
-  ])
-# ---
-# name: test_switches[A6.111111111111].2
-  list([
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_file': '/A6.111111111111/IAD',
-        'friendly_name': 'A6.111111111111 Current A/D control',
-        'raw_value': 1.0,
-      }),
-      'context': <ANY>,
-      'entity_id': 'switch.a6_111111111111_current_a_d_control',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': 'on',
-    }),
-  ])
-# ---
-# name: test_switches[EF.111111111111]
-  list([
-    DeviceRegistryEntrySnapshot({
-      'area_id': None,
-      'config_entries': <ANY>,
-      'configuration_url': None,
-      'connections': set({
-      }),
-      'disabled_by': None,
-      'entry_type': None,
-      'hw_version': None,
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'onewire',
-          'EF.111111111111',
-        ),
-      }),
-      'is_new': False,
-      'labels': set({
-      }),
-      'manufacturer': 'Hobby Boards',
-      'model': 'HobbyBoards_EF',
-      'model_id': None,
-      'name': 'EF.111111111111',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': None,
-      'suggested_area': None,
-      'sw_version': None,
-      'via_device_id': None,
-    }),
-  ])
-# ---
-# name: test_switches[EF.111111111111].1
-  list([
-  ])
-# ---
-# name: test_switches[EF.111111111111].2
-  list([
-  ])
-# ---
-# name: test_switches[EF.111111111112]
-  list([
-    DeviceRegistryEntrySnapshot({
-      'area_id': None,
-      'config_entries': <ANY>,
-      'configuration_url': None,
-      'connections': set({
-      }),
-      'disabled_by': None,
-      'entry_type': None,
-      'hw_version': None,
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'onewire',
-          'EF.111111111112',
-        ),
-      }),
-      'is_new': False,
-      'labels': set({
-      }),
-      'manufacturer': 'Hobby Boards',
-      'model': 'HB_MOISTURE_METER',
-      'model_id': None,
-      'name': 'EF.111111111112',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': None,
-      'suggested_area': None,
-      'sw_version': None,
-      'via_device_id': None,
-    }),
-  ])
-# ---
-# name: test_switches[EF.111111111112].1
-  list([
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': None,
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'switch',
-      'entity_category': <EntityCategory.CONFIG: 'config'>,
-      'entity_id': 'switch.ef_111111111112_leaf_sensor_0',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': None,
-      'original_icon': None,
-      'original_name': 'Leaf sensor 0',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'leaf_sensor_id',
-      'unique_id': '/EF.111111111112/moisture/is_leaf.0',
-      'unit_of_measurement': None,
-    }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': None,
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'switch',
-      'entity_category': <EntityCategory.CONFIG: 'config'>,
-      'entity_id': 'switch.ef_111111111112_leaf_sensor_1',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': None,
-      'original_icon': None,
-      'original_name': 'Leaf sensor 1',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'leaf_sensor_id',
-      'unique_id': '/EF.111111111112/moisture/is_leaf.1',
-      'unit_of_measurement': None,
-    }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': None,
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'switch',
-      'entity_category': <EntityCategory.CONFIG: 'config'>,
-      'entity_id': 'switch.ef_111111111112_leaf_sensor_2',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': None,
-      'original_icon': None,
-      'original_name': 'Leaf sensor 2',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'leaf_sensor_id',
-      'unique_id': '/EF.111111111112/moisture/is_leaf.2',
-      'unit_of_measurement': None,
-    }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': None,
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'switch',
-      'entity_category': <EntityCategory.CONFIG: 'config'>,
-      'entity_id': 'switch.ef_111111111112_leaf_sensor_3',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': None,
-      'original_icon': None,
-      'original_name': 'Leaf sensor 3',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'leaf_sensor_id',
-      'unique_id': '/EF.111111111112/moisture/is_leaf.3',
-      'unit_of_measurement': None,
-    }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': None,
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'switch',
-      'entity_category': <EntityCategory.CONFIG: 'config'>,
-      'entity_id': 'switch.ef_111111111112_moisture_sensor_0',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': None,
-      'original_icon': None,
-      'original_name': 'Moisture sensor 0',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'moisture_sensor_id',
-      'unique_id': '/EF.111111111112/moisture/is_moisture.0',
-      'unit_of_measurement': None,
-    }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': None,
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'switch',
-      'entity_category': <EntityCategory.CONFIG: 'config'>,
-      'entity_id': 'switch.ef_111111111112_moisture_sensor_1',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': None,
-      'original_icon': None,
-      'original_name': 'Moisture sensor 1',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'moisture_sensor_id',
-      'unique_id': '/EF.111111111112/moisture/is_moisture.1',
-      'unit_of_measurement': None,
-    }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': None,
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'switch',
-      'entity_category': <EntityCategory.CONFIG: 'config'>,
-      'entity_id': 'switch.ef_111111111112_moisture_sensor_2',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': None,
-      'original_icon': None,
-      'original_name': 'Moisture sensor 2',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'moisture_sensor_id',
-      'unique_id': '/EF.111111111112/moisture/is_moisture.2',
-      'unit_of_measurement': None,
-    }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': None,
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'switch',
-      'entity_category': <EntityCategory.CONFIG: 'config'>,
-      'entity_id': 'switch.ef_111111111112_moisture_sensor_3',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': None,
-      'original_icon': None,
-      'original_name': 'Moisture sensor 3',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'moisture_sensor_id',
-      'unique_id': '/EF.111111111112/moisture/is_moisture.3',
-      'unit_of_measurement': None,
-    }),
-  ])
-# ---
-# name: test_switches[EF.111111111112].2
-  list([
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_file': '/EF.111111111112/moisture/is_leaf.0',
-        'friendly_name': 'EF.111111111112 Leaf sensor 0',
-        'raw_value': 1.0,
-      }),
-      'context': <ANY>,
-      'entity_id': 'switch.ef_111111111112_leaf_sensor_0',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': 'on',
-    }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_file': '/EF.111111111112/moisture/is_leaf.1',
-        'friendly_name': 'EF.111111111112 Leaf sensor 1',
-        'raw_value': 1.0,
-      }),
-      'context': <ANY>,
-      'entity_id': 'switch.ef_111111111112_leaf_sensor_1',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': 'on',
-    }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_file': '/EF.111111111112/moisture/is_leaf.2',
-        'friendly_name': 'EF.111111111112 Leaf sensor 2',
-        'raw_value': 0.0,
-      }),
-      'context': <ANY>,
-      'entity_id': 'switch.ef_111111111112_leaf_sensor_2',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': 'off',
-    }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_file': '/EF.111111111112/moisture/is_leaf.3',
-        'friendly_name': 'EF.111111111112 Leaf sensor 3',
-        'raw_value': 0.0,
-      }),
-      'context': <ANY>,
-      'entity_id': 'switch.ef_111111111112_leaf_sensor_3',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': 'off',
-    }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_file': '/EF.111111111112/moisture/is_moisture.0',
-        'friendly_name': 'EF.111111111112 Moisture sensor 0',
-        'raw_value': 1.0,
-      }),
-      'context': <ANY>,
-      'entity_id': 'switch.ef_111111111112_moisture_sensor_0',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': 'on',
-    }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_file': '/EF.111111111112/moisture/is_moisture.1',
-        'friendly_name': 'EF.111111111112 Moisture sensor 1',
-        'raw_value': 1.0,
-      }),
-      'context': <ANY>,
-      'entity_id': 'switch.ef_111111111112_moisture_sensor_1',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': 'on',
-    }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_file': '/EF.111111111112/moisture/is_moisture.2',
-        'friendly_name': 'EF.111111111112 Moisture sensor 2',
-        'raw_value': 0.0,
-      }),
-      'context': <ANY>,
-      'entity_id': 'switch.ef_111111111112_moisture_sensor_2',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': 'off',
-    }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_file': '/EF.111111111112/moisture/is_moisture.3',
-        'friendly_name': 'EF.111111111112 Moisture sensor 3',
-        'raw_value': 0.0,
-      }),
-      'context': <ANY>,
-      'entity_id': 'switch.ef_111111111112_moisture_sensor_3',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': 'off',
-    }),
-  ])
-# ---
-# name: test_switches[EF.111111111113]
-  list([
-    DeviceRegistryEntrySnapshot({
-      'area_id': None,
-      'config_entries': <ANY>,
-      'configuration_url': None,
-      'connections': set({
-      }),
-      'disabled_by': None,
-      'entry_type': None,
-      'hw_version': None,
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'onewire',
-          'EF.111111111113',
-        ),
-      }),
-      'is_new': False,
-      'labels': set({
-      }),
-      'manufacturer': 'Hobby Boards',
-      'model': 'HB_HUB',
-      'model_id': None,
-      'name': 'EF.111111111113',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': None,
-      'suggested_area': None,
-      'sw_version': None,
-      'via_device_id': None,
-    }),
-  ])
-# ---
-# name: test_switches[EF.111111111113].1
-  list([
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': None,
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'switch',
-      'entity_category': <EntityCategory.CONFIG: 'config'>,
-      'entity_id': 'switch.ef_111111111113_hub_branch_0',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': None,
-      'original_icon': None,
-      'original_name': 'Hub branch 0',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'hub_branch_id',
-      'unique_id': '/EF.111111111113/hub/branch.0',
-      'unit_of_measurement': None,
-    }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': None,
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'switch',
-      'entity_category': <EntityCategory.CONFIG: 'config'>,
-      'entity_id': 'switch.ef_111111111113_hub_branch_1',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': None,
-      'original_icon': None,
-      'original_name': 'Hub branch 1',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'hub_branch_id',
-      'unique_id': '/EF.111111111113/hub/branch.1',
-      'unit_of_measurement': None,
-    }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': None,
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'switch',
-      'entity_category': <EntityCategory.CONFIG: 'config'>,
-      'entity_id': 'switch.ef_111111111113_hub_branch_2',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': None,
-      'original_icon': None,
-      'original_name': 'Hub branch 2',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'hub_branch_id',
-      'unique_id': '/EF.111111111113/hub/branch.2',
-      'unit_of_measurement': None,
-    }),
-    EntityRegistryEntrySnapshot({
-      'aliases': set({
-      }),
-      'area_id': None,
-      'capabilities': None,
-      'config_entry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
-      'domain': 'switch',
-      'entity_category': <EntityCategory.CONFIG: 'config'>,
-      'entity_id': 'switch.ef_111111111113_hub_branch_3',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'options': dict({
-      }),
-      'original_device_class': None,
-      'original_icon': None,
-      'original_name': 'Hub branch 3',
-      'platform': 'onewire',
-      'previous_unique_id': None,
-      'supported_features': 0,
-      'translation_key': 'hub_branch_id',
-      'unique_id': '/EF.111111111113/hub/branch.3',
-      'unit_of_measurement': None,
-    }),
-  ])
-# ---
-# name: test_switches[EF.111111111113].2
-  list([
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_file': '/EF.111111111113/hub/branch.0',
-        'friendly_name': 'EF.111111111113 Hub branch 0',
-        'raw_value': 1.0,
-      }),
-      'context': <ANY>,
-      'entity_id': 'switch.ef_111111111113_hub_branch_0',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': 'on',
-    }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_file': '/EF.111111111113/hub/branch.1',
-        'friendly_name': 'EF.111111111113 Hub branch 1',
-        'raw_value': 0.0,
-      }),
-      'context': <ANY>,
-      'entity_id': 'switch.ef_111111111113_hub_branch_1',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': 'off',
-    }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_file': '/EF.111111111113/hub/branch.2',
-        'friendly_name': 'EF.111111111113 Hub branch 2',
-        'raw_value': 1.0,
-      }),
-      'context': <ANY>,
-      'entity_id': 'switch.ef_111111111113_hub_branch_2',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': 'on',
-    }),
-    StateSnapshot({
-      'attributes': ReadOnlyDict({
-        'device_file': '/EF.111111111113/hub/branch.3',
-        'friendly_name': 'EF.111111111113 Hub branch 3',
-        'raw_value': 0.0,
-      }),
-      'context': <ANY>,
-      'entity_id': 'switch.ef_111111111113_hub_branch_3',
-      'last_changed': <ANY>,
-      'last_reported': <ANY>,
-      'last_updated': <ANY>,
-      'state': 'off',
-    }),
-  ])
+# name: test_switches[switch.05_111111111111_programmed_input_output-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.05_111111111111_programmed_input_output',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Programmed input-output',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'pio',
+    'unique_id': '/05.111111111111/PIO',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.05_111111111111_programmed_input_output-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_file': '/05.111111111111/PIO',
+      'friendly_name': '05.111111111111 Programmed input-output',
+      'raw_value': 1.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.05_111111111111_programmed_input_output',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_switches[switch.12_111111111111_latch_a-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.12_111111111111_latch_a',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Latch A',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'latch_id',
+    'unique_id': '/12.111111111111/latch.A',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.12_111111111111_latch_a-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_file': '/12.111111111111/latch.A',
+      'friendly_name': '12.111111111111 Latch A',
+      'raw_value': 1.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.12_111111111111_latch_a',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_switches[switch.12_111111111111_latch_b-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.12_111111111111_latch_b',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Latch B',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'latch_id',
+    'unique_id': '/12.111111111111/latch.B',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.12_111111111111_latch_b-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_file': '/12.111111111111/latch.B',
+      'friendly_name': '12.111111111111 Latch B',
+      'raw_value': 0.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.12_111111111111_latch_b',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_switches[switch.12_111111111111_programmed_input_output_a-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.12_111111111111_programmed_input_output_a',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Programmed input-output A',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'pio_id',
+    'unique_id': '/12.111111111111/PIO.A',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.12_111111111111_programmed_input_output_a-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_file': '/12.111111111111/PIO.A',
+      'friendly_name': '12.111111111111 Programmed input-output A',
+      'raw_value': 1.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.12_111111111111_programmed_input_output_a',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_switches[switch.12_111111111111_programmed_input_output_b-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.12_111111111111_programmed_input_output_b',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Programmed input-output B',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'pio_id',
+    'unique_id': '/12.111111111111/PIO.B',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.12_111111111111_programmed_input_output_b-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_file': '/12.111111111111/PIO.B',
+      'friendly_name': '12.111111111111 Programmed input-output B',
+      'raw_value': 0.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.12_111111111111_programmed_input_output_b',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_switches[switch.26_111111111111_current_a_d_control-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.26_111111111111_current_a_d_control',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Current A/D control',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'iad',
+    'unique_id': '/26.111111111111/IAD',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.26_111111111111_current_a_d_control-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_file': '/26.111111111111/IAD',
+      'friendly_name': '26.111111111111 Current A/D control',
+      'raw_value': 1.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.26_111111111111_current_a_d_control',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_switches[switch.29_111111111111_latch_0-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.29_111111111111_latch_0',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Latch 0',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'latch_id',
+    'unique_id': '/29.111111111111/latch.0',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.29_111111111111_latch_0-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_file': '/29.111111111111/latch.0',
+      'friendly_name': '29.111111111111 Latch 0',
+      'raw_value': 1.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.29_111111111111_latch_0',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_switches[switch.29_111111111111_latch_1-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.29_111111111111_latch_1',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Latch 1',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'latch_id',
+    'unique_id': '/29.111111111111/latch.1',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.29_111111111111_latch_1-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_file': '/29.111111111111/latch.1',
+      'friendly_name': '29.111111111111 Latch 1',
+      'raw_value': 0.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.29_111111111111_latch_1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_switches[switch.29_111111111111_latch_2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.29_111111111111_latch_2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Latch 2',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'latch_id',
+    'unique_id': '/29.111111111111/latch.2',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.29_111111111111_latch_2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_file': '/29.111111111111/latch.2',
+      'friendly_name': '29.111111111111 Latch 2',
+      'raw_value': 1.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.29_111111111111_latch_2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_switches[switch.29_111111111111_latch_3-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.29_111111111111_latch_3',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Latch 3',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'latch_id',
+    'unique_id': '/29.111111111111/latch.3',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.29_111111111111_latch_3-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_file': '/29.111111111111/latch.3',
+      'friendly_name': '29.111111111111 Latch 3',
+      'raw_value': 0.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.29_111111111111_latch_3',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_switches[switch.29_111111111111_latch_4-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.29_111111111111_latch_4',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Latch 4',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'latch_id',
+    'unique_id': '/29.111111111111/latch.4',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.29_111111111111_latch_4-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_file': '/29.111111111111/latch.4',
+      'friendly_name': '29.111111111111 Latch 4',
+      'raw_value': 1.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.29_111111111111_latch_4',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_switches[switch.29_111111111111_latch_5-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.29_111111111111_latch_5',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Latch 5',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'latch_id',
+    'unique_id': '/29.111111111111/latch.5',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.29_111111111111_latch_5-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_file': '/29.111111111111/latch.5',
+      'friendly_name': '29.111111111111 Latch 5',
+      'raw_value': 0.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.29_111111111111_latch_5',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_switches[switch.29_111111111111_latch_6-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.29_111111111111_latch_6',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Latch 6',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'latch_id',
+    'unique_id': '/29.111111111111/latch.6',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.29_111111111111_latch_6-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_file': '/29.111111111111/latch.6',
+      'friendly_name': '29.111111111111 Latch 6',
+      'raw_value': 1.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.29_111111111111_latch_6',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_switches[switch.29_111111111111_latch_7-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.29_111111111111_latch_7',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Latch 7',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'latch_id',
+    'unique_id': '/29.111111111111/latch.7',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.29_111111111111_latch_7-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_file': '/29.111111111111/latch.7',
+      'friendly_name': '29.111111111111 Latch 7',
+      'raw_value': 0.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.29_111111111111_latch_7',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_switches[switch.29_111111111111_programmed_input_output_0-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.29_111111111111_programmed_input_output_0',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Programmed input-output 0',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'pio_id',
+    'unique_id': '/29.111111111111/PIO.0',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.29_111111111111_programmed_input_output_0-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_file': '/29.111111111111/PIO.0',
+      'friendly_name': '29.111111111111 Programmed input-output 0',
+      'raw_value': 1.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.29_111111111111_programmed_input_output_0',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_switches[switch.29_111111111111_programmed_input_output_1-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.29_111111111111_programmed_input_output_1',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Programmed input-output 1',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'pio_id',
+    'unique_id': '/29.111111111111/PIO.1',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.29_111111111111_programmed_input_output_1-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_file': '/29.111111111111/PIO.1',
+      'friendly_name': '29.111111111111 Programmed input-output 1',
+      'raw_value': 0.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.29_111111111111_programmed_input_output_1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_switches[switch.29_111111111111_programmed_input_output_2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.29_111111111111_programmed_input_output_2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Programmed input-output 2',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'pio_id',
+    'unique_id': '/29.111111111111/PIO.2',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.29_111111111111_programmed_input_output_2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_file': '/29.111111111111/PIO.2',
+      'friendly_name': '29.111111111111 Programmed input-output 2',
+      'raw_value': 1.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.29_111111111111_programmed_input_output_2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_switches[switch.29_111111111111_programmed_input_output_3-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.29_111111111111_programmed_input_output_3',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Programmed input-output 3',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'pio_id',
+    'unique_id': '/29.111111111111/PIO.3',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.29_111111111111_programmed_input_output_3-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_file': '/29.111111111111/PIO.3',
+      'friendly_name': '29.111111111111 Programmed input-output 3',
+      'raw_value': None,
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.29_111111111111_programmed_input_output_3',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_switches[switch.29_111111111111_programmed_input_output_4-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.29_111111111111_programmed_input_output_4',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Programmed input-output 4',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'pio_id',
+    'unique_id': '/29.111111111111/PIO.4',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.29_111111111111_programmed_input_output_4-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_file': '/29.111111111111/PIO.4',
+      'friendly_name': '29.111111111111 Programmed input-output 4',
+      'raw_value': 1.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.29_111111111111_programmed_input_output_4',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_switches[switch.29_111111111111_programmed_input_output_5-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.29_111111111111_programmed_input_output_5',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Programmed input-output 5',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'pio_id',
+    'unique_id': '/29.111111111111/PIO.5',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.29_111111111111_programmed_input_output_5-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_file': '/29.111111111111/PIO.5',
+      'friendly_name': '29.111111111111 Programmed input-output 5',
+      'raw_value': 0.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.29_111111111111_programmed_input_output_5',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_switches[switch.29_111111111111_programmed_input_output_6-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.29_111111111111_programmed_input_output_6',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Programmed input-output 6',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'pio_id',
+    'unique_id': '/29.111111111111/PIO.6',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.29_111111111111_programmed_input_output_6-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_file': '/29.111111111111/PIO.6',
+      'friendly_name': '29.111111111111 Programmed input-output 6',
+      'raw_value': 1.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.29_111111111111_programmed_input_output_6',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_switches[switch.29_111111111111_programmed_input_output_7-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.29_111111111111_programmed_input_output_7',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Programmed input-output 7',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'pio_id',
+    'unique_id': '/29.111111111111/PIO.7',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.29_111111111111_programmed_input_output_7-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_file': '/29.111111111111/PIO.7',
+      'friendly_name': '29.111111111111 Programmed input-output 7',
+      'raw_value': 0.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.29_111111111111_programmed_input_output_7',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_switches[switch.3a_111111111111_programmed_input_output_a-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.3a_111111111111_programmed_input_output_a',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Programmed input-output A',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'pio_id',
+    'unique_id': '/3A.111111111111/PIO.A',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.3a_111111111111_programmed_input_output_a-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_file': '/3A.111111111111/PIO.A',
+      'friendly_name': '3A.111111111111 Programmed input-output A',
+      'raw_value': 1.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.3a_111111111111_programmed_input_output_a',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_switches[switch.3a_111111111111_programmed_input_output_b-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.3a_111111111111_programmed_input_output_b',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Programmed input-output B',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'pio_id',
+    'unique_id': '/3A.111111111111/PIO.B',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.3a_111111111111_programmed_input_output_b-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_file': '/3A.111111111111/PIO.B',
+      'friendly_name': '3A.111111111111 Programmed input-output B',
+      'raw_value': 0.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.3a_111111111111_programmed_input_output_b',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_switches[switch.a6_111111111111_current_a_d_control-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.a6_111111111111_current_a_d_control',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Current A/D control',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'iad',
+    'unique_id': '/A6.111111111111/IAD',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.a6_111111111111_current_a_d_control-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_file': '/A6.111111111111/IAD',
+      'friendly_name': 'A6.111111111111 Current A/D control',
+      'raw_value': 1.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.a6_111111111111_current_a_d_control',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_switches[switch.ef_111111111112_leaf_sensor_0-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.ef_111111111112_leaf_sensor_0',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Leaf sensor 0',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'leaf_sensor_id',
+    'unique_id': '/EF.111111111112/moisture/is_leaf.0',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.ef_111111111112_leaf_sensor_0-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_file': '/EF.111111111112/moisture/is_leaf.0',
+      'friendly_name': 'EF.111111111112 Leaf sensor 0',
+      'raw_value': 1.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.ef_111111111112_leaf_sensor_0',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_switches[switch.ef_111111111112_leaf_sensor_1-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.ef_111111111112_leaf_sensor_1',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Leaf sensor 1',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'leaf_sensor_id',
+    'unique_id': '/EF.111111111112/moisture/is_leaf.1',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.ef_111111111112_leaf_sensor_1-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_file': '/EF.111111111112/moisture/is_leaf.1',
+      'friendly_name': 'EF.111111111112 Leaf sensor 1',
+      'raw_value': 1.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.ef_111111111112_leaf_sensor_1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_switches[switch.ef_111111111112_leaf_sensor_2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.ef_111111111112_leaf_sensor_2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Leaf sensor 2',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'leaf_sensor_id',
+    'unique_id': '/EF.111111111112/moisture/is_leaf.2',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.ef_111111111112_leaf_sensor_2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_file': '/EF.111111111112/moisture/is_leaf.2',
+      'friendly_name': 'EF.111111111112 Leaf sensor 2',
+      'raw_value': 0.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.ef_111111111112_leaf_sensor_2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_switches[switch.ef_111111111112_leaf_sensor_3-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.ef_111111111112_leaf_sensor_3',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Leaf sensor 3',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'leaf_sensor_id',
+    'unique_id': '/EF.111111111112/moisture/is_leaf.3',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.ef_111111111112_leaf_sensor_3-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_file': '/EF.111111111112/moisture/is_leaf.3',
+      'friendly_name': 'EF.111111111112 Leaf sensor 3',
+      'raw_value': 0.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.ef_111111111112_leaf_sensor_3',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_switches[switch.ef_111111111112_moisture_sensor_0-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.ef_111111111112_moisture_sensor_0',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Moisture sensor 0',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'moisture_sensor_id',
+    'unique_id': '/EF.111111111112/moisture/is_moisture.0',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.ef_111111111112_moisture_sensor_0-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_file': '/EF.111111111112/moisture/is_moisture.0',
+      'friendly_name': 'EF.111111111112 Moisture sensor 0',
+      'raw_value': 1.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.ef_111111111112_moisture_sensor_0',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_switches[switch.ef_111111111112_moisture_sensor_1-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.ef_111111111112_moisture_sensor_1',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Moisture sensor 1',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'moisture_sensor_id',
+    'unique_id': '/EF.111111111112/moisture/is_moisture.1',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.ef_111111111112_moisture_sensor_1-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_file': '/EF.111111111112/moisture/is_moisture.1',
+      'friendly_name': 'EF.111111111112 Moisture sensor 1',
+      'raw_value': 1.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.ef_111111111112_moisture_sensor_1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_switches[switch.ef_111111111112_moisture_sensor_2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.ef_111111111112_moisture_sensor_2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Moisture sensor 2',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'moisture_sensor_id',
+    'unique_id': '/EF.111111111112/moisture/is_moisture.2',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.ef_111111111112_moisture_sensor_2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_file': '/EF.111111111112/moisture/is_moisture.2',
+      'friendly_name': 'EF.111111111112 Moisture sensor 2',
+      'raw_value': 0.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.ef_111111111112_moisture_sensor_2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_switches[switch.ef_111111111112_moisture_sensor_3-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.ef_111111111112_moisture_sensor_3',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Moisture sensor 3',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'moisture_sensor_id',
+    'unique_id': '/EF.111111111112/moisture/is_moisture.3',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.ef_111111111112_moisture_sensor_3-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_file': '/EF.111111111112/moisture/is_moisture.3',
+      'friendly_name': 'EF.111111111112 Moisture sensor 3',
+      'raw_value': 0.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.ef_111111111112_moisture_sensor_3',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_switches[switch.ef_111111111113_hub_branch_0-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.ef_111111111113_hub_branch_0',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Hub branch 0',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'hub_branch_id',
+    'unique_id': '/EF.111111111113/hub/branch.0',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.ef_111111111113_hub_branch_0-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_file': '/EF.111111111113/hub/branch.0',
+      'friendly_name': 'EF.111111111113 Hub branch 0',
+      'raw_value': 1.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.ef_111111111113_hub_branch_0',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_switches[switch.ef_111111111113_hub_branch_1-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.ef_111111111113_hub_branch_1',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Hub branch 1',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'hub_branch_id',
+    'unique_id': '/EF.111111111113/hub/branch.1',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.ef_111111111113_hub_branch_1-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_file': '/EF.111111111113/hub/branch.1',
+      'friendly_name': 'EF.111111111113 Hub branch 1',
+      'raw_value': 0.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.ef_111111111113_hub_branch_1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_switches[switch.ef_111111111113_hub_branch_2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.ef_111111111113_hub_branch_2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Hub branch 2',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'hub_branch_id',
+    'unique_id': '/EF.111111111113/hub/branch.2',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.ef_111111111113_hub_branch_2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_file': '/EF.111111111113/hub/branch.2',
+      'friendly_name': 'EF.111111111113 Hub branch 2',
+      'raw_value': 1.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.ef_111111111113_hub_branch_2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_switches[switch.ef_111111111113_hub_branch_3-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.ef_111111111113_hub_branch_3',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Hub branch 3',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'hub_branch_id',
+    'unique_id': '/EF.111111111113/hub/branch.3',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.ef_111111111113_hub_branch_3-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_file': '/EF.111111111113/hub/branch.3',
+      'friendly_name': 'EF.111111111113 Hub branch 3',
+      'raw_value': 0.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.ef_111111111113_hub_branch_3',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
 # ---

--- a/tests/components/onewire/test_binary_sensor.py
+++ b/tests/components/onewire/test_binary_sensor.py
@@ -8,11 +8,12 @@ from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers import entity_registry as er
 
 from . import setup_owproxy_mock_devices
+from .const import MOCK_OWPROXY_DEVICES
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, snapshot_platform
 
 
 @pytest.fixture(autouse=True)
@@ -22,39 +23,16 @@ def override_platforms() -> Generator[None]:
         yield
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_binary_sensors(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
     owproxy: MagicMock,
-    device_id: str,
-    device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test for 1-Wire binary sensors."""
-    setup_owproxy_mock_devices(owproxy, [device_id])
+    setup_owproxy_mock_devices(owproxy, MOCK_OWPROXY_DEVICES.keys())
     await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
 
-    # Ensure devices are correctly registered
-    device_entries = dr.async_entries_for_config_entry(
-        device_registry, config_entry.entry_id
-    )
-    assert device_entries == snapshot
-
-    # Ensure entities are correctly registered
-    entity_entries = er.async_entries_for_config_entry(
-        entity_registry, config_entry.entry_id
-    )
-    assert entity_entries == snapshot
-
-    setup_owproxy_mock_devices(owproxy, [device_id])
-    # Some entities are disabled, enable them and reload before checking states
-    for ent in entity_entries:
-        entity_registry.async_update_entity(ent.entity_id, disabled_by=None)
-    await hass.config_entries.async_reload(config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    # Ensure entity states are correct
-    states = [hass.states.get(ent.entity_id) for ent in entity_entries]
-    assert states == snapshot
+    await snapshot_platform(hass, entity_registry, snapshot, config_entry.entry_id)

--- a/tests/components/onewire/test_sensor.py
+++ b/tests/components/onewire/test_sensor.py
@@ -11,12 +11,12 @@ from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers import entity_registry as er
 
 from . import setup_owproxy_mock_devices
 from .const import ATTR_INJECT_READS, MOCK_OWPROXY_DEVICES
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, snapshot_platform
 
 
 @pytest.fixture(autouse=True)
@@ -26,42 +26,19 @@ def override_platforms() -> Generator[None]:
         yield
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_sensors(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
     owproxy: MagicMock,
-    device_id: str,
-    device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test for 1-Wire sensors."""
-    setup_owproxy_mock_devices(owproxy, [device_id])
+    setup_owproxy_mock_devices(owproxy, MOCK_OWPROXY_DEVICES.keys())
     await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
 
-    # Ensure devices are correctly registered
-    device_entries = dr.async_entries_for_config_entry(
-        device_registry, config_entry.entry_id
-    )
-    assert device_entries == snapshot
-
-    # Ensure entities are correctly registered
-    entity_entries = er.async_entries_for_config_entry(
-        entity_registry, config_entry.entry_id
-    )
-    assert entity_entries == snapshot
-
-    setup_owproxy_mock_devices(owproxy, [device_id])
-    # Some entities are disabled, enable them and reload before checking states
-    for ent in entity_entries:
-        entity_registry.async_update_entity(ent.entity_id, disabled_by=None)
-    await hass.config_entries.async_reload(config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    # Ensure entity states are correct
-    states = [hass.states.get(ent.entity_id) for ent in entity_entries]
-    assert states == snapshot
+    await snapshot_platform(hass, entity_registry, snapshot, config_entry.entry_id)
 
 
 @pytest.mark.parametrize("device_id", ["12.111111111111"])

--- a/tests/components/onewire/test_switch.py
+++ b/tests/components/onewire/test_switch.py
@@ -15,11 +15,12 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers import entity_registry as er
 
 from . import setup_owproxy_mock_devices
+from .const import MOCK_OWPROXY_DEVICES
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, snapshot_platform
 
 
 @pytest.fixture(autouse=True)
@@ -29,42 +30,19 @@ def override_platforms() -> Generator[None]:
         yield
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_switches(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
     owproxy: MagicMock,
-    device_id: str,
-    device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test for 1-Wire switches."""
-    setup_owproxy_mock_devices(owproxy, [device_id])
+    setup_owproxy_mock_devices(owproxy, MOCK_OWPROXY_DEVICES.keys())
     await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
 
-    # Ensure devices are correctly registered
-    device_entries = dr.async_entries_for_config_entry(
-        device_registry, config_entry.entry_id
-    )
-    assert device_entries == snapshot
-
-    # Ensure entities are correctly registered
-    entity_entries = er.async_entries_for_config_entry(
-        entity_registry, config_entry.entry_id
-    )
-    assert entity_entries == snapshot
-
-    setup_owproxy_mock_devices(owproxy, [device_id])
-    # Some entities are disabled, enable them and reload before checking states
-    for ent in entity_entries:
-        entity_registry.async_update_entity(ent.entity_id, disabled_by=None)
-    await hass.config_entries.async_reload(config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    # Ensure entity states are correct
-    states = [hass.states.get(ent.entity_id) for ent in entity_entries]
-    assert states == snapshot
+    await snapshot_platform(hass, entity_registry, snapshot, config_entry.entry_id)
 
 
 @pytest.mark.parametrize("device_id", ["05.111111111111"])


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
