### PR TITLE
Fix inconsistently spelled occurrences of "ID" in telegram_bot integration

### DIFF
--- a/homeassistant/components/telegram_bot/strings.json
+++ b/homeassistant/components/telegram_bot/strings.json
@@ -30,7 +30,7 @@
         },
         "timeout": {
           "name": "Read timeout",
-          "description": "Read timeout for send message. Will help with timeout errors (poor internet connection, etc)s."
+          "description": "Timeout for sending the message in seconds. Will help with timeout errors (poor Internet connection, etc)."
         },
         "keyboard": {
           "name": "Keyboard",
@@ -100,7 +100,7 @@
         },
         "timeout": {
           "name": "Read timeout",
-          "description": "Read timeout for send photo."
+          "description": "Timeout for sending the photo in seconds."
         },
         "keyboard": {
           "name": "[%key:component::telegram_bot::services::send_message::fields::keyboard::name%]",
@@ -166,7 +166,7 @@
         },
         "timeout": {
           "name": "Read timeout",
-          "description": "Read timeout for send sticker."
+          "description": "Timeout for sending the sticker in seconds."
         },
         "keyboard": {
           "name": "[%key:component::telegram_bot::services::send_message::fields::keyboard::name%]",
@@ -306,7 +306,7 @@
         },
         "timeout": {
           "name": "Read timeout",
-          "description": "Read timeout for send video."
+          "description": "Timeout for sending the video in seconds."
         },
         "keyboard": {
           "name": "[%key:component::telegram_bot::services::send_message::fields::keyboard::name%]",
@@ -372,7 +372,7 @@
         },
         "timeout": {
           "name": "Read timeout",
-          "description": "Read timeout for send voice."
+          "description": "Timeout for sending the voice in seconds."
         },
         "keyboard": {
           "name": "[%key:component::telegram_bot::services::send_message::fields::keyboard::name%]",
@@ -442,7 +442,7 @@
         },
         "timeout": {
           "name": "Read timeout",
-          "description": "Read timeout for send document."
+          "description": "Timeout for sending the document in seconds."
         },
         "keyboard": {
           "name": "[%key:component::telegram_bot::services::send_message::fields::keyboard::name%]",
@@ -546,7 +546,7 @@
         },
         "timeout": {
           "name": "Read timeout",
-          "description": "Read timeout for send poll."
+          "description": "Timeout for sending the poll in seconds."
         },
         "message_tag": {
           "name": "[%key:component::telegram_bot::services::send_message::fields::message_tag::name%]",
@@ -628,7 +628,7 @@
         },
         "chat_id": {
           "name": "[%key:component::telegram_bot::services::edit_message::fields::chat_id::name%]",
-          "description": "ID of the chat where to edit the reply_markup."
+          "description": "ID of the chat where to edit the reply markup."
         },
         "inline_keyboard": {
           "name": "[%key:component::telegram_bot::services::send_message::fields::inline_keyboard::name%]",
@@ -654,7 +654,7 @@
         },
         "timeout": {
           "name": "Read timeout",
-          "description": "Read timeout for sending the answer."
+          "description": "Timeout for sending the answer in seconds."
         }
       }
     },

--- a/homeassistant/components/telegram_bot/strings.json
+++ b/homeassistant/components/telegram_bot/strings.json
@@ -14,7 +14,7 @@
         },
         "target": {
           "name": "Target",
-          "description": "An array of pre-authorized chat_ids to send the notification to. If not present, first allowed chat_id is the default."
+          "description": "An array of pre-authorized chat IDs to send the notification to. If not present, first allowed chat ID is the default."
         },
         "parse_mode": {
           "name": "Parse mode",
@@ -45,11 +45,11 @@
           "description": "Tag for sent message."
         },
         "reply_to_message_id": {
-          "name": "Reply to message id",
+          "name": "Reply to message ID",
           "description": "Mark the message as a reply to a previous message."
         },
         "message_thread_id": {
-          "name": "Message thread id",
+          "name": "Message thread ID",
           "description": "Unique identifier for the target message thread (topic) of the forum; for forum supergroups only."
         }
       }
@@ -84,7 +84,7 @@
         },
         "target": {
           "name": "Target",
-          "description": "An array of pre-authorized chat_ids to send the document to. If not present, first allowed chat_id is the default."
+          "description": "An array of pre-authorized chat IDs to send the document to. If not present, first allowed chat ID is the default."
         },
         "parse_mode": {
           "name": "[%key:component::telegram_bot::services::send_message::fields::parse_mode::name%]",
@@ -480,7 +480,7 @@
         },
         "target": {
           "name": "Target",
-          "description": "An array of pre-authorized chat_ids to send the location to. If not present, first allowed chat_id is the default."
+          "description": "An array of pre-authorized chat IDs to send the location to. If not present, first allowed chat ID is the default."
         },
         "disable_notification": {
           "name": "[%key:component::telegram_bot::services::send_message::fields::disable_notification::name%]",
@@ -568,11 +568,11 @@
       "fields": {
         "message_id": {
           "name": "Message ID",
-          "description": "Id of the message to edit."
+          "description": "ID of the message to edit."
         },
         "chat_id": {
           "name": "Chat ID",
-          "description": "The chat_id where to edit the message."
+          "description": "ID of the chat where to edit the message."
         },
         "message": {
           "name": "Message",
@@ -606,7 +606,7 @@
         },
         "chat_id": {
           "name": "[%key:component::telegram_bot::services::edit_message::fields::chat_id::name%]",
-          "description": "The chat_id where to edit the caption."
+          "description": "ID of the chat where to edit the caption."
         },
         "caption": {
           "name": "[%key:component::telegram_bot::services::send_photo::fields::caption::name%]",
@@ -620,7 +620,7 @@
     },
     "edit_replymarkup": {
       "name": "Edit reply markup",
-      "description": "Edit the inline keyboard of a previously sent message.",
+      "description": "Edits the inline keyboard of a previously sent message.",
       "fields": {
         "message_id": {
           "name": "[%key:component::telegram_bot::services::edit_message::fields::message_id::name%]",
@@ -628,7 +628,7 @@
         },
         "chat_id": {
           "name": "[%key:component::telegram_bot::services::edit_message::fields::chat_id::name%]",
-          "description": "The chat_id where to edit the reply_markup."
+          "description": "ID of the chat where to edit the reply_markup."
         },
         "inline_keyboard": {
           "name": "[%key:component::telegram_bot::services::send_message::fields::inline_keyboard::name%]",
@@ -646,7 +646,7 @@
         },
         "callback_query_id": {
           "name": "Callback query ID",
-          "description": "Unique id of the callback response."
+          "description": "Unique ID of the callback response."
         },
         "show_alert": {
           "name": "Show alert",
@@ -664,11 +664,11 @@
       "fields": {
         "message_id": {
           "name": "[%key:component::telegram_bot::services::edit_message::fields::message_id::name%]",
-          "description": "Id of the message to delete."
+          "description": "ID of the message to delete."
         },
         "chat_id": {
           "name": "[%key:component::telegram_bot::services::edit_message::fields::chat_id::name%]",
-          "description": "The chat_id where to delete the message."
+          "description": "ID of the chat where to delete the message."
         }
       }
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR contains a collection of smaller strings fixes in the telegram_bot integration:
- change all remaining occurrences of "id" or "Id" to the correct spelling "ID"
- change "chat_id" to the UI-friedly "chat ID"
- use "ID of the chat …" in descriptions, matching "ID of the message …"
- fix the edit_replymarkup action's description to also use "Edits …", matching all other with "Sends …" or "Edits …"
- replace "reply_markup" with "reply markup"
- use translatable descriptions for the Timeout fields

The latter change uses the descriptions from the online documentation that can be translated while the current ones repeat the action name (in lowercase) which makes it difficult to handle in other languages.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
