### PR TITLE
Fix Tado config flow

### DIFF
--- a/homeassistant/components/tado/config_flow.py
+++ b/homeassistant/components/tado/config_flow.py
@@ -49,7 +49,7 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
         tado = await hass.async_add_executor_job(
             Tado, data[CONF_USERNAME], data[CONF_PASSWORD]
         )
-        tado_me = await hass.async_add_executor_job(tado.getMe)
+        tado_me = await hass.async_add_executor_job(tado.get_me)
     except KeyError as ex:
         raise InvalidAuth from ex
     except RuntimeError as ex:

--- a/tests/components/tado/test_config_flow.py
+++ b/tests/components/tado/test_config_flow.py
@@ -23,12 +23,12 @@ from homeassistant.data_entry_flow import FlowResultType
 from tests.common import MockConfigEntry
 
 
-def _get_mock_tado_api(getMe=None) -> MagicMock:
+def _get_mock_tado_api(get_me=None) -> MagicMock:
     mock_tado = MagicMock()
-    if isinstance(getMe, Exception):
-        type(mock_tado).getMe = MagicMock(side_effect=getMe)
+    if isinstance(get_me, Exception):
+        type(mock_tado).get_me = MagicMock(side_effect=get_me)
     else:
-        type(mock_tado).getMe = MagicMock(return_value=getMe)
+        type(mock_tado).get_me = MagicMock(return_value=get_me)
     return mock_tado
 
 
@@ -61,7 +61,7 @@ async def test_form_exceptions(
     assert result["errors"] == {"base": error}
 
     # Test a retry to recover, upon failure
-    mock_tado_api = _get_mock_tado_api(getMe={"homes": [{"id": 1, "name": "myhome"}]})
+    mock_tado_api = _get_mock_tado_api(get_me={"homes": [{"id": 1, "name": "myhome"}]})
 
     with (
         patch(
@@ -131,7 +131,7 @@ async def test_create_entry(hass: HomeAssistant) -> None:
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {}
 
-    mock_tado_api = _get_mock_tado_api(getMe={"homes": [{"id": 1, "name": "myhome"}]})
+    mock_tado_api = _get_mock_tado_api(get_me={"homes": [{"id": 1, "name": "myhome"}]})
 
     with (
         patch(
@@ -166,7 +166,9 @@ async def test_form_invalid_auth(hass: HomeAssistant) -> None:
 
     response_mock = MagicMock()
     type(response_mock).status_code = HTTPStatus.UNAUTHORIZED
-    mock_tado_api = _get_mock_tado_api(getMe=requests.HTTPError(response=response_mock))
+    mock_tado_api = _get_mock_tado_api(
+        get_me=requests.HTTPError(response=response_mock)
+    )
 
     with patch(
         "homeassistant.components.tado.config_flow.Tado",
@@ -189,7 +191,9 @@ async def test_form_cannot_connect(hass: HomeAssistant) -> None:
 
     response_mock = MagicMock()
     type(response_mock).status_code = HTTPStatus.INTERNAL_SERVER_ERROR
-    mock_tado_api = _get_mock_tado_api(getMe=requests.HTTPError(response=response_mock))
+    mock_tado_api = _get_mock_tado_api(
+        get_me=requests.HTTPError(response=response_mock)
+    )
 
     with patch(
         "homeassistant.components.tado.config_flow.Tado",
@@ -210,7 +214,7 @@ async def test_no_homes(hass: HomeAssistant) -> None:
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    mock_tado_api = _get_mock_tado_api(getMe={"homes": []})
+    mock_tado_api = _get_mock_tado_api(get_me={"homes": []})
 
     with patch(
         "homeassistant.components.tado.config_flow.Tado",
@@ -314,7 +318,7 @@ async def test_reconfigure_flow(
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": error}
 
-    mock_tado_api = _get_mock_tado_api(getMe={"homes": [{"id": 1, "name": "myhome"}]})
+    mock_tado_api = _get_mock_tado_api(get_me={"homes": [{"id": 1, "name": "myhome"}]})
     with (
         patch(
             "homeassistant.components.tado.config_flow.Tado",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As reported, due the config flow wasn't working any longer. Fixed, including the tests.
This has a direct link with #133988. Please release both, if approved, in the same version.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #134919
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
