### PR TITLE
Drop Python 3.12 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,8 +41,8 @@ env:
   UV_CACHE_VERSION: 1
   MYPY_CACHE_VERSION: 9
   HA_SHORT_VERSION: "2025.2"
-  DEFAULT_PYTHON: "3.12"
-  ALL_PYTHON_VERSIONS: "['3.12', '3.13']"
+  DEFAULT_PYTHON: "3.13"
+  ALL_PYTHON_VERSIONS: "['3.13']"
   # 10.3 is the oldest supported version
   # - 10.3.32 is the version currently shipped with Synology (as of 17 Feb 2022)
   # 10.6 is the current long-term-support

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -10,7 +10,7 @@ on:
       - "**strings.json"
 
 env:
-  DEFAULT_PYTHON: "3.12"
+  DEFAULT_PYTHON: "3.13"
 
 jobs:
   upload:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -17,7 +17,7 @@ on:
       - "script/gen_requirements_all.py"
 
 env:
-  DEFAULT_PYTHON: "3.12"
+  DEFAULT_PYTHON: "3.13"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name}}

--- a/homeassistant/auth/mfa_modules/__init__.py
+++ b/homeassistant/auth/mfa_modules/__init__.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 import logging
 import types
-from typing import Any, Generic
+from typing import Any, Generic, TypeVar
 
-from typing_extensions import TypeVar
 import voluptuous as vol
 from voluptuous.humanize import humanize_error
 

--- a/homeassistant/auth/providers/__init__.py
+++ b/homeassistant/auth/providers/__init__.py
@@ -5,9 +5,8 @@ from __future__ import annotations
 from collections.abc import Mapping
 import logging
 import types
-from typing import Any, Generic
+from typing import Any, Generic, TypeVar
 
-from typing_extensions import TypeVar
 import voluptuous as vol
 from voluptuous.humanize import humanize_error
 

--- a/homeassistant/components/actiontec/device_tracker.py
+++ b/homeassistant/components/actiontec/device_tracker.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import logging
-import telnetlib  # pylint: disable=deprecated-module
 from typing import Final
 
+import telnetlib  # pylint: disable=deprecated-module
 import voluptuous as vol
 
 from homeassistant.components.device_tracker import (

--- a/homeassistant/components/assist_pipeline/websocket_api.py
+++ b/homeassistant/components/assist_pipeline/websocket_api.py
@@ -1,9 +1,6 @@
 """Assist pipeline Websocket API."""
 
 import asyncio
-
-# Suppressing disable=deprecated-module is needed for Python 3.11
-import audioop  # pylint: disable=deprecated-module
 import base64
 from collections.abc import AsyncGenerator, Callable
 import contextlib
@@ -11,6 +8,8 @@ import logging
 import math
 from typing import Any, Final
 
+# Suppressing disable=deprecated-module is needed for Python 3.11
+import audioop  # pylint: disable=deprecated-module
 import voluptuous as vol
 
 from homeassistant.components import conversation, stt, tts, websocket_api

--- a/homeassistant/components/bluetooth/passive_update_coordinator.py
+++ b/homeassistant/components/bluetooth/passive_update_coordinator.py
@@ -2,9 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
-
-from typing_extensions import TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.helpers.update_coordinator import (

--- a/homeassistant/components/broadlink/device.py
+++ b/homeassistant/components/broadlink/device.py
@@ -3,7 +3,7 @@
 from contextlib import suppress
 from functools import partial
 import logging
-from typing import Generic
+from typing import Generic, TypeVar
 
 import broadlink as blk
 from broadlink.exceptions import (
@@ -13,7 +13,6 @@ from broadlink.exceptions import (
     ConnectionClosedError,
     NetworkTimeoutError,
 )
-from typing_extensions import TypeVar
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (

--- a/homeassistant/components/broadlink/updater.py
+++ b/homeassistant/components/broadlink/updater.py
@@ -5,11 +5,10 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from datetime import datetime, timedelta
 import logging
-from typing import TYPE_CHECKING, Any, Generic
+from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
 import broadlink as blk
 from broadlink.exceptions import AuthorizationError, BroadlinkException
-from typing_extensions import TypeVar
 
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util import dt as dt_util

--- a/homeassistant/components/denon/media_player.py
+++ b/homeassistant/components/denon/media_player.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import logging
-import telnetlib  # pylint: disable=deprecated-module
 
+import telnetlib  # pylint: disable=deprecated-module
 import voluptuous as vol
 
 from homeassistant.components.media_player import (

--- a/homeassistant/components/hddtemp/sensor.py
+++ b/homeassistant/components/hddtemp/sensor.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 from datetime import timedelta
 import logging
 import socket
-from telnetlib import Telnet  # pylint: disable=deprecated-module
 from typing import Any
 
+from telnetlib import Telnet  # pylint: disable=deprecated-module
 import voluptuous as vol
 
 from homeassistant.components.sensor import (

--- a/homeassistant/components/http/static.py
+++ b/homeassistant/components/http/static.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from pathlib import Path
-import sys
 from typing import Final
 
 from aiohttp.hdrs import CACHE_CONTROL, CONTENT_TYPE
@@ -18,14 +17,7 @@ CACHE_HEADER = f"public, max-age={CACHE_TIME}"
 CACHE_HEADERS: Mapping[str, str] = {CACHE_CONTROL: CACHE_HEADER}
 RESPONSE_CACHE: LRU[tuple[str, Path], tuple[Path, str]] = LRU(512)
 
-if sys.version_info >= (3, 13):
-    # guess_type is soft-deprecated in 3.13
-    # for paths and should only be used for
-    # URLs. guess_file_type should be used
-    # for paths instead.
-    _GUESSER = CONTENT_TYPES.guess_file_type
-else:
-    _GUESSER = CONTENT_TYPES.guess_type
+_GUESSER = CONTENT_TYPES.guess_file_type
 
 
 class CachingStaticResource(StaticResource):

--- a/homeassistant/components/http/static.py
+++ b/homeassistant/components/http/static.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from pathlib import Path
-from typing import Final
+from typing import TYPE_CHECKING, Final
 
 from aiohttp.hdrs import CACHE_CONTROL, CONTENT_TYPE
 from aiohttp.web import FileResponse, Request, StreamResponse
@@ -17,7 +17,12 @@ CACHE_HEADER = f"public, max-age={CACHE_TIME}"
 CACHE_HEADERS: Mapping[str, str] = {CACHE_CONTROL: CACHE_HEADER}
 RESPONSE_CACHE: LRU[tuple[str, Path], tuple[Path, str]] = LRU(512)
 
-_GUESSER = CONTENT_TYPES.guess_file_type
+if TYPE_CHECKING:
+    # mypy uses Python 3.12 syntax for type checking
+    # once it uses Python 3.13, this can be removed
+    _GUESSER = CONTENT_TYPES.guess_type
+else:
+    _GUESSER = CONTENT_TYPES.guess_file_type
 
 
 class CachingStaticResource(StaticResource):

--- a/homeassistant/components/pioneer/media_player.py
+++ b/homeassistant/components/pioneer/media_player.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import logging
-import telnetlib  # pylint: disable=deprecated-module
 from typing import Final
 
+import telnetlib  # pylint: disable=deprecated-module
 import voluptuous as vol
 
 from homeassistant.components.media_player import (

--- a/homeassistant/components/ring/entity.py
+++ b/homeassistant/components/ring/entity.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Awaitable, Callable, Coroutine
 from dataclasses import dataclass
-from typing import Any, Concatenate, Generic, cast
+from typing import Any, Concatenate, Generic, TypeVar, cast
 
 from ring_doorbell import (
     AuthenticationError,
@@ -11,7 +11,6 @@ from ring_doorbell import (
     RingGeneric,
     RingTimeout,
 )
-from typing_extensions import TypeVar
 
 from homeassistant.components.automation import automations_with_entity
 from homeassistant.components.script import scripts_with_entity

--- a/homeassistant/components/telnet/switch.py
+++ b/homeassistant/components/telnet/switch.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 from datetime import timedelta
 import logging
-import telnetlib  # pylint: disable=deprecated-module
 from typing import Any
 
+import telnetlib  # pylint: disable=deprecated-module
 import voluptuous as vol
 
 from homeassistant.components.switch import (

--- a/homeassistant/components/thomson/device_tracker.py
+++ b/homeassistant/components/thomson/device_tracker.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import logging
 import re
-import telnetlib  # pylint: disable=deprecated-module
 
+import telnetlib  # pylint: disable=deprecated-module
 import voluptuous as vol
 
 from homeassistant.components.device_tracker import (

--- a/homeassistant/components/weather/__init__.py
+++ b/homeassistant/components/weather/__init__.py
@@ -8,10 +8,19 @@ from contextlib import suppress
 from datetime import timedelta
 from functools import partial
 import logging
-from typing import Any, Final, Generic, Literal, Required, TypedDict, cast, final
+from typing import (
+    Any,
+    Final,
+    Generic,
+    Literal,
+    Required,
+    TypedDict,
+    TypeVar,
+    cast,
+    final,
+)
 
 from propcache import cached_property
-from typing_extensions import TypeVar
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -22,11 +22,10 @@ from functools import cache
 import logging
 from random import randint
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any, Generic, Self, cast
+from typing import TYPE_CHECKING, Any, Generic, Self, TypeVar, cast
 
 from async_interrupt import interrupt
 from propcache import cached_property
-from typing_extensions import TypeVar
 import voluptuous as vol
 
 from . import data_entry_flow, loader

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -28,10 +28,10 @@ MINOR_VERSION: Final = 2
 PATCH_VERSION: Final = "0.dev0"
 __short_version__: Final = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__: Final = f"{__short_version__}.{PATCH_VERSION}"
-REQUIRED_PYTHON_VER: Final[tuple[int, int, int]] = (3, 12, 0)
+REQUIRED_PYTHON_VER: Final[tuple[int, int, int]] = (3, 13, 0)
 REQUIRED_NEXT_PYTHON_VER: Final[tuple[int, int, int]] = (3, 13, 0)
 # Truthy date string triggers showing related deprecation warning messages.
-REQUIRED_NEXT_PYTHON_HA_RELEASE: Final = "2025.2"
+REQUIRED_NEXT_PYTHON_HA_RELEASE: Final = ""
 
 # Format for platform files
 PLATFORM_FORMAT: Final = "{platform}.{domain}"

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -36,12 +36,12 @@ from typing import (
     NotRequired,
     Self,
     TypedDict,
+    TypeVar,
     cast,
     overload,
 )
 
 from propcache import cached_property, under_cached_property
-from typing_extensions import TypeVar
 import voluptuous as vol
 
 from . import util

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -12,9 +12,8 @@ from dataclasses import dataclass
 from enum import StrEnum
 import logging
 from types import MappingProxyType
-from typing import Any, Generic, Required, TypedDict, cast
+from typing import Any, Generic, Required, TypedDict, TypeVar, cast
 
-from typing_extensions import TypeVar
 import voluptuous as vol
 
 from .core import HomeAssistant, callback

--- a/homeassistant/helpers/collection.py
+++ b/homeassistant/helpers/collection.py
@@ -11,9 +11,8 @@ from hashlib import md5
 from itertools import groupby
 import logging
 from operator import attrgetter
-from typing import Any, Generic, TypedDict
+from typing import Any, Generic, TypedDict, TypeVar
 
-from typing_extensions import TypeVar
 import voluptuous as vol
 from voluptuous.humanize import humanize_error
 

--- a/homeassistant/helpers/data_entry_flow.py
+++ b/homeassistant/helpers/data_entry_flow.py
@@ -3,10 +3,9 @@
 from __future__ import annotations
 
 from http import HTTPStatus
-from typing import Any, Generic
+from typing import Any, Generic, TypeVar
 
 from aiohttp import web
-from typing_extensions import TypeVar
 import voluptuous as vol
 import voluptuous_serialize
 

--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -7,9 +7,7 @@ from collections.abc import Callable, Iterable
 from datetime import timedelta
 import logging
 from types import ModuleType
-from typing import Any, Generic
-
-from typing_extensions import TypeVar
+from typing import Any, Generic, TypeVar
 
 from homeassistant import config as conf_util
 from homeassistant.config_entries import ConfigEntry

--- a/homeassistant/helpers/update_coordinator.py
+++ b/homeassistant/helpers/update_coordinator.py
@@ -9,13 +9,12 @@ from datetime import datetime, timedelta
 import logging
 from random import randint
 from time import monotonic
-from typing import Any, Generic, Protocol
+from typing import Any, Generic, Protocol, TypeVar
 import urllib.error
 
 import aiohttp
 from propcache import cached_property
 import requests
-from typing_extensions import TypeVar
 
 from homeassistant import config_entries
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP

--- a/homeassistant/util/event_type.py
+++ b/homeassistant/util/event_type.py
@@ -6,9 +6,7 @@ Custom for type checking. See stub file.
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, Generic
-
-from typing_extensions import TypeVar
+from typing import Any, Generic, TypeVar
 
 _DataT = TypeVar("_DataT", bound=Mapping[str, Any], default=Mapping[str, Any])
 

--- a/homeassistant/util/event_type.pyi
+++ b/homeassistant/util/event_type.pyi
@@ -2,9 +2,7 @@
 # ruff: noqa: PYI021  # Allow docstrings
 
 from collections.abc import Mapping
-from typing import Any, Generic
-
-from typing_extensions import TypeVar
+from typing import Any, Generic, TypeVar
 
 __all__ = [
     "EventType",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,11 +18,10 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Topic :: Home Automation",
 ]
-requires-python = ">=3.12.0"
+requires-python = ">=3.13.0"
 dependencies    = [
     "aiodns==3.2.0",
     # Integrations may depend on hassio integration without listing it to
@@ -104,7 +103,7 @@ include-package-data = true
 include = ["homeassistant*"]
 
 [tool.pylint.MAIN]
-py-version = "3.12"
+py-version = "3.13"
 # Use a conservative default here; 2 should speed up most setups and not hurt
 # any too bad. Override on command line as appropriate.
 jobs = 2

--- a/script/hassfest/mypy_config.py
+++ b/script/hassfest/mypy_config.py
@@ -9,8 +9,6 @@ import os
 from pathlib import Path
 from typing import Final
 
-from homeassistant.const import REQUIRED_PYTHON_VER
-
 from .model import Config, Integration
 
 # Component modules which should set no_implicit_reexport = true.
@@ -31,7 +29,18 @@ HEADER: Final = """
 """.lstrip()
 
 GENERAL_SETTINGS: Final[dict[str, str]] = {
-    "python_version": ".".join(str(x) for x in REQUIRED_PYTHON_VER[:2]),
+    # We use @dataclass_transform in all our EntityDescriptions, causing
+    # `__replace__` to be already synthesized by mypy, causing **every** use of
+    # our entity descriptions to fail:
+    #
+    # error: Signature of "__replace__" incompatible with supertype "EntityDescription"
+    #
+    # Until this is fixed in mypy, we keep mypy locked on to Python 3.12 as we
+    # have done for the past few releases.
+    #
+    # Ref: https://github.com/python/mypy/issues/18216
+    # "python_version": ".".join(str(x) for x in REQUIRED_PYTHON_VER[:2]),
+    "python_version": "3.12",
     "platform": "linux",
     "plugins": ", ".join(  # noqa: FLY002
         [

--- a/tests/common.py
+++ b/tests/common.py
@@ -25,13 +25,12 @@ import os
 import pathlib
 import time
 from types import FrameType, ModuleType
-from typing import Any, Literal, NoReturn
+from typing import Any, Literal, NoReturn, TypeVar
 from unittest.mock import AsyncMock, Mock, patch
 
 from aiohttp.test_utils import unused_port as get_test_instance_port  # noqa: F401
 import pytest
 from syrupy import SnapshotAssertion
-from typing_extensions import TypeVar
 import voluptuous as vol
 
 from homeassistant import auth, bootstrap, config_entries, loader

--- a/tests/components/homee/conftest.py
+++ b/tests/components/homee/conftest.py
@@ -1,9 +1,9 @@
 """Fixtures for Homee integration tests."""
 
+from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from typing_extensions import Generator
 
 from homeassistant.components.homee.const import DOMAIN
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

Support for Python 3.12 has been dropped. If you run Home Assistant Core, you need to make sure you run Python 3.13.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Python 3.12 was deprecated in #130425 and announced in 2024.12 to be dropped in the upcoming 2025.2 release.


For `mypy` we keep it thinking it is using Python 3.12. We use `@dataclass_transform` in all our `EntityDescriptions`, causing `__replace__` to be already synthesized by `mypy`, causing **every** use of our entity descriptions to fail:

`error: Signature of "__replace__" incompatible with supertype "EntityDescription"`

Until this is fixed in `mypy`, we keep `mypy` locked on to Python 3.12 as we have done for the past few releases.

Ref: https://github.com/python/mypy/issues/18216

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
