### PR TITLE
Set Netgear device entities to unavailable when the device is not connected

### DIFF
--- a/homeassistant/components/netgear/router.py
+++ b/homeassistant/components/netgear/router.py
@@ -210,6 +210,12 @@ class NetgearRouter:
 
         for device in self.devices.values():
             device["active"] = now - device["last_seen"] <= self._consider_home
+            if not device["active"]:
+                device["link_rate"] = None
+                device["signal"] = None
+                device["ip"] = None
+                device["ssid"] = None
+                device["conn_ap_mac"] = None
 
         if new_device:
             _LOGGER.debug("Netgear tracker: new device found")

--- a/homeassistant/components/netgear/sensor.py
+++ b/homeassistant/components/netgear/sensor.py
@@ -339,7 +339,6 @@ class NetgearSensorEntity(NetgearDeviceEntity, SensorEntity):
     ) -> None:
         """Initialize a Netgear device."""
         super().__init__(coordinator, router, device)
-        self._device = device
         self._attribute = attribute
         self.entity_description = SENSOR_TYPES[attribute]
         self._attr_unique_id = f"{self._mac}-{attribute}"
@@ -348,7 +347,7 @@ class NetgearSensorEntity(NetgearDeviceEntity, SensorEntity):
     @property
     def available(self) -> bool:
         """Return if entity is available."""
-        return self._device.get(self._attribute) is not None
+        return super().available and self._device.get(self._attribute) is not None
 
     @property
     def native_value(self):

--- a/homeassistant/components/netgear/sensor.py
+++ b/homeassistant/components/netgear/sensor.py
@@ -339,10 +339,16 @@ class NetgearSensorEntity(NetgearDeviceEntity, SensorEntity):
     ) -> None:
         """Initialize a Netgear device."""
         super().__init__(coordinator, router, device)
+        self._device = device
         self._attribute = attribute
         self.entity_description = SENSOR_TYPES[attribute]
         self._attr_unique_id = f"{self._mac}-{attribute}"
         self._state = device.get(attribute)
+
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return self._device.get(self._attribute) is not None
 
     @property
     def native_value(self):


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

Reset sensor values when the device is not connected. Otherwise a device that isn't connected to the network might have an IP or SSID set.  as it doesn't make sense for a device which isn't connected to the router to have an IP or a SSID.

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: n/a
- This PR is related to issue: n/a
- Link to documentation pull request: n/a

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
