### PR TITLE
Bump Devialet to 1.5.7

### DIFF
--- a/homeassistant/components/devialet/manifest.json
+++ b/homeassistant/components/devialet/manifest.json
@@ -7,6 +7,6 @@
   "documentation": "https://www.home-assistant.io/integrations/devialet",
   "integration_type": "device",
   "iot_class": "local_polling",
-  "requirements": ["devialet==1.4.5"],
+  "requirements": ["devialet==1.5.7"],
   "zeroconf": ["_devialet-http._tcp.local."]
 }

--- a/homeassistant/components/devialet/media_player.py
+++ b/homeassistant/components/devialet/media_player.py
@@ -122,10 +122,10 @@ class DevialetMediaPlayerEntity(
         if self.coordinator.client.source_state is None:
             return features
 
-        if not self.coordinator.client.available_options:
+        if not self.coordinator.client.available_operations:
             return features
 
-        for option in self.coordinator.client.available_options:
+        for option in self.coordinator.client.available_operations:
             features |= DEVIALET_TO_HA_FEATURE_MAP.get(option, 0)
         return features
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -755,7 +755,7 @@ demetriek==1.1.0
 denonavr==1.0.1
 
 # homeassistant.components.devialet
-devialet==1.4.5
+devialet==1.5.7
 
 # homeassistant.components.devolo_home_control
 devolo-home-control-api==0.18.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -645,7 +645,7 @@ demetriek==1.1.0
 denonavr==1.0.1
 
 # homeassistant.components.devialet
-devialet==1.4.5
+devialet==1.5.7
 
 # homeassistant.components.devolo_home_control
 devolo-home-control-api==0.18.3

--- a/tests/components/devialet/fixtures/general_info.json
+++ b/tests/components/devialet/fixtures/general_info.json
@@ -1,18 +1,22 @@
 {
+  "availableFeatures": ["powerManagement"],
   "deviceId": "1abcdef2-3456-67g8-9h0i-1jk23456lm78",
   "deviceName": "Livingroom",
   "firmwareFamily": "DOS",
   "groupId": "12345678-901a-2b3c-def4-567g89h0i12j",
+  "installationId": "abc1eca1-1234-5251-a123-12ac1a3e9fe8",
   "ipControlVersion": "1",
+  "isSystemLeader": true,
   "model": "Phantom I Silver",
+  "modelFamily": "Phantom I",
+  "powerRating": "105 dB",
   "release": {
     "buildType": "release",
-    "canonicalVersion": "2.16.1.49152",
-    "version": "2.16.1"
+    "canonicalVersion": "2.17.6.49152",
+    "version": "2.17.6"
   },
   "role": "FrontLeft",
   "serial": "L00P00000AB11",
-  "standbyEntryDelay": 0,
-  "standbyState": "Unknown",
+  "setupState": "ongoing",
   "systemId": "a12b345c-67d8-90e1-12f4-g5hij67890kl"
 }

--- a/tests/components/devialet/fixtures/source_state.json
+++ b/tests/components/devialet/fixtures/source_state.json
@@ -1,5 +1,5 @@
 {
-  "availableOptions": ["play", "pause", "previous", "next", "seek"],
+  "availableOperations": ["play", "pause", "previous", "next", "seek"],
   "metadata": {
     "album": "1 (Remastered)",
     "artist": "The Beatles",

--- a/tests/components/devialet/fixtures/system_info.json
+++ b/tests/components/devialet/fixtures/system_info.json
@@ -1,6 +1,29 @@
 {
-  "availableFeatures": ["nightMode", "equalizer", "balance"],
+  "availableFeatures": [
+    "nightMode",
+    "equalizer",
+    "balance",
+    "preferredInterfaceControl"
+  ],
+  "devices": [
+    {
+      "deviceId": "1abcdef2-3456-67g8-9h0i-1jk23456lm78",
+      "isSystemLeader": true,
+      "name": "Livingroom",
+      "role": null,
+      "serial": "L05P00066EW14"
+    },
+    {
+      "deviceId": "1zzyyxx2-3456-67g8-9h0i-1zz23456lz78",
+      "isSystemLeader": false,
+      "name": "Phantom I Silver-123a",
+      "role": null,
+      "serial": "M05P00066EW15"
+    }
+  ],
   "groupId": "12345678-901a-2b3c-def4-567g89h0i12j",
+  "multiroomFamily": "sync33",
   "systemId": "a12b345c-67d8-90e1-12f4-g5hij67890kl",
-  "systemName": "Devialet"
+  "systemName": "Devialet",
+  "systemType": "stereo"
 }

--- a/tests/components/devialet/test_diagnostics.py
+++ b/tests/components/devialet/test_diagnostics.py
@@ -31,11 +31,13 @@ async def test_diagnostics(
         "source_list": [
             "Airplay",
             "Bluetooth",
-            "Online",
             "Optical left",
             "Optical right",
             "Raat",
             "Spotify Connect",
+            "UPnP",
         ],
         "source": "spotifyconnect",
+        "upnp_device_type": "Not available",
+        "upnp_device_url": "Not available",
     }

--- a/tests/components/devialet/test_media_player.py
+++ b/tests/components/devialet/test_media_player.py
@@ -96,7 +96,7 @@ SERVICE_TO_DATA = {
     ],
     SERVICE_SELECT_SOURCE: [
         {ATTR_INPUT_SOURCE: "Optical left"},
-        {ATTR_INPUT_SOURCE: "Online"},
+        {ATTR_INPUT_SOURCE: "UPnP"},
     ],
 }
 
@@ -203,7 +203,7 @@ async def test_media_player_playing(
             )
 
     with patch.object(
-        DevialetApi, "available_options", new_callable=PropertyMock
+        DevialetApi, "available_operations", new_callable=PropertyMock
     ) as mock:
         mock.return_value = None
         await hass.config_entries.async_reload(entry.entry_id)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is an update to make sure Devialet speakers keep working. Because with the update also the JSON response have changed, the fixtures and some tests are updated.

Diff: https://github.com/fwestenberg/devialet/compare/v1.4.5...v1.5.7

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/124395
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description. 

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
