### PR TITLE
Prevent pylint out-of-memory failures

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,13 +61,14 @@ repos:
         name: mypy
         entry: script/run-in-env.sh mypy
         language: script
-        types_or: [python, pyi]
         require_serial: true
+        types_or: [python, pyi]
         files: ^(homeassistant|pylint)/.+\.(py|pyi)$
       - id: pylint
         name: pylint
-        entry: script/run-in-env.sh pylint -j 0 --ignore-missing-annotations=y
+        entry: script/run-in-env.sh pylint --ignore-missing-annotations=y
         language: script
+        require_serial: true
         types_or: [python, pyi]
         files: ^(homeassistant|tests)/.+\.(py|pyi)$
       - id: gen_requirements_all


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The HA [developer documentation](https://developers.home-assistant.io/docs/development_testing/) suggests running `pre-commit run --all-files` to run the linters.  However, every time I attempted to run that on my system, it spawned >1000 processes, attempted to consume far more than 100GB of memory, and crashed my system.

There are two underlying problems which this PR addresses:

1. Both `pre-commit` and `pylint` were configured for parallel execution.  When configured for parallel execution, both will detect the number of CPUs on the system and spawn that many parallel processes.  Hence, on my 32-core system, `pre-commit` was running 32 copies of `pylint` in parallel, then each of those copies of `pylint` was spawning 32 worker processes, resulting in >1000 parallel processes.
2. `pylint` memory consumption increases approximately linearly with the number of files scanned (~.33MB/file), and when parallel execution is enabled in `pylint` the memory consumption is approximately multiplied by the number of parallel processes.  Given that HA contains >14,000 Python files, scanning all of them in one batch with parallel execution enabled (in `pylint` only) on a 32-core system would require around 150GB of memory.

The first commit in this PR corrects the first problem by disabling the `pre-commit` parallel execution behavior for the `pylint` hook (while leaving parallel execution enabled in `pylint`).

The second commit in this PR addresses the second problem by wrapping `pylint` with a script which:

- Detects the amount of available memory on the system.
- Estimates the amount of memory that `pylint` will require.
- Splits the file list into smaller batches to control `pylint` memory usage, and runs a series of `pylint` jobs serially on those batches.
- If necessary, limits or disables parallel execution within `pylint` to stay within the memory limits of the system.

(More details on the wrapper script's behavior and the reasoning behind that behavior are in comments in the script.)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
