### PR TITLE
Incorporate ControllerManager into HEOS Coordinator

### DIFF
--- a/homeassistant/components/heos/config_flow.py
+++ b/homeassistant/components/heos/config_flow.py
@@ -10,6 +10,7 @@ import voluptuous as vol
 
 from homeassistant.config_entries import (
     ConfigEntry,
+    ConfigEntryState,
     ConfigFlow,
     ConfigFlowResult,
     OptionsFlow,
@@ -186,6 +187,7 @@ class HeosFlowHandler(ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
         entry = cast(HeosConfigEntry, self._get_reauth_entry())
         if user_input is not None:
+            assert entry.state is ConfigEntryState.LOADED
             if await _validate_auth(
                 user_input, entry.runtime_data.coordinator.heos, errors
             ):

--- a/homeassistant/components/heos/config_flow.py
+++ b/homeassistant/components/heos/config_flow.py
@@ -22,6 +22,7 @@ from homeassistant.helpers.service_info.ssdp import (
     SsdpServiceInfo,
 )
 
+from . import HeosConfigEntry
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
@@ -183,10 +184,11 @@ class HeosFlowHandler(ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Validate account credentials and update options."""
         errors: dict[str, str] = {}
-        entry = self._get_reauth_entry()
+        entry = cast(HeosConfigEntry, self._get_reauth_entry())
         if user_input is not None:
-            heos = cast(Heos, entry.runtime_data.coordinator.heos)
-            if await _validate_auth(user_input, heos, errors):
+            if await _validate_auth(
+                user_input, entry.runtime_data.coordinator.heos, errors
+            ):
                 return self.async_update_reload_and_abort(entry, options=user_input)
 
         return self.async_show_form(
@@ -207,8 +209,10 @@ class HeosOptionsFlowHandler(OptionsFlow):
         """Manage the options."""
         errors: dict[str, str] = {}
         if user_input is not None:
-            heos = cast(Heos, self.config_entry.runtime_data.coordinator.heos)
-            if await _validate_auth(user_input, heos, errors):
+            entry = cast(HeosConfigEntry, self.config_entry)
+            if await _validate_auth(
+                user_input, entry.runtime_data.coordinator.heos, errors
+            ):
                 return self.async_create_entry(data=user_input)
 
         return self.async_show_form(

--- a/homeassistant/components/heos/config_flow.py
+++ b/homeassistant/components/heos/config_flow.py
@@ -185,7 +185,7 @@ class HeosFlowHandler(ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
         entry = self._get_reauth_entry()
         if user_input is not None:
-            heos = cast(Heos, entry.runtime_data.controller_manager.controller)
+            heos = cast(Heos, entry.runtime_data.coordinator.heos)
             if await _validate_auth(user_input, heos, errors):
                 return self.async_update_reload_and_abort(entry, options=user_input)
 
@@ -207,9 +207,7 @@ class HeosOptionsFlowHandler(OptionsFlow):
         """Manage the options."""
         errors: dict[str, str] = {}
         if user_input is not None:
-            heos = cast(
-                Heos, self.config_entry.runtime_data.controller_manager.controller
-            )
+            heos = cast(Heos, self.config_entry.runtime_data.coordinator.heos)
             if await _validate_auth(user_input, heos, errors):
                 return self.async_create_entry(data=user_input)
 

--- a/homeassistant/components/heos/config_flow.py
+++ b/homeassistant/components/heos/config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import logging
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
 from pyheos import CommandAuthenticationError, Heos, HeosError, HeosOptions
@@ -185,7 +185,7 @@ class HeosFlowHandler(ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Validate account credentials and update options."""
         errors: dict[str, str] = {}
-        entry = cast(HeosConfigEntry, self._get_reauth_entry())
+        entry: HeosConfigEntry = self._get_reauth_entry()
         if user_input is not None:
             assert entry.state is ConfigEntryState.LOADED
             if await _validate_auth(
@@ -211,7 +211,7 @@ class HeosOptionsFlowHandler(OptionsFlow):
         """Manage the options."""
         errors: dict[str, str] = {}
         if user_input is not None:
-            entry = cast(HeosConfigEntry, self.config_entry)
+            entry: HeosConfigEntry = self.config_entry
             if await _validate_auth(
                 user_input, entry.runtime_data.coordinator.heos, errors
             ):

--- a/homeassistant/components/heos/quality_scale.yaml
+++ b/homeassistant/components/heos/quality_scale.yaml
@@ -29,10 +29,7 @@ rules:
   docs-installation-parameters: done
   entity-unavailable: done
   integration-owner: done
-  log-when-unavailable:
-    status: todo
-    comment: |
-      The integration currently spams the logs until reconnected
+  log-when-unavailable: done
   parallel-updates: done
   reauthentication-flow: done
   test-coverage:

--- a/homeassistant/components/heos/services.py
+++ b/homeassistant/components/heos/services.py
@@ -64,7 +64,7 @@ def _get_controller(hass: HomeAssistant) -> Heos:
         raise HomeAssistantError(
             translation_domain=DOMAIN, translation_key="integration_not_loaded"
         )
-    return entry.runtime_data.controller_manager.controller
+    return entry.runtime_data.coordinator.heos
 
 
 async def _sign_in_handler(service: ServiceCall) -> None:

--- a/tests/components/heos/test_config_flow.py
+++ b/tests/components/heos/test_config_flow.py
@@ -4,7 +4,7 @@ from pyheos import CommandAuthenticationError, CommandFailedError, Heos, HeosErr
 import pytest
 
 from homeassistant.components.heos.const import DOMAIN
-from homeassistant.config_entries import SOURCE_SSDP, SOURCE_USER
+from homeassistant.config_entries import SOURCE_SSDP, SOURCE_USER, ConfigEntryState
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -358,6 +358,7 @@ async def test_reauth_signs_in_aborts(
     config_entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     result = await config_entry.start_reauth_flow(hass)
+    assert config_entry.state is ConfigEntryState.LOADED
 
     assert result["step_id"] == "reauth_confirm"
     assert result["errors"] == {}
@@ -396,6 +397,7 @@ async def test_reauth_signs_out(
     config_entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     result = await config_entry.start_reauth_flow(hass)
+    assert config_entry.state is ConfigEntryState.LOADED
 
     assert result["step_id"] == "reauth_confirm"
     assert result["errors"] == {}
@@ -447,6 +449,7 @@ async def test_reauth_flow_missing_one_param_recovers(
 
     # Start the options flow. Entry has not current options.
     result = await config_entry.start_reauth_flow(hass)
+    assert config_entry.state is ConfigEntryState.LOADED
     assert result["step_id"] == "reauth_confirm"
     assert result["errors"] == {}
     assert result["type"] is FlowResultType.FORM

--- a/tests/components/heos/test_media_player.py
+++ b/tests/components/heos/test_media_player.py
@@ -180,7 +180,7 @@ async def test_updates_from_connection_event_new_player_ids(
     controller: Heos,
     change_data_mapped_ids: PlayerUpdateResult,
 ) -> None:
-    """Test player updates from changes to available players."""
+    """Test player ids changed after reconnection updates ids."""
     config_entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(config_entry.entry_id)
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In the next step of the HEOS Coordinator implementation, this change incorporates the functionality of the `ControllerManager` into the coordinator in order to leverage the ability to update listeners and centralize event callback logic. 

The ControllerManager was responsible for triggering entity updates so they reflect available/unavailable based on connection events and handled the need to update device `identifiers` and entity `unique_ids` if the `player_id ` changed. One improvement was made to the previous code so that it now properly handles multiple device identifiers when needing to update.

This also marked the QS item `log-when-unavailable` as done as this now properly logs once when unavailable and once when available. The integration didn't spam the logs previously (contrary to the previous comment in the quality scale), it just didn't log when disconnected and reconnected.

Next steps are to incorporate the `SourceManager` and `GroupManager`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
