### PR TITLE
Set friendly name for PT2262 sensors to masked name

### DIFF
--- a/homeassistant/components/rfxtrx/entity.py
+++ b/homeassistant/components/rfxtrx/entity.py
@@ -46,7 +46,7 @@ class RfxtrxEntity(RestoreEntity):
         self._attr_device_info = DeviceInfo(
             identifiers=_get_identifiers_from_device_tuple(device_id),
             model=device.type_string,
-            name=f"{device.type_string} {device.id_string}",
+            name=f"{device.type_string} {device_id.id_string}",
         )
         self._attr_unique_id = "_".join(x for x in device_id)
         self._device = device
@@ -54,7 +54,7 @@ class RfxtrxEntity(RestoreEntity):
         self._device_id = device_id
         # If id_string is 213c7f2:1, the group_id is 213c7f2, and the device will respond to
         # group events regardless of their group indices.
-        (self._group_id, _, _) = cast(str, device.id_string).partition(":")
+        (self._group_id, _, _) = device_id.id_string.partition(":")
 
     async def async_added_to_hass(self) -> None:
         """Restore RFXtrx device state (ON/OFF)."""

--- a/tests/components/rfxtrx/test_binary_sensor.py
+++ b/tests/components/rfxtrx/test_binary_sensor.py
@@ -58,17 +58,17 @@ async def test_one_pt2262(hass: HomeAssistant, rfxtrx) -> None:
     await hass.async_block_till_done()
     await hass.async_start()
 
-    state = hass.states.get("binary_sensor.pt2262_22670e")
+    state = hass.states.get("binary_sensor.pt2262_226700")
     assert state
     assert state.state == STATE_UNKNOWN
-    assert state.attributes.get("friendly_name") == "PT2262 22670e"
+    assert state.attributes.get("friendly_name") == "PT2262 226700"
 
     await rfxtrx.signal("0913000022670e013970")
-    state = hass.states.get("binary_sensor.pt2262_22670e")
+    state = hass.states.get("binary_sensor.pt2262_226700")
     assert state.state == "on"
 
     await rfxtrx.signal("09130000226707013d70")
-    state = hass.states.get("binary_sensor.pt2262_22670e")
+    state = hass.states.get("binary_sensor.pt2262_226700")
     assert state.state == "off"
 
 
@@ -85,10 +85,10 @@ async def test_pt2262_unconfigured(hass: HomeAssistant, rfxtrx) -> None:
     await hass.async_block_till_done()
     await hass.async_start()
 
-    state = hass.states.get("binary_sensor.pt2262_22670e")
+    state = hass.states.get("binary_sensor.pt2262_226707")
     assert state
     assert state.state == STATE_UNKNOWN
-    assert state.attributes.get("friendly_name") == "PT2262 22670e"
+    assert state.attributes.get("friendly_name") == "PT2262 226707"
 
     state = hass.states.get("binary_sensor.pt2262_226707")
     assert state
@@ -318,7 +318,7 @@ async def test_pt2262_duplicate_id(hass: HomeAssistant, rfxtrx) -> None:
     await hass.async_block_till_done()
     await hass.async_start()
 
-    state = hass.states.get("binary_sensor.pt2262_22670e")
+    state = hass.states.get("binary_sensor.pt2262_226700")
     assert state
     assert state.state == STATE_UNKNOWN
-    assert state.attributes.get("friendly_name") == "PT2262 22670e"
+    assert state.attributes.get("friendly_name") == "PT2262 226700"

--- a/tests/components/rfxtrx/test_config_flow.py
+++ b/tests/components/rfxtrx/test_config_flow.py
@@ -758,10 +758,10 @@ async def test_options_add_and_configure_device(
     assert entry.data["devices"]["0913000022670e013970"]
     assert entry.data["devices"]["0913000022670e013970"]["off_delay"] == 9
 
-    state = hass.states.get("binary_sensor.pt2262_22670e")
+    state = hass.states.get("binary_sensor.pt2262_226700")
     assert state
     assert state.state == STATE_UNKNOWN
-    assert state.attributes.get("friendly_name") == "PT2262 22670e"
+    assert state.attributes.get("friendly_name") == "PT2262 226700"
 
     device_entries = dr.async_entries_for_config_entry(device_registry, entry.entry_id)
 

--- a/tests/components/rfxtrx/test_sensor.py
+++ b/tests/components/rfxtrx/test_sensor.py
@@ -330,10 +330,10 @@ async def test_rssi_sensor(hass: HomeAssistant, rfxtrx) -> None:
     await hass.async_block_till_done()
     await hass.async_start()
 
-    state = hass.states.get("sensor.pt2262_22670e_signal_strength")
+    state = hass.states.get("sensor.pt2262_226700_signal_strength")
     assert state
     assert state.state == "unknown"
-    assert state.attributes.get("friendly_name") == "PT2262 22670e Signal strength"
+    assert state.attributes.get("friendly_name") == "PT2262 226700 Signal strength"
     assert (
         state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
         == SIGNAL_STRENGTH_DECIBELS_MILLIWATT
@@ -351,7 +351,7 @@ async def test_rssi_sensor(hass: HomeAssistant, rfxtrx) -> None:
     await rfxtrx.signal("0913000022670e013b70")
     await rfxtrx.signal("0b1100cd0213c7f230010f71")
 
-    state = hass.states.get("sensor.pt2262_22670e_signal_strength")
+    state = hass.states.get("sensor.pt2262_226700_signal_strength")
     assert state
     assert state.state == "-64"
 
@@ -362,7 +362,7 @@ async def test_rssi_sensor(hass: HomeAssistant, rfxtrx) -> None:
     await rfxtrx.signal("0913000022670e013b60")
     await rfxtrx.signal("0b1100cd0213c7f230010f61")
 
-    state = hass.states.get("sensor.pt2262_22670e_signal_strength")
+    state = hass.states.get("sensor.pt2262_226700_signal_strength")
     assert state
     assert state.state == "-72"
 

--- a/tests/components/rfxtrx/test_switch.py
+++ b/tests/components/rfxtrx/test_switch.py
@@ -70,23 +70,23 @@ async def test_one_pt2262_switch(hass: HomeAssistant, rfxtrx) -> None:
     await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
 
-    state = hass.states.get("switch.pt2262_22670e")
+    state = hass.states.get("switch.pt2262_226700")
     assert state
     assert state.state == STATE_UNKNOWN
-    assert state.attributes.get("friendly_name") == "PT2262 22670e"
+    assert state.attributes.get("friendly_name") == "PT2262 226700"
 
     await hass.services.async_call(
-        "switch", "turn_on", {"entity_id": "switch.pt2262_22670e"}, blocking=True
+        "switch", "turn_on", {"entity_id": "switch.pt2262_226700"}, blocking=True
     )
 
-    state = hass.states.get("switch.pt2262_22670e")
+    state = hass.states.get("switch.pt2262_226700")
     assert state.state == "on"
 
     await hass.services.async_call(
-        "switch", "turn_off", {"entity_id": "switch.pt2262_22670e"}, blocking=True
+        "switch", "turn_off", {"entity_id": "switch.pt2262_226700"}, blocking=True
     )
 
-    state = hass.states.get("switch.pt2262_22670e")
+    state = hass.states.get("switch.pt2262_226700")
     assert state.state == "off"
 
     assert rfxtrx.transport.send.mock_calls == [
@@ -220,26 +220,26 @@ async def test_pt2262_switch_events(hass: HomeAssistant, rfxtrx) -> None:
     await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
 
-    state = hass.states.get("switch.pt2262_22670e")
+    state = hass.states.get("switch.pt2262_226700")
     assert state
     assert state.state == STATE_UNKNOWN
-    assert state.attributes.get("friendly_name") == "PT2262 22670e"
+    assert state.attributes.get("friendly_name") == "PT2262 226700"
 
     # "Command: 0xE"
     await rfxtrx.signal("0913000022670e013970")
-    assert hass.states.get("switch.pt2262_22670e").state == "on"
+    assert hass.states.get("switch.pt2262_226700").state == "on"
 
     # "Command: 0x0"
     await rfxtrx.signal("09130000226700013970")
-    assert hass.states.get("switch.pt2262_22670e").state == "on"
+    assert hass.states.get("switch.pt2262_226700").state == "on"
 
     # "Command: 0x7"
     await rfxtrx.signal("09130000226707013d70")
-    assert hass.states.get("switch.pt2262_22670e").state == "off"
+    assert hass.states.get("switch.pt2262_226700").state == "off"
 
     # "Command: 0x1"
     await rfxtrx.signal("09130000226701013d70")
-    assert hass.states.get("switch.pt2262_22670e").state == "off"
+    assert hass.states.get("switch.pt2262_226700").state == "off"
 
 
 async def test_discover_switch(hass: HomeAssistant, rfxtrx_automatic) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Make sure the friendly name follow the masking of the ID code used as identifier. The unique identifier already did follow this change so when adjusting the data bits field, two devices would appear with same name.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
