### PR TITLE
New paint_theme service added to the LIFX integration

### DIFF
--- a/homeassistant/components/lifx/icons.json
+++ b/homeassistant/components/lifx/icons.json
@@ -26,6 +26,9 @@
     },
     "effect_stop": {
       "service": "mdi:stop"
+    },
+    "paint_theme": {
+      "service": "mdi:palette"
     }
   }
 }

--- a/homeassistant/components/lifx/manager.py
+++ b/homeassistant/components/lifx/manager.py
@@ -338,6 +338,203 @@ class LIFXManager:
 
         return theme
 
+    async def _start_effect_flame(
+        self,
+        bulbs: list[Light],
+        coordinators: list[LIFXUpdateCoordinator],
+        **kwargs: Any,
+    ) -> None:
+        """Start the firmware-based Flame effect."""
+
+        await asyncio.gather(
+            *(
+                coordinator.async_set_matrix_effect(
+                    effect=EFFECT_FLAME,
+                    speed=kwargs.get(ATTR_SPEED, EFFECT_FLAME_DEFAULT_SPEED),
+                    power_on=kwargs.get(ATTR_POWER_ON, True),
+                )
+                for coordinator in coordinators
+            )
+        )
+
+    async def _start_paint_theme(
+        self,
+        bulbs: list[Light],
+        coordinators: list[LIFXUpdateCoordinator],
+        **kwargs: Any,
+    ) -> None:
+        """Paint a theme across one or more LIFX bulbs."""
+        theme_name = kwargs.get(ATTR_THEME, "exciting")
+        palette = kwargs.get(ATTR_PALETTE)
+
+        theme = self.build_theme(theme_name, palette)
+
+        await ThemePainter(self.hass.loop).paint(
+            theme,
+            bulbs,
+            duration=kwargs.get(ATTR_TRANSITION, PAINT_THEME_DEFAULT_TRANSITION),
+            power_on=kwargs.get(ATTR_POWER_ON, True),
+        )
+
+    async def _start_effect_morph(
+        self,
+        bulbs: list[Light],
+        coordinators: list[LIFXUpdateCoordinator],
+        **kwargs: Any,
+    ) -> None:
+        """Start the firmware-based Morph effect."""
+        theme_name = kwargs.get(ATTR_THEME, "exciting")
+        palette = kwargs.get(ATTR_PALETTE)
+
+        theme = self.build_theme(theme_name, palette)
+
+        await asyncio.gather(
+            *(
+                coordinator.async_set_matrix_effect(
+                    effect=EFFECT_MORPH,
+                    speed=kwargs.get(ATTR_SPEED, EFFECT_MORPH_DEFAULT_SPEED),
+                    palette=theme.colors,
+                    power_on=kwargs.get(ATTR_POWER_ON, True),
+                )
+                for coordinator in coordinators
+            )
+        )
+
+    async def _start_effect_move(
+        self,
+        bulbs: list[Light],
+        coordinators: list[LIFXUpdateCoordinator],
+        **kwargs: Any,
+    ) -> None:
+        """Start the firmware-based Move effect."""
+        await asyncio.gather(
+            *(
+                coordinator.async_set_multizone_effect(
+                    effect=EFFECT_MOVE,
+                    speed=kwargs.get(ATTR_SPEED, EFFECT_MOVE_DEFAULT_SPEED),
+                    direction=kwargs.get(ATTR_DIRECTION, EFFECT_MOVE_DEFAULT_DIRECTION),
+                    theme_name=kwargs.get(ATTR_THEME),
+                    power_on=kwargs.get(ATTR_POWER_ON, False),
+                )
+                for coordinator in coordinators
+            )
+        )
+
+    async def _start_effect_pulse(
+        self,
+        bulbs: list[Light],
+        coordinators: list[LIFXUpdateCoordinator],
+        **kwargs: Any,
+    ) -> None:
+        """Start the software-based Pulse effect."""
+        effect = aiolifx_effects.EffectPulse(
+            power_on=bool(kwargs.get(ATTR_POWER_ON)),
+            period=kwargs.get(ATTR_PERIOD),
+            cycles=kwargs.get(ATTR_CYCLES),
+            mode=kwargs.get(ATTR_MODE),
+            hsbk=find_hsbk(self.hass, **kwargs),
+        )
+        await self.effects_conductor.start(effect, bulbs)
+
+    async def _start_effect_colorloop(
+        self,
+        bulbs: list[Light],
+        coordinators: list[LIFXUpdateCoordinator],
+        **kwargs: Any,
+    ) -> None:
+        """Start the software based Color Loop effect."""
+        brightness = None
+        saturation_max = None
+        saturation_min = None
+
+        if ATTR_BRIGHTNESS in kwargs:
+            brightness = convert_8_to_16(kwargs[ATTR_BRIGHTNESS])
+        elif ATTR_BRIGHTNESS_PCT in kwargs:
+            brightness = convert_8_to_16(round(255 * kwargs[ATTR_BRIGHTNESS_PCT] / 100))
+
+        if ATTR_SATURATION_MAX in kwargs:
+            saturation_max = int(kwargs[ATTR_SATURATION_MAX] / 100 * 65535)
+
+        if ATTR_SATURATION_MIN in kwargs:
+            saturation_min = int(kwargs[ATTR_SATURATION_MIN] / 100 * 65535)
+
+        effect = aiolifx_effects.EffectColorloop(
+            power_on=bool(kwargs.get(ATTR_POWER_ON)),
+            period=kwargs.get(ATTR_PERIOD),
+            change=kwargs.get(ATTR_CHANGE),
+            spread=kwargs.get(ATTR_SPREAD),
+            transition=kwargs.get(ATTR_TRANSITION),
+            brightness=brightness,
+            saturation_max=saturation_max,
+            saturation_min=saturation_min,
+        )
+        await self.effects_conductor.start(effect, bulbs)
+
+    async def _start_effect_sky(
+        self,
+        bulbs: list[Light],
+        coordinators: list[LIFXUpdateCoordinator],
+        **kwargs: Any,
+    ) -> None:
+        """Start the firmware-based Sky effect."""
+        palette = kwargs.get(ATTR_PALETTE)
+        if palette is not None:
+            theme = Theme()
+            for hsbk in palette:
+                theme.add_hsbk(hsbk[0], hsbk[1], hsbk[2], hsbk[3])
+
+        speed = kwargs.get(ATTR_SPEED, EFFECT_SKY_DEFAULT_SPEED)
+        sky_type = kwargs.get(ATTR_SKY_TYPE, EFFECT_SKY_DEFAULT_SKY_TYPE)
+
+        cloud_saturation_min = kwargs.get(
+            ATTR_CLOUD_SATURATION_MIN,
+            EFFECT_SKY_DEFAULT_CLOUD_SATURATION_MIN,
+        )
+        cloud_saturation_max = kwargs.get(
+            ATTR_CLOUD_SATURATION_MAX,
+            EFFECT_SKY_DEFAULT_CLOUD_SATURATION_MAX,
+        )
+
+        await asyncio.gather(
+            *(
+                coordinator.async_set_matrix_effect(
+                    effect=EFFECT_SKY,
+                    speed=speed,
+                    sky_type=sky_type,
+                    cloud_saturation_min=cloud_saturation_min,
+                    cloud_saturation_max=cloud_saturation_max,
+                    palette=theme.colors,
+                )
+                for coordinator in coordinators
+            )
+        )
+
+    async def _start_effect_stop(
+        self,
+        bulbs: list[Light],
+        coordinators: list[LIFXUpdateCoordinator],
+        **kwargs: Any,
+    ) -> None:
+        """Stop any running software or firmware effect."""
+        await self.effects_conductor.stop(bulbs)
+
+        for coordinator in coordinators:
+            await coordinator.async_set_matrix_effect(effect=EFFECT_OFF, power_on=False)
+            await coordinator.async_set_multizone_effect(
+                effect=EFFECT_OFF, power_on=False
+            )
+
+    _effect_dispatch = {
+        SERVICE_EFFECT_COLORLOOP: _start_effect_colorloop,
+        SERVICE_EFFECT_FLAME: _start_effect_flame,
+        SERVICE_EFFECT_MORPH: _start_effect_morph,
+        SERVICE_EFFECT_MOVE: _start_effect_move,
+        SERVICE_EFFECT_PULSE: _start_effect_pulse,
+        SERVICE_EFFECT_SKY: _start_effect_sky,
+        SERVICE_EFFECT_STOP: _start_effect_stop,
+        SERVICE_PAINT_THEME: _start_paint_theme,
+    }
+
     async def start_effect(
         self, entity_ids: set[str], service: str, **kwargs: Any
     ) -> None:
@@ -354,145 +551,5 @@ class LIFXManager:
                 coordinators.append(coordinator)
                 bulbs.append(coordinator.device)
 
-        if service == SERVICE_EFFECT_FLAME:
-            await asyncio.gather(
-                *(
-                    coordinator.async_set_matrix_effect(
-                        effect=EFFECT_FLAME,
-                        speed=kwargs.get(ATTR_SPEED, EFFECT_FLAME_DEFAULT_SPEED),
-                        power_on=kwargs.get(ATTR_POWER_ON, True),
-                    )
-                    for coordinator in coordinators
-                )
-            )
-
-        elif service == SERVICE_PAINT_THEME:
-            theme_name = kwargs.get(ATTR_THEME, "exciting")
-            palette = kwargs.get(ATTR_PALETTE)
-
-            theme = self.build_theme(theme_name, palette)
-
-            await ThemePainter(self.hass.loop).paint(
-                theme,
-                bulbs,
-                duration=kwargs.get(ATTR_TRANSITION, PAINT_THEME_DEFAULT_TRANSITION),
-                power_on=kwargs.get(ATTR_POWER_ON, True),
-            )
-
-        elif service == SERVICE_EFFECT_MORPH:
-            theme_name = kwargs.get(ATTR_THEME, "exciting")
-            palette = kwargs.get(ATTR_PALETTE)
-
-            theme = self.build_theme(theme_name, palette)
-
-            await asyncio.gather(
-                *(
-                    coordinator.async_set_matrix_effect(
-                        effect=EFFECT_MORPH,
-                        speed=kwargs.get(ATTR_SPEED, EFFECT_MORPH_DEFAULT_SPEED),
-                        palette=theme.colors,
-                        power_on=kwargs.get(ATTR_POWER_ON, True),
-                    )
-                    for coordinator in coordinators
-                )
-            )
-
-        elif service == SERVICE_EFFECT_MOVE:
-            await asyncio.gather(
-                *(
-                    coordinator.async_set_multizone_effect(
-                        effect=EFFECT_MOVE,
-                        speed=kwargs.get(ATTR_SPEED, EFFECT_MOVE_DEFAULT_SPEED),
-                        direction=kwargs.get(
-                            ATTR_DIRECTION, EFFECT_MOVE_DEFAULT_DIRECTION
-                        ),
-                        theme_name=kwargs.get(ATTR_THEME),
-                        power_on=kwargs.get(ATTR_POWER_ON, False),
-                    )
-                    for coordinator in coordinators
-                )
-            )
-
-        elif service == SERVICE_EFFECT_PULSE:
-            effect = aiolifx_effects.EffectPulse(
-                power_on=kwargs.get(ATTR_POWER_ON),
-                period=kwargs.get(ATTR_PERIOD),
-                cycles=kwargs.get(ATTR_CYCLES),
-                mode=kwargs.get(ATTR_MODE),
-                hsbk=find_hsbk(self.hass, **kwargs),
-            )
-            await self.effects_conductor.start(effect, bulbs)
-
-        elif service == SERVICE_EFFECT_COLORLOOP:
-            brightness = None
-            saturation_max = None
-            saturation_min = None
-
-            if ATTR_BRIGHTNESS in kwargs:
-                brightness = convert_8_to_16(kwargs[ATTR_BRIGHTNESS])
-            elif ATTR_BRIGHTNESS_PCT in kwargs:
-                brightness = convert_8_to_16(
-                    round(255 * kwargs[ATTR_BRIGHTNESS_PCT] / 100)
-                )
-
-            if ATTR_SATURATION_MAX in kwargs:
-                saturation_max = int(kwargs[ATTR_SATURATION_MAX] / 100 * 65535)
-
-            if ATTR_SATURATION_MIN in kwargs:
-                saturation_min = int(kwargs[ATTR_SATURATION_MIN] / 100 * 65535)
-
-            effect = aiolifx_effects.EffectColorloop(
-                power_on=kwargs.get(ATTR_POWER_ON),
-                period=kwargs.get(ATTR_PERIOD),
-                change=kwargs.get(ATTR_CHANGE),
-                spread=kwargs.get(ATTR_SPREAD),
-                transition=kwargs.get(ATTR_TRANSITION),
-                brightness=brightness,
-                saturation_max=saturation_max,
-                saturation_min=saturation_min,
-            )
-            await self.effects_conductor.start(effect, bulbs)
-
-        elif service == SERVICE_EFFECT_SKY:
-            palette = kwargs.get(ATTR_PALETTE)
-            if palette is not None:
-                theme = Theme()
-                for hsbk in palette:
-                    theme.add_hsbk(hsbk[0], hsbk[1], hsbk[2], hsbk[3])
-
-            speed = kwargs.get(ATTR_SPEED, EFFECT_SKY_DEFAULT_SPEED)
-            sky_type = kwargs.get(ATTR_SKY_TYPE, EFFECT_SKY_DEFAULT_SKY_TYPE)
-
-            cloud_saturation_min = kwargs.get(
-                ATTR_CLOUD_SATURATION_MIN,
-                EFFECT_SKY_DEFAULT_CLOUD_SATURATION_MIN,
-            )
-            cloud_saturation_max = kwargs.get(
-                ATTR_CLOUD_SATURATION_MAX,
-                EFFECT_SKY_DEFAULT_CLOUD_SATURATION_MAX,
-            )
-
-            await asyncio.gather(
-                *(
-                    coordinator.async_set_matrix_effect(
-                        effect=EFFECT_SKY,
-                        speed=speed,
-                        sky_type=sky_type,
-                        cloud_saturation_min=cloud_saturation_min,
-                        cloud_saturation_max=cloud_saturation_max,
-                        palette=theme.colors,
-                    )
-                    for coordinator in coordinators
-                )
-            )
-
-        elif service == SERVICE_EFFECT_STOP:
-            await self.effects_conductor.stop(bulbs)
-
-            for coordinator in coordinators:
-                await coordinator.async_set_matrix_effect(
-                    effect=EFFECT_OFF, power_on=False
-                )
-                await coordinator.async_set_multizone_effect(
-                    effect=EFFECT_OFF, power_on=False
-                )
+        if start_effect_func := self._effect_dispatch.get(service):
+            await start_effect_func(self, bulbs, coordinators, **kwargs)

--- a/homeassistant/components/lifx/services.yaml
+++ b/homeassistant/components/lifx/services.yaml
@@ -186,28 +186,46 @@ effect_move:
           options:
             - "autumn"
             - "blissful"
+            - "bias_lighting"
+            - "calaveras"
             - "cheerful"
+            - "christmas"
             - "dream"
             - "energizing"
             - "epic"
+            - "evening"
             - "exciting"
+            - "fantasy"
             - "focusing"
+            - "gentle"
             - "halloween"
             - "hanukkah"
             - "holly"
-            - "independence_day"
+            - "hygge"
+            - "independence"
             - "intense"
+            - "love"
+            - "kwanzaa"
             - "mellow"
+            - "party"
             - "peaceful"
             - "powerful"
+            - "proud"
+            - "pumpkin"
             - "relaxing"
+            - "romance"
             - "santa"
             - "serene"
+            - "shamrock"
             - "soothing"
+            - "spacey"
             - "sports"
             - "spring"
+            - "stardust"
+            - "thanksgiving"
             - "tranquil"
             - "warming"
+            - "zombie"
     power_on:
       default: true
       selector:
@@ -255,28 +273,46 @@ effect_morph:
           options:
             - "autumn"
             - "blissful"
+            - "bias_lighting"
+            - "calaveras"
             - "cheerful"
+            - "christmas"
             - "dream"
             - "energizing"
             - "epic"
+            - "evening"
             - "exciting"
+            - "fantasy"
             - "focusing"
+            - "gentle"
             - "halloween"
             - "hanukkah"
             - "holly"
-            - "independence_day"
+            - "hygge"
+            - "independence"
             - "intense"
+            - "love"
+            - "kwanzaa"
             - "mellow"
+            - "party"
             - "peaceful"
             - "powerful"
+            - "proud"
+            - "pumpkin"
             - "relaxing"
+            - "romance"
             - "santa"
             - "serene"
+            - "shamrock"
             - "soothing"
+            - "spacey"
             - "sports"
             - "spring"
+            - "stardust"
+            - "thanksgiving"
             - "tranquil"
             - "warming"
+            - "zombie"
     power_on:
       default: true
       selector:
@@ -338,3 +374,73 @@ effect_stop:
     entity:
       integration: lifx
       domain: light
+paint_theme:
+  target:
+    entity:
+      integration: lifx
+      domain: light
+  fields:
+    palette:
+      example:
+        - "[[0, 100, 100, 3500], [60, 100, 100, 3500]]"
+      selector:
+        object:
+    theme:
+      example: exciting
+      default: exciting
+      selector:
+        select:
+          mode: dropdown
+          options:
+            - "autumn"
+            - "blissful"
+            - "bias_lighting"
+            - "calaveras"
+            - "cheerful"
+            - "christmas"
+            - "dream"
+            - "energizing"
+            - "epic"
+            - "evening"
+            - "exciting"
+            - "fantasy"
+            - "focusing"
+            - "gentle"
+            - "halloween"
+            - "hanukkah"
+            - "holly"
+            - "hygge"
+            - "independence"
+            - "intense"
+            - "love"
+            - "kwanzaa"
+            - "mellow"
+            - "party"
+            - "peaceful"
+            - "powerful"
+            - "proud"
+            - "pumpkin"
+            - "relaxing"
+            - "romance"
+            - "santa"
+            - "serene"
+            - "shamrock"
+            - "soothing"
+            - "spacey"
+            - "sports"
+            - "spring"
+            - "stardust"
+            - "thanksgiving"
+            - "tranquil"
+            - "warming"
+            - "zombie"
+    transition:
+      selector:
+        number:
+          min: 0
+          max: 3600
+          unit_of_measurement: seconds
+    power_on:
+      default: true
+      selector:
+        boolean:

--- a/homeassistant/components/lifx/strings.json
+++ b/homeassistant/components/lifx/strings.json
@@ -209,7 +209,7 @@
         },
         "palette": {
           "name": "Palette",
-          "description": "List of at least 2 and at most 16 colors as hue (0-360), saturation (0-100), brightness (0-100) and kelvin (1500-900) values to use for this effect. Overrides the theme attribute."
+          "description": "List of at least 2 and at most 16 colors as hue (0-360), saturation (0-100), brightness (0-100) and kelvin (1500-9000) values to use for this effect. Overrides the theme attribute."
         },
         "theme": {
           "name": "[%key:component::lifx::entity::select::theme::name%]",
@@ -254,6 +254,28 @@
     "effect_stop": {
       "name": "Stop effect",
       "description": "Stops a running effect."
+    },
+    "paint_theme": {
+      "name": "Paint Theme",
+      "description": "Paint either a provided theme or custom palette across one or more LIFX lights.",
+      "fields": {
+        "palette": {
+          "name": "Palette",
+          "description": "List of at least 2 and at most 16 colors as hue (0-360), saturation (0-100), brightness (0-100) and kelvin (1500-9000) values to paint across the target lights. Overrides the theme attribute."
+        },
+        "theme": {
+          "name": "[%key:component::lifx::entity::select::theme::name%]",
+          "description": "Predefined color theme to paint. Overridden by the palette attribute."
+        },
+        "transition": {
+          "name": "Transition",
+          "description": "Duration in seconds to paint the theme."
+        },
+        "power_on": {
+          "name": "Power on",
+          "description": "Powered off lights will be turned on before painting the theme."
+        }
+      }
     }
   }
 }

--- a/tests/components/lifx/test_light.py
+++ b/tests/components/lifx/test_light.py
@@ -25,6 +25,7 @@ from homeassistant.components.lifx.manager import (
     SERVICE_EFFECT_MORPH,
     SERVICE_EFFECT_MOVE,
     SERVICE_EFFECT_SKY,
+    SERVICE_PAINT_THEME,
 )
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
@@ -1042,6 +1043,104 @@ async def test_lightstrip_move_effect(hass: HomeAssistant) -> None:
     }
     bulb.get_multizone_effect.reset_mock()
     bulb.set_multizone_effect.reset_mock()
+    bulb.set_power.reset_mock()
+
+
+@pytest.mark.usefixtures("mock_discovery")
+async def test_paint_theme_service(hass: HomeAssistant) -> None:
+    """Test the firmware flame and morph effects on a matrix device."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_HOST: "127.0.0.1"}, unique_id=SERIAL
+    )
+    config_entry.add_to_hass(hass)
+    bulb = _mocked_bulb()
+    bulb.power_level = 0
+    bulb.color = [65535, 65535, 65535, 65535]
+    with (
+        _patch_discovery(device=bulb),
+        _patch_config_flow_try_connect(device=bulb),
+        _patch_device(device=bulb),
+    ):
+        await async_setup_component(hass, lifx.DOMAIN, {lifx.DOMAIN: {}})
+        await hass.async_block_till_done()
+
+    entity_id = "light.my_bulb"
+
+    bulb.power_level = 0
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_PAINT_THEME,
+        {ATTR_ENTITY_ID: entity_id, ATTR_TRANSITION: 4, ATTR_THEME: "autumn"},
+        blocking=True,
+    )
+
+    bulb.power_level = 65535
+
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=30))
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_ON
+
+    assert len(bulb.set_power.calls) == 1
+    assert len(bulb.set_color.calls) == 1
+    call_dict = bulb.set_color.calls[0][1]
+    call_dict.pop("callb")
+    assert call_dict["value"] in [
+        (5643, 65535, 32768, 3500),
+        (15109, 65535, 32768, 3500),
+        (8920, 65535, 32768, 3500),
+        (10558, 65535, 32768, 3500),
+    ]
+    assert call_dict["duration"] == 4000
+    bulb.set_color.reset_mock()
+    bulb.set_power.reset_mock()
+
+    bulb.power_level = 0
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_PAINT_THEME,
+        {
+            ATTR_ENTITY_ID: entity_id,
+            ATTR_TRANSITION: 6,
+            ATTR_PALETTE: [
+                (0, 100, 255, 3500),
+                (60, 100, 255, 3500),
+                (120, 100, 255, 3500),
+                (180, 100, 255, 3500),
+                (240, 100, 255, 3500),
+                (300, 100, 255, 3500),
+            ],
+        },
+        blocking=True,
+    )
+
+    bulb.power_level = 65535
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=30))
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_ON
+
+    assert len(bulb.set_power.calls) == 1
+    assert len(bulb.set_color.calls) == 1
+    call_dict = bulb.set_color.calls[0][1]
+    call_dict.pop("callb")
+    hue = round(call_dict["value"][0] / 65535 * 360)
+    sat = round(call_dict["value"][1] / 65535 * 100)
+    bri = call_dict["value"][2] >> 8
+    kel = call_dict["value"][3]
+    assert (hue, sat, bri, kel) in [
+        (0, 100, 255, 3500),
+        (60, 100, 255, 3500),
+        (120, 100, 255, 3500),
+        (180, 100, 255, 3500),
+        (240, 100, 255, 3500),
+        (300, 100, 255, 3500),
+    ]
+    assert call_dict["duration"] == 6000
+
+    bulb.set_color.reset_mock()
     bulb.set_power.reset_mock()
 
 


### PR DESCRIPTION
## Proposed change

Add a new `paint_theme` action for the LIFX integration. This allows users to select one or more LIFX devices and then paint either a pre-configured theme or their own set of custom colours across those devices.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/36931

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
