### PR TITLE
Adjust HomeWizard Zeroconf flow to handle v2 API authorization

### DIFF
--- a/homeassistant/components/homewizard/config_flow.py
+++ b/homeassistant/components/homewizard/config_flow.py
@@ -181,7 +181,6 @@ class HomeWizardConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input is not None or not onboarding.async_is_onboarded(self.hass):
             try:
                 await self._async_try_connect(self.ip_address)
-
             except RecoverableError as ex:
                 LOGGER.error(ex)
                 errors = {"base": ex.error_code}

--- a/homeassistant/components/homewizard/config_flow.py
+++ b/homeassistant/components/homewizard/config_flow.py
@@ -22,21 +22,14 @@ import voluptuous as vol
 
 from homeassistant.components import onboarding
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
-from homeassistant.const import CONF_IP_ADDRESS, CONF_PATH, CONF_TOKEN
+from homeassistant.const import CONF_IP_ADDRESS, CONF_TOKEN
 from homeassistant.data_entry_flow import AbortFlow
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.selector import TextSelector
 from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
-from .const import (
-    CONF_API_ENABLED,
-    CONF_PRODUCT_NAME,
-    CONF_PRODUCT_TYPE,
-    CONF_SERIAL,
-    DOMAIN,
-    LOGGER,
-)
+from .const import CONF_PRODUCT_NAME, CONF_PRODUCT_TYPE, CONF_SERIAL, DOMAIN, LOGGER
 
 
 class HomeWizardConfigFlow(ConfigFlow, domain=DOMAIN):
@@ -105,6 +98,7 @@ class HomeWizardConfigFlow(ConfigFlow, domain=DOMAIN):
             return self.async_show_form(step_id="authorize", errors=errors)
 
         # Now we got a token, we can ask for some more info
+
         async with HomeWizardEnergyV2(self.ip_address, token=token) as api:
             device_info = await api.device()
 
@@ -126,17 +120,13 @@ class HomeWizardConfigFlow(ConfigFlow, domain=DOMAIN):
         self, discovery_info: ZeroconfServiceInfo
     ) -> ConfigFlowResult:
         """Handle zeroconf discovery."""
+
         if (
-            CONF_API_ENABLED not in discovery_info.properties
-            or CONF_PATH not in discovery_info.properties
-            or CONF_PRODUCT_NAME not in discovery_info.properties
+            CONF_PRODUCT_NAME not in discovery_info.properties
             or CONF_PRODUCT_TYPE not in discovery_info.properties
             or CONF_SERIAL not in discovery_info.properties
         ):
             return self.async_abort(reason="invalid_discovery_parameters")
-
-        if (discovery_info.properties[CONF_PATH]) != "/api/v1":
-            return self.async_abort(reason="unsupported_api_version")
 
         self.ip_address = discovery_info.host
         self.product_type = discovery_info.properties[CONF_PRODUCT_TYPE]
@@ -191,9 +181,12 @@ class HomeWizardConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input is not None or not onboarding.async_is_onboarded(self.hass):
             try:
                 await self._async_try_connect(self.ip_address)
+
             except RecoverableError as ex:
                 LOGGER.error(ex)
                 errors = {"base": ex.error_code}
+            except UnauthorizedError:
+                return await self.async_step_authorize()
             else:
                 return self.async_create_entry(
                     title=self.product_name,

--- a/homeassistant/components/homewizard/const.py
+++ b/homeassistant/components/homewizard/const.py
@@ -13,8 +13,6 @@ PLATFORMS = [Platform.BUTTON, Platform.NUMBER, Platform.SENSOR, Platform.SWITCH]
 LOGGER = logging.getLogger(__package__)
 
 # Platform config.
-CONF_API_ENABLED = "api_enabled"
-CONF_DATA = "data"
 CONF_PRODUCT_NAME = "product_name"
 CONF_PRODUCT_TYPE = "product_type"
 CONF_SERIAL = "serial"

--- a/homeassistant/components/homewizard/const.py
+++ b/homeassistant/components/homewizard/const.py
@@ -13,6 +13,8 @@ PLATFORMS = [Platform.BUTTON, Platform.NUMBER, Platform.SENSOR, Platform.SWITCH]
 LOGGER = logging.getLogger(__package__)
 
 # Platform config.
+CONF_API_ENABLED = "api_enabled"
+CONF_DATA = "data"
 CONF_PRODUCT_NAME = "product_name"
 CONF_PRODUCT_TYPE = "product_type"
 CONF_SERIAL = "serial"

--- a/homeassistant/components/homewizard/manifest.json
+++ b/homeassistant/components/homewizard/manifest.json
@@ -13,5 +13,5 @@
   "loggers": ["homewizard_energy"],
   "quality_scale": "silver",
   "requirements": ["python-homewizard-energy==v8.1.1"],
-  "zeroconf": ["_hwenergy._tcp.local."]
+  "zeroconf": ["_hwenergy._tcp.local.", "_homewizard._tcp.local."]
 }

--- a/homeassistant/generated/zeroconf.py
+++ b/homeassistant/generated/zeroconf.py
@@ -522,6 +522,11 @@ ZEROCONF = {
             "domain": "homekit",
         },
     ],
+    "_homewizard._tcp.local.": [
+        {
+            "domain": "homewizard",
+        },
+    ],
     "_hscp._tcp.local.": [
         {
             "domain": "apple_tv",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adjust HomeWizard Zeroconf flow to handle v2 API authorization; When v2 API is detected the authorization step is triggered.

In this PR we also remove the version check during Discovery; The v1 API will not update and (at this moment) all v2 versions are supported.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
