### PR TITLE
Use new ServiceInfo location in component tests (part 2)

### DIFF
--- a/tests/components/insteon/test_config_flow.py
+++ b/tests/components/insteon/test_config_flow.py
@@ -8,7 +8,6 @@ import pytest
 from voluptuous_serialize import convert
 
 from homeassistant import config_entries
-from homeassistant.components import dhcp
 from homeassistant.components.insteon.config_flow import (
     STEP_HUB_V1,
     STEP_HUB_V2,
@@ -20,6 +19,7 @@ from homeassistant.config_entries import ConfigEntryState, ConfigFlowResult
 from homeassistant.const import CONF_DEVICE, CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 from homeassistant.helpers.service_info.usb import UsbServiceInfo
 
 from .const import (
@@ -210,7 +210,7 @@ async def test_form_select_hub_v2(hass: HomeAssistant) -> None:
 
 async def test_form_discovery_dhcp(hass: HomeAssistant) -> None:
     """Test the discovery of the Hub via DHCP."""
-    discovery_info = dhcp.DhcpServiceInfo("1.2.3.4", "", "aabbccddeeff")
+    discovery_info = DhcpServiceInfo("1.2.3.4", "", "aabbccddeeff")
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_DHCP}, data=discovery_info
     )

--- a/tests/components/intellifire/test_config_flow.py
+++ b/tests/components/intellifire/test_config_flow.py
@@ -5,11 +5,11 @@ from unittest.mock import AsyncMock
 from intellifire4py.exceptions import LoginError
 
 from homeassistant import config_entries
-from homeassistant.components import dhcp
 from homeassistant.components.intellifire.const import CONF_SERIAL, DOMAIN
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
 from tests.common import MockConfigEntry
 
@@ -166,7 +166,7 @@ async def test_dhcp_discovery_intellifire_device(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_DHCP},
-        data=dhcp.DhcpServiceInfo(
+        data=DhcpServiceInfo(
             ip="1.1.1.1",
             macaddress="aabbcceeddff",
             hostname="zentrios-Test",
@@ -196,7 +196,7 @@ async def test_dhcp_discovery_non_intellifire_device(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_DHCP},
-        data=dhcp.DhcpServiceInfo(
+        data=DhcpServiceInfo(
             ip="1.1.1.1",
             macaddress="aabbcceeddff",
             hostname="zentrios-Evil",

--- a/tests/components/ipp/__init__.py
+++ b/tests/components/ipp/__init__.py
@@ -2,9 +2,9 @@
 
 from ipaddress import ip_address
 
-from homeassistant.components import zeroconf
 from homeassistant.components.ipp.const import CONF_BASE_PATH
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_SSL, CONF_VERIFY_SSL
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 ATTR_HOSTNAME = "hostname"
 ATTR_PROPERTIES = "properties"
@@ -30,7 +30,7 @@ MOCK_USER_INPUT = {
     CONF_BASE_PATH: BASE_PATH,
 }
 
-MOCK_ZEROCONF_IPP_SERVICE_INFO = zeroconf.ZeroconfServiceInfo(
+MOCK_ZEROCONF_IPP_SERVICE_INFO = ZeroconfServiceInfo(
     type=IPP_ZEROCONF_SERVICE_TYPE,
     name=f"{ZEROCONF_NAME}.{IPP_ZEROCONF_SERVICE_TYPE}",
     ip_address=ip_address(ZEROCONF_HOST),
@@ -40,7 +40,7 @@ MOCK_ZEROCONF_IPP_SERVICE_INFO = zeroconf.ZeroconfServiceInfo(
     properties={"rp": ZEROCONF_RP},
 )
 
-MOCK_ZEROCONF_IPPS_SERVICE_INFO = zeroconf.ZeroconfServiceInfo(
+MOCK_ZEROCONF_IPPS_SERVICE_INFO = ZeroconfServiceInfo(
     type=IPPS_ZEROCONF_SERVICE_TYPE,
     name=f"{ZEROCONF_NAME}.{IPPS_ZEROCONF_SERVICE_TYPE}",
     ip_address=ip_address(ZEROCONF_HOST),

--- a/tests/components/isy994/test_config_flow.py
+++ b/tests/components/isy994/test_config_flow.py
@@ -7,7 +7,6 @@ from pyisy import ISYConnectionError, ISYInvalidAuthError
 import pytest
 
 from homeassistant import config_entries
-from homeassistant.components import dhcp, ssdp
 from homeassistant.components.isy994.const import (
     CONF_TLS_VER,
     DOMAIN,
@@ -18,6 +17,12 @@ from homeassistant.config_entries import SOURCE_DHCP, SOURCE_IGNORE, SOURCE_SSDP
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
+from homeassistant.helpers.service_info.ssdp import (
+    ATTR_UPNP_FRIENDLY_NAME,
+    ATTR_UPNP_UDN,
+    SsdpServiceInfo,
+)
 
 from tests.common import MockConfigEntry
 
@@ -255,13 +260,13 @@ async def test_form_ssdp_already_configured(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_SSDP},
-        data=ssdp.SsdpServiceInfo(
+        data=SsdpServiceInfo(
             ssdp_usn="mock_usn",
             ssdp_st="mock_st",
             ssdp_location=f"http://{MOCK_HOSTNAME}{ISY_URL_POSTFIX}",
             upnp={
-                ssdp.ATTR_UPNP_FRIENDLY_NAME: "myisy",
-                ssdp.ATTR_UPNP_UDN: f"{UDN_UUID_PREFIX}{MOCK_UUID}",
+                ATTR_UPNP_FRIENDLY_NAME: "myisy",
+                ATTR_UPNP_UDN: f"{UDN_UUID_PREFIX}{MOCK_UUID}",
             },
         ),
     )
@@ -274,13 +279,13 @@ async def test_form_ssdp(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_SSDP},
-        data=ssdp.SsdpServiceInfo(
+        data=SsdpServiceInfo(
             ssdp_usn="mock_usn",
             ssdp_st="mock_st",
             ssdp_location=f"http://{MOCK_HOSTNAME}{ISY_URL_POSTFIX}",
             upnp={
-                ssdp.ATTR_UPNP_FRIENDLY_NAME: "myisy",
-                ssdp.ATTR_UPNP_UDN: f"{UDN_UUID_PREFIX}{MOCK_UUID}",
+                ATTR_UPNP_FRIENDLY_NAME: "myisy",
+                ATTR_UPNP_UDN: f"{UDN_UUID_PREFIX}{MOCK_UUID}",
             },
         ),
     )
@@ -322,13 +327,13 @@ async def test_form_ssdp_existing_entry(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": SOURCE_SSDP},
-            data=ssdp.SsdpServiceInfo(
+            data=SsdpServiceInfo(
                 ssdp_usn="mock_usn",
                 ssdp_st="mock_st",
                 ssdp_location=f"http://3.3.3.3{ISY_URL_POSTFIX}",
                 upnp={
-                    ssdp.ATTR_UPNP_FRIENDLY_NAME: "myisy",
-                    ssdp.ATTR_UPNP_UDN: f"{UDN_UUID_PREFIX}{MOCK_UUID}",
+                    ATTR_UPNP_FRIENDLY_NAME: "myisy",
+                    ATTR_UPNP_UDN: f"{UDN_UUID_PREFIX}{MOCK_UUID}",
                 },
             ),
         )
@@ -353,13 +358,13 @@ async def test_form_ssdp_existing_entry_with_no_port(hass: HomeAssistant) -> Non
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": SOURCE_SSDP},
-            data=ssdp.SsdpServiceInfo(
+            data=SsdpServiceInfo(
                 ssdp_usn="mock_usn",
                 ssdp_st="mock_st",
                 ssdp_location=f"http://3.3.3.3/{ISY_URL_POSTFIX}",
                 upnp={
-                    ssdp.ATTR_UPNP_FRIENDLY_NAME: "myisy",
-                    ssdp.ATTR_UPNP_UDN: f"{UDN_UUID_PREFIX}{MOCK_UUID}",
+                    ATTR_UPNP_FRIENDLY_NAME: "myisy",
+                    ATTR_UPNP_UDN: f"{UDN_UUID_PREFIX}{MOCK_UUID}",
                 },
             ),
         )
@@ -386,13 +391,13 @@ async def test_form_ssdp_existing_entry_with_alternate_port(
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": SOURCE_SSDP},
-            data=ssdp.SsdpServiceInfo(
+            data=SsdpServiceInfo(
                 ssdp_usn="mock_usn",
                 ssdp_st="mock_st",
                 ssdp_location=f"http://3.3.3.3:1443/{ISY_URL_POSTFIX}",
                 upnp={
-                    ssdp.ATTR_UPNP_FRIENDLY_NAME: "myisy",
-                    ssdp.ATTR_UPNP_UDN: f"{UDN_UUID_PREFIX}{MOCK_UUID}",
+                    ATTR_UPNP_FRIENDLY_NAME: "myisy",
+                    ATTR_UPNP_UDN: f"{UDN_UUID_PREFIX}{MOCK_UUID}",
                 },
             ),
         )
@@ -417,13 +422,13 @@ async def test_form_ssdp_existing_entry_no_port_https(hass: HomeAssistant) -> No
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": SOURCE_SSDP},
-            data=ssdp.SsdpServiceInfo(
+            data=SsdpServiceInfo(
                 ssdp_usn="mock_usn",
                 ssdp_st="mock_st",
                 ssdp_location=f"https://3.3.3.3/{ISY_URL_POSTFIX}",
                 upnp={
-                    ssdp.ATTR_UPNP_FRIENDLY_NAME: "myisy",
-                    ssdp.ATTR_UPNP_UDN: f"{UDN_UUID_PREFIX}{MOCK_UUID}",
+                    ATTR_UPNP_FRIENDLY_NAME: "myisy",
+                    ATTR_UPNP_UDN: f"{UDN_UUID_PREFIX}{MOCK_UUID}",
                 },
             ),
         )
@@ -440,7 +445,7 @@ async def test_form_dhcp(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_DHCP},
-        data=dhcp.DhcpServiceInfo(
+        data=DhcpServiceInfo(
             ip="1.2.3.4",
             hostname="isy994-ems",
             macaddress=MOCK_MAC,
@@ -476,7 +481,7 @@ async def test_form_dhcp_with_polisy(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_DHCP},
-        data=dhcp.DhcpServiceInfo(
+        data=DhcpServiceInfo(
             ip="1.2.3.4",
             hostname="polisy",
             macaddress=MOCK_POLISY_MAC,
@@ -516,7 +521,7 @@ async def test_form_dhcp_with_eisy(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_DHCP},
-        data=dhcp.DhcpServiceInfo(
+        data=DhcpServiceInfo(
             ip="1.2.3.4",
             hostname="eisy",
             macaddress=MOCK_MAC,
@@ -564,7 +569,7 @@ async def test_form_dhcp_existing_entry(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": SOURCE_DHCP},
-            data=dhcp.DhcpServiceInfo(
+            data=DhcpServiceInfo(
                 ip="1.2.3.4",
                 hostname="isy994-ems",
                 macaddress=MOCK_MAC,
@@ -594,7 +599,7 @@ async def test_form_dhcp_existing_entry_preserves_port(hass: HomeAssistant) -> N
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": SOURCE_DHCP},
-            data=dhcp.DhcpServiceInfo(
+            data=DhcpServiceInfo(
                 ip="1.2.3.4",
                 hostname="isy994-ems",
                 macaddress=MOCK_MAC,
@@ -620,7 +625,7 @@ async def test_form_dhcp_existing_ignored_entry(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": SOURCE_DHCP},
-            data=dhcp.DhcpServiceInfo(
+            data=DhcpServiceInfo(
                 ip="1.2.3.4",
                 hostname="isy994-ems",
                 macaddress=MOCK_MAC,

--- a/tests/components/kaleidescape/__init__.py
+++ b/tests/components/kaleidescape/__init__.py
@@ -1,16 +1,16 @@
 """Tests for Kaleidescape integration."""
 
-from homeassistant.components import ssdp
 from homeassistant.helpers.service_info.ssdp import (
     ATTR_UPNP_FRIENDLY_NAME,
     ATTR_UPNP_SERIAL,
+    SsdpServiceInfo,
 )
 
 MOCK_HOST = "127.0.0.1"
 MOCK_SERIAL = "123456"
 MOCK_NAME = "Theater"
 
-MOCK_SSDP_DISCOVERY_INFO = ssdp.SsdpServiceInfo(
+MOCK_SSDP_DISCOVERY_INFO = SsdpServiceInfo(
     ssdp_usn="mock_usn",
     ssdp_st="mock_st",
     ssdp_location=f"http://{MOCK_HOST}",

--- a/tests/components/keenetic_ndms2/__init__.py
+++ b/tests/components/keenetic_ndms2/__init__.py
@@ -1,6 +1,5 @@
 """Tests for the Keenetic NDMS2 component."""
 
-from homeassistant.components import ssdp
 from homeassistant.components.keenetic_ndms2 import const
 from homeassistant.const import (
     CONF_HOST,
@@ -8,6 +7,11 @@ from homeassistant.const import (
     CONF_PORT,
     CONF_SCAN_INTERVAL,
     CONF_USERNAME,
+)
+from homeassistant.helpers.service_info.ssdp import (
+    ATTR_UPNP_FRIENDLY_NAME,
+    ATTR_UPNP_UDN,
+    SsdpServiceInfo,
 )
 
 MOCK_NAME = "Keenetic Ultra 2030"
@@ -30,12 +34,12 @@ MOCK_OPTIONS = {
     const.CONF_INTERFACES: ["Home", "VPS0"],
 }
 
-MOCK_SSDP_DISCOVERY_INFO = ssdp.SsdpServiceInfo(
+MOCK_SSDP_DISCOVERY_INFO = SsdpServiceInfo(
     ssdp_usn="mock_usn",
     ssdp_st="mock_st",
     ssdp_location=SSDP_LOCATION,
     upnp={
-        ssdp.ATTR_UPNP_UDN: "uuid:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
-        ssdp.ATTR_UPNP_FRIENDLY_NAME: MOCK_NAME,
+        ATTR_UPNP_UDN: "uuid:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+        ATTR_UPNP_FRIENDLY_NAME: MOCK_NAME,
     },
 )

--- a/tests/components/keenetic_ndms2/test_config_flow.py
+++ b/tests/components/keenetic_ndms2/test_config_flow.py
@@ -8,11 +8,15 @@ from ndms2_client.client import InterfaceInfo, RouterInfo
 import pytest
 
 from homeassistant import config_entries
-from homeassistant.components import keenetic_ndms2 as keenetic, ssdp
+from homeassistant.components import keenetic_ndms2 as keenetic
 from homeassistant.components.keenetic_ndms2 import const
 from homeassistant.const import CONF_HOST, CONF_SOURCE
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.ssdp import (
+    ATTR_UPNP_FRIENDLY_NAME,
+    ATTR_UPNP_UDN,
+)
 
 from . import MOCK_DATA, MOCK_NAME, MOCK_OPTIONS, MOCK_SSDP_DISCOVERY_INFO
 
@@ -200,7 +204,7 @@ async def test_ssdp_ignored(hass: HomeAssistant) -> None:
     entry = MockConfigEntry(
         domain=keenetic.DOMAIN,
         source=config_entries.SOURCE_IGNORE,
-        unique_id=MOCK_SSDP_DISCOVERY_INFO.upnp[ssdp.ATTR_UPNP_UDN],
+        unique_id=MOCK_SSDP_DISCOVERY_INFO.upnp[ATTR_UPNP_UDN],
     )
     entry.add_to_hass(hass)
 
@@ -222,7 +226,7 @@ async def test_ssdp_update_host(hass: HomeAssistant) -> None:
         domain=keenetic.DOMAIN,
         data=MOCK_DATA,
         options=MOCK_OPTIONS,
-        unique_id=MOCK_SSDP_DISCOVERY_INFO.upnp[ssdp.ATTR_UPNP_UDN],
+        unique_id=MOCK_SSDP_DISCOVERY_INFO.upnp[ATTR_UPNP_UDN],
     )
     entry.add_to_hass(hass)
 
@@ -247,7 +251,7 @@ async def test_ssdp_reject_no_udn(hass: HomeAssistant) -> None:
 
     discovery_info = dataclasses.replace(MOCK_SSDP_DISCOVERY_INFO)
     discovery_info.upnp = {**discovery_info.upnp}
-    discovery_info.upnp.pop(ssdp.ATTR_UPNP_UDN)
+    discovery_info.upnp.pop(ATTR_UPNP_UDN)
 
     result = await hass.config_entries.flow.async_init(
         keenetic.DOMAIN,
@@ -264,7 +268,7 @@ async def test_ssdp_reject_non_keenetic(hass: HomeAssistant) -> None:
 
     discovery_info = dataclasses.replace(MOCK_SSDP_DISCOVERY_INFO)
     discovery_info.upnp = {**discovery_info.upnp}
-    discovery_info.upnp[ssdp.ATTR_UPNP_FRIENDLY_NAME] = "Suspicious device"
+    discovery_info.upnp[ATTR_UPNP_FRIENDLY_NAME] = "Suspicious device"
     result = await hass.config_entries.flow.async_init(
         keenetic.DOMAIN,
         context={CONF_SOURCE: config_entries.SOURCE_SSDP},

--- a/tests/components/kodi/util.py
+++ b/tests/components/kodi/util.py
@@ -2,8 +2,8 @@
 
 from ipaddress import ip_address
 
-from homeassistant.components import zeroconf
 from homeassistant.components.kodi.const import DEFAULT_SSL
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 TEST_HOST = {
     "host": "1.1.1.1",
@@ -17,7 +17,7 @@ TEST_CREDENTIALS = {"username": "username", "password": "password"}
 TEST_WS_PORT = {"ws_port": 9090}
 
 UUID = "11111111-1111-1111-1111-111111111111"
-TEST_DISCOVERY = zeroconf.ZeroconfServiceInfo(
+TEST_DISCOVERY = ZeroconfServiceInfo(
     ip_address=ip_address("1.1.1.1"),
     ip_addresses=[ip_address("1.1.1.1")],
     port=8080,
@@ -28,7 +28,7 @@ TEST_DISCOVERY = zeroconf.ZeroconfServiceInfo(
 )
 
 
-TEST_DISCOVERY_WO_UUID = zeroconf.ZeroconfServiceInfo(
+TEST_DISCOVERY_WO_UUID = ZeroconfServiceInfo(
     ip_address=ip_address("1.1.1.1"),
     ip_addresses=[ip_address("1.1.1.1")],
     port=8080,

--- a/tests/components/konnected/test_config_flow.py
+++ b/tests/components/konnected/test_config_flow.py
@@ -5,10 +5,11 @@ from unittest.mock import patch
 import pytest
 
 from homeassistant import config_entries
-from homeassistant.components import konnected, ssdp
+from homeassistant.components import konnected
 from homeassistant.components.konnected import config_flow
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.ssdp import SsdpServiceInfo
 
 from tests.common import MockConfigEntry
 
@@ -116,7 +117,7 @@ async def test_ssdp(hass: HomeAssistant, mock_panel) -> None:
     result = await hass.config_entries.flow.async_init(
         config_flow.DOMAIN,
         context={"source": config_entries.SOURCE_SSDP},
-        data=ssdp.SsdpServiceInfo(
+        data=SsdpServiceInfo(
             ssdp_usn="mock_usn",
             ssdp_st="mock_st",
             ssdp_location="http://1.2.3.4:1234/Device.xml",
@@ -141,7 +142,7 @@ async def test_ssdp(hass: HomeAssistant, mock_panel) -> None:
     result = await hass.config_entries.flow.async_init(
         config_flow.DOMAIN,
         context={"source": config_entries.SOURCE_SSDP},
-        data=ssdp.SsdpServiceInfo(
+        data=SsdpServiceInfo(
             ssdp_usn="mock_usn",
             ssdp_st="mock_st",
             ssdp_location="http://1.2.3.4:1234/Device.xml",
@@ -160,7 +161,7 @@ async def test_ssdp(hass: HomeAssistant, mock_panel) -> None:
     result = await hass.config_entries.flow.async_init(
         config_flow.DOMAIN,
         context={"source": config_entries.SOURCE_SSDP},
-        data=ssdp.SsdpServiceInfo(
+        data=SsdpServiceInfo(
             ssdp_usn="mock_usn",
             ssdp_st="mock_st",
             ssdp_location="http://1.2.3.4:1234/Device.xml",
@@ -175,7 +176,7 @@ async def test_ssdp(hass: HomeAssistant, mock_panel) -> None:
     result = await hass.config_entries.flow.async_init(
         config_flow.DOMAIN,
         context={"source": config_entries.SOURCE_SSDP},
-        data=ssdp.SsdpServiceInfo(
+        data=SsdpServiceInfo(
             ssdp_usn="mock_usn",
             ssdp_st="mock_st",
             ssdp_location="http://1.2.3.4:1234/Device.xml",
@@ -193,7 +194,7 @@ async def test_ssdp(hass: HomeAssistant, mock_panel) -> None:
     result = await hass.config_entries.flow.async_init(
         config_flow.DOMAIN,
         context={"source": config_entries.SOURCE_SSDP},
-        data=ssdp.SsdpServiceInfo(
+        data=SsdpServiceInfo(
             ssdp_usn="mock_usn",
             ssdp_st="mock_st",
             ssdp_location="http://1.2.3.4:1234/Device.xml",
@@ -217,7 +218,7 @@ async def test_ssdp(hass: HomeAssistant, mock_panel) -> None:
     result = await hass.config_entries.flow.async_init(
         config_flow.DOMAIN,
         context={"source": config_entries.SOURCE_SSDP},
-        data=ssdp.SsdpServiceInfo(
+        data=SsdpServiceInfo(
             ssdp_usn="mock_usn",
             ssdp_st="mock_st",
             ssdp_location="http://1.2.3.4:1234/Device.xml",
@@ -343,7 +344,7 @@ async def test_import_ssdp_host_user_finish(hass: HomeAssistant, mock_panel) -> 
     ssdp_result = await hass.config_entries.flow.async_init(
         config_flow.DOMAIN,
         context={"source": config_entries.SOURCE_SSDP},
-        data=ssdp.SsdpServiceInfo(
+        data=SsdpServiceInfo(
             ssdp_usn="mock_usn",
             ssdp_st="mock_st",
             ssdp_location="http://0.0.0.0:1234/Device.xml",
@@ -390,7 +391,7 @@ async def test_ssdp_already_configured(hass: HomeAssistant, mock_panel) -> None:
     result = await hass.config_entries.flow.async_init(
         config_flow.DOMAIN,
         context={"source": config_entries.SOURCE_SSDP},
-        data=ssdp.SsdpServiceInfo(
+        data=SsdpServiceInfo(
             ssdp_usn="mock_usn",
             ssdp_st="mock_st",
             ssdp_location="http://0.0.0.0:1234/Device.xml",
@@ -470,7 +471,7 @@ async def test_ssdp_host_update(hass: HomeAssistant, mock_panel) -> None:
     result = await hass.config_entries.flow.async_init(
         config_flow.DOMAIN,
         context={"source": config_entries.SOURCE_SSDP},
-        data=ssdp.SsdpServiceInfo(
+        data=SsdpServiceInfo(
             ssdp_usn="mock_usn",
             ssdp_st="mock_st",
             ssdp_location="http://1.1.1.1:1234/Device.xml",

--- a/tests/components/lifx/test_config_flow.py
+++ b/tests/components/lifx/test_config_flow.py
@@ -8,7 +8,6 @@ from unittest.mock import patch
 import pytest
 
 from homeassistant import config_entries
-from homeassistant.components import dhcp, zeroconf
 from homeassistant.components.lifx import DOMAIN
 from homeassistant.components.lifx.config_flow import LifXConfigFlow
 from homeassistant.components.lifx.const import CONF_SERIAL
@@ -16,6 +15,11 @@ from homeassistant.const import CONF_DEVICE, CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
+from homeassistant.helpers.service_info.zeroconf import (
+    ATTR_PROPERTIES_ID,
+    ZeroconfServiceInfo,
+)
 from homeassistant.setup import async_setup_component
 
 from . import (
@@ -362,7 +366,7 @@ async def test_discovered_by_discovery_and_dhcp(hass: HomeAssistant) -> None:
         result2 = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_DHCP},
-            data=dhcp.DhcpServiceInfo(
+            data=DhcpServiceInfo(
                 ip=IP_ADDRESS, macaddress=DHCP_FORMATTED_MAC, hostname=LABEL
             ),
         )
@@ -385,7 +389,7 @@ async def test_discovered_by_discovery_and_dhcp(hass: HomeAssistant) -> None:
         result3 = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_DHCP},
-            data=dhcp.DhcpServiceInfo(
+            data=DhcpServiceInfo(
                 ip=IP_ADDRESS, macaddress="000000000000", hostname="mock_hostname"
             ),
         )
@@ -402,7 +406,7 @@ async def test_discovered_by_discovery_and_dhcp(hass: HomeAssistant) -> None:
         result3 = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_DHCP},
-            data=dhcp.DhcpServiceInfo(
+            data=DhcpServiceInfo(
                 ip="1.2.3.5", macaddress="000000000001", hostname="mock_hostname"
             ),
         )
@@ -416,19 +420,19 @@ async def test_discovered_by_discovery_and_dhcp(hass: HomeAssistant) -> None:
     [
         (
             config_entries.SOURCE_DHCP,
-            dhcp.DhcpServiceInfo(
+            DhcpServiceInfo(
                 ip=IP_ADDRESS, macaddress=DHCP_FORMATTED_MAC, hostname=LABEL
             ),
         ),
         (
             config_entries.SOURCE_HOMEKIT,
-            zeroconf.ZeroconfServiceInfo(
+            ZeroconfServiceInfo(
                 ip_address=ip_address(IP_ADDRESS),
                 ip_addresses=[ip_address(IP_ADDRESS)],
                 hostname=LABEL,
                 name=LABEL,
                 port=None,
-                properties={zeroconf.ATTR_PROPERTIES_ID: "any"},
+                properties={ATTR_PROPERTIES_ID: "any"},
                 type="mock_type",
             ),
         ),
@@ -476,19 +480,19 @@ async def test_discovered_by_dhcp_or_discovery(
     [
         (
             config_entries.SOURCE_DHCP,
-            dhcp.DhcpServiceInfo(
+            DhcpServiceInfo(
                 ip=IP_ADDRESS, macaddress=DHCP_FORMATTED_MAC, hostname=LABEL
             ),
         ),
         (
             config_entries.SOURCE_HOMEKIT,
-            zeroconf.ZeroconfServiceInfo(
+            ZeroconfServiceInfo(
                 ip_address=ip_address(IP_ADDRESS),
                 ip_addresses=[ip_address(IP_ADDRESS)],
                 hostname=LABEL,
                 name=LABEL,
                 port=None,
-                properties={zeroconf.ATTR_PROPERTIES_ID: "any"},
+                properties={ATTR_PROPERTIES_ID: "any"},
                 type="mock_type",
             ),
         ),
@@ -520,19 +524,19 @@ async def test_discovered_by_dhcp_or_discovery_failed_to_get_device(
     [
         (
             config_entries.SOURCE_DHCP,
-            dhcp.DhcpServiceInfo(
+            DhcpServiceInfo(
                 ip=IP_ADDRESS, macaddress=DHCP_FORMATTED_MAC, hostname=LABEL
             ),
         ),
         (
             config_entries.SOURCE_HOMEKIT,
-            zeroconf.ZeroconfServiceInfo(
+            ZeroconfServiceInfo(
                 ip_address=ip_address(IP_ADDRESS),
                 ip_addresses=[ip_address(IP_ADDRESS)],
                 hostname=LABEL,
                 name=LABEL,
                 port=None,
-                properties={zeroconf.ATTR_PROPERTIES_ID: "any"},
+                properties={ATTR_PROPERTIES_ID: "any"},
                 type="mock_type",
             ),
         ),

--- a/tests/components/loqed/test_config_flow.py
+++ b/tests/components/loqed/test_config_flow.py
@@ -8,16 +8,16 @@ import aiohttp
 from loqedAPI import loqed
 
 from homeassistant import config_entries
-from homeassistant.components import zeroconf
 from homeassistant.components.loqed.const import DOMAIN
 from homeassistant.const import CONF_API_TOKEN, CONF_NAME, CONF_WEBHOOK_ID
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from tests.common import load_fixture
 from tests.test_util.aiohttp import AiohttpClientMocker
 
-zeroconf_data = zeroconf.ZeroconfServiceInfo(
+zeroconf_data = ZeroconfServiceInfo(
     ip_address=ip_address("192.168.12.34"),
     ip_addresses=[ip_address("192.168.12.34")],
     hostname="LOQED-ffeeddccbbaa.local",

--- a/tests/components/lutron_caseta/test_config_flow.py
+++ b/tests/components/lutron_caseta/test_config_flow.py
@@ -10,7 +10,6 @@ from pylutron_caseta.smartbridge import Smartbridge
 import pytest
 
 from homeassistant import config_entries
-from homeassistant.components import zeroconf
 from homeassistant.components.lutron_caseta import DOMAIN
 import homeassistant.components.lutron_caseta.config_flow as CasetaConfigFlow
 from homeassistant.components.lutron_caseta.const import (
@@ -23,6 +22,7 @@ from homeassistant.components.lutron_caseta.const import (
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from . import ENTRY_MOCK_DATA, MockBridge
 
@@ -421,7 +421,7 @@ async def test_zeroconf_host_already_configured(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("1.1.1.1"),
             ip_addresses=[ip_address("1.1.1.1")],
             hostname="LuTrOn-abc.local.",
@@ -449,7 +449,7 @@ async def test_zeroconf_lutron_id_already_configured(hass: HomeAssistant) -> Non
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("1.1.1.1"),
             ip_addresses=[ip_address("1.1.1.1")],
             hostname="LuTrOn-abc.local.",
@@ -472,7 +472,7 @@ async def test_zeroconf_not_lutron_device(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("1.1.1.1"),
             ip_addresses=[ip_address("1.1.1.1")],
             hostname="notlutron-abc.local.",
@@ -500,7 +500,7 @@ async def test_zeroconf(hass: HomeAssistant, source, tmp_path: Path) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": source},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("1.1.1.1"),
             ip_addresses=[ip_address("1.1.1.1")],
             hostname="LuTrOn-abc.local.",

--- a/tests/components/modern_forms/test_config_flow.py
+++ b/tests/components/modern_forms/test_config_flow.py
@@ -6,12 +6,12 @@ from unittest.mock import MagicMock, patch
 import aiohttp
 from aiomodernforms import ModernFormsConnectionError
 
-from homeassistant.components import zeroconf
 from homeassistant.components.modern_forms.const import DOMAIN
 from homeassistant.config_entries import SOURCE_USER, SOURCE_ZEROCONF
 from homeassistant.const import CONF_HOST, CONF_MAC, CONF_NAME, CONTENT_TYPE_JSON
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from . import init_integration
 
@@ -66,7 +66,7 @@ async def test_full_zeroconf_flow_implementation(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("192.168.1.123"),
             ip_addresses=[ip_address("192.168.1.123")],
             hostname="example.local.",
@@ -138,7 +138,7 @@ async def test_zeroconf_connection_error(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("192.168.1.123"),
             ip_addresses=[ip_address("192.168.1.123")],
             hostname="example.local.",
@@ -170,7 +170,7 @@ async def test_zeroconf_confirm_connection_error(
             CONF_HOST: "example.com",
             CONF_NAME: "test",
         },
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("192.168.1.123"),
             ip_addresses=[ip_address("192.168.1.123")],
             hostname="example.com.",
@@ -220,7 +220,7 @@ async def test_zeroconf_with_mac_device_exists_abort(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("192.168.1.123"),
             ip_addresses=[ip_address("192.168.1.123")],
             hostname="example.local.",

--- a/tests/components/motion_blinds/test_config_flow.py
+++ b/tests/components/motion_blinds/test_config_flow.py
@@ -6,12 +6,12 @@ from unittest.mock import Mock, patch
 import pytest
 
 from homeassistant import config_entries
-from homeassistant.components import dhcp
 from homeassistant.components.motion_blinds import const
 from homeassistant.components.motion_blinds.config_flow import DEFAULT_GATEWAY_NAME
 from homeassistant.const import CONF_API_KEY, CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
 from tests.common import MockConfigEntry
 
@@ -346,7 +346,7 @@ async def test_config_flow_invalid_interface(hass: HomeAssistant) -> None:
 
 async def test_dhcp_flow(hass: HomeAssistant) -> None:
     """Successful flow from DHCP discovery."""
-    dhcp_data = dhcp.DhcpServiceInfo(
+    dhcp_data = DhcpServiceInfo(
         ip=TEST_HOST,
         hostname="MOTION_abcdef",
         macaddress=DHCP_FORMATTED_MAC,
@@ -380,7 +380,7 @@ async def test_dhcp_flow(hass: HomeAssistant) -> None:
 
 async def test_dhcp_flow_abort(hass: HomeAssistant) -> None:
     """Test that DHCP discovery aborts if not Motionblinds."""
-    dhcp_data = dhcp.DhcpServiceInfo(
+    dhcp_data = DhcpServiceInfo(
         ip=TEST_HOST,
         hostname="MOTION_abcdef",
         macaddress=DHCP_FORMATTED_MAC,
@@ -400,7 +400,7 @@ async def test_dhcp_flow_abort(hass: HomeAssistant) -> None:
 
 async def test_dhcp_flow_abort_invalid_response(hass: HomeAssistant) -> None:
     """Test that DHCP discovery aborts if device responded with invalid data."""
-    dhcp_data = dhcp.DhcpServiceInfo(
+    dhcp_data = DhcpServiceInfo(
         ip=TEST_HOST,
         hostname="MOTION_abcdef",
         macaddress=DHCP_FORMATTED_MAC,

--- a/tests/components/motionmount/__init__.py
+++ b/tests/components/motionmount/__init__.py
@@ -2,8 +2,8 @@
 
 from ipaddress import ip_address
 
-from homeassistant.components import zeroconf
 from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 HOST = "192.168.1.31"
 PORT = 23
@@ -21,7 +21,7 @@ MOCK_USER_INPUT = {
     CONF_PORT: PORT,
 }
 
-MOCK_ZEROCONF_TVM_SERVICE_INFO_V1 = zeroconf.ZeroconfServiceInfo(
+MOCK_ZEROCONF_TVM_SERVICE_INFO_V1 = ZeroconfServiceInfo(
     type=TVM_ZEROCONF_SERVICE_TYPE,
     name=f"{ZEROCONF_NAME}.{TVM_ZEROCONF_SERVICE_TYPE}",
     ip_address=ip_address(ZEROCONF_HOST),
@@ -31,7 +31,7 @@ MOCK_ZEROCONF_TVM_SERVICE_INFO_V1 = zeroconf.ZeroconfServiceInfo(
     properties={"txtvers": "1", "model": "TVM 7675"},
 )
 
-MOCK_ZEROCONF_TVM_SERVICE_INFO_V2 = zeroconf.ZeroconfServiceInfo(
+MOCK_ZEROCONF_TVM_SERVICE_INFO_V2 = ZeroconfServiceInfo(
     type=TVM_ZEROCONF_SERVICE_TYPE,
     name=f"{ZEROCONF_NAME}.{TVM_ZEROCONF_SERVICE_TYPE}",
     ip_address=ip_address(ZEROCONF_HOST),

--- a/tests/components/nam/test_config_flow.py
+++ b/tests/components/nam/test_config_flow.py
@@ -6,16 +6,16 @@ from unittest.mock import patch
 from nettigo_air_monitor import ApiError, AuthFailedError, CannotGetMacError
 import pytest
 
-from homeassistant.components import zeroconf
 from homeassistant.components.nam.const import DOMAIN
 from homeassistant.config_entries import SOURCE_USER, SOURCE_ZEROCONF
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from tests.common import MockConfigEntry
 
-DISCOVERY_INFO = zeroconf.ZeroconfServiceInfo(
+DISCOVERY_INFO = ZeroconfServiceInfo(
     ip_address=ip_address("10.10.2.3"),
     ip_addresses=[ip_address("10.10.2.3")],
     hostname="mock_hostname",

--- a/tests/components/nanoleaf/test_config_flow.py
+++ b/tests/components/nanoleaf/test_config_flow.py
@@ -9,11 +9,15 @@ from aionanoleaf import InvalidToken, Unauthorized, Unavailable
 import pytest
 
 from homeassistant import config_entries
-from homeassistant.components import ssdp, zeroconf
 from homeassistant.components.nanoleaf.const import DOMAIN
 from homeassistant.const import CONF_HOST, CONF_TOKEN
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.ssdp import SsdpServiceInfo
+from homeassistant.helpers.service_info.zeroconf import (
+    ATTR_PROPERTIES_ID,
+    ZeroconfServiceInfo,
+)
 
 from tests.common import MockConfigEntry
 
@@ -248,13 +252,13 @@ async def test_discovery_link_unavailable(
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": source},
-            data=zeroconf.ZeroconfServiceInfo(
+            data=ZeroconfServiceInfo(
                 ip_address=ip_address(TEST_HOST),
                 ip_addresses=[ip_address(TEST_HOST)],
                 hostname="mock_hostname",
                 name=f"{TEST_NAME}.{type_in_discovery_info}",
                 port=None,
-                properties={zeroconf.ATTR_PROPERTIES_ID: TEST_DEVICE_ID},
+                properties={ATTR_PROPERTIES_ID: TEST_DEVICE_ID},
                 type=type_in_discovery_info,
             ),
         )
@@ -384,13 +388,13 @@ async def test_import_discovery_integration(
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": source},
-            data=zeroconf.ZeroconfServiceInfo(
+            data=ZeroconfServiceInfo(
                 ip_address=ip_address(TEST_HOST),
                 ip_addresses=[ip_address(TEST_HOST)],
                 hostname="mock_hostname",
                 name=f"{TEST_NAME}.{type_in_discovery}",
                 port=None,
-                properties={zeroconf.ATTR_PROPERTIES_ID: TEST_DEVICE_ID},
+                properties={ATTR_PROPERTIES_ID: TEST_DEVICE_ID},
                 type=type_in_discovery,
             ),
         )
@@ -432,7 +436,7 @@ async def test_ssdp_discovery(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_SSDP},
-            data=ssdp.SsdpServiceInfo(
+            data=SsdpServiceInfo(
                 ssdp_usn="mock_usn",
                 ssdp_st="mock_st",
                 upnp={},

--- a/tests/components/nest/test_config_flow.py
+++ b/tests/components/nest/test_config_flow.py
@@ -10,12 +10,12 @@ from google_nest_sdm.exceptions import AuthException
 import pytest
 
 from homeassistant import config_entries
-from homeassistant.components import dhcp
 from homeassistant.components.nest.const import DOMAIN, OAUTH2_AUTHORIZE, OAUTH2_TOKEN
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult, FlowResultType
 from homeassistant.helpers import config_entry_oauth2_flow
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
 from .common import (
     CLIENT_ID,
@@ -36,7 +36,7 @@ WEB_REDIRECT_URL = "https://example.com/auth/external/callback"
 APP_REDIRECT_URL = "urn:ietf:wg:oauth:2.0:oob"
 RAND_SUBSCRIBER_SUFFIX = "ABCDEF"
 
-FAKE_DHCP_DATA = dhcp.DhcpServiceInfo(
+FAKE_DHCP_DATA = DhcpServiceInfo(
     ip="127.0.0.2", macaddress="001122334455", hostname="fake_hostname"
 )
 

--- a/tests/components/netatmo/test_config_flow.py
+++ b/tests/components/netatmo/test_config_flow.py
@@ -7,7 +7,6 @@ from pyatmo.const import ALL_SCOPES
 import pytest
 
 from homeassistant import config_entries
-from homeassistant.components import zeroconf
 from homeassistant.components.netatmo import config_flow
 from homeassistant.components.netatmo.const import (
     CONF_NEW_AREA,
@@ -20,6 +19,10 @@ from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers import config_entry_oauth2_flow
+from homeassistant.helpers.service_info.zeroconf import (
+    ATTR_PROPERTIES_ID,
+    ZeroconfServiceInfo,
+)
 
 from .conftest import CLIENT_ID
 
@@ -46,13 +49,13 @@ async def test_abort_if_existing_entry(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         "netatmo",
         context={"source": config_entries.SOURCE_HOMEKIT},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("192.168.1.5"),
             ip_addresses=[ip_address("192.168.1.5")],
             hostname="mock_hostname",
             name="mock_name",
             port=None,
-            properties={zeroconf.ATTR_PROPERTIES_ID: "aa:bb:cc:dd:ee:ff"},
+            properties={ATTR_PROPERTIES_ID: "aa:bb:cc:dd:ee:ff"},
             type="mock_type",
         ),
     )

--- a/tests/components/netgear/test_config_flow.py
+++ b/tests/components/netgear/test_config_flow.py
@@ -5,7 +5,6 @@ from unittest.mock import Mock, patch
 from pynetgear import DEFAULT_USER
 import pytest
 
-from homeassistant.components import ssdp
 from homeassistant.components.netgear.const import (
     CONF_CONSIDER_HOME,
     DOMAIN,
@@ -23,6 +22,12 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.ssdp import (
+    ATTR_UPNP_MODEL_NUMBER,
+    ATTR_UPNP_PRESENTATION_URL,
+    ATTR_UPNP_SERIAL,
+    SsdpServiceInfo,
+)
 
 from tests.common import MockConfigEntry
 
@@ -208,14 +213,14 @@ async def test_ssdp_already_configured(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_SSDP},
-        data=ssdp.SsdpServiceInfo(
+        data=SsdpServiceInfo(
             ssdp_usn="mock_usn",
             ssdp_st="mock_st",
             ssdp_location=SSDP_URL_SLL,
             upnp={
-                ssdp.ATTR_UPNP_MODEL_NUMBER: "RBR20",
-                ssdp.ATTR_UPNP_PRESENTATION_URL: URL,
-                ssdp.ATTR_UPNP_SERIAL: SERIAL,
+                ATTR_UPNP_MODEL_NUMBER: "RBR20",
+                ATTR_UPNP_PRESENTATION_URL: URL,
+                ATTR_UPNP_SERIAL: SERIAL,
             },
         ),
     )
@@ -228,13 +233,13 @@ async def test_ssdp_no_serial(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_SSDP},
-        data=ssdp.SsdpServiceInfo(
+        data=SsdpServiceInfo(
             ssdp_usn="mock_usn",
             ssdp_st="mock_st",
             ssdp_location=SSDP_URL,
             upnp={
-                ssdp.ATTR_UPNP_MODEL_NUMBER: "RBR20",
-                ssdp.ATTR_UPNP_PRESENTATION_URL: URL,
+                ATTR_UPNP_MODEL_NUMBER: "RBR20",
+                ATTR_UPNP_PRESENTATION_URL: URL,
             },
         ),
     )
@@ -253,14 +258,14 @@ async def test_ssdp_ipv6(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_SSDP},
-        data=ssdp.SsdpServiceInfo(
+        data=SsdpServiceInfo(
             ssdp_usn="mock_usn",
             ssdp_st="mock_st",
             ssdp_location=SSDP_URLipv6,
             upnp={
-                ssdp.ATTR_UPNP_MODEL_NUMBER: "RBR20",
-                ssdp.ATTR_UPNP_PRESENTATION_URL: URL,
-                ssdp.ATTR_UPNP_SERIAL: SERIAL,
+                ATTR_UPNP_MODEL_NUMBER: "RBR20",
+                ATTR_UPNP_PRESENTATION_URL: URL,
+                ATTR_UPNP_SERIAL: SERIAL,
             },
         ),
     )
@@ -273,14 +278,14 @@ async def test_ssdp(hass: HomeAssistant, service) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_SSDP},
-        data=ssdp.SsdpServiceInfo(
+        data=SsdpServiceInfo(
             ssdp_usn="mock_usn",
             ssdp_st="mock_st",
             ssdp_location=SSDP_URL,
             upnp={
-                ssdp.ATTR_UPNP_MODEL_NUMBER: "RBR20",
-                ssdp.ATTR_UPNP_PRESENTATION_URL: URL,
-                ssdp.ATTR_UPNP_SERIAL: SERIAL,
+                ATTR_UPNP_MODEL_NUMBER: "RBR20",
+                ATTR_UPNP_PRESENTATION_URL: URL,
+                ATTR_UPNP_SERIAL: SERIAL,
             },
         ),
     )
@@ -305,14 +310,14 @@ async def test_ssdp_port_5555(hass: HomeAssistant, service) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_SSDP},
-        data=ssdp.SsdpServiceInfo(
+        data=SsdpServiceInfo(
             ssdp_usn="mock_usn",
             ssdp_st="mock_st",
             ssdp_location=SSDP_URL_SLL,
             upnp={
-                ssdp.ATTR_UPNP_MODEL_NUMBER: MODELS_PORT_5555[0],
-                ssdp.ATTR_UPNP_PRESENTATION_URL: URL_SSL,
-                ssdp.ATTR_UPNP_SERIAL: SERIAL,
+                ATTR_UPNP_MODEL_NUMBER: MODELS_PORT_5555[0],
+                ATTR_UPNP_PRESENTATION_URL: URL_SSL,
+                ATTR_UPNP_SERIAL: SERIAL,
             },
         ),
     )

--- a/tests/components/nuki/test_config_flow.py
+++ b/tests/components/nuki/test_config_flow.py
@@ -6,11 +6,11 @@ from pynuki.bridge import InvalidCredentialsException
 from requests.exceptions import RequestException
 
 from homeassistant import config_entries
-from homeassistant.components import dhcp
 from homeassistant.components.nuki.const import DOMAIN
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TOKEN
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
 from .mock import DHCP_FORMATTED_MAC, HOST, MOCK_INFO, NAME, setup_nuki_integration
 
@@ -151,9 +151,7 @@ async def test_dhcp_flow(hass: HomeAssistant) -> None:
     """Test that DHCP discovery for new bridge works."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
-        data=dhcp.DhcpServiceInfo(
-            hostname=NAME, ip=HOST, macaddress=DHCP_FORMATTED_MAC
-        ),
+        data=DhcpServiceInfo(hostname=NAME, ip=HOST, macaddress=DHCP_FORMATTED_MAC),
         context={"source": config_entries.SOURCE_DHCP},
     )
 
@@ -196,9 +194,7 @@ async def test_dhcp_flow_already_configured(hass: HomeAssistant) -> None:
     await setup_nuki_integration(hass)
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
-        data=dhcp.DhcpServiceInfo(
-            hostname=NAME, ip=HOST, macaddress=DHCP_FORMATTED_MAC
-        ),
+        data=DhcpServiceInfo(hostname=NAME, ip=HOST, macaddress=DHCP_FORMATTED_MAC),
         context={"source": config_entries.SOURCE_DHCP},
     )
 

--- a/tests/components/nut/test_config_flow.py
+++ b/tests/components/nut/test_config_flow.py
@@ -6,7 +6,6 @@ from unittest.mock import patch
 from aionut import NUTError, NUTLoginError
 
 from homeassistant import config_entries, setup
-from homeassistant.components import zeroconf
 from homeassistant.components.nut.const import DOMAIN
 from homeassistant.const import (
     CONF_ALIAS,
@@ -20,6 +19,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from .util import _get_mock_nutclient
 
@@ -38,7 +38,7 @@ async def test_form_zeroconf(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("192.168.1.5"),
             ip_addresses=[ip_address("192.168.1.5")],
             hostname="mock_hostname",

--- a/tests/components/obihai/__init__.py
+++ b/tests/components/obihai/__init__.py
@@ -1,7 +1,7 @@
 """Tests for the Obihai Integration."""
 
-from homeassistant.components import dhcp
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
 USER_INPUT = {
     CONF_HOST: "10.10.10.30",
@@ -9,7 +9,7 @@ USER_INPUT = {
     CONF_USERNAME: "admin",
 }
 
-DHCP_SERVICE_INFO = dhcp.DhcpServiceInfo(
+DHCP_SERVICE_INFO = DhcpServiceInfo(
     hostname="obi200",
     ip="192.168.1.100",
     macaddress="9cadef000000",

--- a/tests/components/octoprint/test_config_flow.py
+++ b/tests/components/octoprint/test_config_flow.py
@@ -6,10 +6,11 @@ from unittest.mock import patch
 from pyoctoprintapi import ApiError, DiscoverySettings
 
 from homeassistant import config_entries
-from homeassistant.components import ssdp, zeroconf
 from homeassistant.components.octoprint.const import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.ssdp import SsdpServiceInfo
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from tests.common import MockConfigEntry
 
@@ -183,7 +184,7 @@ async def test_show_zerconf_form(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("192.168.1.123"),
             ip_addresses=[ip_address("192.168.1.123")],
             hostname="example.local.",
@@ -252,7 +253,7 @@ async def test_show_ssdp_form(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_SSDP},
-        data=ssdp.SsdpServiceInfo(
+        data=SsdpServiceInfo(
             ssdp_usn="mock_usn",
             ssdp_st="mock_st",
             upnp={
@@ -525,7 +526,7 @@ async def test_duplicate_zerconf_ignored(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("192.168.1.123"),
             ip_addresses=[ip_address("192.168.1.123")],
             hostname="example.local.",
@@ -551,7 +552,7 @@ async def test_duplicate_ssdp_ignored(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_SSDP},
-        data=ssdp.SsdpServiceInfo(
+        data=SsdpServiceInfo(
             ssdp_usn="mock_usn",
             ssdp_st="mock_st",
             upnp={

--- a/tests/components/onkyo/test_config_flow.py
+++ b/tests/components/onkyo/test_config_flow.py
@@ -6,7 +6,6 @@ from unittest.mock import patch
 import pytest
 
 from homeassistant import config_entries
-from homeassistant.components import ssdp
 from homeassistant.components.onkyo import InputSource
 from homeassistant.components.onkyo.config_flow import OnkyoConfigFlow
 from homeassistant.components.onkyo.const import (
@@ -18,6 +17,10 @@ from homeassistant.config_entries import SOURCE_USER
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType, InvalidData
+from homeassistant.helpers.service_info.ssdp import (
+    ATTR_UPNP_FRIENDLY_NAME,
+    SsdpServiceInfo,
+)
 
 from . import (
     create_config_entry_from_info,
@@ -95,9 +98,9 @@ async def test_ssdp_discovery_already_configured(
     )
     config_entry.add_to_hass(hass)
 
-    discovery_info = ssdp.SsdpServiceInfo(
+    discovery_info = SsdpServiceInfo(
         ssdp_location="http://192.168.1.100:8080",
-        upnp={ssdp.ATTR_UPNP_FRIENDLY_NAME: "Onkyo Receiver"},
+        upnp={ATTR_UPNP_FRIENDLY_NAME: "Onkyo Receiver"},
         ssdp_usn="uuid:mock_usn",
         ssdp_udn="uuid:00000000-0000-0000-0000-000000000000",
         ssdp_st="mock_st",
@@ -232,9 +235,9 @@ async def test_ssdp_discovery_success(
     hass: HomeAssistant, default_mock_discovery
 ) -> None:
     """Test SSDP discovery with valid host."""
-    discovery_info = ssdp.SsdpServiceInfo(
+    discovery_info = SsdpServiceInfo(
         ssdp_location="http://192.168.1.100:8080",
-        upnp={ssdp.ATTR_UPNP_FRIENDLY_NAME: "Onkyo Receiver"},
+        upnp={ATTR_UPNP_FRIENDLY_NAME: "Onkyo Receiver"},
         ssdp_usn="uuid:mock_usn",
         ssdp_udn="uuid:00000000-0000-0000-0000-000000000000",
         ssdp_st="mock_st",
@@ -261,9 +264,9 @@ async def test_ssdp_discovery_success(
 
 async def test_ssdp_discovery_host_info_error(hass: HomeAssistant) -> None:
     """Test SSDP discovery with host info error."""
-    discovery_info = ssdp.SsdpServiceInfo(
+    discovery_info = SsdpServiceInfo(
         ssdp_location="http://192.168.1.100:8080",
-        upnp={ssdp.ATTR_UPNP_FRIENDLY_NAME: "Onkyo Receiver"},
+        upnp={ATTR_UPNP_FRIENDLY_NAME: "Onkyo Receiver"},
         ssdp_usn="uuid:mock_usn",
         ssdp_st="mock_st",
     )
@@ -286,9 +289,9 @@ async def test_ssdp_discovery_host_none_info(
     hass: HomeAssistant, stub_mock_discovery
 ) -> None:
     """Test SSDP discovery with host info error."""
-    discovery_info = ssdp.SsdpServiceInfo(
+    discovery_info = SsdpServiceInfo(
         ssdp_location="http://192.168.1.100:8080",
-        upnp={ssdp.ATTR_UPNP_FRIENDLY_NAME: "Onkyo Receiver"},
+        upnp={ATTR_UPNP_FRIENDLY_NAME: "Onkyo Receiver"},
         ssdp_usn="uuid:mock_usn",
         ssdp_st="mock_st",
     )
@@ -307,9 +310,9 @@ async def test_ssdp_discovery_no_location(
     hass: HomeAssistant, default_mock_discovery
 ) -> None:
     """Test SSDP discovery with no location."""
-    discovery_info = ssdp.SsdpServiceInfo(
+    discovery_info = SsdpServiceInfo(
         ssdp_location=None,
-        upnp={ssdp.ATTR_UPNP_FRIENDLY_NAME: "Onkyo Receiver"},
+        upnp={ATTR_UPNP_FRIENDLY_NAME: "Onkyo Receiver"},
         ssdp_usn="uuid:mock_usn",
         ssdp_st="mock_st",
     )
@@ -328,9 +331,9 @@ async def test_ssdp_discovery_no_host(
     hass: HomeAssistant, default_mock_discovery
 ) -> None:
     """Test SSDP discovery with no host."""
-    discovery_info = ssdp.SsdpServiceInfo(
+    discovery_info = SsdpServiceInfo(
         ssdp_location="http://",
-        upnp={ssdp.ATTR_UPNP_FRIENDLY_NAME: "Onkyo Receiver"},
+        upnp={ATTR_UPNP_FRIENDLY_NAME: "Onkyo Receiver"},
         ssdp_usn="uuid:mock_usn",
         ssdp_st="mock_st",
     )

--- a/tests/components/onvif/test_config_flow.py
+++ b/tests/components/onvif/test_config_flow.py
@@ -6,13 +6,13 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from homeassistant import config_entries
-from homeassistant.components import dhcp
 from homeassistant.components.onvif import DOMAIN, config_flow
 from homeassistant.config_entries import SOURCE_DHCP
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
 from . import (
     HOST,
@@ -44,10 +44,10 @@ DISCOVERY = [
         "MAC": "ff:ee:dd:cc:bb:aa",
     },
 ]
-DHCP_DISCOVERY = dhcp.DhcpServiceInfo(
+DHCP_DISCOVERY = DhcpServiceInfo(
     hostname="any", ip="5.6.7.8", macaddress=MAC.lower().replace(":", "")
 )
-DHCP_DISCOVERY_SAME_IP = dhcp.DhcpServiceInfo(
+DHCP_DISCOVERY_SAME_IP = DhcpServiceInfo(
     hostname="any", ip="1.2.3.4", macaddress=MAC.lower().replace(":", "")
 )
 

--- a/tests/components/overkiz/test_config_flow.py
+++ b/tests/components/overkiz/test_config_flow.py
@@ -17,10 +17,10 @@ from pyoverkiz.exceptions import (
 import pytest
 
 from homeassistant import config_entries
-from homeassistant.components import dhcp
 from homeassistant.components.overkiz.const import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from tests.common import MockConfigEntry
@@ -742,7 +742,7 @@ async def test_dhcp_flow(hass: HomeAssistant, mock_setup_entry: AsyncMock) -> No
     """Test that DHCP discovery for new bridge works."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
-        data=dhcp.DhcpServiceInfo(
+        data=DhcpServiceInfo(
             hostname="gateway-1234-5678-9123",
             ip="192.168.1.4",
             macaddress="f8811a000000",
@@ -801,7 +801,7 @@ async def test_dhcp_flow_already_configured(hass: HomeAssistant) -> None:
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
-        data=dhcp.DhcpServiceInfo(
+        data=DhcpServiceInfo(
             hostname="gateway-1234-5678-9123",
             ip="192.168.1.4",
             macaddress="f8811a000000",

--- a/tests/components/palazzetti/test_config_flow.py
+++ b/tests/components/palazzetti/test_config_flow.py
@@ -4,12 +4,12 @@ from unittest.mock import AsyncMock
 
 from pypalazzetti.exceptions import CommunicationError
 
-from homeassistant.components import dhcp
 from homeassistant.components.palazzetti.const import DOMAIN
 from homeassistant.config_entries import SOURCE_DHCP, SOURCE_USER
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
 from tests.common import MockConfigEntry
 
@@ -101,7 +101,7 @@ async def test_dhcp_flow(
     """Test the DHCP flow."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
-        data=dhcp.DhcpServiceInfo(
+        data=DhcpServiceInfo(
             hostname="connbox1234", ip="192.168.1.1", macaddress="11:22:33:44:55:66"
         ),
         context={"source": SOURCE_DHCP},
@@ -130,7 +130,7 @@ async def test_dhcp_flow_error(
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
-        data=dhcp.DhcpServiceInfo(
+        data=DhcpServiceInfo(
             hostname="connbox1234", ip="192.168.1.1", macaddress="11:22:33:44:55:66"
         ),
         context={"source": SOURCE_DHCP},

--- a/tests/components/peblar/test_config_flow.py
+++ b/tests/components/peblar/test_config_flow.py
@@ -6,12 +6,12 @@ from unittest.mock import MagicMock
 from peblar import PeblarAuthenticationError, PeblarConnectionError
 import pytest
 
-from homeassistant.components import zeroconf
 from homeassistant.components.peblar.const import DOMAIN
 from homeassistant.config_entries import SOURCE_USER, SOURCE_ZEROCONF
 from homeassistant.const import CONF_HOST, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from tests.common import MockConfigEntry
 
@@ -232,7 +232,7 @@ async def test_zeroconf_flow(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("127.0.0.1"),
             ip_addresses=[ip_address("127.0.0.1")],
             port=80,
@@ -273,7 +273,7 @@ async def test_zeroconf_flow_abort_no_serial(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("127.0.0.1"),
             ip_addresses=[ip_address("127.0.0.1")],
             port=80,
@@ -308,7 +308,7 @@ async def test_zeroconf_flow_errors(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("127.0.0.1"),
             ip_addresses=[ip_address("127.0.0.1")],
             port=80,
@@ -362,7 +362,7 @@ async def test_zeroconf_flow_not_discovered_again(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("127.0.0.1"),
             ip_addresses=[ip_address("127.0.0.1")],
             port=80,
@@ -389,7 +389,7 @@ async def test_user_flow_with_zeroconf_in_progress(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("127.0.0.1"),
             ip_addresses=[ip_address("127.0.0.1")],
             port=80,

--- a/tests/components/powerfox/test_config_flow.py
+++ b/tests/components/powerfox/test_config_flow.py
@@ -5,18 +5,18 @@ from unittest.mock import AsyncMock, patch
 from powerfox import PowerfoxAuthenticationError, PowerfoxConnectionError
 import pytest
 
-from homeassistant.components import zeroconf
 from homeassistant.components.powerfox.const import DOMAIN
 from homeassistant.config_entries import SOURCE_USER, SOURCE_ZEROCONF
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from . import MOCK_DIRECT_HOST
 
 from tests.common import MockConfigEntry
 
-MOCK_ZEROCONF_DISCOVERY_INFO = zeroconf.ZeroconfServiceInfo(
+MOCK_ZEROCONF_DISCOVERY_INFO = ZeroconfServiceInfo(
     ip_address=MOCK_DIRECT_HOST,
     ip_addresses=[MOCK_DIRECT_HOST],
     hostname="powerfox.local",

--- a/tests/components/powerwall/test_config_flow.py
+++ b/tests/components/powerwall/test_config_flow.py
@@ -11,12 +11,12 @@ from tesla_powerwall import (
 )
 
 from homeassistant import config_entries
-from homeassistant.components import dhcp
 from homeassistant.components.powerwall.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_IP_ADDRESS, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 import homeassistant.util.dt as dt_util
 
 from .mocks import (
@@ -161,7 +161,7 @@ async def test_already_configured(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_DHCP},
-        data=dhcp.DhcpServiceInfo(
+        data=DhcpServiceInfo(
             ip="1.1.1.1",
             macaddress="aabbcceeddff",
             hostname="any",
@@ -188,7 +188,7 @@ async def test_already_configured_with_ignored(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_DHCP},
-            data=dhcp.DhcpServiceInfo(
+            data=DhcpServiceInfo(
                 ip="1.1.1.1",
                 macaddress="aabbcceeddff",
                 hostname="00GGX",
@@ -230,7 +230,7 @@ async def test_dhcp_discovery_manual_configure(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_DHCP},
-            data=dhcp.DhcpServiceInfo(
+            data=DhcpServiceInfo(
                 ip="1.1.1.1",
                 macaddress="aabbcceeddff",
                 hostname="any",
@@ -272,7 +272,7 @@ async def test_dhcp_discovery_auto_configure(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_DHCP},
-            data=dhcp.DhcpServiceInfo(
+            data=DhcpServiceInfo(
                 ip="1.1.1.1",
                 macaddress="aabbcceeddff",
                 hostname="00GGX",
@@ -316,7 +316,7 @@ async def test_dhcp_discovery_cannot_connect(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_DHCP},
-            data=dhcp.DhcpServiceInfo(
+            data=DhcpServiceInfo(
                 ip="1.1.1.1",
                 macaddress="aabbcceeddff",
                 hostname="00GGX",
@@ -394,7 +394,7 @@ async def test_dhcp_discovery_update_ip_address(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_DHCP},
-            data=dhcp.DhcpServiceInfo(
+            data=DhcpServiceInfo(
                 ip="1.1.1.1",
                 macaddress="aabbcceeddff",
                 hostname=MOCK_GATEWAY_DIN.lower(),
@@ -431,7 +431,7 @@ async def test_dhcp_discovery_does_not_update_ip_when_auth_fails(
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_DHCP},
-            data=dhcp.DhcpServiceInfo(
+            data=DhcpServiceInfo(
                 ip="1.1.1.1",
                 macaddress="aabbcceeddff",
                 hostname=MOCK_GATEWAY_DIN.lower(),
@@ -468,7 +468,7 @@ async def test_dhcp_discovery_does_not_update_ip_when_auth_successful(
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_DHCP},
-            data=dhcp.DhcpServiceInfo(
+            data=DhcpServiceInfo(
                 ip="1.1.1.1",
                 macaddress="aabbcceeddff",
                 hostname=MOCK_GATEWAY_DIN.lower(),
@@ -503,7 +503,7 @@ async def test_dhcp_discovery_updates_unique_id(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_DHCP},
-            data=dhcp.DhcpServiceInfo(
+            data=DhcpServiceInfo(
                 ip="1.2.3.4",
                 macaddress="aabbcceeddff",
                 hostname=MOCK_GATEWAY_DIN.lower(),
@@ -542,7 +542,7 @@ async def test_dhcp_discovery_updates_unique_id_when_entry_is_failed(
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_DHCP},
-            data=dhcp.DhcpServiceInfo(
+            data=DhcpServiceInfo(
                 ip="1.2.3.4",
                 macaddress="aabbcceeddff",
                 hostname=MOCK_GATEWAY_DIN.lower(),
@@ -581,7 +581,7 @@ async def test_discovered_wifi_does_not_update_ip_if_is_still_online(
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_DHCP},
-            data=dhcp.DhcpServiceInfo(
+            data=DhcpServiceInfo(
                 ip="1.2.3.5",
                 macaddress="aabbcceeddff",
                 hostname=MOCK_GATEWAY_DIN.lower(),
@@ -630,7 +630,7 @@ async def test_discovered_wifi_does_not_update_ip_online_but_access_denied(
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_DHCP},
-            data=dhcp.DhcpServiceInfo(
+            data=DhcpServiceInfo(
                 ip="1.2.3.5",
                 macaddress="aabbcceeddff",
                 hostname=MOCK_GATEWAY_DIN.lower(),

--- a/tests/components/pure_energie/test_config_flow.py
+++ b/tests/components/pure_energie/test_config_flow.py
@@ -5,12 +5,12 @@ from unittest.mock import MagicMock
 
 from gridnet import GridNetConnectionError
 
-from homeassistant.components import zeroconf
 from homeassistant.components.pure_energie.const import DOMAIN
 from homeassistant.config_entries import SOURCE_USER, SOURCE_ZEROCONF
 from homeassistant.const import CONF_HOST, CONF_MAC, CONF_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 
 async def test_full_user_flow_implementation(
@@ -48,7 +48,7 @@ async def test_full_zeroconf_flow_implementationn(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("192.168.1.123"),
             ip_addresses=[ip_address("192.168.1.123")],
             hostname="example.local.",
@@ -104,7 +104,7 @@ async def test_zeroconf_connection_error(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("192.168.1.123"),
             ip_addresses=[ip_address("192.168.1.123")],
             hostname="example.local.",

--- a/tests/components/qnap_qsw/test_config_flow.py
+++ b/tests/components/qnap_qsw/test_config_flow.py
@@ -6,19 +6,19 @@ from aioqsw.const import API_MAC_ADDR, API_PRODUCT, API_RESULT
 from aioqsw.exceptions import LoginError, QswError
 
 from homeassistant import config_entries
-from homeassistant.components import dhcp
 from homeassistant.components.qnap_qsw.const import DOMAIN
 from homeassistant.config_entries import SOURCE_USER, ConfigEntryState
 from homeassistant.const import CONF_PASSWORD, CONF_URL, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers.device_registry import format_mac
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
 from .util import CONFIG, LIVE_MOCK, SYSTEM_BOARD_MOCK, USERS_LOGIN_MOCK
 
 from tests.common import MockConfigEntry
 
-DHCP_SERVICE_INFO = dhcp.DhcpServiceInfo(
+DHCP_SERVICE_INFO = DhcpServiceInfo(
     hostname="qsw-m408-4c",
     ip="192.168.1.200",
     macaddress="245ebe000000",

--- a/tests/components/rabbitair/test_config_flow.py
+++ b/tests/components/rabbitair/test_config_flow.py
@@ -10,12 +10,12 @@ import pytest
 from rabbitair import Mode, Model, Speed
 
 from homeassistant import config_entries
-from homeassistant.components import zeroconf
 from homeassistant.components.rabbitair.const import DOMAIN
 from homeassistant.const import CONF_ACCESS_TOKEN, CONF_HOST, CONF_MAC
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers.device_registry import format_mac
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 TEST_HOST = "1.1.1.1"
 TEST_NAME = "abcdef1234_123456789012345678"
@@ -26,7 +26,7 @@ TEST_HARDWARE = "1.0.0.4"
 TEST_UNIQUE_ID = format_mac(TEST_MAC)
 TEST_TITLE = "Rabbit Air"
 
-ZEROCONF_DATA = zeroconf.ZeroconfServiceInfo(
+ZEROCONF_DATA = ZeroconfServiceInfo(
     ip_address=ip_address(TEST_HOST),
     ip_addresses=[ip_address(TEST_HOST)],
     port=9009,

--- a/tests/components/rachio/test_config_flow.py
+++ b/tests/components/rachio/test_config_flow.py
@@ -4,7 +4,6 @@ from ipaddress import ip_address
 from unittest.mock import MagicMock, patch
 
 from homeassistant import config_entries
-from homeassistant.components import zeroconf
 from homeassistant.components.rachio.const import (
     CONF_CUSTOM_URL,
     CONF_MANUAL_RUN_MINS,
@@ -13,6 +12,10 @@ from homeassistant.components.rachio.const import (
 from homeassistant.const import CONF_API_KEY
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.zeroconf import (
+    ATTR_PROPERTIES_ID,
+    ZeroconfServiceInfo,
+)
 
 from tests.common import MockConfigEntry
 
@@ -120,13 +123,13 @@ async def test_form_homekit(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_HOMEKIT},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("127.0.0.1"),
             ip_addresses=[ip_address("127.0.0.1")],
             hostname="mock_hostname",
             name="mock_name",
             port=None,
-            properties={zeroconf.ATTR_PROPERTIES_ID: "AA:BB:CC:DD:EE:FF"},
+            properties={ATTR_PROPERTIES_ID: "AA:BB:CC:DD:EE:FF"},
             type="mock_type",
         ),
     )
@@ -145,13 +148,13 @@ async def test_form_homekit(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_HOMEKIT},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("127.0.0.1"),
             ip_addresses=[ip_address("127.0.0.1")],
             hostname="mock_hostname",
             name="mock_name",
             port=None,
-            properties={zeroconf.ATTR_PROPERTIES_ID: "AA:BB:CC:DD:EE:FF"},
+            properties={ATTR_PROPERTIES_ID: "AA:BB:CC:DD:EE:FF"},
             type="mock_type",
         ),
     )
@@ -171,13 +174,13 @@ async def test_form_homekit_ignored(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_HOMEKIT},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("127.0.0.1"),
             ip_addresses=[ip_address("127.0.0.1")],
             hostname="mock_hostname",
             name="mock_name",
             port=None,
-            properties={zeroconf.ATTR_PROPERTIES_ID: "AA:BB:CC:DD:EE:FF"},
+            properties={ATTR_PROPERTIES_ID: "AA:BB:CC:DD:EE:FF"},
             type="mock_type",
         ),
     )

--- a/tests/components/radiotherm/test_config_flow.py
+++ b/tests/components/radiotherm/test_config_flow.py
@@ -6,11 +6,11 @@ from radiotherm import CommonThermostat
 from radiotherm.validate import RadiothermTstatError
 
 from homeassistant import config_entries
-from homeassistant.components import dhcp
 from homeassistant.components.radiotherm.const import DOMAIN
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
 from tests.common import MockConfigEntry
 
@@ -112,7 +112,7 @@ async def test_dhcp_can_confirm(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_DHCP},
-            data=dhcp.DhcpServiceInfo(
+            data=DhcpServiceInfo(
                 hostname="radiotherm",
                 ip="1.2.3.4",
                 macaddress="aabbccddeeff",
@@ -156,7 +156,7 @@ async def test_dhcp_fails_to_connect(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_DHCP},
-            data=dhcp.DhcpServiceInfo(
+            data=DhcpServiceInfo(
                 hostname="radiotherm",
                 ip="1.2.3.4",
                 macaddress="aabbccddeeff",
@@ -185,7 +185,7 @@ async def test_dhcp_already_exists(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_DHCP},
-            data=dhcp.DhcpServiceInfo(
+            data=DhcpServiceInfo(
                 hostname="radiotherm",
                 ip="1.2.3.4",
                 macaddress="aabbccddeeff",

--- a/tests/components/rainmachine/test_config_flow.py
+++ b/tests/components/rainmachine/test_config_flow.py
@@ -7,7 +7,6 @@ import pytest
 from regenmaschine.errors import RainMachineError
 
 from homeassistant import config_entries, setup
-from homeassistant.components import zeroconf
 from homeassistant.components.rainmachine import (
     CONF_ALLOW_INACTIVE_ZONES_TO_RUN,
     CONF_DEFAULT_ZONE_RUN_TIME,
@@ -18,6 +17,7 @@ from homeassistant.const import CONF_IP_ADDRESS, CONF_PASSWORD, CONF_PORT, CONF_
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 
 async def test_duplicate_error(hass: HomeAssistant, config, config_entry) -> None:
@@ -168,7 +168,7 @@ async def test_step_homekit_zeroconf_ip_already_exists(
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": source},
-            data=zeroconf.ZeroconfServiceInfo(
+            data=ZeroconfServiceInfo(
                 ip_address=ip_address("192.168.1.100"),
                 ip_addresses=[ip_address("192.168.1.100")],
                 hostname="mock_hostname",
@@ -196,7 +196,7 @@ async def test_step_homekit_zeroconf_ip_change(
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": source},
-            data=zeroconf.ZeroconfServiceInfo(
+            data=ZeroconfServiceInfo(
                 ip_address=ip_address("192.168.1.2"),
                 ip_addresses=[ip_address("192.168.1.2")],
                 hostname="mock_hostname",
@@ -225,7 +225,7 @@ async def test_step_homekit_zeroconf_new_controller_when_some_exist(
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": source},
-            data=zeroconf.ZeroconfServiceInfo(
+            data=ZeroconfServiceInfo(
                 ip_address=ip_address("192.168.1.100"),
                 ip_addresses=[ip_address("192.168.1.100")],
                 hostname="mock_hostname",
@@ -279,7 +279,7 @@ async def test_discovery_by_homekit_and_zeroconf_same_time(
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_ZEROCONF},
-            data=zeroconf.ZeroconfServiceInfo(
+            data=ZeroconfServiceInfo(
                 ip_address=ip_address("192.168.1.100"),
                 ip_addresses=[ip_address("192.168.1.100")],
                 hostname="mock_hostname",
@@ -299,7 +299,7 @@ async def test_discovery_by_homekit_and_zeroconf_same_time(
         result2 = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_HOMEKIT},
-            data=zeroconf.ZeroconfServiceInfo(
+            data=ZeroconfServiceInfo(
                 ip_address=ip_address("192.168.1.100"),
                 ip_addresses=[ip_address("192.168.1.100")],
                 hostname="mock_hostname",

--- a/tests/components/reolink/test_config_flow.py
+++ b/tests/components/reolink/test_config_flow.py
@@ -15,7 +15,6 @@ from reolink_aio.exceptions import (
 )
 
 from homeassistant import config_entries
-from homeassistant.components import dhcp
 from homeassistant.components.reolink import DEVICE_UPDATE_INTERVAL
 from homeassistant.components.reolink.config_flow import DEFAULT_PROTOCOL
 from homeassistant.components.reolink.const import CONF_USE_HTTPS, DOMAIN
@@ -32,6 +31,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers.device_registry import format_mac
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
 from .conftest import (
     DHCP_FORMATTED_MAC,
@@ -381,7 +381,7 @@ async def test_reauth_abort_unique_id_mismatch(
 
 async def test_dhcp_flow(hass: HomeAssistant, mock_setup_entry: MagicMock) -> None:
     """Successful flow from DHCP discovery."""
-    dhcp_data = dhcp.DhcpServiceInfo(
+    dhcp_data = DhcpServiceInfo(
         ip=TEST_HOST,
         hostname="Reolink",
         macaddress=DHCP_FORMATTED_MAC,
@@ -451,7 +451,7 @@ async def test_dhcp_ip_update_aborted_if_wrong_mac(
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
-    dhcp_data = dhcp.DhcpServiceInfo(
+    dhcp_data = DhcpServiceInfo(
         ip=TEST_HOST2,
         hostname="Reolink",
         macaddress=DHCP_FORMATTED_MAC,
@@ -548,7 +548,7 @@ async def test_dhcp_ip_update(
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
-    dhcp_data = dhcp.DhcpServiceInfo(
+    dhcp_data = DhcpServiceInfo(
         ip=TEST_HOST2,
         hostname="Reolink",
         macaddress=DHCP_FORMATTED_MAC,
@@ -620,7 +620,7 @@ async def test_dhcp_ip_update_ingnored_if_still_connected(
     await hass.async_block_till_done()
     assert config_entry.state is ConfigEntryState.LOADED
 
-    dhcp_data = dhcp.DhcpServiceInfo(
+    dhcp_data = DhcpServiceInfo(
         ip=TEST_HOST2,
         hostname="Reolink",
         macaddress=DHCP_FORMATTED_MAC,

--- a/tests/components/ring/test_config_flow.py
+++ b/tests/components/ring/test_config_flow.py
@@ -6,12 +6,12 @@ import pytest
 import ring_doorbell
 
 from homeassistant import config_entries
-from homeassistant.components import dhcp
 from homeassistant.components.ring import DOMAIN
 from homeassistant.const import CONF_DEVICE_ID, CONF_PASSWORD, CONF_TOKEN, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
 from .conftest import MOCK_HARDWARE_ID
 
@@ -269,9 +269,7 @@ async def test_dhcp_discovery(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_DHCP},
-        data=dhcp.DhcpServiceInfo(
-            ip=ip_address, macaddress=mac_address, hostname=hostname
-        ),
+        data=DhcpServiceInfo(ip=ip_address, macaddress=mac_address, hostname=hostname),
     )
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {}
@@ -302,9 +300,7 @@ async def test_dhcp_discovery(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_DHCP},
-        data=dhcp.DhcpServiceInfo(
-            ip=ip_address, macaddress=mac_address, hostname=hostname
-        ),
+        data=DhcpServiceInfo(ip=ip_address, macaddress=mac_address, hostname=hostname),
     )
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"

--- a/tests/components/roku/__init__.py
+++ b/tests/components/roku/__init__.py
@@ -2,10 +2,14 @@
 
 from ipaddress import ip_address
 
-from homeassistant.components import ssdp, zeroconf
 from homeassistant.helpers.service_info.ssdp import (
     ATTR_UPNP_FRIENDLY_NAME,
     ATTR_UPNP_SERIAL,
+    SsdpServiceInfo,
+)
+from homeassistant.helpers.service_info.zeroconf import (
+    ATTR_PROPERTIES_ID,
+    ZeroconfServiceInfo,
 )
 
 NAME = "Roku 3"
@@ -16,7 +20,7 @@ SSDP_LOCATION = "http://192.168.1.160/"
 UPNP_FRIENDLY_NAME = "My Roku 3"
 UPNP_SERIAL = "1GU48T017973"
 
-MOCK_SSDP_DISCOVERY_INFO = ssdp.SsdpServiceInfo(
+MOCK_SSDP_DISCOVERY_INFO = SsdpServiceInfo(
     ssdp_usn="mock_usn",
     ssdp_st="mock_st",
     ssdp_location=SSDP_LOCATION,
@@ -28,14 +32,14 @@ MOCK_SSDP_DISCOVERY_INFO = ssdp.SsdpServiceInfo(
 
 HOMEKIT_HOST = "192.168.1.161"
 
-MOCK_HOMEKIT_DISCOVERY_INFO = zeroconf.ZeroconfServiceInfo(
+MOCK_HOMEKIT_DISCOVERY_INFO = ZeroconfServiceInfo(
     ip_address=ip_address(HOMEKIT_HOST),
     ip_addresses=[ip_address(HOMEKIT_HOST)],
     hostname="mock_hostname",
     name="onn._hap._tcp.local.",
     port=None,
     properties={
-        zeroconf.ATTR_PROPERTIES_ID: "2d:97:da:ee:dc:99",
+        ATTR_PROPERTIES_ID: "2d:97:da:ee:dc:99",
     },
     type="mock_type",
 )

--- a/tests/components/romy/test_config_flow.py
+++ b/tests/components/romy/test_config_flow.py
@@ -6,11 +6,14 @@ from unittest.mock import Mock, PropertyMock, patch
 from romy import RomyRobot
 
 from homeassistant import config_entries
-from homeassistant.components import zeroconf
 from homeassistant.components.romy.const import DOMAIN
 from homeassistant.const import CONF_HOST, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.zeroconf import (
+    ATTR_PROPERTIES_ID,
+    ZeroconfServiceInfo,
+)
 
 
 def _create_mocked_romy(
@@ -164,14 +167,14 @@ async def test_show_user_form_robot_reachable_again(hass: HomeAssistant) -> None
         assert result2["type"] is FlowResultType.CREATE_ENTRY
 
 
-DISCOVERY_INFO = zeroconf.ZeroconfServiceInfo(
+DISCOVERY_INFO = ZeroconfServiceInfo(
     ip_address=ip_address("1.2.3.4"),
     ip_addresses=[ip_address("1.2.3.4")],
     port=8080,
     hostname="aicu-aicgsbksisfapcjqmqjq.local",
     type="mock_type",
     name="myROMY",
-    properties={zeroconf.ATTR_PROPERTIES_ID: "aicu-aicgsbksisfapcjqmqjqZERO"},
+    properties={ATTR_PROPERTIES_ID: "aicu-aicgsbksisfapcjqmqjqZERO"},
 )
 
 

--- a/tests/components/roomba/test_config_flow.py
+++ b/tests/components/roomba/test_config_flow.py
@@ -6,7 +6,6 @@ from unittest.mock import MagicMock, PropertyMock, patch
 import pytest
 from roombapy import RoombaConnectionError, RoombaInfo
 
-from homeassistant.components import dhcp, zeroconf
 from homeassistant.components.roomba import config_flow
 from homeassistant.components.roomba.const import (
     CONF_BLID,
@@ -23,6 +22,8 @@ from homeassistant.config_entries import (
 from homeassistant.const import CONF_DELAY, CONF_HOST, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from tests.common import MockConfigEntry
 
@@ -32,7 +33,7 @@ VALID_CONFIG = {CONF_HOST: MOCK_IP, CONF_BLID: "BLID", CONF_PASSWORD: "password"
 DISCOVERY_DEVICES = [
     (
         SOURCE_DHCP,
-        dhcp.DhcpServiceInfo(
+        DhcpServiceInfo(
             ip=MOCK_IP,
             macaddress="501479ddeeff",
             hostname="irobot-blid",
@@ -40,7 +41,7 @@ DISCOVERY_DEVICES = [
     ),
     (
         SOURCE_DHCP,
-        dhcp.DhcpServiceInfo(
+        DhcpServiceInfo(
             ip=MOCK_IP,
             macaddress="80a589ddeeff",
             hostname="roomba-blid",
@@ -48,7 +49,7 @@ DISCOVERY_DEVICES = [
     ),
     (
         SOURCE_ZEROCONF,
-        zeroconf.ZeroconfServiceInfo(
+        ZeroconfServiceInfo(
             ip_address=ip_address(MOCK_IP),
             ip_addresses=[ip_address(MOCK_IP)],
             hostname="irobot-blid.local.",
@@ -60,7 +61,7 @@ DISCOVERY_DEVICES = [
     ),
     (
         SOURCE_ZEROCONF,
-        zeroconf.ZeroconfServiceInfo(
+        ZeroconfServiceInfo(
             ip_address=ip_address(MOCK_IP),
             ip_addresses=[ip_address(MOCK_IP)],
             hostname="roomba-blid.local.",
@@ -74,12 +75,12 @@ DISCOVERY_DEVICES = [
 
 
 DHCP_DISCOVERY_DEVICES_WITHOUT_MATCHING_IP = [
-    dhcp.DhcpServiceInfo(
+    DhcpServiceInfo(
         ip="4.4.4.4",
         macaddress="50:14:79:DD:EE:FF",
         hostname="irobot-blid",
     ),
-    dhcp.DhcpServiceInfo(
+    DhcpServiceInfo(
         ip="5.5.5.5",
         macaddress="80:A5:89:DD:EE:FF",
         hostname="roomba-blid",
@@ -692,7 +693,7 @@ async def test_form_user_discovery_and_password_fetch_gets_connection_refused(
 @pytest.mark.parametrize("discovery_data", DISCOVERY_DEVICES)
 async def test_dhcp_discovery_and_roomba_discovery_finds(
     hass: HomeAssistant,
-    discovery_data: tuple[str, dhcp.DhcpServiceInfo | zeroconf.ZeroconfServiceInfo],
+    discovery_data: tuple[str, DhcpServiceInfo | ZeroconfServiceInfo],
 ) -> None:
     """Test we can process the discovery from dhcp and roomba discovery matches the device."""
 
@@ -910,7 +911,7 @@ async def test_dhcp_discovery_with_ignored(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": SOURCE_DHCP},
-            data=dhcp.DhcpServiceInfo(
+            data=DhcpServiceInfo(
                 ip=MOCK_IP,
                 macaddress="aabbccddeeff",
                 hostname="irobot-blid",
@@ -933,7 +934,7 @@ async def test_dhcp_discovery_already_configured_host(hass: HomeAssistant) -> No
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": SOURCE_DHCP},
-            data=dhcp.DhcpServiceInfo(
+            data=DhcpServiceInfo(
                 ip=MOCK_IP,
                 macaddress="aabbccddeeff",
                 hostname="irobot-blid",
@@ -959,7 +960,7 @@ async def test_dhcp_discovery_already_configured_blid(hass: HomeAssistant) -> No
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": SOURCE_DHCP},
-            data=dhcp.DhcpServiceInfo(
+            data=DhcpServiceInfo(
                 ip=MOCK_IP,
                 macaddress="aabbccddeeff",
                 hostname="irobot-blid",
@@ -985,7 +986,7 @@ async def test_dhcp_discovery_not_irobot(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": SOURCE_DHCP},
-            data=dhcp.DhcpServiceInfo(
+            data=DhcpServiceInfo(
                 ip=MOCK_IP,
                 macaddress="aabbccddeeff",
                 hostname="Notirobot-blid",
@@ -1006,7 +1007,7 @@ async def test_dhcp_discovery_partial_hostname(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": SOURCE_DHCP},
-            data=dhcp.DhcpServiceInfo(
+            data=DhcpServiceInfo(
                 ip=MOCK_IP,
                 macaddress="aabbccddeeff",
                 hostname="irobot-blid",
@@ -1023,7 +1024,7 @@ async def test_dhcp_discovery_partial_hostname(hass: HomeAssistant) -> None:
         result2 = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": SOURCE_DHCP},
-            data=dhcp.DhcpServiceInfo(
+            data=DhcpServiceInfo(
                 ip=MOCK_IP,
                 macaddress="aabbccddeeff",
                 hostname="irobot-blidthatislonger",
@@ -1044,7 +1045,7 @@ async def test_dhcp_discovery_partial_hostname(hass: HomeAssistant) -> None:
         result3 = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": SOURCE_DHCP},
-            data=dhcp.DhcpServiceInfo(
+            data=DhcpServiceInfo(
                 ip=MOCK_IP,
                 macaddress="aabbccddeeff",
                 hostname="irobot-bl",
@@ -1082,7 +1083,7 @@ async def test_dhcp_discovery_when_user_flow_in_progress(hass: HomeAssistant) ->
         result2 = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": SOURCE_DHCP},
-            data=dhcp.DhcpServiceInfo(
+            data=DhcpServiceInfo(
                 ip=MOCK_IP,
                 macaddress="aabbccddeeff",
                 hostname="irobot-blidthatislonger",

--- a/tests/components/ruuvi_gateway/test_config_flow.py
+++ b/tests/components/ruuvi_gateway/test_config_flow.py
@@ -6,10 +6,10 @@ from aioruuvigateway.excs import CannotConnect, InvalidAuth
 import pytest
 
 from homeassistant import config_entries
-from homeassistant.components import dhcp
 from homeassistant.components.ruuvi_gateway.const import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
 from .consts import (
     BASE_DATA,
@@ -32,7 +32,7 @@ DHCP_DATA = {**BASE_DATA, "host": DHCP_IP}
             BASE_DATA,
         ),
         (
-            dhcp.DhcpServiceInfo(
+            DhcpServiceInfo(
                 hostname="RuuviGateway1234",
                 ip=DHCP_IP,
                 macaddress="1234567890ab",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As follow-up to #135653 / #135658 / #135661 / #135663

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
