### PR TITLE
Fix grammar and plural handling in action descriptions

### DIFF
--- a/homeassistant/components/soundtouch/strings.json
+++ b/homeassistant/components/soundtouch/strings.json
@@ -42,13 +42,13 @@
         },
         "slaves": {
           "name": "Slaves",
-          "description": "Name of slaves entities to add to the new zone."
+          "description": "Names of slave entities to add to the new zone."
         }
       }
     },
     "add_zone_slave": {
       "name": "Add zone slave",
-      "description": "Adds a slave to a SoundTouch multi-room zone.",
+      "description": "Adds slaves to a SoundTouch multi-room zone.",
       "fields": {
         "master": {
           "name": "Master",
@@ -56,13 +56,13 @@
         },
         "slaves": {
           "name": "[%key:component::soundtouch::services::create_zone::fields::slaves::name%]",
-          "description": "Name of slaves entities to add to the existing zone."
+          "description": "Names of slave entities to add to the existing zone."
         }
       }
     },
     "remove_zone_slave": {
       "name": "Remove zone slave",
-      "description": "Removes a slave from the SoundTouch multi-room zone.",
+      "description": "Removes slaves from a SoundTouch multi-room zone.",
       "fields": {
         "master": {
           "name": "Master",
@@ -70,7 +70,7 @@
         },
         "slaves": {
           "name": "[%key:component::soundtouch::services::create_zone::fields::slaves::name%]",
-          "description": "Name of slaves entities to remove from the existing zone."
+          "description": "Names of slave entities to remove from the existing zone."
         }
       }
     }

--- a/homeassistant/components/soundtouch/strings.json
+++ b/homeassistant/components/soundtouch/strings.json
@@ -51,7 +51,7 @@
       "description": "Adds media players to a SoundTouch multi-room zone.",
       "fields": {
         "master": {
-          "name": "Leader",
+          "name": "[%key:component::soundtouch::services::create_zone::fields::master::name%]",
           "description": "The media player entity that is coordinating the multi-room zone. Platform dependent."
         },
         "slaves": {
@@ -65,7 +65,7 @@
       "description": "Removes media players from a SoundTouch multi-room zone.",
       "fields": {
         "master": {
-          "name": "Leader",
+          "name": "[%key:component::soundtouch::services::create_zone::fields::master::name%]",
           "description": "[%key:component::soundtouch::services::add_zone_slave::fields::master::description%]"
         },
         "slaves": {

--- a/homeassistant/components/soundtouch/strings.json
+++ b/homeassistant/components/soundtouch/strings.json
@@ -27,8 +27,8 @@
       "description": "Plays on all Bose SoundTouch devices.",
       "fields": {
         "master": {
-          "name": "Master",
-          "description": "Name of the master entity that will coordinate the grouping. Platform dependent. It is a shortcut for creating a multi-room zone with all devices."
+          "name": "Leader",
+          "description": "The media player entity that will coordinate the grouping. Platform dependent. It is a shortcut for creating a multi-room zone with all devices."
         }
       }
     },
@@ -37,40 +37,40 @@
       "description": "Creates a SoundTouch multi-room zone.",
       "fields": {
         "master": {
-          "name": "Master",
-          "description": "Name of the master entity that will coordinate the multi-room zone. Platform dependent."
+          "name": "Leader",
+          "description": "The media player entity that will coordinate the multi-room zone. Platform dependent."
         },
         "slaves": {
-          "name": "Slaves",
-          "description": "Names of slave entities to add to the new zone."
+          "name": "Follower",
+          "description": "The media player entities to add to the new zone."
         }
       }
     },
     "add_zone_slave": {
-      "name": "Add zone slave",
-      "description": "Adds slaves to a SoundTouch multi-room zone.",
+      "name": "Add zone follower",
+      "description": "Adds media players to a SoundTouch multi-room zone.",
       "fields": {
         "master": {
-          "name": "Master",
-          "description": "Name of the master entity that is coordinating the multi-room zone. Platform dependent."
+          "name": "Leader",
+          "description": "The media player entity that is coordinating the multi-room zone. Platform dependent."
         },
         "slaves": {
           "name": "[%key:component::soundtouch::services::create_zone::fields::slaves::name%]",
-          "description": "Names of slave entities to add to the existing zone."
+          "description": "The media player entities to add to the existing zone."
         }
       }
     },
     "remove_zone_slave": {
-      "name": "Remove zone slave",
-      "description": "Removes slaves from a SoundTouch multi-room zone.",
+      "name": "Remove zone follower",
+      "description": "Removes media players from a SoundTouch multi-room zone.",
       "fields": {
         "master": {
-          "name": "Master",
+          "name": "Leader",
           "description": "[%key:component::soundtouch::services::add_zone_slave::fields::master::description%]"
         },
         "slaves": {
           "name": "[%key:component::soundtouch::services::create_zone::fields::slaves::name%]",
-          "description": "Names of slave entities to remove from the existing zone."
+          "description": "The media player entities to remove from the existing zone."
         }
       }
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The three Soundtouch actions 
- create_zone
- add_zone_slave
- remove_zone_slave

all take a list of slave entity IDs as arguments. [See the online documentation](https://www.home-assistant.io/integrations/soundtouch/#action-create_zone).

This PR changes the descriptions in the UI to correctly reflect that along with replacing "master" / "slave" with "leader" / "follower".

Along with that this also fixes the grammar mistake in "Name of slaves entities" by replacing this with "Names of slave entities" and replaces "the … zone" with "a … zone" to make the corresponding action descriptions consistent.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
