### PR TITLE
Add button to set date and time for thermopro TP358/TP393 

### DIFF
--- a/homeassistant/components/thermopro/__init__.py
+++ b/homeassistant/components/thermopro/__init__.py
@@ -13,10 +13,13 @@ from homeassistant.components.bluetooth.passive_update_processor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import config_validation as cv
 
 from .const import DOMAIN
 
-PLATFORMS: list[Platform] = [Platform.SENSOR]
+CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
+
+PLATFORMS: list[Platform] = [Platform.BUTTON, Platform.SENSOR]
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -39,6 +42,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     entry.async_on_unload(
         coordinator.async_start()
     )  # only start after all platforms have had a chance to subscribe
+
     return True
 
 

--- a/homeassistant/components/thermopro/__init__.py
+++ b/homeassistant/components/thermopro/__init__.py
@@ -47,7 +47,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up ThermoPro BLE device from a config entry."""
     address = entry.unique_id
     assert address is not None
-
     data = ThermoProBluetoothDeviceData()
     coordinator = hass.data.setdefault(DOMAIN, {})[entry.entry_id] = (
         PassiveBluetoothProcessorCoordinator(

--- a/homeassistant/components/thermopro/__init__.py
+++ b/homeassistant/components/thermopro/__init__.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+from functools import partial
 import logging
 
-from thermopro_ble import ThermoProBluetoothDeviceData
+from thermopro_ble import SensorUpdate, ThermoProBluetoothDeviceData
 
-from homeassistant.components.bluetooth import BluetoothScanningMode
+from homeassistant.components.bluetooth import (
+    BluetoothScanningMode,
+    BluetoothServiceInfoBleak,
+)
 from homeassistant.components.bluetooth.passive_update_processor import (
     PassiveBluetoothProcessorCoordinator,
 )
@@ -14,14 +18,29 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.dispatcher import async_dispatcher_send
 
-from .const import DOMAIN
+from .const import DOMAIN, SIGNAL_DATA_UPDATED
 
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 PLATFORMS: list[Platform] = [Platform.BUTTON, Platform.SENSOR]
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def process_service_info(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    data: ThermoProBluetoothDeviceData,
+    service_info: BluetoothServiceInfoBleak,
+) -> SensorUpdate:
+    """Process a BluetoothServiceInfoBleak, running side effects and returning sensor data."""
+    update = data.update(service_info)
+    async_dispatcher_send(
+        hass, f"{SIGNAL_DATA_UPDATED}_{entry.entry_id}", data, service_info, update
+    )
+    return update
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -35,14 +54,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             _LOGGER,
             address=address,
             mode=BluetoothScanningMode.ACTIVE,
-            update_method=data.update,
+            update_method=partial(process_service_info, hass, entry, data),
         )
     )
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-    entry.async_on_unload(
-        coordinator.async_start()
-    )  # only start after all platforms have had a chance to subscribe
-
+    # only start after all platforms have had a chance to subscribe
+    entry.async_on_unload(coordinator.async_start())
     return True
 
 

--- a/homeassistant/components/thermopro/__init__.py
+++ b/homeassistant/components/thermopro/__init__.py
@@ -47,6 +47,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up ThermoPro BLE device from a config entry."""
     address = entry.unique_id
     assert address is not None
+
     data = ThermoProBluetoothDeviceData()
     coordinator = hass.data.setdefault(DOMAIN, {})[entry.entry_id] = (
         PassiveBluetoothProcessorCoordinator(

--- a/homeassistant/components/thermopro/button.py
+++ b/homeassistant/components/thermopro/button.py
@@ -39,7 +39,7 @@ async def _async_set_datetime(hass: HomeAssistant, address: str) -> None:
     """Set Date&Time for a given device."""
     ble_device = async_ble_device_from_address(hass, address, connectable=True)
     assert ble_device is not None
-    await ThermoProDevice(ble_device).set_datetime(now(), False)
+    await ThermoProDevice(ble_device).set_datetime(now(), am_pm=False)
 
 
 BUTTON_ENTITIES: tuple[ThermoProButtonEntityDescription, ...] = (

--- a/homeassistant/components/thermopro/button.py
+++ b/homeassistant/components/thermopro/button.py
@@ -72,7 +72,7 @@ async def async_setup_entry(
                     description=description,
                     data=data,
                     availability_signal=availability_signal,
-                    service_info=service_info,
+                    address=address,
                 )
                 for description in BUTTON_ENTITIES
             )
@@ -88,9 +88,7 @@ async def async_setup_entry(
     )
 
 
-class ThermoProDateTimeButtonEntity(
-    ButtonEntity,
-):
+class ThermoProDateTimeButtonEntity(ButtonEntity):
     """Representation of a ThermoProDateTime button entity."""
 
     _attr_has_entity_name = True
@@ -100,12 +98,11 @@ class ThermoProDateTimeButtonEntity(
         description: ButtonEntityDescription,
         data: ThermoProBluetoothDeviceData,
         availability_signal: str,
-        service_info: BluetoothServiceInfoBleak,
+        address: str,
     ) -> None:
         """Initialize the thermopro datetime button entity."""
-        address = service_info.address
-        self.address = address
         self.entity_description = description
+        self._address = address
         self._availability_signal = availability_signal
         self._attr_unique_id = f"{address}-{description.key}"
         self._attr_device_info = dr.DeviceInfo(
@@ -129,7 +126,7 @@ class ThermoProDateTimeButtonEntity(
         )
         self.async_on_remove(
             async_track_unavailable(
-                self.hass, self._async_on_unavailable, self.address, connectable=True
+                self.hass, self._async_on_unavailable, self._address, connectable=True
             )
         )
 
@@ -150,7 +147,8 @@ class ThermoProDateTimeButtonEntity(
 
     async def async_press(self) -> None:
         """Set Date&Time for a given device."""
-        address = self.address
-        ble_device = async_ble_device_from_address(self.hass, address, connectable=True)
+        ble_device = async_ble_device_from_address(
+            self.hass, self._address, connectable=True
+        )
         assert ble_device is not None
         await ThermoProDevice(ble_device).set_datetime(now(), False)

--- a/homeassistant/components/thermopro/button.py
+++ b/homeassistant/components/thermopro/button.py
@@ -143,7 +143,7 @@ class ThermoProDateTimeButtonEntity(ButtonEntity):
             self._availability_signal,
         )
         self._attr_available = available
-        self.async_write_ha_state()  # write state to state machine
+        self.async_write_ha_state()
 
     async def async_press(self) -> None:
         """Set Date&Time for a given device."""

--- a/homeassistant/components/thermopro/button.py
+++ b/homeassistant/components/thermopro/button.py
@@ -76,9 +76,6 @@ async def async_setup_entry(
         update: SensorUpdate,
     ) -> None:
         nonlocal entity_added
-        _LOGGER.debug(
-            "update data=%s update=%s service_info=%s", data, update, service_info
-        )
         sensor_device_info = update.devices[data.primary_device_id]
         if sensor_device_info.model not in MODELS_THAT_SUPPORT_BUTTONS:
             return
@@ -98,7 +95,6 @@ async def async_setup_entry(
             )
 
         if service_info.connectable:
-            _LOGGER.debug("sending availability '%s' for %s", True, availability_signal)
             async_dispatcher_send(hass, availability_signal, True)
 
     entry.async_on_unload(
@@ -135,9 +131,6 @@ class ThermoProButtonEntity(ButtonEntity):
     async def async_added_to_hass(self) -> None:
         """Connect availability dispatcher."""
         await super().async_added_to_hass()
-        _LOGGER.debug(
-            "registering for availability callback for %s", self._availability_signal
-        )
         self.async_on_remove(
             async_dispatcher_connect(
                 self.hass,
@@ -153,16 +146,10 @@ class ThermoProButtonEntity(ButtonEntity):
 
     @callback
     def _async_on_unavailable(self, service_info: BluetoothServiceInfoBleak) -> None:
-        _LOGGER.debug("service info unavailable %s", service_info)
         self._async_on_availability_changed(False)
 
     @callback
     def _async_on_availability_changed(self, available: bool) -> None:
-        _LOGGER.debug(
-            "got availability callback with '%s' for %s",
-            available,
-            self._availability_signal,
-        )
         self._attr_available = available
         self.async_write_ha_state()
 

--- a/homeassistant/components/thermopro/button.py
+++ b/homeassistant/components/thermopro/button.py
@@ -112,7 +112,7 @@ class ThermoProDateTimeButtonEntity(
         self.address = address
         self.entity_description = description
         self.availability_topic = availability_topic
-        self._attr_unique_id = f"{device_name}-{description.key}"
+        self._attr_unique_id = f"{address}-{description.key}"
 
         self._attr_device_info = dr.DeviceInfo(
             identifiers={(DOMAIN, address)},
@@ -157,9 +157,6 @@ class ThermoProDateTimeButtonEntity(
     async def async_press(self) -> None:
         """Set Date&Time for a given device."""
         address = self.address
-
-        assert address is not None
-
         ble = async_ble_device_from_address(self.hass, address, connectable=True)
 
         assert ble is not None

--- a/homeassistant/components/thermopro/button.py
+++ b/homeassistant/components/thermopro/button.py
@@ -43,7 +43,7 @@ async def async_setup_entry(
     entry: ConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
-    """Set up the demo button platform."""
+    """Set up the thermopro button platform."""
     address = entry.unique_id
     assert address is not None
     availability_signal = f"{SIGNAL_AVAILABILITY_UPDATED}_{entry.entry_id}"

--- a/homeassistant/components/thermopro/button.py
+++ b/homeassistant/components/thermopro/button.py
@@ -145,7 +145,7 @@ class ThermoProButtonEntity(ButtonEntity):
         )
 
     @callback
-    def _async_on_unavailable(self, service_info: BluetoothServiceInfoBleak) -> None:
+    def _async_on_unavailable(self, _: BluetoothServiceInfoBleak) -> None:
         self._async_on_availability_changed(False)
 
     @callback

--- a/homeassistant/components/thermopro/button.py
+++ b/homeassistant/components/thermopro/button.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
-import logging
 from typing import Any
 
 from thermopro_ble import SensorUpdate, ThermoProBluetoothDeviceData, ThermoProDevice
@@ -27,8 +26,6 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.util.dt import now
 
 from .const import DOMAIN, SIGNAL_AVAILABILITY_UPDATED, SIGNAL_DATA_UPDATED
-
-_LOGGER = logging.getLogger(__name__)
 
 
 @dataclass(kw_only=True, frozen=True)

--- a/homeassistant/components/thermopro/button.py
+++ b/homeassistant/components/thermopro/button.py
@@ -1,0 +1,123 @@
+"""Demo platform that offers a fake button entity."""
+
+from __future__ import annotations
+
+import logging
+
+from thermopro_ble import ThermoProBluetoothDeviceData, ThermoProDevice
+
+from homeassistant.components.bluetooth import (
+    BluetoothScanningMode,
+    BluetoothServiceInfoBleak,
+    async_ble_device_from_address,
+    async_process_advertisements,
+)
+from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.util.dt import now
+
+from . import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+DATETIME_UPDATE = ButtonEntityDescription(
+    key="datetime",
+    translation_key="set_datetime",
+    icon="mdi:calendar-clock",
+    entity_category=EntityCategory.CONFIG,
+)
+
+ADDITIONAL_DISCOVERY_TIMEOUT = 60
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up the demo button platform."""
+
+    assert config_entry.unique_id is not None
+
+    data = ThermoProBluetoothDeviceData()
+    parsed = None
+
+    def no_more_updates(service_info: BluetoothServiceInfoBleak) -> bool:
+        nonlocal parsed
+        parsed = data.update(service_info)
+        return None in parsed.devices
+
+    try:
+        await async_process_advertisements(
+            hass,
+            no_more_updates,
+            {"address": config_entry.unique_id, "connectable": False},
+            BluetoothScanningMode.ACTIVE,
+            ADDITIONAL_DISCOVERY_TIMEOUT,
+        )
+    except TimeoutError:
+        _LOGGER.debug(
+            (
+                "timeout while waiting for ThermoPro device %s"
+                "- additional features will not be available"
+            ),
+            config_entry.unique_id,
+        )
+        return
+
+    assert parsed is not None
+
+    _LOGGER.debug("got parsed devices %s", parsed.devices)
+
+    assert None in parsed.devices
+    assert parsed.title is not None
+
+    if parsed.devices[None].model not in ("TP358", "TP393"):
+        return
+
+    async_add_entities(
+        [
+            ThermoProDateTimeButtonEntity(
+                address=config_entry.unique_id,
+                title=parsed.title,
+                description=DATETIME_UPDATE,
+            ),
+        ]
+    )
+
+
+class ThermoProDateTimeButtonEntity(
+    ButtonEntity,
+):
+    """Representation of a ThermoProDateTime button entity."""
+
+    def __init__(
+        self, address: str, title: str, description: ButtonEntityDescription
+    ) -> None:
+        """Initialize the Demo button entity."""
+        self.address = address
+        self.entity_description = description
+        self._attr_unique_id = f"{title}-{description.key}"
+
+        self._attr_device_info = dr.DeviceInfo(
+            identifiers={(DOMAIN, address)},
+            connections={(dr.CONNECTION_BLUETOOTH, address)},
+        )
+
+    async def async_press(self) -> None:
+        """Send out a persistent notification."""
+        address = self.address
+
+        assert address is not None
+
+        ble = async_ble_device_from_address(self.hass, address, connectable=True)
+
+        assert ble is not None
+
+        tpd = ThermoProDevice(ble)
+
+        await tpd.set_datetime(now(), False)

--- a/homeassistant/components/thermopro/button.py
+++ b/homeassistant/components/thermopro/button.py
@@ -18,6 +18,7 @@ from homeassistant.components.button import ButtonEntity, ButtonEntityDescriptio
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect,
@@ -154,6 +155,8 @@ class ThermoProButtonEntity(ButtonEntity):
 
     async def async_press(self) -> None:
         """Execute the press action for the entity."""
+        if self._action_lock.locked():
+            raise HomeAssistantError(f"Connecting to {self.name} already in progress")
         async with self._action_lock:
             # Only one connection at a time
             await self.entity_description.press_action_fn(self.hass, self._address)

--- a/homeassistant/components/thermopro/button.py
+++ b/homeassistant/components/thermopro/button.py
@@ -1,7 +1,8 @@
-"""Demo platform that offers a fake button entity."""
+"""Thermopro button platform."""
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
 from typing import Any
@@ -124,6 +125,7 @@ class ThermoProButtonEntity(ButtonEntity):
             identifiers={(DOMAIN, address)},
             connections={(dr.CONNECTION_BLUETOOTH, address)},
         )
+        self._action_lock = asyncio.Lock()
 
     async def async_added_to_hass(self) -> None:
         """Connect availability dispatcher."""
@@ -152,4 +154,6 @@ class ThermoProButtonEntity(ButtonEntity):
 
     async def async_press(self) -> None:
         """Execute the press action for the entity."""
-        await self.entity_description.press_action_fn(self.hass, self._address)
+        async with self._action_lock:
+            # Only one connection at a time
+            await self.entity_description.press_action_fn(self.hass, self._address)

--- a/homeassistant/components/thermopro/const.py
+++ b/homeassistant/components/thermopro/const.py
@@ -3,3 +3,4 @@
 DOMAIN = "thermopro"
 
 SIGNAL_DATA_UPDATED = f"{DOMAIN}_service_info_updated"
+SIGNAL_AVAILABILITY_UPDATED = f"{DOMAIN}_availability_updated"

--- a/homeassistant/components/thermopro/const.py
+++ b/homeassistant/components/thermopro/const.py
@@ -1,3 +1,5 @@
 """Constants for the ThermoPro Bluetooth integration."""
 
 DOMAIN = "thermopro"
+
+SIGNAL_DATA_UPDATED = f"{DOMAIN}_service_info_updated"

--- a/homeassistant/components/thermopro/sensor.py
+++ b/homeassistant/components/thermopro/sensor.py
@@ -9,7 +9,6 @@ from thermopro_ble import (
     Units,
 )
 
-from homeassistant import config_entries
 from homeassistant.components.bluetooth.passive_update_processor import (
     PassiveBluetoothDataProcessor,
     PassiveBluetoothDataUpdate,
@@ -23,6 +22,7 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     PERCENTAGE,
     SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
@@ -110,7 +110,7 @@ def sensor_update_to_bluetooth_data_update(
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: config_entries.ConfigEntry,
+    entry: ConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the ThermoPro BLE sensors."""

--- a/homeassistant/components/thermopro/strings.json
+++ b/homeassistant/components/thermopro/strings.json
@@ -17,5 +17,12 @@
       "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
     }
+  },
+  "entity": {
+    "button": {
+      "set_datetime": {
+        "name": "Set Date&Time"
+      }
+    }
   }
 }

--- a/tests/components/thermopro/__init__.py
+++ b/tests/components/thermopro/__init__.py
@@ -23,6 +23,16 @@ TP357_SERVICE_INFO = BluetoothServiceInfo(
     source="local",
 )
 
+TP358_SERVICE_INFO = BluetoothServiceInfo(
+    name="TP358 (4221)",
+    manufacturer_data={61890: b"\x00\x1d\x02,"},
+    service_uuids=[],
+    address="aa:bb:cc:dd:ee:ff",
+    rssi=-65,
+    service_data={},
+    source="local",
+)
+
 TP962R_SERVICE_INFO = BluetoothServiceInfo(
     name="TP962R (0000)",
     manufacturer_data={14081: b"\x00;\x0b7\x00"},

--- a/tests/components/thermopro/conftest.py
+++ b/tests/components/thermopro/conftest.py
@@ -6,7 +6,11 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from thermopro_ble import ThermoProDevice
 
+from homeassistant.components.thermopro.const import DOMAIN
+from homeassistant.core import HomeAssistant
 from homeassistant.util.dt import now
+
+from tests.common import MockConfigEntry
 
 
 @pytest.fixture(autouse=True)
@@ -31,7 +35,6 @@ def mock_thermoprodevice(
         "homeassistant.components.thermopro.button.ThermoProDevice",
         MagicMock(return_value=dummy_thermoprodevice),
     )
-
     return dummy_thermoprodevice
 
 
@@ -39,10 +42,23 @@ def mock_thermoprodevice(
 def mock_now(monkeypatch: pytest.MonkeyPatch) -> datetime:
     """Return fixed datetime for comparison."""
     fixed_now = now()
-
     monkeypatch.setattr(
         "homeassistant.components.thermopro.button.now",
         MagicMock(return_value=fixed_now),
     )
-
     return fixed_now
+
+
+@pytest.fixture
+async def setup_thermopro(
+    hass: HomeAssistant, mock_thermoprodevice: ThermoProDevice
+) -> None:
+    """Set up the Thermopro integration."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="aa:bb:cc:dd:ee:ff",
+    )
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    return entry

--- a/tests/components/thermopro/conftest.py
+++ b/tests/components/thermopro/conftest.py
@@ -1,8 +1,23 @@
 """ThermoPro session fixtures."""
 
+from unittest.mock import AsyncMock
+
 import pytest
 
 
 @pytest.fixture(autouse=True)
 def mock_bluetooth(enable_bluetooth: None) -> None:
     """Auto mock bluetooth."""
+
+
+@pytest.fixture
+def mock_bluetooth_adverts(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
+    """Allow mocking returned bt adverts."""
+    mock = AsyncMock(side_effect=TimeoutError())
+
+    monkeypatch.setattr(
+        "homeassistant.components.thermopro.button.async_process_advertisements",
+        mock,
+    )
+
+    return mock

--- a/tests/components/thermopro/test_button.py
+++ b/tests/components/thermopro/test_button.py
@@ -129,7 +129,7 @@ async def test_buttons_tp358_press(
         blocking=True,
     )
 
-    mock_thermoprodevice.set_datetime.assert_awaited_once_with(mock_now, False)
+    mock_thermoprodevice.set_datetime.assert_awaited_once_with(mock_now, am_pm=False)
 
     button_state = hass.states.get("button.tp358_4221_set_date_time")
     assert button_state.state != STATE_UNKNOWN

--- a/tests/components/thermopro/test_button.py
+++ b/tests/components/thermopro/test_button.py
@@ -26,7 +26,7 @@ from tests.components.bluetooth import (
 @pytest.mark.usefixtures("setup_thermopro")
 async def test_buttons_tp357(hass: HomeAssistant) -> None:
     """Test setting up creates the sensors."""
-    assert len(hass.states.async_all()) == 0
+    assert not hass.states.async_all()
     assert not hass.states.get("button.tp358_4221_set_date_time")
     inject_bluetooth_service_info(hass, TP357_SERVICE_INFO)
     await hass.async_block_till_done()
@@ -36,7 +36,7 @@ async def test_buttons_tp357(hass: HomeAssistant) -> None:
 @pytest.mark.usefixtures("setup_thermopro")
 async def test_buttons_tp358_discovery(hass: HomeAssistant) -> None:
     """Test discovery of device with button."""
-    assert len(hass.states.async_all()) == 0
+    assert not hass.states.async_all()
     assert not hass.states.get("button.tp358_4221_set_date_time")
     inject_bluetooth_service_info(hass, TP358_SERVICE_INFO)
     await hass.async_block_till_done()
@@ -50,7 +50,7 @@ async def test_buttons_tp358_discovery(hass: HomeAssistant) -> None:
 async def test_buttons_tp358_unavailable(hass: HomeAssistant) -> None:
     """Test tp358 set date&time button goes to unavailability."""
     start_monotonic = time.monotonic()
-    assert len(hass.states.async_all()) == 0
+    assert not hass.states.async_all()
     assert not hass.states.get("button.tp358_4221_set_date_time")
     inject_bluetooth_service_info(hass, TP358_SERVICE_INFO)
     await hass.async_block_till_done()
@@ -79,7 +79,7 @@ async def test_buttons_tp358_unavailable(hass: HomeAssistant) -> None:
 async def test_buttons_tp358_reavailable(hass: HomeAssistant) -> None:
     """Test TP358/TP393 set date&time button goes to unavailablity and recovers."""
     start_monotonic = time.monotonic()
-    assert len(hass.states.async_all()) == 0
+    assert not hass.states.async_all()
     assert not hass.states.get("button.tp358_4221_set_date_time")
     inject_bluetooth_service_info(hass, TP358_SERVICE_INFO)
     await hass.async_block_till_done()
@@ -116,7 +116,7 @@ async def test_buttons_tp358_press(
     hass: HomeAssistant, mock_now: datetime, mock_thermoprodevice: ThermoProDevice
 ) -> None:
     """Test TP358/TP393 set date&time button press."""
-    assert len(hass.states.async_all()) == 0
+    assert not hass.states.async_all()
     assert not hass.states.get("button.tp358_4221_set_date_time")
     inject_bluetooth_service_info(hass, TP358_SERVICE_INFO)
     await hass.async_block_till_done()

--- a/tests/components/thermopro/test_button.py
+++ b/tests/components/thermopro/test_button.py
@@ -1,0 +1,201 @@
+"""Test the ThermoPro config flow."""
+
+from datetime import datetime, timedelta
+import time
+
+from thermopro_ble import ThermoProDevice
+
+from homeassistant.components.bluetooth import (
+    FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS,
+)
+from homeassistant.components.thermopro.const import DOMAIN
+from homeassistant.const import ATTR_ENTITY_ID, STATE_UNAVAILABLE, Platform
+from homeassistant.core import HomeAssistant, split_entity_id
+from homeassistant.helpers import entity_registry as er
+from homeassistant.util import dt as dt_util
+
+from . import TP357_SERVICE_INFO, TP358_SERVICE_INFO
+
+from tests.common import MockConfigEntry, async_fire_time_changed
+from tests.components.bluetooth import (
+    inject_bluetooth_service_info,
+    patch_all_discovered_devices,
+    patch_bluetooth_time,
+)
+
+
+# borrowed from unifiprotect
+def assert_entity_counts(
+    hass: HomeAssistant, platform: Platform, total: int, enabled: int
+) -> None:
+    """Assert entity counts for a given platform."""
+
+    entity_registry = er.async_get(hass)
+
+    entities = [
+        e for e in entity_registry.entities if split_entity_id(e)[0] == platform.value
+    ]
+
+    assert len(entities) == total
+    assert len(hass.states.async_all(platform.value)) == enabled
+
+
+# ---
+
+
+async def test_buttons_tp357(hass: HomeAssistant) -> None:
+    """Test setting up creates the sensors."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="aa:bb:cc:dd:ee:ff",
+    )
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert len(hass.states.async_all()) == 0
+    assert_entity_counts(hass, Platform.BUTTON, 0, 0)
+    inject_bluetooth_service_info(hass, TP357_SERVICE_INFO)
+    await hass.async_block_till_done()
+    assert_entity_counts(hass, Platform.BUTTON, 0, 0)
+
+
+async def test_buttons_tp358_discovery(hass: HomeAssistant) -> None:
+    """Test discovery of device with button."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="aa:bb:cc:dd:ee:ff",
+    )
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert len(hass.states.async_all()) == 0
+    assert_entity_counts(hass, Platform.BUTTON, 0, 0)
+    inject_bluetooth_service_info(hass, TP358_SERVICE_INFO)
+    await hass.async_block_till_done()
+    assert_entity_counts(hass, Platform.BUTTON, 1, 1)
+
+    button = hass.states.get("button.thermopro_tp358_4221_datetime")
+    assert button.state == "unknown"
+
+
+async def test_buttons_tp358_unavailable(hass: HomeAssistant) -> None:
+    """Test tp358 set date&time button goes to unavailability."""
+    start_monotonic = time.monotonic()
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="aa:bb:cc:dd:ee:ff",
+    )
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert len(hass.states.async_all()) == 0
+    assert_entity_counts(hass, Platform.BUTTON, 0, 0)
+    inject_bluetooth_service_info(hass, TP358_SERVICE_INFO)
+    await hass.async_block_till_done()
+    assert_entity_counts(hass, Platform.BUTTON, 1, 1)
+
+    button = hass.states.get("button.thermopro_tp358_4221_datetime")
+    assert button.state == "unknown"
+
+    # borrowed from bthome test_sensor.py
+    # Fastforward time without BLE advertisements
+    monotonic_now = start_monotonic + FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS + 15
+
+    with patch_bluetooth_time(monotonic_now), patch_all_discovered_devices([]):
+        async_fire_time_changed(
+            hass,
+            dt_util.utcnow()
+            + timedelta(seconds=FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS + 15),
+        )
+        await hass.async_block_till_done()
+
+    # ---
+
+    button = hass.states.get("button.thermopro_tp358_4221_datetime")
+    # Normal devices should go to unavailable
+    # TODO: can't get this to work, always "unknown"!
+    assert button.state == STATE_UNAVAILABLE
+
+
+async def test_buttons_tp358_reavailable(hass: HomeAssistant) -> None:
+    """Test TP358/TP393 set date&time button goes to unavailablity and recovers."""
+    start_monotonic = time.monotonic()
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="aa:bb:cc:dd:ee:ff",
+    )
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert len(hass.states.async_all()) == 0
+    assert_entity_counts(hass, Platform.BUTTON, 0, 0)
+    inject_bluetooth_service_info(hass, TP358_SERVICE_INFO)
+    await hass.async_block_till_done()
+    assert_entity_counts(hass, Platform.BUTTON, 1, 1)
+
+    button = hass.states.get("button.thermopro_tp358_4221_datetime")
+    assert button.state == "unknown"
+
+    # borrowed from bthome test_sensor.py
+    # Fastforward time without BLE advertisements
+    monotonic_now = start_monotonic + FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS + 15
+
+    with patch_bluetooth_time(monotonic_now), patch_all_discovered_devices([]):
+        async_fire_time_changed(
+            hass,
+            dt_util.utcnow()
+            + timedelta(seconds=FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS + 15),
+        )
+        await hass.async_block_till_done()
+
+    # ---
+
+    # Normal devices should go to unavailable
+    # TODO: can't get this to work, always "unknown"!
+    # assert button.state == STATE_UNAVAILABLE
+
+    inject_bluetooth_service_info(hass, TP358_SERVICE_INFO)
+    await hass.async_block_till_done()
+
+    button = hass.states.get("button.thermopro_tp358_4221_datetime")
+
+    assert button.state == "unknown"
+
+
+async def test_buttons_tp358_press(
+    hass: HomeAssistant, mock_now: datetime, mock_thermoprodevice: ThermoProDevice
+) -> None:
+    """Test TP358/TP393 set date&time button press."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="aa:bb:cc:dd:ee:ff",
+    )
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert len(hass.states.async_all()) == 0
+    assert_entity_counts(hass, Platform.BUTTON, 0, 0)
+    inject_bluetooth_service_info(hass, TP358_SERVICE_INFO)
+    await hass.async_block_till_done()
+    assert_entity_counts(hass, Platform.BUTTON, 1, 1)
+
+    await hass.services.async_call(
+        "button",
+        "press",
+        {ATTR_ENTITY_ID: "button.thermopro_tp358_4221_datetime"},
+        blocking=True,
+    )
+
+    mock_thermoprodevice.set_datetime.assert_awaited_once_with(mock_now, False)

--- a/tests/components/thermopro/test_button.py
+++ b/tests/components/thermopro/test_button.py
@@ -78,7 +78,7 @@ async def test_buttons_tp358_discovery(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
     assert_entity_counts(hass, Platform.BUTTON, 1, 1)
 
-    button = hass.states.get("button.thermopro_tp358_4221_datetime")
+    button = hass.states.get("button.tp358_4221_set_date_time")
     assert button.state == "unknown"
 
 
@@ -101,7 +101,7 @@ async def test_buttons_tp358_unavailable(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
     assert_entity_counts(hass, Platform.BUTTON, 1, 1)
 
-    button = hass.states.get("button.thermopro_tp358_4221_datetime")
+    button = hass.states.get("button.tp358_4221_set_date_time")
     assert button.state == "unknown"
 
     # borrowed from bthome test_sensor.py
@@ -118,7 +118,7 @@ async def test_buttons_tp358_unavailable(hass: HomeAssistant) -> None:
 
     # ---
 
-    button = hass.states.get("button.thermopro_tp358_4221_datetime")
+    button = hass.states.get("button.tp358_4221_set_date_time")
 
     assert button.state == STATE_UNAVAILABLE
 
@@ -142,7 +142,7 @@ async def test_buttons_tp358_reavailable(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
     assert_entity_counts(hass, Platform.BUTTON, 1, 1)
 
-    button = hass.states.get("button.thermopro_tp358_4221_datetime")
+    button = hass.states.get("button.tp358_4221_set_date_time")
     assert button.state == "unknown"
 
     # borrowed from bthome test_sensor.py
@@ -159,14 +159,14 @@ async def test_buttons_tp358_reavailable(hass: HomeAssistant) -> None:
 
         # ---
 
-        button = hass.states.get("button.thermopro_tp358_4221_datetime")
+        button = hass.states.get("button.tp358_4221_set_date_time")
 
         assert button.state == STATE_UNAVAILABLE
 
         inject_bluetooth_service_info(hass, TP358_SERVICE_INFO)
         await hass.async_block_till_done()
 
-        button = hass.states.get("button.thermopro_tp358_4221_datetime")
+        button = hass.states.get("button.tp358_4221_set_date_time")
 
         assert button.state == "unknown"
 
@@ -193,7 +193,7 @@ async def test_buttons_tp358_press(
     await hass.services.async_call(
         "button",
         "press",
-        {ATTR_ENTITY_ID: "button.thermopro_tp358_4221_datetime"},
+        {ATTR_ENTITY_ID: "button.tp358_4221_set_date_time"},
         blocking=True,
     )
 

--- a/tests/components/thermopro/test_button.py
+++ b/tests/components/thermopro/test_button.py
@@ -9,7 +9,7 @@ from thermopro_ble import ThermoProDevice
 from homeassistant.components.bluetooth import (
     FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS,
 )
-from homeassistant.const import ATTR_ENTITY_ID, STATE_UNAVAILABLE
+from homeassistant.const import ATTR_ENTITY_ID, STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
 
@@ -43,7 +43,7 @@ async def test_buttons_tp358_discovery(hass: HomeAssistant) -> None:
 
     button = hass.states.get("button.tp358_4221_set_date_time")
     assert button is not None
-    assert button.state == "unknown"
+    assert button.state == STATE_UNKNOWN
 
 
 @pytest.mark.usefixtures("setup_thermopro")
@@ -57,7 +57,7 @@ async def test_buttons_tp358_unavailable(hass: HomeAssistant) -> None:
 
     button = hass.states.get("button.tp358_4221_set_date_time")
     assert button is not None
-    assert button.state == "unknown"
+    assert button.state == STATE_UNKNOWN
 
     # Fast-forward time without BLE advertisements
     monotonic_now = start_monotonic + FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS + 15
@@ -86,7 +86,7 @@ async def test_buttons_tp358_reavailable(hass: HomeAssistant) -> None:
 
     button = hass.states.get("button.tp358_4221_set_date_time")
     assert button is not None
-    assert button.state == "unknown"
+    assert button.state == STATE_UNKNOWN
 
     # Fast-forward time without BLE advertisements
     monotonic_now = start_monotonic + FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS + 15
@@ -108,7 +108,7 @@ async def test_buttons_tp358_reavailable(hass: HomeAssistant) -> None:
 
         button = hass.states.get("button.tp358_4221_set_date_time")
 
-        assert button.state == "unknown"
+        assert button.state == STATE_UNKNOWN
 
 
 @pytest.mark.usefixtures("setup_thermopro")
@@ -130,3 +130,6 @@ async def test_buttons_tp358_press(
     )
 
     mock_thermoprodevice.set_datetime.assert_awaited_once_with(mock_now, False)
+
+    button_state = hass.states.get("button.tp358_4221_set_date_time")
+    assert button_state.state != STATE_UNKNOWN

--- a/tests/components/thermopro/test_button.py
+++ b/tests/components/thermopro/test_button.py
@@ -1,4 +1,4 @@
-"""Test the ThermoPro config flow."""
+"""Test the ThermoPro button platform."""
 
 from datetime import datetime, timedelta
 import time

--- a/tests/components/thermopro/test_button.py
+++ b/tests/components/thermopro/test_button.py
@@ -3,19 +3,19 @@
 from datetime import datetime, timedelta
 import time
 
+import pytest
 from thermopro_ble import ThermoProDevice
 
 from homeassistant.components.bluetooth import (
     FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS,
 )
-from homeassistant.components.thermopro.const import DOMAIN
 from homeassistant.const import ATTR_ENTITY_ID, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
 
 from . import TP357_SERVICE_INFO, TP358_SERVICE_INFO
 
-from tests.common import MockConfigEntry, async_fire_time_changed
+from tests.common import async_fire_time_changed
 from tests.components.bluetooth import (
     inject_bluetooth_service_info,
     patch_all_discovered_devices,
@@ -23,17 +23,9 @@ from tests.components.bluetooth import (
 )
 
 
+@pytest.mark.usefixtures("setup_thermopro")
 async def test_buttons_tp357(hass: HomeAssistant) -> None:
     """Test setting up creates the sensors."""
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        unique_id="aa:bb:cc:dd:ee:ff",
-    )
-    entry.add_to_hass(hass)
-
-    assert await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
-
     assert len(hass.states.async_all()) == 0
     assert not hass.states.get("button.tp358_4221_set_date_time")
     inject_bluetooth_service_info(hass, TP357_SERVICE_INFO)
@@ -41,17 +33,9 @@ async def test_buttons_tp357(hass: HomeAssistant) -> None:
     assert not hass.states.get("button.tp358_4221_set_date_time")
 
 
+@pytest.mark.usefixtures("setup_thermopro")
 async def test_buttons_tp358_discovery(hass: HomeAssistant) -> None:
     """Test discovery of device with button."""
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        unique_id="aa:bb:cc:dd:ee:ff",
-    )
-    entry.add_to_hass(hass)
-
-    assert await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
-
     assert len(hass.states.async_all()) == 0
     assert not hass.states.get("button.tp358_4221_set_date_time")
     inject_bluetooth_service_info(hass, TP358_SERVICE_INFO)
@@ -62,19 +46,10 @@ async def test_buttons_tp358_discovery(hass: HomeAssistant) -> None:
     assert button.state == "unknown"
 
 
+@pytest.mark.usefixtures("setup_thermopro")
 async def test_buttons_tp358_unavailable(hass: HomeAssistant) -> None:
     """Test tp358 set date&time button goes to unavailability."""
     start_monotonic = time.monotonic()
-
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        unique_id="aa:bb:cc:dd:ee:ff",
-    )
-    entry.add_to_hass(hass)
-
-    assert await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
-
     assert len(hass.states.async_all()) == 0
     assert not hass.states.get("button.tp358_4221_set_date_time")
     inject_bluetooth_service_info(hass, TP358_SERVICE_INFO)
@@ -100,19 +75,10 @@ async def test_buttons_tp358_unavailable(hass: HomeAssistant) -> None:
     assert button.state == STATE_UNAVAILABLE
 
 
+@pytest.mark.usefixtures("setup_thermopro")
 async def test_buttons_tp358_reavailable(hass: HomeAssistant) -> None:
     """Test TP358/TP393 set date&time button goes to unavailablity and recovers."""
     start_monotonic = time.monotonic()
-
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        unique_id="aa:bb:cc:dd:ee:ff",
-    )
-    entry.add_to_hass(hass)
-
-    assert await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
-
     assert len(hass.states.async_all()) == 0
     assert not hass.states.get("button.tp358_4221_set_date_time")
     inject_bluetooth_service_info(hass, TP358_SERVICE_INFO)
@@ -145,19 +111,11 @@ async def test_buttons_tp358_reavailable(hass: HomeAssistant) -> None:
         assert button.state == "unknown"
 
 
+@pytest.mark.usefixtures("setup_thermopro")
 async def test_buttons_tp358_press(
     hass: HomeAssistant, mock_now: datetime, mock_thermoprodevice: ThermoProDevice
 ) -> None:
     """Test TP358/TP393 set date&time button press."""
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        unique_id="aa:bb:cc:dd:ee:ff",
-    )
-    entry.add_to_hass(hass)
-
-    assert await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
-
     assert len(hass.states.async_all()) == 0
     assert not hass.states.get("button.tp358_4221_set_date_time")
     inject_bluetooth_service_info(hass, TP358_SERVICE_INFO)

--- a/tests/components/thermopro/test_button.py
+++ b/tests/components/thermopro/test_button.py
@@ -119,8 +119,7 @@ async def test_buttons_tp358_unavailable(hass: HomeAssistant) -> None:
     # ---
 
     button = hass.states.get("button.thermopro_tp358_4221_datetime")
-    # Normal devices should go to unavailable
-    # TODO: can't get this to work, always "unknown"!
+
     assert button.state == STATE_UNAVAILABLE
 
 
@@ -158,18 +157,18 @@ async def test_buttons_tp358_reavailable(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
 
-    # ---
+        # ---
 
-    # Normal devices should go to unavailable
-    # TODO: can't get this to work, always "unknown"!
-    # assert button.state == STATE_UNAVAILABLE
+        button = hass.states.get("button.thermopro_tp358_4221_datetime")
 
-    inject_bluetooth_service_info(hass, TP358_SERVICE_INFO)
-    await hass.async_block_till_done()
+        assert button.state == STATE_UNAVAILABLE
 
-    button = hass.states.get("button.thermopro_tp358_4221_datetime")
+        inject_bluetooth_service_info(hass, TP358_SERVICE_INFO)
+        await hass.async_block_till_done()
 
-    assert button.state == "unknown"
+        button = hass.states.get("button.thermopro_tp358_4221_datetime")
+
+        assert button.state == "unknown"
 
 
 async def test_buttons_tp358_press(

--- a/tests/components/thermopro/test_sensor.py
+++ b/tests/components/thermopro/test_sensor.py
@@ -1,5 +1,7 @@
 """Test the ThermoPro config flow."""
 
+from unittest.mock import AsyncMock
+
 from homeassistant.components.sensor import ATTR_STATE_CLASS
 from homeassistant.components.thermopro.const import DOMAIN
 from homeassistant.const import ATTR_FRIENDLY_NAME, ATTR_UNIT_OF_MEASUREMENT
@@ -11,13 +13,17 @@ from tests.common import MockConfigEntry
 from tests.components.bluetooth import inject_bluetooth_service_info
 
 
-async def test_sensors_tp962r(hass: HomeAssistant) -> None:
+async def test_sensors_tp962r(
+    hass: HomeAssistant, mock_bluetooth_adverts: AsyncMock
+) -> None:
     """Test setting up creates the sensors."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         unique_id="aa:bb:cc:dd:ee:ff",
     )
     entry.add_to_hass(hass)
+
+    mock_bluetooth_adverts.side_effect = TP962R_SERVICE_INFO
 
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()

--- a/tests/components/thermopro/test_sensor.py
+++ b/tests/components/thermopro/test_sensor.py
@@ -1,7 +1,5 @@
 """Test the ThermoPro config flow."""
 
-from unittest.mock import AsyncMock
-
 from homeassistant.components.sensor import ATTR_STATE_CLASS
 from homeassistant.components.thermopro.const import DOMAIN
 from homeassistant.const import ATTR_FRIENDLY_NAME, ATTR_UNIT_OF_MEASUREMENT
@@ -13,17 +11,13 @@ from tests.common import MockConfigEntry
 from tests.components.bluetooth import inject_bluetooth_service_info
 
 
-async def test_sensors_tp962r(
-    hass: HomeAssistant, mock_bluetooth_adverts: AsyncMock
-) -> None:
+async def test_sensors_tp962r(hass: HomeAssistant) -> None:
     """Test setting up creates the sensors."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         unique_id="aa:bb:cc:dd:ee:ff",
     )
     entry.add_to_hass(hass)
-
-    mock_bluetooth_adverts.side_effect = TP962R_SERVICE_INFO
 
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR adds a new feature to set the device time for ThermoPro TP358/TP393 devices.

This could previously be done by opening the [ThermoPro App](https://play.google.com/store/apps/details?id=com.ihunuo.ykr_hn_2005a_tlw66&hl=en) and syncing a sensor or via [this]( https://github.com/koenvervloesem/bluetooth-clocks) GH project.

By calling this service you can either set the system time HA is running on or a user defined time (with optional 12/24hour mode).

It was tested against a single TP358 device. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/36987

This is a draft, I expect to finish it with some more input over the next few days. Initial commit may be force pushed clean.

Open questions:
- Is a service scoped to the integration right or a service coped to the entity(async_register_service vs async_register_entity_service) - the characteristic sets the device time.
- I referenced some code from other integrations/sources, what attribution is best done and where?
There is a thermopro_ble python module handling parsing of received advertisements, should the time formatting code go in there?
- I am unsure how schema validation for the service would work, do I add entity and device Id as possible fields, marking them exlusive via the validator?

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description. 

Dependency Update PR - https://github.com/home-assistant/core/pull/137381

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr