### PR TITLE
Update Python version for mypy to 3.13

### DIFF
--- a/homeassistant/components/http/static.py
+++ b/homeassistant/components/http/static.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from pathlib import Path
-from typing import TYPE_CHECKING, Final
+from typing import Final
 
 from aiohttp.hdrs import CACHE_CONTROL, CONTENT_TYPE
 from aiohttp.web import FileResponse, Request, StreamResponse
@@ -17,12 +17,7 @@ CACHE_HEADER = f"public, max-age={CACHE_TIME}"
 CACHE_HEADERS: Mapping[str, str] = {CACHE_CONTROL: CACHE_HEADER}
 RESPONSE_CACHE: LRU[tuple[str, Path], tuple[Path, str]] = LRU(512)
 
-if TYPE_CHECKING:
-    # mypy uses Python 3.12 syntax for type checking
-    # once it uses Python 3.13, this can be removed
-    _GUESSER = CONTENT_TYPES.guess_type
-else:
-    _GUESSER = CONTENT_TYPES.guess_file_type
+_GUESSER = CONTENT_TYPES.guess_file_type
 
 
 class CachingStaticResource(StaticResource):

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -1,8 +1,6 @@
 """Helpers for config validation using voluptuous."""
 
-# PEP 563 seems to break typing.get_type_hints when used
-# with PEP 695 syntax. Fixed in Python 3.13.
-# from __future__ import annotations
+from __future__ import annotations
 
 from collections.abc import Callable, Hashable, Mapping
 import contextlib
@@ -354,7 +352,7 @@ def ensure_list[_T](value: _T | None) -> list[_T] | list[Any]:
     """Wrap value in list if it is not one."""
     if value is None:
         return []
-    return cast("list[_T]", value) if isinstance(value, list) else [value]
+    return cast(list[_T], value) if isinstance(value, list) else [value]
 
 
 def entity_id(value: Any) -> str:

--- a/mypy.ini
+++ b/mypy.ini
@@ -3,7 +3,7 @@
 # To update, run python3 -m script.hassfest -p mypy_config
 
 [mypy]
-python_version = 3.12
+python_version = 3.13
 platform = linux
 plugins = pydantic.mypy, pydantic.v1.mypy
 show_error_codes = true

--- a/script/hassfest/mypy_config.py
+++ b/script/hassfest/mypy_config.py
@@ -9,6 +9,8 @@ import os
 from pathlib import Path
 from typing import Final
 
+from homeassistant.const import REQUIRED_PYTHON_VER
+
 from .model import Config, Integration
 
 # Component modules which should set no_implicit_reexport = true.
@@ -29,18 +31,7 @@ HEADER: Final = """
 """.lstrip()
 
 GENERAL_SETTINGS: Final[dict[str, str]] = {
-    # We use @dataclass_transform in all our EntityDescriptions, causing
-    # `__replace__` to be already synthesized by mypy, causing **every** use of
-    # our entity descriptions to fail:
-    #
-    # error: Signature of "__replace__" incompatible with supertype "EntityDescription"
-    #
-    # Until this is fixed in mypy, we keep mypy locked on to Python 3.12 as we
-    # have done for the past few releases.
-    #
-    # Ref: https://github.com/python/mypy/issues/18216
-    # "python_version": ".".join(str(x) for x in REQUIRED_PYTHON_VER[:2]),
-    "python_version": "3.12",
+    "python_version": ".".join(str(x) for x in REQUIRED_PYTHON_VER[:2]),
     "platform": "linux",
     "plugins": ", ".join(  # noqa: FLY002
         [


### PR DESCRIPTION
## Proposed change
Followup to #135589

Update the Python version for mypy to 3.13 now that the LSP violations issue is fixed.

--
Refs
- https://github.com/python/mypy/pull/18464
- #135633

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
