### PR TITLE
Fix LG webOS TV media player test coverage

### DIFF
--- a/homeassistant/components/webostv/media_player.py
+++ b/homeassistant/components/webostv/media_player.py
@@ -326,7 +326,7 @@ class LgWebOSMediaPlayerEntity(RestoreEntity, MediaPlayerEntity):
         if self._client.is_connected():
             return
 
-        with suppress(*WEBOSTV_EXCEPTIONS, WebOsTvPairError):
+        with suppress(*WEBOSTV_EXCEPTIONS):
             try:
                 await self._client.connect()
             except WebOsTvPairError:

--- a/tests/components/webostv/test_media_player.py
+++ b/tests/components/webostv/test_media_player.py
@@ -487,8 +487,8 @@ async def test_client_key_update_on_connect(
 
     assert config_entry.data[CONF_CLIENT_SECRET] == client.client_key
 
-    monkeypatch.setattr(client, "is_connected", Mock(return_value=False))
-    monkeypatch.setattr(client, "client_key", "new_key")
+    client.is_connected.return_value = False
+    client.client_key = "new_key"
 
     freezer.tick(timedelta(seconds=20))
     async_fire_time_changed(hass)

--- a/tests/components/webostv/test_media_player.py
+++ b/tests/components/webostv/test_media_player.py
@@ -2,7 +2,6 @@
 
 from datetime import timedelta
 from http import HTTPStatus
-from unittest.mock import AsyncMock, Mock
 
 from aiowebostv import WebOsTvPairError
 from freezegun.api import FrozenDateTimeFactory
@@ -144,7 +143,7 @@ async def test_media_play_pause(hass: HomeAssistant, client) -> None:
     ],
 )
 async def test_media_next_previous_track(
-    hass: HomeAssistant, client, service, client_call, monkeypatch: pytest.MonkeyPatch
+    hass: HomeAssistant, client, service, client_call
 ) -> None:
     """Test media next/previous track services."""
     await setup_webostv(hass)
@@ -157,7 +156,7 @@ async def test_media_next_previous_track(
     getattr(client, client_call[1]).assert_called_once()
 
     # check next/previous for not Live TV channels
-    monkeypatch.setattr(client, "current_app_id", "in1")
+    client.current_app_id = "in1"
     data = {ATTR_ENTITY_ID: ENTITY_ID}
     await hass.services.async_call(MP_DOMAIN, service, data, True)
 
@@ -270,14 +269,11 @@ async def test_select_sound_output(hass: HomeAssistant, client) -> None:
 
 
 async def test_device_info_startup_off(
-    hass: HomeAssistant,
-    client,
-    monkeypatch: pytest.MonkeyPatch,
-    device_registry: dr.DeviceRegistry,
+    hass: HomeAssistant, client, device_registry: dr.DeviceRegistry
 ) -> None:
     """Test device info when device is off at startup."""
-    monkeypatch.setattr(client, "system_info", None)
-    monkeypatch.setattr(client, "is_on", False)
+    client.system_info = None
+    client.is_on = False
     entry = await setup_webostv(hass)
     await client.mock_state_update()
 
@@ -296,7 +292,6 @@ async def test_device_info_startup_off(
 async def test_entity_attributes(
     hass: HomeAssistant,
     client,
-    monkeypatch: pytest.MonkeyPatch,
     device_registry: dr.DeviceRegistry,
     snapshot: SnapshotAssertion,
 ) -> None:
@@ -309,14 +304,14 @@ async def test_entity_attributes(
     assert state == snapshot(exclude=props("entity_picture"))
 
     # Volume level not available
-    monkeypatch.setattr(client, "volume", None)
+    client.volume = None
     await client.mock_state_update()
     attrs = hass.states.get(ENTITY_ID).attributes
 
     assert attrs.get(ATTR_MEDIA_VOLUME_LEVEL) is None
 
     # Channel change
-    monkeypatch.setattr(client, "current_channel", CHANNEL_2)
+    client.current_channel = CHANNEL_2
     await client.mock_state_update()
     attrs = hass.states.get(ENTITY_ID).attributes
 
@@ -327,8 +322,8 @@ async def test_entity_attributes(
     assert device == snapshot
 
     # Sound output when off
-    monkeypatch.setattr(client, "sound_output", None)
-    monkeypatch.setattr(client, "is_on", False)
+    client.sound_output = None
+    client.is_on = False
     await client.mock_state_update()
     state = hass.states.get(ENTITY_ID)
 
@@ -372,9 +367,7 @@ async def test_play_media(hass: HomeAssistant, client, media_id, ch_id) -> None:
     client.set_channel.assert_called_once_with(ch_id)
 
 
-async def test_update_sources_live_tv_find(
-    hass: HomeAssistant, client, monkeypatch: pytest.MonkeyPatch
-) -> None:
+async def test_update_sources_live_tv_find(hass: HomeAssistant, client) -> None:
     """Test finding live TV app id in update sources."""
     await setup_webostv(hass)
     await client.mock_state_update()
@@ -386,14 +379,13 @@ async def test_update_sources_live_tv_find(
     assert len(sources) == 3
 
     # Live TV is current app
-    apps = {
+    client.apps = {
         LIVE_TV_APP_ID: {
             "title": "Live TV",
             "id": "some_id",
         },
     }
-    monkeypatch.setattr(client, "apps", apps)
-    monkeypatch.setattr(client, "current_app_id", "some_id")
+    client.current_app_id = "some_id"
     await client.mock_state_update()
     sources = hass.states.get(ENTITY_ID).attributes[ATTR_INPUT_SOURCE_LIST]
 
@@ -401,14 +393,13 @@ async def test_update_sources_live_tv_find(
     assert len(sources) == 3
 
     # Live TV is is in inputs
-    inputs = {
+    client.inputs = {
         LIVE_TV_APP_ID: {
             "label": "Live TV",
             "id": "some_id",
             "appId": LIVE_TV_APP_ID,
         },
     }
-    monkeypatch.setattr(client, "inputs", inputs)
     await client.mock_state_update()
     sources = hass.states.get(ENTITY_ID).attributes[ATTR_INPUT_SOURCE_LIST]
 
@@ -416,14 +407,13 @@ async def test_update_sources_live_tv_find(
     assert len(sources) == 1
 
     # Live TV is current input
-    inputs = {
+    client.inputs = {
         LIVE_TV_APP_ID: {
             "label": "Live TV",
             "id": "some_id",
             "appId": "some_id",
         },
     }
-    monkeypatch.setattr(client, "inputs", inputs)
     await client.mock_state_update()
     sources = hass.states.get(ENTITY_ID).attributes[ATTR_INPUT_SOURCE_LIST]
 
@@ -431,7 +421,7 @@ async def test_update_sources_live_tv_find(
     assert len(sources) == 1
 
     # Live TV not found
-    monkeypatch.setattr(client, "current_app_id", "other_id")
+    client.current_app_id = "other_id"
     await client.mock_state_update()
     sources = hass.states.get(ENTITY_ID).attributes[ATTR_INPUT_SOURCE_LIST]
 
@@ -439,8 +429,8 @@ async def test_update_sources_live_tv_find(
     assert len(sources) == 1
 
     # Live TV not found in sources/apps but is current app
-    monkeypatch.setattr(client, "apps", {})
-    monkeypatch.setattr(client, "current_app_id", LIVE_TV_APP_ID)
+    client.apps = {}
+    client.current_app_id = LIVE_TV_APP_ID
     await client.mock_state_update()
     sources = hass.states.get(ENTITY_ID).attributes[ATTR_INPUT_SOURCE_LIST]
 
@@ -448,7 +438,7 @@ async def test_update_sources_live_tv_find(
     assert len(sources) == 1
 
     # Bad update, keep old update
-    monkeypatch.setattr(client, "inputs", {})
+    client.inputs = {}
     await client.mock_state_update()
     sources = hass.states.get(ENTITY_ID).attributes[ATTR_INPUT_SOURCE_LIST]
 
@@ -459,14 +449,13 @@ async def test_update_sources_live_tv_find(
 async def test_client_disconnected(
     hass: HomeAssistant,
     client,
-    monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
     freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test error not raised when client is disconnected."""
     await setup_webostv(hass)
-    monkeypatch.setattr(client, "is_connected", Mock(return_value=False))
-    monkeypatch.setattr(client, "connect", Mock(side_effect=TimeoutError))
+    client.is_connected.return_value = False
+    client.connect.side_effect = TimeoutError
 
     freezer.tick(timedelta(seconds=20))
     async_fire_time_changed(hass)
@@ -476,11 +465,7 @@ async def test_client_disconnected(
 
 
 async def test_client_key_update_on_connect(
-    hass: HomeAssistant,
-    client,
-    monkeypatch: pytest.MonkeyPatch,
-    caplog: pytest.LogCaptureFixture,
-    freezer: FrozenDateTimeFactory,
+    hass: HomeAssistant, client, freezer: FrozenDateTimeFactory
 ) -> None:
     """Test client key update upon connect."""
     config_entry = await setup_webostv(hass)
@@ -498,14 +483,11 @@ async def test_client_key_update_on_connect(
 
 
 async def test_control_error_handling(
-    hass: HomeAssistant,
-    client,
-    caplog: pytest.LogCaptureFixture,
-    monkeypatch: pytest.MonkeyPatch,
+    hass: HomeAssistant, client, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test control errors handling."""
     await setup_webostv(hass)
-    monkeypatch.setattr(client, "play", AsyncMock(side_effect=WebOsTvCommandError))
+    client.play.side_effect = WebOsTvCommandError
     data = {ATTR_ENTITY_ID: ENTITY_ID}
 
     # Device on, raise HomeAssistantError
@@ -519,23 +501,21 @@ async def test_control_error_handling(
     assert client.play.call_count == 1
 
     # Device off, log a warning
-    monkeypatch.setattr(client, "is_on", False)
-    monkeypatch.setattr(client, "play", AsyncMock(side_effect=TimeoutError))
+    client.is_on = False
+    client.play.side_effect = TimeoutError
     await client.mock_state_update()
     await hass.services.async_call(MP_DOMAIN, SERVICE_MEDIA_PLAY, data, True)
 
-    assert client.play.call_count == 1
+    assert client.play.call_count == 2
     assert (
         f"Error calling async_media_play on entity {ENTITY_ID}, state:off, error:"
         " TimeoutError()" in caplog.text
     )
 
 
-async def test_supported_features(
-    hass: HomeAssistant, client, monkeypatch: pytest.MonkeyPatch
-) -> None:
+async def test_supported_features(hass: HomeAssistant, client) -> None:
     """Test test supported features."""
-    monkeypatch.setattr(client, "sound_output", "lineout")
+    client.sound_output = "lineout"
     await setup_webostv(hass)
     await client.mock_state_update()
 
@@ -546,7 +526,7 @@ async def test_supported_features(
     assert attrs[ATTR_SUPPORTED_FEATURES] == supported
 
     # Support volume mute, step
-    monkeypatch.setattr(client, "sound_output", "external_speaker")
+    client.sound_output = "external_speaker"
     await client.mock_state_update()
     supported = supported | SUPPORT_WEBOSTV_VOLUME
     attrs = hass.states.get(ENTITY_ID).attributes
@@ -554,7 +534,7 @@ async def test_supported_features(
     assert attrs[ATTR_SUPPORTED_FEATURES] == supported
 
     # Support volume mute, step, set
-    monkeypatch.setattr(client, "sound_output", "speaker")
+    client.sound_output = "speaker"
     await client.mock_state_update()
     supported = supported | SUPPORT_WEBOSTV_VOLUME | MediaPlayerEntityFeature.VOLUME_SET
     attrs = hass.states.get(ENTITY_ID).attributes
@@ -590,12 +570,10 @@ async def test_supported_features(
     assert attrs[ATTR_SUPPORTED_FEATURES] == supported
 
 
-async def test_cached_supported_features(
-    hass: HomeAssistant, client, monkeypatch: pytest.MonkeyPatch
-) -> None:
+async def test_cached_supported_features(hass: HomeAssistant, client) -> None:
     """Test test supported features."""
-    monkeypatch.setattr(client, "is_on", False)
-    monkeypatch.setattr(client, "sound_output", None)
+    client.is_on = False
+    client.sound_output = None
     supported = (
         SUPPORT_WEBOSTV | SUPPORT_WEBOSTV_VOLUME | MediaPlayerEntityFeature.TURN_ON
     )
@@ -623,8 +601,8 @@ async def test_cached_supported_features(
     )
 
     # TV on, support volume mute, step
-    monkeypatch.setattr(client, "is_on", True)
-    monkeypatch.setattr(client, "sound_output", "external_speaker")
+    client.is_on = True
+    client.sound_output = "external_speaker"
     await client.mock_state_update()
 
     supported = SUPPORT_WEBOSTV | SUPPORT_WEBOSTV_VOLUME
@@ -633,8 +611,8 @@ async def test_cached_supported_features(
     assert attrs[ATTR_SUPPORTED_FEATURES] == supported
 
     # TV off, support volume mute, step
-    monkeypatch.setattr(client, "is_on", False)
-    monkeypatch.setattr(client, "sound_output", None)
+    client.is_on = False
+    client.sound_output = None
     await client.mock_state_update()
 
     supported = SUPPORT_WEBOSTV | SUPPORT_WEBOSTV_VOLUME
@@ -643,8 +621,8 @@ async def test_cached_supported_features(
     assert attrs[ATTR_SUPPORTED_FEATURES] == supported
 
     # TV on, support volume mute, step, set
-    monkeypatch.setattr(client, "is_on", True)
-    monkeypatch.setattr(client, "sound_output", "speaker")
+    client.is_on = True
+    client.sound_output = "speaker"
     await client.mock_state_update()
 
     supported = (
@@ -655,8 +633,8 @@ async def test_cached_supported_features(
     assert attrs[ATTR_SUPPORTED_FEATURES] == supported
 
     # TV off, support volume mute, step, set
-    monkeypatch.setattr(client, "is_on", False)
-    monkeypatch.setattr(client, "sound_output", None)
+    client.is_on = False
+    client.sound_output = None
     await client.mock_state_update()
 
     supported = (
@@ -697,12 +675,10 @@ async def test_cached_supported_features(
     )
 
 
-async def test_supported_features_no_cache(
-    hass: HomeAssistant, client, monkeypatch: pytest.MonkeyPatch
-) -> None:
+async def test_supported_features_no_cache(hass: HomeAssistant, client) -> None:
     """Test supported features if device is off and no cache."""
-    monkeypatch.setattr(client, "is_on", False)
-    monkeypatch.setattr(client, "sound_output", None)
+    client.is_on = False
+    client.sound_output = None
     await setup_webostv(hass)
 
     supported = (
@@ -742,11 +718,10 @@ async def test_get_image_http(
     client,
     hass_client_no_auth: ClientSessionGenerator,
     aioclient_mock: AiohttpClientMocker,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test get image via http."""
     url = "http://something/valid_icon"
-    monkeypatch.setitem(client.apps[LIVE_TV_APP_ID], "icon", url)
+    client.apps[LIVE_TV_APP_ID]["icon"] = url
     await setup_webostv(hass)
     await client.mock_state_update()
 
@@ -768,11 +743,10 @@ async def test_get_image_http_error(
     hass_client_no_auth: ClientSessionGenerator,
     aioclient_mock: AiohttpClientMocker,
     caplog: pytest.LogCaptureFixture,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test get image via http error."""
     url = "http://something/icon_error"
-    monkeypatch.setitem(client.apps[LIVE_TV_APP_ID], "icon", url)
+    client.apps[LIVE_TV_APP_ID]["icon"] = url
     await setup_webostv(hass)
     await client.mock_state_update()
 
@@ -795,11 +769,10 @@ async def test_get_image_https(
     client,
     hass_client_no_auth: ClientSessionGenerator,
     aioclient_mock: AiohttpClientMocker,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test get image via http."""
     url = "https://something/valid_icon_https"
-    monkeypatch.setitem(client.apps[LIVE_TV_APP_ID], "icon", url)
+    client.apps[LIVE_TV_APP_ID]["icon"] = url
     await setup_webostv(hass)
     await client.mock_state_update()
 
@@ -816,15 +789,12 @@ async def test_get_image_https(
 
 
 async def test_reauth_reconnect(
-    hass: HomeAssistant,
-    client,
-    monkeypatch: pytest.MonkeyPatch,
-    freezer: FrozenDateTimeFactory,
+    hass: HomeAssistant, client, freezer: FrozenDateTimeFactory
 ) -> None:
     """Test reauth flow triggered by reconnect."""
     entry = await setup_webostv(hass)
-    monkeypatch.setattr(client, "is_connected", Mock(return_value=False))
-    monkeypatch.setattr(client, "connect", AsyncMock(side_effect=WebOsTvPairError))
+    client.is_connected.return_value = False
+    client.connect.side_effect = WebOsTvPairError
 
     assert entry.state is ConfigEntryState.LOADED
 
@@ -846,27 +816,22 @@ async def test_reauth_reconnect(
     assert flow["context"].get("entry_id") == entry.entry_id
 
 
-async def test_update_media_state(
-    hass: HomeAssistant, client, monkeypatch: pytest.MonkeyPatch
-) -> None:
+async def test_update_media_state(hass: HomeAssistant, client) -> None:
     """Test updating media state."""
     await setup_webostv(hass)
 
-    data = {"foregroundAppInfo": [{"playState": "playing"}]}
-    monkeypatch.setattr(client, "media_state", data)
+    client.media_state = {"foregroundAppInfo": [{"playState": "playing"}]}
     await client.mock_state_update()
     assert hass.states.get(ENTITY_ID).state == MediaPlayerState.PLAYING
 
-    data = {"foregroundAppInfo": [{"playState": "paused"}]}
-    monkeypatch.setattr(client, "media_state", data)
+    client.media_state = {"foregroundAppInfo": [{"playState": "paused"}]}
     await client.mock_state_update()
     assert hass.states.get(ENTITY_ID).state == MediaPlayerState.PAUSED
 
-    data = {"foregroundAppInfo": [{"playState": "unloaded"}]}
-    monkeypatch.setattr(client, "media_state", data)
+    client.media_state = {"foregroundAppInfo": [{"playState": "unloaded"}]}
     await client.mock_state_update()
     assert hass.states.get(ENTITY_ID).state == MediaPlayerState.IDLE
 
-    monkeypatch.setattr(client, "is_on", False)
+    client.is_on = False
     await client.mock_state_update()
     assert hass.states.get(ENTITY_ID).state == STATE_OFF


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Bring LG webOS TV media player test coverage to 100%
- Remove `WebOsTvPairError` from suppress as it already cached inside.
- Make sure all tests uses `FreezeGun` and correct async mocks.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
