### PR TITLE
Enforce `from...import...as` via pylint plugin

### DIFF
--- a/pylint/plugins/hass_imports.py
+++ b/pylint/plugins/hass_imports.py
@@ -228,7 +228,7 @@ class HassImportsFormatChecker(BaseChecker):
             "Used when a constant should be imported as an alias",
         ),
         "W7427": (
-            "`%s` should be import using `from %s import %s as %s`",
+            "`%s` should be imported using `from %s import %s as %s`",
             "hass-alias-import",
             "Used when an alias import should be imported with from ... import ... as ...",
         ),

--- a/pylint/plugins/hass_imports.py
+++ b/pylint/plugins/hass_imports.py
@@ -271,7 +271,7 @@ class HassImportsFormatChecker(BaseChecker):
                 continue
 
             # Prefer `from ... import ... as ...` over `import ... as ...`
-            if alias and "." in module:
+            if alias and module.startswith("homeassistant."):
                 prefix, _delimiter, imported_module = module.rpartition(".")
                 self.add_message(
                     "hass-alias-import",

--- a/tests/pylint/__init__.py
+++ b/tests/pylint/__init__.py
@@ -1,19 +1,24 @@
 """Tests for pylint."""
 
+from collections.abc import Generator
 import contextlib
 
 from pylint.testutils.unittest_linter import UnittestLinter
 
 
 @contextlib.contextmanager
-def assert_no_messages(linter: UnittestLinter):
+def assert_no_messages(
+    linter: UnittestLinter, *, ignore_codes: list[str] | None = None
+) -> Generator[None]:
     """Assert that no messages are added by the given method."""
-    with assert_adds_messages(linter):
+    with assert_adds_messages(linter, ignore_codes=ignore_codes):
         yield
 
 
 @contextlib.contextmanager
-def assert_adds_messages(linter: UnittestLinter, *messages):
+def assert_adds_messages(
+    linter: UnittestLinter, *messages, ignore_codes: list[str] | None = None
+) -> Generator[None]:
     """Assert that exactly the given method adds the given messages.
 
     The list of messages must exactly match *all* the messages added by the
@@ -22,6 +27,8 @@ def assert_adds_messages(linter: UnittestLinter, *messages):
     """
     yield
     got = linter.release_messages()
+    if ignore_codes:
+        got = [msg for msg in got if msg.msg_id not in ignore_codes]
     no_msg = "No message."
     expected = "\n".join(repr(m) for m in messages) or no_msg
     got_str = "\n".join(repr(m) for m in got) or no_msg

--- a/tests/pylint/test_imports.py
+++ b/tests/pylint/test_imports.py
@@ -376,12 +376,18 @@ def test_import_as(linter: UnittestLinter, imports_checker: BaseChecker) -> None
     module_name = "pylint_test"
 
     import_nodes = astroid.extract_node(
-        "import foo #@\n"
-        "import foo as my_foo #@\n"
-        "import foo.bar #@\n"
-        "import foo.bar as my_bar #@\n"
-        "import foo.local.bar #@\n"
-        "import foo.local.bar as my_bar #@\n",
+        """
+        import foo #@
+        import foo as my_foo #@
+        import foo.bar #@
+        import foo.bar as my_bar #@
+        import foo.local.bar #@
+        import foo.local.bar as my_bar #@
+        import homeassistant.bar #@
+        import homeassistant.bar as my_bar #@
+        import homeassistant.local.bar #@
+        import homeassistant.local.bar as my_bar #@
+        """,
         module_name,
     )
     imports_checker.visit_module(import_nodes[0].parent)
@@ -389,21 +395,21 @@ def test_import_as(linter: UnittestLinter, imports_checker: BaseChecker) -> None
     expected_messages = [
         pylint.testutils.MessageTest(
             msg_id="hass-alias-import",
-            node=import_nodes[3],
-            args=("bar", "foo", "bar", "my_bar"),
-            line=4,
+            node=import_nodes[7],
+            args=("bar", "homeassistant", "bar", "my_bar"),
+            line=9,
             col_offset=0,
-            end_line=4,
-            end_col_offset=24,
+            end_line=9,
+            end_col_offset=34,
         ),
         pylint.testutils.MessageTest(
             msg_id="hass-alias-import",
-            node=import_nodes[5],
-            args=("bar", "foo.local", "bar", "my_bar"),
-            line=6,
+            node=import_nodes[9],
+            args=("bar", "homeassistant.local", "bar", "my_bar"),
+            line=11,
             col_offset=0,
-            end_line=6,
-            end_col_offset=30,
+            end_line=11,
+            end_col_offset=40,
         ),
     ]
     with assert_adds_messages(linter, *expected_messages):


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Prefer `from...import...as` over  `import...as`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
