### PR TITLE
Bump Weheat to 2025.1.15

### DIFF
--- a/homeassistant/components/weheat/__init__.py
+++ b/homeassistant/components/weheat/__init__.py
@@ -12,6 +12,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ACCESS_TOKEN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.config_entry_oauth2_flow import (
     OAuth2Session,
     async_get_config_entry_implementation,
@@ -49,7 +50,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: WeheatConfigEntry) -> bo
     # fetch a list of the heat pumps the entry can access
     try:
         discovered_heat_pumps = await HeatPumpDiscovery.async_discover_active(
-            API_URL, token
+            API_URL, token, async_get_clientsession(hass)
         )
     except UnauthorizedException as error:
         raise ConfigEntryAuthFailed from error

--- a/homeassistant/components/weheat/config_flow.py
+++ b/homeassistant/components/weheat/config_flow.py
@@ -8,6 +8,7 @@ from weheat.abstractions.user import async_get_user_id_from_token
 
 from homeassistant.config_entries import SOURCE_REAUTH, ConfigFlowResult
 from homeassistant.const import CONF_ACCESS_TOKEN, CONF_TOKEN
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.config_entry_oauth2_flow import AbstractOAuth2FlowHandler
 
 from .const import API_URL, DOMAIN, ENTRY_TITLE, OAUTH2_SCOPES
@@ -34,7 +35,9 @@ class OAuth2FlowHandler(AbstractOAuth2FlowHandler, domain=DOMAIN):
         """Override the create entry method to change to the step to find the heat pumps."""
         # get the user id and use that as unique id for this entry
         user_id = await async_get_user_id_from_token(
-            API_URL, data[CONF_TOKEN][CONF_ACCESS_TOKEN]
+            API_URL,
+            data[CONF_TOKEN][CONF_ACCESS_TOKEN],
+            async_get_clientsession(self.hass),
         )
         await self.async_set_unique_id(user_id)
         if self.source != SOURCE_REAUTH:

--- a/homeassistant/components/weheat/coordinator.py
+++ b/homeassistant/components/weheat/coordinator.py
@@ -16,6 +16,7 @@ from weheat.exceptions import (
 from homeassistant.const import CONF_ACCESS_TOKEN
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.config_entry_oauth2_flow import OAuth2Session
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
@@ -47,7 +48,9 @@ class WeheatDataUpdateCoordinator(DataUpdateCoordinator[HeatPump]):
             update_interval=timedelta(seconds=UPDATE_INTERVAL),
         )
         self.heat_pump_info = heat_pump
-        self._heat_pump_data = HeatPump(API_URL, heat_pump.uuid)
+        self._heat_pump_data = HeatPump(
+            API_URL, heat_pump.uuid, async_get_clientsession(hass)
+        )
 
         self.session = session
 

--- a/homeassistant/components/weheat/manifest.json
+++ b/homeassistant/components/weheat/manifest.json
@@ -6,5 +6,5 @@
   "dependencies": ["application_credentials"],
   "documentation": "https://www.home-assistant.io/integrations/weheat",
   "iot_class": "cloud_polling",
-  "requirements": ["weheat==2025.1.14"]
+  "requirements": ["weheat==2025.1.15"]
 }

--- a/homeassistant/components/weheat/quality_scale.yaml
+++ b/homeassistant/components/weheat/quality_scale.yaml
@@ -88,9 +88,6 @@ rules:
       While unlikely to happen. Check if it is easily integrated.
 
   # Platinum
-  async-dependency:
-    status: todo
-    comment: |
-      Dependency uses asyncio.to_thread, but this is not real async.
-  inject-websession: todo
+  async-dependency: done
+  inject-websession: done
   strict-typing: todo

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3033,7 +3033,7 @@ webio-api==0.1.11
 webmin-xmlrpc==0.0.2
 
 # homeassistant.components.weheat
-weheat==2025.1.14
+weheat==2025.1.15
 
 # homeassistant.components.whirlpool
 whirlpool-sixth-sense==0.18.11

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2437,7 +2437,7 @@ webio-api==0.1.11
 webmin-xmlrpc==0.0.2
 
 # homeassistant.components.weheat
-weheat==2025.1.14
+weheat==2025.1.15
 
 # homeassistant.components.whirlpool
 whirlpool-sixth-sense==0.18.11


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Attempt number 2 for the async dependency.
Weheat bumped to 2025.1.15: https://github.com/wefabricate/wh-python/releases/tag/2025.1.15
It now uses aiohttp, which i think is the correct method. you can take a look [here](https://github.com/wefabricate/wh-python/blob/aa044d340d260ab435483557cf9a1f8a0d77e479/weheat/rest.py#L51)
Ran into [some known issues](https://developers.home-assistant.io/docs/asyncio_blocking_operations/#load_default_certs) so now it also takes the client session into weheat.
@epenet Thanks for that comment, you're welcome to review this as well. I learned something because of it.



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
