### PR TITLE
Bump reolink_aio to 0.11.8

### DIFF
--- a/homeassistant/components/reolink/manifest.json
+++ b/homeassistant/components/reolink/manifest.json
@@ -19,5 +19,5 @@
   "iot_class": "local_push",
   "loggers": ["reolink_aio"],
   "quality_scale": "platinum",
-  "requirements": ["reolink-aio==0.11.6"]
+  "requirements": ["reolink-aio==0.11.8"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2596,7 +2596,7 @@ renault-api==0.2.9
 renson-endura-delta==1.7.2
 
 # homeassistant.components.reolink
-reolink-aio==0.11.6
+reolink-aio==0.11.8
 
 # homeassistant.components.idteck_prox
 rfk101py==0.0.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2099,7 +2099,7 @@ renault-api==0.2.9
 renson-endura-delta==1.7.2
 
 # homeassistant.components.reolink
-reolink-aio==0.11.6
+reolink-aio==0.11.8
 
 # homeassistant.components.rflink
 rflink==0.0.66


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump reolink-aio to 0.11.8:
**Additions:**
- [Add Baichuan privacy mode support](https://github.com/starkillerOG/reolink_aio/commit/a1568d5238e7edb94b686be1309894125524aa68)
  - [Parse Baichuan privacy mode from login response](https://github.com/starkillerOG/reolink_aio/commit/334cfe764cab49988e25ce57c1feb8a2dfb92962)
  - [Check privacy mode during login and raise LoginPrivacyModeError](https://github.com/starkillerOG/reolink_aio/commit/e717a626de7239e6c0d267b1e22ca55ff2f46cf2)
  - [Improve privacy mode checking](https://github.com/starkillerOG/reolink_aio/commit/0c3b3d59aa4ebef824a0fbe157319eb3fbd6aec5)
- [Add SetNetPort baichuan fallback](https://github.com/starkillerOG/reolink_aio/commit/f9bb61de783ed65d0be2bed67fec60d4fc13df2f)
- Add get_raw_host_data and set_raw_host_data

**Bug fixes:**
- [Fix wrong channel used for include check of DingDongOpt](https://github.com/starkillerOG/reolink_aio/commit/2e9bc051281ebca2e8a01e9e35040280207caaf8)
- [Ensure previous futures throw their exceptions before opening a new connection](https://github.com/starkillerOG/reolink_aio/commit/d408d77cd776ecfc8137d6dac4b55c7ec1c2bade)
- [Wait before sending identical cmd_ids simultaneously](https://github.com/starkillerOG/reolink_aio/commit/120813c63323196b616a77e93138d2185cf51e3f)
- [ensure stream URLs are available when privacy mode enabled](https://github.com/starkillerOG/reolink_aio/commit/6046201a9c0cd854ff5744950e35f1d88d0af7e7)

**Optimizations:**
- Do not temporarily disable privacy mode
- [Change return type of check_new_firmware to a dict](https://github.com/starkillerOG/reolink_aio/commit/4fc4aebf12cda5a66fa6bcc8c63d87d745b4fb70)
- [Add RLC-810A IPC_56064M8MP minimum firmware](https://github.com/starkillerOG/reolink_aio/commit/febac356797c0bfdf65dae8d08ce3a9351c0fb84)

**Full Changelog**: https://github.com/starkillerOG/reolink_aio/compare/0.11.6...0.11.8

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
