### PR TITLE
Add select platform to onewire

### DIFF
--- a/homeassistant/components/onewire/__init__.py
+++ b/homeassistant/components/onewire/__init__.py
@@ -16,6 +16,7 @@ _LOGGER = logging.getLogger(__name__)
 
 _PLATFORMS = [
     Platform.BINARY_SENSOR,
+    Platform.SELECT,
     Platform.SENSOR,
     Platform.SWITCH,
 ]

--- a/homeassistant/components/onewire/select.py
+++ b/homeassistant/components/onewire/select.py
@@ -1,0 +1,93 @@
+"""Support for 1-Wire environment select entities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import timedelta
+import os
+
+from homeassistant.components.select import SelectEntity, SelectEntityDescription
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import READ_MODE_INT
+from .entity import OneWireEntity, OneWireEntityDescription
+from .onewirehub import OneWireConfigEntry, OneWireHub
+
+PARALLEL_UPDATES = 1
+SCAN_INTERVAL = timedelta(seconds=30)
+
+
+@dataclass(frozen=True)
+class OneWireSelectEntityDescription(OneWireEntityDescription, SelectEntityDescription):
+    """Class describing OneWire select entities."""
+
+
+ENTITY_DESCRIPTIONS: dict[str, tuple[OneWireEntityDescription, ...]] = {
+    "28": (
+        OneWireSelectEntityDescription(
+            key="tempres",
+            entity_category=EntityCategory.CONFIG,
+            read_mode=READ_MODE_INT,
+            options=["9", "10", "11", "12"],
+            translation_key="tempres",
+        ),
+    ),
+}
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: OneWireConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up 1-Wire platform."""
+    entities = await hass.async_add_executor_job(
+        get_entities, config_entry.runtime_data
+    )
+    async_add_entities(entities, True)
+
+
+def get_entities(onewire_hub: OneWireHub) -> list[OneWireSelectEntity]:
+    """Get a list of entities."""
+    if not onewire_hub.devices:
+        return []
+
+    entities: list[OneWireSelectEntity] = []
+
+    for device in onewire_hub.devices:
+        family = device.family
+        device_id = device.id
+        device_info = device.device_info
+
+        if family not in ENTITY_DESCRIPTIONS:
+            continue
+        for description in ENTITY_DESCRIPTIONS[family]:
+            device_file = os.path.join(os.path.split(device.path)[0], description.key)
+            entities.append(
+                OneWireSelectEntity(
+                    description=description,
+                    device_id=device_id,
+                    device_file=device_file,
+                    device_info=device_info,
+                    owproxy=onewire_hub.owproxy,
+                )
+            )
+
+    return entities
+
+
+class OneWireSelectEntity(OneWireEntity, SelectEntity):
+    """Implementation of a 1-Wire switch."""
+
+    entity_description: OneWireSelectEntityDescription
+
+    @property
+    def current_option(self) -> str | None:
+        """Return the selected entity option to represent the entity state."""
+        return str(self._state)
+
+    def select_option(self, option: str) -> None:
+        """Change the selected option."""
+        self._write_value(option.encode("ascii"))

--- a/homeassistant/components/onewire/select.py
+++ b/homeassistant/components/onewire/select.py
@@ -15,7 +15,9 @@ from .const import READ_MODE_INT
 from .entity import OneWireEntity, OneWireEntityDescription
 from .onewirehub import OneWireConfigEntry, OneWireHub
 
-PARALLEL_UPDATES = 1
+# the library uses non-persistent connections
+# and concurrent access to the bus is managed by the server
+PARALLEL_UPDATES = 0
 SCAN_INTERVAL = timedelta(seconds=30)
 
 

--- a/homeassistant/components/onewire/strings.json
+++ b/homeassistant/components/onewire/strings.json
@@ -41,6 +41,17 @@
         "name": "Hub short on branch {id}"
       }
     },
+    "select": {
+      "tempres": {
+        "name": "Temperature resolution",
+        "state": {
+          "9": "9 bits (0.5°C, fastest, up to 93.75ms)",
+          "10": "10 bits (0.25°C, up to 187.5ms)",
+          "11": "11 bits (0.125°C, up to 375ms)",
+          "12": "12 bits (0.0625°C, slowest, up to 750ms)"
+        }
+      }
+    },
     "sensor": {
       "counter_id": {
         "name": "Counter {id}"

--- a/tests/components/onewire/const.py
+++ b/tests/components/onewire/const.py
@@ -92,6 +92,7 @@ MOCK_OWPROXY_DEVICES = {
         ATTR_INJECT_READS: {
             "/type": [b"DS18B20"],
             "/temperature": [b"    26.984"],
+            "/tempres": [b"    12"],
         },
     },
     "28.222222222222": {

--- a/tests/components/onewire/snapshots/test_select.ambr
+++ b/tests/components/onewire/snapshots/test_select.ambr
@@ -1,0 +1,62 @@
+# serializer version: 1
+# name: test_selects[select.28_111111111111_temperature_resolution-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        '9',
+        '10',
+        '11',
+        '12',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'select.28_111111111111_temperature_resolution',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Temperature resolution',
+    'platform': 'onewire',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'tempres',
+    'unique_id': '/28.111111111111/tempres',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_selects[select.28_111111111111_temperature_resolution-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_file': '/28.111111111111/tempres',
+      'friendly_name': '28.111111111111 Temperature resolution',
+      'options': list([
+        '9',
+        '10',
+        '11',
+        '12',
+      ]),
+      'raw_value': 12.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.28_111111111111_temperature_resolution',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '12',
+  })
+# ---

--- a/tests/components/onewire/test_select.py
+++ b/tests/components/onewire/test_select.py
@@ -1,0 +1,67 @@
+"""Tests for 1-Wire selects."""
+
+from collections.abc import Generator
+from unittest.mock import MagicMock, patch
+
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.select import (
+    DOMAIN as SELECT_DOMAIN,
+    SERVICE_SELECT_OPTION,
+)
+from homeassistant.const import ATTR_ENTITY_ID, ATTR_OPTION, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from . import setup_owproxy_mock_devices
+from .const import MOCK_OWPROXY_DEVICES
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+
+@pytest.fixture(autouse=True)
+def override_platforms() -> Generator[None]:
+    """Override PLATFORMS."""
+    with patch("homeassistant.components.onewire._PLATFORMS", [Platform.SELECT]):
+        yield
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_selects(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    owproxy: MagicMock,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test for 1-Wire switches."""
+    setup_owproxy_mock_devices(owproxy, MOCK_OWPROXY_DEVICES.keys())
+    await hass.config_entries.async_setup(config_entry.entry_id)
+
+    await snapshot_platform(hass, entity_registry, snapshot, config_entry.entry_id)
+
+
+@pytest.mark.parametrize("device_id", ["28.111111111111"])
+async def test_switch_toggle(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    owproxy: MagicMock,
+    device_id: str,
+) -> None:
+    """Test for 1-Wire select option service."""
+    setup_owproxy_mock_devices(owproxy, [device_id])
+    await hass.config_entries.async_setup(config_entry.entry_id)
+
+    entity_id = "select.28_111111111111_temperature_resolution"
+    assert hass.states.get(entity_id).state == "12"
+
+    # Test SELECT_OPTION service
+    owproxy.return_value.read.side_effect = [b"         9"]
+    await hass.services.async_call(
+        SELECT_DOMAIN,
+        SERVICE_SELECT_OPTION,
+        {ATTR_ENTITY_ID: entity_id, ATTR_OPTION: "9"},
+        blocking=True,
+    )
+    assert hass.states.get(entity_id).state == "9"

--- a/tests/components/onewire/test_select.py
+++ b/tests/components/onewire/test_select.py
@@ -35,7 +35,7 @@ async def test_selects(
     entity_registry: er.EntityRegistry,
     snapshot: SnapshotAssertion,
 ) -> None:
-    """Test for 1-Wire switches."""
+    """Test for 1-Wire select entities."""
     setup_owproxy_mock_devices(owproxy, MOCK_OWPROXY_DEVICES.keys())
     await hass.config_entries.async_setup(config_entry.entry_id)
 
@@ -43,7 +43,7 @@ async def test_selects(
 
 
 @pytest.mark.parametrize("device_id", ["28.111111111111"])
-async def test_switch_toggle(
+async def test_selection_option_service(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
     owproxy: MagicMock,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add configuration entity to be able to select the temperature resolution on DS18B20 temperature sensors.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/36828

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
