### PR TITLE
Fallback to None for literal "Blank" serial number for APCUPSD integration

### DIFF
--- a/homeassistant/components/apcupsd/coordinator.py
+++ b/homeassistant/components/apcupsd/coordinator.py
@@ -44,7 +44,10 @@ class APCUPSdData(dict[str, str]):
     @property
     def serial_no(self) -> str | None:
         """Return the unique serial number of the UPS, if available."""
-        return self.get("SERIALNO")
+        sn = self.get("SERIALNO")
+        # We had user reports that some UPS models simply return "Blank" as serial number, in
+        # which case we fall back to `None` to indicate that it is actually not available.
+        return None if sn == "Blank" else sn
 
 
 class APCUPSdCoordinator(DataUpdateCoordinator[APCUPSdData]):

--- a/tests/components/apcupsd/test_config_flow.py
+++ b/tests/components/apcupsd/test_config_flow.py
@@ -125,6 +125,8 @@ async def test_flow_works(hass: HomeAssistant) -> None:
         ({"UPSNAME": "Friendly Name"}, "Friendly Name"),
         ({"MODEL": "MODEL X"}, "MODEL X"),
         ({"SERIALNO": "ZZZZ"}, "ZZZZ"),
+        # Some models report "Blank" as serial number, which we should ignore.
+        ({"SERIALNO": "Blank"}, "APC UPS"),
         ({}, "APC UPS"),
     ],
 )

--- a/tests/components/apcupsd/test_config_flow.py
+++ b/tests/components/apcupsd/test_config_flow.py
@@ -125,7 +125,7 @@ async def test_flow_works(hass: HomeAssistant) -> None:
         ({"UPSNAME": "Friendly Name"}, "Friendly Name"),
         ({"MODEL": "MODEL X"}, "MODEL X"),
         ({"SERIALNO": "ZZZZ"}, "ZZZZ"),
-        # Some models report "Blank" as serial number, which we should ignore.
+        # Some models report "Blank" as serial number, which we should treat it as not reported.
         ({"SERIALNO": "Blank"}, "APC UPS"),
         ({}, "APC UPS"),
     ],


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

We had user reports where the some APC UPS models are literally reporting "Blank" as the serial number, which obviously isn't unique. This has caused problems when adding two UPSes to Home assistant, since we prevent devices with same serial number to be added twice.

This PR treats "Blank" serial number as `None` to indicate that no serial number is available. Tests are also added to prevent future regressions.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #136219
- This PR is related to issue: #136219
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
