### PR TITLE
Add scheduled envoy firmware checks to enphase_envoy coordinator

### DIFF
--- a/homeassistant/components/enphase_envoy/__init__.py
+++ b/homeassistant/components/enphase_envoy/__init__.py
@@ -79,6 +79,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: EnphaseConfigEntry) -> 
     """Unload a config entry."""
     coordinator = entry.runtime_data
     coordinator.async_cancel_token_refresh()
+    coordinator.async_cancel_firmware_refresh()
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
 

--- a/homeassistant/components/enphase_envoy/coordinator.py
+++ b/homeassistant/components/enphase_envoy/coordinator.py
@@ -25,6 +25,7 @@ SCAN_INTERVAL = timedelta(seconds=60)
 TOKEN_REFRESH_CHECK_INTERVAL = timedelta(days=1)
 STALE_TOKEN_THRESHOLD = timedelta(days=30).total_seconds()
 NOTIFICATION_ID = "enphase_envoy_notification"
+FIRMWARE_REFRESH_INTERVAL = timedelta(seconds=90)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -50,6 +51,7 @@ class EnphaseUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._setup_complete = False
         self.envoy_firmware = ""
         self._cancel_token_refresh: CALLBACK_TYPE | None = None
+        self._cancel_firmware_refresh: CALLBACK_TYPE | None = None
         super().__init__(
             hass,
             _LOGGER,
@@ -88,9 +90,47 @@ class EnphaseUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._async_update_saved_token()
 
     @callback
+    def _async_refresh_firmware(self, now: datetime.datetime) -> None:
+        """Proactively check for firmware changes in Envoy."""
+        self.hass.async_create_background_task(
+            self._async_try_refresh_firmware(), "{name} firmware refresh"
+        )
+
+    async def _async_try_refresh_firmware(self) -> None:
+        """Check firmware in Envoy and reload config entry if changed."""
+        # envoy.setup just reads firmware, serial and partnumber from /info
+        try:
+            await self.envoy.setup()
+        except EnvoyError as err:
+            # just try again next time
+            _LOGGER.debug("%s: Error reading firmware: %s", err, self.name)
+            return
+        if (current_firmware := self.envoy_firmware) and current_firmware != (
+            new_firmware := self.envoy.firmware
+        ):
+            self.envoy_firmware = new_firmware
+            _LOGGER.warning(
+                "Envoy firmware changed from: %s to: %s, reloading config entry %s",
+                current_firmware,
+                new_firmware,
+                self.name,
+            )
+            # reload the integration to get all established again
+            self.hass.async_create_task(
+                self.hass.config_entries.async_reload(self.config_entry.entry_id)
+            )
+
+    @callback
     def _async_mark_setup_complete(self) -> None:
-        """Mark setup as complete and setup token refresh if needed."""
+        """Mark setup as complete and setup firmware checks and token refresh if needed."""
         self._setup_complete = True
+        self.async_cancel_firmware_refresh()
+        self._cancel_firmware_refresh = async_track_time_interval(
+            self.hass,
+            self._async_refresh_firmware,
+            FIRMWARE_REFRESH_INTERVAL,
+            cancel_on_shutdown=True,
+        )
         self.async_cancel_token_refresh()
         if not isinstance(self.envoy.auth, EnvoyTokenAuth):
             return
@@ -204,3 +244,10 @@ class EnphaseUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         if self._cancel_token_refresh:
             self._cancel_token_refresh()
             self._cancel_token_refresh = None
+
+    @callback
+    def async_cancel_firmware_refresh(self) -> None:
+        """Cancel firmware refresh."""
+        if self._cancel_firmware_refresh:
+            self._cancel_firmware_refresh()
+            self._cancel_firmware_refresh = None

--- a/homeassistant/components/enphase_envoy/coordinator.py
+++ b/homeassistant/components/enphase_envoy/coordinator.py
@@ -25,7 +25,7 @@ SCAN_INTERVAL = timedelta(seconds=60)
 TOKEN_REFRESH_CHECK_INTERVAL = timedelta(days=1)
 STALE_TOKEN_THRESHOLD = timedelta(days=30).total_seconds()
 NOTIFICATION_ID = "enphase_envoy_notification"
-FIRMWARE_REFRESH_INTERVAL = timedelta(seconds=90)
+FIRMWARE_REFRESH_INTERVAL = timedelta(hours=4)
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/tests/components/enphase_envoy/test_init.py
+++ b/tests/components/enphase_envoy/test_init.py
@@ -436,6 +436,20 @@ async def test_coordinator_firmware_refresh(
         envoy = config_entry.runtime_data.envoy
         assert envoy.firmware == "9.9.9999"
 
+
+@respx.mock
+async def test_coordinator_firmware_refresh_with_envoy_error(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    mock_envoy: AsyncMock,
+    freezer: FrozenDateTimeFactory,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test coordinator scheduled firmware check."""
+    await setup_integration(hass, config_entry)
+    await hass.async_block_till_done(wait_background_tasks=True)
+    assert config_entry.state is ConfigEntryState.LOADED
+
     caplog.set_level(logging.DEBUG)
     logging.getLogger("homeassistant.components.enphase_envoy.coordinator").setLevel(
         logging.DEBUG

--- a/tests/components/enphase_envoy/test_init.py
+++ b/tests/components/enphase_envoy/test_init.py
@@ -1,6 +1,8 @@
 """Test Enphase Envoy runtime."""
 
-from unittest.mock import AsyncMock, patch
+from datetime import timedelta
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from freezegun.api import FrozenDateTimeFactory
 from jwt import encode
@@ -15,7 +17,10 @@ from homeassistant.components.enphase_envoy.const import (
     OPTION_DISABLE_KEEP_ALIVE,
     Platform,
 )
-from homeassistant.components.enphase_envoy.coordinator import SCAN_INTERVAL
+from homeassistant.components.enphase_envoy.coordinator import (
+    FIRMWARE_REFRESH_INTERVAL,
+    SCAN_INTERVAL,
+)
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import (
     CONF_HOST,
@@ -377,3 +382,68 @@ async def test_option_change_reload(
         OPTION_DIAGNOSTICS_INCLUDE_FIXTURES: True,
         OPTION_DISABLE_KEEP_ALIVE: False,
     }
+
+
+def mock_envoy_setup(mock_envoy: AsyncMock):
+    """Mock envoy.setup."""
+    mock_envoy.firmware = "9.9.9999"
+
+
+@patch(
+    "homeassistant.components.enphase_envoy.coordinator.SCAN_INTERVAL",
+    timedelta(days=1),
+)
+@respx.mock
+async def test_coordinator_firmware_refresh(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    mock_envoy: AsyncMock,
+    freezer: FrozenDateTimeFactory,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test coordinator scheduled firmware check."""
+    await setup_integration(hass, config_entry)
+    await hass.async_block_till_done(wait_background_tasks=True)
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    # Move time to next firmware check moment
+    # SCAN_INTERVAL is patched to 1 day to disable it's firmware detection
+    mock_envoy.setup.reset_mock()
+    freezer.tick(FIRMWARE_REFRESH_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    mock_envoy.setup.assert_called_once_with()
+    mock_envoy.setup.reset_mock()
+
+    envoy = config_entry.runtime_data.envoy
+    assert envoy.firmware == "7.6.175"
+
+    caplog.set_level(logging.WARNING)
+
+    with patch(
+        "homeassistant.components.enphase_envoy.Envoy.setup",
+        MagicMock(return_value=mock_envoy_setup(mock_envoy)),
+    ):
+        freezer.tick(FIRMWARE_REFRESH_INTERVAL)
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+        assert (
+            "Envoy firmware changed from: 7.6.175 to: 9.9.9999, reloading config entry Envoy 1234"
+            in caplog.text
+        )
+        envoy = config_entry.runtime_data.envoy
+        assert envoy.firmware == "9.9.9999"
+
+    caplog.set_level(logging.DEBUG)
+    logging.getLogger("homeassistant.components.enphase_envoy.coordinator").setLevel(
+        logging.DEBUG
+    )
+
+    mock_envoy.setup.side_effect = EnvoyError
+    freezer.tick(FIRMWARE_REFRESH_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert "Error reading firmware:" in caplog.text


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The enphase_envoy integration currently only reads the envoy firmware version when the configuration entry is loaded. Firmware updates may be pushed to the Envoy by Enphase any moment they like, not always accompanied by announcements. When this occurs the firmware version attribute of the Envoy device is incorrect and a reload may be needed as well.

This PR adds a read of the envoy firmware every 4 hours. If the Envoy firmware is changed, the configuration entry is reloaded and the envoy attribute updated. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/37022

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
