### PR TITLE
Replace key names with translatable friendly names in zwave_js

### DIFF
--- a/homeassistant/components/zwave_js/strings.json
+++ b/homeassistant/components/zwave_js/strings.json
@@ -306,7 +306,7 @@
       "description": "Calls a Command Class API on a node. Some Command Classes can't be fully controlled via the `set_value` action and require direct calls to the Command Class API.",
       "fields": {
         "area_id": {
-          "description": "The area(s) to target for this action. If an area is specified, all zwave_js devices and entities in that area will be targeted for this action.",
+          "description": "The area(s) to target for this action. If an area is specified, all Z-Wave JS devices and entities in that area will be targeted for this action.",
           "name": "Area ID(s)"
         },
         "command_class": {
@@ -474,7 +474,7 @@
           "name": "[%key:component::zwave_js::services::set_value::fields::area_id::name%]"
         },
         "bitmask": {
-          "description": "Target a specific bitmask (see the documentation for more information). Cannot be combined with value_size or value_format.",
+          "description": "Target a specific bitmask (see the documentation for more information). Cannot be combined with 'Value size' or 'Value format'.",
           "name": "Bitmask"
         },
         "device_id": {
@@ -498,11 +498,11 @@
           "name": "Value"
         },
         "value_format": {
-          "description": "Format of the value, 0 for signed integer, 1 for unsigned integer, 2 for enumerated, 3 for bitfield. Used in combination with value_size when a config parameter is not defined in your device's configuration file. Cannot be combined with bitmask.",
+          "description": "Format of the value, 0 for signed integer, 1 for unsigned integer, 2 for enumerated, 3 for bitfield. Used in combination with 'Value size' when a config parameter is not defined in your device's configuration file. Cannot be combined with 'Bitmask'.",
           "name": "Value format"
         },
         "value_size": {
-          "description": "Size of the value, either 1, 2, or 4. Used in combination with value_format when a config parameter is not defined in your device's configuration file. Cannot be combined with bitmask.",
+          "description": "Size of the value, either 1, 2, or 4. Used in combination with 'Value format' when a config parameter is not defined in your device's configuration file. Cannot be combined with 'Bitmask'.",
           "name": "Value size"
         }
       },
@@ -556,7 +556,7 @@
       "description": "Changes any value that Z-Wave JS recognizes on a Z-Wave device. This action has minimal validation so only use this action if you know what you are doing.",
       "fields": {
         "area_id": {
-          "description": "The area(s) to target for this action. If an area is specified, all zwave_js devices and entities in that area will be targeted for this action.",
+          "description": "The area(s) to target for this action. If an area is specified, all Z-Wave JS devices and entities in that area will be targeted for this action.",
           "name": "Area ID(s)"
         },
         "command_class": {

--- a/homeassistant/components/zwave_js/strings.json
+++ b/homeassistant/components/zwave_js/strings.json
@@ -306,7 +306,7 @@
       "description": "Calls a Command Class API on a node. Some Command Classes can't be fully controlled via the `set_value` action and require direct calls to the Command Class API.",
       "fields": {
         "area_id": {
-          "description": "The area(s) to target for this action. If an area is specified, all Z-Wave JS devices and entities in that area will be targeted for this action.",
+          "description": "The area(s) to target for this action. If an area is specified, all Z-Wave devices and entities in that area will be targeted for this action.",
           "name": "Area ID(s)"
         },
         "command_class": {

--- a/homeassistant/components/zwave_js/strings.json
+++ b/homeassistant/components/zwave_js/strings.json
@@ -556,7 +556,7 @@
       "description": "Changes any value that Z-Wave JS recognizes on a Z-Wave device. This action has minimal validation so only use this action if you know what you are doing.",
       "fields": {
         "area_id": {
-          "description": "The area(s) to target for this action. If an area is specified, all Z-Wave JS devices and entities in that area will be targeted for this action.",
+          "description": "The area(s) to target for this action. If an area is specified, all Z-Wave devices and entities in that area will be targeted for this action.",
           "name": "Area ID(s)"
         },
         "command_class": {

--- a/homeassistant/components/zwave_js/strings.json
+++ b/homeassistant/components/zwave_js/strings.json
@@ -1,28 +1,28 @@
 {
   "config": {
     "abort": {
-      "addon_get_discovery_info_failed": "Failed to get Z-Wave JS add-on discovery info.",
-      "addon_info_failed": "Failed to get Z-Wave JS add-on info.",
-      "addon_install_failed": "Failed to install the Z-Wave JS add-on.",
-      "addon_set_config_failed": "Failed to set Z-Wave JS configuration.",
-      "addon_start_failed": "Failed to start the Z-Wave JS add-on.",
+      "addon_get_discovery_info_failed": "Failed to get Z-Wave add-on discovery info.",
+      "addon_info_failed": "Failed to get Z-Wave add-on info.",
+      "addon_install_failed": "Failed to install the Z-Wave add-on.",
+      "addon_set_config_failed": "Failed to set Z-Wave configuration.",
+      "addon_start_failed": "Failed to start the Z-Wave add-on.",
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
       "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "discovery_requires_supervisor": "Discovery requires the supervisor.",
       "not_zwave_device": "Discovered device is not a Z-Wave device.",
-      "not_zwave_js_addon": "Discovered add-on is not the official Z-Wave JS add-on."
+      "not_zwave_js_addon": "Discovered add-on is not the official Z-Wave add-on."
     },
     "error": {
-      "addon_start_failed": "Failed to start the Z-Wave JS add-on. Check the configuration.",
+      "addon_start_failed": "Failed to start the Z-Wave add-on. Check the configuration.",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_ws_url": "Invalid websocket URL",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "flow_title": "{name}",
     "progress": {
-      "install_addon": "Please wait while the Z-Wave JS add-on installation finishes. This can take several minutes.",
-      "start_addon": "Please wait while the Z-Wave JS add-on start completes. This may take some seconds."
+      "install_addon": "Please wait while the Z-Wave add-on installation finishes. This can take several minutes.",
+      "start_addon": "Please wait while the Z-Wave add-on start completes. This may take some seconds."
     },
     "step": {
       "configure_addon": {
@@ -34,13 +34,13 @@
           "usb_path": "[%key:common::config_flow::data::usb_path%]"
         },
         "description": "The add-on will generate security keys if those fields are left empty.",
-        "title": "Enter the Z-Wave JS add-on configuration"
+        "title": "Enter the Z-Wave add-on configuration"
       },
       "hassio_confirm": {
-        "title": "Set up Z-Wave JS integration with the Z-Wave JS add-on"
+        "title": "Set up Z-Wave integration with the Z-Wave add-on"
       },
       "install_addon": {
-        "title": "The Z-Wave JS add-on installation has started"
+        "title": "The Z-Wave add-on installation has started"
       },
       "manual": {
         "data": {
@@ -49,20 +49,20 @@
       },
       "on_supervisor": {
         "data": {
-          "use_addon": "Use the Z-Wave JS Supervisor add-on"
+          "use_addon": "Use the Z-Wave Supervisor add-on"
         },
-        "description": "Do you want to use the Z-Wave JS Supervisor add-on?",
+        "description": "Do you want to use the Z-Wave Supervisor add-on?",
         "title": "Select connection method"
       },
       "start_addon": {
-        "title": "The Z-Wave JS add-on is starting."
+        "title": "The Z-Wave add-on is starting."
       },
       "usb_confirm": {
-        "description": "Do you want to set up {name} with the Z-Wave JS add-on?"
+        "description": "Do you want to set up {name} with the Z-Wave add-on?"
       },
       "zeroconf_confirm": {
-        "description": "Do you want to add the Z-Wave JS Server with home ID {home_id} found at {url} to Home Assistant?",
-        "title": "Discovered Z-Wave JS Server"
+        "description": "Do you want to add the Z-Wave Server with home ID {home_id} found at {url} to Home Assistant?",
+        "title": "Discovered Z-Wave Server"
       }
     }
   },
@@ -89,7 +89,7 @@
       "event.value_notification.scene_activation": "Scene Activation on {subtype}",
       "state.node_status": "Node status changed",
       "zwave_js.value_updated.config_parameter": "Value change on config parameter {subtype}",
-      "zwave_js.value_updated.value": "Value change on a Z-Wave JS Value"
+      "zwave_js.value_updated.value": "Value change on a Z-Wave Value"
     },
     "extra_fields": {
       "code_slot": "Code slot",
@@ -191,7 +191,7 @@
         },
         "step": {
           "init": {
-            "description": "The device configuration file for {device_name} has changed.\n\nZ-Wave JS discovers a lot of device metadata by interviewing the device. However, some of the information has to be loaded from a configuration file. Some of this information is only evaluated once, during the device interview.\n\nWhen a device config file is updated, this information may be stale and and the device must be re-interviewed to pick up the changes.\n\n This is not a required operation and device functionality will be impacted during the re-interview process, but you may see improvements for your device once it is complete.\n\nIf you decide to proceed with the re-interview, it will take place in the background.",
+            "description": "The device configuration file for {device_name} has changed.\n\nZ-Wave discovers a lot of device metadata by interviewing the device. However, some of the information has to be loaded from a configuration file. Some of this information is only evaluated once, during the device interview.\n\nWhen a device config file is updated, this information may be stale and and the device must be re-interviewed to pick up the changes.\n\n This is not a required operation and device functionality will be impacted during the re-interview process, but you may see improvements for your device once it is complete.\n\nIf you decide to proceed with the re-interview, it will take place in the background.",
             "menu_options": {
               "confirm": "Re-interview device",
               "ignore": "Ignore device config update"
@@ -203,8 +203,8 @@
       "title": "Device configuration file changed: {device_name}"
     },
     "invalid_server_version": {
-      "description": "The version of Z-Wave JS Server you are currently running is too old for this version of Home Assistant. Please update the Z-Wave JS Server to the latest version to fix this issue.",
-      "title": "Newer version of Z-Wave JS Server needed"
+      "description": "The version of Z-Wave Server you are currently running is too old for this version of Home Assistant. Please update the Z-Wave Server to the latest version to fix this issue.",
+      "title": "Newer version of Z-Wave Server needed"
     }
   },
   "options": {
@@ -326,18 +326,18 @@
           "name": "Entity ID(s)"
         },
         "method_name": {
-          "description": "The name of the API method to call. Refer to the Z-Wave JS Command Class API documentation (https://zwave-js.github.io/node-zwave-js/#/api/CCs/index) for available methods.",
+          "description": "The name of the API method to call. Refer to the Z-Wave Command Class API documentation (https://zwave-js.github.io/node-zwave-js/#/api/CCs/index) for available methods.",
           "name": "Method name"
         },
         "parameters": {
-          "description": "A list of parameters to pass to the API method. Refer to the Z-Wave JS Command Class API documentation (https://zwave-js.github.io/node-zwave-js/#/api/CCs/index) for parameters.",
+          "description": "A list of parameters to pass to the API method. Refer to the Z-Wave Command Class API documentation (https://zwave-js.github.io/node-zwave-js/#/api/CCs/index) for parameters.",
           "name": "Parameters"
         }
       },
       "name": "Invoke a Command Class API on a node (advanced)"
     },
     "multicast_set_value": {
-      "description": "Changes any value that Z-Wave JS recognizes on multiple Z-Wave devices using multicast, so all devices receive the message simultaneously. This action has minimal validation so only use this action if you know what you are doing.",
+      "description": "Changes any value that Z-Wave recognizes on multiple Z-Wave devices using multicast, so all devices receive the message simultaneously. This action has minimal validation so only use this action if you know what you are doing.",
       "fields": {
         "area_id": {
           "description": "[%key:component::zwave_js::services::set_value::fields::area_id::description%]",
@@ -383,7 +383,7 @@
       "name": "Set a value on multiple devices via multicast (advanced)"
     },
     "ping": {
-      "description": "Forces Z-Wave JS to try to reach a node. This can be used to update the status of the node in Z-Wave JS when you think it doesn't accurately reflect reality, e.g. reviving a failed/dead node or marking the node as asleep.",
+      "description": "Forces Z-Wave to try to reach a node. This can be used to update the status of the node in Z-Wave when you think it doesn't accurately reflect reality, e.g. reviving a failed/dead node or marking the node as asleep.",
       "fields": {
         "area_id": {
           "description": "[%key:component::zwave_js::services::set_value::fields::area_id::description%]",
@@ -553,7 +553,7 @@
       "name": "Set lock user code"
     },
     "set_value": {
-      "description": "Changes any value that Z-Wave JS recognizes on a Z-Wave device. This action has minimal validation so only use this action if you know what you are doing.",
+      "description": "Changes any value that Z-Wave recognizes on a Z-Wave device. This action has minimal validation so only use this action if you know what you are doing.",
       "fields": {
         "area_id": {
           "description": "The area(s) to target for this action. If an area is specified, all Z-Wave devices and entities in that area will be targeted for this action.",
@@ -576,7 +576,7 @@
           "name": "Entity ID(s)"
         },
         "options": {
-          "description": "Set value options map. Refer to the Z-Wave JS documentation for more information on what options can be set.",
+          "description": "Set value options map. Refer to the Z-Wave documentation for more information on what options can be set.",
           "name": "Options"
         },
         "property": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

- In descriptions replace the field keys `bitmask`, `value_size`, `value_format` with friendly names to allow matching translations.
- Replace two remaining occurrences of `zwave_js` with "Z-Wave" 
- Replace all remaining occurrences of "Z-Wave JS" with "Z-Wave"

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
