### PR TITLE
Reword action descriptions for better translations in Teslemetry

### DIFF
--- a/homeassistant/components/teslemetry/strings.json
+++ b/homeassistant/components/teslemetry/strings.json
@@ -610,7 +610,7 @@
   },
   "services": {
     "navigation_gps_request": {
-      "description": "Set vehicle navigation to the provided latitude/longitude coordinates.",
+      "description": "Sets vehicle navigation to the provided latitude/longitude coordinates.",
       "fields": {
         "device_id": {
           "description": "Vehicle to share to.",
@@ -646,7 +646,7 @@
       "name": "Set scheduled charging"
     },
     "set_scheduled_departure": {
-      "description": "Sets a time at which departure should be completed.",
+      "description": "Sets the departure time for a vehicle to schedule charging and preconditioning.",
       "fields": {
         "departure_time": {
           "description": "Time to be preconditioned by.",
@@ -684,7 +684,7 @@
       "name": "Set scheduled departure"
     },
     "speed_limit": {
-      "description": "Activate the speed limit of the vehicle.",
+      "description": "Activates the speed limit of a vehicle.",
       "fields": {
         "device_id": {
           "description": "Vehicle to limit.",
@@ -702,7 +702,7 @@
       "name": "Set speed limit"
     },
     "time_of_use": {
-      "description": "Update the time of use settings for the energy site.",
+      "description": "Updates the time of use settings for an energy site.",
       "fields": {
         "device_id": {
           "description": "Energy Site to configure.",
@@ -716,7 +716,7 @@
       "name": "Time of use settings"
     },
     "valet_mode": {
-      "description": "Activate the valet mode of the vehicle.",
+      "description": "Activates the valet mode of a vehicle.",
       "fields": {
         "device_id": {
           "description": "Vehicle to limit.",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Currently only one of the action descriptions in the Teslemetry integration uses the descriptive form of third person plural which can cause wrong and misleading translations.

This commit changes the remaining descriptions to adopt the same language and changes "the" to "a" as the actual action target (vehicle or energy site) is defined later, below that in the UI.

In addition the description of the set_scheduled_departure action is updated to better explain what the options are.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
