### PR TITLE
Fix casing and spelling in user-facing strings of homematicip_cloud

### DIFF
--- a/homeassistant/components/homematicip_cloud/strings.json
+++ b/homeassistant/components/homematicip_cloud/strings.json
@@ -2,7 +2,7 @@
   "config": {
     "step": {
       "init": {
-        "title": "Pick HomematicIP Access point",
+        "title": "Pick Homematic IP access point",
         "data": {
           "hapid": "Access point ID (SGTIN)",
           "pin": "[%key:common::config_flow::data::pin%]",
@@ -10,8 +10,8 @@
         }
       },
       "link": {
-        "title": "Link Access point",
-        "description": "Press the blue button on the access point and the **Submit** button to register HomematicIP with Home Assistant.\n\n![Location of button on bridge](/static/images/config_flows/config_homematicip_cloud.png)"
+        "title": "Link access point",
+        "description": "Press the blue button on the access point and the **Submit** button to register Homematic IP with Home Assistant.\n\n![Location of button on bridge](/static/images/config_flows/config_homematicip_cloud.png)"
       }
     },
     "error": {
@@ -28,7 +28,7 @@
   },
   "exceptions": {
     "access_point_not_found": {
-      "message": "No matching access point found for access point id {id}"
+      "message": "No matching access point found for access point ID {id}"
     }
   },
   "services": {
@@ -41,8 +41,8 @@
           "description": "The duration of eco mode in minutes."
         },
         "accesspoint_id": {
-          "name": "Accesspoint ID",
-          "description": "The ID of the Homematic IP Access Point."
+          "name": "Access point ID",
+          "description": "The ID of the Homematic IP access point."
         }
       }
     },
@@ -113,20 +113,20 @@
       }
     },
     "dump_hap_config": {
-      "name": "Dump hap config",
-      "description": "Dumps the configuration of the Homematic IP Access Point(s).",
+      "name": "Dump HAP config",
+      "description": "Dumps the configuration of the Homematic IP access point(s).",
       "fields": {
         "config_output_path": {
           "name": "Config output path",
-          "description": "(Default is 'Your home-assistant config directory') Path where to store the config."
+          "description": "Path where to store the config. Default is 'Your Home Assistant config directory'."
         },
         "config_output_file_prefix": {
           "name": "Config output file prefix",
-          "description": "Name of the config file. The SGTIN of the AP will always be appended."
+          "description": "Name of the config file. The SGTIN of the HAP will always be appended."
         },
         "anonymize": {
           "name": "Anonymize",
-          "description": "Should the Configuration be anonymized?"
+          "description": "Should the configuration be anonymized?"
         }
       }
     },
@@ -142,7 +142,7 @@
     },
     "set_home_cooling_mode": {
       "name": "Set home cooling mode",
-      "description": "Set the heating/cooling mode for the entire home",
+      "description": "Sets the heating/cooling mode for the entire home",
       "fields": {
         "accesspoint_id": {
           "name": "[%key:component::homematicip_cloud::services::activate_eco_mode_with_duration::fields::accesspoint_id::name%]",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

- change all occurrences of "HomematicIP" to "Homematic IP" for consistency
- use sentence-casing for "access point" and "configuration"
- write all occurrences of "access point" in two words
- change "id" to uppercase "ID"
- Change abbreviation "hap" to "HAP" (Homematic access point)
- make one action description consistent with HA standard
- Reword config_output_path description to avoid starting with brackets
- change one occurrence of "home-assistant" to "Home Assistant"

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
