### PR TITLE
Satellite announcement to track original media id

### DIFF
--- a/homeassistant/components/assist_satellite/entity.py
+++ b/homeassistant/components/assist_satellite/entity.py
@@ -97,7 +97,7 @@ class AssistSatelliteAnnouncement:
     """Media ID to be played."""
 
     original_media_id: str
-    """Internal media ID to be played."""
+    """The raw media ID before processing."""
 
     media_id_source: Literal["url", "media_id", "tts"]
     """Source of the media ID."""

--- a/homeassistant/components/assist_satellite/entity.py
+++ b/homeassistant/components/assist_satellite/entity.py
@@ -96,7 +96,11 @@ class AssistSatelliteAnnouncement:
     media_id: str
     """Media ID to be played."""
 
+    original_media_id: str
+    """Internal media ID to be played."""
+
     media_id_source: Literal["url", "media_id", "tts"]
+    """Source of the media ID."""
 
 
 class AssistSatelliteEntity(entity.Entity):
@@ -396,7 +400,10 @@ class AssistSatelliteEntity(entity.Entity):
         """Resolve the media ID."""
         media_id_source: Literal["url", "media_id", "tts"] | None = None
 
-        if not media_id:
+        if media_id:
+            original_media_id = media_id
+
+        else:
             media_id_source = "tts"
             # Synthesize audio and get URL
             pipeline_id = self._resolve_pipeline()
@@ -416,6 +423,7 @@ class AssistSatelliteEntity(entity.Entity):
                 language=pipeline.tts_language,
                 options=tts_options,
             )
+            original_media_id = media_id
 
         if media_source.is_media_source_id(media_id):
             if not media_id_source:
@@ -433,4 +441,6 @@ class AssistSatelliteEntity(entity.Entity):
         # Resolve to full URL
         media_id = async_process_play_media_url(self.hass, media_id)
 
-        return AssistSatelliteAnnouncement(message, media_id, media_id_source)
+        return AssistSatelliteAnnouncement(
+            message, media_id, original_media_id, media_id_source
+        )

--- a/tests/components/assist_satellite/test_entity.py
+++ b/tests/components/assist_satellite/test_entity.py
@@ -163,21 +163,32 @@ async def test_new_pipeline_cancels_pipeline(
         (
             {"message": "Hello"},
             AssistSatelliteAnnouncement(
-                "Hello", "https://www.home-assistant.io/resolved.mp3", "tts"
+                message="Hello",
+                media_id="https://www.home-assistant.io/resolved.mp3",
+                original_media_id="media-source://bla",
+                media_id_source="tts",
             ),
         ),
         (
             {
                 "message": "Hello",
-                "media_id": "media-source://bla",
+                "media_id": "media-source://given",
             },
             AssistSatelliteAnnouncement(
-                "Hello", "https://www.home-assistant.io/resolved.mp3", "media_id"
+                message="Hello",
+                media_id="https://www.home-assistant.io/resolved.mp3",
+                original_media_id="media-source://given",
+                media_id_source="media_id",
             ),
         ),
         (
             {"media_id": "http://example.com/bla.mp3"},
-            AssistSatelliteAnnouncement("", "http://example.com/bla.mp3", "url"),
+            AssistSatelliteAnnouncement(
+                message="",
+                media_id="http://example.com/bla.mp3",
+                original_media_id="http://example.com/bla.mp3",
+                media_id_source="url",
+            ),
         ),
     ],
 )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Extracted from #135291 by @jaminh and adjusted to fit our naming. 

The announcement was always converted to a URL, assuming it was consumed externally. The VoIP integration needs to consume it internally 

Certain integrations, like VoIP, need to access the original media source ID so they can fetch the data internally, instead of going through a URL.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
