### PR TITLE
Use new ServiceInfo location in component tests (part 3)

### DIFF
--- a/tests/components/daikin/test_config_flow.py
+++ b/tests/components/daikin/test_config_flow.py
@@ -7,12 +7,12 @@ from aiohttp import ClientError, web_exceptions
 from pydaikin.exceptions import DaikinException
 import pytest
 
-from homeassistant.components import zeroconf
 from homeassistant.components.daikin.const import KEY_MAC
 from homeassistant.config_entries import SOURCE_USER, SOURCE_ZEROCONF
 from homeassistant.const import CONF_API_KEY, CONF_HOST, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from tests.common import MockConfigEntry
 
@@ -121,7 +121,7 @@ async def test_api_password_abort(hass: HomeAssistant) -> None:
     [
         (
             SOURCE_ZEROCONF,
-            zeroconf.ZeroconfServiceInfo(
+            ZeroconfServiceInfo(
                 ip_address=ip_address(HOST),
                 ip_addresses=[ip_address(HOST)],
                 hostname="mock_hostname",

--- a/tests/components/deconz/test_config_flow.py
+++ b/tests/components/deconz/test_config_flow.py
@@ -6,7 +6,6 @@ from unittest.mock import patch
 import pydeconz
 import pytest
 
-from homeassistant.components import ssdp
 from homeassistant.components.deconz.config_flow import (
     CONF_MANUAL_INPUT,
     CONF_SERIAL,
@@ -28,6 +27,7 @@ from homeassistant.helpers.service_info.hassio import HassioServiceInfo
 from homeassistant.helpers.service_info.ssdp import (
     ATTR_UPNP_MANUFACTURER_URL,
     ATTR_UPNP_SERIAL,
+    SsdpServiceInfo,
 )
 
 from .conftest import API_KEY, BRIDGE_ID
@@ -438,7 +438,7 @@ async def test_flow_ssdp_discovery(
     """Test that config flow for one discovered bridge works."""
     result = await hass.config_entries.flow.async_init(
         DECONZ_DOMAIN,
-        data=ssdp.SsdpServiceInfo(
+        data=SsdpServiceInfo(
             ssdp_usn="mock_usn",
             ssdp_st="mock_st",
             ssdp_location="http://1.2.3.4:80/",
@@ -486,7 +486,7 @@ async def test_ssdp_discovery_update_configuration(
     ) as mock_setup_entry:
         result = await hass.config_entries.flow.async_init(
             DECONZ_DOMAIN,
-            data=ssdp.SsdpServiceInfo(
+            data=SsdpServiceInfo(
                 ssdp_usn="mock_usn",
                 ssdp_st="mock_st",
                 ssdp_location="http://2.3.4.5:80/",
@@ -512,7 +512,7 @@ async def test_ssdp_discovery_dont_update_configuration(
 
     result = await hass.config_entries.flow.async_init(
         DECONZ_DOMAIN,
-        data=ssdp.SsdpServiceInfo(
+        data=SsdpServiceInfo(
             ssdp_usn="mock_usn",
             ssdp_st="mock_st",
             ssdp_location="http://1.2.3.4:80/",
@@ -536,7 +536,7 @@ async def test_ssdp_discovery_dont_update_existing_hassio_configuration(
     """Test to ensure the SSDP discovery does not update an Hass.io entry."""
     result = await hass.config_entries.flow.async_init(
         DECONZ_DOMAIN,
-        data=ssdp.SsdpServiceInfo(
+        data=SsdpServiceInfo(
             ssdp_usn="mock_usn",
             ssdp_st="mock_st",
             ssdp_location="http://1.2.3.4:80/",

--- a/tests/components/deconz/test_hub.py
+++ b/tests/components/deconz/test_hub.py
@@ -6,7 +6,6 @@ from pydeconz.websocket import State
 import pytest
 from syrupy import SnapshotAssertion
 
-from homeassistant.components import ssdp
 from homeassistant.components.deconz.config_flow import DECONZ_MANUFACTURERURL
 from homeassistant.components.deconz.const import DOMAIN as DECONZ_DOMAIN
 from homeassistant.config_entries import SOURCE_SSDP
@@ -17,6 +16,7 @@ from homeassistant.helpers.service_info.ssdp import (
     ATTR_UPNP_MANUFACTURER_URL,
     ATTR_UPNP_SERIAL,
     ATTR_UPNP_UDN,
+    SsdpServiceInfo,
 )
 
 from .conftest import BRIDGE_ID
@@ -81,7 +81,7 @@ async def test_update_address(
     ):
         await hass.config_entries.flow.async_init(
             DECONZ_DOMAIN,
-            data=ssdp.SsdpServiceInfo(
+            data=SsdpServiceInfo(
                 ssdp_st="mock_st",
                 ssdp_usn="mock_usn",
                 ssdp_location="http://2.3.4.5:80/",

--- a/tests/components/denonavr/test_config_flow.py
+++ b/tests/components/denonavr/test_config_flow.py
@@ -5,7 +5,6 @@ from unittest.mock import patch
 import pytest
 
 from homeassistant import config_entries
-from homeassistant.components import ssdp
 from homeassistant.components.denonavr.config_flow import (
     CONF_MANUFACTURER,
     CONF_SERIAL_NUMBER,
@@ -21,6 +20,12 @@ from homeassistant.components.denonavr.config_flow import (
 from homeassistant.const import CONF_HOST, CONF_MODEL
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.ssdp import (
+    ATTR_UPNP_MANUFACTURER,
+    ATTR_UPNP_MODEL_NAME,
+    ATTR_UPNP_SERIAL,
+    SsdpServiceInfo,
+)
 
 from tests.common import MockConfigEntry
 
@@ -313,14 +318,14 @@ async def test_config_flow_ssdp(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_SSDP},
-        data=ssdp.SsdpServiceInfo(
+        data=SsdpServiceInfo(
             ssdp_usn="mock_usn",
             ssdp_st="mock_st",
             ssdp_location=TEST_SSDP_LOCATION,
             upnp={
-                ssdp.ATTR_UPNP_MANUFACTURER: TEST_MANUFACTURER,
-                ssdp.ATTR_UPNP_MODEL_NAME: TEST_MODEL,
-                ssdp.ATTR_UPNP_SERIAL: TEST_SERIALNUMBER,
+                ATTR_UPNP_MANUFACTURER: TEST_MANUFACTURER,
+                ATTR_UPNP_MODEL_NAME: TEST_MODEL,
+                ATTR_UPNP_SERIAL: TEST_SERIALNUMBER,
             },
         ),
     )
@@ -353,14 +358,14 @@ async def test_config_flow_ssdp_not_denon(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_SSDP},
-        data=ssdp.SsdpServiceInfo(
+        data=SsdpServiceInfo(
             ssdp_usn="mock_usn",
             ssdp_st="mock_st",
             ssdp_location=TEST_SSDP_LOCATION,
             upnp={
-                ssdp.ATTR_UPNP_MANUFACTURER: "NotSupported",
-                ssdp.ATTR_UPNP_MODEL_NAME: TEST_MODEL,
-                ssdp.ATTR_UPNP_SERIAL: TEST_SERIALNUMBER,
+                ATTR_UPNP_MANUFACTURER: "NotSupported",
+                ATTR_UPNP_MODEL_NAME: TEST_MODEL,
+                ATTR_UPNP_SERIAL: TEST_SERIALNUMBER,
             },
         ),
     )
@@ -377,12 +382,12 @@ async def test_config_flow_ssdp_missing_info(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_SSDP},
-        data=ssdp.SsdpServiceInfo(
+        data=SsdpServiceInfo(
             ssdp_usn="mock_usn",
             ssdp_st="mock_st",
             ssdp_location=TEST_SSDP_LOCATION,
             upnp={
-                ssdp.ATTR_UPNP_MANUFACTURER: TEST_MANUFACTURER,
+                ATTR_UPNP_MANUFACTURER: TEST_MANUFACTURER,
             },
         ),
     )
@@ -399,14 +404,14 @@ async def test_config_flow_ssdp_ignored_model(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_SSDP},
-        data=ssdp.SsdpServiceInfo(
+        data=SsdpServiceInfo(
             ssdp_usn="mock_usn",
             ssdp_st="mock_st",
             ssdp_location=TEST_SSDP_LOCATION,
             upnp={
-                ssdp.ATTR_UPNP_MANUFACTURER: TEST_MANUFACTURER,
-                ssdp.ATTR_UPNP_MODEL_NAME: TEST_IGNORED_MODEL,
-                ssdp.ATTR_UPNP_SERIAL: TEST_SERIALNUMBER,
+                ATTR_UPNP_MANUFACTURER: TEST_MANUFACTURER,
+                ATTR_UPNP_MODEL_NAME: TEST_IGNORED_MODEL,
+                ATTR_UPNP_SERIAL: TEST_SERIALNUMBER,
             },
         ),
     )

--- a/tests/components/devialet/__init__.py
+++ b/tests/components/devialet/__init__.py
@@ -5,10 +5,10 @@ from ipaddress import ip_address
 from aiohttp import ClientError as ServerTimeoutError
 from devialet.const import UrlSuffix
 
-from homeassistant.components import zeroconf
 from homeassistant.components.devialet.const import DOMAIN
 from homeassistant.const import CONF_HOST, CONF_NAME, CONTENT_TYPE_JSON
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from tests.common import MockConfigEntry, load_fixture
 from tests.test_util.aiohttp import AiohttpClientMocker
@@ -25,7 +25,7 @@ CONF_DATA = {
 
 MOCK_CONFIG = {DOMAIN: [{CONF_HOST: HOST}]}
 MOCK_USER_INPUT = {CONF_HOST: HOST}
-MOCK_ZEROCONF_DATA = zeroconf.ZeroconfServiceInfo(
+MOCK_ZEROCONF_DATA = ZeroconfServiceInfo(
     ip_address=ip_address(HOST),
     ip_addresses=[ip_address(HOST)],
     hostname="PhantomISilver-L00P00000AB11.local.",

--- a/tests/components/devolo_home_control/const.py
+++ b/tests/components/devolo_home_control/const.py
@@ -2,9 +2,9 @@
 
 from ipaddress import ip_address
 
-from homeassistant.components import zeroconf
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
-DISCOVERY_INFO = zeroconf.ZeroconfServiceInfo(
+DISCOVERY_INFO = ZeroconfServiceInfo(
     ip_address=ip_address("192.168.0.1"),
     ip_addresses=[ip_address("192.168.0.1")],
     port=14791,
@@ -22,7 +22,7 @@ DISCOVERY_INFO = zeroconf.ZeroconfServiceInfo(
     },
 )
 
-DISCOVERY_INFO_WRONG_DEVOLO_DEVICE = zeroconf.ZeroconfServiceInfo(
+DISCOVERY_INFO_WRONG_DEVOLO_DEVICE = ZeroconfServiceInfo(
     ip_address=ip_address("192.168.0.1"),
     ip_addresses=[ip_address("192.168.0.1")],
     hostname="mock_hostname",
@@ -32,7 +32,7 @@ DISCOVERY_INFO_WRONG_DEVOLO_DEVICE = zeroconf.ZeroconfServiceInfo(
     type="mock_type",
 )
 
-DISCOVERY_INFO_WRONG_DEVICE = zeroconf.ZeroconfServiceInfo(
+DISCOVERY_INFO_WRONG_DEVICE = ZeroconfServiceInfo(
     ip_address=ip_address("192.168.0.1"),
     ip_addresses=[ip_address("192.168.0.1")],
     hostname="mock_hostname",

--- a/tests/components/directv/__init__.py
+++ b/tests/components/directv/__init__.py
@@ -2,10 +2,10 @@
 
 from http import HTTPStatus
 
-from homeassistant.components import ssdp
 from homeassistant.components.directv.const import CONF_RECEIVER_ID, DOMAIN
 from homeassistant.const import CONF_HOST, CONTENT_TYPE_JSON
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.service_info.ssdp import SsdpServiceInfo
 
 from tests.common import MockConfigEntry, load_fixture
 from tests.test_util.aiohttp import AiohttpClientMocker
@@ -16,7 +16,7 @@ SSDP_LOCATION = "http://127.0.0.1/"
 UPNP_SERIAL = "RID-028877455858"
 
 MOCK_CONFIG = {DOMAIN: [{CONF_HOST: HOST}]}
-MOCK_SSDP_DISCOVERY_INFO = ssdp.SsdpServiceInfo(
+MOCK_SSDP_DISCOVERY_INFO = SsdpServiceInfo(
     ssdp_usn="mock_usn",
     ssdp_st="mock_st",
     ssdp_location=SSDP_LOCATION,

--- a/tests/components/dlink/conftest.py
+++ b/tests/components/dlink/conftest.py
@@ -6,11 +6,11 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from homeassistant.components import dhcp
 from homeassistant.components.dlink.const import CONF_USE_LEGACY_PROTOCOL, DOMAIN
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import format_mac
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
@@ -29,13 +29,13 @@ CONF_DHCP_DATA = {
 
 CONF_DATA = CONF_DHCP_DATA | {CONF_HOST: HOST}
 
-CONF_DHCP_FLOW = dhcp.DhcpServiceInfo(
+CONF_DHCP_FLOW = DhcpServiceInfo(
     ip=HOST,
     macaddress=DHCP_FORMATTED_MAC,
     hostname="dsp-w215",
 )
 
-CONF_DHCP_FLOW_NEW_IP = dhcp.DhcpServiceInfo(
+CONF_DHCP_FLOW_NEW_IP = DhcpServiceInfo(
     ip="5.6.7.8",
     macaddress=DHCP_FORMATTED_MAC,
     hostname="dsp-w215",

--- a/tests/components/dlink/test_config_flow.py
+++ b/tests/components/dlink/test_config_flow.py
@@ -2,12 +2,12 @@
 
 from unittest.mock import MagicMock, patch
 
-from homeassistant.components import dhcp
 from homeassistant.components.dlink.const import DEFAULT_NAME, DOMAIN
 from homeassistant.config_entries import SOURCE_DHCP, SOURCE_USER
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
 from .conftest import (
     CONF_DATA,
@@ -160,7 +160,7 @@ async def test_dhcp_unique_id_assignment(
     hass: HomeAssistant, mocked_plug: MagicMock
 ) -> None:
     """Test dhcp initialized flow with no unique id for matching entry."""
-    dhcp_data = dhcp.DhcpServiceInfo(
+    dhcp_data = DhcpServiceInfo(
         ip="2.3.4.5",
         macaddress="11:22:33:44:55:66",
         hostname="dsp-w215",

--- a/tests/components/dlna_dmr/test_media_player.py
+++ b/tests/components/dlna_dmr/test_media_player.py
@@ -47,6 +47,7 @@ from homeassistant.const import (
 from homeassistant.core import CoreState, HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_component import async_update_entity
+from homeassistant.helpers.service_info.ssdp import SsdpServiceInfo
 from homeassistant.setup import async_setup_component
 
 from .conftest import (
@@ -1413,7 +1414,7 @@ async def test_become_available(
     # Send an SSDP notification from the now alive device
     ssdp_callback = ssdp_scanner_mock.async_register_callback.call_args.args[0].target
     await ssdp_callback(
-        ssdp.SsdpServiceInfo(
+        SsdpServiceInfo(
             ssdp_usn=MOCK_DEVICE_USN,
             ssdp_location=NEW_DEVICE_LOCATION,
             ssdp_st=MOCK_DEVICE_TYPE,
@@ -1484,7 +1485,7 @@ async def test_alive_but_gone(
     # Send an SSDP notification from the still missing device
     ssdp_callback = ssdp_scanner_mock.async_register_callback.call_args.args[0].target
     await ssdp_callback(
-        ssdp.SsdpServiceInfo(
+        SsdpServiceInfo(
             ssdp_usn=MOCK_DEVICE_USN,
             ssdp_location=NEW_DEVICE_LOCATION,
             ssdp_st=MOCK_DEVICE_TYPE,
@@ -1506,7 +1507,7 @@ async def test_alive_but_gone(
     # Send the same SSDP notification, expecting no extra connection attempts
     domain_data_mock.upnp_factory.async_create_device.reset_mock()
     await ssdp_callback(
-        ssdp.SsdpServiceInfo(
+        SsdpServiceInfo(
             ssdp_usn=MOCK_DEVICE_USN,
             ssdp_location=NEW_DEVICE_LOCATION,
             ssdp_st=MOCK_DEVICE_TYPE,
@@ -1525,7 +1526,7 @@ async def test_alive_but_gone(
     # Send an SSDP notification with a new BOOTID, indicating the device has rebooted
     domain_data_mock.upnp_factory.async_create_device.reset_mock()
     await ssdp_callback(
-        ssdp.SsdpServiceInfo(
+        SsdpServiceInfo(
             ssdp_usn=MOCK_DEVICE_USN,
             ssdp_location=NEW_DEVICE_LOCATION,
             ssdp_st=MOCK_DEVICE_TYPE,
@@ -1546,7 +1547,7 @@ async def test_alive_but_gone(
     # should result in a reconnect attempt even with same BOOTID.
     domain_data_mock.upnp_factory.async_create_device.reset_mock()
     await ssdp_callback(
-        ssdp.SsdpServiceInfo(
+        SsdpServiceInfo(
             ssdp_usn=MOCK_DEVICE_USN,
             ssdp_st=MOCK_DEVICE_TYPE,
             upnp={},
@@ -1554,7 +1555,7 @@ async def test_alive_but_gone(
         ssdp.SsdpChange.BYEBYE,
     )
     await ssdp_callback(
-        ssdp.SsdpServiceInfo(
+        SsdpServiceInfo(
             ssdp_usn=MOCK_DEVICE_USN,
             ssdp_location=NEW_DEVICE_LOCATION,
             ssdp_st=MOCK_DEVICE_TYPE,
@@ -1597,7 +1598,7 @@ async def test_multiple_ssdp_alive(
     # Send two SSDP notifications with the new device URL
     ssdp_callback = ssdp_scanner_mock.async_register_callback.call_args.args[0].target
     await ssdp_callback(
-        ssdp.SsdpServiceInfo(
+        SsdpServiceInfo(
             ssdp_usn=MOCK_DEVICE_USN,
             ssdp_location=NEW_DEVICE_LOCATION,
             ssdp_st=MOCK_DEVICE_TYPE,
@@ -1606,7 +1607,7 @@ async def test_multiple_ssdp_alive(
         ssdp.SsdpChange.ALIVE,
     )
     await ssdp_callback(
-        ssdp.SsdpServiceInfo(
+        SsdpServiceInfo(
             ssdp_usn=MOCK_DEVICE_USN,
             ssdp_location=NEW_DEVICE_LOCATION,
             ssdp_st=MOCK_DEVICE_TYPE,
@@ -1637,7 +1638,7 @@ async def test_ssdp_byebye(
     # First byebye will cause a disconnect
     ssdp_callback = ssdp_scanner_mock.async_register_callback.call_args.args[0].target
     await ssdp_callback(
-        ssdp.SsdpServiceInfo(
+        SsdpServiceInfo(
             ssdp_usn=MOCK_DEVICE_USN,
             ssdp_udn=MOCK_DEVICE_UDN,
             ssdp_headers={"NTS": "ssdp:byebye"},
@@ -1656,7 +1657,7 @@ async def test_ssdp_byebye(
 
     # Second byebye will do nothing
     await ssdp_callback(
-        ssdp.SsdpServiceInfo(
+        SsdpServiceInfo(
             ssdp_usn=MOCK_DEVICE_USN,
             ssdp_udn=MOCK_DEVICE_UDN,
             ssdp_headers={"NTS": "ssdp:byebye"},
@@ -1689,7 +1690,7 @@ async def test_ssdp_update_seen_bootid(
     # Send SSDP alive with boot ID
     ssdp_callback = ssdp_scanner_mock.async_register_callback.call_args.args[0].target
     await ssdp_callback(
-        ssdp.SsdpServiceInfo(
+        SsdpServiceInfo(
             ssdp_usn=MOCK_DEVICE_USN,
             ssdp_location=MOCK_DEVICE_LOCATION,
             ssdp_headers={ssdp.ATTR_SSDP_BOOTID: "1"},
@@ -1702,7 +1703,7 @@ async def test_ssdp_update_seen_bootid(
 
     # Send SSDP update with next boot ID
     await ssdp_callback(
-        ssdp.SsdpServiceInfo(
+        SsdpServiceInfo(
             ssdp_usn=MOCK_DEVICE_USN,
             ssdp_udn=MOCK_DEVICE_UDN,
             ssdp_headers={
@@ -1727,7 +1728,7 @@ async def test_ssdp_update_seen_bootid(
 
     # Send SSDP update with same next boot ID, again
     await ssdp_callback(
-        ssdp.SsdpServiceInfo(
+        SsdpServiceInfo(
             ssdp_usn=MOCK_DEVICE_USN,
             ssdp_udn=MOCK_DEVICE_UDN,
             ssdp_headers={
@@ -1752,7 +1753,7 @@ async def test_ssdp_update_seen_bootid(
 
     # Send SSDP update with bad next boot ID
     await ssdp_callback(
-        ssdp.SsdpServiceInfo(
+        SsdpServiceInfo(
             ssdp_usn=MOCK_DEVICE_USN,
             ssdp_udn=MOCK_DEVICE_UDN,
             ssdp_headers={
@@ -1777,7 +1778,7 @@ async def test_ssdp_update_seen_bootid(
 
     # Send a new SSDP alive with the new boot ID, device should not reconnect
     await ssdp_callback(
-        ssdp.SsdpServiceInfo(
+        SsdpServiceInfo(
             ssdp_usn=MOCK_DEVICE_USN,
             ssdp_location=MOCK_DEVICE_LOCATION,
             ssdp_headers={ssdp.ATTR_SSDP_BOOTID: "2"},
@@ -1816,7 +1817,7 @@ async def test_ssdp_update_missed_bootid(
     # Send SSDP alive with boot ID
     ssdp_callback = ssdp_scanner_mock.async_register_callback.call_args.args[0].target
     await ssdp_callback(
-        ssdp.SsdpServiceInfo(
+        SsdpServiceInfo(
             ssdp_usn=MOCK_DEVICE_USN,
             ssdp_location=MOCK_DEVICE_LOCATION,
             ssdp_headers={ssdp.ATTR_SSDP_BOOTID: "1"},
@@ -1829,7 +1830,7 @@ async def test_ssdp_update_missed_bootid(
 
     # Send SSDP update with skipped boot ID (not previously seen)
     await ssdp_callback(
-        ssdp.SsdpServiceInfo(
+        SsdpServiceInfo(
             ssdp_usn=MOCK_DEVICE_USN,
             ssdp_udn=MOCK_DEVICE_UDN,
             ssdp_headers={
@@ -1854,7 +1855,7 @@ async def test_ssdp_update_missed_bootid(
 
     # Send a new SSDP alive with the new boot ID, device should reconnect
     await ssdp_callback(
-        ssdp.SsdpServiceInfo(
+        SsdpServiceInfo(
             ssdp_usn=MOCK_DEVICE_USN,
             ssdp_location=MOCK_DEVICE_LOCATION,
             ssdp_headers={ssdp.ATTR_SSDP_BOOTID: "3"},
@@ -1893,7 +1894,7 @@ async def test_ssdp_bootid(
     # Send SSDP alive with boot ID
     ssdp_callback = ssdp_scanner_mock.async_register_callback.call_args.args[0].target
     await ssdp_callback(
-        ssdp.SsdpServiceInfo(
+        SsdpServiceInfo(
             ssdp_usn=MOCK_DEVICE_USN,
             ssdp_location=MOCK_DEVICE_LOCATION,
             ssdp_headers={ssdp.ATTR_SSDP_BOOTID: "1"},
@@ -1913,7 +1914,7 @@ async def test_ssdp_bootid(
 
     # Send SSDP alive with same boot ID, nothing should happen
     await ssdp_callback(
-        ssdp.SsdpServiceInfo(
+        SsdpServiceInfo(
             ssdp_usn=MOCK_DEVICE_USN,
             ssdp_location=MOCK_DEVICE_LOCATION,
             ssdp_headers={ssdp.ATTR_SSDP_BOOTID: "1"},
@@ -1933,7 +1934,7 @@ async def test_ssdp_bootid(
 
     # Send a new SSDP alive with an incremented boot ID, device should be dis/reconnected
     await ssdp_callback(
-        ssdp.SsdpServiceInfo(
+        SsdpServiceInfo(
             ssdp_usn=MOCK_DEVICE_USN,
             ssdp_location=MOCK_DEVICE_LOCATION,
             ssdp_headers={ssdp.ATTR_SSDP_BOOTID: "2"},
@@ -2354,7 +2355,7 @@ async def test_connections_restored(
     # Send an SSDP notification from the now alive device
     ssdp_callback = ssdp_scanner_mock.async_register_callback.call_args.args[0].target
     await ssdp_callback(
-        ssdp.SsdpServiceInfo(
+        SsdpServiceInfo(
             ssdp_usn=MOCK_DEVICE_USN,
             ssdp_location=NEW_DEVICE_LOCATION,
             ssdp_st=MOCK_DEVICE_TYPE,

--- a/tests/components/dlna_dms/test_device_availability.py
+++ b/tests/components/dlna_dms/test_device_availability.py
@@ -18,6 +18,7 @@ from homeassistant.components.dlna_dms.dms import get_domain_data
 from homeassistant.components.media_player import BrowseError
 from homeassistant.components.media_source import Unresolvable
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.service_info.ssdp import SsdpServiceInfo
 
 from .conftest import (
     MOCK_DEVICE_LOCATION,
@@ -179,7 +180,7 @@ async def test_become_available(
     # Send an SSDP notification from the now alive device
     ssdp_callback = ssdp_scanner_mock.async_register_callback.call_args.args[0].target
     await ssdp_callback(
-        ssdp.SsdpServiceInfo(
+        SsdpServiceInfo(
             ssdp_usn=MOCK_DEVICE_USN,
             ssdp_location=NEW_DEVICE_LOCATION,
             ssdp_st=MOCK_DEVICE_TYPE,
@@ -207,7 +208,7 @@ async def test_alive_but_gone(
     # Send an SSDP notification from the still missing device
     ssdp_callback = ssdp_scanner_mock.async_register_callback.call_args.args[0].target
     await ssdp_callback(
-        ssdp.SsdpServiceInfo(
+        SsdpServiceInfo(
             ssdp_usn=MOCK_DEVICE_USN,
             ssdp_location=NEW_DEVICE_LOCATION,
             ssdp_st=MOCK_DEVICE_TYPE,
@@ -227,7 +228,7 @@ async def test_alive_but_gone(
     # Send the same SSDP notification, expecting no extra connection attempts
     upnp_factory_mock.async_create_device.reset_mock()
     await ssdp_callback(
-        ssdp.SsdpServiceInfo(
+        SsdpServiceInfo(
             ssdp_usn=MOCK_DEVICE_USN,
             ssdp_location=NEW_DEVICE_LOCATION,
             ssdp_st=MOCK_DEVICE_TYPE,
@@ -244,7 +245,7 @@ async def test_alive_but_gone(
     # Send an SSDP notification with a new BOOTID, indicating the device has rebooted
     upnp_factory_mock.async_create_device.reset_mock()
     await ssdp_callback(
-        ssdp.SsdpServiceInfo(
+        SsdpServiceInfo(
             ssdp_usn=MOCK_DEVICE_USN,
             ssdp_location=NEW_DEVICE_LOCATION,
             ssdp_st=MOCK_DEVICE_TYPE,
@@ -263,7 +264,7 @@ async def test_alive_but_gone(
     # should result in a reconnect attempt even with same BOOTID.
     upnp_factory_mock.async_create_device.reset_mock()
     await ssdp_callback(
-        ssdp.SsdpServiceInfo(
+        SsdpServiceInfo(
             ssdp_usn=MOCK_DEVICE_USN,
             ssdp_st=MOCK_DEVICE_TYPE,
             upnp={},
@@ -271,7 +272,7 @@ async def test_alive_but_gone(
         ssdp.SsdpChange.BYEBYE,
     )
     await ssdp_callback(
-        ssdp.SsdpServiceInfo(
+        SsdpServiceInfo(
             ssdp_usn=MOCK_DEVICE_USN,
             ssdp_location=NEW_DEVICE_LOCATION,
             ssdp_st=MOCK_DEVICE_TYPE,
@@ -310,7 +311,7 @@ async def test_multiple_ssdp_alive(
     # Send two SSDP notifications with the new device URL
     ssdp_callback = ssdp_scanner_mock.async_register_callback.call_args.args[0].target
     await ssdp_callback(
-        ssdp.SsdpServiceInfo(
+        SsdpServiceInfo(
             ssdp_usn=MOCK_DEVICE_USN,
             ssdp_location=NEW_DEVICE_LOCATION,
             ssdp_st=MOCK_DEVICE_TYPE,
@@ -319,7 +320,7 @@ async def test_multiple_ssdp_alive(
         ssdp.SsdpChange.ALIVE,
     )
     await ssdp_callback(
-        ssdp.SsdpServiceInfo(
+        SsdpServiceInfo(
             ssdp_usn=MOCK_DEVICE_USN,
             ssdp_location=NEW_DEVICE_LOCATION,
             ssdp_st=MOCK_DEVICE_TYPE,
@@ -345,7 +346,7 @@ async def test_ssdp_byebye(
     # First byebye will cause a disconnect
     ssdp_callback = ssdp_scanner_mock.async_register_callback.call_args.args[0].target
     await ssdp_callback(
-        ssdp.SsdpServiceInfo(
+        SsdpServiceInfo(
             ssdp_usn=MOCK_DEVICE_USN,
             ssdp_udn=MOCK_DEVICE_UDN,
             ssdp_headers={"NTS": "ssdp:byebye"},
@@ -360,7 +361,7 @@ async def test_ssdp_byebye(
 
     # Second byebye will do nothing
     await ssdp_callback(
-        ssdp.SsdpServiceInfo(
+        SsdpServiceInfo(
             ssdp_usn=MOCK_DEVICE_USN,
             ssdp_udn=MOCK_DEVICE_UDN,
             ssdp_headers={"NTS": "ssdp:byebye"},
@@ -388,7 +389,7 @@ async def test_ssdp_update_seen_bootid(
     # Send SSDP alive with boot ID
     ssdp_callback = ssdp_scanner_mock.async_register_callback.call_args.args[0].target
     await ssdp_callback(
-        ssdp.SsdpServiceInfo(
+        SsdpServiceInfo(
             ssdp_usn=MOCK_DEVICE_USN,
             ssdp_location=MOCK_DEVICE_LOCATION,
             ssdp_headers={ssdp.ATTR_SSDP_BOOTID: "1"},
@@ -405,7 +406,7 @@ async def test_ssdp_update_seen_bootid(
 
     # Send SSDP update with next boot ID
     await ssdp_callback(
-        ssdp.SsdpServiceInfo(
+        SsdpServiceInfo(
             ssdp_usn=MOCK_DEVICE_USN,
             ssdp_udn=MOCK_DEVICE_UDN,
             ssdp_headers={
@@ -426,7 +427,7 @@ async def test_ssdp_update_seen_bootid(
 
     # Send SSDP update with same next boot ID, again
     await ssdp_callback(
-        ssdp.SsdpServiceInfo(
+        SsdpServiceInfo(
             ssdp_usn=MOCK_DEVICE_USN,
             ssdp_udn=MOCK_DEVICE_UDN,
             ssdp_headers={
@@ -447,7 +448,7 @@ async def test_ssdp_update_seen_bootid(
 
     # Send SSDP update with bad next boot ID
     await ssdp_callback(
-        ssdp.SsdpServiceInfo(
+        SsdpServiceInfo(
             ssdp_usn=MOCK_DEVICE_USN,
             ssdp_udn=MOCK_DEVICE_UDN,
             ssdp_headers={
@@ -468,7 +469,7 @@ async def test_ssdp_update_seen_bootid(
 
     # Send a new SSDP alive with the new boot ID, device should not reconnect
     await ssdp_callback(
-        ssdp.SsdpServiceInfo(
+        SsdpServiceInfo(
             ssdp_usn=MOCK_DEVICE_USN,
             ssdp_location=MOCK_DEVICE_LOCATION,
             ssdp_headers={ssdp.ATTR_SSDP_BOOTID: "2"},
@@ -500,7 +501,7 @@ async def test_ssdp_update_missed_bootid(
     # Send SSDP alive with boot ID
     ssdp_callback = ssdp_scanner_mock.async_register_callback.call_args.args[0].target
     await ssdp_callback(
-        ssdp.SsdpServiceInfo(
+        SsdpServiceInfo(
             ssdp_usn=MOCK_DEVICE_USN,
             ssdp_location=MOCK_DEVICE_LOCATION,
             ssdp_headers={ssdp.ATTR_SSDP_BOOTID: "1"},
@@ -517,7 +518,7 @@ async def test_ssdp_update_missed_bootid(
 
     # Send SSDP update with skipped boot ID (not previously seen)
     await ssdp_callback(
-        ssdp.SsdpServiceInfo(
+        SsdpServiceInfo(
             ssdp_usn=MOCK_DEVICE_USN,
             ssdp_udn=MOCK_DEVICE_UDN,
             ssdp_headers={
@@ -538,7 +539,7 @@ async def test_ssdp_update_missed_bootid(
 
     # Send a new SSDP alive with the new boot ID, device should reconnect
     await ssdp_callback(
-        ssdp.SsdpServiceInfo(
+        SsdpServiceInfo(
             ssdp_usn=MOCK_DEVICE_USN,
             ssdp_location=MOCK_DEVICE_LOCATION,
             ssdp_headers={ssdp.ATTR_SSDP_BOOTID: "3"},
@@ -570,7 +571,7 @@ async def test_ssdp_bootid(
     # Send SSDP alive with boot ID
     ssdp_callback = ssdp_scanner_mock.async_register_callback.call_args.args[0].target
     await ssdp_callback(
-        ssdp.SsdpServiceInfo(
+        SsdpServiceInfo(
             ssdp_usn=MOCK_DEVICE_USN,
             ssdp_location=MOCK_DEVICE_LOCATION,
             ssdp_headers={ssdp.ATTR_SSDP_BOOTID: "1"},
@@ -586,7 +587,7 @@ async def test_ssdp_bootid(
 
     # Send SSDP alive with same boot ID, nothing should happen
     await ssdp_callback(
-        ssdp.SsdpServiceInfo(
+        SsdpServiceInfo(
             ssdp_usn=MOCK_DEVICE_USN,
             ssdp_location=MOCK_DEVICE_LOCATION,
             ssdp_headers={ssdp.ATTR_SSDP_BOOTID: "1"},
@@ -602,7 +603,7 @@ async def test_ssdp_bootid(
 
     # Send a new SSDP alive with an incremented boot ID, device should be dis/reconnected
     await ssdp_callback(
-        ssdp.SsdpServiceInfo(
+        SsdpServiceInfo(
             ssdp_usn=MOCK_DEVICE_USN,
             ssdp_location=MOCK_DEVICE_LOCATION,
             ssdp_headers={ssdp.ATTR_SSDP_BOOTID: "2"},

--- a/tests/components/dlna_dms/test_dms_device_source.py
+++ b/tests/components/dlna_dms/test_dms_device_source.py
@@ -16,6 +16,7 @@ from homeassistant.components.dlna_dms.dms import DidlPlayMedia
 from homeassistant.components.media_player import BrowseError
 from homeassistant.components.media_source import BrowseMediaSource, Unresolvable
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.service_info.ssdp import SsdpServiceInfo
 
 from .conftest import (
     MOCK_DEVICE_BASE_URL,
@@ -68,7 +69,7 @@ async def test_catch_request_error_unavailable(
     # DmsDevice notifies of disconnect via SSDP
     ssdp_callback = ssdp_scanner_mock.async_register_callback.call_args.args[0].target
     await ssdp_callback(
-        ssdp.SsdpServiceInfo(
+        SsdpServiceInfo(
             ssdp_usn=MOCK_DEVICE_USN,
             ssdp_udn=MOCK_DEVICE_UDN,
             ssdp_headers={"NTS": "ssdp:byebye"},

--- a/tests/components/doorbird/test_config_flow.py
+++ b/tests/components/doorbird/test_config_flow.py
@@ -8,7 +8,6 @@ from doorbirdpy import DoorBird
 import pytest
 
 from homeassistant import config_entries
-from homeassistant.components import zeroconf
 from homeassistant.components.doorbird.const import (
     CONF_EVENTS,
     DEFAULT_DOORBELL_EVENT,
@@ -18,6 +17,7 @@ from homeassistant.components.doorbird.const import (
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from . import (
     VALID_CONFIG,
@@ -74,7 +74,7 @@ async def test_form_zeroconf_wrong_oui(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("192.168.1.8"),
             ip_addresses=[ip_address("192.168.1.8")],
             hostname="mock_hostname",
@@ -94,7 +94,7 @@ async def test_form_zeroconf_link_local_ignored(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("169.254.103.61"),
             ip_addresses=[ip_address("169.254.103.61")],
             hostname="mock_hostname",
@@ -121,7 +121,7 @@ async def test_form_zeroconf_ipv4_address(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("4.4.4.4"),
             ip_addresses=[ip_address("4.4.4.4")],
             hostname="mock_hostname",
@@ -142,7 +142,7 @@ async def test_form_zeroconf_non_ipv4_ignored(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("fd00::b27c:63bb:cc85:4ea0"),
             ip_addresses=[ip_address("fd00::b27c:63bb:cc85:4ea0")],
             hostname="mock_hostname",
@@ -164,7 +164,7 @@ async def test_form_zeroconf_correct_oui(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("192.168.1.5"),
             ip_addresses=[ip_address("192.168.1.5")],
             hostname="mock_hostname",
@@ -230,7 +230,7 @@ async def test_form_zeroconf_correct_oui_wrong_device(
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_ZEROCONF},
-            data=zeroconf.ZeroconfServiceInfo(
+            data=ZeroconfServiceInfo(
                 ip_address=ip_address("192.168.1.5"),
                 ip_addresses=[ip_address("192.168.1.5")],
                 hostname="mock_hostname",

--- a/tests/components/elgato/test_config_flow.py
+++ b/tests/components/elgato/test_config_flow.py
@@ -6,12 +6,12 @@ from unittest.mock import AsyncMock, MagicMock
 from elgato import ElgatoConnectionError
 import pytest
 
-from homeassistant.components import zeroconf
 from homeassistant.components.elgato.const import DOMAIN
 from homeassistant.config_entries import SOURCE_USER, SOURCE_ZEROCONF
 from homeassistant.const import CONF_HOST, CONF_MAC, CONF_SOURCE
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from tests.common import MockConfigEntry
 
@@ -57,7 +57,7 @@ async def test_full_zeroconf_flow_implementation(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("127.0.0.1"),
             ip_addresses=[ip_address("127.0.0.1")],
             hostname="example.local.",
@@ -141,7 +141,7 @@ async def test_zeroconf_connection_error(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("127.0.0.1"),
             ip_addresses=[ip_address("127.0.0.1")],
             hostname="mock_hostname",
@@ -181,7 +181,7 @@ async def test_zeroconf_device_exists_abort(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={CONF_SOURCE: SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("127.0.0.1"),
             ip_addresses=[ip_address("127.0.0.1")],
             hostname="mock_hostname",
@@ -202,7 +202,7 @@ async def test_zeroconf_device_exists_abort(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={CONF_SOURCE: SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("127.0.0.2"),
             ip_addresses=[ip_address("127.0.0.2")],
             hostname="mock_hostname",
@@ -230,7 +230,7 @@ async def test_zeroconf_during_onboarding(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("127.0.0.1"),
             ip_addresses=[ip_address("127.0.0.1")],
             hostname="example.local.",

--- a/tests/components/elkm1/test_config_flow.py
+++ b/tests/components/elkm1/test_config_flow.py
@@ -7,12 +7,12 @@ from elkm1_lib.discovery import ElkSystem
 import pytest
 
 from homeassistant import config_entries
-from homeassistant.components import dhcp
 from homeassistant.components.elkm1.const import DOMAIN
 from homeassistant.const import CONF_HOST, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
 from . import (
     ELK_DISCOVERY,
@@ -27,7 +27,7 @@ from . import (
 
 from tests.common import MockConfigEntry
 
-DHCP_DISCOVERY = dhcp.DhcpServiceInfo(
+DHCP_DISCOVERY = DhcpServiceInfo(
     MOCK_IP_ADDRESS, "", dr.format_mac(MOCK_MAC).replace(":", "")
 )
 ELK_DISCOVERY_INFO = asdict(ELK_DISCOVERY)
@@ -1141,7 +1141,7 @@ async def test_discovered_by_discovery_and_dhcp(hass: HomeAssistant) -> None:
         result3 = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_DHCP},
-            data=dhcp.DhcpServiceInfo(
+            data=DhcpServiceInfo(
                 hostname="any",
                 ip=MOCK_IP_ADDRESS,
                 macaddress="00:00:00:00:00:00",

--- a/tests/components/elmax/test_config_flow.py
+++ b/tests/components/elmax/test_config_flow.py
@@ -5,7 +5,6 @@ from unittest.mock import patch
 from elmax_api.exceptions import ElmaxBadLoginError, ElmaxBadPinError, ElmaxNetworkError
 
 from homeassistant import config_entries
-from homeassistant.components import zeroconf
 from homeassistant.components.elmax.const import (
     CONF_ELMAX_MODE,
     CONF_ELMAX_MODE_CLOUD,
@@ -23,6 +22,7 @@ from homeassistant.components.elmax.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from . import (
     MOCK_DIRECT_CERT,
@@ -40,7 +40,7 @@ from . import (
 
 from tests.common import MockConfigEntry
 
-MOCK_ZEROCONF_DISCOVERY_INFO = zeroconf.ZeroconfServiceInfo(
+MOCK_ZEROCONF_DISCOVERY_INFO = ZeroconfServiceInfo(
     ip_address=MOCK_DIRECT_HOST,
     ip_addresses=[MOCK_DIRECT_HOST],
     hostname="VideoBox.local",
@@ -54,7 +54,7 @@ MOCK_ZEROCONF_DISCOVERY_INFO = zeroconf.ZeroconfServiceInfo(
     },
     type="_elmax-ssl._tcp",
 )
-MOCK_ZEROCONF_DISCOVERY_CHANGED_INFO = zeroconf.ZeroconfServiceInfo(
+MOCK_ZEROCONF_DISCOVERY_CHANGED_INFO = ZeroconfServiceInfo(
     ip_address=MOCK_DIRECT_HOST_CHANGED,
     ip_addresses=[MOCK_DIRECT_HOST_CHANGED],
     hostname="VideoBox.local",
@@ -68,7 +68,7 @@ MOCK_ZEROCONF_DISCOVERY_CHANGED_INFO = zeroconf.ZeroconfServiceInfo(
     },
     type="_elmax-ssl._tcp",
 )
-MOCK_ZEROCONF_DISCOVERY_INFO_NOT_SUPPORTED = zeroconf.ZeroconfServiceInfo(
+MOCK_ZEROCONF_DISCOVERY_INFO_NOT_SUPPORTED = ZeroconfServiceInfo(
     ip_address=MOCK_DIRECT_HOST,
     ip_addresses=[MOCK_DIRECT_HOST],
     hostname="VideoBox.local",

--- a/tests/components/emonitor/test_config_flow.py
+++ b/tests/components/emonitor/test_config_flow.py
@@ -6,15 +6,15 @@ from aioemonitor.monitor import EmonitorNetwork, EmonitorStatus
 import aiohttp
 
 from homeassistant import config_entries
-from homeassistant.components import dhcp
 from homeassistant.components.emonitor.const import DOMAIN
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
 from tests.common import MockConfigEntry
 
-DHCP_SERVICE_INFO = dhcp.DhcpServiceInfo(
+DHCP_SERVICE_INFO = DhcpServiceInfo(
     hostname="emonitor",
     ip="1.2.3.4",
     macaddress="aabbccddeeff",

--- a/tests/components/enphase_envoy/test_config_flow.py
+++ b/tests/components/enphase_envoy/test_config_flow.py
@@ -7,7 +7,6 @@ from unittest.mock import AsyncMock
 from pyenphase import EnvoyAuthenticationError, EnvoyError
 import pytest
 
-from homeassistant.components import zeroconf
 from homeassistant.components.enphase_envoy.const import (
     DOMAIN,
     OPTION_DIAGNOSTICS_INCLUDE_FIXTURES,
@@ -19,6 +18,7 @@ from homeassistant.config_entries import SOURCE_USER, SOURCE_ZEROCONF
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from . import setup_integration
 
@@ -163,7 +163,7 @@ async def test_zeroconf(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("1.1.1.1"),
             ip_addresses=[ip_address("1.1.1.1")],
             hostname="mock_hostname",
@@ -273,7 +273,7 @@ async def test_zeroconf_serial_already_exists(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("4.4.4.4"),
             ip_addresses=[ip_address("4.4.4.4")],
             hostname="mock_hostname",
@@ -301,7 +301,7 @@ async def test_zeroconf_serial_already_exists_ignores_ipv6(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("fd00::b27c:63bb:cc85:4ea0"),
             ip_addresses=[ip_address("fd00::b27c:63bb:cc85:4ea0")],
             hostname="mock_hostname",
@@ -330,7 +330,7 @@ async def test_zeroconf_host_already_exists(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("1.1.1.1"),
             ip_addresses=[ip_address("1.1.1.1")],
             hostname="mock_hostname",
@@ -363,7 +363,7 @@ async def test_zero_conf_while_form(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("1.1.1.1"),
             ip_addresses=[ip_address("1.1.1.1")],
             hostname="mock_hostname",
@@ -396,7 +396,7 @@ async def test_zero_conf_second_envoy_while_form(
     result2 = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("4.4.4.4"),
             ip_addresses=[ip_address("4.4.4.4")],
             hostname="mock_hostname",
@@ -455,7 +455,7 @@ async def test_zero_conf_old_blank_entry(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("1.1.1.1"),
             ip_addresses=[ip_address("1.1.1.1"), ip_address("1.1.1.2")],
             hostname="mock_hostname",
@@ -496,7 +496,7 @@ async def test_zero_conf_old_blank_entry_standard_title(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("1.1.1.1"),
             ip_addresses=[ip_address("1.1.1.1"), ip_address("1.1.1.2")],
             hostname="mock_hostname",
@@ -537,7 +537,7 @@ async def test_zero_conf_old_blank_entry_user_title(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("1.1.1.1"),
             ip_addresses=[ip_address("1.1.1.1"), ip_address("1.1.1.2")],
             hostname="mock_hostname",

--- a/tests/components/esphome/test_config_flow.py
+++ b/tests/components/esphome/test_config_flow.py
@@ -18,7 +18,6 @@ import aiohttp
 import pytest
 
 from homeassistant import config_entries
-from homeassistant.components import dhcp, zeroconf
 from homeassistant.components.esphome import dashboard
 from homeassistant.components.esphome.const import (
     CONF_ALLOW_SERVICE_CALLS,
@@ -30,8 +29,10 @@ from homeassistant.components.esphome.const import (
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 from homeassistant.helpers.service_info.hassio import HassioServiceInfo
 from homeassistant.helpers.service_info.mqtt import MqttServiceInfo
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from . import VALID_NOISE_PSK
 
@@ -126,7 +127,7 @@ async def test_user_sets_unique_id(
     hass: HomeAssistant, mock_client, mock_setup_entry: None
 ) -> None:
     """Test that the user flow sets the unique id."""
-    service_info = zeroconf.ZeroconfServiceInfo(
+    service_info = ZeroconfServiceInfo(
         ip_address=ip_address("192.168.43.183"),
         ip_addresses=[ip_address("192.168.43.183")],
         hostname="test8266.local.",
@@ -205,7 +206,7 @@ async def test_user_causes_zeroconf_to_abort(
     hass: HomeAssistant, mock_client, mock_setup_entry: None
 ) -> None:
     """Test that the user flow sets the unique id and aborts the zeroconf flow."""
-    service_info = zeroconf.ZeroconfServiceInfo(
+    service_info = ZeroconfServiceInfo(
         ip_address=ip_address("192.168.43.183"),
         ip_addresses=[ip_address("192.168.43.183")],
         hostname="test8266.local.",
@@ -568,7 +569,7 @@ async def test_discovery_initiation(
     hass: HomeAssistant, mock_client, mock_setup_entry: None
 ) -> None:
     """Test discovery importing works."""
-    service_info = zeroconf.ZeroconfServiceInfo(
+    service_info = ZeroconfServiceInfo(
         ip_address=ip_address("192.168.43.183"),
         ip_addresses=[ip_address("192.168.43.183")],
         hostname="test.local.",
@@ -601,7 +602,7 @@ async def test_discovery_no_mac(
     hass: HomeAssistant, mock_client, mock_setup_entry: None
 ) -> None:
     """Test discovery aborted if old ESPHome without mac in zeroconf."""
-    service_info = zeroconf.ZeroconfServiceInfo(
+    service_info = ZeroconfServiceInfo(
         ip_address=ip_address("192.168.43.183"),
         ip_addresses=[ip_address("192.168.43.183")],
         hostname="test8266.local.",
@@ -629,7 +630,7 @@ async def test_discovery_already_configured(
 
     entry.add_to_hass(hass)
 
-    service_info = zeroconf.ZeroconfServiceInfo(
+    service_info = ZeroconfServiceInfo(
         ip_address=ip_address("192.168.43.183"),
         ip_addresses=[ip_address("192.168.43.183")],
         hostname="test8266.local.",
@@ -650,7 +651,7 @@ async def test_discovery_duplicate_data(
     hass: HomeAssistant, mock_client: APIClient, mock_setup_entry: None
 ) -> None:
     """Test discovery aborts if same mDNS packet arrives."""
-    service_info = zeroconf.ZeroconfServiceInfo(
+    service_info = ZeroconfServiceInfo(
         ip_address=ip_address("192.168.43.183"),
         ip_addresses=[ip_address("192.168.43.183")],
         hostname="test.local.",
@@ -685,7 +686,7 @@ async def test_discovery_updates_unique_id(
 
     entry.add_to_hass(hass)
 
-    service_info = zeroconf.ZeroconfServiceInfo(
+    service_info = ZeroconfServiceInfo(
         ip_address=ip_address("192.168.43.183"),
         ip_addresses=[ip_address("192.168.43.183")],
         hostname="test8266.local.",
@@ -1056,7 +1057,7 @@ async def test_discovery_dhcp_updates_host(
     )
     entry.add_to_hass(hass)
 
-    service_info = dhcp.DhcpServiceInfo(
+    service_info = DhcpServiceInfo(
         ip="192.168.43.184",
         hostname="test8266",
         macaddress="1122334455aa",
@@ -1083,7 +1084,7 @@ async def test_discovery_dhcp_no_changes(
 
     mock_client.device_info = AsyncMock(return_value=DeviceInfo(name="test8266"))
 
-    service_info = dhcp.DhcpServiceInfo(
+    service_info = DhcpServiceInfo(
         ip="192.168.43.183",
         hostname="test8266",
         macaddress="000000000000",
@@ -1132,7 +1133,7 @@ async def test_zeroconf_encryption_key_via_dashboard(
     mock_setup_entry: None,
 ) -> None:
     """Test encryption key retrieved from dashboard."""
-    service_info = zeroconf.ZeroconfServiceInfo(
+    service_info = ZeroconfServiceInfo(
         ip_address=ip_address("192.168.43.183"),
         ip_addresses=[ip_address("192.168.43.183")],
         hostname="test8266.local.",
@@ -1198,7 +1199,7 @@ async def test_zeroconf_encryption_key_via_dashboard_with_api_encryption_prop(
     mock_setup_entry: None,
 ) -> None:
     """Test encryption key retrieved from dashboard with api_encryption property set."""
-    service_info = zeroconf.ZeroconfServiceInfo(
+    service_info = ZeroconfServiceInfo(
         ip_address=ip_address("192.168.43.183"),
         ip_addresses=[ip_address("192.168.43.183")],
         hostname="test8266.local.",
@@ -1264,7 +1265,7 @@ async def test_zeroconf_no_encryption_key_via_dashboard(
     mock_setup_entry: None,
 ) -> None:
     """Test encryption key not retrieved from dashboard."""
-    service_info = zeroconf.ZeroconfServiceInfo(
+    service_info = ZeroconfServiceInfo(
         ip_address=ip_address("192.168.43.183"),
         ip_addresses=[ip_address("192.168.43.183")],
         hostname="test8266.local.",

--- a/tests/components/esphome/test_manager.py
+++ b/tests/components/esphome/test_manager.py
@@ -21,7 +21,6 @@ from aioesphomeapi import (
 import pytest
 
 from homeassistant import config_entries
-from homeassistant.components import dhcp
 from homeassistant.components.esphome.const import (
     CONF_ALLOW_SERVICE_CALLS,
     CONF_DEVICE_NAME,
@@ -37,6 +36,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers import device_registry as dr, issue_registry as ir
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 from homeassistant.setup import async_setup_component
 
 from .conftest import MockESPHomeDevice
@@ -598,7 +598,7 @@ async def test_connection_aborted_wrong_device(
     mock_client.disconnect = AsyncMock()
     caplog.clear()
     # Make sure discovery triggers a reconnect
-    service_info = dhcp.DhcpServiceInfo(
+    service_info = DhcpServiceInfo(
         ip="192.168.43.184",
         hostname="test",
         macaddress="1122334455aa",

--- a/tests/components/flux_led/__init__.py
+++ b/tests/components/flux_led/__init__.py
@@ -24,12 +24,12 @@ from flux_led.protocol import (
 )
 from flux_led.scanner import FluxLEDDiscovery
 
-from homeassistant.components import dhcp
 from homeassistant.components.flux_led.const import DOMAIN
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import format_mac
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
 from tests.common import MockConfigEntry
 
@@ -49,7 +49,7 @@ SHORT_MAC_ADDRESS = "DDEEFF"
 DEFAULT_ENTRY_TITLE = f"{MODEL_DESCRIPTION} {SHORT_MAC_ADDRESS}"
 
 
-DHCP_DISCOVERY = dhcp.DhcpServiceInfo(
+DHCP_DISCOVERY = DhcpServiceInfo(
     hostname=MODEL,
     ip=IP_ADDRESS,
     macaddress=format_mac(MAC_ADDRESS).replace(":", ""),

--- a/tests/components/flux_led/test_config_flow.py
+++ b/tests/components/flux_led/test_config_flow.py
@@ -7,7 +7,6 @@ from unittest.mock import patch
 import pytest
 
 from homeassistant import config_entries
-from homeassistant.components import dhcp
 from homeassistant.components.flux_led.config_flow import FluxLedConfigFlow
 from homeassistant.components.flux_led.const import (
     CONF_CUSTOM_EFFECT_COLORS,
@@ -27,6 +26,7 @@ from homeassistant.components.flux_led.const import (
 from homeassistant.const import CONF_DEVICE, CONF_HOST, CONF_MODEL
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
 from . import (
     DEFAULT_ENTRY_TITLE,
@@ -424,7 +424,7 @@ async def test_discovered_by_discovery_and_dhcp(hass: HomeAssistant) -> None:
         result3 = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_DHCP},
-            data=dhcp.DhcpServiceInfo(
+            data=DhcpServiceInfo(
                 hostname="any",
                 ip=IP_ADDRESS,
                 macaddress="000000000000",

--- a/tests/components/forked_daapd/test_config_flow.py
+++ b/tests/components/forked_daapd/test_config_flow.py
@@ -5,7 +5,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from homeassistant.components import zeroconf
 from homeassistant.components.forked_daapd.const import (
     CONF_LIBRESPOT_JAVA_PORT,
     CONF_MAX_PLAYLISTS,
@@ -19,6 +18,7 @@ from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.exceptions import PlatformNotReady
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from tests.common import MockConfigEntry
 
@@ -109,7 +109,7 @@ async def test_zeroconf_updates_title(
     MockConfigEntry(domain=DOMAIN, data={CONF_HOST: "different host"}).add_to_hass(hass)
     config_entry.add_to_hass(hass)
     assert len(hass.config_entries.async_entries(DOMAIN)) == 2
-    discovery_info = zeroconf.ZeroconfServiceInfo(
+    discovery_info = ZeroconfServiceInfo(
         ip_address=ip_address("192.168.1.1"),
         ip_addresses=[ip_address("192.168.1.1")],
         hostname="mock_hostname",
@@ -146,7 +146,7 @@ async def test_config_flow_no_websocket(
 async def test_config_flow_zeroconf_invalid(hass: HomeAssistant) -> None:
     """Test that an invalid zeroconf entry doesn't work."""
     # test with no discovery properties
-    discovery_info = zeroconf.ZeroconfServiceInfo(
+    discovery_info = ZeroconfServiceInfo(
         ip_address=ip_address("127.0.0.1"),
         ip_addresses=[ip_address("127.0.0.1")],
         hostname="mock_hostname",
@@ -161,7 +161,7 @@ async def test_config_flow_zeroconf_invalid(hass: HomeAssistant) -> None:
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "not_forked_daapd"
     # test with forked-daapd version < 27
-    discovery_info = zeroconf.ZeroconfServiceInfo(
+    discovery_info = ZeroconfServiceInfo(
         ip_address=ip_address("127.0.0.1"),
         ip_addresses=[ip_address("127.0.0.1")],
         hostname="mock_hostname",
@@ -176,7 +176,7 @@ async def test_config_flow_zeroconf_invalid(hass: HomeAssistant) -> None:
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "not_forked_daapd"
     # test with verbose mtd-version from Firefly
-    discovery_info = zeroconf.ZeroconfServiceInfo(
+    discovery_info = ZeroconfServiceInfo(
         ip_address=ip_address("127.0.0.1"),
         ip_addresses=[ip_address("127.0.0.1")],
         hostname="mock_hostname",
@@ -191,7 +191,7 @@ async def test_config_flow_zeroconf_invalid(hass: HomeAssistant) -> None:
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "not_forked_daapd"
     # test with svn mtd-version from Firefly
-    discovery_info = zeroconf.ZeroconfServiceInfo(
+    discovery_info = ZeroconfServiceInfo(
         ip_address=ip_address("127.0.0.1"),
         ip_addresses=[ip_address("127.0.0.1")],
         hostname="mock_hostname",
@@ -209,7 +209,7 @@ async def test_config_flow_zeroconf_invalid(hass: HomeAssistant) -> None:
 
 async def test_config_flow_zeroconf_valid(hass: HomeAssistant) -> None:
     """Test that a valid zeroconf entry works."""
-    discovery_info = zeroconf.ZeroconfServiceInfo(
+    discovery_info = ZeroconfServiceInfo(
         ip_address=ip_address("192.168.1.1"),
         ip_addresses=[ip_address("192.168.1.1")],
         hostname="mock_hostname",

--- a/tests/components/freebox/test_config_flow.py
+++ b/tests/components/freebox/test_config_flow.py
@@ -9,18 +9,18 @@ from freebox_api.exceptions import (
     InvalidTokenError,
 )
 
-from homeassistant.components import zeroconf
 from homeassistant.components.freebox.const import DOMAIN
 from homeassistant.config_entries import SOURCE_USER, SOURCE_ZEROCONF
 from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from .const import MOCK_HOST, MOCK_PORT
 
 from tests.common import MockConfigEntry
 
-MOCK_ZEROCONF_DATA = zeroconf.ZeroconfServiceInfo(
+MOCK_ZEROCONF_DATA = ZeroconfServiceInfo(
     ip_address=ip_address("192.168.0.254"),
     ip_addresses=[ip_address("192.168.0.254")],
     port=80,

--- a/tests/components/fritz/const.py
+++ b/tests/components/fritz/const.py
@@ -1,6 +1,5 @@
 """Common stuff for Fritz!Tools tests."""
 
-from homeassistant.components import ssdp
 from homeassistant.components.fritz.const import DOMAIN
 from homeassistant.const import (
     CONF_DEVICES,
@@ -13,6 +12,7 @@ from homeassistant.const import (
 from homeassistant.helpers.service_info.ssdp import (
     ATTR_UPNP_FRIENDLY_NAME,
     ATTR_UPNP_UDN,
+    SsdpServiceInfo,
 )
 
 ATTR_HOST = "host"
@@ -944,7 +944,7 @@ MOCK_DEVICE_INFO = {
     ATTR_HOST: MOCK_HOST,
     ATTR_NEW_SERIAL_NUMBER: MOCK_SERIAL_NUMBER,
 }
-MOCK_SSDP_DATA = ssdp.SsdpServiceInfo(
+MOCK_SSDP_DATA = SsdpServiceInfo(
     ssdp_usn="mock_usn",
     ssdp_st="mock_st",
     ssdp_location=f"https://{MOCK_IPS['fritz.box']}:12345/test",

--- a/tests/components/fritz/test_config_flow.py
+++ b/tests/components/fritz/test_config_flow.py
@@ -10,7 +10,6 @@ from fritzconnection.core.exceptions import (
 )
 import pytest
 
-from homeassistant.components import ssdp
 from homeassistant.components.device_tracker import (
     CONF_CONSIDER_HOME,
     DEFAULT_CONSIDER_HOME,
@@ -33,6 +32,11 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.ssdp import (
+    ATTR_UPNP_FRIENDLY_NAME,
+    ATTR_UPNP_UDN,
+    SsdpServiceInfo,
+)
 
 from .const import (
     MOCK_FIRMWARE_INFO,
@@ -644,7 +648,7 @@ async def test_ssdp_already_in_progress_host(
 
         MOCK_NO_UNIQUE_ID = dataclasses.replace(MOCK_SSDP_DATA)
         MOCK_NO_UNIQUE_ID.upnp = MOCK_NO_UNIQUE_ID.upnp.copy()
-        del MOCK_NO_UNIQUE_ID.upnp[ssdp.ATTR_UPNP_UDN]
+        del MOCK_NO_UNIQUE_ID.upnp[ATTR_UPNP_UDN]
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_SSDP}, data=MOCK_NO_UNIQUE_ID
         )
@@ -745,13 +749,13 @@ async def test_ssdp_ipv6_link_local(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_SSDP},
-        data=ssdp.SsdpServiceInfo(
+        data=SsdpServiceInfo(
             ssdp_usn="mock_usn",
             ssdp_st="mock_st",
             ssdp_location="https://[fe80::1ff:fe23:4567:890a]:12345/test",
             upnp={
-                ssdp.ATTR_UPNP_FRIENDLY_NAME: "fake_name",
-                ssdp.ATTR_UPNP_UDN: "uuid:only-a-test",
+                ATTR_UPNP_FRIENDLY_NAME: "fake_name",
+                ATTR_UPNP_UDN: "uuid:only-a-test",
             },
         ),
     )

--- a/tests/components/fritzbox/test_config_flow.py
+++ b/tests/components/fritzbox/test_config_flow.py
@@ -9,7 +9,6 @@ from pyfritzhome import LoginError
 import pytest
 from requests.exceptions import HTTPError
 
-from homeassistant.components import ssdp
 from homeassistant.components.fritzbox.const import DOMAIN
 from homeassistant.config_entries import SOURCE_SSDP, SOURCE_USER
 from homeassistant.const import CONF_DEVICES, CONF_HOST, CONF_PASSWORD, CONF_USERNAME
@@ -18,6 +17,7 @@ from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers.service_info.ssdp import (
     ATTR_UPNP_FRIENDLY_NAME,
     ATTR_UPNP_UDN,
+    SsdpServiceInfo,
 )
 
 from .const import CONF_FAKE_NAME, MOCK_CONFIG
@@ -26,7 +26,7 @@ from tests.common import MockConfigEntry
 
 MOCK_USER_DATA = MOCK_CONFIG[DOMAIN][CONF_DEVICES][0]
 MOCK_SSDP_DATA = {
-    "ip4_valid": ssdp.SsdpServiceInfo(
+    "ip4_valid": SsdpServiceInfo(
         ssdp_usn="mock_usn",
         ssdp_st="mock_st",
         ssdp_location="https://10.0.0.1:12345/test",
@@ -35,7 +35,7 @@ MOCK_SSDP_DATA = {
             ATTR_UPNP_UDN: "uuid:only-a-test",
         },
     ),
-    "ip6_valid": ssdp.SsdpServiceInfo(
+    "ip6_valid": SsdpServiceInfo(
         ssdp_usn="mock_usn",
         ssdp_st="mock_st",
         ssdp_location="https://[1234::1]:12345/test",
@@ -44,7 +44,7 @@ MOCK_SSDP_DATA = {
             ATTR_UPNP_UDN: "uuid:only-a-test",
         },
     ),
-    "ip6_invalid": ssdp.SsdpServiceInfo(
+    "ip6_invalid": SsdpServiceInfo(
         ssdp_usn="mock_usn",
         ssdp_st="mock_st",
         ssdp_location="https://[fe80::1%1]:12345/test",
@@ -267,7 +267,7 @@ async def test_reconfigure_failed(hass: HomeAssistant, fritz: Mock) -> None:
 async def test_ssdp(
     hass: HomeAssistant,
     fritz: Mock,
-    test_data: ssdp.SsdpServiceInfo,
+    test_data: SsdpServiceInfo,
     expected_result: str,
 ) -> None:
     """Test starting a flow from discovery."""

--- a/tests/components/frontier_silicon/test_config_flow.py
+++ b/tests/components/frontier_silicon/test_config_flow.py
@@ -6,7 +6,6 @@ from afsapi import ConnectionError, InvalidPinException, NotImplementedException
 import pytest
 
 from homeassistant import config_entries
-from homeassistant.components import ssdp
 from homeassistant.components.frontier_silicon.const import (
     CONF_WEBFSAPI_URL,
     DEFAULT_PIN,
@@ -15,13 +14,14 @@ from homeassistant.components.frontier_silicon.const import (
 from homeassistant.const import CONF_HOST, CONF_PIN, CONF_PORT
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.ssdp import SsdpServiceInfo
 
 from tests.common import MockConfigEntry
 
 pytestmark = pytest.mark.usefixtures("mock_setup_entry")
 
 
-MOCK_DISCOVERY = ssdp.SsdpServiceInfo(
+MOCK_DISCOVERY = SsdpServiceInfo(
     ssdp_usn="mock_usn",
     ssdp_udn="uuid:3dcc7100-f76c-11dd-87af-00226124ca30",
     ssdp_st="mock_st",
@@ -30,7 +30,7 @@ MOCK_DISCOVERY = ssdp.SsdpServiceInfo(
     upnp={"SPEAKER-NAME": "Speaker Name"},
 )
 
-INVALID_MOCK_DISCOVERY = ssdp.SsdpServiceInfo(
+INVALID_MOCK_DISCOVERY = SsdpServiceInfo(
     ssdp_usn="mock_usn",
     ssdp_udn="uuid:3dcc7100-f76c-11dd-87af-00226124ca30",
     ssdp_st="mock_st",

--- a/tests/components/goalzero/__init__.py
+++ b/tests/components/goalzero/__init__.py
@@ -2,11 +2,11 @@
 
 from unittest.mock import AsyncMock, patch
 
-from homeassistant.components import dhcp
 from homeassistant.components.goalzero.const import DEFAULT_NAME, DOMAIN
 from homeassistant.const import CONF_HOST, CONF_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import format_mac
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
 from tests.common import MockConfigEntry, load_fixture
 from tests.test_util.aiohttp import AiohttpClientMocker
@@ -19,7 +19,7 @@ CONF_DATA = {
     CONF_NAME: DEFAULT_NAME,
 }
 
-CONF_DHCP_FLOW = dhcp.DhcpServiceInfo(
+CONF_DHCP_FLOW = DhcpServiceInfo(
     ip=HOST,
     macaddress=format_mac("AA:BB:CC:DD:EE:FF").replace(":", ""),
     hostname="yeti",

--- a/tests/components/gogogate2/test_config_flow.py
+++ b/tests/components/gogogate2/test_config_flow.py
@@ -8,7 +8,6 @@ from ismartgate.common import ApiError
 from ismartgate.const import GogoGate2ApiErrorCode
 
 from homeassistant import config_entries
-from homeassistant.components import dhcp, zeroconf
 from homeassistant.components.gogogate2.const import (
     DEVICE_TYPE_GOGOGATE2,
     DEVICE_TYPE_ISMARTGATE,
@@ -23,6 +22,11 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
+from homeassistant.helpers.service_info.zeroconf import (
+    ATTR_PROPERTIES_ID,
+    ZeroconfServiceInfo,
+)
 
 from . import _mocked_ismartgate_closed_door_response
 
@@ -105,13 +109,13 @@ async def test_form_homekit_unique_id_already_setup(hass: HomeAssistant) -> None
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_HOMEKIT},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("1.2.3.4"),
             ip_addresses=[ip_address("1.2.3.4")],
             hostname="mock_hostname",
             name="mock_name",
             port=None,
-            properties={zeroconf.ATTR_PROPERTIES_ID: MOCK_MAC_ADDR},
+            properties={ATTR_PROPERTIES_ID: MOCK_MAC_ADDR},
             type="mock_type",
         ),
     )
@@ -133,13 +137,13 @@ async def test_form_homekit_unique_id_already_setup(hass: HomeAssistant) -> None
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_HOMEKIT},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("1.2.3.4"),
             ip_addresses=[ip_address("1.2.3.4")],
             hostname="mock_hostname",
             name="mock_name",
             port=None,
-            properties={zeroconf.ATTR_PROPERTIES_ID: MOCK_MAC_ADDR},
+            properties={ATTR_PROPERTIES_ID: MOCK_MAC_ADDR},
             type="mock_type",
         ),
     )
@@ -158,13 +162,13 @@ async def test_form_homekit_ip_address_already_setup(hass: HomeAssistant) -> Non
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_HOMEKIT},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("1.2.3.4"),
             ip_addresses=[ip_address("1.2.3.4")],
             hostname="mock_hostname",
             name="mock_name",
             port=None,
-            properties={zeroconf.ATTR_PROPERTIES_ID: MOCK_MAC_ADDR},
+            properties={ATTR_PROPERTIES_ID: MOCK_MAC_ADDR},
             type="mock_type",
         ),
     )
@@ -177,13 +181,13 @@ async def test_form_homekit_ip_address(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_HOMEKIT},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("1.2.3.4"),
             ip_addresses=[ip_address("1.2.3.4")],
             hostname="mock_hostname",
             name="mock_name",
             port=None,
-            properties={zeroconf.ATTR_PROPERTIES_ID: MOCK_MAC_ADDR},
+            properties={ATTR_PROPERTIES_ID: MOCK_MAC_ADDR},
             type="mock_type",
         ),
     )
@@ -213,7 +217,7 @@ async def test_discovered_dhcp(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_DHCP},
-        data=dhcp.DhcpServiceInfo(
+        data=DhcpServiceInfo(
             ip="1.2.3.4", macaddress=MOCK_MAC_ADDR, hostname="mock_hostname"
         ),
     )
@@ -260,13 +264,13 @@ async def test_discovered_by_homekit_and_dhcp(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_HOMEKIT},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("1.2.3.4"),
             ip_addresses=[ip_address("1.2.3.4")],
             hostname="mock_hostname",
             name="mock_name",
             port=None,
-            properties={zeroconf.ATTR_PROPERTIES_ID: MOCK_MAC_ADDR},
+            properties={ATTR_PROPERTIES_ID: MOCK_MAC_ADDR},
             type="mock_type",
         ),
     )
@@ -276,7 +280,7 @@ async def test_discovered_by_homekit_and_dhcp(hass: HomeAssistant) -> None:
     result2 = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_DHCP},
-        data=dhcp.DhcpServiceInfo(
+        data=DhcpServiceInfo(
             ip="1.2.3.4", macaddress=MOCK_MAC_ADDR, hostname="mock_hostname"
         ),
     )
@@ -286,7 +290,7 @@ async def test_discovered_by_homekit_and_dhcp(hass: HomeAssistant) -> None:
     result3 = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_DHCP},
-        data=dhcp.DhcpServiceInfo(
+        data=DhcpServiceInfo(
             ip="1.2.3.4", macaddress="00:00:00:00:00:00", hostname="mock_hostname"
         ),
     )

--- a/tests/components/guardian/test_config_flow.py
+++ b/tests/components/guardian/test_config_flow.py
@@ -7,7 +7,6 @@ from unittest.mock import patch
 from aioguardian.errors import GuardianError
 import pytest
 
-from homeassistant.components import dhcp, zeroconf
 from homeassistant.components.guardian import CONF_UID, DOMAIN
 from homeassistant.components.guardian.config_flow import (
     async_get_pin_from_discovery_hostname,
@@ -17,6 +16,8 @@ from homeassistant.config_entries import SOURCE_DHCP, SOURCE_USER, SOURCE_ZEROCO
 from homeassistant.const import CONF_IP_ADDRESS, CONF_PORT
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from tests.common import MockConfigEntry
 
@@ -82,7 +83,7 @@ async def test_step_user(hass: HomeAssistant, config: dict[str, Any]) -> None:
 @pytest.mark.usefixtures("setup_guardian")
 async def test_step_zeroconf(hass: HomeAssistant) -> None:
     """Test the zeroconf step."""
-    zeroconf_data = zeroconf.ZeroconfServiceInfo(
+    zeroconf_data = ZeroconfServiceInfo(
         ip_address=ip_address("192.168.1.100"),
         ip_addresses=[ip_address("192.168.1.100")],
         port=7777,
@@ -112,7 +113,7 @@ async def test_step_zeroconf(hass: HomeAssistant) -> None:
 
 async def test_step_zeroconf_already_in_progress(hass: HomeAssistant) -> None:
     """Test the zeroconf step aborting because it's already in progress."""
-    zeroconf_data = zeroconf.ZeroconfServiceInfo(
+    zeroconf_data = ZeroconfServiceInfo(
         ip_address=ip_address("192.168.1.100"),
         ip_addresses=[ip_address("192.168.1.100")],
         port=7777,
@@ -138,7 +139,7 @@ async def test_step_zeroconf_already_in_progress(hass: HomeAssistant) -> None:
 @pytest.mark.usefixtures("setup_guardian")
 async def test_step_dhcp(hass: HomeAssistant) -> None:
     """Test the dhcp step."""
-    dhcp_data = dhcp.DhcpServiceInfo(
+    dhcp_data = DhcpServiceInfo(
         ip="192.168.1.100",
         hostname="GVC1-ABCD.local.",
         macaddress="aabbccddeeff",
@@ -164,7 +165,7 @@ async def test_step_dhcp(hass: HomeAssistant) -> None:
 
 async def test_step_dhcp_already_in_progress(hass: HomeAssistant) -> None:
     """Test the zeroconf step aborting because it's already in progress."""
-    dhcp_data = dhcp.DhcpServiceInfo(
+    dhcp_data = DhcpServiceInfo(
         ip="192.168.1.100",
         hostname="GVC1-ABCD.local.",
         macaddress="aabbccddeeff",
@@ -193,7 +194,7 @@ async def test_step_dhcp_already_setup_match_mac(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_DHCP},
-        data=dhcp.DhcpServiceInfo(
+        data=DhcpServiceInfo(
             ip="192.168.1.100",
             hostname="GVC1-ABCD.local.",
             macaddress="aabbccddabcd",
@@ -215,7 +216,7 @@ async def test_step_dhcp_already_setup_match_ip(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_DHCP},
-        data=dhcp.DhcpServiceInfo(
+        data=DhcpServiceInfo(
             ip="192.168.1.100",
             hostname="GVC1-ABCD.local.",
             macaddress="aabbccddabcd",

--- a/tests/components/harmony/test_config_flow.py
+++ b/tests/components/harmony/test_config_flow.py
@@ -5,12 +5,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import aiohttp
 
 from homeassistant import config_entries
-from homeassistant.components import ssdp
 from homeassistant.components.harmony.config_flow import CannotConnect
 from homeassistant.components.harmony.const import DOMAIN, PREVIOUS_ACTIVE_ACTIVITY
 from homeassistant.const import CONF_HOST, CONF_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.ssdp import SsdpServiceInfo
 
 from tests.common import MockConfigEntry
 
@@ -65,7 +65,7 @@ async def test_form_ssdp(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_SSDP},
-            data=ssdp.SsdpServiceInfo(
+            data=SsdpServiceInfo(
                 ssdp_usn="mock_usn",
                 ssdp_st="mock_st",
                 ssdp_location="http://192.168.1.12:8088/description",
@@ -120,7 +120,7 @@ async def test_form_ssdp_fails_to_get_remote_id(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_SSDP},
-            data=ssdp.SsdpServiceInfo(
+            data=SsdpServiceInfo(
                 ssdp_usn="mock_usn",
                 ssdp_st="mock_st",
                 ssdp_location="http://192.168.1.12:8088/description",
@@ -159,7 +159,7 @@ async def test_form_ssdp_aborts_before_checking_remoteid_if_host_known(
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_SSDP},
-            data=ssdp.SsdpServiceInfo(
+            data=SsdpServiceInfo(
                 ssdp_usn="mock_usn",
                 ssdp_st="mock_st",
                 ssdp_location="http://2.2.2.2:8088/description",

--- a/tests/components/heos/conftest.py
+++ b/tests/components/heos/conftest.py
@@ -24,7 +24,6 @@ from pyheos import (
 import pytest
 import pytest_asyncio
 
-from homeassistant.components import ssdp
 from homeassistant.components.heos import (
     CONF_PASSWORD,
     DOMAIN,
@@ -34,6 +33,16 @@ from homeassistant.components.heos import (
     SourceManager,
 )
 from homeassistant.const import CONF_HOST, CONF_USERNAME
+from homeassistant.helpers.service_info.ssdp import (
+    ATTR_UPNP_DEVICE_TYPE,
+    ATTR_UPNP_FRIENDLY_NAME,
+    ATTR_UPNP_MANUFACTURER,
+    ATTR_UPNP_MODEL_NAME,
+    ATTR_UPNP_MODEL_NUMBER,
+    ATTR_UPNP_SERIAL,
+    ATTR_UPNP_UDN,
+    SsdpServiceInfo,
+)
 
 from tests.common import MockConfigEntry
 
@@ -236,18 +245,18 @@ async def dispatcher_fixture() -> Dispatcher:
 @pytest.fixture(name="discovery_data")
 def discovery_data_fixture() -> dict:
     """Return mock discovery data for testing."""
-    return ssdp.SsdpServiceInfo(
+    return SsdpServiceInfo(
         ssdp_usn="mock_usn",
         ssdp_st="mock_st",
         ssdp_location="http://127.0.0.1:60006/upnp/desc/aios_device/aios_device.xml",
         upnp={
-            ssdp.ATTR_UPNP_DEVICE_TYPE: "urn:schemas-denon-com:device:AiosDevice:1",
-            ssdp.ATTR_UPNP_FRIENDLY_NAME: "Office",
-            ssdp.ATTR_UPNP_MANUFACTURER: "Denon",
-            ssdp.ATTR_UPNP_MODEL_NAME: "HEOS Drive",
-            ssdp.ATTR_UPNP_MODEL_NUMBER: "DWSA-10 4.0",
-            ssdp.ATTR_UPNP_SERIAL: None,
-            ssdp.ATTR_UPNP_UDN: "uuid:e61de70c-2250-1c22-0080-0005cdf512be",
+            ATTR_UPNP_DEVICE_TYPE: "urn:schemas-denon-com:device:AiosDevice:1",
+            ATTR_UPNP_FRIENDLY_NAME: "Office",
+            ATTR_UPNP_MANUFACTURER: "Denon",
+            ATTR_UPNP_MODEL_NAME: "HEOS Drive",
+            ATTR_UPNP_MODEL_NUMBER: "DWSA-10 4.0",
+            ATTR_UPNP_SERIAL: None,
+            ATTR_UPNP_UDN: "uuid:e61de70c-2250-1c22-0080-0005cdf512be",
         },
     )
 
@@ -255,18 +264,18 @@ def discovery_data_fixture() -> dict:
 @pytest.fixture(name="discovery_data_bedroom")
 def discovery_data_fixture_bedroom() -> dict:
     """Return mock discovery data for testing."""
-    return ssdp.SsdpServiceInfo(
+    return SsdpServiceInfo(
         ssdp_usn="mock_usn",
         ssdp_st="mock_st",
         ssdp_location="http://127.0.0.2:60006/upnp/desc/aios_device/aios_device.xml",
         upnp={
-            ssdp.ATTR_UPNP_DEVICE_TYPE: "urn:schemas-denon-com:device:AiosDevice:1",
-            ssdp.ATTR_UPNP_FRIENDLY_NAME: "Bedroom",
-            ssdp.ATTR_UPNP_MANUFACTURER: "Denon",
-            ssdp.ATTR_UPNP_MODEL_NAME: "HEOS Drive",
-            ssdp.ATTR_UPNP_MODEL_NUMBER: "DWSA-10 4.0",
-            ssdp.ATTR_UPNP_SERIAL: None,
-            ssdp.ATTR_UPNP_UDN: "uuid:e61de70c-2250-1c22-0080-0005cdf512be",
+            ATTR_UPNP_DEVICE_TYPE: "urn:schemas-denon-com:device:AiosDevice:1",
+            ATTR_UPNP_FRIENDLY_NAME: "Bedroom",
+            ATTR_UPNP_MANUFACTURER: "Denon",
+            ATTR_UPNP_MODEL_NAME: "HEOS Drive",
+            ATTR_UPNP_MODEL_NUMBER: "DWSA-10 4.0",
+            ATTR_UPNP_SERIAL: None,
+            ATTR_UPNP_UDN: "uuid:e61de70c-2250-1c22-0080-0005cdf512be",
         },
     )
 

--- a/tests/components/heos/test_config_flow.py
+++ b/tests/components/heos/test_config_flow.py
@@ -3,12 +3,13 @@
 from pyheos import CommandAuthenticationError, CommandFailedError, HeosError
 import pytest
 
-from homeassistant.components import heos, ssdp
+from homeassistant.components import heos
 from homeassistant.components.heos.const import DOMAIN
 from homeassistant.config_entries import SOURCE_SSDP, SOURCE_USER
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.ssdp import SsdpServiceInfo
 
 from tests.common import MockConfigEntry
 
@@ -86,8 +87,8 @@ async def test_create_entry_when_friendly_name_valid(
 async def test_discovery_shows_create_form(
     hass: HomeAssistant,
     controller,
-    discovery_data: ssdp.SsdpServiceInfo,
-    discovery_data_bedroom: ssdp.SsdpServiceInfo,
+    discovery_data: SsdpServiceInfo,
+    discovery_data_bedroom: SsdpServiceInfo,
 ) -> None:
     """Test discovery shows form to confirm setup."""
 
@@ -112,7 +113,7 @@ async def test_discovery_shows_create_form(
 
 
 async def test_discovery_flow_aborts_already_setup(
-    hass: HomeAssistant, controller, discovery_data: ssdp.SsdpServiceInfo, config_entry
+    hass: HomeAssistant, controller, discovery_data: SsdpServiceInfo, config_entry
 ) -> None:
     """Test discovery flow aborts when entry already setup."""
     config_entry.add_to_hass(hass)

--- a/tests/components/homekit_controller/test_config_flow.py
+++ b/tests/components/homekit_controller/test_config_flow.py
@@ -15,7 +15,6 @@ from bleak.exc import BleakError
 import pytest
 
 from homeassistant import config_entries
-from homeassistant.components import zeroconf
 from homeassistant.components.homekit_controller import config_flow
 from homeassistant.components.homekit_controller.const import KNOWN_DEVICES
 from homeassistant.components.homekit_controller.storage import async_get_entity_storage
@@ -23,6 +22,10 @@ from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.service_info.bluetooth import BluetoothServiceInfo
+from homeassistant.helpers.service_info.zeroconf import (
+    ATTR_PROPERTIES_ID,
+    ZeroconfServiceInfo,
+)
 
 from tests.common import MockConfigEntry
 
@@ -176,9 +179,9 @@ def get_flow_context(
 
 def get_device_discovery_info(
     device, upper_case_props=False, missing_csharp=False, paired=False
-) -> zeroconf.ZeroconfServiceInfo:
+) -> ZeroconfServiceInfo:
     """Turn a aiohomekit format zeroconf entry into a homeassistant one."""
-    result = zeroconf.ZeroconfServiceInfo(
+    result = ZeroconfServiceInfo(
         ip_address=ip_address("127.0.0.1"),
         ip_addresses=[ip_address("127.0.0.1")],
         hostname=device.description.name,
@@ -187,7 +190,7 @@ def get_device_discovery_info(
         properties={
             "md": device.description.model,
             "pv": "1.0",
-            zeroconf.ATTR_PROPERTIES_ID: device.description.id,
+            ATTR_PROPERTIES_ID: device.description.id,
             "c#": device.description.config_num,
             "s#": device.description.state_num,
             "ff": "0",
@@ -330,7 +333,7 @@ async def test_id_missing(hass: HomeAssistant, controller) -> None:
     discovery_info = get_device_discovery_info(device)
 
     # Remove id from device
-    del discovery_info.properties[zeroconf.ATTR_PROPERTIES_ID]
+    del discovery_info.properties[ATTR_PROPERTIES_ID]
 
     # Device is discovered
     result = await hass.config_entries.flow.async_init(
@@ -346,7 +349,7 @@ async def test_discovery_ignored_model(hass: HomeAssistant, controller) -> None:
     """Already paired."""
     device = setup_mock_accessory(controller)
     discovery_info = get_device_discovery_info(device)
-    discovery_info.properties[zeroconf.ATTR_PROPERTIES_ID] = "AA:BB:CC:DD:EE:FF"
+    discovery_info.properties[ATTR_PROPERTIES_ID] = "AA:BB:CC:DD:EE:FF"
     discovery_info.properties["md"] = "HHKBridge1,1"
 
     # Device is discovered
@@ -375,7 +378,7 @@ async def test_discovery_ignored_hk_bridge(
         connections={(dr.CONNECTION_NETWORK_MAC, formatted_mac)},
     )
 
-    discovery_info.properties[zeroconf.ATTR_PROPERTIES_ID] = "AA:BB:CC:DD:EE:FF"
+    discovery_info.properties[ATTR_PROPERTIES_ID] = "AA:BB:CC:DD:EE:FF"
 
     # Device is discovered
     result = await hass.config_entries.flow.async_init(
@@ -403,7 +406,7 @@ async def test_discovery_does_not_ignore_non_homekit(
         connections={(dr.CONNECTION_NETWORK_MAC, formatted_mac)},
     )
 
-    discovery_info.properties[zeroconf.ATTR_PROPERTIES_ID] = "AA:BB:CC:DD:EE:FF"
+    discovery_info.properties[ATTR_PROPERTIES_ID] = "AA:BB:CC:DD:EE:FF"
 
     # Device is discovered
     result = await hass.config_entries.flow.async_init(
@@ -582,7 +585,7 @@ async def test_discovery_already_configured_update_csharp(
     # Set device as already paired
     discovery_info.properties["sf"] = 0x00
     discovery_info.properties["c#"] = 99999
-    discovery_info.properties[zeroconf.ATTR_PROPERTIES_ID] = "AA:BB:CC:DD:EE:FF"
+    discovery_info.properties[ATTR_PROPERTIES_ID] = "AA:BB:CC:DD:EE:FF"
 
     # Device is discovered
     result = await hass.config_entries.flow.async_init(
@@ -967,7 +970,7 @@ async def test_discovery_dismiss_existing_flow_on_paired(
     # Set device as already not paired
     discovery_info.properties["sf"] = 0x01
     discovery_info.properties["c#"] = 99999
-    discovery_info.properties[zeroconf.ATTR_PROPERTIES_ID] = "AA:BB:CC:DD:EE:FF"
+    discovery_info.properties[ATTR_PROPERTIES_ID] = "AA:BB:CC:DD:EE:FF"
 
     # Device is discovered
     result = await hass.config_entries.flow.async_init(
@@ -1201,7 +1204,7 @@ async def test_discovery_updates_ip_when_config_entry_set_up(
 
     # Set device as already paired
     discovery_info.properties["sf"] = 0x00
-    discovery_info.properties[zeroconf.ATTR_PROPERTIES_ID] = "Aa:bB:cC:dD:eE:fF"
+    discovery_info.properties[ATTR_PROPERTIES_ID] = "Aa:bB:cC:dD:eE:fF"
 
     # Device is discovered
     result = await hass.config_entries.flow.async_init(
@@ -1239,7 +1242,7 @@ async def test_discovery_updates_ip_config_entry_not_set_up(
 
     # Set device as already paired
     discovery_info.properties["sf"] = 0x00
-    discovery_info.properties[zeroconf.ATTR_PROPERTIES_ID] = "Aa:bB:cC:dD:eE:fF"
+    discovery_info.properties[ATTR_PROPERTIES_ID] = "Aa:bB:cC:dD:eE:fF"
 
     # Device is discovered
     result = await hass.config_entries.flow.async_init(

--- a/tests/components/homewizard/test_config_flow.py
+++ b/tests/components/homewizard/test_config_flow.py
@@ -8,11 +8,12 @@ import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant import config_entries
-from homeassistant.components import dhcp, zeroconf
 from homeassistant.components.homewizard.const import DOMAIN
 from homeassistant.const import CONF_IP_ADDRESS
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from tests.common import MockConfigEntry
 
@@ -54,7 +55,7 @@ async def test_discovery_flow_works(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("127.0.0.1"),
             ip_addresses=[ip_address("127.0.0.1")],
             port=80,
@@ -100,7 +101,7 @@ async def test_discovery_flow_during_onboarding(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("127.0.0.1"),
             ip_addresses=[ip_address("127.0.0.1")],
             port=80,
@@ -137,7 +138,7 @@ async def test_discovery_flow_during_onboarding_disabled_api(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("127.0.0.1"),
             ip_addresses=[ip_address("127.0.0.1")],
             port=80,
@@ -181,7 +182,7 @@ async def test_discovery_disabled_api(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("127.0.0.1"),
             ip_addresses=[ip_address("127.0.0.1")],
             port=80,
@@ -216,7 +217,7 @@ async def test_discovery_missing_data_in_service_info(hass: HomeAssistant) -> No
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("127.0.0.1"),
             ip_addresses=[ip_address("127.0.0.1")],
             port=80,
@@ -242,7 +243,7 @@ async def test_discovery_invalid_api(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("127.0.0.1"),
             ip_addresses=[ip_address("127.0.0.1")],
             port=80,
@@ -274,7 +275,7 @@ async def test_dhcp_discovery_updates_entry(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_DHCP},
-        data=dhcp.DhcpServiceInfo(
+        data=DhcpServiceInfo(
             ip="1.0.0.127",
             hostname="HW-p1meter-aabbcc",
             macaddress="5c2fafabcdef",
@@ -304,7 +305,7 @@ async def test_dhcp_discovery_updates_entry_fails(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_DHCP},
-        data=dhcp.DhcpServiceInfo(
+        data=DhcpServiceInfo(
             ip="1.0.0.127",
             hostname="HW-p1meter-aabbcc",
             macaddress="5c2fafabcdef",
@@ -326,7 +327,7 @@ async def test_dhcp_discovery_ignores_unknown(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_DHCP},
-        data=dhcp.DhcpServiceInfo(
+        data=DhcpServiceInfo(
             ip="127.0.0.1",
             hostname="HW-p1meter-aabbcc",
             macaddress="5c2fafabcdef",
@@ -350,7 +351,7 @@ async def test_discovery_flow_updates_new_ip(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("1.0.0.127"),
             ip_addresses=[ip_address("1.0.0.127")],
             port=80,

--- a/tests/components/huawei_lte/test_config_flow.py
+++ b/tests/components/huawei_lte/test_config_flow.py
@@ -13,7 +13,6 @@ import requests_mock
 from requests_mock import ANY
 
 from homeassistant import config_entries
-from homeassistant.components import ssdp
 from homeassistant.components.huawei_lte.const import CONF_UNAUTHENTICATED_MODE, DOMAIN
 from homeassistant.const import (
     CONF_NAME,
@@ -25,6 +24,18 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.ssdp import (
+    ATTR_UPNP_DEVICE_TYPE,
+    ATTR_UPNP_FRIENDLY_NAME,
+    ATTR_UPNP_MANUFACTURER,
+    ATTR_UPNP_MANUFACTURER_URL,
+    ATTR_UPNP_MODEL_NAME,
+    ATTR_UPNP_MODEL_NUMBER,
+    ATTR_UPNP_PRESENTATION_URL,
+    ATTR_UPNP_SERIAL,
+    ATTR_UPNP_UDN,
+    SsdpServiceInfo,
+)
 
 from tests.common import MockConfigEntry
 
@@ -267,8 +278,8 @@ async def test_success(hass: HomeAssistant, login_requests_mock, scheme: str) ->
                 "text": "<response><devicename>Mock device</devicename></response>",
             },
             {
-                ssdp.ATTR_UPNP_FRIENDLY_NAME: "Mobile Wi-Fi",
-                ssdp.ATTR_UPNP_SERIAL: "00000000",
+                ATTR_UPNP_FRIENDLY_NAME: "Mobile Wi-Fi",
+                ATTR_UPNP_SERIAL: "00000000",
             },
             {
                 "type": FlowResultType.FORM,
@@ -283,8 +294,8 @@ async def test_success(hass: HomeAssistant, login_requests_mock, scheme: str) ->
                 "text": "<error><code>100002</code><message/></error>",
             },
             {
-                ssdp.ATTR_UPNP_FRIENDLY_NAME: "Mobile Wi-Fi",
-                # No ssdp.ATTR_UPNP_SERIAL
+                ATTR_UPNP_FRIENDLY_NAME: "Mobile Wi-Fi",
+                # No ATTR_UPNP_SERIAL
             },
             {
                 "type": FlowResultType.FORM,
@@ -322,18 +333,18 @@ async def test_ssdp(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context=context,
-        data=ssdp.SsdpServiceInfo(
+        data=SsdpServiceInfo(
             ssdp_usn="mock_usn",
             ssdp_st="upnp:rootdevice",
             ssdp_location=f"{url}:60957/rootDesc.xml",
             upnp={
-                ssdp.ATTR_UPNP_DEVICE_TYPE: "urn:schemas-upnp-org:device:InternetGatewayDevice:1",
-                ssdp.ATTR_UPNP_MANUFACTURER: "Huawei",
-                ssdp.ATTR_UPNP_MANUFACTURER_URL: "http://www.huawei.com/",
-                ssdp.ATTR_UPNP_MODEL_NAME: "Huawei router",
-                ssdp.ATTR_UPNP_MODEL_NUMBER: "12345678",
-                ssdp.ATTR_UPNP_PRESENTATION_URL: url,
-                ssdp.ATTR_UPNP_UDN: "uuid:XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX",
+                ATTR_UPNP_DEVICE_TYPE: "urn:schemas-upnp-org:device:InternetGatewayDevice:1",
+                ATTR_UPNP_MANUFACTURER: "Huawei",
+                ATTR_UPNP_MANUFACTURER_URL: "http://www.huawei.com/",
+                ATTR_UPNP_MODEL_NAME: "Huawei router",
+                ATTR_UPNP_MODEL_NUMBER: "12345678",
+                ATTR_UPNP_PRESENTATION_URL: url,
+                ATTR_UPNP_UDN: "uuid:XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX",
                 **upnp_data,
             },
         ),

--- a/tests/components/hue/test_config_flow.py
+++ b/tests/components/hue/test_config_flow.py
@@ -9,12 +9,15 @@ import pytest
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.components import zeroconf
 from homeassistant.components.hue import config_flow, const
 from homeassistant.components.hue.errors import CannotConnect
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.service_info.zeroconf import (
+    ATTR_PROPERTIES_ID,
+    ZeroconfServiceInfo,
+)
 
 from tests.common import MockConfigEntry
 from tests.test_util.aiohttp import AiohttpClientMocker, ClientError
@@ -424,13 +427,13 @@ async def test_bridge_homekit(
     result = await hass.config_entries.flow.async_init(
         const.DOMAIN,
         context={"source": config_entries.SOURCE_HOMEKIT},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("0.0.0.0"),
             ip_addresses=[ip_address("0.0.0.0")],
             hostname="mock_hostname",
             name="mock_name",
             port=None,
-            properties={zeroconf.ATTR_PROPERTIES_ID: "aa:bb:cc:dd:ee:ff"},
+            properties={ATTR_PROPERTIES_ID: "aa:bb:cc:dd:ee:ff"},
             type="mock_type",
         ),
     )
@@ -474,13 +477,13 @@ async def test_bridge_homekit_already_configured(
     result = await hass.config_entries.flow.async_init(
         const.DOMAIN,
         context={"source": config_entries.SOURCE_HOMEKIT},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("0.0.0.0"),
             ip_addresses=[ip_address("0.0.0.0")],
             hostname="mock_hostname",
             name="mock_name",
             port=None,
-            properties={zeroconf.ATTR_PROPERTIES_ID: "aa:bb:cc:dd:ee:ff"},
+            properties={ATTR_PROPERTIES_ID: "aa:bb:cc:dd:ee:ff"},
             type="mock_type",
         ),
     )
@@ -578,7 +581,7 @@ async def test_bridge_zeroconf(
     result = await hass.config_entries.flow.async_init(
         const.DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("192.168.1.217"),
             ip_addresses=[ip_address("192.168.1.217")],
             port=443,
@@ -614,7 +617,7 @@ async def test_bridge_zeroconf_already_exists(
     result = await hass.config_entries.flow.async_init(
         const.DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("192.168.1.217"),
             ip_addresses=[ip_address("192.168.1.217")],
             port=443,
@@ -639,7 +642,7 @@ async def test_bridge_zeroconf_ipv6(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         const.DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("fd00::eeb5:faff:fe84:b17d"),
             ip_addresses=[ip_address("fd00::eeb5:faff:fe84:b17d")],
             port=443,
@@ -687,7 +690,7 @@ async def test_bridge_connection_failed(
         result = await hass.config_entries.flow.async_init(
             const.DOMAIN,
             context={"source": config_entries.SOURCE_ZEROCONF},
-            data=zeroconf.ZeroconfServiceInfo(
+            data=ZeroconfServiceInfo(
                 ip_address=ip_address("1.2.3.4"),
                 ip_addresses=[ip_address("1.2.3.4")],
                 port=443,
@@ -708,13 +711,13 @@ async def test_bridge_connection_failed(
         result = await hass.config_entries.flow.async_init(
             const.DOMAIN,
             context={"source": config_entries.SOURCE_HOMEKIT},
-            data=zeroconf.ZeroconfServiceInfo(
+            data=ZeroconfServiceInfo(
                 ip_address=ip_address("0.0.0.0"),
                 ip_addresses=[ip_address("0.0.0.0")],
                 hostname="mock_hostname",
                 name="mock_name",
                 port=None,
-                properties={zeroconf.ATTR_PROPERTIES_ID: "aa:bb:cc:dd:ee:ff"},
+                properties={ATTR_PROPERTIES_ID: "aa:bb:cc:dd:ee:ff"},
                 type="mock_type",
             ),
         )

--- a/tests/components/hunterdouglas_powerview/const.py
+++ b/tests/components/hunterdouglas_powerview/const.py
@@ -3,32 +3,36 @@
 from ipaddress import IPv4Address
 
 from homeassistant import config_entries
-from homeassistant.components import dhcp, zeroconf
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
+from homeassistant.helpers.service_info.zeroconf import (
+    ATTR_PROPERTIES_ID,
+    ZeroconfServiceInfo,
+)
 
 MOCK_MAC = "AA::BB::CC::DD::EE::FF"
 MOCK_SERIAL = "A1B2C3D4E5G6H7"
 
-HOMEKIT_DISCOVERY_GEN2 = zeroconf.ZeroconfServiceInfo(
+HOMEKIT_DISCOVERY_GEN2 = ZeroconfServiceInfo(
     ip_address="1.2.3.4",
     ip_addresses=[IPv4Address("1.2.3.4")],
     hostname="mock_hostname",
     name="Powerview Generation 2._hap._tcp.local.",
     port=None,
-    properties={zeroconf.ATTR_PROPERTIES_ID: MOCK_MAC},
+    properties={ATTR_PROPERTIES_ID: MOCK_MAC},
     type="mock_type",
 )
 
-HOMEKIT_DISCOVERY_GEN3 = zeroconf.ZeroconfServiceInfo(
+HOMEKIT_DISCOVERY_GEN3 = ZeroconfServiceInfo(
     ip_address="1.2.3.4",
     ip_addresses=[IPv4Address("1.2.3.4")],
     hostname="mock_hostname",
     name="Powerview Generation 3._hap._tcp.local.",
     port=None,
-    properties={zeroconf.ATTR_PROPERTIES_ID: MOCK_MAC},
+    properties={ATTR_PROPERTIES_ID: MOCK_MAC},
     type="mock_type",
 )
 
-ZEROCONF_DISCOVERY_GEN2 = zeroconf.ZeroconfServiceInfo(
+ZEROCONF_DISCOVERY_GEN2 = ZeroconfServiceInfo(
     ip_address="1.2.3.4",
     ip_addresses=[IPv4Address("1.2.3.4")],
     hostname="mock_hostname",
@@ -38,7 +42,7 @@ ZEROCONF_DISCOVERY_GEN2 = zeroconf.ZeroconfServiceInfo(
     type="mock_type",
 )
 
-ZEROCONF_DISCOVERY_GEN3 = zeroconf.ZeroconfServiceInfo(
+ZEROCONF_DISCOVERY_GEN3 = ZeroconfServiceInfo(
     ip_address="1.2.3.4",
     ip_addresses=[IPv4Address("1.2.3.4")],
     hostname="mock_hostname",
@@ -48,19 +52,19 @@ ZEROCONF_DISCOVERY_GEN3 = zeroconf.ZeroconfServiceInfo(
     type="mock_type",
 )
 
-DHCP_DISCOVERY_GEN2 = dhcp.DhcpServiceInfo(
+DHCP_DISCOVERY_GEN2 = DhcpServiceInfo(
     hostname="Powerview Generation 2",
     ip="1.2.3.4",
     macaddress="aabbccddeeff",
 )
 
-DHCP_DISCOVERY_GEN2_NO_NAME = dhcp.DhcpServiceInfo(
+DHCP_DISCOVERY_GEN2_NO_NAME = DhcpServiceInfo(
     hostname="",
     ip="1.2.3.4",
     macaddress="aabbccddeeff",
 )
 
-DHCP_DISCOVERY_GEN3 = dhcp.DhcpServiceInfo(
+DHCP_DISCOVERY_GEN3 = DhcpServiceInfo(
     hostname="Powerview Generation 3",
     ip="1.2.3.4",
     macaddress="aabbccddeeff",

--- a/tests/components/hunterdouglas_powerview/test_config_flow.py
+++ b/tests/components/hunterdouglas_powerview/test_config_flow.py
@@ -5,12 +5,13 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from homeassistant import config_entries
-from homeassistant.components import dhcp, zeroconf
 from homeassistant.components.hunterdouglas_powerview.const import DOMAIN
 from homeassistant.const import CONF_API_VERSION, CONF_HOST, CONF_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 import homeassistant.helpers.entity_registry as er
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from .const import DHCP_DATA, DISCOVERY_DATA, HOMEKIT_DATA, MOCK_SERIAL
 
@@ -65,7 +66,7 @@ async def test_form_homekit_and_dhcp_cannot_connect(
     hass: HomeAssistant,
     mock_setup_entry: MagicMock,
     source: str,
-    discovery_info: dhcp.DhcpServiceInfo,
+    discovery_info: DhcpServiceInfo,
     api_version: int,
 ) -> None:
     """Test we get the form with homekit and dhcp source."""
@@ -112,7 +113,7 @@ async def test_form_homekit_and_dhcp(
     hass: HomeAssistant,
     mock_setup_entry: MagicMock,
     source: str,
-    discovery_info: dhcp.DhcpServiceInfo | zeroconf.ZeroconfServiceInfo,
+    discovery_info: DhcpServiceInfo | ZeroconfServiceInfo,
     api_version: int,
 ) -> None:
     """Test we get the form with homekit and dhcp source."""
@@ -166,10 +167,10 @@ async def test_discovered_by_homekit_and_dhcp(
     hass: HomeAssistant,
     mock_setup_entry: MagicMock,
     homekit_source: str,
-    homekit_discovery: zeroconf.ZeroconfServiceInfo,
+    homekit_discovery: ZeroconfServiceInfo,
     api_version: int,
     dhcp_source: str,
-    dhcp_discovery: dhcp.DhcpServiceInfo,
+    dhcp_discovery: DhcpServiceInfo,
     dhcp_api_version: int,
 ) -> None:
     """Test we get the form with homekit and abort for dhcp source when we get both."""

--- a/tests/components/hyperion/test_config_flow.py
+++ b/tests/components/hyperion/test_config_flow.py
@@ -10,7 +10,6 @@ from unittest.mock import AsyncMock, Mock, patch
 
 from hyperion import const
 
-from homeassistant.components import ssdp
 from homeassistant.components.hyperion.const import (
     CONF_AUTH_ID,
     CONF_CREATE_TOKEN,
@@ -30,6 +29,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult, FlowResultType
+from homeassistant.helpers.service_info.ssdp import SsdpServiceInfo
 
 from . import (
     TEST_AUTH_REQUIRED_RESP,
@@ -67,7 +67,7 @@ TEST_REQUEST_TOKEN_FAIL = {
     "error": "Token request timeout or denied",
 }
 
-TEST_SSDP_SERVICE_INFO = ssdp.SsdpServiceInfo(
+TEST_SSDP_SERVICE_INFO = SsdpServiceInfo(
     ssdp_st="upnp:rootdevice",
     ssdp_location=f"http://{TEST_HOST}:{TEST_PORT_UI}/description.xml",
     ssdp_usn=f"uuid:{TEST_SYSINFO_ID}",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As follow-up to #135653 / #135658 / #135661 / #135663

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
