### PR TITLE
Hide some Hydrawise sensors behind an option.

### DIFF
--- a/homeassistant/components/hydrawise/__init__.py
+++ b/homeassistant/components/hydrawise/__init__.py
@@ -6,8 +6,9 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers import issue_registry as ir
 
-from .const import APP_ID, DOMAIN
+from .const import APP_ID, CONF_ADVANCED_SENSORS, DOMAIN, LOGGER
 from .coordinator import (
     HydrawiseMainDataUpdateCoordinator,
     HydrawiseUpdateCoordinators,
@@ -30,16 +31,24 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         raise ConfigEntryAuthFailed
 
     hydrawise = client.Hydrawise(
-        auth.Auth(config_entry.data[CONF_USERNAME], config_entry.data[CONF_PASSWORD]),
+        auth.Auth(
+            config_entry.data[CONF_USERNAME],
+            config_entry.data[CONF_PASSWORD],
+        ),
         app_id=APP_ID,
     )
 
     main_coordinator = HydrawiseMainDataUpdateCoordinator(hass, hydrawise)
     await main_coordinator.async_config_entry_first_refresh()
+
     water_use_coordinator = HydrawiseWaterUseDataUpdateCoordinator(
-        hass, hydrawise, main_coordinator
+        hass,
+        hydrawise,
+        main_coordinator,
+        enabled=config_entry.options.get(CONF_ADVANCED_SENSORS, False),
     )
-    await water_use_coordinator.async_config_entry_first_refresh()
+    if water_use_coordinator.enabled:
+        await water_use_coordinator.async_config_entry_first_refresh()
     hass.data.setdefault(DOMAIN, {})[config_entry.entry_id] = (
         HydrawiseUpdateCoordinators(
             main=main_coordinator,
@@ -47,7 +56,13 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         )
     )
     await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
+    config_entry.async_on_unload(config_entry.add_update_listener(async_update_options))
     return True
+
+
+async def async_update_options(hass: HomeAssistant, config_entry: ConfigEntry) -> None:
+    """Handle an options update."""
+    await hass.config_entries.async_reload(config_entry.entry_id)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -55,3 +70,32 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         hass.data[DOMAIN].pop(entry.entry_id)
     return unload_ok
+
+
+async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+    """Migrate old entry."""
+    LOGGER.debug(
+        "Migrating configuration from version %s.%s",
+        config_entry.version,
+        config_entry.minor_version,
+    )
+
+    if config_entry.version == 1:
+        if config_entry.minor_version < 2:
+            ir.async_create_issue(
+                hass,
+                DOMAIN,
+                "hydrawise_advanced_sensors_disabled",
+                breaks_in_ha_version="2025.2.0",
+                is_fixable=False,
+                learn_more_url="https://github.com/home-assistant/core/issues/130857#issuecomment-2600919282",
+                severity=ir.IssueSeverity.ERROR,
+                translation_key="advanced_sensors_disabled",
+            )
+
+    LOGGER.debug(
+        "Migration to configuration version %s.%s successful",
+        config_entry.version,
+        config_entry.minor_version,
+    )
+    return True

--- a/homeassistant/components/hydrawise/const.py
+++ b/homeassistant/components/hydrawise/const.py
@@ -25,3 +25,5 @@ SERVICE_SUSPEND = "suspend"
 
 ATTR_DURATION = "duration"
 ATTR_UNTIL = "until"
+
+CONF_ADVANCED_SENSORS = "advanced_sensors"

--- a/homeassistant/components/hydrawise/coordinator.py
+++ b/homeassistant/components/hydrawise/coordinator.py
@@ -39,6 +39,7 @@ class HydrawiseDataUpdateCoordinator(DataUpdateCoordinator[HydrawiseData]):
     """Base class for Hydrawise Data Update Coordinators."""
 
     api: Hydrawise
+    enabled: bool = True
 
 
 class HydrawiseMainDataUpdateCoordinator(HydrawiseDataUpdateCoordinator):
@@ -84,16 +85,28 @@ class HydrawiseWaterUseDataUpdateCoordinator(HydrawiseDataUpdateCoordinator):
         hass: HomeAssistant,
         api: Hydrawise,
         main_coordinator: HydrawiseMainDataUpdateCoordinator,
+        enabled: bool = False,
     ) -> None:
         """Initialize HydrawiseWaterUseDataUpdateCoordinator."""
         super().__init__(
             hass,
             LOGGER,
             name=f"{DOMAIN} water use",
-            update_interval=WATER_USE_SCAN_INTERVAL,
         )
         self.api = api
         self._main_coordinator = main_coordinator
+        self.enabled = enabled
+
+    @property
+    def enabled(self) -> bool:
+        """Whether the update coordinator is enabled."""
+        return self._enabled
+
+    @enabled.setter
+    def enabled(self, value: bool) -> None:
+        """Enable or disable the update coordinator."""
+        self._enabled = value
+        self.update_interval = WATER_USE_SCAN_INTERVAL if value else None
 
     async def _async_update_data(self) -> HydrawiseData:
         """Fetch the latest data from Hydrawise."""

--- a/homeassistant/components/hydrawise/strings.json
+++ b/homeassistant/components/hydrawise/strings.json
@@ -28,6 +28,25 @@
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     }
   },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Configure options for Hydrawise",
+        "data": {
+          "advanced_sensors": "Enable advanced sensors"
+        },
+        "data_description": {
+          "advanced_sensors": "Setting this enables water use and flow sensors. These require additional polling to the Hydrawise and may cause account throttling. Use at your own risk."
+        }
+      }
+    }
+  },
+  "issues": {
+    "advanced_sensors_disabled": {
+      "title": "Some Hydrawise sensors have been removed",
+      "description": "Advanced Hydrawise sensors (water use and water time) have been removed by default. They can be re-added through the integraiton options."
+    }
+  },
   "entity": {
     "binary_sensor": {
       "watering": {

--- a/tests/components/hydrawise/conftest.py
+++ b/tests/components/hydrawise/conftest.py
@@ -21,7 +21,7 @@ from pydrawise.schema import (
 )
 import pytest
 
-from homeassistant.components.hydrawise.const import DOMAIN
+from homeassistant.components.hydrawise.const import CONF_ADVANCED_SENSORS, DOMAIN
 from homeassistant.const import CONF_API_KEY, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
@@ -207,7 +207,19 @@ def mock_config_entry_legacy() -> MockConfigEntry:
 
 
 @pytest.fixture
-def mock_config_entry() -> MockConfigEntry:
+def config_entry_options() -> dict:
+    """Fixture for config entry options."""
+    return {CONF_ADVANCED_SENSORS: False}
+
+
+@pytest.fixture
+def enable_advanced_sensors(config_entry_options):
+    """Fixture to enable advanced sensors."""
+    config_entry_options[CONF_ADVANCED_SENSORS] = True
+
+
+@pytest.fixture
+def mock_config_entry(config_entry_options) -> MockConfigEntry:
     """Mock ConfigEntry."""
     return MockConfigEntry(
         title="Hydrawise",
@@ -216,6 +228,7 @@ def mock_config_entry() -> MockConfigEntry:
             CONF_USERNAME: "asfd@asdf.com",
             CONF_PASSWORD: "__password__",
         },
+        options=config_entry_options,
         unique_id="hydrawise-customerid",
         version=1,
         minor_version=2,

--- a/tests/components/hydrawise/snapshots/test_sensor.ambr
+++ b/tests/components/hydrawise/snapshots/test_sensor.ambr
@@ -614,3 +614,195 @@
     'state': '29',
   })
 # ---
+# name: test_disable_advanced_sensors[sensor.zone_one_next_cycle-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.zone_one_next_cycle',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': None,
+    'original_name': 'Next cycle',
+    'platform': 'hydrawise',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'next_cycle',
+    'unique_id': '5965394_next_cycle',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_disable_advanced_sensors[sensor.zone_one_next_cycle-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by hydrawise.com',
+      'device_class': 'timestamp',
+      'friendly_name': 'Zone One Next cycle',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.zone_one_next_cycle',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2023-10-04T19:49:57+00:00',
+  })
+# ---
+# name: test_disable_advanced_sensors[sensor.zone_one_remaining_watering_time-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.zone_one_remaining_watering_time',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Remaining watering time',
+    'platform': 'hydrawise',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'watering_time',
+    'unique_id': '5965394_watering_time',
+    'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+  })
+# ---
+# name: test_disable_advanced_sensors[sensor.zone_one_remaining_watering_time-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by hydrawise.com',
+      'friendly_name': 'Zone One Remaining watering time',
+      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.zone_one_remaining_watering_time',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_disable_advanced_sensors[sensor.zone_two_next_cycle-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.zone_two_next_cycle',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': None,
+    'original_name': 'Next cycle',
+    'platform': 'hydrawise',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'next_cycle',
+    'unique_id': '5965395_next_cycle',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_disable_advanced_sensors[sensor.zone_two_next_cycle-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by hydrawise.com',
+      'device_class': 'timestamp',
+      'friendly_name': 'Zone Two Next cycle',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.zone_two_next_cycle',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_disable_advanced_sensors[sensor.zone_two_remaining_watering_time-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.zone_two_remaining_watering_time',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Remaining watering time',
+    'platform': 'hydrawise',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'watering_time',
+    'unique_id': '5965395_watering_time',
+    'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+  })
+# ---
+# name: test_disable_advanced_sensors[sensor.zone_two_remaining_watering_time-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by hydrawise.com',
+      'friendly_name': 'Zone Two Remaining watering time',
+      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.zone_two_remaining_watering_time',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '29',
+  })
+# ---

--- a/tests/components/hydrawise/test_init.py
+++ b/tests/components/hydrawise/test_init.py
@@ -1,9 +1,11 @@
 """Tests for the Hydrawise integration."""
 
+from collections.abc import Awaitable, Callable
 from unittest.mock import AsyncMock
 
 from aiohttp import ClientError
 
+from homeassistant.components.hydrawise.const import CONF_ADVANCED_SENSORS
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 
@@ -32,3 +34,26 @@ async def test_update_version(
 
     # Make sure reauth flow has been initiated
     assert any(mock_config_entry_legacy.async_get_active_flows(hass, {"reauth"}))
+
+
+async def test_update_options(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockConfigEntry]],
+    mock_pydrawise: AsyncMock,
+) -> None:
+    """Test that the integration is reloaded when options are updated."""
+    mock_config_entry = await mock_add_config_entry()
+    # The initial load should fetch the current user, but not water use summaries.
+    mock_pydrawise.get_user.assert_awaited_once()
+    mock_pydrawise.get_water_use_summary.assert_not_awaited()
+    mock_pydrawise.get_user.reset_mock()
+
+    # Enable the advanced sensors option.
+    hass.config_entries.async_update_entry(
+        mock_config_entry,
+        options=mock_config_entry.options | {CONF_ADVANCED_SENSORS: True},
+    )
+    await hass.async_block_till_done()
+    # With the advanced sensors option enabled, we should now query water use summaries.
+    mock_pydrawise.get_user.assert_awaited_once()
+    mock_pydrawise.get_water_use_summary.assert_awaited_once()


### PR DESCRIPTION
## Breaking change
Certain "advanced" sensors are no longer added by default, and are instead added by enabling an option.

The following sensors are affected:

* (controller) daily_active_water_use
* (controller) daily_active_watering_time
* (controller) daily_inactive_water_use
* (controller) daily_total_water_use
* (zone) daily_active_water_use
* (zone) daily_active_watering_time

These sensors require separate polling to the Hydrawise API which are expensive to compute both server-side and client-side. Hiding them behind an option makes the default behavior of the integration friendlier to the Hydrawise cloud service.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #130857
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
