### PR TITLE
Add concentration sensors for WAQI

### DIFF
--- a/homeassistant/components/waqi/converters.py
+++ b/homeassistant/components/waqi/converters.py
@@ -1,0 +1,108 @@
+"""Converters for the World Air Quality Index (WAQI) integration.
+
+This module provides functions to convert between AQI (Air Quality Index) values
+and actual pollutant concentrations in their respective units (μg/m³, ppb, ppm).
+"""
+
+from typing import Literal, TypedDict
+
+
+class ScaleDict(TypedDict):
+    """Type for scale dictionary."""
+
+    aqi: list[float]
+    conc: list[float]
+
+
+class ScalesType(TypedDict):
+    """Type for scales dictionary."""
+
+    pm25: ScaleDict
+    pm10: ScaleDict
+    o31: ScaleDict
+    o38: ScaleDict
+    so21: ScaleDict
+    so224: ScaleDict
+    no2: ScaleDict
+    co: ScaleDict
+
+
+PollutantType = Literal["pm25", "pm10", "o31", "o38", "so21", "so224", "no2", "co"]
+
+
+def aqi_to_concentration(aqi: float, pollutant: PollutantType) -> float:
+    """Convert AQI score to concentration in appropriate units.
+
+    Args:
+        aqi: Air Quality Index value (0-500)
+        pollutant: One of 'pm25', 'pm10', 'o31', 'o38', 'so21', 'so224', 'no2', 'co'
+
+    Returns:
+        Concentration in appropriate units (μg/m³, ppb, or ppm)
+
+    Raises:
+        ValueError: If AQI is out of range or pollutant is invalid
+
+    """
+    # Scales definition for all pollutants
+    scales: ScalesType = {
+        "pm25": {  # μg/m³
+            "aqi": [0, 50, 100, 150, 200, 300, 400, 500],
+            "conc": [0, 12, 35.5, 55.5, 150.5, 250.5, 350.5, 500.5],
+        },
+        "pm10": {  # μg/m³
+            "aqi": [0, 50, 100, 150, 200, 300, 400, 500],
+            "conc": [0, 55, 155, 255, 355, 425, 505, 605],
+        },
+        "o31": {  # ppb (1 hour average)
+            "aqi": [0, 50, 100, 150, 200, 300, 400, 500],
+            "conc": [0, 54, 125, 165, 205, 405, 505, 605],
+        },
+        "o38": {  # ppb (8 hours average)
+            "aqi": [0, 50, 100, 150, 200, 300],
+            "conc": [0, 54, 70, 85, 105, 200],
+        },
+        "so21": {  # ppb (1 hour average)
+            "aqi": [0, 50, 100, 150, 200],
+            "conc": [0, 36, 76, 186, 304, 604],
+        },
+        "so224": {  # ppb (24 hours average)
+            "aqi": [200, 300, 400, 500],
+            "conc": [304, 605, 805, 1004],
+        },
+        "no2": {  # ppb
+            "aqi": [0, 50, 100, 150, 200, 300, 400, 500],
+            "conc": [0, 0.054, 0.101, 0.361, 0.65, 1.25, 1.65, 2.049],
+        },
+        "co": {  # ppm
+            "aqi": [0, 50, 100, 150, 200, 300, 400, 500],
+            "conc": [0, 4.5, 9.5, 12.5, 15.5, 30.5, 40.5, 50.5],
+        },
+    }
+
+    if pollutant not in scales:
+        raise ValueError(f"Pollutant must be one of {list(scales.keys())}")
+
+    if aqi < 0 or aqi > 500:
+        raise ValueError(f"AQI must be between 0 and 500, not {aqi}")
+
+    scale = scales[pollutant]
+
+    # Find appropriate interval
+    for i in range(len(scale["aqi"]) - 1):
+        aqi_low = scale["aqi"][i]
+        aqi_high = scale["aqi"][i + 1]
+
+        if aqi_low <= aqi <= aqi_high:
+            conc_low = scale["conc"][i]
+            conc_high = scale["conc"][i + 1]
+
+            # Inverse AQI conversion formula
+            concentration = conc_low + (aqi - aqi_low) * (conc_high - conc_low) / (
+                aqi_high - aqi_low
+            )
+            return round(concentration, 3)
+
+    raise ValueError(
+        f"Could not find concentration for AQI {aqi} and pollutant {pollutant}"
+    )

--- a/homeassistant/components/waqi/sensor.py
+++ b/homeassistant/components/waqi/sensor.py
@@ -24,6 +24,7 @@ from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
+from .converters import aqi_to_concentration
 from .coordinator import WAQIDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -133,6 +134,60 @@ SENSORS: list[WAQISensorEntityDescription] = [
         device_class=SensorDeviceClass.ENUM,
         options=[pollutant.value for pollutant in Pollutant],
         value_fn=lambda aq: aq.dominant_pollutant,
+    ),
+    WAQISensorEntityDescription(
+        key="pm25_concentration",
+        translation_key="pm25_concentration",
+        native_unit_of_measurement="µg/m³",
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda aq: aqi_to_concentration(aq.extended_air_quality.pm25, "pm25")
+        if aq.extended_air_quality.pm25 is not None
+        else None,
+        available_fn=lambda aq: aq.extended_air_quality.pm25 is not None,
+    ),
+    WAQISensorEntityDescription(
+        key="pm10_concentration",
+        translation_key="pm10_concentration",
+        native_unit_of_measurement="µg/m³",
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda aq: aqi_to_concentration(aq.extended_air_quality.pm10, "pm10")
+        if aq.extended_air_quality.pm10 is not None
+        else None,
+        available_fn=lambda aq: aq.extended_air_quality.pm10 is not None,
+    ),
+    WAQISensorEntityDescription(
+        key="o3_concentration",
+        translation_key="o3_concentration",
+        native_unit_of_measurement="ppb",
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda aq: aqi_to_concentration(aq.extended_air_quality.ozone, "o38")
+        if aq.extended_air_quality.ozone is not None
+        else None,
+        available_fn=lambda aq: aq.extended_air_quality.ozone is not None,
+    ),
+    WAQISensorEntityDescription(
+        key="no2_concentration",
+        translation_key="no2_concentration",
+        native_unit_of_measurement="ppb",
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda aq: aqi_to_concentration(
+            aq.extended_air_quality.nitrogen_dioxide, "no2"
+        )
+        if aq.extended_air_quality.nitrogen_dioxide is not None
+        else None,
+        available_fn=lambda aq: aq.extended_air_quality.nitrogen_dioxide is not None,
+    ),
+    WAQISensorEntityDescription(
+        key="so2_concentration",
+        translation_key="so2_concentration",
+        native_unit_of_measurement="ppb",
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda aq: aqi_to_concentration(
+            aq.extended_air_quality.sulfur_dioxide, "so21"
+        )
+        if aq.extended_air_quality.sulfur_dioxide is not None
+        else None,
+        available_fn=lambda aq: aq.extended_air_quality.sulfur_dioxide is not None,
     ),
 ]
 

--- a/homeassistant/components/waqi/strings.json
+++ b/homeassistant/components/waqi/strings.json
@@ -70,6 +70,21 @@
           "pm10": "[%key:component::sensor::entity_component::pm10::name%]",
           "pm25": "[%key:component::sensor::entity_component::pm25::name%]"
         }
+      },
+      "pm25_concentration": {
+        "name": "PM2.5 Concentration"
+      },
+      "pm10_concentration": {
+        "name": "PM10 Concentration"
+      },
+      "o3_concentration": {
+        "name": "Ozone Concentration"
+      },
+      "no2_concentration": {
+        "name": "Nitrogen Dioxide Concentration"
+      },
+      "so2_concentration": {
+        "name": "Sulfur Dioxide Concentration"
       }
     }
   }

--- a/tests/components/waqi/test_converters.py
+++ b/tests/components/waqi/test_converters.py
@@ -1,0 +1,119 @@
+"""Test the World Air Quality Index (WAQI) converters from AQI."""
+
+import pytest
+
+from homeassistant.components.waqi.converters import aqi_to_concentration
+
+
+def test_pm25_conversion() -> None:
+    """Test PM2.5 AQI to μg/m³ conversion."""
+    assert aqi_to_concentration(0, "pm25") == 0
+    assert aqi_to_concentration(50, "pm25") == 12.0
+    assert aqi_to_concentration(100, "pm25") == 35.5
+    assert aqi_to_concentration(200, "pm25") == 150.5
+    assert aqi_to_concentration(300, "pm25") == 250.5
+    assert aqi_to_concentration(400, "pm25") == 350.5
+    assert aqi_to_concentration(500, "pm25") == 500.5
+
+
+def test_pm10_conversion() -> None:
+    """Test PM10 AQI to μg/m³ conversion."""
+    assert aqi_to_concentration(0, "pm10") == 0
+    assert aqi_to_concentration(50, "pm10") == 55
+    assert aqi_to_concentration(100, "pm10") == 155
+    assert aqi_to_concentration(150, "pm10") == 255
+    assert aqi_to_concentration(200, "pm10") == 355
+    assert aqi_to_concentration(300, "pm10") == 425
+    assert aqi_to_concentration(400, "pm10") == 505
+    assert aqi_to_concentration(500, "pm10") == 605
+
+
+def test_o3_1h_conversion() -> None:
+    """Test O3 (1 hour) AQI to ppb conversion."""
+    assert aqi_to_concentration(0, "o31") == 0
+    assert aqi_to_concentration(100, "o31") == 0.125
+    assert aqi_to_concentration(150, "o31") == 0.165
+    assert aqi_to_concentration(200, "o31") == 0.205
+    assert aqi_to_concentration(300, "o31") == 0.405
+    assert aqi_to_concentration(400, "o31") == 0.505
+    assert aqi_to_concentration(500, "o31") == 0.605
+
+
+def test_o3_8h_conversion() -> None:
+    """Test O3 (8 hours) AQI to ppb conversion."""
+    assert aqi_to_concentration(0, "o38") == 0
+    assert aqi_to_concentration(50, "o38") == 0.06
+    assert aqi_to_concentration(100, "o38") == 0.076
+    assert aqi_to_concentration(150, "o38") == 0.096
+    assert aqi_to_concentration(200, "o38") == 0.116
+    assert aqi_to_concentration(300, "o38") == 0.375
+
+
+def test_so2_1h_conversion() -> None:
+    """Test SO2 (1 hour) AQI to ppb conversion."""
+    assert aqi_to_concentration(0, "so21") == 0
+    assert aqi_to_concentration(50, "so21") == 36
+    assert aqi_to_concentration(100, "so21") == 76
+    assert aqi_to_concentration(150, "so21") == 186
+    assert aqi_to_concentration(200, "so21") == 304
+
+
+def test_so2_24h_conversion() -> None:
+    """Test SO2 (24 hours) AQI to ppb conversion."""
+    assert aqi_to_concentration(200, "so224") == 304
+    assert aqi_to_concentration(300, "so224") == 605
+    assert aqi_to_concentration(400, "so224") == 805
+    assert aqi_to_concentration(500, "so224") == 1004
+
+
+def test_no2_conversion() -> None:
+    """Test NO2 AQI to ppb conversion."""
+    assert aqi_to_concentration(0, "no2") == 0
+    assert aqi_to_concentration(50, "no2") == 0.054
+    assert aqi_to_concentration(100, "no2") == 0.101
+    assert aqi_to_concentration(150, "no2") == 0.361
+    assert aqi_to_concentration(200, "no2") == 0.65
+    assert aqi_to_concentration(300, "no2") == 1.25
+    assert aqi_to_concentration(400, "no2") == 1.65
+    assert aqi_to_concentration(500, "no2") == 2.049
+
+
+def test_co_conversion() -> None:
+    """Test CO AQI to ppm conversion."""
+    assert aqi_to_concentration(0, "co") == 0
+    assert aqi_to_concentration(50, "co") == 4.5
+    assert aqi_to_concentration(100, "co") == 9.5
+    assert aqi_to_concentration(150, "co") == 12.5
+    assert aqi_to_concentration(200, "co") == 15.5
+    assert aqi_to_concentration(300, "co") == 30.5
+    assert aqi_to_concentration(400, "co") == 40.5
+    assert aqi_to_concentration(500, "co") == 50.5
+
+
+def test_invalid_pollutant() -> None:
+    """Test invalid pollutant raises ValueError."""
+    with pytest.raises(ValueError, match="Pollutant must be one of"):
+        aqi_to_concentration(50, "invalid")
+
+
+def test_invalid_aqi() -> None:
+    """Test invalid AQI raises ValueError."""
+    with pytest.raises(ValueError, match="AQI must be between 0 and 500"):
+        aqi_to_concentration(-1, "pm25")
+    with pytest.raises(ValueError, match="AQI must be between 0 and 500"):
+        aqi_to_concentration(501, "pm25")
+
+
+def test_intermediate_values() -> None:
+    """Test some intermediate AQI values."""
+    # PM2.5 at AQI 75 should be between 12 and 35.5 μg/m³
+    result = aqi_to_concentration(75, "pm25")
+    assert 12 < result < 35.5
+
+    # PM10 at AQI 125 should be between 155 and 255 μg/m³
+    result = aqi_to_concentration(125, "pm10")
+    assert 155 < result < 255
+
+    # O3 at AQI 175 should be between 0.165 and 0.205 ppb
+    result = aqi_to_concentration(175, "o31")
+    assert 0.165 < result < 0.205


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

First, thanks for this super useful integration !

## Proposed change
Right now the integration is only integrating AQI values, which are not always relevant, real concentrations can be pretty useful.
I tried to use https://aqicn.org/calculator/ and https://aqicn.org/air-cache/calculator/dist/calculator.js to make a converter from AQI to concentration.

![image](https://github.com/user-attachments/assets/ffdd75ba-01f9-4966-b81d-dc49324a738e)
![image](https://github.com/user-attachments/assets/ff287b51-467c-4011-b4d8-aa3e96e6d6ab)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
