### PR TITLE
Incorporate SourceManager into HEOS Coordinator

### DIFF
--- a/homeassistant/components/heos/const.py
+++ b/homeassistant/components/heos/const.py
@@ -2,8 +2,6 @@
 
 ATTR_PASSWORD = "password"
 ATTR_USERNAME = "username"
-COMMAND_RETRY_ATTEMPTS = 2
-COMMAND_RETRY_DELAY = 1
 DOMAIN = "heos"
 SERVICE_SIGN_IN = "sign_in"
 SERVICE_SIGN_OUT = "sign_out"

--- a/homeassistant/components/heos/coordinator.py
+++ b/homeassistant/components/heos/coordinator.py
@@ -238,7 +238,7 @@ class HeosCoordinator(DataUpdateCoordinator[None]):
                 if input_source.media_id == now_playing_media.media_id:
                     return input_source.name
         # Try matching favorite
-        if now_playing_media.type is MediaType.STATION:
+        if now_playing_media.type == MediaType.STATION:
             # Some stations match on name:station, others match on media_id:album_id
             for favorite in self._favorites.values():
                 if (

--- a/homeassistant/components/heos/coordinator.py
+++ b/homeassistant/components/heos/coordinator.py
@@ -5,23 +5,28 @@ The coordinator is responsible for refreshing data in response to system-wide ev
 entities to update. Entities subscribe to entity-specific updates within the entity class itself.
 """
 
+from datetime import datetime, timedelta
 import logging
 
 from pyheos import (
     Credentials,
     Heos,
     HeosError,
+    HeosNowPlayingMedia,
     HeosOptions,
+    HeosPlayer,
     MediaItem,
+    MediaType,
     PlayerUpdateResult,
     const,
 )
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME, Platform
-from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.core import HassJob, HomeAssistant, callback
+from homeassistant.exceptions import ConfigEntryNotReady, ServiceValidationError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from . import DOMAIN
@@ -50,8 +55,10 @@ class HeosCoordinator(DataUpdateCoordinator[None]):
                 credentials=credentials,
             )
         )
-        self.favorites: dict[int, MediaItem] = {}
-        self.inputs: list[MediaItem] = []
+        self._update_sources_pending: bool = False
+        self._source_list: list[str] = []
+        self._favorites: dict[int, MediaItem] = {}
+        self._inputs: list[MediaItem] = []
         super().__init__(hass, _LOGGER, config_entry=config_entry, name=DOMAIN)
 
     async def async_setup(self) -> None:
@@ -99,6 +106,7 @@ class HeosCoordinator(DataUpdateCoordinator[None]):
     async def _async_on_reconnected(self) -> None:
         """Handle when reconnected so resources are updated and entities marked available."""
         await self._async_update_players()
+        await self._async_update_sources()
         _LOGGER.warning("Successfully reconnected to HEOS host %s", self.host)
         self.async_update_listeners()
 
@@ -110,6 +118,31 @@ class HeosCoordinator(DataUpdateCoordinator[None]):
             assert data is not None
             if data.updated_player_ids:
                 self._async_update_player_ids(data.updated_player_ids)
+        elif (
+            event in (const.EVENT_SOURCES_CHANGED, const.EVENT_USER_CHANGED)
+            and not self._update_sources_pending
+        ):
+            # Update the sources after a brief delay as we may have received multiple qualifying
+            # events at once and devices cannot handle immediately attempting to refresh sources.
+            self._update_sources_pending = True
+
+            async def update_sources_job(_: datetime | None = None) -> None:
+                await self._async_update_sources()
+                self._update_sources_pending = False
+                self.async_update_listeners()
+
+            assert self.config_entry is not None
+            self.config_entry.async_on_unload(
+                async_call_later(
+                    self.hass,
+                    timedelta(seconds=1),
+                    HassJob(
+                        update_sources_job,
+                        "heos_update_sources",
+                        cancel_on_shutdown=True,
+                    ),
+                )
+            )
         self.async_update_listeners()
 
     def _async_update_player_ids(self, updated_player_ids: dict[int, int]) -> None:
@@ -145,17 +178,24 @@ class HeosCoordinator(DataUpdateCoordinator[None]):
 
     async def _async_update_sources(self) -> None:
         """Build source list for entities."""
+        self._source_list.clear()
         # Get favorites only if reportedly signed in.
         if self.heos.is_signed_in:
             try:
-                self.favorites = await self.heos.get_favorites()
+                self._favorites = await self.heos.get_favorites()
             except HeosError as error:
                 _LOGGER.error("Unable to retrieve favorites: %s", error)
+            else:
+                self._source_list.extend(
+                    [favorite.name for favorite in self._favorites.values()]
+                )
         # Get input sources (across all devices in the HEOS system)
         try:
-            self.inputs = await self.heos.get_input_sources()
+            self._inputs = await self.heos.get_input_sources()
         except HeosError as error:
             _LOGGER.error("Unable to retrieve input sources: %s", error)
+        else:
+            self._source_list.extend([source.name for source in self._inputs])
 
     async def _async_update_players(self) -> None:
         """Update players after reconnection."""
@@ -167,3 +207,61 @@ class HeosCoordinator(DataUpdateCoordinator[None]):
         # After reconnecting, player_id may have changed
         if player_updates.updated_player_ids:
             self._async_update_player_ids(player_updates.updated_player_ids)
+
+    @callback
+    def async_get_source_list(self) -> list[str]:
+        """Return the list of sources for players."""
+        return list(self._source_list)
+
+    @callback
+    def async_get_favorite_index(self, name: str) -> int | None:
+        """Get the index of a favorite by name."""
+        for index, favorite in self._favorites.items():
+            if favorite.name == name:
+                return index
+        return None
+
+    @callback
+    def async_get_current_source(
+        self, now_playing_media: HeosNowPlayingMedia
+    ) -> str | None:
+        """Determine current source from now playing media (either input source or favorite)."""
+        # Try matching input source
+        if now_playing_media.source_id == const.MUSIC_SOURCE_AUX_INPUT:
+            # If playing a remote input, name will match station
+            for input_source in self._inputs:
+                if input_source.name == now_playing_media.station:
+                    return input_source.name
+            # If playing a local input, match media_id. This needs to be a second loop as media_id
+            # will match both local and remote inputs, so prioritize remote match by name first.
+            for input_source in self._inputs:
+                if input_source.media_id == now_playing_media.media_id:
+                    return input_source.name
+        # Try matching favorite
+        if now_playing_media.type is MediaType.STATION:
+            # Some stations match on name:station, others match on media_id:album_id
+            for favorite in self._favorites.values():
+                if (
+                    favorite.name == now_playing_media.station
+                    or favorite.media_id == now_playing_media.album_id
+                ):
+                    return favorite.name
+        return None
+
+    async def async_play_source(self, source: str, player: HeosPlayer) -> None:
+        """Determine type of source and play it."""
+        # Favorite
+        if (index := self.async_get_favorite_index(source)) is not None:
+            await player.play_preset_station(index)
+            return
+        # Input source
+        for input_source in self._inputs:
+            if input_source.name == source:
+                await player.play_media(input_source)
+                return
+
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="unknown_source",
+            translation_placeholders={"source": source},
+        )

--- a/homeassistant/components/heos/coordinator.py
+++ b/homeassistant/components/heos/coordinator.py
@@ -187,7 +187,7 @@ class HeosCoordinator(DataUpdateCoordinator[None]):
                 _LOGGER.error("Unable to retrieve favorites: %s", error)
             else:
                 self._source_list.extend(
-                    [favorite.name for favorite in self._favorites.values()]
+                    favorite.name for favorite in self._favorites.values()
                 )
         # Get input sources (across all devices in the HEOS system)
         try:

--- a/tests/components/heos/conftest.py
+++ b/tests/components/heos/conftest.py
@@ -139,7 +139,7 @@ def players_fixture(quick_selects: dict[int, str]) -> dict[int, HeosPlayer]:
         player.mute = AsyncMock()
         player.pause = AsyncMock()
         player.play = AsyncMock()
-        player.play_input_source = AsyncMock()
+        player.play_media = AsyncMock()
         player.play_next = AsyncMock()
         player.play_previous = AsyncMock()
         player.play_preset_station = AsyncMock()
@@ -193,17 +193,28 @@ def favorites_fixture() -> dict[int, MediaItem]:
 @pytest.fixture(name="input_sources")
 def input_sources_fixture() -> list[MediaItem]:
     """Create a set of input sources for testing."""
-    source = MediaItem(
-        source_id=1,
-        name="HEOS Drive - Line In 1",
-        media_id=const.INPUT_AUX_IN_1,
-        type=MediaType.STATION,
-        playable=True,
-        browsable=False,
-        image_url="",
-        heos=None,
-    )
-    return [source]
+    return [
+        MediaItem(
+            source_id=const.MUSIC_SOURCE_AUX_INPUT,
+            name="HEOS Drive - Line In 1",
+            media_id=const.INPUT_AUX_IN_1,
+            type=MediaType.STATION,
+            playable=True,
+            browsable=False,
+            image_url="",
+            heos=None,
+        ),
+        MediaItem(
+            source_id=const.MUSIC_SOURCE_AUX_INPUT,
+            name="Speaker - Line In 1",
+            media_id=const.INPUT_AUX_IN_1,
+            type=MediaType.STATION,
+            playable=True,
+            browsable=False,
+            image_url="",
+            heos=None,
+        ),
+    ]
 
 
 @pytest.fixture(name="discovery_data")

--- a/tests/components/heos/snapshots/test_media_player.ambr
+++ b/tests/components/heos/snapshots/test_media_player.ambr
@@ -25,6 +25,7 @@
         "Today's Hits Radio",
         'Classical MPR (Classical Music)',
         'HEOS Drive - Line In 1',
+        'Speaker - Line In 1',
       ]),
       'supported_features': <MediaPlayerEntityFeature: 3079741>,
       'volume_level': 0.25,

--- a/tests/components/heos/test_init.py
+++ b/tests/components/heos/test_init.py
@@ -2,15 +2,7 @@
 
 from typing import cast
 
-from pyheos import (
-    CommandFailedError,
-    Heos,
-    HeosError,
-    HeosOptions,
-    SignalHeosEvent,
-    SignalType,
-    const,
-)
+from pyheos import Heos, HeosError, HeosOptions, SignalHeosEvent, SignalType
 import pytest
 
 from homeassistant.components.heos.const import DOMAIN
@@ -161,27 +153,6 @@ async def test_unload_entry(
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     assert await hass.config_entries.async_unload(config_entry.entry_id)
     assert controller.disconnect.call_count == 1
-
-
-async def test_update_sources_retry(
-    hass: HomeAssistant,
-    config_entry: MockConfigEntry,
-    controller: Heos,
-) -> None:
-    """Test update sources retries on failures to max attempts."""
-    config_entry.add_to_hass(hass)
-    assert await hass.config_entries.async_setup(config_entry.entry_id)
-    controller.get_favorites.reset_mock()
-    controller.get_input_sources.reset_mock()
-    source_manager = config_entry.runtime_data.source_manager
-    source_manager.retry_delay = 0
-    source_manager.max_retry_attempts = 1
-    controller.get_favorites.side_effect = CommandFailedError("Test", "test", 0)
-    await controller.dispatcher.wait_send(
-        SignalType.CONTROLLER_EVENT, const.EVENT_SOURCES_CHANGED, {}
-    )
-    await hass.async_block_till_done()
-    assert controller.get_favorites.call_count == 2
 
 
 async def test_device_info(

--- a/tests/components/heos/test_media_player.py
+++ b/tests/components/heos/test_media_player.py
@@ -1,14 +1,17 @@
 """Tests for the Heos Media Player platform."""
 
+from datetime import timedelta
 import re
 from typing import Any
 
+from freezegun.api import FrozenDateTimeFactory
 from pyheos import (
     AddCriteriaType,
     CommandFailedError,
     Heos,
     HeosError,
     MediaItem,
+    MediaType as HeosMediaType,
     PlayerUpdateResult,
     PlayState,
     RepeatType,
@@ -63,7 +66,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, async_fire_time_changed
 
 
 async def test_state_attributes(
@@ -206,18 +209,21 @@ async def test_updates_from_sources_updated(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
     controller: Heos,
-    input_sources: list[MediaItem],
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Tests player updates from changes in sources list."""
     config_entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     player = controller.players[1]
 
-    input_sources.clear()
+    controller.get_input_sources.return_value = []
     await player.heos.dispatcher.wait_send(
         SignalType.CONTROLLER_EVENT, const.EVENT_SOURCES_CHANGED, {}
     )
+    freezer.tick(timedelta(seconds=1))
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
+
     state = hass.states.get("media_player.test_player")
     assert state.attributes[ATTR_INPUT_SOURCE_LIST] == [
         "Today's Hits Radio",
@@ -288,6 +294,7 @@ async def test_updates_from_user_changed(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
     controller: Heos,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Tests player updates from changes in user."""
     config_entry.add_to_hass(hass)
@@ -298,10 +305,15 @@ async def test_updates_from_user_changed(
     await player.heos.dispatcher.wait_send(
         SignalType.CONTROLLER_EVENT, const.EVENT_USER_CHANGED, None
     )
+    freezer.tick(timedelta(seconds=1))
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
     state = hass.states.get("media_player.test_player")
-    assert state.attributes[ATTR_INPUT_SOURCE_LIST] == ["HEOS Drive - Line In 1"]
+    assert state.attributes[ATTR_INPUT_SOURCE_LIST] == [
+        "HEOS Drive - Line In 1",
+        "Speaker - Line In 1",
+    ]
 
 
 async def test_clear_playlist(
@@ -694,6 +706,7 @@ async def test_select_favorite(
     )
     player.play_preset_station.assert_called_once_with(1)
     # Test state is matched by station name
+    player.now_playing_media.type = HeosMediaType.STATION
     player.now_playing_media.station = favorite.name
     await player.heos.dispatcher.wait_send(
         SignalType.PLAYER_EVENT, player.player_id, const.EVENT_PLAYER_STATE_CHANGED
@@ -723,6 +736,7 @@ async def test_select_radio_favorite(
     )
     player.play_preset_station.assert_called_once_with(2)
     # Test state is matched by album id
+    player.now_playing_media.type = HeosMediaType.STATION
     player.now_playing_media.station = "Classical"
     player.now_playing_media.album_id = favorite.media_id
     await player.heos.dispatcher.wait_send(
@@ -762,37 +776,52 @@ async def test_select_radio_favorite_command_error(
     player.play_preset_station.assert_called_once_with(2)
 
 
+@pytest.mark.parametrize(
+    ("source_name", "station", "media_id"),
+    [
+        ("HEOS Drive - Line In 1", "Line In 1", const.INPUT_AUX_IN_1),
+        ("Speaker - Line In 1", "Speaker - Line In 1", const.INPUT_AUX_IN_1),
+    ],
+)
 async def test_select_input_source(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
     controller: Heos,
     input_sources: list[MediaItem],
+    source_name: str,
+    station: str,
+    media_id: str,
 ) -> None:
     """Tests selecting input source and state."""
     config_entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     player = controller.players[1]
-    # Test proper service called
-    input_source = input_sources[0]
+
     await hass.services.async_call(
         MEDIA_PLAYER_DOMAIN,
         SERVICE_SELECT_SOURCE,
         {
             ATTR_ENTITY_ID: "media_player.test_player",
-            ATTR_INPUT_SOURCE: input_source.name,
+            ATTR_INPUT_SOURCE: source_name,
         },
         blocking=True,
     )
-    player.play_input_source.assert_called_once_with(input_source.media_id)
-    # Test state is matched by media id
+    input_sources = next(
+        input_sources
+        for input_sources in input_sources
+        if input_sources.name == source_name
+    )
+    player.play_media.assert_called_once_with(input_sources)
+    # Update the now_playing_media to reflect play_media
     player.now_playing_media.source_id = const.MUSIC_SOURCE_AUX_INPUT
-    player.now_playing_media.media_id = const.INPUT_AUX_IN_1
+    player.now_playing_media.station = station
+    player.now_playing_media.media_id = media_id
     await player.heos.dispatcher.wait_send(
         SignalType.PLAYER_EVENT, player.player_id, const.EVENT_PLAYER_STATE_CHANGED
     )
     await hass.async_block_till_done()
     state = hass.states.get("media_player.test_player")
-    assert state.attributes[ATTR_INPUT_SOURCE] == input_source.name
+    assert state.attributes[ATTR_INPUT_SOURCE] == source_name
 
 
 async def test_select_input_unknown_raises(
@@ -824,7 +853,7 @@ async def test_select_input_command_error(
     await hass.config_entries.async_setup(config_entry.entry_id)
     player = controller.players[1]
     input_source = input_sources[0]
-    player.play_input_source.side_effect = CommandFailedError(None, "Failure", 1)
+    player.play_media.side_effect = CommandFailedError(None, "Failure", 1)
     with pytest.raises(
         HomeAssistantError,
         match=re.escape("Unable to select source: Failure (1)"),
@@ -838,7 +867,7 @@ async def test_select_input_command_error(
             },
             blocking=True,
         )
-    player.play_input_source.assert_called_once_with(input_source.media_id)
+    player.play_media.assert_called_once_with(input_source)
 
 
 async def test_unload_config_entry(

--- a/tests/components/heos/test_media_player.py
+++ b/tests/components/heos/test_media_player.py
@@ -777,10 +777,10 @@ async def test_select_radio_favorite_command_error(
 
 
 @pytest.mark.parametrize(
-    ("source_name", "station", "media_id"),
+    ("source_name", "station"),
     [
-        ("HEOS Drive - Line In 1", "Line In 1", const.INPUT_AUX_IN_1),
-        ("Speaker - Line In 1", "Speaker - Line In 1", const.INPUT_AUX_IN_1),
+        ("HEOS Drive - Line In 1", "Line In 1"),
+        ("Speaker - Line In 1", "Speaker - Line In 1"),
     ],
 )
 async def test_select_input_source(
@@ -790,7 +790,6 @@ async def test_select_input_source(
     input_sources: list[MediaItem],
     source_name: str,
     station: str,
-    media_id: str,
 ) -> None:
     """Tests selecting input source and state."""
     config_entry.add_to_hass(hass)
@@ -815,7 +814,7 @@ async def test_select_input_source(
     # Update the now_playing_media to reflect play_media
     player.now_playing_media.source_id = const.MUSIC_SOURCE_AUX_INPUT
     player.now_playing_media.station = station
-    player.now_playing_media.media_id = media_id
+    player.now_playing_media.media_id = const.INPUT_AUX_IN_1
     await player.heos.dispatcher.wait_send(
         SignalType.PLAYER_EVENT, player.player_id, const.EVENT_PLAYER_STATE_CHANGED
     )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In the penultimate HEOS coordinator change, this incorporates the functionality of the `SourceManager` into the coordinator in order to leverage the ability to update listeners and centralize event callback logic.

The `SourceManager` was responsible for maintaining a consolidated list of inputs and favorites for media players and updating sources when events are received that affect their availability. It also contained functions like playing a source and determining the current source. The previous implementation used a debouncer and complex retry logic to handle HEOS's inability to refresh sources immediately. This was changed to a more elegant and simple solution by simply updating sources after a 1s delay. This also corrects a bug where input sources on other devices were not handled properly.

The final step after this is to incorporate the `GroupManager`. 🚀 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
