### PR TITLE
Fix descriptions of send_message action of Bring! integration

### DIFF
--- a/homeassistant/components/bring/strings.json
+++ b/homeassistant/components/bring/strings.json
@@ -102,7 +102,7 @@
       "message": "Authentication failed for {email}, check your email and password"
     },
     "notify_missing_argument_item": {
-      "message": "Failed to perform action {service}. Notification type 'Urgent message' requires a value in 'Article'"
+      "message": "Failed to perform action {service}. 'URGENT_MESSAGE' requires a value @ data['item']. Got None"
     },
     "notify_request_failed": {
       "message": "Failed to send push notification for Bring! due to a connection error, try again later"

--- a/homeassistant/components/bring/strings.json
+++ b/homeassistant/components/bring/strings.json
@@ -102,7 +102,7 @@
       "message": "Authentication failed for {email}, check your email and password"
     },
     "notify_missing_argument_item": {
-      "message": "Failed to perform action {service}. Notification type `Urgent message` requires a value in `Article`"
+      "message": "Failed to perform action {service}. Notification type 'Urgent message' requires a value in 'Article'"
     },
     "notify_request_failed": {
       "message": "Failed to send push notification for Bring! due to a connection error, try again later"
@@ -134,7 +134,7 @@
         "going_shopping": "I'm going shopping! - Last chance to make changes",
         "changed_list": "List updated - Take a look at the articles",
         "shopping_done": "Shopping done - The fridge is well stocked",
-        "urgent_message": "Urgent message - Please buy `Article name` urgently"
+        "urgent_message": "Urgent message - Please buy `Article` urgently"
       }
     }
   }

--- a/homeassistant/components/bring/strings.json
+++ b/homeassistant/components/bring/strings.json
@@ -122,7 +122,7 @@
           "description": "Type of push notification to send to list members."
         },
         "item": {
-          "name": "Article (Required if Notification type `Urgent message` selected)",
+          "name": "Article (Required if notification type `Urgent message` is selected)",
           "description": "Article name to include in an urgent message e.g. `Urgent message - Please buy Cilantro urgently`"
         }
       }

--- a/homeassistant/components/bring/strings.json
+++ b/homeassistant/components/bring/strings.json
@@ -102,16 +102,16 @@
       "message": "Authentication failed for {email}, check your email and password"
     },
     "notify_missing_argument_item": {
-      "message": "Failed to perform action {service}. 'URGENT_MESSAGE' requires a value @ data['item']. Got None"
+      "message": "Failed to perform action {service}. Notification type `Urgent message` requires a value in `Article`"
     },
     "notify_request_failed": {
-      "message": "Failed to send push notification for bring due to a connection error, try again later"
+      "message": "Failed to send push notification for Bring! due to a connection error, try again later"
     }
   },
   "services": {
     "send_message": {
       "name": "[%key:component::notify::services::notify::name%]",
-      "description": "Send a mobile push notification to members of a shared Bring! list.",
+      "description": "Sends a mobile push notification to members of a shared Bring! list.",
       "fields": {
         "entity_id": {
           "name": "List",
@@ -122,8 +122,8 @@
           "description": "Type of push notification to send to list members."
         },
         "item": {
-          "name": "Article (Required if message type `Urgent Message` selected)",
-          "description": "Article name to include in an urgent message e.g. `Urgent Message - Please buy Cilantro urgently`"
+          "name": "Article (Required if Notification type `Urgent message` selected)",
+          "description": "Article name to include in an urgent message e.g. `Urgent message - Please buy Cilantro urgently`"
         }
       }
     }
@@ -134,7 +134,7 @@
         "going_shopping": "I'm going shopping! - Last chance to make changes",
         "changed_list": "List updated - Take a look at the articles",
         "shopping_done": "Shopping done - The fridge is well stocked",
-        "urgent_message": "Urgent Message - Please buy `Article name` urgently"
+        "urgent_message": "Urgent message - Please buy `Article name` urgently"
       }
     }
   }

--- a/homeassistant/components/bring/strings.json
+++ b/homeassistant/components/bring/strings.json
@@ -105,7 +105,7 @@
       "message": "Failed to perform action {service}. 'URGENT_MESSAGE' requires a value @ data['item']. Got None"
     },
     "notify_request_failed": {
-      "message": "Failed to send push notification for Bring! due to a connection error, try again later"
+      "message": "Failed to send push notification for bring due to a connection error, try again later"
     }
   },
   "services": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Several smaller fixes in the strings.json of the Bring! integration:
- Change description of action to third-person singular for consistency in Home Assistant
- Make all occurrences of the selector "Urgent message" consistent (in sentence case) so they all get consistent translations, too
- Change "message type" to "Notification type" to match the actual field name in the UI
- Change "Article name" to just "Article" to match the field name this refers to

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
