### PR TITLE
Improve exception handling in Habitica integration

### DIFF
--- a/homeassistant/components/habitica/button.py
+++ b/homeassistant/components/habitica/button.py
@@ -335,16 +335,24 @@ class HabiticaButton(HabiticaBase, ButtonEntity):
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="setup_rate_limit_exception",
+                translation_placeholders={"retry_after": str(e.retry_after)},
             ) from e
         except NotAuthorizedError as e:
             raise ServiceValidationError(
                 translation_domain=DOMAIN,
                 translation_key="service_call_unallowed",
             ) from e
-        except (HabiticaException, ClientError) as e:
+        except HabiticaException as e:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="service_call_exception",
+                translation_placeholders={"reason": e.error.message},
+            ) from e
+        except ClientError as e:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="service_call_exception",
+                translation_placeholders={"reason": str(e)},
             ) from e
         else:
             await self.coordinator.async_request_refresh()

--- a/homeassistant/components/habitica/coordinator.py
+++ b/homeassistant/components/habitica/coordinator.py
@@ -85,11 +85,19 @@ class HabiticaDataUpdateCoordinator(DataUpdateCoordinator[HabiticaData]):
             raise ConfigEntryNotReady(
                 translation_domain=DOMAIN,
                 translation_key="setup_rate_limit_exception",
+                translation_placeholders={"retry_after": str(e.retry_after)},
             ) from e
-        except (HabiticaException, ClientError) as e:
+        except HabiticaException as e:
             raise ConfigEntryNotReady(
                 translation_domain=DOMAIN,
                 translation_key="service_call_exception",
+                translation_placeholders={"reason": str(e.error.message)},
+            ) from e
+        except ClientError as e:
+            raise ConfigEntryNotReady(
+                translation_domain=DOMAIN,
+                translation_key="service_call_exception",
+                translation_placeholders={"reason": str(e)},
             ) from e
 
         if not self.config_entry.data.get(CONF_NAME):
@@ -108,8 +116,18 @@ class HabiticaDataUpdateCoordinator(DataUpdateCoordinator[HabiticaData]):
         except TooManyRequestsError:
             _LOGGER.debug("Rate limit exceeded, will try again later")
             return self.data
-        except (HabiticaException, ClientError) as e:
-            raise UpdateFailed(f"Unable to connect to Habitica: {e}") from e
+        except HabiticaException as e:
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="service_call_exception",
+                translation_placeholders={"reason": str(e.error.message)},
+            ) from e
+        except ClientError as e:
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="service_call_exception",
+                translation_placeholders={"reason": str(e)},
+            ) from e
         else:
             return HabiticaData(user=user, tasks=tasks + completed_todos)
 
@@ -124,11 +142,19 @@ class HabiticaDataUpdateCoordinator(DataUpdateCoordinator[HabiticaData]):
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="setup_rate_limit_exception",
+                translation_placeholders={"retry_after": str(e.retry_after)},
             ) from e
-        except (HabiticaException, ClientError) as e:
+        except HabiticaException as e:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="service_call_exception",
+                translation_placeholders={"reason": e.error.message},
+            ) from e
+        except ClientError as e:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="service_call_exception",
+                translation_placeholders={"reason": str(e)},
             ) from e
         else:
             await self.async_request_refresh()

--- a/homeassistant/components/habitica/quality_scale.yaml
+++ b/homeassistant/components/habitica/quality_scale.yaml
@@ -65,7 +65,7 @@ rules:
   entity-disabled-by-default: done
   entity-translations: done
   exception-translations:
-    status: todo
+    status: done
     comment: translations for UpdateFailed missing
   icon-translations: done
   reconfiguration-flow: todo

--- a/homeassistant/components/habitica/quality_scale.yaml
+++ b/homeassistant/components/habitica/quality_scale.yaml
@@ -64,9 +64,7 @@ rules:
   entity-device-class: done
   entity-disabled-by-default: done
   entity-translations: done
-  exception-translations:
-    status: done
-    comment: translations for UpdateFailed missing
+  exception-translations: done
   icon-translations: done
   reconfiguration-flow: todo
   repair-issues:

--- a/homeassistant/components/habitica/services.py
+++ b/homeassistant/components/habitica/services.py
@@ -224,6 +224,7 @@ def async_setup_services(hass: HomeAssistant) -> None:  # noqa: C901
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="setup_rate_limit_exception",
+                translation_placeholders={"retry_after": str(e.retry_after)},
             ) from e
         except NotAuthorizedError as e:
             raise ServiceValidationError(
@@ -243,10 +244,17 @@ def async_setup_services(hass: HomeAssistant) -> None:  # noqa: C901
                 translation_key="skill_not_found",
                 translation_placeholders={"skill": call.data[ATTR_SKILL]},
             ) from e
-        except (HabiticaException, ClientError) as e:
+        except HabiticaException as e:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="service_call_exception",
+                translation_placeholders={"reason": str(e.error.message)},
+            ) from e
+        except ClientError as e:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="service_call_exception",
+                translation_placeholders={"reason": str(e)},
             ) from e
         else:
             await coordinator.async_request_refresh()
@@ -274,6 +282,7 @@ def async_setup_services(hass: HomeAssistant) -> None:  # noqa: C901
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="setup_rate_limit_exception",
+                translation_placeholders={"retry_after": str(e.retry_after)},
             ) from e
         except NotAuthorizedError as e:
             raise ServiceValidationError(
@@ -283,9 +292,17 @@ def async_setup_services(hass: HomeAssistant) -> None:  # noqa: C901
             raise ServiceValidationError(
                 translation_domain=DOMAIN, translation_key="quest_not_found"
             ) from e
-        except (HabiticaException, ClientError) as e:
+        except HabiticaException as e:
             raise HomeAssistantError(
-                translation_domain=DOMAIN, translation_key="service_call_exception"
+                translation_domain=DOMAIN,
+                translation_key="service_call_exception",
+                translation_placeholders={"reason": str(e.error.message)},
+            ) from e
+        except ClientError as e:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="service_call_exception",
+                translation_placeholders={"reason": str(e)},
             ) from e
         else:
             return asdict(response.data)
@@ -335,6 +352,7 @@ def async_setup_services(hass: HomeAssistant) -> None:  # noqa: C901
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="setup_rate_limit_exception",
+                translation_placeholders={"retry_after": str(e.retry_after)},
             ) from e
         except NotAuthorizedError as e:
             if task_value is not None:
@@ -349,11 +367,19 @@ def async_setup_services(hass: HomeAssistant) -> None:  # noqa: C901
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="service_call_exception",
+                translation_placeholders={"reason": e.error.message},
             ) from e
-        except (HabiticaException, ClientError) as e:
+        except HabiticaException as e:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="service_call_exception",
+                translation_placeholders={"reason": str(e.error.message)},
+            ) from e
+        except ClientError as e:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="service_call_exception",
+                translation_placeholders={"reason": str(e)},
             ) from e
         else:
             await coordinator.async_request_refresh()
@@ -382,10 +408,17 @@ def async_setup_services(hass: HomeAssistant) -> None:  # noqa: C901
                     translation_domain=DOMAIN,
                     translation_key="party_not_found",
                 ) from e
-            except (ClientError, HabiticaException) as e:
+            except HabiticaException as e:
                 raise HomeAssistantError(
                     translation_domain=DOMAIN,
                     translation_key="service_call_exception",
+                    translation_placeholders={"reason": str(e.error.message)},
+                ) from e
+            except ClientError as e:
+                raise HomeAssistantError(
+                    translation_domain=DOMAIN,
+                    translation_key="service_call_exception",
+                    translation_placeholders={"reason": str(e)},
                 ) from e
             try:
                 target_id = next(
@@ -411,6 +444,7 @@ def async_setup_services(hass: HomeAssistant) -> None:  # noqa: C901
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="setup_rate_limit_exception",
+                translation_placeholders={"retry_after": str(e.retry_after)},
             ) from e
         except NotAuthorizedError as e:
             raise ServiceValidationError(
@@ -418,10 +452,17 @@ def async_setup_services(hass: HomeAssistant) -> None:  # noqa: C901
                 translation_key="item_not_found",
                 translation_placeholders={"item": call.data[ATTR_ITEM]},
             ) from e
-        except (HabiticaException, ClientError) as e:
+        except HabiticaException as e:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="service_call_exception",
+                translation_placeholders={"reason": str(e.error.message)},
+            ) from e
+        except ClientError as e:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="service_call_exception",
+                translation_placeholders={"reason": str(e)},
             ) from e
         else:
             return asdict(response.data)

--- a/homeassistant/components/habitica/strings.json
+++ b/homeassistant/components/habitica/strings.json
@@ -375,13 +375,13 @@
       "message": "Unable to create new to-do `{name}` for Habitica, please try again"
     },
     "setup_rate_limit_exception": {
-      "message": "Rate limit exceeded, try again later"
+      "message": "Rate limit exceeded, try again in {retry_after} seconds"
     },
     "service_call_unallowed": {
       "message": "Unable to complete action, the required conditions are not met"
     },
     "service_call_exception": {
-      "message": "Unable to connect to Habitica, try again later"
+      "message": "Unable to connect to Habitica: {reason}"
     },
     "not_enough_mana": {
       "message": "Unable to cast skill, not enough mana. Your character has {mana}, but the skill costs {cost}."

--- a/tests/components/habitica/conftest.py
+++ b/tests/components/habitica/conftest.py
@@ -32,11 +32,13 @@ from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry, load_fixture
 
-ERROR_RESPONSE = HabiticaErrorResponse(success=False, error="error", message="message")
+ERROR_RESPONSE = HabiticaErrorResponse(success=False, error="error", message="reason")
 ERROR_NOT_AUTHORIZED = NotAuthorizedError(error=ERROR_RESPONSE, headers={})
 ERROR_NOT_FOUND = NotFoundError(error=ERROR_RESPONSE, headers={})
 ERROR_BAD_REQUEST = BadRequestError(error=ERROR_RESPONSE, headers={})
-ERROR_TOO_MANY_REQUESTS = TooManyRequestsError(error=ERROR_RESPONSE, headers={})
+ERROR_TOO_MANY_REQUESTS = TooManyRequestsError(
+    error=ERROR_RESPONSE, headers={"retry-after": 5}
+)
 
 
 @pytest.fixture(name="config_entry")

--- a/tests/components/habitica/test_button.py
+++ b/tests/components/habitica/test_button.py
@@ -4,6 +4,7 @@ from collections.abc import Generator
 from datetime import timedelta
 from unittest.mock import AsyncMock, patch
 
+from aiohttp import ClientError
 from freezegun.api import FrozenDateTimeFactory
 from habiticalib import HabiticaUserResponse, Skill
 import pytest
@@ -215,18 +216,23 @@ async def test_button_press(
     [
         (
             ERROR_TOO_MANY_REQUESTS,
-            "Rate limit exceeded, try again later",
+            "Rate limit exceeded, try again in 5 seconds",
             HomeAssistantError,
         ),
         (
             ERROR_BAD_REQUEST,
-            "Unable to connect to Habitica, try again later",
+            "Unable to connect to Habitica: reason",
             HomeAssistantError,
         ),
         (
             ERROR_NOT_AUTHORIZED,
             "Unable to complete action, the required conditions are not met",
             ServiceValidationError,
+        ),
+        (
+            ClientError,
+            "Unable to connect to Habitica: ",
+            HomeAssistantError,
         ),
     ],
 )

--- a/tests/components/habitica/test_switch.py
+++ b/tests/components/habitica/test_switch.py
@@ -3,6 +3,7 @@
 from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
+from aiohttp import ClientError
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
@@ -96,6 +97,7 @@ async def test_turn_on_off_toggle(
     [
         (ERROR_TOO_MANY_REQUESTS, HomeAssistantError),
         (ERROR_BAD_REQUEST, HomeAssistantError),
+        (ClientError, HomeAssistantError),
     ],
 )
 async def test_turn_on_off_toggle_exceptions(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


rate limit exceptions are catched now explicitly in all actions and also display  the time until the rate limiting is lifted.

HabiticaExceptions return an error attribute with the error message returned from the Habitica API, which is now displayed in the error message.  
ClientError is catched separately and the error is inserted in the exception text

Missing exception translations were added and `exception-translations` in the quality scale is marked as done

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
