### PR TITLE
Update translations and error messages in Bring! integration

### DIFF
--- a/homeassistant/components/bring/strings.json
+++ b/homeassistant/components/bring/strings.json
@@ -102,7 +102,7 @@
       "message": "Authentication failed for {email}, check your email and password"
     },
     "notify_missing_argument_item": {
-      "message": "This action requires field item, please enter a valid value for item"
+      "message": "This action requires field {field}, please enter a valid value for {field}"
     },
     "notify_request_failed": {
       "message": "Failed to send push notification for Bring! due to a connection error, try again later"

--- a/homeassistant/components/bring/strings.json
+++ b/homeassistant/components/bring/strings.json
@@ -101,7 +101,7 @@
     "setup_authentication_exception": {
       "message": "Authentication failed for {email}, check your email and password"
     },
-    "notify_missing_argument_item": {
+    "notify_missing_argument": {
       "message": "This action requires field {field}, please enter a valid value for {field}"
     },
     "notify_request_failed": {

--- a/homeassistant/components/bring/strings.json
+++ b/homeassistant/components/bring/strings.json
@@ -102,10 +102,10 @@
       "message": "Authentication failed for {email}, check your email and password"
     },
     "notify_missing_argument_item": {
-      "message": "Failed to perform action {service}. 'URGENT_MESSAGE' requires a value @ data['item']. Got None"
+      "message": "This action requires field item, please enter a valid value for item"
     },
     "notify_request_failed": {
-      "message": "Failed to send push notification for bring due to a connection error, try again later"
+      "message": "Failed to send push notification for Bring! due to a connection error, try again later"
     }
   },
   "services": {
@@ -122,8 +122,8 @@
           "description": "Type of push notification to send to list members."
         },
         "item": {
-          "name": "Article (Required if notification type `Urgent message` is selected)",
-          "description": "Article name to include in an urgent message e.g. `Urgent message - Please buy Cilantro urgently`"
+          "name": "Item (Required if notification type 'Urgent message' is selected)",
+          "description": "Item name(s) to include in an urgent message e.g. 'Attention! Attention! - We still urgently need: [Items]'"
         }
       }
     }
@@ -131,10 +131,10 @@
   "selector": {
     "notification_type_selector": {
       "options": {
-        "going_shopping": "I'm going shopping! - Last chance to make changes",
-        "changed_list": "List updated - Take a look at the articles",
-        "shopping_done": "Shopping done - The fridge is well stocked",
-        "urgent_message": "Urgent message - Please buy `Article` urgently"
+        "going_shopping": "I'm going shopping! - Last chance for adjustments",
+        "changed_list": "I changed the list! - Take a look at the items",
+        "shopping_done": "The shopping is done - Our fridge is well stocked",
+        "urgent_message": "Attention! Attention! - We still urgently need: [Items]"
       }
     }
   }

--- a/homeassistant/components/bring/todo.py
+++ b/homeassistant/components/bring/todo.py
@@ -262,6 +262,6 @@ class BringTodoListEntity(BringBaseEntity, TodoListEntity):
         except ValueError as e:
             raise ServiceValidationError(
                 translation_domain=DOMAIN,
-                translation_key="notify_missing_argument_item",
+                translation_key="notify_missing_argument",
                 translation_placeholders={"field": "item"},
             ) from e

--- a/homeassistant/components/bring/todo.py
+++ b/homeassistant/components/bring/todo.py
@@ -263,4 +263,5 @@ class BringTodoListEntity(BringBaseEntity, TodoListEntity):
             raise ServiceValidationError(
                 translation_domain=DOMAIN,
                 translation_key="notify_missing_argument_item",
+                translation_placeholders={"field": "item"},
             ) from e

--- a/homeassistant/components/bring/todo.py
+++ b/homeassistant/components/bring/todo.py
@@ -263,7 +263,4 @@ class BringTodoListEntity(BringBaseEntity, TodoListEntity):
             raise ServiceValidationError(
                 translation_domain=DOMAIN,
                 translation_key="notify_missing_argument_item",
-                translation_placeholders={
-                    "service": f"{DOMAIN}.{SERVICE_PUSH_NOTIFICATION}",
-                },
             ) from e

--- a/tests/components/bring/test_notification.py
+++ b/tests/components/bring/test_notification.py
@@ -65,7 +65,7 @@ async def test_send_notification_exception(
     mock_bring_client.notify.side_effect = BringRequestException
     with pytest.raises(
         HomeAssistantError,
-        match="Failed to send push notification for bring due to a connection error, try again later",
+        match="Failed to send push notification for Bring! due to a connection error, try again later",
     ):
         await hass.services.async_call(
             DOMAIN,
@@ -94,7 +94,7 @@ async def test_send_notification_service_validation_error(
     with pytest.raises(
         HomeAssistantError,
         match=re.escape(
-            "Failed to perform action bring.send_message. 'URGENT_MESSAGE' requires a value @ data['item']. Got None"
+            "This action requires field item, please enter a valid value for item"
         ),
     ):
         await hass.services.async_call(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Follow-up to https://github.com/home-assistant/core/pull/135446

- Updated the labels for the notifications so that they are en par with the button labels in the latest version of the Bring! app
![image](https://github.com/user-attachments/assets/df065f86-aba1-4949-ab41-83fb0271d4e6)

- Updated missing argument exception to be consistent with other Home Assistant error messages 
- Change field name from Articles to Items for consistency
- Removed backticks and replaced with single quotes were HA doesn't support markdown formatting.

Tests have been updated and a now unnecessary translation placeholder has been removed (changed key to prevent conflicts)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
