### PR TITLE
Swistakm/fix blebox light temperature scaling

### DIFF
--- a/homeassistant/components/blebox/const.py
+++ b/homeassistant/components/blebox/const.py
@@ -13,3 +13,6 @@ UNKNOWN = "unknown"
 
 DEFAULT_HOST = "192.168.0.2"
 DEFAULT_PORT = 80
+
+LIGHT_MAX_MIREDS = 370  # 1,000,000 divided by 2700 Kelvin = 370 Mireds
+LIGHT_MIN_MIREDS = 154  # 1,000,000 divided by 6500 Kelvin = 154 Mireds

--- a/homeassistant/components/blebox/light.py
+++ b/homeassistant/components/blebox/light.py
@@ -80,7 +80,7 @@ class BleBoxLightEntity(BleBoxEntity[blebox_uniapi.light.Light], LightEntity):
     @property
     def color_temp(self):
         """Return color temperature."""
-        return self._feature.color_temp
+        return self._color_temp_from_native_scale(self._feature.color_temp)
 
     @property
     def color_mode(self):
@@ -130,23 +130,36 @@ class BleBoxLightEntity(BleBoxEntity[blebox_uniapi.light.Light], LightEntity):
             return None
         return tuple(blebox_uniapi.light.Light.rgb_hex_to_rgb_list(rgbww_hex))
 
+    def _color_temp_to_native_scale(self, x):
+        """Convert color temperature from mireds to native Blebox temperature scale."""
+        scaled = ((x - self.min_mireds) / (self.max_mireds - self.min_mireds)) * 255
+        bounded = max(min(scaled, 255), 0)
+        return int(bounded)
+
+    def _color_temp_from_native_scale(self, x):
+        """Convert color temperature from native Blebox temperature scale to mireds."""
+        scaled = (x / 255) * (self.max_mireds - self.min_mireds) + self.min_mireds
+        bounded = max(min(scaled, self.max_mireds), self.min_mireds)
+        return int(bounded)
+
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the light on."""
-
         rgbw = kwargs.get(ATTR_RGBW_COLOR)
         brightness = kwargs.get(ATTR_BRIGHTNESS)
         effect = kwargs.get(ATTR_EFFECT)
         color_temp = kwargs.get(ATTR_COLOR_TEMP)
         rgbww = kwargs.get(ATTR_RGBWW_COLOR)
+        rgb = kwargs.get(ATTR_RGB_COLOR)
+
         feature = self._feature
         value = feature.sensible_on_value
-        rgb = kwargs.get(ATTR_RGB_COLOR)
 
         if rgbw is not None:
             value = list(rgbw)
+
         if color_temp is not None:
             value = feature.return_color_temp_with_brightness(
-                int(color_temp), self.brightness
+                self._color_temp_to_native_scale(color_temp), self.brightness
             )
 
         if rgbww is not None:

--- a/tests/components/blebox/test_light.py
+++ b/tests/components/blebox/test_light.py
@@ -6,8 +6,10 @@ from unittest.mock import AsyncMock, PropertyMock
 import blebox_uniapi
 import pytest
 
+from homeassistant.components.blebox.const import LIGHT_MAX_MIREDS, LIGHT_MIN_MIREDS
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
+    ATTR_COLOR_TEMP,
     ATTR_EFFECT,
     ATTR_RGBW_COLOR,
     ATTR_SUPPORTED_COLOR_MODES,
@@ -329,6 +331,32 @@ def wlightbox_fixture():
     return (feature, "light.wlightbox_color")
 
 
+@pytest.fixture(name="wlightbox_ctx2")
+def wlightbox_ctx2_fixture():
+    """Return a default light entity mock."""
+
+    feature = mock_feature(
+        "lights",
+        blebox_uniapi.light.Light,
+        unique_id="BleBox-wLightBox-1afe34e750b8-color",
+        full_name="wLightBox-ctx2",
+        device_class=None,
+        is_on=None,
+        supports_color=True,
+        supports_white=True,
+        white_value=None,
+        rgbw_hex=None,
+        color_mode=blebox_uniapi.light.BleboxColorMode.CTx2,
+        effect="NONE",
+        effect_list=["NONE", "PL", "POLICE"],
+        # color_temp=3,
+    )
+    product = feature.product
+    type(product).name = PropertyMock(return_value="My wLightBox")
+    type(product).model = PropertyMock(return_value="wLightBox")
+    return (feature, "light.wlightbox_ctx2")
+
+
 async def test_wlightbox_init(
     wlightbox, hass: HomeAssistant, device_registry: dr.DeviceRegistry
 ) -> None:
@@ -423,6 +451,66 @@ async def test_wlightbox_on_rgbw(wlightbox, hass: HomeAssistant) -> None:
     state = hass.states.get(entity_id)
     assert state.state == STATE_ON
     assert state.attributes[ATTR_RGBW_COLOR] == (0xC1, 0xD2, 0xF3, 0xC7)
+
+
+# note: it is a good idea to test wide range of values including those
+# outside of the operating range to make sure that bounds are properly
+# corrected
+@pytest.mark.parametrize("temp_requested", [1, 100, 150, 200, 300, 400])
+async def test_wlightbox_on_temp(
+    wlightbox_ctx2, hass: HomeAssistant, temp_requested: int
+) -> None:
+    """Test light on with temperature change."""
+
+    feature_mock, entity_id = wlightbox_ctx2
+
+    # note: testing color temperature modification is tricky as neither
+    # blebox_uniapi nor blebox devices operate on color_temperature concept.
+    # Instead, it uses a mixture of brightness and temperature value encoded
+    # with known formula that is exposed by return_color_temp_with_brightness()
+    # method. To make testing simpler let's hijack the requested value
+    # with transient nonlocal value.
+    transient_temp: int = -1
+
+    def return_color_temp_with_brightness(value, brightness):
+        nonlocal transient_temp
+        transient_temp = value
+        return [0x00, 0x39, 0xB0, 0xFF]
+
+    def initial_update():
+        feature_mock.is_on = False
+
+    feature_mock.color_temp = 128
+    feature_mock.async_update = AsyncMock(side_effect=initial_update)
+    feature_mock.return_color_temp_with_brightness = return_color_temp_with_brightness
+
+    await async_setup_entity(hass, entity_id)
+    feature_mock.async_update = AsyncMock()
+
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_OFF
+
+    def turn_on(value):
+        feature_mock.is_on = True
+        assert value == [0x00, 0x39, 0xB0, 0xFF]
+        feature_mock.color_temp = transient_temp
+
+    feature_mock.async_on = AsyncMock(side_effect=turn_on)
+
+    await hass.services.async_call(
+        "light",
+        SERVICE_TURN_ON,
+        {"entity_id": entity_id, ATTR_COLOR_TEMP: temp_requested},
+        blocking=True,
+    )
+
+    state = hass.states.get(entity_id)
+    mired_temp = state.attributes[ATTR_COLOR_TEMP]
+
+    assert state.state == STATE_ON
+    assert LIGHT_MIN_MIREDS <= mired_temp <= LIGHT_MAX_MIREDS
+    assert mired_temp == max(min(mired_temp, LIGHT_MAX_MIREDS), LIGHT_MIN_MIREDS)
+    assert 0 <= transient_temp <= 255
 
 
 async def test_wlightbox_on_to_last_color(wlightbox, hass: HomeAssistant) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
In https://github.com/home-assistant/core/pull/124258 I have fixed the mired temperature range used by blebox light controllers as they typically operate typically in 2700-6500K range. Unfortunately I have missed the fact that homeassistant mired range needs to be normalized into 0-255 integer values.

This PR fixes the problem by bi-directionally mapping between the min/max mired range assigned to blebox light entities (154-370) and value range expected by the blebox_uniapi library.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

This PR fixes or closes issue: fixes #
This PR is related to issue: https://github.com/home-assistant/core/pull/124258
Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
