### PR TITLE
Use new ServiceInfo location in component tests (part 4)

### DIFF
--- a/tests/components/airzone/test_config_flow.py
+++ b/tests/components/airzone/test_config_flow.py
@@ -12,7 +12,6 @@ from aioairzone.exceptions import (
 )
 
 from homeassistant import config_entries
-from homeassistant.components import dhcp
 from homeassistant.components.airzone.config_flow import short_mac
 from homeassistant.components.airzone.const import DOMAIN
 from homeassistant.config_entries import SOURCE_USER, ConfigEntryState
@@ -20,6 +19,7 @@ from homeassistant.const import CONF_HOST, CONF_ID, CONF_PORT
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
 from .util import (
     CONFIG,
@@ -32,7 +32,7 @@ from .util import (
 
 from tests.common import MockConfigEntry
 
-DHCP_SERVICE_INFO = dhcp.DhcpServiceInfo(
+DHCP_SERVICE_INFO = DhcpServiceInfo(
     hostname="airzone",
     ip="192.168.1.100",
     macaddress=dr.format_mac("E84F25000000").replace(":", ""),

--- a/tests/components/androidtv_remote/test_config_flow.py
+++ b/tests/components/androidtv_remote/test_config_flow.py
@@ -6,7 +6,6 @@ from unittest.mock import AsyncMock, MagicMock
 from androidtvremote2 import CannotConnect, ConnectionClosed, InvalidAuth
 
 from homeassistant import config_entries
-from homeassistant.components import zeroconf
 from homeassistant.components.androidtv_remote.config_flow import (
     APPS_NEW_ID,
     CONF_APP_DELETE,
@@ -22,6 +21,7 @@ from homeassistant.components.androidtv_remote.const import (
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from tests.common import MockConfigEntry
 
@@ -444,7 +444,7 @@ async def test_zeroconf_flow_success(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address(host),
             ip_addresses=[ip_address(host)],
             port=6466,
@@ -522,7 +522,7 @@ async def test_zeroconf_flow_cannot_connect(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address(host),
             ip_addresses=[ip_address(host)],
             port=6466,
@@ -573,7 +573,7 @@ async def test_zeroconf_flow_pairing_invalid_auth(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address(host),
             ip_addresses=[ip_address(host)],
             port=6466,
@@ -657,7 +657,7 @@ async def test_zeroconf_flow_already_configured_host_changed_reloads_entry(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address(host),
             ip_addresses=[ip_address(host)],
             port=6466,
@@ -710,7 +710,7 @@ async def test_zeroconf_flow_already_configured_host_not_changed_no_reload_entry
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address(host),
             ip_addresses=[ip_address(host)],
             port=6466,
@@ -743,7 +743,7 @@ async def test_zeroconf_flow_abort_if_mac_is_missing(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address(host),
             ip_addresses=[ip_address(host)],
             port=6466,
@@ -787,7 +787,7 @@ async def test_zeroconf_flow_already_configured_zeroconf_has_multiple_invalid_ip
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("1.2.3.5"),
             ip_addresses=[ip_address("1.2.3.5"), ip_address(host)],
             port=6466,

--- a/tests/components/apple_tv/test_config_flow.py
+++ b/tests/components/apple_tv/test_config_flow.py
@@ -9,7 +9,6 @@ from pyatv.const import PairingRequirement, Protocol
 import pytest
 
 from homeassistant import config_entries
-from homeassistant.components import zeroconf
 from homeassistant.components.apple_tv import CONF_ADDRESS, config_flow
 from homeassistant.components.apple_tv.const import (
     CONF_IDENTIFIERS,
@@ -19,12 +18,13 @@ from homeassistant.components.apple_tv.const import (
 from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from .common import airplay_service, create_conf, mrp_service, raop_service
 
 from tests.common import MockConfigEntry
 
-DMAP_SERVICE = zeroconf.ZeroconfServiceInfo(
+DMAP_SERVICE = ZeroconfServiceInfo(
     ip_address=ip_address("127.0.0.1"),
     ip_addresses=[ip_address("127.0.0.1")],
     hostname="mock_hostname",
@@ -35,7 +35,7 @@ DMAP_SERVICE = zeroconf.ZeroconfServiceInfo(
 )
 
 
-RAOP_SERVICE = zeroconf.ZeroconfServiceInfo(
+RAOP_SERVICE = ZeroconfServiceInfo(
     ip_address=ip_address("127.0.0.1"),
     ip_addresses=[ip_address("127.0.0.1")],
     hostname="mock_hostname",
@@ -566,7 +566,7 @@ async def test_zeroconf_unsupported_service_aborts(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("127.0.0.1"),
             ip_addresses=[ip_address("127.0.0.1")],
             hostname="mock_hostname",
@@ -586,7 +586,7 @@ async def test_zeroconf_add_mrp_device(hass: HomeAssistant) -> None:
     unrelated_result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("127.0.0.2"),
             ip_addresses=[ip_address("127.0.0.2")],
             hostname="mock_hostname",
@@ -601,7 +601,7 @@ async def test_zeroconf_add_mrp_device(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("127.0.0.1"),
             ip_addresses=[ip_address("127.0.0.1")],
             hostname="mock_hostname",
@@ -883,7 +883,7 @@ async def test_zeroconf_abort_if_other_in_progress(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("127.0.0.1"),
             ip_addresses=[ip_address("127.0.0.1")],
             hostname="mock_hostname",
@@ -906,7 +906,7 @@ async def test_zeroconf_abort_if_other_in_progress(
     result2 = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("127.0.0.1"),
             ip_addresses=[ip_address("127.0.0.1")],
             hostname="mock_hostname",
@@ -933,7 +933,7 @@ async def test_zeroconf_missing_device_during_protocol_resolve(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("127.0.0.1"),
             ip_addresses=[ip_address("127.0.0.1")],
             hostname="mock_hostname",
@@ -955,7 +955,7 @@ async def test_zeroconf_missing_device_during_protocol_resolve(
     await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("127.0.0.1"),
             ip_addresses=[ip_address("127.0.0.1")],
             hostname="mock_hostname",
@@ -992,7 +992,7 @@ async def test_zeroconf_additional_protocol_resolve_failure(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("127.0.0.1"),
             ip_addresses=[ip_address("127.0.0.1")],
             hostname="mock_hostname",
@@ -1014,7 +1014,7 @@ async def test_zeroconf_additional_protocol_resolve_failure(
     await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("127.0.0.1"),
             ip_addresses=[ip_address("127.0.0.1")],
             hostname="mock_hostname",
@@ -1053,7 +1053,7 @@ async def test_zeroconf_pair_additionally_found_protocols(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("127.0.0.1"),
             ip_addresses=[ip_address("127.0.0.1")],
             hostname="mock_hostname",
@@ -1096,7 +1096,7 @@ async def test_zeroconf_pair_additionally_found_protocols(
     await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("127.0.0.1"),
             ip_addresses=[ip_address("127.0.0.1")],
             hostname="mock_hostname",
@@ -1158,7 +1158,7 @@ async def test_zeroconf_mismatch(hass: HomeAssistant, mock_scan: AsyncMock) -> N
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("127.0.0.1"),
             ip_addresses=[ip_address("127.0.0.1")],
             hostname="mock_hostname",
@@ -1242,7 +1242,7 @@ async def test_zeroconf_rejects_ipv6(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("fd00::b27c:63bb:cc85:4ea0"),
             ip_addresses=[ip_address("fd00::b27c:63bb:cc85:4ea0")],
             hostname="mock_hostname",

--- a/tests/components/arcam_fmj/test_config_flow.py
+++ b/tests/components/arcam_fmj/test_config_flow.py
@@ -7,12 +7,21 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from arcam.fmj.client import ConnectionFailed
 import pytest
 
-from homeassistant.components import ssdp
 from homeassistant.components.arcam_fmj.const import DOMAIN
 from homeassistant.config_entries import SOURCE_SSDP, SOURCE_USER
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_SOURCE
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.ssdp import (
+    ATTR_UPNP_DEVICE_TYPE,
+    ATTR_UPNP_FRIENDLY_NAME,
+    ATTR_UPNP_MANUFACTURER,
+    ATTR_UPNP_MODEL_NAME,
+    ATTR_UPNP_MODEL_NUMBER,
+    ATTR_UPNP_SERIAL,
+    ATTR_UPNP_UDN,
+    SsdpServiceInfo,
+)
 
 from .conftest import (
     MOCK_CONFIG_ENTRY,
@@ -36,18 +45,18 @@ MOCK_UPNP_DEVICE = f"""
 
 MOCK_UPNP_LOCATION = f"http://{MOCK_HOST}:8080/dd.xml"
 
-MOCK_DISCOVER = ssdp.SsdpServiceInfo(
+MOCK_DISCOVER = SsdpServiceInfo(
     ssdp_usn="mock_usn",
     ssdp_st="mock_st",
     ssdp_location=f"http://{MOCK_HOST}:8080/dd.xml",
     upnp={
-        ssdp.ATTR_UPNP_MANUFACTURER: "ARCAM",
-        ssdp.ATTR_UPNP_MODEL_NAME: " ",
-        ssdp.ATTR_UPNP_MODEL_NUMBER: "AVR450, AVR750",
-        ssdp.ATTR_UPNP_FRIENDLY_NAME: f"Arcam media client {MOCK_UUID}",
-        ssdp.ATTR_UPNP_SERIAL: "12343",
-        ssdp.ATTR_UPNP_UDN: MOCK_UDN,
-        ssdp.ATTR_UPNP_DEVICE_TYPE: "urn:schemas-upnp-org:device:MediaRenderer:1",
+        ATTR_UPNP_MANUFACTURER: "ARCAM",
+        ATTR_UPNP_MODEL_NAME: " ",
+        ATTR_UPNP_MODEL_NUMBER: "AVR450, AVR750",
+        ATTR_UPNP_FRIENDLY_NAME: f"Arcam media client {MOCK_UUID}",
+        ATTR_UPNP_SERIAL: "12343",
+        ATTR_UPNP_UDN: MOCK_UDN,
+        ATTR_UPNP_DEVICE_TYPE: "urn:schemas-upnp-org:device:MediaRenderer:1",
     },
 )
 
@@ -115,7 +124,7 @@ async def test_ssdp_unable_to_connect(
 async def test_ssdp_invalid_id(hass: HomeAssistant) -> None:
     """Test a ssdp with invalid  UDN."""
     discover = replace(
-        MOCK_DISCOVER, upnp=MOCK_DISCOVER.upnp | {ssdp.ATTR_UPNP_UDN: "invalid"}
+        MOCK_DISCOVER, upnp=MOCK_DISCOVER.upnp | {ATTR_UPNP_UDN: "invalid"}
     )
 
     result = await hass.config_entries.flow.async_init(

--- a/tests/components/awair/const.py
+++ b/tests/components/awair/const.py
@@ -2,15 +2,15 @@
 
 from ipaddress import ip_address
 
-from homeassistant.components import zeroconf
 from homeassistant.const import CONF_ACCESS_TOKEN, CONF_HOST
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 AWAIR_UUID = "awair_24947"
 CLOUD_CONFIG = {CONF_ACCESS_TOKEN: "12345"}
 LOCAL_CONFIG = {CONF_HOST: "192.0.2.5"}
 CLOUD_UNIQUE_ID = "foo@bar.com"
 LOCAL_UNIQUE_ID = "00:B0:D0:63:C2:26"
-ZEROCONF_DISCOVERY = zeroconf.ZeroconfServiceInfo(
+ZEROCONF_DISCOVERY = ZeroconfServiceInfo(
     ip_address=ip_address("192.0.2.5"),
     ip_addresses=[ip_address("192.0.2.5")],
     hostname="mock_hostname",

--- a/tests/components/axis/test_config_flow.py
+++ b/tests/components/axis/test_config_flow.py
@@ -6,7 +6,6 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant.components import dhcp, ssdp, zeroconf
 from homeassistant.components.axis import config_flow
 from homeassistant.components.axis.const import (
     CONF_STREAM_PROFILE,
@@ -33,6 +32,9 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import BaseServiceInfo, FlowResultType
 from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
+from homeassistant.helpers.service_info.ssdp import SsdpServiceInfo
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from .const import DEFAULT_HOST, MAC, MODEL, NAME
 
@@ -268,7 +270,7 @@ async def test_reconfiguration_flow_update_configuration(
     [
         (
             SOURCE_DHCP,
-            dhcp.DhcpServiceInfo(
+            DhcpServiceInfo(
                 hostname=f"axis-{MAC}",
                 ip=DEFAULT_HOST,
                 macaddress=DHCP_FORMATTED_MAC,
@@ -276,7 +278,7 @@ async def test_reconfiguration_flow_update_configuration(
         ),
         (
             SOURCE_SSDP,
-            ssdp.SsdpServiceInfo(
+            SsdpServiceInfo(
                 ssdp_usn="mock_usn",
                 ssdp_st="mock_st",
                 upnp={
@@ -312,7 +314,7 @@ async def test_reconfiguration_flow_update_configuration(
         ),
         (
             SOURCE_ZEROCONF,
-            zeroconf.ZeroconfServiceInfo(
+            ZeroconfServiceInfo(
                 ip_address=ip_address(DEFAULT_HOST),
                 ip_addresses=[ip_address(DEFAULT_HOST)],
                 port=80,
@@ -376,7 +378,7 @@ async def test_discovery_flow(
     [
         (
             SOURCE_DHCP,
-            dhcp.DhcpServiceInfo(
+            DhcpServiceInfo(
                 hostname=f"axis-{MAC}",
                 ip=DEFAULT_HOST,
                 macaddress=DHCP_FORMATTED_MAC,
@@ -384,7 +386,7 @@ async def test_discovery_flow(
         ),
         (
             SOURCE_SSDP,
-            ssdp.SsdpServiceInfo(
+            SsdpServiceInfo(
                 ssdp_usn="mock_usn",
                 ssdp_st="mock_st",
                 upnp={
@@ -396,7 +398,7 @@ async def test_discovery_flow(
         ),
         (
             SOURCE_ZEROCONF,
-            zeroconf.ZeroconfServiceInfo(
+            ZeroconfServiceInfo(
                 ip_address=ip_address(DEFAULT_HOST),
                 ip_addresses=[ip_address(DEFAULT_HOST)],
                 hostname="mock_hostname",
@@ -431,7 +433,7 @@ async def test_discovered_device_already_configured(
     [
         (
             SOURCE_DHCP,
-            dhcp.DhcpServiceInfo(
+            DhcpServiceInfo(
                 hostname=f"axis-{MAC}",
                 ip="2.3.4.5",
                 macaddress=DHCP_FORMATTED_MAC,
@@ -440,7 +442,7 @@ async def test_discovered_device_already_configured(
         ),
         (
             SOURCE_SSDP,
-            ssdp.SsdpServiceInfo(
+            SsdpServiceInfo(
                 ssdp_usn="mock_usn",
                 ssdp_st="mock_st",
                 upnp={
@@ -453,7 +455,7 @@ async def test_discovered_device_already_configured(
         ),
         (
             SOURCE_ZEROCONF,
-            zeroconf.ZeroconfServiceInfo(
+            ZeroconfServiceInfo(
                 ip_address=ip_address("2.3.4.5"),
                 ip_addresses=[ip_address("2.3.4.5")],
                 hostname="mock_hostname",
@@ -507,7 +509,7 @@ async def test_discovery_flow_updated_configuration(
     [
         (
             SOURCE_DHCP,
-            dhcp.DhcpServiceInfo(
+            DhcpServiceInfo(
                 hostname="",
                 ip="",
                 macaddress=dr.format_mac("01234567890").replace(":", ""),
@@ -515,7 +517,7 @@ async def test_discovery_flow_updated_configuration(
         ),
         (
             SOURCE_SSDP,
-            ssdp.SsdpServiceInfo(
+            SsdpServiceInfo(
                 ssdp_usn="mock_usn",
                 ssdp_st="mock_st",
                 upnp={
@@ -527,7 +529,7 @@ async def test_discovery_flow_updated_configuration(
         ),
         (
             SOURCE_ZEROCONF,
-            zeroconf.ZeroconfServiceInfo(
+            ZeroconfServiceInfo(
                 ip_address=None,
                 ip_addresses=[],
                 hostname="mock_hostname",
@@ -556,7 +558,7 @@ async def test_discovery_flow_ignore_non_axis_device(
     [
         (
             SOURCE_DHCP,
-            dhcp.DhcpServiceInfo(
+            DhcpServiceInfo(
                 hostname=f"axis-{MAC}",
                 ip="169.254.3.4",
                 macaddress=DHCP_FORMATTED_MAC,
@@ -564,7 +566,7 @@ async def test_discovery_flow_ignore_non_axis_device(
         ),
         (
             SOURCE_SSDP,
-            ssdp.SsdpServiceInfo(
+            SsdpServiceInfo(
                 ssdp_usn="mock_usn",
                 ssdp_st="mock_st",
                 upnp={
@@ -576,7 +578,7 @@ async def test_discovery_flow_ignore_non_axis_device(
         ),
         (
             SOURCE_ZEROCONF,
-            zeroconf.ZeroconfServiceInfo(
+            ZeroconfServiceInfo(
                 ip_address=ip_address("169.254.3.4"),
                 ip_addresses=[ip_address("169.254.3.4")],
                 hostname="mock_hostname",

--- a/tests/components/axis/test_hub.py
+++ b/tests/components/axis/test_hub.py
@@ -11,13 +11,14 @@ import axis as axislib
 import pytest
 from syrupy import SnapshotAssertion
 
-from homeassistant.components import axis, zeroconf
+from homeassistant.components import axis
 from homeassistant.components.axis.const import DOMAIN as AXIS_DOMAIN
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
 from homeassistant.config_entries import SOURCE_ZEROCONF, ConfigEntryState
 from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from .conftest import RtspEventMock, RtspStateType
 from .const import (
@@ -93,7 +94,7 @@ async def test_update_address(
     mock_requests("2.3.4.5")
     await hass.config_entries.flow.async_init(
         AXIS_DOMAIN,
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("2.3.4.5"),
             ip_addresses=[ip_address("2.3.4.5")],
             hostname="mock_hostname",

--- a/tests/components/baf/test_config_flow.py
+++ b/tests/components/baf/test_config_flow.py
@@ -4,11 +4,11 @@ from ipaddress import ip_address
 from unittest.mock import patch
 
 from homeassistant import config_entries
-from homeassistant.components import zeroconf
 from homeassistant.components.baf.const import DOMAIN
 from homeassistant.const import CONF_IP_ADDRESS
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from . import MOCK_NAME, MOCK_UUID, MockBAFDevice
 
@@ -90,7 +90,7 @@ async def test_zeroconf_discovery(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("127.0.0.1"),
             ip_addresses=[ip_address("127.0.0.1")],
             hostname="mock_hostname",
@@ -128,7 +128,7 @@ async def test_zeroconf_updates_existing_ip(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("127.0.0.1"),
             ip_addresses=[ip_address("127.0.0.1")],
             hostname="mock_hostname",
@@ -148,7 +148,7 @@ async def test_zeroconf_rejects_ipv6(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("fd00::b27c:63bb:cc85:4ea0"),
             ip_addresses=[ip_address("fd00::b27c:63bb:cc85:4ea0")],
             hostname="mock_hostname",
@@ -167,7 +167,7 @@ async def test_user_flow_is_not_blocked_by_discovery(hass: HomeAssistant) -> Non
     discovery_result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("127.0.0.1"),
             ip_addresses=[ip_address("127.0.0.1")],
             hostname="mock_hostname",

--- a/tests/components/blebox/test_config_flow.py
+++ b/tests/components/blebox/test_config_flow.py
@@ -7,12 +7,12 @@ import blebox_uniapi
 import pytest
 
 from homeassistant import config_entries
-from homeassistant.components import zeroconf
 from homeassistant.components.blebox import config_flow
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_IP_ADDRESS
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 from homeassistant.setup import async_setup_component
 
 from .conftest import mock_config, mock_feature, mock_only_feature, setup_product_mock
@@ -227,7 +227,7 @@ async def test_flow_with_zeroconf(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         config_flow.DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("172.100.123.4"),
             ip_addresses=[ip_address("172.100.123.4")],
             port=80,
@@ -267,7 +267,7 @@ async def test_flow_with_zeroconf_when_already_configured(hass: HomeAssistant) -
         result2 = await hass.config_entries.flow.async_init(
             config_flow.DOMAIN,
             context={"source": config_entries.SOURCE_ZEROCONF},
-            data=zeroconf.ZeroconfServiceInfo(
+            data=ZeroconfServiceInfo(
                 ip_address=ip_address("172.100.123.4"),
                 ip_addresses=[ip_address("172.100.123.4")],
                 port=80,
@@ -291,7 +291,7 @@ async def test_flow_with_zeroconf_when_device_unsupported(hass: HomeAssistant) -
         result = await hass.config_entries.flow.async_init(
             config_flow.DOMAIN,
             context={"source": config_entries.SOURCE_ZEROCONF},
-            data=zeroconf.ZeroconfServiceInfo(
+            data=ZeroconfServiceInfo(
                 ip_address=ip_address("172.100.123.4"),
                 ip_addresses=[ip_address("172.100.123.4")],
                 port=80,
@@ -317,7 +317,7 @@ async def test_flow_with_zeroconf_when_device_response_unsupported(
         result = await hass.config_entries.flow.async_init(
             config_flow.DOMAIN,
             context={"source": config_entries.SOURCE_ZEROCONF},
-            data=zeroconf.ZeroconfServiceInfo(
+            data=ZeroconfServiceInfo(
                 ip_address=ip_address("172.100.123.4"),
                 ip_addresses=[ip_address("172.100.123.4")],
                 port=80,

--- a/tests/components/bond/test_config_flow.py
+++ b/tests/components/bond/test_config_flow.py
@@ -10,12 +10,12 @@ from unittest.mock import MagicMock, Mock, patch
 from aiohttp import ClientConnectionError, ClientResponseError
 
 from homeassistant import config_entries
-from homeassistant.components import zeroconf
 from homeassistant.components.bond.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_ACCESS_TOKEN, CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from .common import (
     patch_bond_bridge,
@@ -219,7 +219,7 @@ async def test_zeroconf_form(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_ZEROCONF},
-            data=zeroconf.ZeroconfServiceInfo(
+            data=ZeroconfServiceInfo(
                 ip_address=ip_address("127.0.0.1"),
                 ip_addresses=[ip_address("127.0.0.1")],
                 hostname="mock_hostname",
@@ -260,7 +260,7 @@ async def test_zeroconf_form_token_unavailable(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_ZEROCONF},
-            data=zeroconf.ZeroconfServiceInfo(
+            data=ZeroconfServiceInfo(
                 ip_address=ip_address("127.0.0.1"),
                 ip_addresses=[ip_address("127.0.0.1")],
                 hostname="mock_hostname",
@@ -302,7 +302,7 @@ async def test_zeroconf_form_token_times_out(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_ZEROCONF},
-            data=zeroconf.ZeroconfServiceInfo(
+            data=ZeroconfServiceInfo(
                 ip_address=ip_address("127.0.0.1"),
                 ip_addresses=[ip_address("127.0.0.1")],
                 hostname="mock_hostname",
@@ -349,7 +349,7 @@ async def test_zeroconf_form_with_token_available(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_ZEROCONF},
-            data=zeroconf.ZeroconfServiceInfo(
+            data=ZeroconfServiceInfo(
                 ip_address=ip_address("127.0.0.1"),
                 ip_addresses=[ip_address("127.0.0.1")],
                 hostname="mock_hostname",
@@ -393,7 +393,7 @@ async def test_zeroconf_form_with_token_available_name_unavailable(
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_ZEROCONF},
-            data=zeroconf.ZeroconfServiceInfo(
+            data=ZeroconfServiceInfo(
                 ip_address=ip_address("127.0.0.1"),
                 ip_addresses=[ip_address("127.0.0.1")],
                 hostname="mock_hostname",
@@ -437,7 +437,7 @@ async def test_zeroconf_already_configured(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_ZEROCONF},
-            data=zeroconf.ZeroconfServiceInfo(
+            data=ZeroconfServiceInfo(
                 ip_address=ip_address("127.0.0.2"),
                 ip_addresses=[ip_address("127.0.0.2")],
                 hostname="mock_hostname",
@@ -475,7 +475,7 @@ async def test_zeroconf_in_setup_retry_state(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_ZEROCONF},
-            data=zeroconf.ZeroconfServiceInfo(
+            data=ZeroconfServiceInfo(
                 ip_address=ip_address("127.0.0.2"),
                 ip_addresses=[ip_address("127.0.0.2")],
                 hostname="mock_hostname",
@@ -522,7 +522,7 @@ async def test_zeroconf_already_configured_refresh_token(hass: HomeAssistant) ->
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_ZEROCONF},
-            data=zeroconf.ZeroconfServiceInfo(
+            data=ZeroconfServiceInfo(
                 ip_address=ip_address("127.0.0.2"),
                 ip_addresses=[ip_address("127.0.0.2")],
                 hostname="mock_hostname",
@@ -561,7 +561,7 @@ async def test_zeroconf_already_configured_no_reload_same_host(
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_ZEROCONF},
-            data=zeroconf.ZeroconfServiceInfo(
+            data=ZeroconfServiceInfo(
                 ip_address=ip_address("127.0.0.3"),
                 ip_addresses=[ip_address("127.0.0.3")],
                 hostname="mock_hostname",
@@ -583,7 +583,7 @@ async def test_zeroconf_form_unexpected_error(hass: HomeAssistant) -> None:
     await _help_test_form_unexpected_error(
         hass,
         source=config_entries.SOURCE_ZEROCONF,
-        initial_input=zeroconf.ZeroconfServiceInfo(
+        initial_input=ZeroconfServiceInfo(
             ip_address=ip_address("127.0.0.1"),
             ip_addresses=[ip_address("127.0.0.1")],
             hostname="mock_hostname",

--- a/tests/components/bosch_shc/test_config_flow.py
+++ b/tests/components/bosch_shc/test_config_flow.py
@@ -13,11 +13,11 @@ from boschshcpy.information import SHCInformation
 import pytest
 
 from homeassistant import config_entries
-from homeassistant.components import zeroconf
 from homeassistant.components.bosch_shc.config_flow import write_tls_asset
 from homeassistant.components.bosch_shc.const import CONF_SHC_CERT, CONF_SHC_KEY, DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from tests.common import MockConfigEntry
 
@@ -25,7 +25,7 @@ MOCK_SETTINGS = {
     "name": "Test name",
     "device": {"mac": "test-mac", "hostname": "test-host"},
 }
-DISCOVERY_INFO = zeroconf.ZeroconfServiceInfo(
+DISCOVERY_INFO = ZeroconfServiceInfo(
     ip_address=ip_address("1.1.1.1"),
     ip_addresses=[ip_address("1.1.1.1")],
     hostname="shc012345.local.",
@@ -615,7 +615,7 @@ async def test_zeroconf_not_bosch_shc(hass: HomeAssistant) -> None:
     """Test we filter out non-bosch_shc devices."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("1.1.1.1"),
             ip_addresses=[ip_address("1.1.1.1")],
             hostname="mock_hostname",

--- a/tests/components/braviatv/test_config_flow.py
+++ b/tests/components/braviatv/test_config_flow.py
@@ -10,7 +10,6 @@ from pybravia import (
 )
 import pytest
 
-from homeassistant.components import ssdp
 from homeassistant.components.braviatv.const import (
     CONF_NICKNAME,
     CONF_USE_PSK,
@@ -22,6 +21,12 @@ from homeassistant.const import CONF_CLIENT_ID, CONF_HOST, CONF_MAC, CONF_PIN
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers import instance_id
+from homeassistant.helpers.service_info.ssdp import (
+    ATTR_UPNP_FRIENDLY_NAME,
+    ATTR_UPNP_MODEL_NAME,
+    ATTR_UPNP_UDN,
+    SsdpServiceInfo,
+)
 
 from tests.common import MockConfigEntry
 
@@ -46,14 +51,14 @@ BRAVIA_SOURCES = [
     {"title": "AV/Component", "uri": "extInput:component?port=1"},
 ]
 
-BRAVIA_SSDP = ssdp.SsdpServiceInfo(
+BRAVIA_SSDP = SsdpServiceInfo(
     ssdp_usn="mock_usn",
     ssdp_st="mock_st",
     ssdp_location="http://bravia-host:52323/dmr.xml",
     upnp={
-        ssdp.ATTR_UPNP_UDN: "uuid:1234",
-        ssdp.ATTR_UPNP_FRIENDLY_NAME: "Living TV",
-        ssdp.ATTR_UPNP_MODEL_NAME: "KE-55XH9096",
+        ATTR_UPNP_UDN: "uuid:1234",
+        ATTR_UPNP_FRIENDLY_NAME: "Living TV",
+        ATTR_UPNP_MODEL_NAME: "KE-55XH9096",
         "X_ScalarWebAPI_DeviceInfo": {
             "X_ScalarWebAPI_ServiceList": {
                 "X_ScalarWebAPI_ServiceType": [
@@ -68,14 +73,14 @@ BRAVIA_SSDP = ssdp.SsdpServiceInfo(
     },
 )
 
-FAKE_BRAVIA_SSDP = ssdp.SsdpServiceInfo(
+FAKE_BRAVIA_SSDP = SsdpServiceInfo(
     ssdp_usn="mock_usn",
     ssdp_st="mock_st",
     ssdp_location="http://soundbar-host:52323/dmr.xml",
     upnp={
-        ssdp.ATTR_UPNP_UDN: "uuid:1234",
-        ssdp.ATTR_UPNP_FRIENDLY_NAME: "Sony Audio Device",
-        ssdp.ATTR_UPNP_MODEL_NAME: "HT-S700RF",
+        ATTR_UPNP_UDN: "uuid:1234",
+        ATTR_UPNP_FRIENDLY_NAME: "Sony Audio Device",
+        ATTR_UPNP_MODEL_NAME: "HT-S700RF",
         "X_ScalarWebAPI_DeviceInfo": {
             "X_ScalarWebAPI_ServiceList": {
                 "X_ScalarWebAPI_ServiceType": ["guide", "system", "audio", "avContent"],

--- a/tests/components/broadlink/test_config_flow.py
+++ b/tests/components/broadlink/test_config_flow.py
@@ -8,10 +8,10 @@ import broadlink.exceptions as blke
 import pytest
 
 from homeassistant import config_entries
-from homeassistant.components import dhcp
 from homeassistant.components.broadlink.const import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
 from . import get_device
 
@@ -828,7 +828,7 @@ async def test_dhcp_can_finish(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_DHCP},
-            data=dhcp.DhcpServiceInfo(
+            data=DhcpServiceInfo(
                 hostname="broadlink",
                 ip="1.2.3.4",
                 macaddress=device.mac,
@@ -862,7 +862,7 @@ async def test_dhcp_fails_to_connect(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_DHCP},
-            data=dhcp.DhcpServiceInfo(
+            data=DhcpServiceInfo(
                 hostname="broadlink",
                 ip="1.2.3.4",
                 macaddress="34ea34b43b5a",
@@ -881,7 +881,7 @@ async def test_dhcp_unreachable(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_DHCP},
-            data=dhcp.DhcpServiceInfo(
+            data=DhcpServiceInfo(
                 hostname="broadlink",
                 ip="1.2.3.4",
                 macaddress="34ea34b43b5a",
@@ -900,7 +900,7 @@ async def test_dhcp_connect_unknown_error(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_DHCP},
-            data=dhcp.DhcpServiceInfo(
+            data=DhcpServiceInfo(
                 hostname="broadlink",
                 ip="1.2.3.4",
                 macaddress="34ea34b43b5a",
@@ -922,7 +922,7 @@ async def test_dhcp_device_not_supported(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_DHCP},
-            data=dhcp.DhcpServiceInfo(
+            data=DhcpServiceInfo(
                 hostname="broadlink",
                 ip=device.host,
                 macaddress=device.mac,
@@ -946,7 +946,7 @@ async def test_dhcp_already_exists(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_DHCP},
-            data=dhcp.DhcpServiceInfo(
+            data=DhcpServiceInfo(
                 hostname="broadlink",
                 ip="1.2.3.4",
                 macaddress="34ea34b43b5a",
@@ -971,7 +971,7 @@ async def test_dhcp_updates_host(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_DHCP},
-            data=dhcp.DhcpServiceInfo(
+            data=DhcpServiceInfo(
                 hostname="broadlink",
                 ip="4.5.6.7",
                 macaddress="34ea34b43b5a",

--- a/tests/components/brother/test_config_flow.py
+++ b/tests/components/brother/test_config_flow.py
@@ -6,12 +6,12 @@ from unittest.mock import AsyncMock, patch
 from brother import SnmpError, UnsupportedModelError
 import pytest
 
-from homeassistant.components import zeroconf
 from homeassistant.components.brother.const import DOMAIN
 from homeassistant.config_entries import SOURCE_USER, SOURCE_ZEROCONF
 from homeassistant.const import CONF_HOST, CONF_TYPE
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from . import init_integration
 
@@ -121,7 +121,7 @@ async def test_zeroconf_exception(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("127.0.0.1"),
             ip_addresses=[ip_address("127.0.0.1")],
             hostname="example.local.",
@@ -145,7 +145,7 @@ async def test_zeroconf_unsupported_model(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": SOURCE_ZEROCONF},
-            data=zeroconf.ZeroconfServiceInfo(
+            data=ZeroconfServiceInfo(
                 ip_address=ip_address("127.0.0.1"),
                 ip_addresses=[ip_address("127.0.0.1")],
                 hostname="example.local.",
@@ -171,7 +171,7 @@ async def test_zeroconf_device_exists_abort(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("127.0.0.1"),
             ip_addresses=[ip_address("127.0.0.1")],
             hostname="example.local.",
@@ -200,7 +200,7 @@ async def test_zeroconf_no_probe_existing_device(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": SOURCE_ZEROCONF},
-            data=zeroconf.ZeroconfServiceInfo(
+            data=ZeroconfServiceInfo(
                 ip_address=ip_address("127.0.0.1"),
                 ip_addresses=[ip_address("127.0.0.1")],
                 hostname="example.local.",
@@ -224,7 +224,7 @@ async def test_zeroconf_confirm_create_entry(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
-        data=zeroconf.ZeroconfServiceInfo(
+        data=ZeroconfServiceInfo(
             ip_address=ip_address("127.0.0.1"),
             ip_addresses=[ip_address("127.0.0.1")],
             hostname="example.local.",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As follow-up to #135653 / #135658 / #135661 / #135663

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
