### PR TITLE
Do not base power switch state on appliance's operation state at Home Connect

### DIFF
--- a/homeassistant/components/home_connect/switch.py
+++ b/homeassistant/components/home_connect/switch.py
@@ -27,7 +27,6 @@ from .const import (
     ATTR_VALUE,
     BSH_ACTIVE_PROGRAM,
     BSH_CHILD_LOCK_STATE,
-    BSH_OPERATION_STATE,
     BSH_POWER_OFF,
     BSH_POWER_ON,
     BSH_POWER_STANDBY,
@@ -394,23 +393,6 @@ class HomeConnectPowerSwitch(HomeConnectEntity, SwitchEntity):
             hasattr(self, "power_off_state")
             and self.device.appliance.status.get(BSH_POWER_STATE, {}).get(ATTR_VALUE)
             == self.power_off_state
-        ):
-            self._attr_is_on = False
-        elif self.device.appliance.status.get(BSH_OPERATION_STATE, {}).get(
-            ATTR_VALUE, None
-        ) in [
-            "BSH.Common.EnumType.OperationState.Ready",
-            "BSH.Common.EnumType.OperationState.DelayedStart",
-            "BSH.Common.EnumType.OperationState.Run",
-            "BSH.Common.EnumType.OperationState.Pause",
-            "BSH.Common.EnumType.OperationState.ActionRequired",
-            "BSH.Common.EnumType.OperationState.Aborting",
-            "BSH.Common.EnumType.OperationState.Finished",
-        ]:
-            self._attr_is_on = True
-        elif (
-            self.device.appliance.status.get(BSH_OPERATION_STATE, {}).get(ATTR_VALUE)
-            == "BSH.Common.EnumType.OperationState.Inactive"
         ):
             self._attr_is_on = False
         else:

--- a/tests/components/home_connect/test_switch.py
+++ b/tests/components/home_connect/test_switch.py
@@ -13,7 +13,6 @@ from homeassistant.components.home_connect.const import (
     ATTR_CONSTRAINTS,
     BSH_ACTIVE_PROGRAM,
     BSH_CHILD_LOCK_STATE,
-    BSH_OPERATION_STATE,
     BSH_POWER_OFF,
     BSH_POWER_ON,
     BSH_POWER_STANDBY,
@@ -373,32 +372,6 @@ async def test_ent_desc_switch_exception_handling(
             {BSH_POWER_STATE: {"value": BSH_POWER_OFF}},
             [BSH_POWER_ON, BSH_POWER_OFF],
             SERVICE_TURN_OFF,
-            STATE_OFF,
-            "Dishwasher",
-        ),
-        (
-            "switch.dishwasher_power",
-            {
-                BSH_POWER_STATE: {"value": ""},
-                BSH_OPERATION_STATE: {
-                    "value": "BSH.Common.EnumType.OperationState.Run"
-                },
-            },
-            [BSH_POWER_ON],
-            SERVICE_TURN_ON,
-            STATE_ON,
-            "Dishwasher",
-        ),
-        (
-            "switch.dishwasher_power",
-            {
-                BSH_POWER_STATE: {"value": ""},
-                BSH_OPERATION_STATE: {
-                    "value": "BSH.Common.EnumType.OperationState.Inactive"
-                },
-            },
-            [BSH_POWER_ON],
-            SERVICE_TURN_ON,
             STATE_OFF,
             "Dishwasher",
         ),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Simplifícate how the state of the power switch is determined by removing unnecessary functionality.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

I don't know what is the reason behind using the appliance's operation state to determine if the appliance is on or off.
If the appliance cannot report on or off, the user will know it and can use the operation state to make automations.
I think that entities states should not be based on other values unless a good reason, which I think is missing in this case as this was added with the first commit (even in the very first commit at #29214 (95aca52f800d3e1c46465a28ec00f8c03d4c4d01)) of this integration and was not reasoned.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
