### PR TITLE
Move lovelace exception class to exceptions.py

### DIFF
--- a/homeassistant/components/lovelace/cast.py
+++ b/homeassistant/components/lovelace/cast.py
@@ -25,7 +25,8 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.network import NoURLAvailableError, get_url
 
-from .const import DOMAIN, LOVELACE_DATA, ConfigNotFound
+from .const import DOMAIN, LOVELACE_DATA
+from .util import ConfigNotFound
 
 DEFAULT_DASHBOARD = "_default_"
 

--- a/homeassistant/components/lovelace/cast.py
+++ b/homeassistant/components/lovelace/cast.py
@@ -26,7 +26,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.network import NoURLAvailableError, get_url
 
 from .const import DOMAIN, LOVELACE_DATA
-from .util import ConfigNotFound
+from .exceptions import ConfigNotFound
 
 DEFAULT_DASHBOARD = "_default_"
 

--- a/homeassistant/components/lovelace/const.py
+++ b/homeassistant/components/lovelace/const.py
@@ -13,7 +13,6 @@ from homeassistant.const import (
     CONF_URL,
     EVENT_LOVELACE_UPDATED,  # noqa: F401
 )
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import VolDictType
 from homeassistant.util.hass_dict import HassKey
@@ -88,7 +87,3 @@ STORAGE_DASHBOARD_CREATE_FIELDS: VolDictType = {
 }
 
 STORAGE_DASHBOARD_UPDATE_FIELDS = DASHBOARD_BASE_UPDATE_FIELDS
-
-
-class ConfigNotFound(HomeAssistantError):
-    """When no config available."""

--- a/homeassistant/components/lovelace/dashboard.py
+++ b/homeassistant/components/lovelace/dashboard.py
@@ -32,8 +32,8 @@ from .const import (
     MODE_YAML,
     STORAGE_DASHBOARD_CREATE_FIELDS,
     STORAGE_DASHBOARD_UPDATE_FIELDS,
-    ConfigNotFound,
 )
+from .util import ConfigNotFound
 
 CONFIG_STORAGE_KEY_DEFAULT = DOMAIN
 CONFIG_STORAGE_KEY = "lovelace.{}"

--- a/homeassistant/components/lovelace/dashboard.py
+++ b/homeassistant/components/lovelace/dashboard.py
@@ -33,7 +33,7 @@ from .const import (
     STORAGE_DASHBOARD_CREATE_FIELDS,
     STORAGE_DASHBOARD_UPDATE_FIELDS,
 )
-from .util import ConfigNotFound
+from .exceptions import ConfigNotFound
 
 CONFIG_STORAGE_KEY_DEFAULT = DOMAIN
 CONFIG_STORAGE_KEY = "lovelace.{}"

--- a/homeassistant/components/lovelace/exceptions.py
+++ b/homeassistant/components/lovelace/exceptions.py
@@ -1,4 +1,4 @@
-"""Utils for Lovelace."""
+"""Exceptions for Lovelace."""
 
 from homeassistant.exceptions import HomeAssistantError
 

--- a/homeassistant/components/lovelace/util.py
+++ b/homeassistant/components/lovelace/util.py
@@ -1,0 +1,7 @@
+"""Utils for Lovelace."""
+
+from homeassistant.exceptions import HomeAssistantError
+
+
+class ConfigNotFound(HomeAssistantError):
+    """When no config available."""

--- a/homeassistant/components/lovelace/websocket.py
+++ b/homeassistant/components/lovelace/websocket.py
@@ -14,8 +14,9 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.json import json_fragment
 
-from .const import CONF_URL_PATH, LOVELACE_DATA, ConfigNotFound
+from .const import CONF_URL_PATH, LOVELACE_DATA
 from .dashboard import LovelaceConfig
+from .exceptions import ConfigNotFound
 
 if TYPE_CHECKING:
     from .resources import ResourceStorageCollection


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

> Does it make sense to have a module for a single exception class?

I think it's worth it if the exception class is shared with multiple modules.

We currently have 6 integrations that have a module holding a single Exception/Error class:
- [dwd_weather_warnings](https://github.com/home-assistant/core/blob/75bdcee3e4921410485e3a99fbc8596036dfc5c6/homeassistant/components/dwd_weather_warnings/exceptions.py#L6)
- [google_tasks](https://github.com/home-assistant/core/blob/75bdcee3e4921410485e3a99fbc8596036dfc5c6/homeassistant/components/google_tasks/exceptions.py#L6)
- [madvr](https://github.com/home-assistant/core/blob/75bdcee3e4921410485e3a99fbc8596036dfc5c6/homeassistant/components/madvr/errors.py#L4)
- [volvooncall](https://github.com/home-assistant/core/blob/75bdcee3e4921410485e3a99fbc8596036dfc5c6/homeassistant/components/volvooncall/errors.py#L6)
- [websocket_api](https://github.com/home-assistant/core/blob/75bdcee3e4921410485e3a99fbc8596036dfc5c6/homeassistant/components/websocket_api/error.py#L6)
- [wyoming](https://github.com/home-assistant/core/blob/75bdcee3e4921410485e3a99fbc8596036dfc5c6/homeassistant/components/wyoming/error.py#L6)

We also have a similar pattern for [media_player](https://github.com/home-assistant/core/blob/73bd21e0ab0a7fc51d52d83d308d7590ebe2a4f8/homeassistant/components/media_player/errors.py#L10) which defines a base exception class `MediaPlayerException` which is only used to expose `BrowseError`

> Exceptions often live in an exceptions module

I did a quick scan regarding the most common file name in our codebase, and I found:
- `exception.py` => 1 integration
- `exceptions.py` => 8 integrations
- `error.py` => 5 integrations
- `errors.py` => 20 integrations

In a follow-up PR, I think these could/should be standardized to always be `exceptions.py`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
