### PR TITLE
Replace additional deprecated USBServiceInfo imports

### DIFF
--- a/homeassistant/components/homeassistant_sky_connect/util.py
+++ b/homeassistant/components/homeassistant_sky_connect/util.py
@@ -4,17 +4,17 @@ from __future__ import annotations
 
 import logging
 
-from homeassistant.components import usb
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.helpers.service_info.usb import UsbServiceInfo
 
 from .const import HardwareVariant
 
 _LOGGER = logging.getLogger(__name__)
 
 
-def get_usb_service_info(config_entry: ConfigEntry) -> usb.UsbServiceInfo:
+def get_usb_service_info(config_entry: ConfigEntry) -> UsbServiceInfo:
     """Return UsbServiceInfo."""
-    return usb.UsbServiceInfo(
+    return UsbServiceInfo(
         device=config_entry.data["device"],
         vid=config_entry.data["vid"],
         pid=config_entry.data["pid"],

--- a/homeassistant/components/zha/radio_manager.py
+++ b/homeassistant/components/zha/radio_manager.py
@@ -29,6 +29,7 @@ from zigpy.exceptions import NetworkNotFormed
 from homeassistant import config_entries
 from homeassistant.components import usb
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.service_info.usb import UsbServiceInfo
 
 from . import repairs
 from .const import (
@@ -86,7 +87,7 @@ HARDWARE_MIGRATION_SCHEMA = vol.Schema(
         vol.Required("old_discovery_info"): vol.Schema(
             {
                 vol.Exclusive("hw", "discovery"): HARDWARE_DISCOVERY_SCHEMA,
-                vol.Exclusive("usb", "discovery"): usb.UsbServiceInfo,
+                vol.Exclusive("usb", "discovery"): UsbServiceInfo,
             }
         ),
     }

--- a/tests/components/homeassistant_sky_connect/test_config_flow.py
+++ b/tests/components/homeassistant_sky_connect/test_config_flow.py
@@ -4,7 +4,6 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from homeassistant.components import usb
 from homeassistant.components.hassio import AddonInfo, AddonState
 from homeassistant.components.homeassistant_hardware.firmware_config_flow import (
     STEP_PICK_FIRMWARE_ZIGBEE,
@@ -17,10 +16,11 @@ from homeassistant.components.homeassistant_hardware.silabs_multiprotocol_addon 
 from homeassistant.components.homeassistant_sky_connect.const import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.usb import UsbServiceInfo
 
 from tests.common import MockConfigEntry
 
-USB_DATA_SKY = usb.UsbServiceInfo(
+USB_DATA_SKY = UsbServiceInfo(
     device="/dev/serial/by-id/usb-Nabu_Casa_SkyConnect_v1.0_9e2adbd75b8beb119fe564a0f320645d-if00-port0",
     vid="10C4",
     pid="EA60",
@@ -29,7 +29,7 @@ USB_DATA_SKY = usb.UsbServiceInfo(
     description="SkyConnect v1.0",
 )
 
-USB_DATA_ZBT1 = usb.UsbServiceInfo(
+USB_DATA_ZBT1 = UsbServiceInfo(
     device="/dev/serial/by-id/usb-Nabu_Casa_Home_Assistant_Connect_ZBT-1_9e2adbd75b8beb119fe564a0f320645d-if00-port0",
     vid="10C4",
     pid="EA60",
@@ -47,7 +47,7 @@ USB_DATA_ZBT1 = usb.UsbServiceInfo(
     ],
 )
 async def test_config_flow(
-    usb_data: usb.UsbServiceInfo, model: str, hass: HomeAssistant
+    usb_data: UsbServiceInfo, model: str, hass: HomeAssistant
 ) -> None:
     """Test the config flow for SkyConnect."""
     result = await hass.config_entries.flow.async_init(
@@ -102,7 +102,7 @@ async def test_config_flow(
     ],
 )
 async def test_options_flow(
-    usb_data: usb.UsbServiceInfo, model: str, hass: HomeAssistant
+    usb_data: UsbServiceInfo, model: str, hass: HomeAssistant
 ) -> None:
     """Test the options flow for SkyConnect."""
     config_entry = MockConfigEntry(
@@ -168,7 +168,7 @@ async def test_options_flow(
     ],
 )
 async def test_options_flow_multipan_uninstall(
-    usb_data: usb.UsbServiceInfo, model: str, hass: HomeAssistant
+    usb_data: UsbServiceInfo, model: str, hass: HomeAssistant
 ) -> None:
     """Test options flow for when multi-PAN firmware is installed."""
     config_entry = MockConfigEntry(

--- a/tests/components/insteon/test_config_flow.py
+++ b/tests/components/insteon/test_config_flow.py
@@ -8,7 +8,7 @@ import pytest
 from voluptuous_serialize import convert
 
 from homeassistant import config_entries
-from homeassistant.components import dhcp, usb
+from homeassistant.components import dhcp
 from homeassistant.components.insteon.config_flow import (
     STEP_HUB_V1,
     STEP_HUB_V2,
@@ -20,6 +20,7 @@ from homeassistant.config_entries import ConfigEntryState, ConfigFlowResult
 from homeassistant.const import CONF_DEVICE, CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.usb import UsbServiceInfo
 
 from .const import (
     MOCK_DEVICE,
@@ -270,7 +271,7 @@ async def test_failed_connection_hub(hass: HomeAssistant) -> None:
 
 async def test_discovery_via_usb(hass: HomeAssistant) -> None:
     """Test usb flow."""
-    discovery_info = usb.UsbServiceInfo(
+    discovery_info = UsbServiceInfo(
         device="/dev/ttyINSTEON",
         pid="AAAA",
         vid="AAAA",
@@ -302,7 +303,7 @@ async def test_discovery_via_usb_already_setup(hass: HomeAssistant) -> None:
         domain=DOMAIN, data={CONF_DEVICE: {CONF_DEVICE: "/dev/ttyUSB1"}}
     ).add_to_hass(hass)
 
-    discovery_info = usb.UsbServiceInfo(
+    discovery_info = UsbServiceInfo(
         device="/dev/ttyINSTEON",
         pid="AAAA",
         vid="AAAA",

--- a/tests/components/modem_callerid/test_config_flow.py
+++ b/tests/components/modem_callerid/test_config_flow.py
@@ -10,10 +10,11 @@ from homeassistant.config_entries import SOURCE_USB, SOURCE_USER
 from homeassistant.const import CONF_DEVICE, CONF_SOURCE
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.usb import UsbServiceInfo
 
 from . import com_port, patch_config_flow_modem
 
-DISCOVERY_INFO = usb.UsbServiceInfo(
+DISCOVERY_INFO = UsbServiceInfo(
     device=phone_modem.DEFAULT_PORT,
     pid="1340",
     vid="0572",

--- a/tests/components/rainforest_raven/const.py
+++ b/tests/components/rainforest_raven/const.py
@@ -13,8 +13,9 @@ from aioraven.data import (
 from iso4217 import Currency
 
 from homeassistant.components import usb
+from homeassistant.helpers.service_info.usb import UsbServiceInfo
 
-DISCOVERY_INFO = usb.UsbServiceInfo(
+DISCOVERY_INFO = UsbServiceInfo(
     device="/dev/ttyACM0",
     pid="0x0003",
     vid="0x04B4",

--- a/tests/components/velbus/test_config_flow.py
+++ b/tests/components/velbus/test_config_flow.py
@@ -7,18 +7,18 @@ import pytest
 import serial.tools.list_ports
 from velbusaio.exceptions import VelbusConnectionFailed
 
-from homeassistant.components import usb
 from homeassistant.components.velbus.const import DOMAIN
 from homeassistant.config_entries import SOURCE_USB, SOURCE_USER
 from homeassistant.const import CONF_NAME, CONF_PORT, CONF_SOURCE
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.usb import UsbServiceInfo
 
 from .const import PORT_SERIAL, PORT_TCP
 
 from tests.common import MockConfigEntry
 
-DISCOVERY_INFO = usb.UsbServiceInfo(
+DISCOVERY_INFO = UsbServiceInfo(
     device=PORT_SERIAL,
     pid="10CF",
     vid="0B1B",

--- a/tests/components/zha/test_config_flow.py
+++ b/tests/components/zha/test_config_flow.py
@@ -20,7 +20,7 @@ from zigpy.exceptions import NetworkNotFormed
 import zigpy.types
 
 from homeassistant import config_entries
-from homeassistant.components import ssdp, usb, zeroconf
+from homeassistant.components import ssdp, zeroconf
 from homeassistant.components.hassio import AddonError, AddonState
 from homeassistant.components.zha import config_flow, radio_manager
 from homeassistant.components.zha.const import (
@@ -46,6 +46,7 @@ from homeassistant.helpers.service_info.ssdp import (
     ATTR_UPNP_MANUFACTURER_URL,
     ATTR_UPNP_SERIAL,
 )
+from homeassistant.helpers.service_info.usb import UsbServiceInfo
 
 from tests.common import MockConfigEntry
 
@@ -432,7 +433,7 @@ async def test_legacy_zeroconf_discovery_confirm_final_abort_if_entries(
 @patch(f"zigpy_znp.{PROBE_FUNCTION_PATH}", AsyncMock(return_value=True))
 async def test_discovery_via_usb(hass: HomeAssistant) -> None:
     """Test usb flow -- radio detected."""
-    discovery_info = usb.UsbServiceInfo(
+    discovery_info = UsbServiceInfo(
         device="/dev/ttyZIGBEE",
         pid="AAAA",
         vid="AAAA",
@@ -478,7 +479,7 @@ async def test_discovery_via_usb(hass: HomeAssistant) -> None:
 @patch(f"zigpy_zigate.{PROBE_FUNCTION_PATH}", return_value=True)
 async def test_zigate_discovery_via_usb(probe_mock, hass: HomeAssistant) -> None:
     """Test zigate usb flow -- radio detected."""
-    discovery_info = usb.UsbServiceInfo(
+    discovery_info = UsbServiceInfo(
         device="/dev/ttyZIGBEE",
         pid="0403",
         vid="6015",
@@ -531,7 +532,7 @@ async def test_zigate_discovery_via_usb(probe_mock, hass: HomeAssistant) -> None
 )
 async def test_discovery_via_usb_no_radio(hass: HomeAssistant) -> None:
     """Test usb flow -- no radio detected."""
-    discovery_info = usb.UsbServiceInfo(
+    discovery_info = UsbServiceInfo(
         device="/dev/null",
         pid="AAAA",
         vid="AAAA",
@@ -564,7 +565,7 @@ async def test_discovery_via_usb_already_setup(hass: HomeAssistant) -> None:
         domain=DOMAIN, data={CONF_DEVICE: {CONF_DEVICE_PATH: "/dev/ttyUSB1"}}
     ).add_to_hass(hass)
 
-    discovery_info = usb.UsbServiceInfo(
+    discovery_info = UsbServiceInfo(
         device="/dev/ttyZIGBEE",
         pid="AAAA",
         vid="AAAA",
@@ -598,7 +599,7 @@ async def test_discovery_via_usb_path_does_not_change(hass: HomeAssistant) -> No
     )
     entry.add_to_hass(hass)
 
-    discovery_info = usb.UsbServiceInfo(
+    discovery_info = UsbServiceInfo(
         device="/dev/ttyZIGBEE",
         pid="AAAA",
         vid="AAAA",
@@ -637,7 +638,7 @@ async def test_discovery_via_usb_deconz_already_discovered(hass: HomeAssistant) 
         context={"source": SOURCE_SSDP},
     )
     await hass.async_block_till_done()
-    discovery_info = usb.UsbServiceInfo(
+    discovery_info = UsbServiceInfo(
         device="/dev/ttyZIGBEE",
         pid="AAAA",
         vid="AAAA",
@@ -659,7 +660,7 @@ async def test_discovery_via_usb_deconz_already_setup(hass: HomeAssistant) -> No
     """Test usb flow -- deconz setup."""
     MockConfigEntry(domain="deconz", data={}).add_to_hass(hass)
     await hass.async_block_till_done()
-    discovery_info = usb.UsbServiceInfo(
+    discovery_info = UsbServiceInfo(
         device="/dev/ttyZIGBEE",
         pid="AAAA",
         vid="AAAA",
@@ -683,7 +684,7 @@ async def test_discovery_via_usb_deconz_ignored(hass: HomeAssistant) -> None:
         domain="deconz", source=config_entries.SOURCE_IGNORE, data={}
     ).add_to_hass(hass)
     await hass.async_block_till_done()
-    discovery_info = usb.UsbServiceInfo(
+    discovery_info = UsbServiceInfo(
         device="/dev/ttyZIGBEE",
         pid="AAAA",
         vid="AAAA",
@@ -711,7 +712,7 @@ async def test_discovery_via_usb_zha_ignored_updates(hass: HomeAssistant) -> Non
     )
     entry.add_to_hass(hass)
     await hass.async_block_till_done()
-    discovery_info = usb.UsbServiceInfo(
+    discovery_info = UsbServiceInfo(
         device="/dev/ttyZIGBEE",
         pid="AAAA",
         vid="AAAA",
@@ -1199,7 +1200,7 @@ async def test_onboarding_auto_formation_new_hardware(
     """Test auto network formation with new hardware during onboarding."""
     mock_app.load_network_info = AsyncMock(side_effect=NetworkNotFormed())
     mock_app.get_device = MagicMock(return_value=MagicMock(spec=zigpy.device.Device))
-    discovery_info = usb.UsbServiceInfo(
+    discovery_info = UsbServiceInfo(
         device="/dev/ttyZIGBEE",
         pid="AAAA",
         vid="AAAA",

--- a/tests/components/zwave_js/test_config_flow.py
+++ b/tests/components/zwave_js/test_config_flow.py
@@ -16,12 +16,12 @@ from serial.tools.list_ports_common import ListPortInfo
 from zwave_js_server.version import VersionInfo
 
 from homeassistant import config_entries
-from homeassistant.components import usb
 from homeassistant.components.zwave_js.config_flow import SERVER_VERSION_TIMEOUT, TITLE
 from homeassistant.components.zwave_js.const import ADDON_SLUG, DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers.service_info.hassio import HassioServiceInfo
+from homeassistant.helpers.service_info.usb import UsbServiceInfo
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from tests.common import MockConfigEntry
@@ -33,7 +33,7 @@ ADDON_DISCOVERY_INFO = {
 }
 
 
-USB_DISCOVERY_INFO = usb.UsbServiceInfo(
+USB_DISCOVERY_INFO = UsbServiceInfo(
     device="/dev/zwave",
     pid="AAAA",
     vid="AAAA",
@@ -42,7 +42,7 @@ USB_DISCOVERY_INFO = usb.UsbServiceInfo(
     manufacturer="test",
 )
 
-NORTEK_ZIGBEE_DISCOVERY_INFO = usb.UsbServiceInfo(
+NORTEK_ZIGBEE_DISCOVERY_INFO = UsbServiceInfo(
     device="/dev/zigbee",
     pid="8A2A",
     vid="10C4",
@@ -51,7 +51,7 @@ NORTEK_ZIGBEE_DISCOVERY_INFO = usb.UsbServiceInfo(
     manufacturer="nortek",
 )
 
-CP2652_ZIGBEE_DISCOVERY_INFO = usb.UsbServiceInfo(
+CP2652_ZIGBEE_DISCOVERY_INFO = UsbServiceInfo(
     device="/dev/zigbee",
     pid="EA60",
     vid="10C4",


### PR DESCRIPTION
## Proposed change
Followup to #135663
Seems these were missed during the first pass.

/CC @epenet 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
