### PR TITLE
Fix httpx late import of trio doing blocking I/O in the event loop

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -112,6 +112,11 @@ with contextlib.suppress(ImportError):
     # Ensure anyio backend is imported to avoid it being imported in the event loop
     from anyio._backends import _asyncio  # noqa: F401
 
+with contextlib.suppress(ImportError):
+    # httpx will import trio if it is installed which does
+    # blocking I/O in the event loop. We want to avoid that.
+    import trio  # noqa: F401
+
 
 if TYPE_CHECKING:
     from .runner import RuntimeConfig


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
While it is nice that httpx doesn't import trio at import time anymore, it still imports it a run time.

httpx 0.28.1 via #133840 moved the trio import to happen a bit later

```
2025-01-23 19:53:12.370 WARNING (MainThread) [homeassistant.util.loop] Detected blocking call to open with args (/lib/c, rb) inside the event loop by integration rest at homeassistant/components/rest/data.py, line 88: self._async_client = create_async_httpx_client( (offender: /usr/local/lib/python3.13/ctypes/util.py, line 285: with open(filepath, rb) as fh:), please create a bug report at https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue+label%3A%22integration%3A+rest%22
For developers, please see https://developers.home-assistant.io/docs/asyncio_blocking_operations/#open
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/usr/src/homeassistant/homeassistant/__main__.py", line 227, in <module>
    sys.exit(main())
  File "/usr/src/homeassistant/homeassistant/__main__.py", line 213, in main
    exit_code = runner.run(runtime_conf)
  File "/usr/src/homeassistant/homeassistant/runner.py", line 154, in run
    return loop.run_until_complete(setup_and_run_hass(runtime_config))
  File "/usr/local/lib/python3.13/asyncio/base_events.py", line 707, in run_until_complete
    self.run_forever()
  File "/usr/local/lib/python3.13/asyncio/base_events.py", line 678, in run_forever
    self._run_once()
  File "/usr/local/lib/python3.13/asyncio/base_events.py", line 2033, in _run_once
    handle._run()
  File "/usr/local/lib/python3.13/asyncio/events.py", line 89, in _run
    self._context.run(self._callback, *self._args)
  File "/usr/src/homeassistant/homeassistant/config_entries.py", line 2360, in _async_forward_entry_setup
    result = await async_setup_component(
  File "/usr/src/homeassistant/homeassistant/setup.py", line 165, in async_setup_component
    result = await _async_setup_component(hass, domain, config)
  File "/usr/src/homeassistant/homeassistant/setup.py", line 420, in _async_setup_component
    result = await task
  File "/usr/src/homeassistant/homeassistant/components/sensor/__init__.py", line 90, in async_setup
    await component.async_setup(config)
  File "/usr/src/homeassistant/homeassistant/helpers/entity_component.py", line 146, in async_setup
    self.hass.async_create_task_internal(
  File "/usr/src/homeassistant/homeassistant/core.py", line 832, in async_create_task_internal
    task = create_eager_task(target, name=name, loop=self.loop)
  File "/usr/src/homeassistant/homeassistant/util/async_.py", line 45, in create_eager_task
    return Task(coro, loop=loop, name=name, eager_start=True)
  File "/usr/src/homeassistant/homeassistant/helpers/entity_component.py", line 307, in async_setup_platform
    await self._platforms[key].async_setup(platform_config, discovery_info)
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 303, in async_setup
    await self._async_setup_platform(async_create_setup_awaitable)
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 363, in _async_setup_platform
    awaitable = create_eager_task(awaitable, loop=hass.loop)
  File "/usr/src/homeassistant/homeassistant/util/async_.py", line 45, in create_eager_task
    return Task(coro, loop=loop, name=name, eager_start=True)
  File "/usr/src/homeassistant/homeassistant/components/rest/sensor.py", line 85, in async_setup_platform
    await rest.async_update(log_errors=False)
  File "/usr/src/homeassistant/homeassistant/components/rest/data.py", line 88, in async_update
    self._async_client = create_async_httpx_client(

2025-01-23 19:53:12.371 WARNING (MainThread) [homeassistant.util.loop] Detected blocking call to glob with args (/lib/libc.so,) inside the event loop by integration rest at homeassistant/components/rest/data.py, line 88: self._async_client = create_async_httpx_client( (offender: /usr/local/lib/python3.13/ctypes/util.py, line 311: for f in glob({0}{1}.format(prefix, suffix)):), please create a bug report at https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue+label%3A%22integration%3A+rest%22
For developers, please see https://developers.home-assistant.io/docs/asyncio_blocking_operations/#glob
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/usr/src/homeassistant/homeassistant/__main__.py", line 227, in <module>
    sys.exit(main())
  File "/usr/src/homeassistant/homeassistant/__main__.py", line 213, in main
    exit_code = runner.run(runtime_conf)
  File "/usr/src/homeassistant/homeassistant/runner.py", line 154, in run
    return loop.run_until_complete(setup_and_run_hass(runtime_config))
  File "/usr/local/lib/python3.13/asyncio/base_events.py", line 707, in run_until_complete
    self.run_forever()
  File "/usr/local/lib/python3.13/asyncio/base_events.py", line 678, in run_forever
    self._run_once()
  File "/usr/local/lib/python3.13/asyncio/base_events.py", line 2033, in _run_once
    handle._run()
  File "/usr/local/lib/python3.13/asyncio/events.py", line 89, in _run
    self._context.run(self._callback, *self._args)
  File "/usr/src/homeassistant/homeassistant/config_entries.py", line 2360, in _async_forward_entry_setup
    result = await async_setup_component(
  File "/usr/src/homeassistant/homeassistant/setup.py", line 165, in async_setup_component
    result = await _async_setup_component(hass, domain, config)
  File "/usr/src/homeassistant/homeassistant/setup.py", line 420, in _async_setup_component
    result = await task
  File "/usr/src/homeassistant/homeassistant/components/sensor/__init__.py", line 90, in async_setup
    await component.async_setup(config)
  File "/usr/src/homeassistant/homeassistant/helpers/entity_component.py", line 146, in async_setup
    self.hass.async_create_task_internal(
  File "/usr/src/homeassistant/homeassistant/core.py", line 832, in async_create_task_internal
    task = create_eager_task(target, name=name, loop=self.loop)
  File "/usr/src/homeassistant/homeassistant/util/async_.py", line 45, in create_eager_task
    return Task(coro, loop=loop, name=name, eager_start=True)
  File "/usr/src/homeassistant/homeassistant/helpers/entity_component.py", line 307, in async_setup_platform
    await self._platforms[key].async_setup(platform_config, discovery_info)
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 303, in async_setup
    await self._async_setup_platform(async_create_setup_awaitable)
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 363, in _async_setup_platform
    awaitable = create_eager_task(awaitable, loop=hass.loop)
  File "/usr/src/homeassistant/homeassistant/util/async_.py", line 45, in create_eager_task
    return Task(coro, loop=loop, name=name, eager_start=True)
  File "/usr/src/homeassistant/homeassistant/components/rest/sensor.py", line 85, in async_setup_platform
    await rest.async_update(log_errors=False)
  File "/usr/src/homeassistant/homeassistant/components/rest/data.py", line 88, in async_update
    self._async_client = create_async_httpx_client(

2025-01-23 19:53:12.372 WARNING (MainThread) [homeassistant.util.loop] Detected blocking call to iglob with args (/lib/libc.so,) inside the event loop by integration rest at homeassistant/components/rest/data.py, line 88: self._async_client = create_async_httpx_client( (offender: /usr/local/lib/python3.13/glob.py, line 31: return list(iglob(pathname, root_dir=root_dir, dir_fd=dir_fd, recursive=recursive,), please create a bug report at https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue+label%3A%22integration%3A+rest%22
For developers, please see https://developers.home-assistant.io/docs/asyncio_blocking_operations/#iglob
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/usr/src/homeassistant/homeassistant/__main__.py", line 227, in <module>
    sys.exit(main())
  File "/usr/src/homeassistant/homeassistant/__main__.py", line 213, in main
    exit_code = runner.run(runtime_conf)
  File "/usr/src/homeassistant/homeassistant/runner.py", line 154, in run
    return loop.run_until_complete(setup_and_run_hass(runtime_config))
  File "/usr/local/lib/python3.13/asyncio/base_events.py", line 707, in run_until_complete
    self.run_forever()
  File "/usr/local/lib/python3.13/asyncio/base_events.py", line 678, in run_forever
    self._run_once()
  File "/usr/local/lib/python3.13/asyncio/base_events.py", line 2033, in _run_once
    handle._run()
  File "/usr/local/lib/python3.13/asyncio/events.py", line 89, in _run
    self._context.run(self._callback, *self._args)
  File "/usr/src/homeassistant/homeassistant/config_entries.py", line 2360, in _async_forward_entry_setup
    result = await async_setup_component(
  File "/usr/src/homeassistant/homeassistant/setup.py", line 165, in async_setup_component
    result = await _async_setup_component(hass, domain, config)
  File "/usr/src/homeassistant/homeassistant/setup.py", line 420, in _async_setup_component
    result = await task
  File "/usr/src/homeassistant/homeassistant/components/sensor/__init__.py", line 90, in async_setup
    await component.async_setup(config)
  File "/usr/src/homeassistant/homeassistant/helpers/entity_component.py", line 146, in async_setup
    self.hass.async_create_task_internal(
  File "/usr/src/homeassistant/homeassistant/core.py", line 832, in async_create_task_internal
    task = create_eager_task(target, name=name, loop=self.loop)
  File "/usr/src/homeassistant/homeassistant/util/async_.py", line 45, in create_eager_task
    return Task(coro, loop=loop, name=name, eager_start=True)
  File "/usr/src/homeassistant/homeassistant/helpers/entity_component.py", line 307, in async_setup_platform
    await self._platforms[key].async_setup(platform_config, discovery_info)
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 303, in async_setup
    await self._async_setup_platform(async_create_setup_awaitable)
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 363, in _async_setup_platform
    awaitable = create_eager_task(awaitable, loop=hass.loop)
  File "/usr/src/homeassistant/homeassistant/util/async_.py", line 45, in create_eager_task
    return Task(coro, loop=loop, name=name, eager_start=True)
  File "/usr/src/homeassistant/homeassistant/components/rest/sensor.py", line 85, in async_setup_platform
    await rest.async_update(log_errors=False)
  File "/usr/src/homeassistant/homeassistant/components/rest/data.py", line 88, in async_update
    self._async_client = create_async_httpx_client(

2025-01-23 19:53:12.374 WARNING (MainThread) [homeassistant.util.loop] Detected blocking call to scandir with args (/lib,) inside the event loop by integration rest at homeassistant/components/rest/data.py, line 88: self._async_client = create_async_httpx_client( (offender: /usr/local/lib/python3.13/glob.py, line 170: with os.scandir(arg) as it:), please create a bug report at https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue+label%3A%22integration%3A+rest%22
For developers, please see https://developers.home-assistant.io/docs/asyncio_blocking_operations/#scandir
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/usr/src/homeassistant/homeassistant/__main__.py", line 227, in <module>
    sys.exit(main())
  File "/usr/src/homeassistant/homeassistant/__main__.py", line 213, in main
    exit_code = runner.run(runtime_conf)
  File "/usr/src/homeassistant/homeassistant/runner.py", line 154, in run
    return loop.run_until_complete(setup_and_run_hass(runtime_config))
  File "/usr/local/lib/python3.13/asyncio/base_events.py", line 707, in run_until_complete
    self.run_forever()
  File "/usr/local/lib/python3.13/asyncio/base_events.py", line 678, in run_forever
    self._run_once()
  File "/usr/local/lib/python3.13/asyncio/base_events.py", line 2033, in _run_once
    handle._run()
  File "/usr/local/lib/python3.13/asyncio/events.py", line 89, in _run
    self._context.run(self._callback, *self._args)
  File "/usr/src/homeassistant/homeassistant/config_entries.py", line 2360, in _async_forward_entry_setup
    result = await async_setup_component(
  File "/usr/src/homeassistant/homeassistant/setup.py", line 165, in async_setup_component
    result = await _async_setup_component(hass, domain, config)
  File "/usr/src/homeassistant/homeassistant/setup.py", line 420, in _async_setup_component
    result = await task
  File "/usr/src/homeassistant/homeassistant/components/sensor/__init__.py", line 90, in async_setup
    await component.async_setup(config)
  File "/usr/src/homeassistant/homeassistant/helpers/entity_component.py", line 146, in async_setup
    self.hass.async_create_task_internal(
  File "/usr/src/homeassistant/homeassistant/core.py", line 832, in async_create_task_internal
    task = create_eager_task(target, name=name, loop=self.loop)
  File "/usr/src/homeassistant/homeassistant/util/async_.py", line 45, in create_eager_task
    return Task(coro, loop=loop, name=name, eager_start=True)
  File "/usr/src/homeassistant/homeassistant/helpers/entity_component.py", line 307, in async_setup_platform
    await self._platforms[key].async_setup(platform_config, discovery_info)
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 303, in async_setup
    await self._async_setup_platform(async_create_setup_awaitable)
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 363, in _async_setup_platform
    awaitable = create_eager_task(awaitable, loop=hass.loop)
  File "/usr/src/homeassistant/homeassistant/util/async_.py", line 45, in create_eager_task
    return Task(coro, loop=loop, name=name, eager_start=True)
  File "/usr/src/homeassistant/homeassistant/components/rest/sensor.py", line 85, in async_setup_platform
    await rest.async_update(log_errors=False)
  File "/usr/src/homeassistant/homeassistant/components/rest/data.py", line 88, in async_update
    self._async_client = create_async_httpx_client(
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
