### PR TITLE
Mark FGLAir entities unavailable if they are reporting to be offline

### DIFF
--- a/homeassistant/components/fujitsu_fglair/coordinator.py
+++ b/homeassistant/components/fujitsu_fglair/coordinator.py
@@ -3,7 +3,7 @@
 import logging
 
 from ayla_iot_unofficial import AylaApi, AylaAuthError
-from ayla_iot_unofficial.fujitsu_hvac import FujitsuHVAC
+from ayla_iot_unofficial.fujitsu_hvac import DeviceOffline, FujitsuHVAC
 
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
@@ -56,7 +56,10 @@ class FGLairCoordinator(DataUpdateCoordinator[dict[str, FujitsuHVAC]]):
 
         try:
             for dev in devices:
-                await dev.async_update()
+                try:
+                    await dev.async_update()
+                except DeviceOffline:
+                    continue
         except AylaAuthError as e:
             raise ConfigEntryAuthFailed("Credentials expired for Ayla IoT API") from e
 

--- a/homeassistant/components/fujitsu_fglair/entity.py
+++ b/homeassistant/components/fujitsu_fglair/entity.py
@@ -28,6 +28,11 @@ class FGLairEntity(CoordinatorEntity[FGLairCoordinator]):
         )
 
     @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return super().available and self.coordinator_context in self.coordinator.data
+
+    @property
     def device(self) -> FujitsuHVAC:
         """Return the device object from the coordinator data."""
         return self.coordinator.data[self.coordinator_context]

--- a/tests/components/fujitsu_fglair/test_init.py
+++ b/tests/components/fujitsu_fglair/test_init.py
@@ -7,6 +7,7 @@ from ayla_iot_unofficial.fujitsu_consts import FGLAIR_APP_CREDENTIALS
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 
+from homeassistant.components.climate import HVACMode
 from homeassistant.components.fujitsu_fglair.const import (
     API_REFRESH,
     API_TIMEOUT,
@@ -122,6 +123,26 @@ async def test_device_auth_failure(
 
     assert hass.states.get(entity_id(mock_devices[0])).state == STATE_UNAVAILABLE
     assert hass.states.get(entity_id(mock_devices[1])).state == STATE_UNAVAILABLE
+
+
+async def test_device_offline(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_ayla_api: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    mock_devices: list[AsyncMock],
+) -> None:
+    """Test entities become unavailable if device if offline."""
+    await setup_integration(hass, mock_config_entry)
+
+    mock_ayla_api.async_get_devices.return_value[0].is_online.return_value = False
+
+    freezer.tick(API_REFRESH)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(entity_id(mock_devices[0])).state == STATE_UNAVAILABLE
+    assert hass.states.get(entity_id(mock_devices[1])).state == HVACMode.COOL
 
 
 async def test_token_expired(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This makes sure that entities associated with a device that is offline are marked unavailable.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #130612
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
