### PR TITLE
Prevent HomeKit from going unavailable when min/max is reversed

### DIFF
--- a/homeassistant/components/homekit/type_lights.py
+++ b/homeassistant/components/homekit/type_lights.py
@@ -122,10 +122,10 @@ class Light(HomeAccessory):
 
         if CHAR_COLOR_TEMPERATURE in self.chars:
             min_mireds = color_temperature_kelvin_to_mired(
-                attributes.get(ATTR_MIN_COLOR_TEMP_KELVIN, DEFAULT_MIN_COLOR_TEMP)
+                attributes.get(ATTR_MAX_COLOR_TEMP_KELVIN, DEFAULT_MAX_COLOR_TEMP)
             )
             max_mireds = color_temperature_kelvin_to_mired(
-                attributes.get(ATTR_MAX_COLOR_TEMP_KELVIN, DEFAULT_MAX_COLOR_TEMP)
+                attributes.get(ATTR_MIN_COLOR_TEMP_KELVIN, DEFAULT_MIN_COLOR_TEMP)
             )
             # Ensure min is less than max
             self.min_mireds, self.max_mireds = get_min_max(min_mireds, max_mireds)

--- a/homeassistant/components/homekit/type_lights.py
+++ b/homeassistant/components/homekit/type_lights.py
@@ -121,14 +121,14 @@ class Light(HomeAccessory):
             self.char_brightness = serv_light.configure_char(CHAR_BRIGHTNESS, value=100)
 
         if CHAR_COLOR_TEMPERATURE in self.chars:
-            self.min_mireds, self.max_mireds = get_min_max(
-                color_temperature_kelvin_to_mired(
-                    attributes.get(ATTR_MIN_COLOR_TEMP_KELVIN, DEFAULT_MIN_COLOR_TEMP)
-                ),
-                color_temperature_kelvin_to_mired(
-                    attributes.get(ATTR_MAX_COLOR_TEMP_KELVIN, DEFAULT_MAX_COLOR_TEMP)
-                ),
+            min_mireds = color_temperature_kelvin_to_mired(
+                attributes.get(ATTR_MIN_COLOR_TEMP_KELVIN, DEFAULT_MIN_COLOR_TEMP)
             )
+            max_mireds = color_temperature_kelvin_to_mired(
+                attributes.get(ATTR_MAX_COLOR_TEMP_KELVIN, DEFAULT_MAX_COLOR_TEMP)
+            )
+            # Ensure min is less than max
+            self.min_mireds, self.max_mireds = get_min_max(min_mireds, max_mireds)
             if not self.color_temp_supported and not self.rgbww_supported:
                 self.max_mireds = self.min_mireds
             self.char_color_temp = serv_light.configure_char(

--- a/homeassistant/components/homekit/type_lights.py
+++ b/homeassistant/components/homekit/type_lights.py
@@ -52,6 +52,7 @@ from .const import (
     PROP_MIN_VALUE,
     SERV_LIGHTBULB,
 )
+from .util import get_min_max
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -120,11 +121,13 @@ class Light(HomeAccessory):
             self.char_brightness = serv_light.configure_char(CHAR_BRIGHTNESS, value=100)
 
         if CHAR_COLOR_TEMPERATURE in self.chars:
-            self.min_mireds = color_temperature_kelvin_to_mired(
-                attributes.get(ATTR_MAX_COLOR_TEMP_KELVIN, DEFAULT_MAX_COLOR_TEMP)
-            )
-            self.max_mireds = color_temperature_kelvin_to_mired(
-                attributes.get(ATTR_MIN_COLOR_TEMP_KELVIN, DEFAULT_MIN_COLOR_TEMP)
+            self.min_mireds, self.max_mireds = get_min_max(
+                color_temperature_kelvin_to_mired(
+                    attributes.get(ATTR_MIN_COLOR_TEMP_KELVIN, DEFAULT_MIN_COLOR_TEMP)
+                ),
+                color_temperature_kelvin_to_mired(
+                    attributes.get(ATTR_MAX_COLOR_TEMP_KELVIN, DEFAULT_MAX_COLOR_TEMP)
+                ),
             )
             if not self.color_temp_supported and not self.rgbww_supported:
                 self.max_mireds = self.min_mireds

--- a/homeassistant/components/homekit/type_thermostats.py
+++ b/homeassistant/components/homekit/type_thermostats.py
@@ -90,7 +90,7 @@ from .const import (
     SERV_FANV2,
     SERV_THERMOSTAT,
 )
-from .util import temperature_to_homekit, temperature_to_states
+from .util import get_min_max, temperature_to_homekit, temperature_to_states
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -838,6 +838,9 @@ def _get_temperature_range_from_state(
         max_temp = round(temperature_to_homekit(max_temp, unit) * 2) / 2
     else:
         max_temp = default_max
+
+    # Handle reversed temperature range
+    min_temp, max_temp = get_min_max(min_temp, max_temp)
 
     # Homekit only supports 10-38, overwriting
     # the max to appears to work, but less than 0 causes

--- a/homeassistant/components/homekit/type_thermostats.py
+++ b/homeassistant/components/homekit/type_thermostats.py
@@ -14,6 +14,7 @@ from homeassistant.components.climate import (
     ATTR_HVAC_ACTION,
     ATTR_HVAC_MODE,
     ATTR_HVAC_MODES,
+    ATTR_MAX_HUMIDITY,
     ATTR_MAX_TEMP,
     ATTR_MIN_HUMIDITY,
     ATTR_MIN_TEMP,
@@ -21,6 +22,7 @@ from homeassistant.components.climate import (
     ATTR_SWING_MODES,
     ATTR_TARGET_TEMP_HIGH,
     ATTR_TARGET_TEMP_LOW,
+    DEFAULT_MAX_HUMIDITY,
     DEFAULT_MAX_TEMP,
     DEFAULT_MIN_HUMIDITY,
     DEFAULT_MIN_TEMP,
@@ -208,7 +210,10 @@ class Thermostat(HomeAccessory):
         self.fan_chars: list[str] = []
 
         attributes = state.attributes
-        min_humidity = attributes.get(ATTR_MIN_HUMIDITY, DEFAULT_MIN_HUMIDITY)
+        min_humidity, _ = get_min_max(
+            attributes.get(ATTR_MIN_HUMIDITY, DEFAULT_MIN_HUMIDITY),
+            attributes.get(ATTR_MAX_HUMIDITY, DEFAULT_MAX_HUMIDITY),
+        )
         features = attributes.get(ATTR_SUPPORTED_FEATURES, 0)
 
         if features & ClimateEntityFeature.TARGET_TEMPERATURE_RANGE:

--- a/homeassistant/components/homekit/util.py
+++ b/homeassistant/components/homekit/util.py
@@ -663,7 +663,7 @@ def get_min_max(value1: float, value2: float) -> tuple[float, float]:
 
     HomeKit will go unavailable if the min and max are reversed
     so we make sure the min is always the min and the max is always the max
-    as any mistakes make in integrations will cause the entire
+    as any mistakes made in integrations will cause the entire
     bridge to go unavailable.
     """
     return min(value1, value2), max(value1, value2)

--- a/homeassistant/components/homekit/util.py
+++ b/homeassistant/components/homekit/util.py
@@ -656,3 +656,14 @@ def state_changed_event_is_same_state(event: Event[EventStateChangedData]) -> bo
     old_state = event_data["old_state"]
     new_state = event_data["new_state"]
     return bool(new_state and old_state and new_state.state == old_state.state)
+
+
+def get_min_max(value1: float, value2: float) -> tuple[float, float]:
+    """Return the minimum and maximum of two values.
+
+    HomeKit will go unavailable if the min and max are reversed
+    so we make sure the min is always the min and the max is always the max
+    as any mistakes make in integrations will cause the entire
+    bridge to go unavailable.
+    """
+    return min(value1, value2), max(value1, value2)

--- a/tests/components/homekit/test_type_lights.py
+++ b/tests/components/homekit/test_type_lights.py
@@ -807,6 +807,156 @@ async def test_light_invalid_values(
     assert acc.char_saturation.value == 95
 
 
+async def test_light_out_of_range_color_temp(hass: HomeAssistant, hk_driver) -> None:
+    """Test light with an out of range color temp."""
+    entity_id = "light.demo"
+
+    hass.states.async_set(
+        entity_id,
+        STATE_ON,
+        {
+            ATTR_SUPPORTED_COLOR_MODES: ["color_temp", "hs"],
+            ATTR_COLOR_MODE: "hs",
+            ATTR_COLOR_TEMP_KELVIN: 2000,
+            ATTR_MAX_COLOR_TEMP_KELVIN: 4000,
+            ATTR_MIN_COLOR_TEMP_KELVIN: 3000,
+            ATTR_HS_COLOR: (-1, -1),
+        },
+    )
+    await hass.async_block_till_done()
+    acc = Light(hass, hk_driver, "Light", entity_id, 1, None)
+    hk_driver.add_accessory(acc)
+
+    assert acc.char_color_temp.value == 333
+    assert acc.char_color_temp.properties[PROP_MAX_VALUE] == 333
+    assert acc.char_color_temp.properties[PROP_MIN_VALUE] == 250
+    assert acc.char_hue.value == 31
+    assert acc.char_saturation.value == 95
+    hass.states.async_set(
+        entity_id,
+        STATE_ON,
+        {
+            ATTR_SUPPORTED_COLOR_MODES: ["color_temp", "hs"],
+            ATTR_COLOR_MODE: "color_temp",
+            ATTR_MAX_COLOR_TEMP_KELVIN: 4000,
+            ATTR_MIN_COLOR_TEMP_KELVIN: 3000,
+            ATTR_COLOR_TEMP_KELVIN: -1,
+        },
+    )
+    await hass.async_block_till_done()
+    acc.run()
+
+    assert acc.char_color_temp.value == 250
+    assert acc.char_hue.value == 16
+    assert acc.char_saturation.value == 100
+    hass.states.async_set(
+        entity_id,
+        STATE_ON,
+        {
+            ATTR_SUPPORTED_COLOR_MODES: ["color_temp", "hs"],
+            ATTR_COLOR_MODE: "color_temp",
+            ATTR_MAX_COLOR_TEMP_KELVIN: 4000,
+            ATTR_MIN_COLOR_TEMP_KELVIN: 3000,
+            ATTR_COLOR_TEMP_KELVIN: sys.maxsize,
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert acc.char_color_temp.value == 250
+    assert acc.char_hue.value == 220
+    assert acc.char_saturation.value == 41
+
+    hass.states.async_set(
+        entity_id,
+        STATE_ON,
+        {
+            ATTR_SUPPORTED_COLOR_MODES: ["color_temp", "hs"],
+            ATTR_COLOR_MODE: "color_temp",
+            ATTR_COLOR_TEMP_KELVIN: 2000,
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert acc.char_color_temp.value == 250
+    assert acc.char_hue.value == 220
+    assert acc.char_saturation.value == 41
+
+
+async def test_reversed_color_temp_min_max(hass: HomeAssistant, hk_driver) -> None:
+    """Test light with a reversed color temp min max."""
+    entity_id = "light.demo"
+
+    hass.states.async_set(
+        entity_id,
+        STATE_ON,
+        {
+            ATTR_SUPPORTED_COLOR_MODES: ["color_temp", "hs"],
+            ATTR_COLOR_MODE: "hs",
+            ATTR_COLOR_TEMP_KELVIN: 2000,
+            ATTR_MAX_COLOR_TEMP_KELVIN: 3000,
+            ATTR_MIN_COLOR_TEMP_KELVIN: 4000,
+            ATTR_HS_COLOR: (-1, -1),
+        },
+    )
+    await hass.async_block_till_done()
+    acc = Light(hass, hk_driver, "Light", entity_id, 1, None)
+    hk_driver.add_accessory(acc)
+
+    assert acc.char_color_temp.value == 333
+    assert acc.char_color_temp.properties[PROP_MAX_VALUE] == 333
+    assert acc.char_color_temp.properties[PROP_MIN_VALUE] == 250
+    assert acc.char_hue.value == 31
+    assert acc.char_saturation.value == 95
+    hass.states.async_set(
+        entity_id,
+        STATE_ON,
+        {
+            ATTR_SUPPORTED_COLOR_MODES: ["color_temp", "hs"],
+            ATTR_COLOR_MODE: "color_temp",
+            ATTR_MAX_COLOR_TEMP_KELVIN: 4000,
+            ATTR_MIN_COLOR_TEMP_KELVIN: 3000,
+            ATTR_COLOR_TEMP_KELVIN: -1,
+        },
+    )
+    await hass.async_block_till_done()
+    acc.run()
+
+    assert acc.char_color_temp.value == 250
+    assert acc.char_hue.value == 16
+    assert acc.char_saturation.value == 100
+    hass.states.async_set(
+        entity_id,
+        STATE_ON,
+        {
+            ATTR_SUPPORTED_COLOR_MODES: ["color_temp", "hs"],
+            ATTR_COLOR_MODE: "color_temp",
+            ATTR_MAX_COLOR_TEMP_KELVIN: 4000,
+            ATTR_MIN_COLOR_TEMP_KELVIN: 3000,
+            ATTR_COLOR_TEMP_KELVIN: sys.maxsize,
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert acc.char_color_temp.value == 250
+    assert acc.char_hue.value == 220
+    assert acc.char_saturation.value == 41
+
+    hass.states.async_set(
+        entity_id,
+        STATE_ON,
+        {
+            ATTR_SUPPORTED_COLOR_MODES: ["color_temp", "hs"],
+            ATTR_COLOR_MODE: "color_temp",
+            ATTR_COLOR_TEMP_KELVIN: 2000,
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert acc.char_color_temp.value == 250
+    assert acc.char_hue.value == 220
+    assert acc.char_saturation.value == 41
+
+
 @pytest.mark.parametrize(
     "supported_color_modes", [[ColorMode.HS], [ColorMode.RGB], [ColorMode.XY]]
 )

--- a/tests/components/homekit/test_type_thermostats.py
+++ b/tests/components/homekit/test_type_thermostats.py
@@ -26,6 +26,7 @@ from homeassistant.components.climate import (
     ATTR_TARGET_TEMP_STEP,
     DEFAULT_MAX_TEMP,
     DEFAULT_MIN_HUMIDITY,
+    DEFAULT_MIN_TEMP,
     DOMAIN as DOMAIN_CLIMATE,
     FAN_AUTO,
     FAN_HIGH,
@@ -2009,8 +2010,8 @@ async def test_thermostat_with_temp_clamps(hass: HomeAssistant, hk_driver) -> No
         ATTR_SUPPORTED_FEATURES: ClimateEntityFeature.TARGET_TEMPERATURE
         | ClimateEntityFeature.TARGET_TEMPERATURE_RANGE,
         ATTR_HVAC_MODES: [HVACMode.HEAT_COOL, HVACMode.AUTO],
-        ATTR_MAX_TEMP: 50,
-        ATTR_MIN_TEMP: 100,
+        ATTR_MAX_TEMP: 100,
+        ATTR_MIN_TEMP: 50,
     }
     hass.states.async_set(
         entity_id,
@@ -2024,14 +2025,14 @@ async def test_thermostat_with_temp_clamps(hass: HomeAssistant, hk_driver) -> No
     acc.run()
     await hass.async_block_till_done()
 
-    assert acc.char_cooling_thresh_temp.value == 100
-    assert acc.char_heating_thresh_temp.value == 100
+    assert acc.char_cooling_thresh_temp.value == 50
+    assert acc.char_heating_thresh_temp.value == 50
 
     assert acc.char_cooling_thresh_temp.properties[PROP_MAX_VALUE] == 100
-    assert acc.char_cooling_thresh_temp.properties[PROP_MIN_VALUE] == 100
+    assert acc.char_cooling_thresh_temp.properties[PROP_MIN_VALUE] == 50
     assert acc.char_cooling_thresh_temp.properties[PROP_MIN_STEP] == 0.1
     assert acc.char_heating_thresh_temp.properties[PROP_MAX_VALUE] == 100
-    assert acc.char_heating_thresh_temp.properties[PROP_MIN_VALUE] == 100
+    assert acc.char_heating_thresh_temp.properties[PROP_MIN_VALUE] == 50
     assert acc.char_heating_thresh_temp.properties[PROP_MIN_STEP] == 0.1
 
     assert acc.char_target_heat_cool.value == 3
@@ -2048,7 +2049,7 @@ async def test_thermostat_with_temp_clamps(hass: HomeAssistant, hk_driver) -> No
         },
     )
     await hass.async_block_till_done()
-    assert acc.char_heating_thresh_temp.value == 100.0
+    assert acc.char_heating_thresh_temp.value == 50.0
     assert acc.char_cooling_thresh_temp.value == 100.0
     assert acc.char_current_heat_cool.value == 1
     assert acc.char_target_heat_cool.value == 3
@@ -2633,3 +2634,44 @@ async def test_thermostat_handles_unknown_state(hass: HomeAssistant, hk_driver) 
     assert call_set_hvac_mode
     assert call_set_hvac_mode[1].data[ATTR_ENTITY_ID] == entity_id
     assert call_set_hvac_mode[1].data[ATTR_HVAC_MODE] == HVACMode.HEAT
+
+
+async def test_thermostat_reversed_min_max(hass: HomeAssistant, hk_driver) -> None:
+    """Test reversed min/max temperatures."""
+    entity_id = "climate.test"
+    base_attrs = {
+        ATTR_SUPPORTED_FEATURES: ClimateEntityFeature.TARGET_TEMPERATURE
+        | ClimateEntityFeature.TARGET_TEMPERATURE_RANGE,
+        ATTR_HVAC_MODES: [
+            HVACMode.HEAT,
+            HVACMode.HEAT_COOL,
+            HVACMode.FAN_ONLY,
+            HVACMode.COOL,
+            HVACMode.OFF,
+            HVACMode.AUTO,
+        ],
+        ATTR_MAX_TEMP: DEFAULT_MAX_TEMP,
+        ATTR_MIN_TEMP: DEFAULT_MIN_TEMP,
+    }
+    # support_auto = True
+    hass.states.async_set(
+        entity_id,
+        HVACMode.OFF,
+        base_attrs,
+    )
+    await hass.async_block_till_done()
+    acc = Thermostat(hass, hk_driver, "Climate", entity_id, 1, None)
+    hk_driver.add_accessory(acc)
+
+    acc.run()
+    await hass.async_block_till_done()
+
+    assert acc.char_cooling_thresh_temp.value == 23.0
+    assert acc.char_heating_thresh_temp.value == 19.0
+
+    assert acc.char_cooling_thresh_temp.properties[PROP_MAX_VALUE] == DEFAULT_MAX_TEMP
+    assert acc.char_cooling_thresh_temp.properties[PROP_MIN_VALUE] == 7.0
+    assert acc.char_cooling_thresh_temp.properties[PROP_MIN_STEP] == 0.1
+    assert acc.char_heating_thresh_temp.properties[PROP_MAX_VALUE] == DEFAULT_MAX_TEMP
+    assert acc.char_heating_thresh_temp.properties[PROP_MIN_VALUE] == 7.0
+    assert acc.char_heating_thresh_temp.properties[PROP_MIN_STEP] == 0.1


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
If min and max values are reversed for any properties, the HomeKit bridge will go unavailable.  This change prevents a single entity from polluting the bridge state and having HomeKit reject the entire bridge which is especially painful to debug since there is no error shown to the client other than HomeKit is unavailable.


fixes #135222
fixes #135401
fixes #135358

While not the first, and it won't be the last, the latest integration to do this happened to be the govee hacs integration. This is a very easy mistake to make when converting kelvin/mireds and back because the scales go opposite directions.

https://github.com/LaggAt/hacs-govee/blob/e940ceffe37bcf787e46ad42a8c86bc39c8278e5/custom_components/govee/light.py#L308
https://github.com/LaggAt/hacs-govee/blob/e940ceffe37bcf787e46ad42a8c86bc39c8278e5/custom_components/govee/light.py#L303

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
