### PR TITLE
Fix loading of SMLIGHT integration when no internet is available

### DIFF
--- a/tests/components/smlight/test_init.py
+++ b/tests/components/smlight/test_init.py
@@ -8,9 +8,13 @@ from pysmlight.exceptions import SmlightAuthError, SmlightConnectionError, Smlig
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.components.smlight.const import DOMAIN, SCAN_INTERVAL
+from homeassistant.components.smlight.const import (
+    DOMAIN,
+    SCAN_FIRMWARE_INTERVAL,
+    SCAN_INTERVAL,
+)
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import STATE_UNAVAILABLE
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.issue_registry import IssueRegistry
@@ -71,6 +75,30 @@ async def test_async_setup_missing_credentials(
     assert len(progress) == 1
     assert progress[0]["step_id"] == "reauth_confirm"
     assert progress[0]["context"]["unique_id"] == "aa:bb:cc:dd:ee:ff"
+
+
+async def test_async_setup_no_internet(
+    hass: HomeAssistant,
+    mock_config_entry_host: MockConfigEntry,
+    mock_smlight_client: MagicMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test we still load integration when no internet is available."""
+    mock_smlight_client.get_firmware_version.side_effect = SmlightConnectionError
+
+    await setup_integration(hass, mock_config_entry_host)
+
+    entity = hass.states.get("update.mock_title_core_firmware")
+    assert entity is not None
+    assert entity.state == STATE_UNKNOWN
+
+    freezer.tick(SCAN_FIRMWARE_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    entity = hass.states.get("update.mock_title_core_firmware")
+    assert entity is not None
+    assert entity.state == STATE_UNKNOWN
 
 
 @pytest.mark.parametrize("error", [SmlightConnectionError, SmlightAuthError])

--- a/tests/components/smlight/test_init.py
+++ b/tests/components/smlight/test_init.py
@@ -13,8 +13,9 @@ from homeassistant.components.smlight.const import (
     SCAN_FIRMWARE_INTERVAL,
     SCAN_INTERVAL,
 )
+from homeassistant.components.update import ATTR_INSTALLED_VERSION
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
+from homeassistant.const import STATE_ON, STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.issue_registry import IssueRegistry
@@ -99,6 +100,17 @@ async def test_async_setup_no_internet(
     entity = hass.states.get("update.mock_title_core_firmware")
     assert entity is not None
     assert entity.state == STATE_UNKNOWN
+
+    mock_smlight_client.get_firmware_version.side_effect = None
+
+    freezer.tick(SCAN_FIRMWARE_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    entity = hass.states.get("update.mock_title_core_firmware")
+    assert entity is not None
+    assert entity.state == STATE_ON
+    assert entity.attributes[ATTR_INSTALLED_VERSION] == "v2.3.6"
 
 
 @pytest.mark.parametrize("error", [SmlightConnectionError, SmlightAuthError])

--- a/tests/components/smlight/test_update.py
+++ b/tests/components/smlight/test_update.py
@@ -81,7 +81,7 @@ async def test_update_setup(
     mock_config_entry: MockConfigEntry,
     snapshot: SnapshotAssertion,
 ) -> None:
-    """Test setup of SMLIGHT switches."""
+    """Test setup of SMLIGHT update entities."""
     entry = await setup_integration(hass, mock_config_entry)
 
     await snapshot_platform(hass, entity_registry, snapshot, entry.entry_id)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently the SMLIGHT integration is failing to load when there is no internet connection available. For the most part this integration works with local LAN requests to the SLZB devices. The only feature that requires internet is the update entities for firmware updates.

Fix this to ensure the integration loads successfully when there is no internet connection.

Can this fix be picked for next stable release.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #132374 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X]  I have followed the [development checklist][dev-checklist]
- [X]  I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X]  Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
