### PR TITLE
Fix grammar of OSO auth and action descriptions

### DIFF
--- a/homeassistant/components/osoenergy/strings.json
+++ b/homeassistant/components/osoenergy/strings.json
@@ -2,15 +2,15 @@
   "config": {
     "step": {
       "user": {
-        "title": "OSO Energy Auth",
-        "description": "Enter the generated 'Subscription Key' for your account at 'https://portal.osoenergy.no/'",
+        "title": "OSO Energy auth",
+        "description": "Enter the 'Subscription key' for your account generated at 'https://portal.osoenergy.no/'",
         "data": {
           "api_key": "[%key:common::config_flow::data::api_key%]"
         }
       },
       "reauth": {
-        "title": "OSO Energy Auth",
-        "description": "Generate and enter a new 'Subscription Key' for your account at 'https://portal.osoenergy.no/'.",
+        "title": "OSO Energy auth",
+        "description": "Enter a new 'Subscription key' for your account generated at 'https://portal.osoenergy.no/'.",
         "data": {
           "api_key": "[%key:common::config_flow::data::api_key%]"
         }
@@ -95,11 +95,11 @@
   "services": {
     "get_profile": {
       "name": "Get heater profile",
-      "description": "Get the temperature profile of water heater"
+      "description": "Gets the temperature profile for water heater"
     },
     "set_profile": {
       "name": "Set heater profile",
-      "description": "Set the temperature profile of water heater",
+      "description": "Sets the temperature profile for water heater",
       "fields": {
         "hour_00": {
           "name": "00:00",
@@ -201,7 +201,7 @@
     },
     "set_v40_min": {
       "name": "Set v40 min",
-      "description": "Set the minimum quantity of water at 40°C for a heater",
+      "description": "Sets the minimum quantity of water at 40°C for a heater",
       "fields": {
         "v40_min": {
           "name": "V40 Min",
@@ -211,7 +211,7 @@
     },
     "turn_off": {
       "name": "Turn off heating",
-      "description": "Turn off heating for one hour or until min temperature is reached",
+      "description": "Turns off heating for one hour or until min temperature is reached",
       "fields": {
         "until_temp_limit": {
           "name": "Until temperature limit",
@@ -221,7 +221,7 @@
     },
     "turn_on": {
       "name": "Turn on heating",
-      "description": "Turn on heating for one hour or until max temperature is reached",
+      "description": "Turns on heating for one hour or until max temperature is reached",
       "fields": {
         "until_temp_limit": {
           "name": "Until temperature limit",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

As the online documentation explains, "the OSO Energy integration uses a subscription key, which a user can create for his account on the [OSO Energy website](https://portal.osoenergy.no/)".

The current onboarding descriptions have this backwards, sounding as if the key is generated and then entered on the website.

This PR fixes this along with proper sentence-casing for a few words and changing all action descriptions to use third-person singular, matching the Home Assistant style and ensuring correct (machine) translations in descriptive language.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
