### PR TITLE
Add TP-Link Tapo pet detection to onvif parsers

### DIFF
--- a/homeassistant/components/onvif/parsers.py
+++ b/homeassistant/components/onvif/parsers.py
@@ -381,6 +381,9 @@ _TAPO_EVENT_TEMPLATES: dict[str, Event] = {
     "IsPeople": Event(
         uid="", name="Person Detection", platform="binary_sensor", device_class="motion"
     ),
+    "IsPet": Event(
+        uid="", name="Pet Detection", platform="binary_sensor", device_class="motion"
+    ),
     "IsLineCross": Event(
         uid="",
         name="Line Detector Crossed",

--- a/tests/components/onvif/test_parsers.py
+++ b/tests/components/onvif/test_parsers.py
@@ -426,6 +426,82 @@ async def test_tapo_tpsmartevent_person(hass: HomeAssistant) -> None:
     )
 
 
+async def test_tapo_tpsmartevent_pet(hass: HomeAssistant) -> None:
+    """Tests tns1:RuleEngine/TPSmartEventDetector/TPSmartEvent - pet."""
+    event = await get_event(
+        {
+            "SubscriptionReference": {
+                "Address": {
+                    "_value_1": "http://192.168.56.63:2020/event-0_2020",
+                    "_attr_1": None,
+                },
+                "ReferenceParameters": None,
+                "Metadata": None,
+                "_value_1": None,
+                "_attr_1": None,
+            },
+            "Topic": {
+                "_value_1": "tns1:RuleEngine/TPSmartEventDetector/TPSmartEvent",
+                "Dialect": "http://www.onvif.org/ver10/tev/topicExpression/ConcreteSet",
+                "_attr_1": {},
+            },
+            "ProducerReference": {
+                "Address": {
+                    "_value_1": "http://192.168.56.63:5656/event",
+                    "_attr_1": None,
+                },
+                "ReferenceParameters": None,
+                "Metadata": None,
+                "_value_1": None,
+                "_attr_1": None,
+            },
+            "Message": {
+                "_value_1": {
+                    "Source": {
+                        "SimpleItem": [
+                            {
+                                "Name": "VideoSourceConfigurationToken",
+                                "Value": "vsconf",
+                            },
+                            {
+                                "Name": "VideoAnalyticsConfigurationToken",
+                                "Value": "VideoAnalyticsToken",
+                            },
+                            {"Name": "Rule", "Value": "MyTPSmartEventDetectorRule"},
+                        ],
+                        "ElementItem": [],
+                        "Extension": None,
+                        "_attr_1": None,
+                    },
+                    "Key": None,
+                    "Data": {
+                        "SimpleItem": [{"Name": "IsPet", "Value": "true"}],
+                        "ElementItem": [],
+                        "Extension": None,
+                        "_attr_1": None,
+                    },
+                    "Extension": None,
+                    "UtcTime": datetime.datetime(
+                        2025, 1, 22, 13, 24, 57, tzinfo=datetime.UTC
+                    ),
+                    "PropertyOperation": "Changed",
+                    "_attr_1": {},
+                }
+            },
+        }
+    )
+
+    assert event is not None
+    assert event.name == "Pet Detection"
+    assert event.platform == "binary_sensor"
+    assert event.device_class == "motion"
+    assert event.value
+    assert event.uid == (
+        f"{TEST_UID}_tns1:RuleEngine/TPSmartEventDetector/"
+        "TPSmartEvent_VideoSourceToken_VideoAnalyticsToken_MyTPSmartEventDetectorRule"
+    )
+
+
 async def test_tapo_cellmotiondetector_person(hass: HomeAssistant) -> None:
     """Tests tns1:RuleEngine/CellMotionDetector/People - person."""
     event = await get_event(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Add onvif parser support for TP-Link's Tapo pet detection events.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is related to issue: https://github.com/JurajNyiri/HomeAssistant-Tapo-Control/issues/304

## Checklist
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
