### PR TITLE
Reuse fixtures in config flow tests for Whirlpool

### DIFF
--- a/tests/components/whirlpool/conftest.py
+++ b/tests/components/whirlpool/conftest.py
@@ -39,7 +39,12 @@ def fixture_brand(request: pytest.FixtureRequest) -> tuple[str, Brand]:
 @pytest.fixture(name="mock_auth_api")
 def fixture_mock_auth_api():
     """Set up Auth fixture."""
-    with mock.patch("homeassistant.components.whirlpool.Auth") as mock_auth:
+    with (
+        mock.patch("homeassistant.components.whirlpool.Auth") as mock_auth,
+        mock.patch(
+            "homeassistant.components.whirlpool.config_flow.Auth", new=mock_auth
+        ),
+    ):
         mock_auth.return_value.do_auth = AsyncMock()
         mock_auth.return_value.is_access_token_valid.return_value = True
         yield mock_auth
@@ -48,9 +53,15 @@ def fixture_mock_auth_api():
 @pytest.fixture(name="mock_appliances_manager_api")
 def fixture_mock_appliances_manager_api():
     """Set up AppliancesManager fixture."""
-    with mock.patch(
-        "homeassistant.components.whirlpool.AppliancesManager"
-    ) as mock_appliances_manager:
+    with (
+        mock.patch(
+            "homeassistant.components.whirlpool.AppliancesManager"
+        ) as mock_appliances_manager,
+        mock.patch(
+            "homeassistant.components.whirlpool.config_flow.AppliancesManager",
+            new=mock_appliances_manager,
+        ),
+    ):
         mock_appliances_manager.return_value.fetch_appliances = AsyncMock()
         mock_appliances_manager.return_value.aircons = [
             {"SAID": MOCK_SAID1, "NAME": "TestZone"},
@@ -81,9 +92,15 @@ def fixture_mock_appliances_manager_laundry_api():
 @pytest.fixture(name="mock_backend_selector_api")
 def fixture_mock_backend_selector_api():
     """Set up BackendSelector fixture."""
-    with mock.patch(
-        "homeassistant.components.whirlpool.BackendSelector"
-    ) as mock_backend_selector:
+    with (
+        mock.patch(
+            "homeassistant.components.whirlpool.BackendSelector"
+        ) as mock_backend_selector,
+        mock.patch(
+            "homeassistant.components.whirlpool.config_flow.BackendSelector",
+            new=mock_backend_selector,
+        ),
+    ):
         yield mock_backend_selector
 
 

--- a/tests/components/whirlpool/test_config_flow.py
+++ b/tests/components/whirlpool/test_config_flow.py
@@ -1,9 +1,10 @@
 """Test the Whirlpool Sixth Sense config flow."""
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import aiohttp
 from aiohttp.client_exceptions import ClientConnectionError
+import pytest
 
 from homeassistant import config_entries
 from homeassistant.components.whirlpool.const import CONF_BRAND, DOMAIN
@@ -19,7 +20,10 @@ CONFIG_INPUT = {
 }
 
 
-async def test_form(hass: HomeAssistant, region, brand) -> None:
+@pytest.mark.usefixtures("mock_auth_api", "mock_appliances_manager_api")
+async def test_form(
+    hass: HomeAssistant, region, brand, mock_backend_selector_api: MagicMock
+) -> None:
     """Test we get the form."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -28,28 +32,9 @@ async def test_form(hass: HomeAssistant, region, brand) -> None:
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == config_entries.SOURCE_USER
 
-    with (
-        patch("homeassistant.components.whirlpool.config_flow.Auth.do_auth"),
-        patch(
-            "homeassistant.components.whirlpool.config_flow.Auth.is_access_token_valid",
-            return_value=True,
-        ),
-        patch(
-            "homeassistant.components.whirlpool.config_flow.BackendSelector"
-        ) as mock_backend_selector,
-        patch(
-            "homeassistant.components.whirlpool.async_setup_entry",
-            return_value=True,
-        ) as mock_setup_entry,
-        patch(
-            "homeassistant.components.whirlpool.config_flow.AppliancesManager.aircons",
-            return_value=["test"],
-        ),
-        patch(
-            "homeassistant.components.whirlpool.config_flow.AppliancesManager.fetch_appliances",
-            return_value=True,
-        ),
-    ):
+    with patch(
+        "homeassistant.components.whirlpool.async_setup_entry", return_value=True
+    ) as mock_setup_entry:
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             CONFIG_INPUT | {"region": region[0], "brand": brand[0]},
@@ -65,92 +50,61 @@ async def test_form(hass: HomeAssistant, region, brand) -> None:
         "brand": brand[0],
     }
     assert len(mock_setup_entry.mock_calls) == 1
-    mock_backend_selector.assert_called_once_with(brand[1], region[1])
+    mock_backend_selector_api.assert_called_once_with(brand[1], region[1])
 
 
-async def test_form_invalid_auth(hass: HomeAssistant, region, brand) -> None:
+async def test_form_invalid_auth(
+    hass: HomeAssistant, region, brand, mock_auth_api: MagicMock
+) -> None:
     """Test we handle invalid auth."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    with (
-        patch("homeassistant.components.whirlpool.config_flow.Auth.do_auth"),
-        patch(
-            "homeassistant.components.whirlpool.config_flow.Auth.is_access_token_valid",
-            return_value=False,
-        ),
-    ):
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            CONFIG_INPUT | {"region": region[0], "brand": brand[0]},
-        )
+
+    mock_auth_api.return_value.is_access_token_valid.return_value = False
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        CONFIG_INPUT | {"region": region[0], "brand": brand[0]},
+    )
     assert result2["type"] is FlowResultType.FORM
     assert result2["errors"] == {"base": "invalid_auth"}
 
 
-async def test_form_cannot_connect(hass: HomeAssistant, region, brand) -> None:
+@pytest.mark.parametrize(
+    ("exception", "expected_error"),
+    [
+        (aiohttp.ClientConnectionError, "cannot_connect"),
+        (TimeoutError, "cannot_connect"),
+        (Exception, "unknown"),
+    ],
+)
+async def test_form_auth_error(
+    exception: Exception,
+    expected_error: str,
+    hass: HomeAssistant,
+    region,
+    brand,
+    mock_auth_api: MagicMock,
+) -> None:
     """Test we handle cannot connect error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    with patch(
-        "homeassistant.components.whirlpool.config_flow.Auth.do_auth",
-        side_effect=aiohttp.ClientConnectionError,
-    ):
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            CONFIG_INPUT
-            | {
-                "region": region[0],
-                "brand": brand[0],
-            },
-        )
-    assert result2["type"] is FlowResultType.FORM
-    assert result2["errors"] == {"base": "cannot_connect"}
 
-
-async def test_form_auth_timeout(hass: HomeAssistant, region, brand) -> None:
-    """Test we handle auth timeout error."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    mock_auth_api.return_value.do_auth.side_effect = exception
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        CONFIG_INPUT
+        | {
+            "region": region[0],
+            "brand": brand[0],
+        },
     )
-    with patch(
-        "homeassistant.components.whirlpool.config_flow.Auth.do_auth",
-        side_effect=TimeoutError,
-    ):
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            CONFIG_INPUT
-            | {
-                "region": region[0],
-                "brand": brand[0],
-            },
-        )
     assert result2["type"] is FlowResultType.FORM
-    assert result2["errors"] == {"base": "cannot_connect"}
+    assert result2["errors"] == {"base": expected_error}
 
 
-async def test_form_generic_auth_exception(hass: HomeAssistant, region, brand) -> None:
-    """Test we handle cannot connect error."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
-    with patch(
-        "homeassistant.components.whirlpool.config_flow.Auth.do_auth",
-        side_effect=Exception,
-    ):
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            CONFIG_INPUT
-            | {
-                "region": region[0],
-                "brand": brand[0],
-            },
-        )
-    assert result2["type"] is FlowResultType.FORM
-    assert result2["errors"] == {"base": "unknown"}
-
-
+@pytest.mark.usefixtures("mock_auth_api", "mock_appliances_manager_api")
 async def test_form_already_configured(hass: HomeAssistant, region, brand) -> None:
     """Test we handle cannot connect error."""
     mock_entry = MockConfigEntry(
@@ -167,36 +121,24 @@ async def test_form_already_configured(hass: HomeAssistant, region, brand) -> No
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == config_entries.SOURCE_USER
 
-    with (
-        patch("homeassistant.components.whirlpool.config_flow.Auth.do_auth"),
-        patch(
-            "homeassistant.components.whirlpool.config_flow.Auth.is_access_token_valid",
-            return_value=True,
-        ),
-        patch(
-            "homeassistant.components.whirlpool.config_flow.AppliancesManager.aircons",
-            return_value=["test"],
-        ),
-        patch(
-            "homeassistant.components.whirlpool.config_flow.AppliancesManager.fetch_appliances",
-            return_value=True,
-        ),
-    ):
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            CONFIG_INPUT
-            | {
-                "region": region[0],
-                "brand": brand[0],
-            },
-        )
-        await hass.async_block_till_done()
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        CONFIG_INPUT
+        | {
+            "region": region[0],
+            "brand": brand[0],
+        },
+    )
+    await hass.async_block_till_done()
 
     assert result2["type"] is FlowResultType.ABORT
     assert result2["reason"] == "already_configured"
 
 
-async def test_no_appliances_flow(hass: HomeAssistant, region, brand) -> None:
+@pytest.mark.usefixtures("mock_auth_api")
+async def test_no_appliances_flow(
+    hass: HomeAssistant, region, brand, mock_appliances_manager_api: MagicMock
+) -> None:
     """Test we get an error with no appliances."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -205,27 +147,19 @@ async def test_no_appliances_flow(hass: HomeAssistant, region, brand) -> None:
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == config_entries.SOURCE_USER
 
-    with (
-        patch("homeassistant.components.whirlpool.config_flow.Auth.do_auth"),
-        patch(
-            "homeassistant.components.whirlpool.config_flow.Auth.is_access_token_valid",
-            return_value=True,
-        ),
-        patch(
-            "homeassistant.components.whirlpool.config_flow.AppliancesManager.fetch_appliances",
-            return_value=True,
-        ),
-    ):
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            CONFIG_INPUT | {"region": region[0], "brand": brand[0]},
-        )
-        await hass.async_block_till_done()
+    mock_appliances_manager_api.return_value.aircons = []
+    mock_appliances_manager_api.return_value.washer_dryers = []
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        CONFIG_INPUT | {"region": region[0], "brand": brand[0]},
+    )
+    await hass.async_block_till_done()
 
     assert result2["type"] is FlowResultType.FORM
     assert result2["errors"] == {"base": "no_appliances"}
 
 
+@pytest.mark.usefixtures("mock_auth_api", "mock_appliances_manager_api")
 async def test_reauth_flow(hass: HomeAssistant, region, brand) -> None:
     """Test a successful reauth flow."""
     mock_entry = MockConfigEntry(
@@ -241,24 +175,8 @@ async def test_reauth_flow(hass: HomeAssistant, region, brand) -> None:
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {}
 
-    with (
-        patch(
-            "homeassistant.components.whirlpool.async_setup_entry",
-            return_value=True,
-        ),
-        patch("homeassistant.components.whirlpool.config_flow.Auth.do_auth"),
-        patch(
-            "homeassistant.components.whirlpool.config_flow.Auth.is_access_token_valid",
-            return_value=True,
-        ),
-        patch(
-            "homeassistant.components.whirlpool.config_flow.AppliancesManager.aircons",
-            return_value=["test"],
-        ),
-        patch(
-            "homeassistant.components.whirlpool.config_flow.AppliancesManager.fetch_appliances",
-            return_value=True,
-        ),
+    with patch(
+        "homeassistant.components.whirlpool.async_setup_entry", return_value=True
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -276,7 +194,10 @@ async def test_reauth_flow(hass: HomeAssistant, region, brand) -> None:
     }
 
 
-async def test_reauth_flow_auth_error(hass: HomeAssistant, region, brand) -> None:
+@pytest.mark.usefixtures("mock_appliances_manager_api")
+async def test_reauth_flow_auth_error(
+    hass: HomeAssistant, region, brand, mock_auth_api: MagicMock
+) -> None:
     """Test an authorization error reauth flow."""
 
     mock_entry = MockConfigEntry(
@@ -290,16 +211,10 @@ async def test_reauth_flow_auth_error(hass: HomeAssistant, region, brand) -> Non
     assert result["step_id"] == "reauth_confirm"
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {}
-    with (
-        patch(
-            "homeassistant.components.whirlpool.async_setup_entry",
-            return_value=True,
-        ),
-        patch("homeassistant.components.whirlpool.config_flow.Auth.do_auth"),
-        patch(
-            "homeassistant.components.whirlpool.config_flow.Auth.is_access_token_valid",
-            return_value=False,
-        ),
+
+    mock_auth_api.return_value.is_access_token_valid.return_value = False
+    with patch(
+        "homeassistant.components.whirlpool.async_setup_entry", return_value=True
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -311,8 +226,9 @@ async def test_reauth_flow_auth_error(hass: HomeAssistant, region, brand) -> Non
     assert result2["errors"] == {"base": "invalid_auth"}
 
 
+@pytest.mark.usefixtures("mock_appliances_manager_api")
 async def test_reauth_flow_connnection_error(
-    hass: HomeAssistant, region, brand
+    hass: HomeAssistant, region, brand, mock_auth_api: MagicMock
 ) -> None:
     """Test a connection error reauth flow."""
 
@@ -329,25 +245,14 @@ async def test_reauth_flow_connnection_error(
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {}
 
-    with (
-        patch(
-            "homeassistant.components.whirlpool.async_setup_entry",
-            return_value=True,
-        ),
-        patch(
-            "homeassistant.components.whirlpool.config_flow.Auth.do_auth",
-            side_effect=ClientConnectionError,
-        ),
-        patch(
-            "homeassistant.components.whirlpool.config_flow.Auth.is_access_token_valid",
-            return_value=False,
-        ),
+    mock_auth_api.return_value.do_auth.side_effect = ClientConnectionError
+    with patch(
+        "homeassistant.components.whirlpool.async_setup_entry", return_value=True
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {CONF_PASSWORD: "new-password", CONF_BRAND: brand[0]},
         )
         await hass.async_block_till_done()
-
     assert result2["type"] is FlowResultType.FORM
     assert result2["errors"] == {"base": "cannot_connect"}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This reuses the existing fixtures instead of patching in the tests repeateadly.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
