### PR TITLE
Fix mqtt number state validation

### DIFF
--- a/homeassistant/components/mqtt/number.py
+++ b/homeassistant/components/mqtt/number.py
@@ -179,14 +179,14 @@ class MqttNumber(MqttEntity, RestoreNumber):
             return
 
         if num_value is not None and (
-            num_value < self.min_value or num_value > self.max_value
+            num_value < self.native_min_value or num_value > self.native_max_value
         ):
             _LOGGER.error(
                 "Invalid value for %s: %s (range %s - %s)",
                 self.entity_id,
                 num_value,
-                self.min_value,
-                self.max_value,
+                self.native_min_value,
+                self.native_max_value,
             )
             return
 

--- a/tests/components/mqtt/test_number.py
+++ b/tests/components/mqtt/test_number.py
@@ -29,6 +29,7 @@ from homeassistant.const import (
     UnitOfTemperature,
 )
 from homeassistant.core import HomeAssistant, State
+from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
 
 from .test_common import (
     help_custom_config,
@@ -155,6 +156,101 @@ async def test_run_number_setup(
     assert state.state == "unknown"
     assert state.attributes.get(ATTR_DEVICE_CLASS) == device_class
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == unit_of_measurement
+
+
+@pytest.mark.parametrize(
+    "hass_config",
+    [
+        {
+            mqtt.DOMAIN: {
+                number.DOMAIN: {
+                    "state_topic": "test/state_number",
+                    "command_topic": "test/cmd_number",
+                    "name": "Test Number",
+                    "min": 15,
+                    "max": 28,
+                    "device_class": "temperature",
+                    "unit_of_measurement": UnitOfTemperature.CELSIUS.value,
+                }
+            }
+        }
+    ],
+)
+async def test_native_value_validation(
+    hass: HomeAssistant,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test state validation and native value conversion."""
+    mqtt_mock = await mqtt_mock_entry()
+
+    async_fire_mqtt_message(hass, "test/state_number", "23.5")
+    state = hass.states.get("number.test_number")
+    assert state is not None
+    assert state.attributes.get(ATTR_MIN) == 15
+    assert state.attributes.get(ATTR_MAX) == 28
+    assert (
+        state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
+        == UnitOfTemperature.CELSIUS.value
+    )
+    assert state.state == "23.5"
+
+    # Test out of range validation
+    async_fire_mqtt_message(hass, "test/state_number", "29.5")
+    state = hass.states.get("number.test_number")
+    assert state is not None
+    assert state.attributes.get(ATTR_MIN) == 15
+    assert state.attributes.get(ATTR_MAX) == 28
+    assert (
+        state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
+        == UnitOfTemperature.CELSIUS.value
+    )
+    assert state.state == "23.5"
+    assert (
+        "Invalid value for number.test_number: 29.5 (range 15.0 - 28.0)" in caplog.text
+    )
+    caplog.clear()
+
+    # Check if validation still works when changing unit system
+    hass.config.units = US_CUSTOMARY_SYSTEM
+    await hass.async_block_till_done()
+
+    async_fire_mqtt_message(hass, "test/state_number", "24.5")
+    state = hass.states.get("number.test_number")
+    assert state is not None
+    assert state.attributes.get(ATTR_MIN) == 59.0
+    assert state.attributes.get(ATTR_MAX) == 82.4
+    assert (
+        state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
+        == UnitOfTemperature.FAHRENHEIT.value
+    )
+    assert state.state == "76.1"
+
+    # Test out of range validation again
+    async_fire_mqtt_message(hass, "test/state_number", "29.5")
+    state = hass.states.get("number.test_number")
+    assert state is not None
+    assert state.attributes.get(ATTR_MIN) == 59.0
+    assert state.attributes.get(ATTR_MAX) == 82.4
+    assert (
+        state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
+        == UnitOfTemperature.FAHRENHEIT.value
+    )
+    assert state.state == "76.1"
+    assert (
+        "Invalid value for number.test_number: 29.5 (range 15.0 - 28.0)" in caplog.text
+    )
+    caplog.clear()
+
+    await hass.services.async_call(
+        NUMBER_DOMAIN,
+        SERVICE_SET_VALUE,
+        {ATTR_ENTITY_ID: "number.test_number", ATTR_VALUE: 68},
+        blocking=True,
+    )
+
+    mqtt_mock.async_publish.assert_called_once_with("test/cmd_number", "20", 0, False)
+    mqtt_mock.async_publish.reset_mock()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When a MQTT number supplies a state in a different unit as the system config, the entity state will show the local system attributes. The state is received as a native value and should be validated against the native min and max values.
This PR fixes this.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #135619
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
