### PR TITLE
Add additional entities for Shelly BLU TRV

### DIFF
--- a/homeassistant/components/shelly/binary_sensor.py
+++ b/homeassistant/components/shelly/binary_sensor.py
@@ -232,6 +232,14 @@ RPC_SENSORS: Final = {
         sub_key="value",
         has_entity_name=True,
     ),
+    "calibration": RpcBinarySensorDescription(
+        key="blutrv",
+        sub_key="errors",
+        name="Calibration",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        value=lambda status, _: False if status is None else "not_calibrated" in status,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
 }
 
 

--- a/homeassistant/components/shelly/binary_sensor.py
+++ b/homeassistant/components/shelly/binary_sensor.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Final, cast
 
@@ -54,8 +53,6 @@ class BlockBinarySensorDescription(
 @dataclass(frozen=True, kw_only=True)
 class RpcBinarySensorDescription(RpcEntityDescription, BinarySensorEntityDescription):
     """Class to describe a RPC binary sensor."""
-
-    entity_class: Callable | None = None
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/homeassistant/components/shelly/binary_sensor.py
+++ b/homeassistant/components/shelly/binary_sensor.py
@@ -74,7 +74,7 @@ class RpcBinarySensor(ShellyRpcAttributeEntity, BinarySensorEntity):
         return bool(self.attribute_value)
 
 
-class RpcBLuTrvBinarySensor(RpcBinarySensor):
+class RpcBluTrvBinarySensor(RpcBinarySensor):
     """Represent a RPC BluTrv binary sensor."""
 
     def __init__(
@@ -273,7 +273,7 @@ RPC_SENSORS: Final = {
         device_class=BinarySensorDeviceClass.PROBLEM,
         value=lambda status, _: False if status is None else "not_calibrated" in status,
         entity_category=EntityCategory.DIAGNOSTIC,
-        entity_class=RpcBLuTrvBinarySensor,
+        entity_class=RpcBluTrvBinarySensor,
     ),
 }
 

--- a/homeassistant/components/shelly/entity.py
+++ b/homeassistant/components/shelly/entity.py
@@ -12,7 +12,11 @@ from aioshelly.exceptions import DeviceConnectionError, InvalidAuthError, RpcCal
 from homeassistant.core import HomeAssistant, State, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
+from homeassistant.helpers.device_registry import (
+    CONNECTION_BLUETOOTH,
+    CONNECTION_NETWORK_MAC,
+    DeviceInfo,
+)
 from homeassistant.helpers.entity import Entity, EntityDescription
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.entity_registry import RegistryEntry
@@ -352,9 +356,13 @@ class ShellyRpcEntity(CoordinatorEntity[ShellyRpcCoordinator]):
         """Initialize Shelly entity."""
         super().__init__(coordinator)
         self.key = key
-        self._attr_device_info = {
-            "connections": {(CONNECTION_NETWORK_MAC, coordinator.mac)}
-        }
+
+        if blu_addr := coordinator.device.config.get(key, {}).get("addr"):
+            self._attr_device_info = {"connections": {(CONNECTION_BLUETOOTH, blu_addr)}}
+        else:
+            self._attr_device_info = {
+                "connections": {(CONNECTION_NETWORK_MAC, coordinator.mac)}
+            }
         self._attr_unique_id = f"{coordinator.mac}-{key}"
         self._attr_name = get_rpc_entity_name(coordinator.device, key)
 

--- a/homeassistant/components/shelly/icons.json
+++ b/homeassistant/components/shelly/icons.json
@@ -12,7 +12,7 @@
       }
     },
     "number": {
-      "external_sensor_temperature": {
+      "external_temperature": {
         "default": "mdi:thermometer-check"
       },
       "valve_position": {

--- a/homeassistant/components/shelly/icons.json
+++ b/homeassistant/components/shelly/icons.json
@@ -29,6 +29,9 @@
       "tilt": {
         "default": "mdi:angle-acute"
       },
+      "valve_position": {
+        "default": "mdi:pipe-valve"
+      },
       "valve_status": {
         "default": "mdi:valve"
       }

--- a/homeassistant/components/shelly/icons.json
+++ b/homeassistant/components/shelly/icons.json
@@ -12,6 +12,9 @@
       }
     },
     "number": {
+      "external_sensor_temperature": {
+        "default": "mdi:thermometer-check"
+      },
       "valve_position": {
         "default": "mdi:pipe-valve"
       }

--- a/homeassistant/components/shelly/number.py
+++ b/homeassistant/components/shelly/number.py
@@ -94,7 +94,7 @@ RPC_NUMBERS: Final = {
         method="BluTRV.Call",
         method_params_fn=lambda idx, value: {
             "id": idx,
-            "method": "TRV.SetExternalTemperature",
+            "method": "Trv.SetExternalTemperature",
             "params": {"id": 0, "t_C": value},
         },
     ),

--- a/homeassistant/components/shelly/number.py
+++ b/homeassistant/components/shelly/number.py
@@ -110,7 +110,7 @@ class RpcNumber(ShellyRpcAttributeEntity, NumberEntity):
         )
 
 
-class RpcBLuTrvNumber(RpcNumber):
+class RpcBluTrvNumber(RpcNumber):
     """Represent a RPC BluTrv number."""
 
     def __init__(
@@ -165,7 +165,7 @@ RPC_NUMBERS: Final = {
             "method": "Trv.SetExternalTemperature",
             "params": {"id": 0, "t_C": value},
         },
-        entity_class=RpcBLuTrvNumber,
+        entity_class=RpcBluTrvNumber,
     ),
     "number": RpcNumberDescription(
         key="number",
@@ -202,7 +202,7 @@ RPC_NUMBERS: Final = {
         },
         removal_condition=lambda config, _status, key: config[key].get("enable", True)
         is True,
-        entity_class=RpcBLuTrvNumber,
+        entity_class=RpcBluTrvNumber,
     ),
 }
 

--- a/homeassistant/components/shelly/number.py
+++ b/homeassistant/components/shelly/number.py
@@ -60,7 +60,6 @@ class RpcNumberDescription(RpcEntityDescription, NumberEntityDescription):
     mode_fn: Callable[[dict], NumberMode] | None = None
     method: str
     method_params_fn: Callable[[int, float], dict]
-    entity_class: Callable | None = None
 
 
 class RpcNumber(ShellyRpcAttributeEntity, NumberEntity):

--- a/homeassistant/components/shelly/number.py
+++ b/homeassistant/components/shelly/number.py
@@ -125,13 +125,14 @@ RPC_NUMBERS: Final = {
         native_step=1,
         mode=NumberMode.SLIDER,
         native_unit_of_measurement=PERCENTAGE,
-        entity_registry_enabled_default=False,
         method="BluTRV.Call",
         method_params_fn=lambda idx, value: {
             "id": idx,
             "method": "Trv.SetPosition",
             "params": {"id": 0, "pos": value},
         },
+        removal_condition=lambda config, _status, key: config[key].get("enable", True)
+        is True,
     ),
 }
 

--- a/homeassistant/components/shelly/number.py
+++ b/homeassistant/components/shelly/number.py
@@ -80,11 +80,11 @@ NUMBERS: dict[tuple[str, str], BlockNumberDescription] = {
 
 
 RPC_NUMBERS: Final = {
-    "external_sensor_temperature": RpcNumberDescription(
+    "external_temperature": RpcNumberDescription(
         key="blutrv",
         sub_key="current_C",
-        translation_key="external_sensor_temperature",
-        name="External sensor temperature",
+        translation_key="external_temperature",
+        name="External temperature",
         native_min_value=-50,
         native_max_value=50,
         native_step=0.1,

--- a/homeassistant/components/shelly/sensor.py
+++ b/homeassistant/components/shelly/sensor.py
@@ -1233,6 +1233,24 @@ RPC_SENSORS: Final = {
         removal_condition=lambda config, _status, key: config[key].get("enable", False)
         is False,
     ),
+    "blutrv_battery": RpcSensorDescription(
+        key="blutrv",
+        sub_key="battery",
+        name="Battery",
+        native_unit_of_measurement=PERCENTAGE,
+        device_class=SensorDeviceClass.BATTERY,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    "blutrv_rssi": RpcSensorDescription(
+        key="blutrv",
+        sub_key="rssi",
+        name="Signal strength",
+        native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+        device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
 }
 
 

--- a/homeassistant/components/shelly/sensor.py
+++ b/homeassistant/components/shelly/sensor.py
@@ -1222,6 +1222,15 @@ RPC_SENSORS: Final = {
         options_fn=lambda config: config["options"],
         device_class=SensorDeviceClass.ENUM,
     ),
+    "valve_position": RpcSensorDescription(
+        key="blutrv",
+        sub_key="pos",
+        name="Valve position",
+        translation_key="valve_position",
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
 }
 
 

--- a/homeassistant/components/shelly/sensor.py
+++ b/homeassistant/components/shelly/sensor.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Final, cast
 
@@ -71,8 +70,6 @@ class BlockSensorDescription(BlockEntityDescription, SensorEntityDescription):
 @dataclass(frozen=True, kw_only=True)
 class RpcSensorDescription(RpcEntityDescription, SensorEntityDescription):
     """Class to describe a RPC sensor."""
-
-    entity_class: Callable | None = None
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/homeassistant/components/shelly/sensor.py
+++ b/homeassistant/components/shelly/sensor.py
@@ -1230,6 +1230,8 @@ RPC_SENSORS: Final = {
         native_unit_of_measurement=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
+        removal_condition=lambda config, _status, key: config[key].get("enable", False)
+        is False,
     ),
 }
 

--- a/homeassistant/components/shelly/sensor.py
+++ b/homeassistant/components/shelly/sensor.py
@@ -112,7 +112,7 @@ class RpcSensor(ShellyRpcAttributeEntity, SensorEntity):
         return self.option_map[attribute_value]
 
 
-class RpcBLuTrvSensor(RpcSensor):
+class RpcBluTrvSensor(RpcSensor):
     """Represent a RPC BluTrv sensor."""
 
     def __init__(
@@ -1287,7 +1287,7 @@ RPC_SENSORS: Final = {
         entity_category=EntityCategory.DIAGNOSTIC,
         removal_condition=lambda config, _status, key: config[key].get("enable", False)
         is False,
-        entity_class=RpcBLuTrvSensor,
+        entity_class=RpcBluTrvSensor,
     ),
     "blutrv_battery": RpcSensorDescription(
         key="blutrv",
@@ -1297,7 +1297,7 @@ RPC_SENSORS: Final = {
         device_class=SensorDeviceClass.BATTERY,
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
-        entity_class=RpcBLuTrvSensor,
+        entity_class=RpcBluTrvSensor,
     ),
     "blutrv_rssi": RpcSensorDescription(
         key="blutrv",
@@ -1307,7 +1307,7 @@ RPC_SENSORS: Final = {
         device_class=SensorDeviceClass.SIGNAL_STRENGTH,
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
-        entity_class=RpcBLuTrvSensor,
+        entity_class=RpcBluTrvSensor,
     ),
 }
 

--- a/tests/components/shelly/conftest.py
+++ b/tests/components/shelly/conftest.py
@@ -255,6 +255,8 @@ MOCK_BLU_TRV_REMOTE_STATUS = {
         "current_C": 15.2,
         "target_C": 17.1,
         "schedule_rev": 0,
+        "rssi": -60,
+        "battery": 100,
         "errors": [],
     },
 }

--- a/tests/components/shelly/snapshots/test_binary_sensor.ambr
+++ b/tests/components/shelly/snapshots/test_binary_sensor.ambr
@@ -1,0 +1,48 @@
+# serializer version: 1
+# name: test_blu_trv_binary_sensor_entity[binary_sensor.trv_name_calibration-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.trv_name_calibration',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': None,
+    'original_name': 'TRV-Name calibration',
+    'platform': 'shelly',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '123456789ABC-blutrv:200-calibration',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_blu_trv_binary_sensor_entity[binary_sensor.trv_name_calibration-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'TRV-Name calibration',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.trv_name_calibration',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---

--- a/tests/components/shelly/snapshots/test_number.ambr
+++ b/tests/components/shelly/snapshots/test_number.ambr
@@ -1,0 +1,113 @@
+# serializer version: 1
+# name: test_blu_trv_number_entity[number.trv_name_external_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'max': 50,
+      'min': -50,
+      'mode': <NumberMode.BOX: 'box'>,
+      'step': 0.1,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'number.trv_name_external_temperature',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'TRV-Name external temperature',
+    'platform': 'shelly',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'external_temperature',
+    'unique_id': '123456789ABC-blutrv:200-external_temperature',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_blu_trv_number_entity[number.trv_name_external_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'TRV-Name external temperature',
+      'max': 50,
+      'min': -50,
+      'mode': <NumberMode.BOX: 'box'>,
+      'step': 0.1,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.trv_name_external_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '15.2',
+  })
+# ---
+# name: test_blu_trv_number_entity[number.trv_name_valve_position-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'max': 100,
+      'min': 0,
+      'mode': <NumberMode.SLIDER: 'slider'>,
+      'step': 1,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': None,
+    'entity_id': 'number.trv_name_valve_position',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'TRV-Name valve position',
+    'platform': 'shelly',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'valve_position',
+    'unique_id': '123456789ABC-blutrv:200-valve_position',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_blu_trv_number_entity[number.trv_name_valve_position-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'TRV-Name valve position',
+      'max': 100,
+      'min': 0,
+      'mode': <NumberMode.SLIDER: 'slider'>,
+      'step': 1,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.trv_name_valve_position',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---

--- a/tests/components/shelly/snapshots/test_sensor.ambr
+++ b/tests/components/shelly/snapshots/test_sensor.ambr
@@ -1,0 +1,153 @@
+# serializer version: 1
+# name: test_blu_trv_sensor_entity[sensor.trv_name_battery-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.trv_name_battery',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
+    'original_icon': None,
+    'original_name': 'TRV-Name battery',
+    'platform': 'shelly',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '123456789ABC-blutrv:200-blutrv_battery',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_blu_trv_sensor_entity[sensor.trv_name_battery-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'battery',
+      'friendly_name': 'TRV-Name battery',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.trv_name_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '100',
+  })
+# ---
+# name: test_blu_trv_sensor_entity[sensor.trv_name_signal_strength-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.trv_name_signal_strength',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.SIGNAL_STRENGTH: 'signal_strength'>,
+    'original_icon': None,
+    'original_name': 'TRV-Name signal strength',
+    'platform': 'shelly',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '123456789ABC-blutrv:200-blutrv_rssi',
+    'unit_of_measurement': 'dBm',
+  })
+# ---
+# name: test_blu_trv_sensor_entity[sensor.trv_name_signal_strength-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'signal_strength',
+      'friendly_name': 'TRV-Name signal strength',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': 'dBm',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.trv_name_signal_strength',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '-60',
+  })
+# ---
+# name: test_blu_trv_sensor_entity[sensor.trv_name_valve_position-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.trv_name_valve_position',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'TRV-Name valve position',
+    'platform': 'shelly',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'valve_position',
+    'unique_id': '123456789ABC-blutrv:200-valve_position',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_blu_trv_sensor_entity[sensor.trv_name_valve_position-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'TRV-Name valve position',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.trv_name_valve_position',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---

--- a/tests/components/shelly/test_binary_sensor.py
+++ b/tests/components/shelly/test_binary_sensor.py
@@ -3,7 +3,7 @@
 from copy import deepcopy
 from unittest.mock import Mock
 
-from aioshelly.const import MODEL_MOTION
+from aioshelly.const import MODEL_BLU_GATEWAY_GEN3, MODEL_MOTION
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 
@@ -477,3 +477,23 @@ async def test_rpc_remove_virtual_binary_sensor_when_orphaned(
 
     entry = entity_registry.async_get(entity_id)
     assert not entry
+
+
+async def test_blu_trv_binary_sensor_entity(
+    hass: HomeAssistant,
+    mock_blu_trv: Mock,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test BLU TRV binary sensor entity."""
+
+    entity_id = "binary_sensor.trv_name_calibration"
+
+    await init_integration(hass, 3, model=MODEL_BLU_GATEWAY_GEN3)
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == STATE_OFF
+
+    entry = entity_registry.async_get(entity_id)
+    assert entry
+    assert entry.unique_id == "123456789ABC-blutrv:200-calibration"

--- a/tests/components/shelly/test_binary_sensor.py
+++ b/tests/components/shelly/test_binary_sensor.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock
 from aioshelly.const import MODEL_BLU_GATEWAY_GEN3, MODEL_MOTION
 from freezegun.api import FrozenDateTimeFactory
 import pytest
+from syrupy import SnapshotAssertion
 
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
 from homeassistant.components.shelly.const import UPDATE_PERIOD_MULTIPLIER
@@ -483,17 +484,16 @@ async def test_blu_trv_binary_sensor_entity(
     hass: HomeAssistant,
     mock_blu_trv: Mock,
     entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
 ) -> None:
     """Test BLU TRV binary sensor entity."""
-
-    entity_id = "binary_sensor.trv_name_calibration"
-
     await init_integration(hass, 3, model=MODEL_BLU_GATEWAY_GEN3)
 
-    state = hass.states.get(entity_id)
-    assert state
-    assert state.state == STATE_OFF
+    for entity in ("calibration",):
+        entity_id = f"{BINARY_SENSOR_DOMAIN}.trv_name_{entity}"
 
-    entry = entity_registry.async_get(entity_id)
-    assert entry
-    assert entry.unique_id == "123456789ABC-blutrv:200-calibration"
+        state = hass.states.get(entity_id)
+        assert state == snapshot(name=f"{entity_id}-state")
+
+        entry = entity_registry.async_get(entity_id)
+        assert entry == snapshot(name=f"{entity_id}-entry")

--- a/tests/components/shelly/test_number.py
+++ b/tests/components/shelly/test_number.py
@@ -3,6 +3,7 @@
 from copy import deepcopy
 from unittest.mock import AsyncMock, Mock
 
+from aioshelly.const import MODEL_BLU_GATEWAY_GEN3
 from aioshelly.exceptions import DeviceConnectionError, InvalidAuthError
 import pytest
 
@@ -390,3 +391,26 @@ async def test_rpc_remove_virtual_number_when_orphaned(
 
     entry = entity_registry.async_get(entity_id)
     assert not entry
+
+
+async def test_blu_trv_number_entity(
+    hass: HomeAssistant,
+    mock_blu_trv: Mock,
+    entity_registry: EntityRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test BLU TRV number entity."""
+
+    entity_id = "number.trv_name_valve_position"
+    # disable automatic temperature control in the device
+    monkeypatch.setitem(mock_blu_trv.config["blutrv:200"], "enable", False)
+
+    await init_integration(hass, 3, model=MODEL_BLU_GATEWAY_GEN3)
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == "0"
+
+    entry = entity_registry.async_get(entity_id)
+    assert entry
+    assert entry.unique_id == "123456789ABC-blutrv:200-valve_position"

--- a/tests/components/shelly/test_number.py
+++ b/tests/components/shelly/test_number.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, Mock
 from aioshelly.const import MODEL_BLU_GATEWAY_GEN3
 from aioshelly.exceptions import DeviceConnectionError, InvalidAuthError
 import pytest
+from syrupy import SnapshotAssertion
 
 from homeassistant.components.number import (
     ATTR_MAX,
@@ -398,19 +399,19 @@ async def test_blu_trv_number_entity(
     mock_blu_trv: Mock,
     entity_registry: EntityRegistry,
     monkeypatch: pytest.MonkeyPatch,
+    snapshot: SnapshotAssertion,
 ) -> None:
     """Test BLU TRV number entity."""
-
-    entity_id = "number.trv_name_valve_position"
     # disable automatic temperature control in the device
     monkeypatch.setitem(mock_blu_trv.config["blutrv:200"], "enable", False)
 
     await init_integration(hass, 3, model=MODEL_BLU_GATEWAY_GEN3)
 
-    state = hass.states.get(entity_id)
-    assert state
-    assert state.state == "0"
+    for entity in ("external_temperature", "valve_position"):
+        entity_id = f"{NUMBER_DOMAIN}.trv_name_{entity}"
 
-    entry = entity_registry.async_get(entity_id)
-    assert entry
-    assert entry.unique_id == "123456789ABC-blutrv:200-valve_position"
+        state = hass.states.get(entity_id)
+        assert state == snapshot(name=f"{entity_id}-state")
+
+        entry = entity_registry.async_get(entity_id)
+        assert entry == snapshot(name=f"{entity_id}-entry")

--- a/tests/components/shelly/test_sensor.py
+++ b/tests/components/shelly/test_sensor.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock
 from aioshelly.const import MODEL_BLU_GATEWAY_GEN3
 from freezegun.api import FrozenDateTimeFactory
 import pytest
+from syrupy import SnapshotAssertion
 
 from homeassistant.components.homeassistant import (
     DOMAIN as HA_DOMAIN,
@@ -1412,17 +1413,16 @@ async def test_blu_trv_sensor_entity(
     hass: HomeAssistant,
     mock_blu_trv: Mock,
     entity_registry: EntityRegistry,
+    snapshot: SnapshotAssertion,
 ) -> None:
     """Test BLU TRV sensor entity."""
-
-    entity_id = "sensor.trv_name_valve_position"
-
     await init_integration(hass, 3, model=MODEL_BLU_GATEWAY_GEN3)
 
-    state = hass.states.get(entity_id)
-    assert state
-    assert state.state == "0"
+    for entity in ("battery", "signal_strength", "valve_position"):
+        entity_id = f"{SENSOR_DOMAIN}.trv_name_{entity}"
 
-    entry = entity_registry.async_get(entity_id)
-    assert entry
-    assert entry.unique_id == "123456789ABC-blutrv:200-valve_position"
+        state = hass.states.get(entity_id)
+        assert state == snapshot(name=f"{entity_id}-state")
+
+        entry = entity_registry.async_get(entity_id)
+        assert entry == snapshot(name=f"{entity_id}-entry")

--- a/tests/components/shelly/test_sensor.py
+++ b/tests/components/shelly/test_sensor.py
@@ -3,6 +3,7 @@
 from copy import deepcopy
 from unittest.mock import Mock
 
+from aioshelly.const import MODEL_BLU_GATEWAY_GEN3
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 
@@ -1405,3 +1406,23 @@ async def test_rpc_voltmeter_value(
     entry = entity_registry.async_get(entity_id)
     assert entry
     assert entry.unique_id == "123456789ABC-voltmeter:100-voltmeter_value"
+
+
+async def test_blu_trv_sensor_entity(
+    hass: HomeAssistant,
+    mock_blu_trv: Mock,
+    entity_registry: EntityRegistry,
+) -> None:
+    """Test BLU TRV sensor entity."""
+
+    entity_id = "sensor.trv_name_valve_position"
+
+    await init_integration(hass, 3, model=MODEL_BLU_GATEWAY_GEN3)
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == "0"
+
+    entry = entity_registry.async_get(entity_id)
+    assert entry
+    assert entry.unique_id == "123456789ABC-blutrv:200-valve_position"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR introduces new entities for Shelly BLU TRV:
- `battery` sensor
- `signal strength` sensor
- `valve position` sensor (only if automatic temperature control is disabled for the device)
- `calibration` binary sensor
- `external temperature` number entity
- `valve position` number entity (only if automatic temperature control is enabled for the device)

PR introduces the ability to select an entity class via `entity description`. I added a helper `get_entity_class` to easily select the appropriate class for the entity. In future changes we may migrate more entity descriptions to pass information about the appropriate entity class.

![obraz](https://github.com/user-attachments/assets/61b4d066-9b87-4348-9f18-a4c8765717a5)



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
