### PR TITLE
Move ZeroconfServiceInfo to service_info helpers

### DIFF
--- a/homeassistant/components/bang_olufsen/config_flow.py
+++ b/homeassistant/components/bang_olufsen/config_flow.py
@@ -10,10 +10,10 @@ from mozart_api.exceptions import ApiException
 from mozart_api.mozart_client import MozartClient
 import voluptuous as vol
 
-from homeassistant.components.zeroconf import ZeroconfServiceInfo
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_HOST, CONF_MODEL
 from homeassistant.helpers.selector import SelectSelector, SelectSelectorConfig
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 from homeassistant.util.ssl import get_default_context
 
 from .const import (

--- a/homeassistant/components/brother/config_flow.py
+++ b/homeassistant/components/brother/config_flow.py
@@ -7,12 +7,12 @@ from typing import Any
 from brother import Brother, SnmpError, UnsupportedModelError
 import voluptuous as vol
 
-from homeassistant.components import zeroconf
 from homeassistant.components.snmp import async_get_snmp_engine
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_HOST, CONF_TYPE
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 from homeassistant.util.network import is_host_valid
 
 from .const import DOMAIN, PRINTER_TYPES
@@ -83,7 +83,7 @@ class BrotherConfigFlow(ConfigFlow, domain=DOMAIN):
         )
 
     async def async_step_zeroconf(
-        self, discovery_info: zeroconf.ZeroconfServiceInfo
+        self, discovery_info: ZeroconfServiceInfo
     ) -> ConfigFlowResult:
         """Handle zeroconf discovery."""
         self.host = discovery_info.host

--- a/homeassistant/components/eheimdigital/config_flow.py
+++ b/homeassistant/components/eheimdigital/config_flow.py
@@ -10,11 +10,11 @@ from eheimdigital.device import EheimDigitalDevice
 from eheimdigital.hub import EheimDigitalHub
 import voluptuous as vol
 
-from homeassistant.components.zeroconf import ZeroconfServiceInfo
 from homeassistant.config_entries import SOURCE_USER, ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_HOST
 from homeassistant.helpers import selector
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from .const import DOMAIN, LOGGER
 

--- a/homeassistant/components/elmax/config_flow.py
+++ b/homeassistant/components/elmax/config_flow.py
@@ -12,9 +12,9 @@ from elmax_api.model.panel import PanelEntry, PanelStatus
 import httpx
 import voluptuous as vol
 
-from homeassistant.components.zeroconf import ZeroconfServiceInfo
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from .common import (
     build_direct_ssl_context,

--- a/homeassistant/components/kodi/config_flow.py
+++ b/homeassistant/components/kodi/config_flow.py
@@ -8,7 +8,6 @@ from typing import Any
 from pykodi import CannotConnectError, InvalidAuthError, Kodi, get_kodi_connection
 import voluptuous as vol
 
-from homeassistant.components import zeroconf
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import (
     CONF_HOST,
@@ -22,6 +21,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from .const import (
     CONF_WS_PORT,
@@ -103,7 +103,7 @@ class KodiConfigFlow(ConfigFlow, domain=DOMAIN):
         self._discovery_name: str | None = None
 
     async def async_step_zeroconf(
-        self, discovery_info: zeroconf.ZeroconfServiceInfo
+        self, discovery_info: ZeroconfServiceInfo
     ) -> ConfigFlowResult:
         """Handle zeroconf discovery."""
         self._host = discovery_info.host

--- a/homeassistant/components/lektrico/config_flow.py
+++ b/homeassistant/components/lektrico/config_flow.py
@@ -7,7 +7,6 @@ from typing import Any
 from lektricowifi import Device, DeviceConnectionError
 import voluptuous as vol
 
-from homeassistant.components.zeroconf import ZeroconfServiceInfo
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import (
     ATTR_HW_VERSION,
@@ -17,6 +16,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import callback
 from homeassistant.helpers.httpx_client import get_async_client
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from .const import DOMAIN
 

--- a/homeassistant/components/loqed/config_flow.py
+++ b/homeassistant/components/loqed/config_flow.py
@@ -11,12 +11,12 @@ from loqedAPI import cloud_loqed, loqed
 import voluptuous as vol
 
 from homeassistant.components import webhook
-from homeassistant.components.zeroconf import ZeroconfServiceInfo
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_API_TOKEN, CONF_NAME, CONF_WEBHOOK_ID
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from .const import DOMAIN
 

--- a/homeassistant/components/matter/config_flow.py
+++ b/homeassistant/components/matter/config_flow.py
@@ -16,7 +16,6 @@ from homeassistant.components.hassio import (
     AddonState,
 )
 from homeassistant.components.onboarding import async_is_onboarded
-from homeassistant.components.zeroconf import ZeroconfServiceInfo
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_URL
 from homeassistant.core import HomeAssistant
@@ -25,6 +24,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import aiohttp_client
 from homeassistant.helpers.hassio import is_hassio
 from homeassistant.helpers.service_info.hassio import HassioServiceInfo
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from .addon import get_addon_manager
 from .const import (

--- a/homeassistant/components/plugwise/config_flow.py
+++ b/homeassistant/components/plugwise/config_flow.py
@@ -16,7 +16,6 @@ from plugwise.exceptions import (
 )
 import voluptuous as vol
 
-from homeassistant.components.zeroconf import ZeroconfServiceInfo
 from homeassistant.config_entries import SOURCE_USER, ConfigFlow, ConfigFlowResult
 from homeassistant.const import (
     ATTR_CONFIGURATION_URL,
@@ -29,6 +28,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from .const import (
     DEFAULT_PORT,

--- a/homeassistant/components/shelly/config_flow.py
+++ b/homeassistant/components/shelly/config_flow.py
@@ -17,7 +17,6 @@ from aioshelly.exceptions import (
 from aioshelly.rpc_device import RpcDevice
 import voluptuous as vol
 
-from homeassistant.components.zeroconf import ZeroconfServiceInfo
 from homeassistant.config_entries import (
     ConfigEntry,
     ConfigFlow,
@@ -34,6 +33,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.selector import SelectSelector, SelectSelectorConfig
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from .const import (
     CONF_BLE_SCANNER_MODE,

--- a/homeassistant/components/slide_local/config_flow.py
+++ b/homeassistant/components/slide_local/config_flow.py
@@ -14,11 +14,11 @@ from goslideapi.goslideapi import (
 )
 import voluptuous as vol
 
-from homeassistant.components.zeroconf import ZeroconfServiceInfo
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult, OptionsFlow
 from homeassistant.const import CONF_API_VERSION, CONF_HOST, CONF_MAC, CONF_PASSWORD
 from homeassistant.core import callback
 from homeassistant.helpers.device_registry import format_mac
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from . import SlideConfigEntry
 from .const import CONF_INVERT_POSITION, DOMAIN

--- a/homeassistant/components/soundtouch/config_flow.py
+++ b/homeassistant/components/soundtouch/config_flow.py
@@ -6,10 +6,10 @@ from libsoundtouch import soundtouch_device
 from requests import RequestException
 import voluptuous as vol
 
-from homeassistant.components.zeroconf import ZeroconfServiceInfo
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_HOST
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from .const import DOMAIN
 

--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 import contextlib
 from contextlib import suppress
-from dataclasses import dataclass
 from fnmatch import translate
-from functools import lru_cache
+from functools import lru_cache, partial
 from ipaddress import IPv4Address, IPv6Address
 import logging
 import re
@@ -30,12 +29,19 @@ from homeassistant.const import (
     __version__,
 )
 from homeassistant.core import Event, HomeAssistant, callback
-from homeassistant.data_entry_flow import BaseServiceInfo
-from homeassistant.helpers import discovery_flow, instance_id
-import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers import config_validation as cv, discovery_flow, instance_id
+from homeassistant.helpers.deprecation import (
+    DeprecatedConstant,
+    all_with_deprecated_constants,
+    check_if_deprecated_constant,
+    dir_with_deprecated_constants,
+)
 from homeassistant.helpers.discovery_flow import DiscoveryKey
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.network import NoURLAvailableError, get_url
+from homeassistant.helpers.service_info.zeroconf import (
+    ZeroconfServiceInfo as _ZeroconfServiceInfo,
+)
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.loader import (
     HomeKitDiscoveredIntegration,
@@ -101,45 +107,11 @@ CONFIG_SCHEMA = vol.Schema(
     extra=vol.ALLOW_EXTRA,
 )
 
-
-@dataclass(slots=True)
-class ZeroconfServiceInfo(BaseServiceInfo):
-    """Prepared info from mDNS entries.
-
-    The ip_address is the most recently updated address
-    that is not a link local or unspecified address.
-
-    The ip_addresses are all addresses in order of most
-    recently updated to least recently updated.
-
-    The host is the string representation of the ip_address.
-
-    The addresses are the string representations of the
-    ip_addresses.
-
-    It is recommended to use the ip_address to determine
-    the address to connect to as it will be the most
-    recently updated address that is not a link local
-    or unspecified address.
-    """
-
-    ip_address: IPv4Address | IPv6Address
-    ip_addresses: list[IPv4Address | IPv6Address]
-    port: int | None
-    hostname: str
-    type: str
-    name: str
-    properties: dict[str, Any]
-
-    @property
-    def host(self) -> str:
-        """Return the host."""
-        return str(self.ip_address)
-
-    @property
-    def addresses(self) -> list[str]:
-        """Return the addresses."""
-        return [str(ip_address) for ip_address in self.ip_addresses]
+_DEPRECATED_HassioServiceInfo = DeprecatedConstant(
+    _ZeroconfServiceInfo,
+    "homeassistant.helpers.service_info.zeroconf.ZeroconfServiceInfo",
+    "2025.11",
+)
 
 
 @bind_hass
@@ -419,7 +391,7 @@ class ZeroconfDiscovery:
     def _async_dismiss_discoveries(self, name: str) -> None:
         """Dismiss all discoveries for the given name."""
         for flow in self.hass.config_entries.flow.async_progress_by_init_data_type(
-            ZeroconfServiceInfo,
+            _ZeroconfServiceInfo,
             lambda service_info: bool(service_info.name == name),
         ):
             self.hass.config_entries.flow.async_abort(flow["flow_id"])
@@ -595,7 +567,7 @@ def async_get_homekit_discovery(
     return None
 
 
-def info_from_service(service: AsyncServiceInfo) -> ZeroconfServiceInfo | None:
+def info_from_service(service: AsyncServiceInfo) -> _ZeroconfServiceInfo | None:
     """Return prepared info from mDNS entries."""
     # See https://ietf.org/rfc/rfc6763.html#section-6.4 and
     # https://ietf.org/rfc/rfc6763.html#section-6.5 for expected encodings
@@ -618,7 +590,7 @@ def info_from_service(service: AsyncServiceInfo) -> ZeroconfServiceInfo | None:
         assert service.server is not None, (
             "server cannot be none if there are addresses"
         )
-    return ZeroconfServiceInfo(
+    return _ZeroconfServiceInfo(
         ip_address=ip_address,
         ip_addresses=ip_addresses,
         port=service.port,
@@ -684,3 +656,11 @@ def _memorized_fnmatch(name: str, pattern: str) -> bool:
     since the devices will not change frequently
     """
     return bool(_compile_fnmatch(pattern).match(name))
+
+
+# These can be removed if no deprecated constant are in this module anymore
+__getattr__ = partial(check_if_deprecated_constant, module_globals=globals())
+__dir__ = partial(
+    dir_with_deprecated_constants, module_globals_keys=[*globals().keys()]
+)
+__all__ = all_with_deprecated_constants(globals())

--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -110,7 +110,7 @@ CONFIG_SCHEMA = vol.Schema(
 _DEPRECATED_HassioServiceInfo = DeprecatedConstant(
     _ZeroconfServiceInfo,
     "homeassistant.helpers.service_info.zeroconf.ZeroconfServiceInfo",
-    "2025.11",
+    "2026.2",
 )
 
 

--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -107,7 +107,7 @@ CONFIG_SCHEMA = vol.Schema(
     extra=vol.ALLOW_EXTRA,
 )
 
-_DEPRECATED_HassioServiceInfo = DeprecatedConstant(
+_DEPRECATED_ZeroconfServiceInfo = DeprecatedConstant(
     _ZeroconfServiceInfo,
     "homeassistant.helpers.service_info.zeroconf.ZeroconfServiceInfo",
     "2026.2",

--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -40,6 +40,7 @@ from homeassistant.helpers.discovery_flow import DiscoveryKey
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.network import NoURLAvailableError, get_url
 from homeassistant.helpers.service_info.zeroconf import (
+    ATTR_PROPERTIES_ID as _ATTR_PROPERTIES_ID,
     ZeroconfServiceInfo as _ZeroconfServiceInfo,
 )
 from homeassistant.helpers.typing import ConfigType
@@ -89,7 +90,11 @@ ATTR_NAME: Final = "name"
 ATTR_PROPERTIES: Final = "properties"
 
 # Attributes for ZeroconfServiceInfo[ATTR_PROPERTIES]
-ATTR_PROPERTIES_ID: Final = "id"
+_DEPRECATED_ATTR_PROPERTIES_ID = DeprecatedConstant(
+    _ATTR_PROPERTIES_ID,
+    "homeassistant.helpers.service_info.zeroconf.ATTR_PROPERTIES_ID",
+    "2026.2",
+)
 
 CONFIG_SCHEMA = vol.Schema(
     {

--- a/homeassistant/components/zwave_js/config_flow.py
+++ b/homeassistant/components/zwave_js/config_flow.py
@@ -19,7 +19,6 @@ from homeassistant.components.hassio import (
     AddonManager,
     AddonState,
 )
-from homeassistant.components.zeroconf import ZeroconfServiceInfo
 from homeassistant.config_entries import (
     SOURCE_USB,
     ConfigEntriesFlowManager,
@@ -39,6 +38,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.hassio import is_hassio
 from homeassistant.helpers.service_info.hassio import HassioServiceInfo
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 from homeassistant.helpers.typing import VolDictType
 
 from . import disconnect_client

--- a/homeassistant/components/zwave_me/config_flow.py
+++ b/homeassistant/components/zwave_me/config_flow.py
@@ -7,9 +7,9 @@ import logging
 from url_normalize import url_normalize
 import voluptuous as vol
 
-from homeassistant.components.zeroconf import ZeroconfServiceInfo
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_TOKEN, CONF_URL
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from . import helpers
 from .const import DOMAIN

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -91,9 +91,9 @@ if TYPE_CHECKING:
     from .components.dhcp import DhcpServiceInfo
     from .components.ssdp import SsdpServiceInfo
     from .components.usb import UsbServiceInfo
-    from .components.zeroconf import ZeroconfServiceInfo
     from .helpers.service_info.hassio import HassioServiceInfo
     from .helpers.service_info.mqtt import MqttServiceInfo
+    from .helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/helpers/config_entry_flow.py
+++ b/homeassistant/helpers/config_entry_flow.py
@@ -18,9 +18,9 @@ if TYPE_CHECKING:
     from homeassistant.components.bluetooth import BluetoothServiceInfoBleak
     from homeassistant.components.dhcp import DhcpServiceInfo
     from homeassistant.components.ssdp import SsdpServiceInfo
-    from homeassistant.components.zeroconf import ZeroconfServiceInfo
 
     from .service_info.mqtt import MqttServiceInfo
+    from .service_info.zeroconf import ZeroconfServiceInfo
 
 type DiscoveryFunctionType[_R] = Callable[[HomeAssistant], _R]
 

--- a/homeassistant/helpers/service_info/zeroconf.py
+++ b/homeassistant/helpers/service_info/zeroconf.py
@@ -2,9 +2,12 @@
 
 from dataclasses import dataclass
 from ipaddress import IPv4Address, IPv6Address
-from typing import Any
+from typing import Any, Final
 
 from homeassistant.data_entry_flow import BaseServiceInfo
+
+# Attributes for ZeroconfServiceInfo[ATTR_PROPERTIES]
+ATTR_PROPERTIES_ID: Final = "id"
 
 
 @dataclass(slots=True)

--- a/homeassistant/helpers/service_info/zeroconf.py
+++ b/homeassistant/helpers/service_info/zeroconf.py
@@ -1,0 +1,47 @@
+"""Zeroconf discovery data."""
+
+from dataclasses import dataclass
+from ipaddress import IPv4Address, IPv6Address
+from typing import Any
+
+from homeassistant.data_entry_flow import BaseServiceInfo
+
+
+@dataclass(slots=True)
+class ZeroconfServiceInfo(BaseServiceInfo):
+    """Prepared info from mDNS entries.
+
+    The ip_address is the most recently updated address
+    that is not a link local or unspecified address.
+
+    The ip_addresses are all addresses in order of most
+    recently updated to least recently updated.
+
+    The host is the string representation of the ip_address.
+
+    The addresses are the string representations of the
+    ip_addresses.
+
+    It is recommended to use the ip_address to determine
+    the address to connect to as it will be the most
+    recently updated address that is not a link local
+    or unspecified address.
+    """
+
+    ip_address: IPv4Address | IPv6Address
+    ip_addresses: list[IPv4Address | IPv6Address]
+    port: int | None
+    hostname: str
+    type: str
+    name: str
+    properties: dict[str, Any]
+
+    @property
+    def host(self) -> str:
+        """Return the host."""
+        return str(self.ip_address)
+
+    @property
+    def addresses(self) -> list[str]:
+        """Return the addresses."""
+        return [str(ip_address) for ip_address in self.ip_addresses]

--- a/tests/components/airgradient/test_config_flow.py
+++ b/tests/components/airgradient/test_config_flow.py
@@ -10,11 +10,11 @@ from airgradient import (
 )
 
 from homeassistant.components.airgradient.const import DOMAIN
-from homeassistant.components.zeroconf import ZeroconfServiceInfo
 from homeassistant.config_entries import SOURCE_USER, SOURCE_ZEROCONF
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from tests.common import MockConfigEntry
 

--- a/tests/components/bang_olufsen/const.py
+++ b/tests/components/bang_olufsen/const.py
@@ -31,8 +31,8 @@ from homeassistant.components.bang_olufsen.const import (
     CONF_BEOLINK_JID,
     BangOlufsenSource,
 )
-from homeassistant.components.zeroconf import ZeroconfServiceInfo
 from homeassistant.const import CONF_HOST, CONF_MODEL, CONF_NAME
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 TEST_HOST = "192.168.0.1"
 TEST_HOST_INVALID = "192.168.0"

--- a/tests/components/bluesound/test_config_flow.py
+++ b/tests/components/bluesound/test_config_flow.py
@@ -5,11 +5,11 @@ from unittest.mock import AsyncMock
 from pyblu.errors import PlayerUnreachableError
 
 from homeassistant.components.bluesound.const import DOMAIN
-from homeassistant.components.zeroconf import ZeroconfServiceInfo
 from homeassistant.config_entries import SOURCE_USER, SOURCE_ZEROCONF
 from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from .conftest import PlayerMocks
 

--- a/tests/components/cambridge_audio/test_config_flow.py
+++ b/tests/components/cambridge_audio/test_config_flow.py
@@ -6,11 +6,11 @@ from unittest.mock import AsyncMock
 from aiostreammagic import StreamMagicError
 
 from homeassistant.components.cambridge_audio.const import DOMAIN
-from homeassistant.components.zeroconf import ZeroconfServiceInfo
 from homeassistant.config_entries import SOURCE_USER, SOURCE_ZEROCONF, ConfigFlowResult
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from tests.common import MockConfigEntry
 

--- a/tests/components/devolo_home_network/const.py
+++ b/tests/components/devolo_home_network/const.py
@@ -14,7 +14,7 @@ from devolo_plc_api.device_api import (
 )
 from devolo_plc_api.plcnet_api import LOCAL, REMOTE, LogicalNetwork
 
-from homeassistant.components.zeroconf import ZeroconfServiceInfo
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 IP = "192.0.2.1"
 IP_ALT = "192.0.2.2"

--- a/tests/components/eheimdigital/test_config_flow.py
+++ b/tests/components/eheimdigital/test_config_flow.py
@@ -7,11 +7,11 @@ from aiohttp import ClientConnectionError
 import pytest
 
 from homeassistant.components.eheimdigital.const import DOMAIN
-from homeassistant.components.zeroconf import ZeroconfServiceInfo
 from homeassistant.config_entries import SOURCE_USER, SOURCE_ZEROCONF
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 ZEROCONF_DISCOVERY = ZeroconfServiceInfo(
     ip_address=ip_address("192.0.2.1"),

--- a/tests/components/lektrico/conftest.py
+++ b/tests/components/lektrico/conftest.py
@@ -8,13 +8,13 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from homeassistant.components.lektrico.const import DOMAIN
-from homeassistant.components.zeroconf import ZeroconfServiceInfo
 from homeassistant.const import (
     ATTR_HW_VERSION,
     ATTR_SERIAL_NUMBER,
     CONF_HOST,
     CONF_TYPE,
 )
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from tests.common import MockConfigEntry, load_fixture
 

--- a/tests/components/linkplay/test_config_flow.py
+++ b/tests/components/linkplay/test_config_flow.py
@@ -7,11 +7,11 @@ from linkplay.exceptions import LinkPlayRequestException
 import pytest
 
 from homeassistant.components.linkplay.const import DOMAIN
-from homeassistant.components.zeroconf import ZeroconfServiceInfo
 from homeassistant.config_entries import SOURCE_USER, SOURCE_ZEROCONF
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from .conftest import HOST, HOST_REENTRY, NAME, UUID
 

--- a/tests/components/lookin/__init__.py
+++ b/tests/components/lookin/__init__.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 
 from aiolookin import Climate, Device, Remote
 
-from homeassistant.components.zeroconf import ZeroconfServiceInfo
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 DEVICE_ID = "98F33163"
 MODULE = "homeassistant.components.lookin"

--- a/tests/components/matter/test_config_flow.py
+++ b/tests/components/matter/test_config_flow.py
@@ -14,10 +14,10 @@ import pytest
 
 from homeassistant import config_entries
 from homeassistant.components.matter.const import ADDON_SLUG, DOMAIN
-from homeassistant.components.zeroconf import ZeroconfServiceInfo
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers.service_info.hassio import HassioServiceInfo
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from tests.common import MockConfigEntry
 

--- a/tests/components/music_assistant/test_config_flow.py
+++ b/tests/components/music_assistant/test_config_flow.py
@@ -15,10 +15,10 @@ import pytest
 
 from homeassistant.components.music_assistant.config_flow import CONF_URL
 from homeassistant.components.music_assistant.const import DEFAULT_NAME, DOMAIN
-from homeassistant.components.zeroconf import ZeroconfServiceInfo
 from homeassistant.config_entries import SOURCE_USER, SOURCE_ZEROCONF
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from tests.common import MockConfigEntry, load_fixture
 

--- a/tests/components/onewire/test_config_flow.py
+++ b/tests/components/onewire/test_config_flow.py
@@ -12,13 +12,13 @@ from homeassistant.components.onewire.const import (
     INPUT_ENTRY_DEVICE_SELECTION,
     MANUFACTURER_MAXIM,
 )
-from homeassistant.components.zeroconf import ZeroconfServiceInfo
 from homeassistant.config_entries import SOURCE_HASSIO, SOURCE_USER, SOURCE_ZEROCONF
 from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.service_info.hassio import HassioServiceInfo
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from tests.common import MockConfigEntry
 

--- a/tests/components/overkiz/test_config_flow.py
+++ b/tests/components/overkiz/test_config_flow.py
@@ -19,9 +19,9 @@ import pytest
 from homeassistant import config_entries
 from homeassistant.components import dhcp
 from homeassistant.components.overkiz.const import DOMAIN
-from homeassistant.components.zeroconf import ZeroconfServiceInfo
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from tests.common import MockConfigEntry
 

--- a/tests/components/plugwise/test_config_flow.py
+++ b/tests/components/plugwise/test_config_flow.py
@@ -13,7 +13,6 @@ from plugwise.exceptions import (
 import pytest
 
 from homeassistant.components.plugwise.const import DEFAULT_PORT, DOMAIN
-from homeassistant.components.zeroconf import ZeroconfServiceInfo
 from homeassistant.config_entries import SOURCE_USER, SOURCE_ZEROCONF, ConfigFlowResult
 from homeassistant.const import (
     CONF_HOST,
@@ -25,6 +24,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from tests.common import MockConfigEntry
 

--- a/tests/components/russound_rio/test_config_flow.py
+++ b/tests/components/russound_rio/test_config_flow.py
@@ -4,11 +4,11 @@ from ipaddress import ip_address
 from unittest.mock import AsyncMock
 
 from homeassistant.components.russound_rio.const import DOMAIN
-from homeassistant.components.zeroconf import ZeroconfServiceInfo
 from homeassistant.config_entries import SOURCE_USER, SOURCE_ZEROCONF, ConfigFlowResult
 from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from .const import MOCK_CONFIG, MOCK_RECONFIGURATION_CONFIG, MODEL
 

--- a/tests/components/slide_local/test_config_flow.py
+++ b/tests/components/slide_local/test_config_flow.py
@@ -12,11 +12,11 @@ from goslideapi.goslideapi import (
 import pytest
 
 from homeassistant.components.slide_local.const import CONF_INVERT_POSITION, DOMAIN
-from homeassistant.components.zeroconf import ZeroconfServiceInfo
 from homeassistant.config_entries import SOURCE_USER, SOURCE_ZEROCONF
 from homeassistant.const import CONF_API_VERSION, CONF_HOST, CONF_PASSWORD, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from . import setup_platform
 from .const import HOST, SLIDE_INFO_DATA

--- a/tests/components/soundtouch/test_config_flow.py
+++ b/tests/components/soundtouch/test_config_flow.py
@@ -8,11 +8,11 @@ import requests_mock
 from requests_mock import ANY, Mocker
 
 from homeassistant.components.soundtouch.const import DOMAIN
-from homeassistant.components.zeroconf import ZeroconfServiceInfo
 from homeassistant.config_entries import SOURCE_USER, SOURCE_ZEROCONF
 from homeassistant.const import CONF_HOST, CONF_SOURCE
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from .conftest import DEVICE_1_ID, DEVICE_1_IP, DEVICE_1_NAME
 

--- a/tests/components/wyoming/test_config_flow.py
+++ b/tests/components/wyoming/test_config_flow.py
@@ -9,10 +9,10 @@ from wyoming.info import Info
 
 from homeassistant import config_entries
 from homeassistant.components.wyoming.const import DOMAIN
-from homeassistant.components.zeroconf import ZeroconfServiceInfo
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers.service_info.hassio import HassioServiceInfo
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from . import EMPTY_INFO, SATELLITE_INFO, STT_INFO, TTS_INFO
 

--- a/tests/components/zeroconf/test_init.py
+++ b/tests/components/zeroconf/test_init.py
@@ -24,7 +24,10 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.generated import zeroconf as zc_gen
 from homeassistant.helpers.discovery_flow import DiscoveryKey
-from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
+from homeassistant.helpers.service_info.zeroconf import (
+    ATTR_PROPERTIES_ID,
+    ZeroconfServiceInfo,
+)
 from homeassistant.setup import ATTR_COMPONENT, async_setup_component
 
 from tests.common import (
@@ -1666,6 +1669,11 @@ async def test_zeroconf_rediscover_no_match(
 @pytest.mark.parametrize(
     ("constant_name", "replacement_name", "replacement"),
     [
+        (
+            "ATTR_PROPERTIES_ID",
+            "homeassistant.helpers.service_info.zeroconf.ATTR_PROPERTIES_ID",
+            ATTR_PROPERTIES_ID,
+        ),
         (
             "ZeroconfServiceInfo",
             "homeassistant.helpers.service_info.zeroconf.ZeroconfServiceInfo",

--- a/tests/components/zeroconf/test_init.py
+++ b/tests/components/zeroconf/test_init.py
@@ -24,9 +24,15 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.generated import zeroconf as zc_gen
 from homeassistant.helpers.discovery_flow import DiscoveryKey
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 from homeassistant.setup import ATTR_COMPONENT, async_setup_component
 
-from tests.common import MockConfigEntry, MockModule, mock_integration
+from tests.common import (
+    MockConfigEntry,
+    MockModule,
+    import_and_test_deprecated_constant,
+    mock_integration,
+)
 
 NON_UTF8_VALUE = b"ABCDEF\x8a"
 NON_ASCII_KEY = b"non-ascii-key\x8a"
@@ -1655,3 +1661,30 @@ async def test_zeroconf_rediscover_no_match(
 
         assert len(mock_service_browser.mock_calls) == 1
         assert len(mock_config_flow.mock_calls) == 1
+
+
+@pytest.mark.parametrize(
+    ("constant_name", "replacement_name", "replacement"),
+    [
+        (
+            "ZeroconfServiceInfo",
+            "homeassistant.helpers.service_info.zeroconf.ZeroconfServiceInfo",
+            ZeroconfServiceInfo,
+        ),
+    ],
+)
+def test_deprecated_constants(
+    caplog: pytest.LogCaptureFixture,
+    constant_name: str,
+    replacement_name: str,
+    replacement: Any,
+) -> None:
+    """Test deprecated automation constants."""
+    import_and_test_deprecated_constant(
+        caplog,
+        zeroconf,
+        constant_name,
+        replacement_name,
+        replacement,
+        "2026.2",
+    )

--- a/tests/components/zwave_js/test_config_flow.py
+++ b/tests/components/zwave_js/test_config_flow.py
@@ -17,12 +17,12 @@ from zwave_js_server.version import VersionInfo
 
 from homeassistant import config_entries
 from homeassistant.components import usb
-from homeassistant.components.zeroconf import ZeroconfServiceInfo
 from homeassistant.components.zwave_js.config_flow import SERVER_VERSION_TIMEOUT, TITLE
 from homeassistant.components.zwave_js.const import ADDON_SLUG, DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers.service_info.hassio import HassioServiceInfo
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from tests.common import MockConfigEntry
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
For developers only: please import ZeroconfServiceInfo from `homeassistant.helpers.service_info.zeroconf`

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Move ZeroconfServiceInfo to service_info helpers, to avoid import issues when zeroconf is not enabled

Based on https://github.com/home-assistant/core/pull/135373#issuecomment-2591789692

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/2532

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
