### PR TITLE
Several fixes in user-facing strings of Renson integration actions

### DIFF
--- a/homeassistant/components/renson/strings.json
+++ b/homeassistant/components/renson/strings.json
@@ -186,46 +186,46 @@
   "services": {
     "set_timer_level": {
       "name": "Set timer",
-      "description": "Set the ventilation timer",
+      "description": "Sets the ventilation timer",
       "fields": {
         "timer_level": {
           "name": "Level",
-          "description": "Level setting"
+          "description": "Ventilation level"
         },
         "minutes": {
           "name": "Time",
-          "description": "Time of the timer (0 will disable the timer)"
+          "description": "Duration of the timer (0 will disable the timer)"
         }
       }
     },
     "set_breeze": {
-      "name": "Set breeze",
-      "description": "Set the breeze function of the ventilation system",
+      "name": "Set Breeze",
+      "description": "Sets the Breeze function of the ventilation system",
       "fields": {
         "breeze_level": {
           "name": "[%key:component::renson::services::set_timer_level::fields::timer_level::name%]",
-          "description": "Ventilation level when breeze function is activated"
+          "description": "Ventilation level when Breeze function is activated"
         },
         "temperature": {
           "name": "Temperature",
-          "description": "Temperature when the breeze function should be activated"
+          "description": "Temperature when the Breeze function should be activated"
         },
         "activate": {
           "name": "Activate",
-          "description": "Activate or disable the breeze feature"
+          "description": "Activate or disable the Breeze feature"
         }
       }
     },
     "set_pollution_settings": {
       "name": "Set pollution settings",
-      "description": "Set all the pollution settings of the ventilation system",
+      "description": "Sets all the pollution settings of the ventilation system",
       "fields": {
         "day_pollution_level": {
-          "name": "Day pollution Level",
+          "name": "Day pollution level",
           "description": "Ventilation level when pollution is detected in the day"
         },
         "night_pollution_level": {
-          "name": "Night pollution Level",
+          "name": "Night pollution level",
           "description": "Ventilation level when pollution is detected in the night"
         },
         "humidity_control": {
@@ -242,11 +242,11 @@
         },
         "co2_threshold": {
           "name": "CO2 threshold",
-          "description": "Sets the CO2 pollution threshold level in ppm"
+          "description": "The CO2 pollution threshold level in ppm"
         },
         "co2_hysteresis": {
           "name": "CO2 hysteresis",
-          "description": "Sets the CO2 pollution threshold hysteresis level in ppm"
+          "description": "The CO2 pollution threshold hysteresis level in ppm"
         }
       }
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The PR contains the following fixes:
- capitalize "Breeze" as [Renson uses this as a name](https://www.renson.eu/de-de/producten-zoeken/ventilatie/mechanische-ventilatie/units/healthbox-go) that is not translated
- use sentence-casing for "pollution level"
- change "Level setting" to "Ventilation level" for clarity
- replace "time of the timer" with "duration of …"
- use third-person singular for descriptive wording of all action descriptions
- Remove "Sets …" from field descriptions for consistency

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
