### PR TITLE
Skip fetching deactivated shopping lists in Bring integration

### DIFF
--- a/homeassistant/components/bring/coordinator.py
+++ b/homeassistant/components/bring/coordinator.py
@@ -70,6 +70,8 @@ class BringDataUpdateCoordinator(DataUpdateCoordinator[dict[str, BringData]]):
 
         list_dict: dict[str, BringData] = {}
         for lst in lists_response["lists"]:
+            if (ctx := set(self.async_contexts())) and lst["listUuid"] not in ctx:
+                continue
             try:
                 items = await self.bring.get_list(lst["listUuid"])
             except BringRequestException as e:

--- a/homeassistant/components/bring/entity.py
+++ b/homeassistant/components/bring/entity.py
@@ -20,7 +20,7 @@ class BringBaseEntity(CoordinatorEntity[BringDataUpdateCoordinator]):
         bring_list: BringData,
     ) -> None:
         """Initialize the entity."""
-        super().__init__(coordinator)
+        super().__init__(coordinator, bring_list["listUuid"])
 
         self._list_uuid = bring_list["listUuid"]
 

--- a/tests/components/bring/test_init.py
+++ b/tests/components/bring/test_init.py
@@ -1,7 +1,9 @@
 """Unit tests for the bring integration."""
 
+from datetime import timedelta
 from unittest.mock import AsyncMock
 
+from freezegun.api import FrozenDateTimeFactory
 import pytest
 
 from homeassistant.components.bring import (
@@ -11,11 +13,14 @@ from homeassistant.components.bring import (
     async_setup_entry,
 )
 from homeassistant.components.bring.const import DOMAIN
-from homeassistant.config_entries import ConfigEntryState
+from homeassistant.config_entries import ConfigEntryDisabler, ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+from homeassistant.helpers import device_registry as dr
 
-from tests.common import MockConfigEntry
+from .conftest import UUID
+
+from tests.common import MockConfigEntry, async_fire_time_changed
 
 
 async def setup_integration(
@@ -133,3 +138,31 @@ async def test_config_entry_not_ready_auth_error(
     await hass.async_block_till_done()
 
     assert bring_config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+@pytest.mark.usefixtures("mock_bring_client")
+async def test_coordinator_skips_deactivated(
+    hass: HomeAssistant,
+    bring_config_entry: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+    mock_bring_client: AsyncMock,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test the coordinator skips fetching lists for deactivated lists."""
+    await setup_integration(hass, bring_config_entry)
+
+    assert bring_config_entry.state is ConfigEntryState.LOADED
+
+    assert mock_bring_client.get_list.await_count == 2
+
+    device = device_registry.async_get_device(
+        identifiers={(DOMAIN, f"{UUID}_b4776778-7f6c-496e-951b-92a35d3db0dd")}
+    )
+    device_registry.async_update_device(device.id, disabled_by=ConfigEntryDisabler.USER)
+
+    mock_bring_client.get_list.reset_mock()
+
+    freezer.tick(timedelta(seconds=90))
+    async_fire_time_changed(hass)
+
+    assert mock_bring_client.get_list.await_count == 1

--- a/tests/components/bring/test_init.py
+++ b/tests/components/bring/test_init.py
@@ -164,5 +164,6 @@ async def test_coordinator_skips_deactivated(
 
     freezer.tick(timedelta(seconds=90))
     async_fire_time_changed(hass)
+    await hass.async_block_till_done()
 
     assert mock_bring_client.get_list.await_count == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


When lists are deactivated they are now skipped in the coordinator data update. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
