### PR TITLE
Remove misleading "Current" in NUT power sensor names

### DIFF
--- a/homeassistant/components/nut/strings.json
+++ b/homeassistant/components/nut/strings.json
@@ -113,15 +113,15 @@
       "input_bypass_l3_n_voltage": { "name": "Input bypass L3-N voltage" },
       "input_bypass_frequency": { "name": "Input bypass frequency" },
       "input_bypass_phases": { "name": "Input bypass phases" },
-      "input_bypass_realpower": { "name": "Current input bypass real power" },
+      "input_bypass_realpower": { "name": "Input bypass real power" },
       "input_bypass_l1_realpower": {
-        "name": "Current input bypass L1 real power"
+        "name": "Input bypass L1 real power"
       },
       "input_bypass_l2_realpower": {
-        "name": "Current input bypass L2 real power"
+        "name": "Input bypass L2 real power"
       },
       "input_bypass_l3_realpower": {
-        "name": "Current input bypass L3 real power"
+        "name": "Input bypass L3 real power"
       },
       "input_current": { "name": "Input current" },
       "input_l1_current": { "name": "Input L1 current" },
@@ -134,10 +134,10 @@
       "input_l2_frequency": { "name": "Input L2 line frequency" },
       "input_l3_frequency": { "name": "Input L3 line frequency" },
       "input_phases": { "name": "Input phases" },
-      "input_realpower": { "name": "Current input real power" },
-      "input_l1_realpower": { "name": "Current input L1 real power" },
-      "input_l2_realpower": { "name": "Current input L2 real power" },
-      "input_l3_realpower": { "name": "Current input L3 real power" },
+      "input_realpower": { "name": "Input real power" },
+      "input_l1_realpower": { "name": "Input L1 real power" },
+      "input_l2_realpower": { "name": "Input L2 real power" },
+      "input_l3_realpower": { "name": "Input L3 real power" },
       "input_sensitivity": { "name": "Input power sensitivity" },
       "input_transfer_high": { "name": "High voltage transfer" },
       "input_transfer_low": { "name": "Low voltage transfer" },
@@ -160,11 +160,11 @@
       "output_l1_power_percent": { "name": "Output L1 power usage" },
       "output_l3_power_percent": { "name": "Output L3 power usage" },
       "output_power_nominal": { "name": "Nominal output power" },
-      "output_realpower": { "name": "Current output real power" },
+      "output_realpower": { "name": "Output real power" },
       "output_realpower_nominal": { "name": "Nominal output real power" },
-      "output_l1_realpower": { "name": "Current output L1 real power" },
-      "output_l2_realpower": { "name": "Current output L2 real power" },
-      "output_l3_realpower": { "name": "Current output L3 real power" },
+      "output_l1_realpower": { "name": "Output L1 real power" },
+      "output_l2_realpower": { "name": "Output L2 real power" },
+      "output_l3_realpower": { "name": "Output L3 real power" },
       "output_voltage": { "name": "Output voltage" },
       "output_voltage_nominal": { "name": "Nominal output voltage" },
       "output_l1_n_voltage": { "name": "Output L1-N voltage" },
@@ -183,9 +183,9 @@
       "ups_id": { "name": "System identifier" },
       "ups_load": { "name": "Load" },
       "ups_load_high": { "name": "Overload setting" },
-      "ups_power": { "name": "Current apparent power" },
+      "ups_power": { "name": "Apparent power" },
       "ups_power_nominal": { "name": "Nominal power" },
-      "ups_realpower": { "name": "Current real power" },
+      "ups_realpower": { "name": "Real power" },
       "ups_realpower_nominal": { "name": "Nominal real power" },
       "ups_shutdown": { "name": "Shutdown ability" },
       "ups_start_auto": { "name": "Start on ac" },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Few NUT sensors beings with `Current` which is misleading since the integration expose electric current sensors, see https://github.com/home-assistant/core/issues/135769

Renaming of the sensors did not break tests and I have verified this change on a real device.

CC @NoRi2909 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/135769
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
