### PR TITLE
Add temperature and humidity entities to area registry

### DIFF
--- a/homeassistant/components/config/area_registry.py
+++ b/homeassistant/components/config/area_registry.py
@@ -41,12 +41,12 @@ def websocket_list_areas(
         vol.Required("type"): "config/area_registry/create",
         vol.Optional("aliases"): list,
         vol.Optional("floor_id"): str,
+        vol.Optional("humidity_entity_id"): vol.Any(str, None),
         vol.Optional("icon"): str,
         vol.Optional("labels"): [str],
         vol.Required("name"): str,
         vol.Optional("picture"): vol.Any(str, None),
         vol.Optional("temperature_entity_id"): vol.Any(str, None),
-        vol.Optional("humidity_entity_id"): vol.Any(str, None),
     }
 )
 @websocket_api.require_admin

--- a/homeassistant/components/config/area_registry.py
+++ b/homeassistant/components/config/area_registry.py
@@ -45,6 +45,8 @@ def websocket_list_areas(
         vol.Optional("labels"): [str],
         vol.Required("name"): str,
         vol.Optional("picture"): vol.Any(str, None),
+        vol.Optional("temperature_entity_id"): vol.Any(str, None),
+        vol.Optional("humidity_entity_id"): vol.Any(str, None),
     }
 )
 @websocket_api.require_admin
@@ -111,6 +113,8 @@ def websocket_delete_area(
         vol.Optional("labels"): [str],
         vol.Optional("name"): str,
         vol.Optional("picture"): vol.Any(str, None),
+        vol.Optional("temperature_entity_id"): vol.Any(str, None),
+        vol.Optional("humidity_entity_id"): vol.Any(str, None),
     }
 )
 @websocket_api.require_admin

--- a/homeassistant/components/config/area_registry.py
+++ b/homeassistant/components/config/area_registry.py
@@ -109,12 +109,12 @@ def websocket_delete_area(
         vol.Optional("aliases"): list,
         vol.Required("area_id"): str,
         vol.Optional("floor_id"): vol.Any(str, None),
+        vol.Optional("humidity_entity_id"): vol.Any(str, None),
         vol.Optional("icon"): vol.Any(str, None),
         vol.Optional("labels"): [str],
         vol.Optional("name"): str,
         vol.Optional("picture"): vol.Any(str, None),
         vol.Optional("temperature_entity_id"): vol.Any(str, None),
-        vol.Optional("humidity_entity_id"): vol.Any(str, None),
     }
 )
 @websocket_api.require_admin

--- a/homeassistant/helpers/area_registry.py
+++ b/homeassistant/helpers/area_registry.py
@@ -382,10 +382,10 @@ class AreaRegistry(BaseRegistry[AreasRegistryStoreData]):
             if value is not UNDEFINED and value != getattr(old, attr_name)
         }
 
-        if "humidity_entity_id" in new_values:
+        if "humidity_entity_id" in new_values and humidity_entity_id is not None:
             _validate_humidity_entity(self.hass, new_values["humidity_entity_id"])
 
-        if "temperature_entity_id" in new_values:
+        if "temperature_entity_id" in new_values and temperature_entity_id is not None:
             _validate_temperature_entity(self.hass, new_values["temperature_entity_id"])
 
         if name is not UNDEFINED and name != old.name:

--- a/homeassistant/helpers/area_registry.py
+++ b/homeassistant/helpers/area_registry.py
@@ -322,11 +322,11 @@ class AreaRegistry(BaseRegistry[AreasRegistryStoreData]):
         *,
         aliases: set[str] | UndefinedType = UNDEFINED,
         floor_id: str | None | UndefinedType = UNDEFINED,
+        humidity_entity_id: str | None | UndefinedType = UNDEFINED,
         icon: str | None | UndefinedType = UNDEFINED,
         labels: set[str] | UndefinedType = UNDEFINED,
         name: str | UndefinedType = UNDEFINED,
         picture: str | None | UndefinedType = UNDEFINED,
-        humidity_entity_id: str | None | UndefinedType = UNDEFINED,
         temperature_entity_id: str | None | UndefinedType = UNDEFINED,
     ) -> AreaEntry:
         """Update name of area."""

--- a/homeassistant/helpers/area_registry.py
+++ b/homeassistant/helpers/area_registry.py
@@ -47,12 +47,12 @@ class _AreaStoreData(TypedDict):
 
     aliases: list[str]
     floor_id: str | None
+    humidity_entity_id: str | None
     icon: str | None
     id: str
     labels: list[str]
     name: str
     picture: str | None
-    humidity_entity_id: str | None
     temperature_entity_id: str | None
     created_at: str
     modified_at: str
@@ -151,10 +151,10 @@ class AreaRegistryStore(Store[AreasRegistryStoreData]):
                     area["created_at"] = area["modified_at"] = created_at
 
             if old_minor_version < 8:
-                # Version 1.8 adds temperature_entity_id and humidity_entity_id
+                # Version 1.8 adds humidity_entity_id and temperature_entity_id
                 for area in old_data["areas"]:
-                    area["temperature_entity_id"] = None
                     area["humidity_entity_id"] = None
+                    area["temperature_entity_id"] = None
 
         if old_major_version > 1:
             raise NotImplementedError
@@ -416,15 +416,15 @@ class AreaRegistry(BaseRegistry[AreasRegistryStoreData]):
                 areas[area["id"]] = AreaEntry(
                     aliases=set(area["aliases"]),
                     floor_id=area["floor_id"],
+                    humidity_entity_id=area["humidity_entity_id"],
                     icon=area["icon"],
                     id=area["id"],
                     labels=set(area["labels"]),
                     name=area["name"],
                     picture=area["picture"],
+                    temperature_entity_id=area["temperature_entity_id"],
                     created_at=datetime.fromisoformat(area["created_at"]),
                     modified_at=datetime.fromisoformat(area["modified_at"]),
-                    temperature_entity_id=area["temperature_entity_id"],
-                    humidity_entity_id=area["humidity_entity_id"],
                 )
 
         self.areas = areas

--- a/homeassistant/helpers/area_registry.py
+++ b/homeassistant/helpers/area_registry.py
@@ -94,14 +94,14 @@ class AreaEntry(NormalizedNameBaseRegistryEntry):
                     "aliases": list(self.aliases),
                     "area_id": self.id,
                     "floor_id": self.floor_id,
+                    "humidity_entity_id": self.humidity_entity_id,
                     "icon": self.icon,
                     "labels": list(self.labels),
                     "name": self.name,
                     "picture": self.picture,
+                    "temperature_entity_id": self.temperature_entity_id,
                     "created_at": self.created_at.timestamp(),
                     "modified_at": self.modified_at.timestamp(),
-                    "temperature_entity_id": self.temperature_entity_id,
-                    "humidity_entity_id": self.humidity_entity_id,
                 }
             )
         )
@@ -270,22 +270,22 @@ class AreaRegistry(BaseRegistry[AreasRegistryStoreData]):
                 f"The name {name} ({area.normalized_name}) is already in use"
             )
 
-        if temperature_entity_id is not None:
-            _validate_temperature_entity(self.hass, temperature_entity_id)
-
         if humidity_entity_id is not None:
             _validate_humidity_entity(self.hass, humidity_entity_id)
+
+        if temperature_entity_id is not None:
+            _validate_temperature_entity(self.hass, temperature_entity_id)
 
         area = AreaEntry(
             aliases=aliases or set(),
             floor_id=floor_id,
             icon=icon,
             id=self._generate_id(name),
+            humidity_entity_id=humidity_entity_id,
             labels=labels or set(),
             name=name,
             picture=picture,
             temperature_entity_id=temperature_entity_id,
-            humidity_entity_id=humidity_entity_id,
         )
         area_id = area.id
         self.areas[area_id] = area
@@ -334,12 +334,12 @@ class AreaRegistry(BaseRegistry[AreasRegistryStoreData]):
             area_id,
             aliases=aliases,
             floor_id=floor_id,
+            humidity_entity_id=humidity_entity_id,
             icon=icon,
             labels=labels,
             name=name,
             picture=picture,
             temperature_entity_id=temperature_entity_id,
-            humidity_entity_id=humidity_entity_id,
         )
         # Since updated may be the old or the new and we always fire
         # an event even if nothing has changed we cannot use async_fire_internal
@@ -372,21 +372,21 @@ class AreaRegistry(BaseRegistry[AreasRegistryStoreData]):
             attr_name: value
             for attr_name, value in (
                 ("aliases", aliases),
+                ("floor_id", floor_id),
+                ("humidity_entity_id", humidity_entity_id),
                 ("icon", icon),
                 ("labels", labels),
                 ("picture", picture),
-                ("floor_id", floor_id),
                 ("temperature_entity_id", temperature_entity_id),
-                ("humidity_entity_id", humidity_entity_id),
             )
             if value is not UNDEFINED and value != getattr(old, attr_name)
         }
 
-        if "temperature_entity_id" in new_values:
-            _validate_temperature_entity(self.hass, new_values["temperature_entity_id"])
-
         if "humidity_entity_id" in new_values:
             _validate_humidity_entity(self.hass, new_values["humidity_entity_id"])
+
+        if "temperature_entity_id" in new_values:
+            _validate_temperature_entity(self.hass, new_values["temperature_entity_id"])
 
         if name is not UNDEFINED and name != old.name:
             new_values["name"] = name
@@ -438,15 +438,15 @@ class AreaRegistry(BaseRegistry[AreasRegistryStoreData]):
                 {
                     "aliases": list(entry.aliases),
                     "floor_id": entry.floor_id,
+                    "humidity_entity_id": entry.humidity_entity_id,
                     "icon": entry.icon,
                     "id": entry.id,
                     "labels": list(entry.labels),
                     "name": entry.name,
                     "picture": entry.picture,
+                    "temperature_entity_id": entry.temperature_entity_id,
                     "created_at": entry.created_at.isoformat(),
                     "modified_at": entry.modified_at.isoformat(),
-                    "temperature_entity_id": entry.temperature_entity_id,
-                    "humidity_entity_id": entry.humidity_entity_id,
                 }
                 for entry in self.areas.values()
             ]

--- a/homeassistant/helpers/area_registry.py
+++ b/homeassistant/helpers/area_registry.py
@@ -52,8 +52,8 @@ class _AreaStoreData(TypedDict):
     labels: list[str]
     name: str
     picture: str | None
-    temperature_entity_id: str | None
     humidity_entity_id: str | None
+    temperature_entity_id: str | None
     created_at: str
     modified_at: str
 
@@ -81,8 +81,8 @@ class AreaEntry(NormalizedNameBaseRegistryEntry):
     id: str
     labels: set[str] = field(default_factory=set)
     picture: str | None
-    temperature_entity_id: str | None
     humidity_entity_id: str | None
+    temperature_entity_id: str | None
     _cache: dict[str, Any] = field(default_factory=dict, compare=False, init=False)
 
     @under_cached_property
@@ -258,8 +258,8 @@ class AreaRegistry(BaseRegistry[AreasRegistryStoreData]):
         icon: str | None = None,
         labels: set[str] | None = None,
         picture: str | None = None,
-        temperature_entity_id: str | None = None,
         humidity_entity_id: str | None = None,
+        temperature_entity_id: str | None = None,
     ) -> AreaEntry:
         """Create a new area."""
 
@@ -326,8 +326,8 @@ class AreaRegistry(BaseRegistry[AreasRegistryStoreData]):
         labels: set[str] | UndefinedType = UNDEFINED,
         name: str | UndefinedType = UNDEFINED,
         picture: str | None | UndefinedType = UNDEFINED,
-        temperature_entity_id: str | None | UndefinedType = UNDEFINED,
         humidity_entity_id: str | None | UndefinedType = UNDEFINED,
+        temperature_entity_id: str | None | UndefinedType = UNDEFINED,
     ) -> AreaEntry:
         """Update name of area."""
         updated = self._async_update(
@@ -362,8 +362,8 @@ class AreaRegistry(BaseRegistry[AreasRegistryStoreData]):
         labels: set[str] | UndefinedType = UNDEFINED,
         name: str | UndefinedType = UNDEFINED,
         picture: str | None | UndefinedType = UNDEFINED,
-        temperature_entity_id: str | None | UndefinedType = UNDEFINED,
         humidity_entity_id: str | None | UndefinedType = UNDEFINED,
+        temperature_entity_id: str | None | UndefinedType = UNDEFINED,
     ) -> AreaEntry:
         """Update name of area."""
         old = self.areas[area_id]

--- a/homeassistant/helpers/area_registry.py
+++ b/homeassistant/helpers/area_registry.py
@@ -77,11 +77,11 @@ class AreaEntry(NormalizedNameBaseRegistryEntry):
 
     aliases: set[str]
     floor_id: str | None
+    humidity_entity_id: str | None
     icon: str | None
     id: str
     labels: set[str] = field(default_factory=set)
     picture: str | None
-    humidity_entity_id: str | None
     temperature_entity_id: str | None
     _cache: dict[str, Any] = field(default_factory=dict, compare=False, init=False)
 
@@ -255,10 +255,10 @@ class AreaRegistry(BaseRegistry[AreasRegistryStoreData]):
         *,
         aliases: set[str] | None = None,
         floor_id: str | None = None,
+        humidity_entity_id: str | None = None,
         icon: str | None = None,
         labels: set[str] | None = None,
         picture: str | None = None,
-        humidity_entity_id: str | None = None,
         temperature_entity_id: str | None = None,
     ) -> AreaEntry:
         """Create a new area."""
@@ -279,9 +279,9 @@ class AreaRegistry(BaseRegistry[AreasRegistryStoreData]):
         area = AreaEntry(
             aliases=aliases or set(),
             floor_id=floor_id,
+            humidity_entity_id=humidity_entity_id,
             icon=icon,
             id=self._generate_id(name),
-            humidity_entity_id=humidity_entity_id,
             labels=labels or set(),
             name=name,
             picture=picture,
@@ -358,11 +358,11 @@ class AreaRegistry(BaseRegistry[AreasRegistryStoreData]):
         *,
         aliases: set[str] | UndefinedType = UNDEFINED,
         floor_id: str | None | UndefinedType = UNDEFINED,
+        humidity_entity_id: str | None | UndefinedType = UNDEFINED,
         icon: str | None | UndefinedType = UNDEFINED,
         labels: set[str] | UndefinedType = UNDEFINED,
         name: str | UndefinedType = UNDEFINED,
         picture: str | None | UndefinedType = UNDEFINED,
-        humidity_entity_id: str | None | UndefinedType = UNDEFINED,
         temperature_entity_id: str | None | UndefinedType = UNDEFINED,
     ) -> AreaEntry:
         """Update name of area."""

--- a/tests/components/config/test_area_registry.py
+++ b/tests/components/config/test_area_registry.py
@@ -7,6 +7,13 @@ import pytest
 from pytest_unordered import unordered
 
 from homeassistant.components.config import area_registry
+from homeassistant.components.sensor import SensorDeviceClass
+from homeassistant.const import (
+    ATTR_DEVICE_CLASS,
+    ATTR_UNIT_OF_MEASUREMENT,
+    PERCENTAGE,
+    UnitOfTemperature,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import area_registry as ar
 from homeassistant.util.dt import utcnow
@@ -24,10 +31,32 @@ async def client_fixture(
     return await hass_ws_client(hass)
 
 
+@pytest.fixture
+async def mock_temperature_humidity_entity(hass: HomeAssistant) -> None:
+    """Mock temperature and humidity sensors."""
+    hass.states.async_set(
+        "sensor.mock_temperature",
+        "20",
+        {
+            ATTR_DEVICE_CLASS: SensorDeviceClass.TEMPERATURE,
+            ATTR_UNIT_OF_MEASUREMENT: UnitOfTemperature.CELSIUS,
+        },
+    )
+    hass.states.async_set(
+        "sensor.mock_humidity",
+        "50",
+        {
+            ATTR_DEVICE_CLASS: SensorDeviceClass.HUMIDITY,
+            ATTR_UNIT_OF_MEASUREMENT: PERCENTAGE,
+        },
+    )
+
+
 async def test_list_areas(
     client: MockHAClientWebSocket,
     area_registry: ar.AreaRegistry,
     freezer: FrozenDateTimeFactory,
+    mock_temperature_humidity_entity: None,
 ) -> None:
     """Test list entries."""
     created_area1 = datetime.fromisoformat("2024-07-16T13:30:00.900075+00:00")
@@ -39,12 +68,12 @@ async def test_list_areas(
     area2 = area_registry.async_create(
         "mock 2",
         aliases={"alias_1", "alias_2"},
-        icon="mdi:garage",
-        picture="/image/example.png",
         floor_id="first_floor",
+        humidity_entity_id="sensor.mock_humidity",
+        icon="mdi:garage",
         labels={"label_1", "label_2"},
-        temperature_entity_id="sensor.temperature",
-        humidity_entity_id="sensor.humidity",
+        picture="/image/example.png",
+        temperature_entity_id="sensor.mock_temperature",
     )
 
     await client.send_json_auto_id({"type": "config/area_registry/list"})
@@ -54,28 +83,28 @@ async def test_list_areas(
         {
             "aliases": [],
             "area_id": area1.id,
+            "created_at": created_area1.timestamp(),
             "floor_id": None,
+            "humidity_entity_id": None,
             "icon": None,
             "labels": [],
+            "modified_at": created_area1.timestamp(),
             "name": "mock 1",
             "picture": None,
-            "created_at": created_area1.timestamp(),
-            "modified_at": created_area1.timestamp(),
             "temperature_entity_id": None,
-            "humidity_entity_id": None,
         },
         {
             "aliases": unordered(["alias_1", "alias_2"]),
             "area_id": area2.id,
+            "created_at": created_area2.timestamp(),
             "floor_id": "first_floor",
+            "humidity_entity_id": "sensor.mock_humidity",
             "icon": "mdi:garage",
             "labels": unordered(["label_1", "label_2"]),
+            "modified_at": created_area2.timestamp(),
             "name": "mock 2",
             "picture": "/image/example.png",
-            "created_at": created_area2.timestamp(),
-            "modified_at": created_area2.timestamp(),
-            "temperature_entity_id": "sensor.temperature",
-            "humidity_entity_id": "sensor.humidity",
+            "temperature_entity_id": "sensor.mock_temperature",
         },
     ]
 
@@ -84,6 +113,7 @@ async def test_create_area(
     client: MockHAClientWebSocket,
     area_registry: ar.AreaRegistry,
     freezer: FrozenDateTimeFactory,
+    mock_temperature_humidity_entity: None,
 ) -> None:
     """Test create entry."""
     # Create area with only mandatory parameters
@@ -117,8 +147,8 @@ async def test_create_area(
             "labels": ["label_1", "label_2"],
             "name": "mock 2",
             "picture": "/image/example.png",
-            "temperature_entity_id": "sensor.temperature",
-            "humidity_entity_id": "sensor.humidity",
+            "temperature_entity_id": "sensor.mock_temperature",
+            "humidity_entity_id": "sensor.mock_humidity",
             "type": "config/area_registry/create",
         }
     )
@@ -136,8 +166,8 @@ async def test_create_area(
         "picture": "/image/example.png",
         "created_at": utcnow().timestamp(),
         "modified_at": utcnow().timestamp(),
-        "temperature_entity_id": "sensor.temperature",
-        "humidity_entity_id": "sensor.humidity",
+        "temperature_entity_id": "sensor.mock_temperature",
+        "humidity_entity_id": "sensor.mock_humidity",
     }
     assert len(area_registry.areas) == 2
 
@@ -198,6 +228,7 @@ async def test_update_area(
     client: MockHAClientWebSocket,
     area_registry: ar.AreaRegistry,
     freezer: FrozenDateTimeFactory,
+    mock_temperature_humidity_entity: None,
 ) -> None:
     """Test update entry."""
     created_at = datetime.fromisoformat("2024-07-16T13:30:00.900075+00:00")
@@ -208,16 +239,16 @@ async def test_update_area(
 
     await client.send_json_auto_id(
         {
+            "type": "config/area_registry/update",
             "aliases": ["alias_1", "alias_2"],
             "area_id": area.id,
             "floor_id": "first_floor",
+            "humidity_entity_id": "sensor.mock_humidity",
             "icon": "mdi:garage",
             "labels": ["label_1", "label_2"],
             "name": "mock 2",
             "picture": "/image/example.png",
-            "temperature_entity_id": "sensor.temperature",
-            "humidity_entity_id": "sensor.humidity",
-            "type": "config/area_registry/update",
+            "temperature_entity_id": "sensor.mock_temperature",
         }
     )
 
@@ -227,12 +258,12 @@ async def test_update_area(
         "aliases": unordered(["alias_1", "alias_2"]),
         "area_id": area.id,
         "floor_id": "first_floor",
+        "humidity_entity_id": "sensor.mock_humidity",
         "icon": "mdi:garage",
         "labels": unordered(["label_1", "label_2"]),
         "name": "mock 2",
         "picture": "/image/example.png",
-        "temperature_entity_id": "sensor.temperature",
-        "humidity_entity_id": "sensor.humidity",
+        "temperature_entity_id": "sensor.mock_temperature",
         "created_at": created_at.timestamp(),
         "modified_at": modified_at.timestamp(),
     }
@@ -243,15 +274,15 @@ async def test_update_area(
 
     await client.send_json_auto_id(
         {
+            "type": "config/area_registry/update",
             "aliases": ["alias_1", "alias_1"],
             "area_id": area.id,
             "floor_id": None,
+            "humidity_entity_id": None,
             "icon": None,
             "labels": [],
             "picture": None,
             "temperature_entity_id": None,
-            "humidity_entity_id": None,
-            "type": "config/area_registry/update",
         }
     )
 

--- a/tests/components/config/test_area_registry.py
+++ b/tests/components/config/test_area_registry.py
@@ -43,6 +43,8 @@ async def test_list_areas(
         picture="/image/example.png",
         floor_id="first_floor",
         labels={"label_1", "label_2"},
+        temperature_entity_id="sensor.temperature",
+        humidity_entity_id="sensor.humidity",
     )
 
     await client.send_json_auto_id({"type": "config/area_registry/list"})
@@ -59,6 +61,8 @@ async def test_list_areas(
             "picture": None,
             "created_at": created_area1.timestamp(),
             "modified_at": created_area1.timestamp(),
+            "temperature_entity_id": None,
+            "humidity_entity_id": None,
         },
         {
             "aliases": unordered(["alias_1", "alias_2"]),
@@ -70,6 +74,8 @@ async def test_list_areas(
             "picture": "/image/example.png",
             "created_at": created_area2.timestamp(),
             "modified_at": created_area2.timestamp(),
+            "temperature_entity_id": "sensor.temperature",
+            "humidity_entity_id": "sensor.humidity",
         },
     ]
 
@@ -97,6 +103,8 @@ async def test_create_area(
         "picture": None,
         "created_at": utcnow().timestamp(),
         "modified_at": utcnow().timestamp(),
+        "temperature_entity_id": None,
+        "humidity_entity_id": None,
     }
     assert len(area_registry.areas) == 1
 
@@ -109,12 +117,15 @@ async def test_create_area(
             "labels": ["label_1", "label_2"],
             "name": "mock 2",
             "picture": "/image/example.png",
+            "temperature_entity_id": "sensor.temperature",
+            "humidity_entity_id": "sensor.humidity",
             "type": "config/area_registry/create",
         }
     )
 
     msg = await client.receive_json()
 
+    assert msg["success"]
     assert msg["result"] == {
         "aliases": unordered(["alias_1", "alias_2"]),
         "area_id": ANY,
@@ -125,6 +136,8 @@ async def test_create_area(
         "picture": "/image/example.png",
         "created_at": utcnow().timestamp(),
         "modified_at": utcnow().timestamp(),
+        "temperature_entity_id": "sensor.temperature",
+        "humidity_entity_id": "sensor.humidity",
     }
     assert len(area_registry.areas) == 2
 
@@ -202,6 +215,8 @@ async def test_update_area(
             "labels": ["label_1", "label_2"],
             "name": "mock 2",
             "picture": "/image/example.png",
+            "temperature_entity_id": "sensor.temperature",
+            "humidity_entity_id": "sensor.humidity",
             "type": "config/area_registry/update",
         }
     )
@@ -216,6 +231,8 @@ async def test_update_area(
         "labels": unordered(["label_1", "label_2"]),
         "name": "mock 2",
         "picture": "/image/example.png",
+        "temperature_entity_id": "sensor.temperature",
+        "humidity_entity_id": "sensor.humidity",
         "created_at": created_at.timestamp(),
         "modified_at": modified_at.timestamp(),
     }
@@ -232,6 +249,8 @@ async def test_update_area(
             "icon": None,
             "labels": [],
             "picture": None,
+            "temperature_entity_id": None,
+            "humidity_entity_id": None,
             "type": "config/area_registry/update",
         }
     )
@@ -246,6 +265,8 @@ async def test_update_area(
         "labels": [],
         "name": "mock 2",
         "picture": None,
+        "temperature_entity_id": None,
+        "humidity_entity_id": None,
         "created_at": created_at.timestamp(),
         "modified_at": modified_at.timestamp(),
     }

--- a/tests/helpers/test_area_registry.py
+++ b/tests/helpers/test_area_registry.py
@@ -48,6 +48,8 @@ async def test_create_area(
         picture=None,
         created_at=utcnow(),
         modified_at=utcnow(),
+        temperature_entity_id=None,
+        humidity_entity_id=None,
     )
     assert len(area_registry.areas) == 1
 
@@ -67,6 +69,8 @@ async def test_create_area(
         aliases={"alias_1", "alias_2"},
         labels={"label1", "label2"},
         picture="/image/example.png",
+        temperature_entity_id="sensor.mock_temperature",
+        humidity_entity_id="sensor.mock_humidity",
     )
 
     assert area2 == ar.AreaEntry(
@@ -79,6 +83,8 @@ async def test_create_area(
         picture="/image/example.png",
         created_at=utcnow(),
         modified_at=utcnow(),
+        temperature_entity_id="sensor.mock_temperature",
+        humidity_entity_id="sensor.mock_humidity",
     )
     assert len(area_registry.areas) == 2
     assert area.created_at != area2.created_at
@@ -184,6 +190,8 @@ async def test_update_area(
         labels={"label1", "label2"},
         name="mock1",
         picture="/image/example.png",
+        temperature_entity_id="sensor.mock_temperature",
+        humidity_entity_id="sensor.mock_humidity",
     )
 
     assert updated_area != area
@@ -197,6 +205,8 @@ async def test_update_area(
         picture="/image/example.png",
         created_at=created_at,
         modified_at=modified_at,
+        temperature_entity_id="sensor.mock_temperature",
+        humidity_entity_id="sensor.mock_humidity",
     )
     assert len(area_registry.areas) == 1
 
@@ -298,6 +308,8 @@ async def test_loading_area_from_storage(
     hass: HomeAssistant, hass_storage: dict[str, Any]
 ) -> None:
     """Test loading stored areas on start."""
+    created_at = datetime.fromisoformat("2024-01-01T01:00:00+00:00")
+    modified_at = datetime.fromisoformat("2024-02-01T01:00:00+00:00")
     hass_storage[ar.STORAGE_KEY] = {
         "version": ar.STORAGE_VERSION_MAJOR,
         "minor_version": ar.STORAGE_VERSION_MINOR,
@@ -311,8 +323,10 @@ async def test_loading_area_from_storage(
                     "labels": ["mock-label1", "mock-label2"],
                     "name": "mock",
                     "picture": "blah",
-                    "created_at": utcnow().isoformat(),
-                    "modified_at": utcnow().isoformat(),
+                    "created_at": created_at.isoformat(),
+                    "modified_at": modified_at.isoformat(),
+                    "temperature_entity_id": "sensor.mock_temperature",
+                    "humidity_entity_id": "sensor.mock_humidity",
                 }
             ]
         },
@@ -322,6 +336,20 @@ async def test_loading_area_from_storage(
     registry = ar.async_get(hass)
 
     assert len(registry.areas) == 1
+    area = registry.areas["12345A"]
+    assert area == ar.AreaEntry(
+        aliases={"alias_1", "alias_2"},
+        floor_id="first_floor",
+        icon="mdi:garage",
+        id="12345A",
+        labels={"mock-label1", "mock-label2"},
+        name="mock",
+        picture="blah",
+        created_at=created_at,
+        modified_at=modified_at,
+        temperature_entity_id="sensor.mock_temperature",
+        humidity_entity_id="sensor.mock_humidity",
+    )
 
 
 @pytest.mark.parametrize("load_registries", [False])
@@ -359,6 +387,8 @@ async def test_migration_from_1_1(
                     "picture": None,
                     "created_at": "1970-01-01T00:00:00+00:00",
                     "modified_at": "1970-01-01T00:00:00+00:00",
+                    "temperature_entity_id": None,
+                    "humidity_entity_id": None,
                 }
             ]
         },

--- a/tests/helpers/test_area_registry.py
+++ b/tests/helpers/test_area_registry.py
@@ -7,6 +7,13 @@ from typing import Any
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 
+from homeassistant.components.sensor import SensorDeviceClass
+from homeassistant.const import (
+    ATTR_DEVICE_CLASS,
+    ATTR_UNIT_OF_MEASUREMENT,
+    PERCENTAGE,
+    UnitOfTemperature,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import (
     area_registry as ar,
@@ -16,6 +23,27 @@ from homeassistant.helpers import (
 from homeassistant.util.dt import utcnow
 
 from tests.common import ANY, async_capture_events, flush_store
+
+
+@pytest.fixture
+async def mock_temperature_humidity_entity(hass: HomeAssistant) -> None:
+    """Mock temperature and humidity sensors."""
+    hass.states.async_set(
+        "sensor.mock_temperature",
+        "20",
+        {
+            ATTR_DEVICE_CLASS: SensorDeviceClass.TEMPERATURE,
+            ATTR_UNIT_OF_MEASUREMENT: UnitOfTemperature.CELSIUS,
+        },
+    )
+    hass.states.async_set(
+        "sensor.mock_humidity",
+        "50",
+        {
+            ATTR_DEVICE_CLASS: SensorDeviceClass.HUMIDITY,
+            ATTR_UNIT_OF_MEASUREMENT: PERCENTAGE,
+        },
+    )
 
 
 async def test_list_areas(area_registry: ar.AreaRegistry) -> None:
@@ -31,6 +59,7 @@ async def test_create_area(
     hass: HomeAssistant,
     freezer: FrozenDateTimeFactory,
     area_registry: ar.AreaRegistry,
+    mock_temperature_humidity_entity: None,
 ) -> None:
     """Make sure that we can create an area."""
     update_events = async_capture_events(hass, ar.EVENT_AREA_REGISTRY_UPDATED)
@@ -170,6 +199,7 @@ async def test_update_area(
     floor_registry: fr.FloorRegistry,
     label_registry: lr.LabelRegistry,
     freezer: FrozenDateTimeFactory,
+    mock_temperature_humidity_entity: None,
 ) -> None:
     """Make sure that we can read areas."""
     created_at = datetime.fromisoformat("2024-01-01T01:00:00+00:00")
@@ -282,6 +312,55 @@ async def test_update_area_with_normalized_name_already_in_use(
     assert area1.name == "mock1"
     assert area2.name == "Moc k2"
     assert len(area_registry.areas) == 2
+
+
+@pytest.mark.parametrize(
+    ("create_kwargs", "error_message"),
+    [
+        (
+            {"temperature_entity_id": "sensor.invalid"},
+            "Entity sensor.invalid does not exist",
+        ),
+        (
+            {"temperature_entity_id": "light.kitchen"},
+            "Entity light.kitchen is not a temperature sensor",
+        ),
+        (
+            {"temperature_entity_id": "sensor.random"},
+            "Entity sensor.random is not a temperature sensor",
+        ),
+        (
+            {"humidity_entity_id": "sensor.invalid"},
+            "Entity sensor.invalid does not exist",
+        ),
+        (
+            {"humidity_entity_id": "light.kitchen"},
+            "Entity light.kitchen is not a humidity sensor",
+        ),
+        (
+            {"humidity_entity_id": "sensor.random"},
+            "Entity sensor.random is not a humidity sensor",
+        ),
+    ],
+)
+async def test_update_area_entity_validation(
+    hass: HomeAssistant,
+    area_registry: ar.AreaRegistry,
+    mock_temperature_humidity_entity: None,
+    create_kwargs: dict[str, Any],
+    error_message: str,
+) -> None:
+    """Make sure that we can't update an area with an invalid entity."""
+    area = area_registry.async_create("mock")
+    hass.states.async_set("light.kitchen", "on", {})
+    hass.states.async_set("sensor.random", "3", {})
+
+    with pytest.raises(ValueError) as e_info:
+        area_registry.async_update(area.id, **create_kwargs)
+    assert str(e_info.value) == error_message
+
+    assert area.temperature_entity_id is None
+    assert area.humidity_entity_id is None
 
 
 async def test_load_area(hass: HomeAssistant, area_registry: ar.AreaRegistry) -> None:

--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -122,6 +122,8 @@ def floor_area_mock(hass: HomeAssistant) -> None:
         floor_id="test-floor",
         icon=None,
         picture=None,
+        temperature_entity_id=None,
+        humidity_entity_id=None,
     )
     area_in_floor_a = ar.AreaEntry(
         id="area-a",
@@ -130,6 +132,8 @@ def floor_area_mock(hass: HomeAssistant) -> None:
         floor_id="floor-a",
         icon=None,
         picture=None,
+        temperature_entity_id=None,
+        humidity_entity_id=None,
     )
     mock_area_registry(
         hass,
@@ -284,6 +288,8 @@ def label_mock(hass: HomeAssistant) -> None:
         icon=None,
         labels={"label_area"},
         picture=None,
+        temperature_entity_id=None,
+        humidity_entity_id=None,
     )
     area_without_labels = ar.AreaEntry(
         id="area-no-labels",
@@ -293,6 +299,8 @@ def label_mock(hass: HomeAssistant) -> None:
         icon=None,
         labels=set(),
         picture=None,
+        temperature_entity_id=None,
+        humidity_entity_id=None,
     )
     mock_area_registry(
         hass,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Implement architecture proposal https://github.com/home-assistant/architecture/discussions/1135

This PR allows users to define which entities represent the temperature and humidity for an area in the area registry.

This is a tiny and first step in working towards a more robust information architecture for Home Assistant.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
