### PR TITLE
Improve remote Bluetooth scanner manufacturer data

### DIFF
--- a/homeassistant/components/bluetooth/__init__.py
+++ b/homeassistant/components/bluetooth/__init__.py
@@ -334,9 +334,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         address = entry.unique_id
         assert address is not None
         assert source_entry is not None
-        manufacturer = (
-            await get_manufacturer_from_mac(address) or entry.data[CONF_SOURCE_DOMAIN]
-        )
+        source_domain = entry.data[CONF_SOURCE_DOMAIN]
+        if mac_manufacturer := await get_manufacturer_from_mac(address):
+            manufacturer = f"{mac_manufacturer} ({source_domain})"
+        else:
+            manufacturer = source_domain
         details = AdapterDetails(
             address=address,
             product=entry.data.get(CONF_SOURCE_MODEL),

--- a/homeassistant/components/bluetooth/__init__.py
+++ b/homeassistant/components/bluetooth/__init__.py
@@ -22,6 +22,7 @@ from bluetooth_adapters import (
     adapter_model,
     adapter_unique_name,
     get_adapters,
+    get_manufacturer_from_mac,
 )
 from bluetooth_data_tools import monotonic_time_coarse as MONOTONIC_TIME
 from habluetooth import (
@@ -333,15 +334,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         address = entry.unique_id
         assert address is not None
         assert source_entry is not None
+        manufacturer = (
+            await get_manufacturer_from_mac(address) or entry.data[CONF_SOURCE_DOMAIN]
+        )
+        details = AdapterDetails(
+            address=address,
+            product=entry.data.get(CONF_SOURCE_MODEL),
+            manufacturer=manufacturer,
+        )
         await async_update_device(
             hass,
             entry,
             source_entry.title,
-            AdapterDetails(
-                address=address,
-                product=entry.data.get(CONF_SOURCE_MODEL),
-                manufacturer=entry.data[CONF_SOURCE_DOMAIN],
-            ),
+            details,
         )
         return True
     manager = _get_manager(hass)

--- a/tests/components/bluetooth/test_base_scanner.py
+++ b/tests/components/bluetooth/test_base_scanner.py
@@ -533,7 +533,10 @@ async def test_scanner_stops_responding(hass: HomeAssistant) -> None:
     ],
 )
 async def test_remote_scanner_bluetooth_config_entry(
-    hass: HomeAssistant, manufacturer: str, source: str
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    manufacturer: str,
+    source: str,
 ) -> None:
     """Test the remote scanner gets a bluetooth config entry."""
     manager: HomeAssistantBluetoothManager = _get_manager()
@@ -579,8 +582,7 @@ async def test_remote_scanner_bluetooth_config_entry(
     assert adapter_entry is not None
     assert adapter_entry.state is ConfigEntryState.LOADED
 
-    dev_reg = dr.async_get(hass)
-    dev = dev_reg.async_get_device(
+    dev = device_registry.async_get_device(
         connections={(dr.CONNECTION_BLUETOOTH, scanner.source)}
     )
     assert dev is not None

--- a/tests/components/bluetooth/test_base_scanner.py
+++ b/tests/components/bluetooth/test_base_scanner.py
@@ -529,7 +529,7 @@ async def test_scanner_stops_responding(hass: HomeAssistant) -> None:
     ("manufacturer", "source"),
     [
         ("test", "test"),
-        ("Raspberry Pi Trading Ltd", "28:CD:C1:11:23:45"),
+        ("Raspberry Pi Trading Ltd (test)", "28:CD:C1:11:23:45"),
     ],
 )
 async def test_remote_scanner_bluetooth_config_entry(

--- a/tests/components/bluetooth/test_base_scanner.py
+++ b/tests/components/bluetooth/test_base_scanner.py
@@ -25,7 +25,9 @@ from homeassistant.components.bluetooth.const import (
     UNAVAILABLE_TRACK_SECONDS,
 )
 from homeassistant.components.bluetooth.manager import HomeAssistantBluetoothManager
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 from homeassistant.util.json import json_loads
@@ -523,7 +525,16 @@ async def test_scanner_stops_responding(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.usefixtures("enable_bluetooth")
-async def test_remote_scanner_bluetooth_config_entry(hass: HomeAssistant) -> None:
+@pytest.mark.parametrize(
+    ("manufacturer", "source"),
+    [
+        ("test", "test"),
+        ("Raspberry Pi Trading Ltd", "28:CD:C1:11:23:45"),
+    ],
+)
+async def test_remote_scanner_bluetooth_config_entry(
+    hass: HomeAssistant, manufacturer: str, source: str
+) -> None:
     """Test the remote scanner gets a bluetooth config entry."""
     manager: HomeAssistantBluetoothManager = _get_manager()
 
@@ -543,8 +554,9 @@ async def test_remote_scanner_bluetooth_config_entry(hass: HomeAssistant) -> Non
     connector = (
         HaBluetoothConnector(MockBleakClient, "mock_bleak_client", lambda: False),
     )
-    scanner = FakeScanner("esp32", "esp32", connector, True)
+    scanner = FakeScanner(source, source, connector, True)
     unsetup = scanner.async_setup()
+    assert scanner.source == source
     entry = MockConfigEntry(domain="test")
     entry.add_to_hass(hass)
     cancel = manager.async_register_hass_scanner(
@@ -561,9 +573,19 @@ async def test_remote_scanner_bluetooth_config_entry(hass: HomeAssistant) -> Non
     cancel()
     unsetup()
 
-    assert hass.config_entries.async_entry_for_domain_unique_id(
+    adapter_entry = hass.config_entries.async_entry_for_domain_unique_id(
         "bluetooth", scanner.source
     )
+    assert adapter_entry is not None
+    assert adapter_entry.state is ConfigEntryState.LOADED
+
+    dev_reg = dr.async_get(hass)
+    dev = dev_reg.async_get_device(
+        connections={(dr.CONNECTION_BLUETOOTH, scanner.source)}
+    )
+    assert dev is not None
+    assert dev.config_entries == {adapter_entry.entry_id}
+    assert dev.manufacturer == manufacturer
 
     manager.async_remove_scanner(scanner.source)
     await hass.async_block_till_done()


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve remote Bluetooth scanner manufacturer data

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
