### PR TITLE
Add quality scale for weheat

### DIFF
--- a/homeassistant/components/weheat/quality_scale.yaml
+++ b/homeassistant/components/weheat/quality_scale.yaml
@@ -47,10 +47,7 @@ rules:
     comment: |
       PARALLEL_UPDATES is not set.
   reauthentication-flow: done
-  test-coverage:
-    status: todo
-    comment: |
-      Total coverage is at 93%
+  test-coverage: done
 
   # Gold
   devices: done

--- a/homeassistant/components/weheat/quality_scale.yaml
+++ b/homeassistant/components/weheat/quality_scale.yaml
@@ -1,0 +1,102 @@
+rules:
+  # Bronze
+  action-setup:
+    status: exempt
+    comment: No service actions currently available
+  appropriate-polling: done
+  brands: done
+  common-modules: done
+  config-flow-test-coverage: done
+  config-flow: done
+  dependency-transparency: done
+  docs-actions: done
+  docs-high-level-description: done
+  docs-installation-instructions: done
+  docs-removal-instructions: done
+  entity-event-setup:
+    status: exempt
+    comment: |
+      No explicit event subscriptions.
+  entity-unique-id: done
+  has-entity-name: done
+  runtime-data: done
+  test-before-configure:
+    status: todo
+    comment: |
+      There are two servers that are used for this integration.
+      If the authentication server is unreachable, the user will not pass the configuration step.
+      If the backend is unreachable, an empty error message is displayed.
+  test-before-setup: done
+  unique-config-entry: done
+
+  # Silver
+  action-exceptions:
+    status: exempt
+    comment: No service actions currently available
+  config-entry-unloading: done
+  docs-configuration-parameters:
+    status: exempt
+    comment: |
+      No configuration parameters available.
+  docs-installation-parameters: done
+  entity-unavailable: done
+  integration-owner: done
+  log-when-unavailable: done
+  parallel-updates:
+    status: todo
+    comment: |
+      PARALLEL_UPDATES is not set.
+  reauthentication-flow: done
+  test-coverage:
+    status: todo
+    comment: |
+      Total coverage is at 93%
+
+  # Gold
+  devices: done
+  diagnostics: todo
+  discovery-update-info:
+    status: exempt
+    comment: |
+      This integration is a cloud service and thus does not support discovery.
+  discovery:
+    status: exempt
+    comment: |
+      This integration is a cloud service and thus does not support discovery.
+  docs-data-update: done
+  docs-examples: todo
+  docs-known-limitations: done
+  docs-supported-devices: done
+  docs-supported-functions: todo
+  docs-troubleshooting: done
+  docs-use-cases: todo
+  dynamic-devices:
+    status: exempt
+    comment: |
+      This integration does not support dynamic devices as it is very unlikely an additional heat pump is added to the system. If it were to happen, reloading the integration will discover the new heat pump.
+  entity-category: todo
+  entity-device-class: done
+  entity-disabled-by-default: todo
+  entity-translations: done
+  exception-translations:
+    status: exempt
+    comment: |
+      No exceptions with custom text are raised in the integration.
+  icon-translations: done
+  reconfiguration-flow:
+    status: exempt
+    comment: |
+      There is no reconfiguration, as the only configuration step is authentication.
+  repair-issues:
+    status: exempt
+    comment: |
+      This is a cloud service and apart form reauthentication there are not user repairable issues.
+  stale-devices:
+    status: exempt
+    comment: |
+      This integration does not support stale devices as it is very unlikely an additional heat pump is removed from the system. If it were to happen, reloading the integration will remove the old heat pump.
+
+  # Platinum
+  async-dependency: todo
+  inject-websession: todo
+  strict-typing: todo

--- a/homeassistant/components/weheat/quality_scale.yaml
+++ b/homeassistant/components/weheat/quality_scale.yaml
@@ -71,17 +71,14 @@ rules:
   docs-troubleshooting: done
   docs-use-cases: todo
   dynamic-devices:
-    status: exempt
+    status: todo
     comment: |
-      This integration does not support dynamic devices as it is very unlikely an additional heat pump is added to the system. If it were to happen, reloading the integration will discover the new heat pump.
+      While unlikely to happen. Check if it is easily integrated.
   entity-category: todo
   entity-device-class: done
   entity-disabled-by-default: todo
   entity-translations: done
-  exception-translations:
-    status: exempt
-    comment: |
-      No exceptions with custom text are raised in the integration.
+  exception-translations: todo
   icon-translations: done
   reconfiguration-flow:
     status: exempt
@@ -92,9 +89,9 @@ rules:
     comment: |
       This is a cloud service and apart form reauthentication there are not user repairable issues.
   stale-devices:
-    status: exempt
+    status: todo
     comment: |
-      This integration does not support stale devices as it is very unlikely an additional heat pump is removed from the system. If it were to happen, reloading the integration will remove the old heat pump.
+      While unlikely to happen. Check if it is easily integrated.
 
   # Platinum
   async-dependency: todo

--- a/script/hassfest/quality_scale.py
+++ b/script/hassfest/quality_scale.py
@@ -1118,7 +1118,6 @@ INTEGRATIONS_WITHOUT_QUALITY_SCALE_FILE = [
     "weatherflow_cloud",
     "weatherkit",
     "webmin",
-    "weheat",
     "wemo",
     "whirlpool",
     "whois",

--- a/tests/components/weheat/test_binary_sensor.py
+++ b/tests/components/weheat/test_binary_sensor.py
@@ -2,7 +2,6 @@
 
 from unittest.mock import AsyncMock, patch
 
-from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy import SnapshotAssertion
 from weheat.abstractions.discovery import HeatPumpDiscovery
@@ -40,7 +39,6 @@ async def test_create_binary_entities(
     mock_weheat_heat_pump: AsyncMock,
     mock_heat_pump_info: HeatPumpDiscovery.HeatPumpInfo,
     mock_config_entry: MockConfigEntry,
-    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test creating entities."""
     mock_weheat_discover.return_value = [mock_heat_pump_info]

--- a/tests/components/weheat/test_sensor.py
+++ b/tests/components/weheat/test_sensor.py
@@ -2,7 +2,6 @@
 
 from unittest.mock import AsyncMock, patch
 
-from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy import SnapshotAssertion
 from weheat.abstractions.discovery import HeatPumpDiscovery
@@ -41,7 +40,6 @@ async def test_create_entities(
     mock_weheat_heat_pump: AsyncMock,
     mock_heat_pump_info: HeatPumpDiscovery.HeatPumpInfo,
     mock_config_entry: MockConfigEntry,
-    freezer: FrozenDateTimeFactory,
     has_dhw: bool,
     nr_of_entities: int,
 ) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The initial quality scale file with the current state filled in.

## Bronze
- [x] `config-flow` - Integration needs to be able to be set up via the UI - Config flow is only oath, so items below are not used. https://github.com/home-assistant/core/blob/8e2b284a7ffb7b824f6a8b5d665c68a95674e0e9/homeassistant/components/weheat/config_flow.py#L16
    - [ ] Uses `data_description` to give context to fields
    - [ ] Uses `ConfigEntry.data` and `ConfigEntry.options` correctly
- [ ] `test-before-configure` - Test a connection in the config flow
- [x] `unique-config-entry` - Don't allow the same device or service to be able to be set up twice - https://github.com/home-assistant/core/blob/8e2b284a7ffb7b824f6a8b5d665c68a95674e0e9/homeassistant/components/weheat/config_flow.py#L45
- [x] `config-flow-test-coverage` - Full test coverage for the config flow - [100%](https://app.codecov.io/gh/home-assistant/core/tree/dev/homeassistant/components/weheat)
- [x] `runtime-data` - Use ConfigEntry.runtime_data to store runtime data - https://github.com/home-assistant/core/blob/a745e079e9132075d2d661d41a4a3cd67b9561c5/homeassistant/components/weheat/__init__.py#L47
- [x] `test-before-setup` - Check during integration initialization if we are able to set it up correctly - Improved in https://github.com/home-assistant/core/pull/135264 (was approved but not yet merged)
- [x] `appropriate-polling` - If it's a polling integration, set an appropriate polling interval - https://github.com/home-assistant/core/blob/8e2b284a7ffb7b824f6a8b5d665c68a95674e0e9/homeassistant/components/weheat/const.py#L20
- [x] `entity-unique-id` - Entities have a unique ID - https://github.com/home-assistant/core/blob/8e2b284a7ffb7b824f6a8b5d665c68a95674e0e9/homeassistant/components/weheat/sensor.py#L235  https://github.com/home-assistant/core/blob/8e2b284a7ffb7b824f6a8b5d665c68a95674e0e9/homeassistant/components/weheat/binary_sensor.py#L94

- [x] `has-entity-name` - Entities use has_entity_name = True - https://github.com/home-assistant/core/blob/a745e079e9132075d2d661d41a4a3cd67b9561c5/homeassistant/components/weheat/entity.py#L13
- [ ] `entity-event-setup` - Entities event setup - No events
- [x] `dependency-transparency` - Dependency transparency - [repo](https://github.com/wefabricate/wh-python) (MIT, with github wornflow for releases)
- [ ] `action-setup` - Service actions are registered in async_setup -  no actions
- [x] `common-modules` - Place common patterns in common modules -  uses coordinator https://github.com/home-assistant/core/blob/a745e079e9132075d2d661d41a4a3cd67b9561c5/homeassistant/components/weheat/coordinator.py#L33
- [x] `docs-high-level-description` - The documentation includes a high-level description of the integration brand, product, or service -  [Link to doc](https://www.home-assistant.io/integrations/weheat)
- [x] `docs-installation-instructions` - The documentation provides step-by-step installation instructions for the integration, including, if needed, prerequisites - [installation instruction](https://www.home-assistant.io/integrations/weheat#configuration)
- [x] `docs-removal-instructions` - The documentation provides removal instructions - [removal instruction](https://www.home-assistant.io/integrations/weheat#remove-integration)
- [ ] `docs-actions` - The documentation describes the provided service actions that can be used - There are no action, this is noted [here](https://www.home-assistant.io/integrations/weheat#actions)
- [x] `brands` - Has branding assets available for the integration - [present](https://github.com/home-assistant/brands/tree/master/core_integrations/weheat)

## Silver
- [x] `config-entry-unloading` - Support config entry unloading - https://github.com/home-assistant/core/blob/a745e079e9132075d2d661d41a4a3cd67b9561c5/homeassistant/components/weheat/__init__.py#L54
- [x] `log-when-unavailable` - If internet/device/service is unavailable, log once when unavailable and once when back connected - Using coordiator updateFailed https://github.com/home-assistant/core/blob/8e2b284a7ffb7b824f6a8b5d665c68a95674e0e9/homeassistant/components/weheat/coordinator.py#L78
- [x] `entity-unavailable` - Mark entity unavailable if appropriate - https://github.com/home-assistant/core/blob/a745e079e9132075d2d661d41a4a3cd67b9561c5/homeassistant/components/weheat/coordinator.py#L78
- [ ] `action-exceptions` - Service actions raise exceptions when encountering failures
- [x] `reauthentication-flow` - Reauthentication flow - https://github.com/home-assistant/core/blob/a745e079e9132075d2d661d41a4a3cd67b9561c5/homeassistant/components/weheat/config_flow.py#L50
- [ ] `parallel-updates` - Set Parallel updates
- [x] `test-coverage` - Above 95% test coverage for all integration modules -  99% after https://github.com/home-assistant/core/pull/135518
- [x] `integration-owner` - Has an integration owner - me https://github.com/home-assistant/core/blob/a745e079e9132075d2d661d41a4a3cd67b9561c5/CODEOWNERS#L1691
- [x] `docs-installation-parameters` - The documentation describes all integration installation parameters - [described here](https://www.home-assistant.io/integrations/weheat#prerequisites)
- [ ] `docs-configuration-parameters` - The documentation describes all integration configuration options

## Gold
- [x] `entity-translations` - Entities have translated names - [string.json](https://github.com/home-assistant/core/blob/dev/homeassistant/components/weheat/strings.json)
- [x] `entity-device-class` - Entities use device classes where possible - https://github.com/home-assistant/core/blob/a745e079e9132075d2d661d41a4a3cd67b9561c5/homeassistant/components/weheat/sensor.py#L47
- [x] `devices` - The integration creates devices - https://github.com/home-assistant/core/blob/a745e079e9132075d2d661d41a4a3cd67b9561c5/homeassistant/components/weheat/entity.py#L22
- [ ] `entity-category` - Entities are assigned an appropriate EntityCategory
- [ ] `entity-disabled-by-default` - Integration disables less popular (or noisy) entities
- [ ] `discovery` - Can be discovered
- [ ] `stale-devices` - Clean up stale devices
- [ ] `diagnostics` - Implements diagnostics
- [ ] `exception-translations` - Exception messages are translatable
- [x] `icon-translations` - Icon translations - [isonc.json](https://github.com/home-assistant/core/blob/dev/homeassistant/components/weheat/icons.json)
- [ ] `reconfiguration-flow` - Integrations should have a reconfigure flow
- [ ] `dynamic-devices` - Devices added after integration setup
- [ ] `discovery-update-info` - Integration uses discovery info to update network information
- [ ] `repair-issues` - Repair issues and repair flows are used when user intervention is needed
- [ ] `docs-use-cases` - The documentation describes use cases to illustrate how this integration can be used
- [x] `docs-supported-devices` - The documentation describes known supported / unsupported devices - [described here](https://www.home-assistant.io/integrations/weheat#supported-devices)
- [ ] `docs-supported-functions` - The documentation describes the supported functionality, including entities, and platforms
- [x] `docs-data-update` - The documentation describes how data is updated - [described here](https://www.home-assistant.io/integrations/weheat#data-updates)
- [x] `docs-known-limitations` - The documentation describes known limitations of the integration (not to be confused with bugs) - [described here](https://www.home-assistant.io/integrations/weheat#known-limitations)
- [x] `docs-troubleshooting` - The documentation provides troubleshooting information - [described here](https://www.home-assistant.io/integrations/weheat#troubleshooting)
- [ ] `docs-examples` - The documentation provides automation examples the user can use.

## Platinum
- [ ] `async-dependency` - Dependency is async
- [ ] `inject-websession` - The integration dependency supports passing in a websession
- [ ] `strict-typing` - Strict typing



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
