### PR TITLE
Add support for HomeWizard System sensors

### DIFF
--- a/homeassistant/components/homewizard/sensor.py
+++ b/homeassistant/components/homewizard/sensor.py
@@ -101,9 +101,11 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         key="active_tariff",
         translation_key="active_tariff",
         has_fn=lambda data: data.measurement.tariff is not None,
-        value_fn=lambda data: None
-        if data.measurement.tariff is None
-        else str(data.measurement.tariff),
+        value_fn=(
+            lambda data: None
+            if data.measurement.tariff is None
+            else str(data.measurement.tariff)
+        ),
         device_class=SensorDeviceClass.ENUM,
         options=["1", "2", "3", "4"],
     ),

--- a/homeassistant/components/homewizard/sensor.py
+++ b/homeassistant/components/homewizard/sensor.py
@@ -90,8 +90,12 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         key="wifi_ssid",
         translation_key="wifi_ssid",
         entity_category=EntityCategory.DIAGNOSTIC,
-        has_fn=lambda data: data.measurement.wifi_ssid is not None,
-        value_fn=lambda data: data.measurement.wifi_ssid,
+        has_fn=(
+            lambda data: data.system is not None and data.system.wifi_ssid is not None
+        ),
+        value_fn=(
+            lambda data: data.system.wifi_ssid if data.system is not None else None
+        ),
     ),
     HomeWizardSensorEntityDescription(
         key="active_tariff",

--- a/homeassistant/components/homewizard/sensor.py
+++ b/homeassistant/components/homewizard/sensor.py
@@ -6,7 +6,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Final
 
-from homewizard_energy.models import ExternalDevice, Measurement
+from homewizard_energy.models import CombinedModels, ExternalDevice
 
 from homeassistant.components.sensor import (
     DEVICE_CLASS_UNITS,
@@ -46,9 +46,9 @@ PARALLEL_UPDATES = 1
 class HomeWizardSensorEntityDescription(SensorEntityDescription):
     """Class describing HomeWizard sensor entities."""
 
-    enabled_fn: Callable[[Measurement], bool] = lambda x: True
-    has_fn: Callable[[Measurement], bool]
-    value_fn: Callable[[Measurement], StateType]
+    enabled_fn: Callable[[CombinedModels], bool] = lambda x: True
+    has_fn: Callable[[CombinedModels], bool]
+    value_fn: Callable[[CombinedModels], StateType]
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -69,35 +69,37 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         key="smr_version",
         translation_key="dsmr_version",
         entity_category=EntityCategory.DIAGNOSTIC,
-        has_fn=lambda data: data.protocol_version is not None,
-        value_fn=lambda data: data.protocol_version,
+        has_fn=lambda data: data.measurement.protocol_version is not None,
+        value_fn=lambda data: data.measurement.protocol_version,
     ),
     HomeWizardSensorEntityDescription(
         key="meter_model",
         translation_key="meter_model",
         entity_category=EntityCategory.DIAGNOSTIC,
-        has_fn=lambda data: data.meter_model is not None,
-        value_fn=lambda data: data.meter_model,
+        has_fn=lambda data: data.measurement.meter_model is not None,
+        value_fn=lambda data: data.measurement.meter_model,
     ),
     HomeWizardSensorEntityDescription(
         key="unique_meter_id",
         translation_key="unique_meter_id",
         entity_category=EntityCategory.DIAGNOSTIC,
-        has_fn=lambda data: data.unique_id is not None,
-        value_fn=lambda data: data.unique_id,
+        has_fn=lambda data: data.measurement.unique_id is not None,
+        value_fn=lambda data: data.measurement.unique_id,
     ),
     HomeWizardSensorEntityDescription(
         key="wifi_ssid",
         translation_key="wifi_ssid",
         entity_category=EntityCategory.DIAGNOSTIC,
-        has_fn=lambda data: data.wifi_ssid is not None,
-        value_fn=lambda data: data.wifi_ssid,
+        has_fn=lambda data: data.measurement.wifi_ssid is not None,
+        value_fn=lambda data: data.measurement.wifi_ssid,
     ),
     HomeWizardSensorEntityDescription(
         key="active_tariff",
         translation_key="active_tariff",
-        has_fn=lambda data: data.tariff is not None,
-        value_fn=lambda data: None if data.tariff is None else str(data.tariff),
+        has_fn=lambda data: data.measurement.tariff is not None,
+        value_fn=lambda data: None
+        if data.measurement.tariff is None
+        else str(data.measurement.tariff),
         device_class=SensorDeviceClass.ENUM,
         options=["1", "2", "3", "4"],
     ),
@@ -108,8 +110,8 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
-        has_fn=lambda data: data.wifi_strength is not None,
-        value_fn=lambda data: data.wifi_strength,
+        has_fn=lambda data: data.measurement.wifi_strength is not None,
+        value_fn=lambda data: data.measurement.wifi_strength,
     ),
     HomeWizardSensorEntityDescription(
         key="total_power_import_kwh",
@@ -117,8 +119,8 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
-        has_fn=lambda data: data.energy_import_kwh is not None,
-        value_fn=lambda data: data.energy_import_kwh,
+        has_fn=lambda data: data.measurement.energy_import_kwh is not None,
+        value_fn=lambda data: data.measurement.energy_import_kwh,
     ),
     HomeWizardSensorEntityDescription(
         key="total_power_import_t1_kwh",
@@ -129,10 +131,10 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         state_class=SensorStateClass.TOTAL_INCREASING,
         has_fn=lambda data: (
             # SKT/SDM230/630 provides both total and tariff 1: duplicate.
-            data.energy_import_t1_kwh is not None
-            and data.energy_export_t2_kwh is not None
+            data.measurement.energy_import_t1_kwh is not None
+            and data.measurement.energy_export_t2_kwh is not None
         ),
-        value_fn=lambda data: data.energy_import_t1_kwh,
+        value_fn=lambda data: data.measurement.energy_import_t1_kwh,
     ),
     HomeWizardSensorEntityDescription(
         key="total_power_import_t2_kwh",
@@ -141,8 +143,8 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
-        has_fn=lambda data: data.energy_import_t2_kwh is not None,
-        value_fn=lambda data: data.energy_import_t2_kwh,
+        has_fn=lambda data: data.measurement.energy_import_t2_kwh is not None,
+        value_fn=lambda data: data.measurement.energy_import_t2_kwh,
     ),
     HomeWizardSensorEntityDescription(
         key="total_power_import_t3_kwh",
@@ -151,8 +153,8 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
-        has_fn=lambda data: data.energy_import_t3_kwh is not None,
-        value_fn=lambda data: data.energy_import_t3_kwh,
+        has_fn=lambda data: data.measurement.energy_import_t3_kwh is not None,
+        value_fn=lambda data: data.measurement.energy_import_t3_kwh,
     ),
     HomeWizardSensorEntityDescription(
         key="total_power_import_t4_kwh",
@@ -161,8 +163,8 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
-        has_fn=lambda data: data.energy_import_t4_kwh is not None,
-        value_fn=lambda data: data.energy_import_t4_kwh,
+        has_fn=lambda data: data.measurement.energy_import_t4_kwh is not None,
+        value_fn=lambda data: data.measurement.energy_import_t4_kwh,
     ),
     HomeWizardSensorEntityDescription(
         key="total_power_export_kwh",
@@ -170,9 +172,9 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
-        has_fn=lambda data: data.energy_export_kwh is not None,
-        enabled_fn=lambda data: data.energy_export_kwh != 0,
-        value_fn=lambda data: data.energy_export_kwh,
+        has_fn=lambda data: data.measurement.energy_export_kwh is not None,
+        enabled_fn=lambda data: data.measurement.energy_export_kwh != 0,
+        value_fn=lambda data: data.measurement.energy_export_kwh,
     ),
     HomeWizardSensorEntityDescription(
         key="total_power_export_t1_kwh",
@@ -183,11 +185,11 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         state_class=SensorStateClass.TOTAL_INCREASING,
         has_fn=lambda data: (
             # SKT/SDM230/630 provides both total and tariff 1: duplicate.
-            data.energy_export_t1_kwh is not None
-            and data.energy_export_t2_kwh is not None
+            data.measurement.energy_export_t1_kwh is not None
+            and data.measurement.energy_export_t2_kwh is not None
         ),
-        enabled_fn=lambda data: data.energy_export_t1_kwh != 0,
-        value_fn=lambda data: data.energy_export_t1_kwh,
+        enabled_fn=lambda data: data.measurement.energy_export_t1_kwh != 0,
+        value_fn=lambda data: data.measurement.energy_export_t1_kwh,
     ),
     HomeWizardSensorEntityDescription(
         key="total_power_export_t2_kwh",
@@ -196,9 +198,9 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
-        has_fn=lambda data: data.energy_export_t2_kwh is not None,
-        enabled_fn=lambda data: data.energy_export_t2_kwh != 0,
-        value_fn=lambda data: data.energy_export_t2_kwh,
+        has_fn=lambda data: data.measurement.energy_export_t2_kwh is not None,
+        enabled_fn=lambda data: data.measurement.energy_export_t2_kwh != 0,
+        value_fn=lambda data: data.measurement.energy_export_t2_kwh,
     ),
     HomeWizardSensorEntityDescription(
         key="total_power_export_t3_kwh",
@@ -207,9 +209,9 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
-        has_fn=lambda data: data.energy_export_t3_kwh is not None,
-        enabled_fn=lambda data: data.energy_export_t3_kwh != 0,
-        value_fn=lambda data: data.energy_export_t3_kwh,
+        has_fn=lambda data: data.measurement.energy_export_t3_kwh is not None,
+        enabled_fn=lambda data: data.measurement.energy_export_t3_kwh != 0,
+        value_fn=lambda data: data.measurement.energy_export_t3_kwh,
     ),
     HomeWizardSensorEntityDescription(
         key="total_power_export_t4_kwh",
@@ -218,9 +220,9 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
-        has_fn=lambda data: data.energy_export_t4_kwh is not None,
-        enabled_fn=lambda data: data.energy_export_t4_kwh != 0,
-        value_fn=lambda data: data.energy_export_t4_kwh,
+        has_fn=lambda data: data.measurement.energy_export_t4_kwh is not None,
+        enabled_fn=lambda data: data.measurement.energy_export_t4_kwh != 0,
+        value_fn=lambda data: data.measurement.energy_export_t4_kwh,
     ),
     HomeWizardSensorEntityDescription(
         key="active_power_w",
@@ -228,8 +230,8 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=0,
-        has_fn=lambda data: data.power_w is not None,
-        value_fn=lambda data: data.power_w,
+        has_fn=lambda data: data.measurement.power_w is not None,
+        value_fn=lambda data: data.measurement.power_w,
     ),
     HomeWizardSensorEntityDescription(
         key="active_power_l1_w",
@@ -239,8 +241,8 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=0,
-        has_fn=lambda data: data.power_l1_w is not None,
-        value_fn=lambda data: data.power_l1_w,
+        has_fn=lambda data: data.measurement.power_l1_w is not None,
+        value_fn=lambda data: data.measurement.power_l1_w,
     ),
     HomeWizardSensorEntityDescription(
         key="active_power_l2_w",
@@ -250,8 +252,8 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=0,
-        has_fn=lambda data: data.power_l2_w is not None,
-        value_fn=lambda data: data.power_l2_w,
+        has_fn=lambda data: data.measurement.power_l2_w is not None,
+        value_fn=lambda data: data.measurement.power_l2_w,
     ),
     HomeWizardSensorEntityDescription(
         key="active_power_l3_w",
@@ -261,8 +263,8 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=0,
-        has_fn=lambda data: data.power_l3_w is not None,
-        value_fn=lambda data: data.power_l3_w,
+        has_fn=lambda data: data.measurement.power_l3_w is not None,
+        value_fn=lambda data: data.measurement.power_l3_w,
     ),
     HomeWizardSensorEntityDescription(
         key="active_voltage_v",
@@ -270,8 +272,8 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         device_class=SensorDeviceClass.VOLTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,
-        has_fn=lambda data: data.voltage_v is not None,
-        value_fn=lambda data: data.voltage_v,
+        has_fn=lambda data: data.measurement.voltage_v is not None,
+        value_fn=lambda data: data.measurement.voltage_v,
     ),
     HomeWizardSensorEntityDescription(
         key="active_voltage_l1_v",
@@ -281,8 +283,8 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         device_class=SensorDeviceClass.VOLTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,
-        has_fn=lambda data: data.voltage_l1_v is not None,
-        value_fn=lambda data: data.voltage_l1_v,
+        has_fn=lambda data: data.measurement.voltage_l1_v is not None,
+        value_fn=lambda data: data.measurement.voltage_l1_v,
     ),
     HomeWizardSensorEntityDescription(
         key="active_voltage_l2_v",
@@ -292,8 +294,8 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         device_class=SensorDeviceClass.VOLTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,
-        has_fn=lambda data: data.voltage_l2_v is not None,
-        value_fn=lambda data: data.voltage_l2_v,
+        has_fn=lambda data: data.measurement.voltage_l2_v is not None,
+        value_fn=lambda data: data.measurement.voltage_l2_v,
     ),
     HomeWizardSensorEntityDescription(
         key="active_voltage_l3_v",
@@ -303,8 +305,8 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         device_class=SensorDeviceClass.VOLTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,
-        has_fn=lambda data: data.voltage_l3_v is not None,
-        value_fn=lambda data: data.voltage_l3_v,
+        has_fn=lambda data: data.measurement.voltage_l3_v is not None,
+        value_fn=lambda data: data.measurement.voltage_l3_v,
     ),
     HomeWizardSensorEntityDescription(
         key="active_current_a",
@@ -312,8 +314,8 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         device_class=SensorDeviceClass.CURRENT,
         state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,
-        has_fn=lambda data: data.current_a is not None,
-        value_fn=lambda data: data.current_a,
+        has_fn=lambda data: data.measurement.current_a is not None,
+        value_fn=lambda data: data.measurement.current_a,
     ),
     HomeWizardSensorEntityDescription(
         key="active_current_l1_a",
@@ -323,8 +325,8 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         device_class=SensorDeviceClass.CURRENT,
         state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,
-        has_fn=lambda data: data.current_l1_a is not None,
-        value_fn=lambda data: data.current_l1_a,
+        has_fn=lambda data: data.measurement.current_l1_a is not None,
+        value_fn=lambda data: data.measurement.current_l1_a,
     ),
     HomeWizardSensorEntityDescription(
         key="active_current_l2_a",
@@ -334,8 +336,8 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         device_class=SensorDeviceClass.CURRENT,
         state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,
-        has_fn=lambda data: data.current_l2_a is not None,
-        value_fn=lambda data: data.current_l2_a,
+        has_fn=lambda data: data.measurement.current_l2_a is not None,
+        value_fn=lambda data: data.measurement.current_l2_a,
     ),
     HomeWizardSensorEntityDescription(
         key="active_current_l3_a",
@@ -345,8 +347,8 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         device_class=SensorDeviceClass.CURRENT,
         state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,
-        has_fn=lambda data: data.current_l3_a is not None,
-        value_fn=lambda data: data.current_l3_a,
+        has_fn=lambda data: data.measurement.current_l3_a is not None,
+        value_fn=lambda data: data.measurement.current_l3_a,
     ),
     HomeWizardSensorEntityDescription(
         key="active_frequency_hz",
@@ -354,8 +356,8 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         device_class=SensorDeviceClass.FREQUENCY,
         state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,
-        has_fn=lambda data: data.frequency_hz is not None,
-        value_fn=lambda data: data.frequency_hz,
+        has_fn=lambda data: data.measurement.frequency_hz is not None,
+        value_fn=lambda data: data.measurement.frequency_hz,
     ),
     HomeWizardSensorEntityDescription(
         key="active_apparent_power_va",
@@ -363,8 +365,8 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         device_class=SensorDeviceClass.APPARENT_POWER,
         state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,
-        has_fn=lambda data: data.apparent_power_va is not None,
-        value_fn=lambda data: data.apparent_power_va,
+        has_fn=lambda data: data.measurement.apparent_power_va is not None,
+        value_fn=lambda data: data.measurement.apparent_power_va,
     ),
     HomeWizardSensorEntityDescription(
         key="active_apparent_power_l1_va",
@@ -374,8 +376,8 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         device_class=SensorDeviceClass.APPARENT_POWER,
         state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,
-        has_fn=lambda data: data.apparent_power_l1_va is not None,
-        value_fn=lambda data: data.apparent_power_l1_va,
+        has_fn=lambda data: data.measurement.apparent_power_l1_va is not None,
+        value_fn=lambda data: data.measurement.apparent_power_l1_va,
     ),
     HomeWizardSensorEntityDescription(
         key="active_apparent_power_l2_va",
@@ -385,8 +387,8 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         device_class=SensorDeviceClass.APPARENT_POWER,
         state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,
-        has_fn=lambda data: data.apparent_power_l2_va is not None,
-        value_fn=lambda data: data.apparent_power_l2_va,
+        has_fn=lambda data: data.measurement.apparent_power_l2_va is not None,
+        value_fn=lambda data: data.measurement.apparent_power_l2_va,
     ),
     HomeWizardSensorEntityDescription(
         key="active_apparent_power_l3_va",
@@ -396,8 +398,8 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         device_class=SensorDeviceClass.APPARENT_POWER,
         state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,
-        has_fn=lambda data: data.apparent_power_l3_va is not None,
-        value_fn=lambda data: data.apparent_power_l3_va,
+        has_fn=lambda data: data.measurement.apparent_power_l3_va is not None,
+        value_fn=lambda data: data.measurement.apparent_power_l3_va,
     ),
     HomeWizardSensorEntityDescription(
         key="active_reactive_power_var",
@@ -405,8 +407,8 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         device_class=SensorDeviceClass.REACTIVE_POWER,
         state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,
-        has_fn=lambda data: data.reactive_power_var is not None,
-        value_fn=lambda data: data.reactive_power_var,
+        has_fn=lambda data: data.measurement.reactive_power_var is not None,
+        value_fn=lambda data: data.measurement.reactive_power_var,
     ),
     HomeWizardSensorEntityDescription(
         key="active_reactive_power_l1_var",
@@ -416,8 +418,8 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         device_class=SensorDeviceClass.REACTIVE_POWER,
         state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,
-        has_fn=lambda data: data.reactive_power_l1_var is not None,
-        value_fn=lambda data: data.reactive_power_l1_var,
+        has_fn=lambda data: data.measurement.reactive_power_l1_var is not None,
+        value_fn=lambda data: data.measurement.reactive_power_l1_var,
     ),
     HomeWizardSensorEntityDescription(
         key="active_reactive_power_l2_var",
@@ -427,8 +429,8 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         device_class=SensorDeviceClass.REACTIVE_POWER,
         state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,
-        has_fn=lambda data: data.reactive_power_l2_var is not None,
-        value_fn=lambda data: data.reactive_power_l2_var,
+        has_fn=lambda data: data.measurement.reactive_power_l2_var is not None,
+        value_fn=lambda data: data.measurement.reactive_power_l2_var,
     ),
     HomeWizardSensorEntityDescription(
         key="active_reactive_power_l3_var",
@@ -438,8 +440,8 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         device_class=SensorDeviceClass.REACTIVE_POWER,
         state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,
-        has_fn=lambda data: data.reactive_power_l3_var is not None,
-        value_fn=lambda data: data.reactive_power_l3_var,
+        has_fn=lambda data: data.measurement.reactive_power_l3_var is not None,
+        value_fn=lambda data: data.measurement.reactive_power_l3_var,
     ),
     HomeWizardSensorEntityDescription(
         key="active_power_factor",
@@ -447,8 +449,8 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         device_class=SensorDeviceClass.POWER_FACTOR,
         state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,
-        has_fn=lambda data: data.power_factor is not None,
-        value_fn=lambda data: to_percentage(data.power_factor),
+        has_fn=lambda data: data.measurement.power_factor is not None,
+        value_fn=lambda data: to_percentage(data.measurement.power_factor),
     ),
     HomeWizardSensorEntityDescription(
         key="active_power_factor_l1",
@@ -458,8 +460,8 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         device_class=SensorDeviceClass.POWER_FACTOR,
         state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,
-        has_fn=lambda data: data.power_factor_l1 is not None,
-        value_fn=lambda data: to_percentage(data.power_factor_l1),
+        has_fn=lambda data: data.measurement.power_factor_l1 is not None,
+        value_fn=lambda data: to_percentage(data.measurement.power_factor_l1),
     ),
     HomeWizardSensorEntityDescription(
         key="active_power_factor_l2",
@@ -469,8 +471,8 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         device_class=SensorDeviceClass.POWER_FACTOR,
         state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,
-        has_fn=lambda data: data.power_factor_l2 is not None,
-        value_fn=lambda data: to_percentage(data.power_factor_l2),
+        has_fn=lambda data: data.measurement.power_factor_l2 is not None,
+        value_fn=lambda data: to_percentage(data.measurement.power_factor_l2),
     ),
     HomeWizardSensorEntityDescription(
         key="active_power_factor_l3",
@@ -480,94 +482,94 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         device_class=SensorDeviceClass.POWER_FACTOR,
         state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,
-        has_fn=lambda data: data.power_factor_l3 is not None,
-        value_fn=lambda data: to_percentage(data.power_factor_l3),
+        has_fn=lambda data: data.measurement.power_factor_l3 is not None,
+        value_fn=lambda data: to_percentage(data.measurement.power_factor_l3),
     ),
     HomeWizardSensorEntityDescription(
         key="voltage_sag_l1_count",
         translation_key="voltage_sag_phase_count",
         translation_placeholders={"phase": "1"},
         entity_category=EntityCategory.DIAGNOSTIC,
-        has_fn=lambda data: data.voltage_sag_l1_count is not None,
-        value_fn=lambda data: data.voltage_sag_l1_count,
+        has_fn=lambda data: data.measurement.voltage_sag_l1_count is not None,
+        value_fn=lambda data: data.measurement.voltage_sag_l1_count,
     ),
     HomeWizardSensorEntityDescription(
         key="voltage_sag_l2_count",
         translation_key="voltage_sag_phase_count",
         translation_placeholders={"phase": "2"},
         entity_category=EntityCategory.DIAGNOSTIC,
-        has_fn=lambda data: data.voltage_sag_l2_count is not None,
-        value_fn=lambda data: data.voltage_sag_l2_count,
+        has_fn=lambda data: data.measurement.voltage_sag_l2_count is not None,
+        value_fn=lambda data: data.measurement.voltage_sag_l2_count,
     ),
     HomeWizardSensorEntityDescription(
         key="voltage_sag_l3_count",
         translation_key="voltage_sag_phase_count",
         translation_placeholders={"phase": "3"},
         entity_category=EntityCategory.DIAGNOSTIC,
-        has_fn=lambda data: data.voltage_sag_l3_count is not None,
-        value_fn=lambda data: data.voltage_sag_l3_count,
+        has_fn=lambda data: data.measurement.voltage_sag_l3_count is not None,
+        value_fn=lambda data: data.measurement.voltage_sag_l3_count,
     ),
     HomeWizardSensorEntityDescription(
         key="voltage_swell_l1_count",
         translation_key="voltage_swell_phase_count",
         translation_placeholders={"phase": "1"},
         entity_category=EntityCategory.DIAGNOSTIC,
-        has_fn=lambda data: data.voltage_swell_l1_count is not None,
-        value_fn=lambda data: data.voltage_swell_l1_count,
+        has_fn=lambda data: data.measurement.voltage_swell_l1_count is not None,
+        value_fn=lambda data: data.measurement.voltage_swell_l1_count,
     ),
     HomeWizardSensorEntityDescription(
         key="voltage_swell_l2_count",
         translation_key="voltage_swell_phase_count",
         translation_placeholders={"phase": "2"},
         entity_category=EntityCategory.DIAGNOSTIC,
-        has_fn=lambda data: data.voltage_swell_l2_count is not None,
-        value_fn=lambda data: data.voltage_swell_l2_count,
+        has_fn=lambda data: data.measurement.voltage_swell_l2_count is not None,
+        value_fn=lambda data: data.measurement.voltage_swell_l2_count,
     ),
     HomeWizardSensorEntityDescription(
         key="voltage_swell_l3_count",
         translation_key="voltage_swell_phase_count",
         translation_placeholders={"phase": "3"},
         entity_category=EntityCategory.DIAGNOSTIC,
-        has_fn=lambda data: data.voltage_swell_l3_count is not None,
-        value_fn=lambda data: data.voltage_swell_l3_count,
+        has_fn=lambda data: data.measurement.voltage_swell_l3_count is not None,
+        value_fn=lambda data: data.measurement.voltage_swell_l3_count,
     ),
     HomeWizardSensorEntityDescription(
         key="any_power_fail_count",
         translation_key="any_power_fail_count",
         entity_category=EntityCategory.DIAGNOSTIC,
-        has_fn=lambda data: data.any_power_fail_count is not None,
-        value_fn=lambda data: data.any_power_fail_count,
+        has_fn=lambda data: data.measurement.any_power_fail_count is not None,
+        value_fn=lambda data: data.measurement.any_power_fail_count,
     ),
     HomeWizardSensorEntityDescription(
         key="long_power_fail_count",
         translation_key="long_power_fail_count",
         entity_category=EntityCategory.DIAGNOSTIC,
-        has_fn=lambda data: data.long_power_fail_count is not None,
-        value_fn=lambda data: data.long_power_fail_count,
+        has_fn=lambda data: data.measurement.long_power_fail_count is not None,
+        value_fn=lambda data: data.measurement.long_power_fail_count,
     ),
     HomeWizardSensorEntityDescription(
         key="active_power_average_w",
         translation_key="active_power_average_w",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
-        has_fn=lambda data: data.average_power_15m_w is not None,
-        value_fn=lambda data: data.average_power_15m_w,
+        has_fn=lambda data: data.measurement.average_power_15m_w is not None,
+        value_fn=lambda data: data.measurement.average_power_15m_w,
     ),
     HomeWizardSensorEntityDescription(
         key="monthly_power_peak_w",
         translation_key="monthly_power_peak_w",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
-        has_fn=lambda data: data.monthly_power_peak_w is not None,
-        value_fn=lambda data: data.monthly_power_peak_w,
+        has_fn=lambda data: data.measurement.monthly_power_peak_w is not None,
+        value_fn=lambda data: data.measurement.monthly_power_peak_w,
     ),
     HomeWizardSensorEntityDescription(
         key="active_liter_lpm",
         translation_key="active_liter_lpm",
         native_unit_of_measurement=UnitOfVolumeFlowRate.LITERS_PER_MINUTE,
         state_class=SensorStateClass.MEASUREMENT,
-        has_fn=lambda data: data.active_liter_lpm is not None,
-        value_fn=lambda data: data.active_liter_lpm,
+        has_fn=lambda data: data.measurement.active_liter_lpm is not None,
+        value_fn=lambda data: data.measurement.active_liter_lpm,
     ),
     HomeWizardSensorEntityDescription(
         key="total_liter_m3",
@@ -575,8 +577,8 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         native_unit_of_measurement=UnitOfVolume.CUBIC_METERS,
         device_class=SensorDeviceClass.WATER,
         state_class=SensorStateClass.TOTAL_INCREASING,
-        has_fn=lambda data: data.total_liter_m3 is not None,
-        value_fn=lambda data: data.total_liter_m3,
+        has_fn=lambda data: data.measurement.total_liter_m3 is not None,
+        value_fn=lambda data: data.measurement.total_liter_m3,
     ),
     HomeWizardSensorEntityDescription(
         key="state_of_charge_pct",
@@ -585,16 +587,16 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         device_class=SensorDeviceClass.BATTERY,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=0,
-        has_fn=lambda data: data.state_of_charge_pct is not None,
-        value_fn=lambda data: data.state_of_charge_pct,
+        has_fn=lambda data: data.measurement.state_of_charge_pct is not None,
+        value_fn=lambda data: data.measurement.state_of_charge_pct,
     ),
     HomeWizardSensorEntityDescription(
         key="cycles",
         translation_key="cycles",
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.TOTAL_INCREASING,
-        has_fn=lambda data: data.cycles is not None,
-        value_fn=lambda data: data.cycles,
+        has_fn=lambda data: data.measurement.cycles is not None,
+        value_fn=lambda data: data.measurement.cycles,
     ),
 )
 
@@ -640,16 +642,15 @@ async def async_setup_entry(
 ) -> None:
     """Initialize sensors."""
 
-    measurement = entry.runtime_data.data.measurement
-
     # Initialize default sensors
     entities: list = [
         HomeWizardSensorEntity(entry.runtime_data, description)
         for description in SENSORS
-        if description.has_fn(measurement)
+        if description.has_fn(entry.runtime_data.data)
     ]
 
     # Initialize external devices
+    measurement = entry.runtime_data.data.measurement
     if measurement.external_devices is not None:
         for unique_id, device in measurement.external_devices.items():
             if device.type is not None and (
@@ -679,13 +680,13 @@ class HomeWizardSensorEntity(HomeWizardEntity, SensorEntity):
         super().__init__(coordinator)
         self.entity_description = description
         self._attr_unique_id = f"{coordinator.config_entry.unique_id}_{description.key}"
-        if not description.enabled_fn(self.coordinator.data.measurement):
+        if not description.enabled_fn(self.coordinator.data):
             self._attr_entity_registry_enabled_default = False
 
     @property
     def native_value(self) -> StateType:
         """Return the sensor value."""
-        return self.entity_description.value_fn(self.coordinator.data.measurement)
+        return self.entity_description.value_fn(self.coordinator.data)
 
     @property
     def available(self) -> bool:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use a lower level of data in lambdas so they can access 'system'. Which is needed to expose the wifi_ssid sensor (which is moved in v2 from 'measurement' to 'system' API).

This allows for new sensors in the future, like 'uptime' and 'wifi_rssi'

The good thing is; No snapshot updates 🎉 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
