### PR TITLE
Add set_control_setpoint function to OpenThermGatewayHub

### DIFF
--- a/homeassistant/components/opentherm_gw/const.py
+++ b/homeassistant/components/opentherm_gw/const.py
@@ -26,6 +26,9 @@ DATA_OPENTHERM_GW = "opentherm_gw"
 
 DOMAIN = "opentherm_gw"
 
+ENTITY_KEY_CENTRAL_HEATING_1_OVERRIDE = "central_heating_1_override"
+ENTITY_KEY_CENTRAL_HEATING_2_OVERRIDE = "central_heating_2_override"
+
 SERVICE_RESET_GATEWAY = "reset_gateway"
 SERVICE_SET_CH_OVRD = "set_central_heating_ovrd"
 SERVICE_SET_CLOCK = "set_clock"

--- a/homeassistant/components/opentherm_gw/switch.py
+++ b/homeassistant/components/opentherm_gw/switch.py
@@ -11,7 +11,13 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import OpenThermGatewayHub
-from .const import DATA_GATEWAYS, DATA_OPENTHERM_GW, GATEWAY_DEVICE_DESCRIPTION
+from .const import (
+    DATA_GATEWAYS,
+    DATA_OPENTHERM_GW,
+    ENTITY_KEY_CENTRAL_HEATING_1_OVERRIDE,
+    ENTITY_KEY_CENTRAL_HEATING_2_OVERRIDE,
+    GATEWAY_DEVICE_DESCRIPTION,
+)
 from .entity import OpenThermEntity, OpenThermEntityDescription
 
 
@@ -27,7 +33,7 @@ class OpenThermSwitchEntityDescription(
 
 SWITCH_DESCRIPTIONS: tuple[OpenThermSwitchEntityDescription, ...] = (
     OpenThermSwitchEntityDescription(
-        key="central_heating_1_override",
+        key=ENTITY_KEY_CENTRAL_HEATING_1_OVERRIDE,
         translation_key="central_heating_override_n",
         translation_placeholders={"circuit_number": "1"},
         device_description=GATEWAY_DEVICE_DESCRIPTION,
@@ -35,7 +41,7 @@ SWITCH_DESCRIPTIONS: tuple[OpenThermSwitchEntityDescription, ...] = (
         turn_on_action=lambda hub: hub.gateway.set_ch_enable_bit(1),
     ),
     OpenThermSwitchEntityDescription(
-        key="central_heating_2_override",
+        key=ENTITY_KEY_CENTRAL_HEATING_2_OVERRIDE,
         translation_key="central_heating_override_n",
         translation_placeholders={"circuit_number": "2"},
         device_description=GATEWAY_DEVICE_DESCRIPTION,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds a `set_control_setpoint` function to the OpenThermGatewayHub class.
This function sets the control setpoint on the gateway and updates the related central heating override `switch` entity accordingly.
This functionality is required for future PRs which add more `button` entities and a `number` platform to `opentherm_gw`. It does not change the behavior of existing entities.
Tests will be added with the entities that use the function.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
