### PR TITLE
Handle invalid HS color values in HomeKit Bridge

### DIFF
--- a/homeassistant/components/homekit/type_lights.py
+++ b/homeassistant/components/homekit/type_lights.py
@@ -282,7 +282,11 @@ class Light(HomeAccessory):
                 hue, saturation = color_temperature_to_hs(color_temp)
             elif color_mode == ColorMode.WHITE:
                 hue, saturation = 0, 0
-            elif hue_sat := attributes.get(ATTR_HS_COLOR):
+            elif (
+                (hue_sat := attributes.get(ATTR_HS_COLOR))
+                and isinstance(hue_sat, (list, tuple))
+                and len(hue_sat) == 2
+            ):
                 hue, saturation = hue_sat
             else:
                 hue = None

--- a/tests/components/homekit/test_type_lights.py
+++ b/tests/components/homekit/test_type_lights.py
@@ -540,6 +540,204 @@ async def test_light_color_temperature_and_rgb_color(
     assert acc.char_saturation.value == 100
 
 
+async def test_light_invalid_hs_color(
+    hass: HomeAssistant, hk_driver, events: list[Event]
+) -> None:
+    """Test light that starts out with an invalid hs color."""
+    entity_id = "light.demo"
+
+    hass.states.async_set(
+        entity_id,
+        STATE_ON,
+        {
+            ATTR_SUPPORTED_COLOR_MODES: ["color_temp", "hs"],
+            ATTR_COLOR_MODE: "hs",
+            ATTR_HS_COLOR: 260,
+        },
+    )
+    await hass.async_block_till_done()
+    acc = Light(hass, hk_driver, "Light", entity_id, 1, None)
+    hk_driver.add_accessory(acc)
+
+    assert acc.char_color_temp.value == 153
+    assert acc.char_hue.value == 0
+    assert acc.char_saturation.value == 75
+
+    assert hasattr(acc, "char_color_temp")
+
+    hass.states.async_set(entity_id, STATE_ON, {ATTR_COLOR_TEMP_KELVIN: 4464})
+    await hass.async_block_till_done()
+    acc.run()
+    await hass.async_block_till_done()
+    assert acc.char_color_temp.value == 224
+    assert acc.char_hue.value == 27
+    assert acc.char_saturation.value == 27
+
+    hass.states.async_set(entity_id, STATE_ON, {ATTR_COLOR_TEMP_KELVIN: 2840})
+    await hass.async_block_till_done()
+    acc.run()
+    await hass.async_block_till_done()
+    assert acc.char_color_temp.value == 352
+    assert acc.char_hue.value == 28
+    assert acc.char_saturation.value == 61
+
+    char_on_iid = acc.char_on.to_HAP()[HAP_REPR_IID]
+    char_brightness_iid = acc.char_brightness.to_HAP()[HAP_REPR_IID]
+    char_hue_iid = acc.char_hue.to_HAP()[HAP_REPR_IID]
+    char_saturation_iid = acc.char_saturation.to_HAP()[HAP_REPR_IID]
+    char_color_temp_iid = acc.char_color_temp.to_HAP()[HAP_REPR_IID]
+
+    # Set from HomeKit
+    call_turn_on = async_mock_service(hass, LIGHT_DOMAIN, "turn_on")
+
+    hk_driver.set_characteristics(
+        {
+            HAP_REPR_CHARS: [
+                {HAP_REPR_AID: acc.aid, HAP_REPR_IID: char_on_iid, HAP_REPR_VALUE: 1},
+                {
+                    HAP_REPR_AID: acc.aid,
+                    HAP_REPR_IID: char_brightness_iid,
+                    HAP_REPR_VALUE: 20,
+                },
+                {
+                    HAP_REPR_AID: acc.aid,
+                    HAP_REPR_IID: char_color_temp_iid,
+                    HAP_REPR_VALUE: 250,
+                },
+                {
+                    HAP_REPR_AID: acc.aid,
+                    HAP_REPR_IID: char_hue_iid,
+                    HAP_REPR_VALUE: 50,
+                },
+                {
+                    HAP_REPR_AID: acc.aid,
+                    HAP_REPR_IID: char_saturation_iid,
+                    HAP_REPR_VALUE: 50,
+                },
+            ]
+        },
+        "mock_addr",
+    )
+    await _wait_for_light_coalesce(hass)
+    assert call_turn_on[0]
+    assert call_turn_on[0].data[ATTR_ENTITY_ID] == entity_id
+    assert call_turn_on[0].data[ATTR_BRIGHTNESS_PCT] == 20
+    assert call_turn_on[0].data[ATTR_COLOR_TEMP_KELVIN] == 4000
+
+    assert len(events) == 1
+    assert (
+        events[-1].data[ATTR_VALUE]
+        == f"Set state to 1, brightness at 20{PERCENTAGE}, color temperature at 250"
+    )
+
+    # Only set Hue
+    hk_driver.set_characteristics(
+        {
+            HAP_REPR_CHARS: [
+                {
+                    HAP_REPR_AID: acc.aid,
+                    HAP_REPR_IID: char_hue_iid,
+                    HAP_REPR_VALUE: 30,
+                }
+            ]
+        },
+        "mock_addr",
+    )
+    await _wait_for_light_coalesce(hass)
+    assert call_turn_on[1]
+    assert call_turn_on[1].data[ATTR_HS_COLOR] == (30, 50)
+
+    assert events[-1].data[ATTR_VALUE] == "set color at (30, 50)"
+
+    # Only set Saturation
+    hk_driver.set_characteristics(
+        {
+            HAP_REPR_CHARS: [
+                {
+                    HAP_REPR_AID: acc.aid,
+                    HAP_REPR_IID: char_saturation_iid,
+                    HAP_REPR_VALUE: 20,
+                }
+            ]
+        },
+        "mock_addr",
+    )
+    await _wait_for_light_coalesce(hass)
+    assert call_turn_on[2]
+    assert call_turn_on[2].data[ATTR_HS_COLOR] == (30, 20)
+
+    assert events[-1].data[ATTR_VALUE] == "set color at (30, 20)"
+
+    # Generate a conflict by setting hue and then color temp
+    hk_driver.set_characteristics(
+        {
+            HAP_REPR_CHARS: [
+                {
+                    HAP_REPR_AID: acc.aid,
+                    HAP_REPR_IID: char_hue_iid,
+                    HAP_REPR_VALUE: 80,
+                }
+            ]
+        },
+        "mock_addr",
+    )
+    hk_driver.set_characteristics(
+        {
+            HAP_REPR_CHARS: [
+                {
+                    HAP_REPR_AID: acc.aid,
+                    HAP_REPR_IID: char_color_temp_iid,
+                    HAP_REPR_VALUE: 320,
+                }
+            ]
+        },
+        "mock_addr",
+    )
+    await _wait_for_light_coalesce(hass)
+    assert call_turn_on[3]
+    assert call_turn_on[3].data[ATTR_COLOR_TEMP_KELVIN] == 3125
+    assert events[-1].data[ATTR_VALUE] == "color temperature at 320"
+
+    # Generate a conflict by setting color temp then saturation
+    hk_driver.set_characteristics(
+        {
+            HAP_REPR_CHARS: [
+                {
+                    HAP_REPR_AID: acc.aid,
+                    HAP_REPR_IID: char_color_temp_iid,
+                    HAP_REPR_VALUE: 404,
+                }
+            ]
+        },
+        "mock_addr",
+    )
+    hk_driver.set_characteristics(
+        {
+            HAP_REPR_CHARS: [
+                {
+                    HAP_REPR_AID: acc.aid,
+                    HAP_REPR_IID: char_saturation_iid,
+                    HAP_REPR_VALUE: 35,
+                }
+            ]
+        },
+        "mock_addr",
+    )
+    await _wait_for_light_coalesce(hass)
+    assert call_turn_on[4]
+    assert call_turn_on[4].data[ATTR_HS_COLOR] == (80, 35)
+    assert events[-1].data[ATTR_VALUE] == "set color at (80, 35)"
+
+    # Set from HASS
+    hass.states.async_set(entity_id, STATE_ON, {ATTR_HS_COLOR: (100, 100)})
+    await hass.async_block_till_done()
+    acc.run()
+    await hass.async_block_till_done()
+    assert acc.char_color_temp.value == 404
+    assert acc.char_hue.value == 100
+    assert acc.char_saturation.value == 100
+
+
 @pytest.mark.parametrize(
     "supported_color_modes", [[ColorMode.HS], [ColorMode.RGB], [ColorMode.XY]]
 )

--- a/tests/components/homekit/test_type_lights.py
+++ b/tests/components/homekit/test_type_lights.py
@@ -1,6 +1,7 @@
 """Test different accessory types: Lights."""
 
 from datetime import timedelta
+import sys
 
 from pyhap.const import HAP_REPR_AID, HAP_REPR_CHARS, HAP_REPR_IID, HAP_REPR_VALUE
 import pytest
@@ -736,6 +737,74 @@ async def test_light_invalid_hs_color(
     assert acc.char_color_temp.value == 404
     assert acc.char_hue.value == 100
     assert acc.char_saturation.value == 100
+
+
+async def test_light_invalid_values(
+    hass: HomeAssistant, hk_driver, events: list[Event]
+) -> None:
+    """Test light with a variety of invalid values."""
+    entity_id = "light.demo"
+
+    hass.states.async_set(
+        entity_id,
+        STATE_ON,
+        {
+            ATTR_SUPPORTED_COLOR_MODES: ["color_temp", "hs"],
+            ATTR_COLOR_MODE: "hs",
+            ATTR_HS_COLOR: (-1, -1),
+        },
+    )
+    await hass.async_block_till_done()
+    acc = Light(hass, hk_driver, "Light", entity_id, 1, None)
+    hk_driver.add_accessory(acc)
+
+    assert acc.char_color_temp.value == 153
+    assert acc.char_hue.value == 0
+    assert acc.char_saturation.value == 0
+    hass.states.async_set(
+        entity_id,
+        STATE_ON,
+        {
+            ATTR_SUPPORTED_COLOR_MODES: ["color_temp", "hs"],
+            ATTR_COLOR_MODE: "color_temp",
+            ATTR_COLOR_TEMP_KELVIN: -1,
+        },
+    )
+    await hass.async_block_till_done()
+    acc.run()
+
+    assert acc.char_color_temp.value == 153
+    assert acc.char_hue.value == 16
+    assert acc.char_saturation.value == 100
+    hass.states.async_set(
+        entity_id,
+        STATE_ON,
+        {
+            ATTR_SUPPORTED_COLOR_MODES: ["color_temp", "hs"],
+            ATTR_COLOR_MODE: "color_temp",
+            ATTR_COLOR_TEMP_KELVIN: sys.maxsize,
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert acc.char_color_temp.value == 153
+    assert acc.char_hue.value == 220
+    assert acc.char_saturation.value == 41
+
+    hass.states.async_set(
+        entity_id,
+        STATE_ON,
+        {
+            ATTR_SUPPORTED_COLOR_MODES: ["color_temp", "hs"],
+            ATTR_COLOR_MODE: "color_temp",
+            ATTR_COLOR_TEMP_KELVIN: 2000,
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert acc.char_color_temp.value == 500
+    assert acc.char_hue.value == 31
+    assert acc.char_saturation.value == 95
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
related issue #135358

Note that this will not fix the problem, but we didn't handle these invalid values well.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
