### PR TITLE
Make the SkyConnect/ZBT-1 config entry title reflect the firmware type

### DIFF
--- a/homeassistant/components/homeassistant_sky_connect/__init__.py
+++ b/homeassistant/components/homeassistant_sky_connect/__init__.py
@@ -8,11 +8,19 @@ from homeassistant.components.homeassistant_hardware.util import guess_firmware_
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
+from .util import create_entry_title
+
 _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up a Home Assistant SkyConnect config entry."""
+
+    # Make sure the device config entry has the appropriate title suffix
+    expected_title = create_entry_title(entry)
+    if entry.title != expected_title:
+        hass.config_entries.async_update_entry(entry, title=expected_title)
+
     return True
 
 

--- a/homeassistant/components/homeassistant_sky_connect/config_flow.py
+++ b/homeassistant/components/homeassistant_sky_connect/config_flow.py
@@ -21,7 +21,7 @@ from homeassistant.config_entries import (
 from homeassistant.core import callback
 
 from .const import DOCS_WEB_FLASHER_URL, DOMAIN, HardwareVariant
-from .util import get_hardware_variant, get_usb_service_info
+from .util import create_entry_title, get_hardware_variant, get_usb_service_info
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -181,6 +181,7 @@ class HomeAssistantSkyConnectMultiPanOptionsFlowHandler(
         """Finish flashing and update the config entry."""
         self.hass.config_entries.async_update_entry(
             entry=self.config_entry,
+            title=create_entry_title(self.config_entry, ApplicationType.EZSP),
             data={
                 **self.config_entry.data,
                 "firmware": ApplicationType.EZSP.value,
@@ -216,6 +217,7 @@ class HomeAssistantSkyConnectOptionsFlowHandler(
 
         self.hass.config_entries.async_update_entry(
             entry=self.config_entry,
+            title=create_entry_title(self.config_entry, self._probed_firmware_type),
             data={
                 **self.config_entry.data,
                 "firmware": self._probed_firmware_type.value,

--- a/homeassistant/components/homeassistant_sky_connect/hardware.py
+++ b/homeassistant/components/homeassistant_sky_connect/hardware.py
@@ -6,7 +6,6 @@ from homeassistant.components.hardware.models import HardwareInfo, USBInfo
 from homeassistant.core import HomeAssistant, callback
 
 from .const import DOMAIN
-from .util import get_hardware_variant
 
 DOCUMENTATION_URL = "https://skyconnect.home-assistant.io/documentation/"
 
@@ -27,7 +26,7 @@ def async_info(hass: HomeAssistant) -> list[HardwareInfo]:
                 manufacturer=entry.data["manufacturer"],
                 description=entry.data["product"],
             ),
-            name=get_hardware_variant(entry).full_name,
+            name=entry.title,
             url=DOCUMENTATION_URL,
         )
         for entry in entries

--- a/homeassistant/components/homeassistant_sky_connect/util.py
+++ b/homeassistant/components/homeassistant_sky_connect/util.py
@@ -5,11 +5,18 @@ from __future__ import annotations
 import logging
 
 from homeassistant.components import usb
+from homeassistant.components.homeassistant_hardware.util import ApplicationType
 from homeassistant.config_entries import ConfigEntry
 
 from .const import HardwareVariant
 
 _LOGGER = logging.getLogger(__name__)
+
+FW_TYPE_NAMES = {
+    ApplicationType.EZSP: "Zigbee",
+    ApplicationType.SPINEL: "Thread",
+    ApplicationType.CPC: "Multiprotocol",
+}
 
 
 def get_usb_service_info(config_entry: ConfigEntry) -> usb.UsbServiceInfo:
@@ -27,3 +34,18 @@ def get_usb_service_info(config_entry: ConfigEntry) -> usb.UsbServiceInfo:
 def get_hardware_variant(config_entry: ConfigEntry) -> HardwareVariant:
     """Get the hardware variant from the config entry."""
     return HardwareVariant.from_usb_product_name(config_entry.data["product"])
+
+
+def create_entry_title(
+    entry: ConfigEntry, firmware_type: ApplicationType | None = None
+) -> str:
+    """Create a title for the config entry, incorporating the firmware type."""
+    hw_variant = get_hardware_variant(entry)
+
+    if firmware_type is None:
+        firmware_type = ApplicationType(entry.data["firmware"])
+
+    if firmware_type not in FW_TYPE_NAMES:
+        return hw_variant.full_name
+
+    return f"{hw_variant.full_name} ({FW_TYPE_NAMES[firmware_type]})"

--- a/tests/components/homeassistant_sky_connect/test_hardware.py
+++ b/tests/components/homeassistant_sky_connect/test_hardware.py
@@ -81,7 +81,7 @@ async def test_hardware_info(
                     "manufacturer": "Nabu Casa",
                     "description": "SkyConnect v1.0",
                 },
-                "name": "Home Assistant SkyConnect",
+                "name": "Home Assistant SkyConnect (Zigbee)",
                 "url": "https://skyconnect.home-assistant.io/documentation/",
             },
             {
@@ -94,7 +94,7 @@ async def test_hardware_info(
                     "manufacturer": "Nabu Casa",
                     "description": "Home Assistant Connect ZBT-1",
                 },
-                "name": "Home Assistant Connect ZBT-1",
+                "name": "Home Assistant Connect ZBT-1 (Zigbee)",
                 "url": "https://skyconnect.home-assistant.io/documentation/",
             },
         ]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Somewhat. This renames all SkyConnect and Connect ZBT-1 config entry titles to use a consistent name: `product (firmware type)`.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR also changes the format of the `hardware` platform provided by the integration to use the config entry title instead of the hardware name itself.

To make sure the title is accurate, we also rename the SkyConnect and Connect ZBT-1 config entry titles when changing firmware in addition to on startup to rename existing ones.

The purpose of this change is to help distinguish devices when multiple of the same type are plugged in.

<img width="626" alt="image" src="https://github.com/user-attachments/assets/30ed3a37-11da-490d-a4a1-a98d289fd8ce" />


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
