### PR TITLE
Grammar and consistency fixes in hdmi_cec strings

### DIFF
--- a/homeassistant/components/hdmi_cec/strings.json
+++ b/homeassistant/components/hdmi_cec/strings.json
@@ -2,7 +2,7 @@
   "services": {
     "power_on": {
       "name": "Power on",
-      "description": "Power on all devices which supports it."
+      "description": "Powers on all devices which support this function."
     },
     "select_device": {
       "name": "Select device",
@@ -10,7 +10,7 @@
       "fields": {
         "device": {
           "name": "[%key:common::config_flow::data::device%]",
-          "description": "Address of device to select. Can be entity_id, physical address or alias from configuration."
+          "description": "Address of device to select. Can be an entity ID, physical address or alias from configuration."
         }
       }
     },
@@ -42,7 +42,7 @@
     },
     "standby": {
       "name": "[%key:common::state::standby%]",
-      "description": "Standby all devices which supports it."
+      "description": "Places in standby all devices which support this function."
     },
     "update": {
       "name": "Update",
@@ -50,19 +50,19 @@
     },
     "volume": {
       "name": "Volume",
-      "description": "Increases or decreases volume of system.",
+      "description": "Increases or decreases the system volume.",
       "fields": {
         "down": {
           "name": "Down",
-          "description": "Decreases volume x levels."
+          "description": "Decreases the volume x levels."
         },
         "mute": {
           "name": "Mute",
-          "description": "Mutes audio system."
+          "description": "Mutes the audio system."
         },
         "up": {
           "name": "Up",
-          "description": "Increases volume x levels."
+          "description": "Increases the volume x levels."
         }
       }
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Two of the action descriptions in the hdmi_cec integration currently contain the grammar error "… all devices which support**s** it."

This PR fixes this by slightly re-wording them, closer to the description in the online docs.

In addition "entity_id" is replaced by the translatable "an entity ID".

Finally "the" is added for better readability of several descriptions.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
