### PR TITLE
Refactor onewire hub

### DIFF
--- a/homeassistant/components/onewire/__init__.py
+++ b/homeassistant/components/onewire/__init__.py
@@ -10,7 +10,7 @@ from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
 
 from .const import DOMAIN
-from .onewirehub import CannotConnect, OneWireConfigEntry, OneWireHub
+from .onewirehub import OneWireConfigEntry, OneWireHub
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -24,11 +24,11 @@ _PLATFORMS = [
 
 async def async_setup_entry(hass: HomeAssistant, entry: OneWireConfigEntry) -> bool:
     """Set up a 1-Wire proxy for a config entry."""
-    onewire_hub = OneWireHub(hass)
+    onewire_hub = OneWireHub(hass, entry)
     try:
-        await onewire_hub.initialize(entry)
+        await onewire_hub.initialize()
     except (
-        CannotConnect,  # Failed to connect to the server
+        protocol.ConnError,  # Failed to connect to the server
         protocol.OwnetError,  # Connected to server, but failed to list the devices
     ) as exc:
         raise ConfigEntryNotReady from exc

--- a/homeassistant/components/onewire/config_flow.py
+++ b/homeassistant/components/onewire/config_flow.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from copy import deepcopy
 from typing import Any
 
+from pyownet import protocol
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult, OptionsFlow
@@ -24,7 +25,7 @@ from .const import (
     OPTION_ENTRY_SENSOR_PRECISION,
     PRECISION_MAPPING_FAMILY_28,
 )
-from .onewirehub import CannotConnect, OneWireConfigEntry, OneWireHub
+from .onewirehub import OneWireConfigEntry
 
 DATA_SCHEMA = vol.Schema(
     {
@@ -38,11 +39,11 @@ async def validate_input(
     hass: HomeAssistant, data: dict[str, Any], errors: dict[str, str]
 ) -> None:
     """Validate the user input allows us to connect."""
-
-    hub = OneWireHub(hass)
     try:
-        await hub.connect(data[CONF_HOST], data[CONF_PORT])
-    except CannotConnect:
+        await hass.async_add_executor_job(
+            protocol.proxy, data[CONF_HOST], data[CONF_PORT]
+        )
+    except protocol.ConnError:
         errors["base"] = "cannot_connect"
 
 

--- a/homeassistant/components/onewire/onewirehub.py
+++ b/homeassistant/components/onewire/onewirehub.py
@@ -63,22 +63,20 @@ class OneWireHub:
         self._hass = hass
         self._config_entry = config_entry
 
-    def _initialize(self, host: str, port: int) -> None:
+    def _initialize(self) -> None:
         """Connect to the server, and discover connected devices.
 
         Needs to be run in executor.
         """
+        host = self._config_entry.data[CONF_HOST]
+        port = self._config_entry.data[CONF_PORT]
         _LOGGER.debug("Initializing connection to %s:%s", host, port)
         self.owproxy = protocol.proxy(host, port)
         self.devices = _discover_devices(self.owproxy)
 
     async def initialize(self) -> None:
         """Initialize a config entry."""
-        await self._hass.async_add_executor_job(
-            self._initialize,
-            self._config_entry.data[CONF_HOST],
-            self._config_entry.data[CONF_PORT],
-        )
+        await self._hass.async_add_executor_job(self._initialize)
         # Populate the device registry
         device_registry = dr.async_get(self._hass)
         for device in self.devices:

--- a/homeassistant/components/onewire/onewirehub.py
+++ b/homeassistant/components/onewire/onewirehub.py
@@ -80,7 +80,7 @@ class OneWireHub:
         # Populate the device registry
         device_registry = dr.async_get(self._hass)
         for device in self.devices:
-            device_info: DeviceInfo = device.device_info
+            device_info = device.device_info
             device_registry.async_get_or_create(
                 config_entry_id=self._config_entry.entry_id,
                 identifiers=device_info[ATTR_IDENTIFIERS],
@@ -109,14 +109,12 @@ def _discover_devices(
                 device_id,
             )
             continue
-        device_info: DeviceInfo = {
-            ATTR_IDENTIFIERS: {(DOMAIN, device_id)},
-            ATTR_MANUFACTURER: DEVICE_MANUFACTURER.get(
-                device_family, MANUFACTURER_MAXIM
-            ),
-            ATTR_MODEL: device_type,
-            ATTR_NAME: device_id,
-        }
+        device_info = DeviceInfo(
+            identifiers={(DOMAIN, device_id)},
+            manufacturer=DEVICE_MANUFACTURER.get(device_family, MANUFACTURER_MAXIM),
+            model=device_type,
+            name=device_id,
+        )
         if parent_id:
             device_info[ATTR_VIA_DEVICE] = (DOMAIN, parent_id)
         device = OWDeviceDescription(

--- a/homeassistant/components/onewire/sensor.py
+++ b/homeassistant/components/onewire/sensor.py
@@ -371,7 +371,6 @@ def get_entities(
         return []
 
     entities: list[OneWireSensor] = []
-    assert onewire_hub.owproxy
     for device in onewire_hub.devices:
         family = device.family
         device_type = device.type


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Move `owproxy` and `devices` to be not-null class attributes
- Move `hass` and `config_entry` to be regular internal class attributes
- Do not rely on hub to validate config-flow input
- Drop custom `CannotConnect` (migrated to `protocol.ConnError`) and `InvalidPath` (unused) exceptions
- Use single executor to run `connect` + `discover_devices`
- Make `_discover_devices` and `_get_device_type` static (module) functions


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
