### PR TITLE
Add HassClimateSetTemperature

### DIFF
--- a/homeassistant/components/climate/__init__.py
+++ b/homeassistant/components/climate/__init__.py
@@ -69,6 +69,7 @@ from .const import (  # noqa: F401
     FAN_TOP,
     HVAC_MODES,
     INTENT_GET_TEMPERATURE,
+    INTENT_SET_TEMPERATURE,
     PRESET_ACTIVITY,
     PRESET_AWAY,
     PRESET_BOOST,

--- a/homeassistant/components/climate/const.py
+++ b/homeassistant/components/climate/const.py
@@ -127,6 +127,7 @@ DEFAULT_MAX_HUMIDITY = 99
 DOMAIN = "climate"
 
 INTENT_GET_TEMPERATURE = "HassClimateGetTemperature"
+INTENT_SET_TEMPERATURE = "HassClimateSetTemperature"
 
 SERVICE_SET_AUX_HEAT = "set_aux_heat"
 SERVICE_SET_FAN_MODE = "set_fan_mode"

--- a/homeassistant/components/climate/intent.py
+++ b/homeassistant/components/climate/intent.py
@@ -4,15 +4,29 @@ from __future__ import annotations
 
 import voluptuous as vol
 
+from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import intent
+from homeassistant.helpers import (
+    area_registry as ar,
+    config_validation as cv,
+    entity_registry as er,
+    intent,
+)
 
-from . import DOMAIN, INTENT_GET_TEMPERATURE
+from . import (
+    ATTR_TEMPERATURE,
+    DOMAIN,
+    INTENT_GET_TEMPERATURE,
+    INTENT_SET_TEMPERATURE,
+    SERVICE_SET_TEMPERATURE,
+    ClimateEntityFeature,
+)
 
 
 async def async_setup_intents(hass: HomeAssistant) -> None:
     """Set up the climate intents."""
     intent.async_register(hass, GetTemperatureIntent())
+    intent.async_register(hass, SetTemperatureIntent())
 
 
 class GetTemperatureIntent(intent.IntentHandler):
@@ -51,4 +65,116 @@ class GetTemperatureIntent(intent.IntentHandler):
         response = intent_obj.create_response()
         response.response_type = intent.IntentResponseType.QUERY_ANSWER
         response.async_set_states(matched_states=match_result.states)
+        return response
+
+
+class SetTemperatureIntent(intent.IntentHandler):
+    """Handle SetTemperature intents."""
+
+    intent_type = INTENT_SET_TEMPERATURE
+    description = "Sets the target temperature of a climate device or entity"
+    slot_schema = {
+        vol.Required("temperature"): vol.Coerce(float),
+        vol.Optional("area"): intent.non_empty_string,
+        vol.Optional("name"): intent.non_empty_string,
+        vol.Optional("floor"): intent.non_empty_string,
+        vol.Optional("preferred_area_id"): cv.string,
+        vol.Optional("preferred_floor_id"): cv.string,
+    }
+    platforms = {DOMAIN}
+
+    async def async_handle(self, intent_obj: intent.Intent) -> intent.IntentResponse:
+        """Handle the intent."""
+        hass = intent_obj.hass
+        slots = self.async_validate_slots(intent_obj.slots)
+
+        temperature: float = slots["temperature"]["value"]
+
+        name: str | None = None
+        if "name" in slots:
+            name = slots["name"]["value"]
+
+        area_name: str | None = None
+        if "area" in slots:
+            area_name = slots["area"]["value"]
+
+        floor_name: str | None = None
+        if "floor" in slots:
+            floor_name = slots["floor"]["value"]
+
+        match_constraints = intent.MatchTargetsConstraints(
+            name=name,
+            area_name=area_name,
+            floor_name=floor_name,
+            domains=[DOMAIN],
+            assistant=intent_obj.assistant,
+            features=ClimateEntityFeature.TARGET_TEMPERATURE,
+        )
+        match_preferences = intent.MatchTargetsPreferences(
+            area_id=slots.get("preferred_area_id", {}).get("value"),
+            floor_id=slots.get("preferred_floor_id", {}).get("value"),
+        )
+        match_result = intent.async_match_targets(
+            hass, match_constraints, match_preferences
+        )
+        if not match_result.is_match:
+            raise intent.MatchFailedError(
+                result=match_result, constraints=match_constraints
+            )
+
+        assert match_result.states
+
+        # Default to first matched state
+        climate_state = match_result.states[0]
+
+        # Find best match using preferences
+        if (len(match_result.states) > 1) and (
+            match_preferences.area_id or match_preferences.floor_id
+        ):
+            entity_registry = er.async_get(hass)
+            area_registry = ar.async_get(hass)
+            for maybe_state in match_result.states:
+                entity = entity_registry.async_get(maybe_state.entity_id)
+                if entity is None:
+                    continue
+
+                if match_preferences.area_id and (
+                    entity.area_id == match_preferences.area_id
+                ):
+                    # In preferred area
+                    climate_state = maybe_state
+                    break
+
+                if (not match_preferences.floor_id) or (not entity.area_id):
+                    continue
+
+                area = area_registry.async_get_area(entity.area_id)
+                if area is None:
+                    continue
+
+                if area.floor_id == match_preferences.floor_id:
+                    # On preferred floor
+                    climate_state = maybe_state
+                    break
+
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SET_TEMPERATURE,
+            service_data={ATTR_TEMPERATURE: temperature},
+            target={ATTR_ENTITY_ID: climate_state.entity_id},
+            blocking=True,
+        )
+
+        response = intent_obj.create_response()
+        response.response_type = intent.IntentResponseType.ACTION_DONE
+        response.async_set_results(
+            success_results=[
+                intent.IntentResponseTarget(
+                    type=intent.IntentResponseTargetType.ENTITY,
+                    name=climate_state.name,
+                    id=climate_state.entity_id,
+                )
+            ]
+        )
+        response.async_set_states(matched_states=[climate_state])
         return response

--- a/tests/components/climate/test_intent.py
+++ b/tests/components/climate/test_intent.py
@@ -1,13 +1,16 @@
 """Test climate intents."""
 
 from collections.abc import Generator
+from typing import Any
 
 import pytest
 
 from homeassistant.components import conversation
 from homeassistant.components.climate import (
+    ATTR_TEMPERATURE,
     DOMAIN,
     ClimateEntity,
+    ClimateEntityFeature,
     HVACMode,
     intent as climate_intent,
 )
@@ -15,7 +18,12 @@ from homeassistant.components.homeassistant.exposed_entities import async_expose
 from homeassistant.config_entries import ConfigEntry, ConfigFlow
 from homeassistant.const import Platform, UnitOfTemperature
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import area_registry as ar, entity_registry as er, intent
+from homeassistant.helpers import (
+    area_registry as ar,
+    entity_registry as er,
+    floor_registry as fr,
+    intent,
+)
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.setup import async_setup_component
 
@@ -102,6 +110,20 @@ async def create_mock_platform(
 
 
 class MockClimateEntity(ClimateEntity):
+    """Mock Climate device to use in tests."""
+
+    _attr_temperature_unit = UnitOfTemperature.CELSIUS
+    _attr_hvac_mode = HVACMode.OFF
+    _attr_hvac_modes = [HVACMode.OFF, HVACMode.HEAT]
+    _attr_supported_features = ClimateEntityFeature.TARGET_TEMPERATURE
+
+    async def async_set_temperature(self, **kwargs: Any) -> None:
+        """Set the thermostat temperature."""
+        value = kwargs[ATTR_TEMPERATURE]
+        self._attr_target_temperature = value
+
+
+class MockClimateEntityNoSetTemperature(ClimateEntity):
     """Mock Climate device to use in tests."""
 
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
@@ -436,3 +458,237 @@ async def test_not_exposed(
                 assistant=conversation.DOMAIN,
             )
         assert err.value.result.no_match_reason == intent.MatchFailedReason.ASSISTANT
+
+
+async def test_set_temperature(
+    hass: HomeAssistant,
+    area_registry: ar.AreaRegistry,
+    entity_registry: er.EntityRegistry,
+    floor_registry: fr.FloorRegistry,
+) -> None:
+    """Test HassClimateSetTemperature intent."""
+    assert await async_setup_component(hass, "homeassistant", {})
+    await climate_intent.async_setup_intents(hass)
+
+    climate_1 = MockClimateEntity()
+    climate_1._attr_name = "Climate 1"
+    climate_1._attr_unique_id = "1234"
+    climate_1._attr_current_temperature = 10.0
+    climate_1._attr_target_temperature = 10.0
+    entity_registry.async_get_or_create(
+        DOMAIN, "test", "1234", suggested_object_id="climate_1"
+    )
+
+    climate_2 = MockClimateEntity()
+    climate_2._attr_name = "Climate 2"
+    climate_2._attr_unique_id = "5678"
+    climate_2._attr_current_temperature = 22.0
+    climate_2._attr_target_temperature = 22.0
+    entity_registry.async_get_or_create(
+        DOMAIN, "test", "5678", suggested_object_id="climate_2"
+    )
+
+    await create_mock_platform(hass, [climate_1, climate_2])
+
+    # Add climate entities to different areas:
+    # climate_1 => living room
+    # climate_2 => bedroom
+    # nothing in office
+    living_room_area = area_registry.async_create(name="Living Room")
+    bedroom_area = area_registry.async_create(name="Bedroom")
+    office_area = area_registry.async_create(name="Office")
+
+    entity_registry.async_update_entity(
+        climate_1.entity_id, area_id=living_room_area.id
+    )
+    entity_registry.async_update_entity(climate_2.entity_id, area_id=bedroom_area.id)
+
+    # Put areas on different floors:
+    # first floor => living room and office
+    # upstairs => bedroom
+    floor_registry = fr.async_get(hass)
+    first_floor = floor_registry.async_create("First floor")
+    living_room_area = area_registry.async_update(
+        living_room_area.id, floor_id=first_floor.floor_id
+    )
+    office_area = area_registry.async_update(
+        office_area.id, floor_id=first_floor.floor_id
+    )
+
+    second_floor = floor_registry.async_create("Second floor")
+    bedroom_area = area_registry.async_update(
+        bedroom_area.id, floor_id=second_floor.floor_id
+    )
+
+    # First climate entity will be selected (no area/floor/name)
+    response = await intent.async_handle(
+        hass,
+        "test",
+        climate_intent.INTENT_SET_TEMPERATURE,
+        {"temperature": {"value": 20}},
+        assistant=conversation.DOMAIN,
+    )
+    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.matched_states
+    assert response.matched_states[0].entity_id == climate_1.entity_id
+    state = hass.states.get(climate_1.entity_id)
+    assert state.attributes[ATTR_TEMPERATURE] == 20.0
+
+    # Select by area explicitly (climate_2)
+    response = await intent.async_handle(
+        hass,
+        "test",
+        climate_intent.INTENT_SET_TEMPERATURE,
+        {"area": {"value": bedroom_area.name}, "temperature": {"value": 20.1}},
+        assistant=conversation.DOMAIN,
+    )
+    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert len(response.matched_states) == 1
+    assert response.matched_states[0].entity_id == climate_2.entity_id
+    state = hass.states.get(climate_2.entity_id)
+    assert state.attributes[ATTR_TEMPERATURE] == 20.1
+
+    # Select by area implicitly (climate_2)
+    response = await intent.async_handle(
+        hass,
+        "test",
+        climate_intent.INTENT_SET_TEMPERATURE,
+        {
+            "preferred_area_id": {"value": bedroom_area.id},
+            "temperature": {"value": 20.2},
+        },
+        assistant=conversation.DOMAIN,
+    )
+    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.matched_states
+    assert response.matched_states[0].entity_id == climate_2.entity_id
+    state = hass.states.get(climate_2.entity_id)
+    assert state.attributes[ATTR_TEMPERATURE] == 20.2
+
+    # Select by floor explicitly (climate_2)
+    response = await intent.async_handle(
+        hass,
+        "test",
+        climate_intent.INTENT_SET_TEMPERATURE,
+        {"floor": {"value": second_floor.name}, "temperature": {"value": 20.3}},
+        assistant=conversation.DOMAIN,
+    )
+    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.matched_states
+    assert response.matched_states[0].entity_id == climate_2.entity_id
+    state = hass.states.get(climate_2.entity_id)
+    assert state.attributes[ATTR_TEMPERATURE] == 20.3
+
+    # Select by floor implicitly (climate_2)
+    response = await intent.async_handle(
+        hass,
+        "test",
+        climate_intent.INTENT_SET_TEMPERATURE,
+        {
+            "preferred_floor_id": {"value": second_floor.floor_id},
+            "temperature": {"value": 20.4},
+        },
+        assistant=conversation.DOMAIN,
+    )
+    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.matched_states
+    assert response.matched_states[0].entity_id == climate_2.entity_id
+    state = hass.states.get(climate_2.entity_id)
+    assert state.attributes[ATTR_TEMPERATURE] == 20.4
+
+    # Select by name (climate_2)
+    response = await intent.async_handle(
+        hass,
+        "test",
+        climate_intent.INTENT_SET_TEMPERATURE,
+        {"name": {"value": "Climate 2"}, "temperature": {"value": 20.5}},
+        assistant=conversation.DOMAIN,
+    )
+    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert len(response.matched_states) == 1
+    assert response.matched_states[0].entity_id == climate_2.entity_id
+    state = hass.states.get(climate_2.entity_id)
+    assert state.attributes[ATTR_TEMPERATURE] == 20.5
+
+    # Check area with no climate entities (explicit)
+    with pytest.raises(intent.MatchFailedError) as error:
+        response = await intent.async_handle(
+            hass,
+            "test",
+            climate_intent.INTENT_SET_TEMPERATURE,
+            {"area": {"value": office_area.name}, "temperature": {"value": 20.6}},
+            assistant=conversation.DOMAIN,
+        )
+
+    # Exception should contain details of what we tried to match
+    assert isinstance(error.value, intent.MatchFailedError)
+    assert error.value.result.no_match_reason == intent.MatchFailedReason.AREA
+    constraints = error.value.constraints
+    assert constraints.name is None
+    assert constraints.area_name == office_area.name
+    assert constraints.domains and (set(constraints.domains) == {DOMAIN})
+    assert constraints.device_classes is None
+
+    # Implicit area with no climate entities should pick the first one
+    response = await intent.async_handle(
+        hass,
+        "test",
+        climate_intent.INTENT_SET_TEMPERATURE,
+        {
+            "preferred_area_id": {"value": office_area.id},
+            "temperature": {"value": 20.7},
+        },
+        assistant=conversation.DOMAIN,
+    )
+    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert response.matched_states
+    assert response.matched_states[0].entity_id == climate_1.entity_id
+    state = hass.states.get(climate_1.entity_id)
+    assert state.attributes[ATTR_TEMPERATURE] == 20.7
+
+
+async def test_set_temperature_no_entities(
+    hass: HomeAssistant,
+) -> None:
+    """Test HassClimateSetTemperature intent with no climate entities."""
+    assert await async_setup_component(hass, "homeassistant", {})
+    await climate_intent.async_setup_intents(hass)
+
+    await create_mock_platform(hass, [])
+
+    with pytest.raises(intent.MatchFailedError) as err:
+        await intent.async_handle(
+            hass,
+            "test",
+            climate_intent.INTENT_SET_TEMPERATURE,
+            {"temperature": {"value": 20}},
+            assistant=conversation.DOMAIN,
+        )
+    assert err.value.result.no_match_reason == intent.MatchFailedReason.DOMAIN
+
+
+async def test_set_temperature_not_supported(hass: HomeAssistant) -> None:
+    """Test HassClimateSetTemperature intent when climate entity doesn't support required feature."""
+    assert await async_setup_component(hass, "homeassistant", {})
+    await climate_intent.async_setup_intents(hass)
+
+    climate_1 = MockClimateEntityNoSetTemperature()
+    climate_1._attr_name = "Climate 1"
+    climate_1._attr_unique_id = "1234"
+    climate_1._attr_current_temperature = 10.0
+    climate_1._attr_target_temperature = 10.0
+
+    await create_mock_platform(hass, [climate_1])
+
+    with pytest.raises(intent.MatchFailedError) as error:
+        await intent.async_handle(
+            hass,
+            "test",
+            climate_intent.INTENT_SET_TEMPERATURE,
+            {"temperature": {"value": 20.0}},
+            assistant=conversation.DOMAIN,
+        )
+
+    # Exception should contain details of what we tried to match
+    assert isinstance(error.value, intent.MatchFailedError)
+    assert error.value.result.no_match_reason == intent.MatchFailedReason.FEATURE


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Implements the `HassClimateSetTemperature` intent. Sentences for this intent are [already present](https://github.com/home-assistant/intents/pull/2921) for some languages.

This intent sets the target temperature of a climate device. The device must support the `TARGET_TEMPERATURE` feature. The specific climate device can be targeted by name, area, or floor as well as implicitly by the area/floor of the voice satellite. Without constraints (or if no climate device is implicitly matched by area/floor), the first climate device available is used.

In order to supported halves of degree for Celsius, [changes to hassil](https://github.com/home-assistant/hassil/pull/191) will be required.

Credit to @mib1185 for prior work: https://github.com/home-assistant/core/pull/134316

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
