### PR TITLE
Add switch platform to LetPot integration

### DIFF
--- a/homeassistant/components/letpot/__init__.py
+++ b/homeassistant/components/letpot/__init__.py
@@ -23,7 +23,7 @@ from .const import (
 )
 from .coordinator import LetPotDeviceCoordinator
 
-PLATFORMS: list[Platform] = [Platform.TIME]
+PLATFORMS: list[Platform] = [Platform.SWITCH, Platform.TIME]
 
 type LetPotConfigEntry = ConfigEntry[list[LetPotDeviceCoordinator]]
 

--- a/homeassistant/components/letpot/icons.json
+++ b/homeassistant/components/letpot/icons.json
@@ -1,0 +1,24 @@
+{
+  "entity": {
+    "switch": {
+      "alarm_sound": {
+        "default": "mdi:bell-ring",
+        "state": {
+          "off": "mdi:bell-off"
+        }
+      },
+      "auto_mode": {
+        "default": "mdi:water-pump",
+        "state": {
+          "off": "mdi:water-pump-off"
+        }
+      },
+      "pump_cycling": {
+        "default": "mdi:pump",
+        "state": {
+          "off": "mdi:pump-off"
+        }
+      }
+    }
+  }
+}

--- a/homeassistant/components/letpot/quality_scale.yaml
+++ b/homeassistant/components/letpot/quality_scale.yaml
@@ -64,7 +64,7 @@ rules:
   entity-disabled-by-default: todo
   entity-translations: done
   exception-translations: done
-  icon-translations: todo
+  icon-translations: done
   reconfiguration-flow: todo
   repair-issues: todo
   stale-devices: todo

--- a/homeassistant/components/letpot/strings.json
+++ b/homeassistant/components/letpot/strings.json
@@ -32,6 +32,20 @@
     }
   },
   "entity": {
+    "switch": {
+      "alarm_sound": {
+        "name": "Alarm sound"
+      },
+      "auto_mode": {
+        "name": "Auto mode"
+      },
+      "power": {
+        "name": "Power"
+      },
+      "pump_cycling": {
+        "name": "Pump cycling"
+      }
+    },
     "time": {
       "light_schedule_end": {
         "name": "Light off"

--- a/homeassistant/components/letpot/switch.py
+++ b/homeassistant/components/letpot/switch.py
@@ -1,0 +1,117 @@
+"""Support for LetPot switch entities."""
+
+from collections.abc import Callable, Coroutine
+from dataclasses import dataclass
+from typing import Any
+
+from letpot.deviceclient import LetPotDeviceClient
+from letpot.models import DeviceFeature, LetPotDeviceStatus
+
+from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import LetPotConfigEntry
+from .coordinator import LetPotDeviceCoordinator
+from .entity import LetPotEntity
+
+# Each change pushes a 'full' device status with the change. The library will cache
+# pending changes to avoid overwriting, but try to avoid a lot of parallelism.
+PARALLEL_UPDATES = 1
+
+
+@dataclass(frozen=True, kw_only=True)
+class LetPotSwitchEntityDescription(SwitchEntityDescription):
+    """Describes a LetPot switch entity."""
+
+    value_fn: Callable[[LetPotDeviceStatus], bool | None]
+    set_value_fn: Callable[[LetPotDeviceClient, bool], Coroutine[Any, Any, None]]
+
+
+BASE_SWITCHES: tuple[LetPotSwitchEntityDescription, ...] = (
+    LetPotSwitchEntityDescription(
+        key="power",
+        translation_key="power",
+        value_fn=lambda status: None if status is None else status.system_on,
+        set_value_fn=lambda deviceclient, value: deviceclient.set_power(value),
+        entity_category=EntityCategory.CONFIG,
+    ),
+    LetPotSwitchEntityDescription(
+        key="pump_cycling",
+        translation_key="pump_cycling",
+        value_fn=lambda status: None if status is None else status.pump_mode == 1,
+        set_value_fn=lambda deviceclient, value: deviceclient.set_pump_mode(value),
+        entity_category=EntityCategory.CONFIG,
+    ),
+)
+ALARM_SWITCH: LetPotSwitchEntityDescription = LetPotSwitchEntityDescription(
+    key="alarm_sound",
+    translation_key="alarm_sound",
+    value_fn=lambda status: None if status is None else status.system_sound,
+    set_value_fn=lambda deviceclient, value: deviceclient.set_sound(value),
+    entity_category=EntityCategory.CONFIG,
+)
+AUTO_MODE_SWITCH: LetPotSwitchEntityDescription = LetPotSwitchEntityDescription(
+    key="auto_mode",
+    translation_key="auto_mode",
+    value_fn=lambda status: None if status is None else status.water_mode == 1,
+    set_value_fn=lambda deviceclient, value: deviceclient.set_water_mode(value),
+    entity_category=EntityCategory.CONFIG,
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: LetPotConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up LetPot switch entities based on a config entry and device status/features."""
+    coordinators = entry.runtime_data
+    entities: list[SwitchEntity] = [
+        LetPotSwitchEntity(coordinator, description)
+        for description in BASE_SWITCHES
+        for coordinator in coordinators
+    ]
+    entities.extend(
+        LetPotSwitchEntity(coordinator, ALARM_SWITCH)
+        for coordinator in coordinators
+        if coordinator.data.system_sound is not None
+    )
+    entities.extend(
+        LetPotSwitchEntity(coordinator, AUTO_MODE_SWITCH)
+        for coordinator in coordinators
+        if DeviceFeature.PUMP_AUTO in coordinator.device_client.device_features
+    )
+    async_add_entities(entities)
+
+
+class LetPotSwitchEntity(LetPotEntity, SwitchEntity):
+    """Defines a LetPot switch entity."""
+
+    entity_description: LetPotSwitchEntityDescription
+
+    def __init__(
+        self,
+        coordinator: LetPotDeviceCoordinator,
+        description: LetPotSwitchEntityDescription,
+    ) -> None:
+        """Initialize LetPot switch entity."""
+        super().__init__(coordinator)
+        self.entity_description = description
+        self._attr_unique_id = f"{coordinator.config_entry.unique_id}_{coordinator.device.serial_number}_{description.key}"
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return if the entity is on."""
+        return self.entity_description.value_fn(self.coordinator.data)
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the entity on."""
+        await self.entity_description.set_value_fn(self.coordinator.device_client, True)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the entity off."""
+        await self.entity_description.set_value_fn(
+            self.coordinator.device_client, False
+        )

--- a/homeassistant/components/letpot/switch.py
+++ b/homeassistant/components/letpot/switch.py
@@ -33,14 +33,14 @@ BASE_SWITCHES: tuple[LetPotSwitchEntityDescription, ...] = (
     LetPotSwitchEntityDescription(
         key="power",
         translation_key="power",
-        value_fn=lambda status: None if status is None else status.system_on,
+        value_fn=lambda status: status.system_on,
         set_value_fn=lambda device_client, value: device_client.set_power(value),
         entity_category=EntityCategory.CONFIG,
     ),
     LetPotSwitchEntityDescription(
         key="pump_cycling",
         translation_key="pump_cycling",
-        value_fn=lambda status: None if status is None else status.pump_mode == 1,
+        value_fn=lambda status: status.pump_mode == 1,
         set_value_fn=lambda device_client, value: device_client.set_pump_mode(value),
         entity_category=EntityCategory.CONFIG,
     ),
@@ -48,14 +48,14 @@ BASE_SWITCHES: tuple[LetPotSwitchEntityDescription, ...] = (
 ALARM_SWITCH: LetPotSwitchEntityDescription = LetPotSwitchEntityDescription(
     key="alarm_sound",
     translation_key="alarm_sound",
-    value_fn=lambda status: None if status is None else status.system_sound,
+    value_fn=lambda status: status.system_sound,
     set_value_fn=lambda device_client, value: device_client.set_sound(value),
     entity_category=EntityCategory.CONFIG,
 )
 AUTO_MODE_SWITCH: LetPotSwitchEntityDescription = LetPotSwitchEntityDescription(
     key="auto_mode",
     translation_key="auto_mode",
-    value_fn=lambda status: None if status is None else status.water_mode == 1,
+    value_fn=lambda status: status.water_mode == 1,
     set_value_fn=lambda device_client, value: device_client.set_water_mode(value),
     entity_category=EntityCategory.CONFIG,
 )

--- a/homeassistant/components/letpot/switch.py
+++ b/homeassistant/components/letpot/switch.py
@@ -14,7 +14,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import LetPotConfigEntry
 from .coordinator import LetPotDeviceCoordinator
-from .entity import LetPotEntity
+from .entity import LetPotEntity, exception_handler
 
 # Each change pushes a 'full' device status with the change. The library will cache
 # pending changes to avoid overwriting, but try to avoid a lot of parallelism.
@@ -106,10 +106,12 @@ class LetPotSwitchEntity(LetPotEntity, SwitchEntity):
         """Return if the entity is on."""
         return self.entity_description.value_fn(self.coordinator.data)
 
+    @exception_handler
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
         await self.entity_description.set_value_fn(self.coordinator.device_client, True)
 
+    @exception_handler
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
         await self.entity_description.set_value_fn(

--- a/homeassistant/components/letpot/switch.py
+++ b/homeassistant/components/letpot/switch.py
@@ -34,14 +34,14 @@ BASE_SWITCHES: tuple[LetPotSwitchEntityDescription, ...] = (
         key="power",
         translation_key="power",
         value_fn=lambda status: None if status is None else status.system_on,
-        set_value_fn=lambda deviceclient, value: deviceclient.set_power(value),
+        set_value_fn=lambda device_client, value: device_client.set_power(value),
         entity_category=EntityCategory.CONFIG,
     ),
     LetPotSwitchEntityDescription(
         key="pump_cycling",
         translation_key="pump_cycling",
         value_fn=lambda status: None if status is None else status.pump_mode == 1,
-        set_value_fn=lambda deviceclient, value: deviceclient.set_pump_mode(value),
+        set_value_fn=lambda device_client, value: device_client.set_pump_mode(value),
         entity_category=EntityCategory.CONFIG,
     ),
 )
@@ -49,14 +49,14 @@ ALARM_SWITCH: LetPotSwitchEntityDescription = LetPotSwitchEntityDescription(
     key="alarm_sound",
     translation_key="alarm_sound",
     value_fn=lambda status: None if status is None else status.system_sound,
-    set_value_fn=lambda deviceclient, value: deviceclient.set_sound(value),
+    set_value_fn=lambda device_client, value: device_client.set_sound(value),
     entity_category=EntityCategory.CONFIG,
 )
 AUTO_MODE_SWITCH: LetPotSwitchEntityDescription = LetPotSwitchEntityDescription(
     key="auto_mode",
     translation_key="auto_mode",
     value_fn=lambda status: None if status is None else status.water_mode == 1,
-    set_value_fn=lambda deviceclient, value: deviceclient.set_water_mode(value),
+    set_value_fn=lambda device_client, value: device_client.set_water_mode(value),
     entity_category=EntityCategory.CONFIG,
 )
 

--- a/tests/components/letpot/test_switch.py
+++ b/tests/components/letpot/test_switch.py
@@ -1,0 +1,53 @@
+"""Test switch entities for the LetPot integration."""
+
+from unittest.mock import MagicMock
+
+from letpot.exceptions import LetPotConnectionException, LetPotException
+import pytest
+
+from homeassistant.components.switch import SERVICE_TURN_OFF, SERVICE_TURN_ON
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+
+from . import setup_integration
+
+from tests.common import MockConfigEntry
+
+
+@pytest.mark.parametrize(
+    ("service", "exception", "user_error"),
+    [
+        (
+            SERVICE_TURN_ON,
+            LetPotConnectionException("Connection failed"),
+            "An error occurred while communicating with the LetPot device: Connection failed",
+        ),
+        (
+            SERVICE_TURN_OFF,
+            LetPotException("Random thing failed"),
+            "An unknown error occurred while communicating with the LetPot device: Random thing failed",
+        ),
+    ],
+)
+async def test_switch_error(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_client: MagicMock,
+    mock_device_client: MagicMock,
+    service: str,
+    exception: Exception,
+    user_error: str,
+) -> None:
+    """Test switch entity exception handling."""
+    await setup_integration(hass, mock_config_entry)
+
+    mock_device_client.set_power.side_effect = exception
+
+    assert hass.states.get("switch.garden_power") is not None
+    with pytest.raises(HomeAssistantError, match=user_error):
+        await hass.services.async_call(
+            "switch",
+            service,
+            blocking=True,
+            target={"entity_id": "switch.garden_power"},
+        )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add a new platform to the LetPot integration: switch. This gives you 2-4 switches (depends on device) to control your hydroponic garden:

![Device page showing 4 switches in the configuration section: Alarm sound, Auto mode, Power, Pump cycling](https://github.com/user-attachments/assets/757488a1-c91a-47a2-ada0-eabb18b5f2fe)

3/4 names of these switches match the app. The exception is Circulation Pump/Pump Switch/Pump Cycle, renamed to Pump cycling for consistency and to better indicate that you're controlling the cycling and not directly turning the pump on/off. (A future sensor will show whether or not the pump is actually on/running or off/resting.)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: home-assistant/home-assistant.io#37076

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
