### PR TITLE
Rename incomfort exceptions classes to fix typo and assign correct translation domain

### DIFF
--- a/homeassistant/components/incomfort/__init__.py
+++ b/homeassistant/components/incomfort/__init__.py
@@ -13,7 +13,7 @@ from homeassistant.helpers import device_registry as dr
 
 from .const import DOMAIN
 from .coordinator import InComfortDataCoordinator, async_connect_gateway
-from .errors import InConfortTimeout, InConfortUnknownError, NoHeaters, NotFound
+from .errors import InComfortTimeout, InComfortUnknownError, NoHeaters, NotFound
 
 PLATFORMS = (
     Platform.WATER_HEATER,
@@ -40,9 +40,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: InComfortConfigEntry) ->
     except ClientResponseError as exc:
         if exc.status == 404:
             raise NotFound from exc
-        raise InConfortUnknownError from exc
+        raise InComfortUnknownError from exc
     except TimeoutError as exc:
-        raise InConfortTimeout from exc
+        raise InComfortTimeout from exc
 
     # Register discovered gateway device
     device_registry = dr.async_get(hass)

--- a/homeassistant/components/incomfort/errors.py
+++ b/homeassistant/components/incomfort/errors.py
@@ -1,32 +1,33 @@
 """Exceptions raised by Intergas InComfort integration."""
 
-from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN
 from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
+
+from .const import DOMAIN
 
 
 class NotFound(HomeAssistantError):
     """Raise exception if no Lan2RF Gateway was found."""
 
-    translation_domain = HOMEASSISTANT_DOMAIN
+    translation_domain = DOMAIN
     translation_key = "not_found"
 
 
 class NoHeaters(ConfigEntryNotReady):
     """Raise exception if no heaters are found."""
 
-    translation_domain = HOMEASSISTANT_DOMAIN
+    translation_domain = DOMAIN
     translation_key = "no_heaters"
 
 
-class InConfortTimeout(ConfigEntryNotReady):
+class InComfortTimeout(ConfigEntryNotReady):
     """Raise exception if no heaters are found."""
 
-    translation_domain = HOMEASSISTANT_DOMAIN
+    translation_domain = DOMAIN
     translation_key = "timeout_error"
 
 
-class InConfortUnknownError(ConfigEntryNotReady):
+class InComfortUnknownError(ConfigEntryNotReady):
     """Raise exception if no heaters are found."""
 
-    translation_domain = HOMEASSISTANT_DOMAIN
+    translation_domain = DOMAIN
     translation_key = "unknown"

--- a/homeassistant/components/incomfort/strings.json
+++ b/homeassistant/components/incomfort/strings.json
@@ -49,8 +49,8 @@
       "auth_error": "Invalid credentials.",
       "no_heaters": "No heaters found.",
       "not_found": "No Lan2RF gateway found.",
-      "timeout_error": "Time out when connection to Lan2RF gateway.",
-      "unknown": "Unknown error when connection to Lan2RF gateway."
+      "timeout_error": "Time out when connecting to Lan2RF gateway.",
+      "unknown": "Unknown error when connecting to Lan2RF gateway."
     }
   },
   "exceptions": {

--- a/homeassistant/components/incomfort/strings.json
+++ b/homeassistant/components/incomfort/strings.json
@@ -53,6 +53,20 @@
       "unknown": "Unknown error when connection to Lan2RF gateway."
     }
   },
+  "exceptions": {
+    "no_heaters": {
+      "message": "[%key:component::incomfort::config::error::no_heaters%]"
+    },
+    "not_found": {
+      "message": "[%key:component::incomfort::config::error::not_found%]"
+    },
+    "timeout_error": {
+      "message": "[%key:component::incomfort::config::error::timeout_error%]"
+    },
+    "unknown": {
+      "message": "[%key:component::incomfort::config::error::unknown%]"
+    }
+  },
   "options": {
     "step": {
       "init": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix translation domain for incomfort errors.
Fix type in class names

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
