### PR TITLE
Allow passing extra metadata to create backup method

### DIFF
--- a/homeassistant/components/backup/manager.py
+++ b/homeassistant/components/backup/manager.py
@@ -672,6 +672,7 @@ class BackupManager:
         self,
         *,
         agent_ids: list[str],
+        extra_metadata: dict[str, bool | str] | None,
         include_addons: list[str] | None,
         include_all_addons: bool,
         include_database: bool,
@@ -684,6 +685,7 @@ class BackupManager:
         """Create a backup."""
         new_backup = await self.async_initiate_backup(
             agent_ids=agent_ids,
+            extra_metadata=extra_metadata,
             include_addons=include_addons,
             include_all_addons=include_all_addons,
             include_database=include_database,
@@ -702,6 +704,7 @@ class BackupManager:
         self,
         *,
         agent_ids: list[str],
+        extra_metadata: dict[str, bool | str] | None,
         include_addons: list[str] | None,
         include_all_addons: bool,
         include_database: bool,
@@ -726,6 +729,7 @@ class BackupManager:
         try:
             return await self._async_create_backup(
                 agent_ids=agent_ids,
+                extra_metadata=extra_metadata,
                 include_addons=include_addons,
                 include_all_addons=include_all_addons,
                 include_database=include_database,
@@ -749,6 +753,7 @@ class BackupManager:
         self,
         *,
         agent_ids: list[str],
+        extra_metadata: dict[str, bool | str] | None,
         include_addons: list[str] | None,
         include_all_addons: bool,
         include_database: bool,
@@ -786,6 +791,7 @@ class BackupManager:
                 extra_metadata={
                     "instance_id": await instance_id.async_get(self.hass),
                     "with_automatic_settings": with_automatic_settings,
+                    **(extra_metadata or {}),
                 },
                 include_addons=include_addons,
                 include_all_addons=include_all_addons,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The `extra_metadata` field is available on the backup writer's `async_create_backup` method but is not passed down from the backup manager's `async_create_backup` method. Being able to specify extra metadata is very useful to 3rd party integrations utilising the new backup integration (particularly my integration [Auto Backup](https://jcwillox.github.io/hass-auto-backup)) so they can store, well, metadata like who the backup was created by.

I've made the additional field optional, and merge it in with the existing metadata the backup integration adds.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
