### PR TITLE
Abort config flow is device is unsupported

### DIFF
--- a/homeassistant/components/smlight/config_flow.py
+++ b/homeassistant/components/smlight/config_flow.py
@@ -6,6 +6,7 @@ from collections.abc import Mapping
 from typing import Any
 
 from pysmlight import Api2
+from pysmlight.const import Devices
 from pysmlight.exceptions import SmlightAuthError, SmlightConnectionError
 import voluptuous as vol
 
@@ -116,6 +117,11 @@ class SmlightConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             user_input[CONF_HOST] = self.host
             try:
+                info = await self.client.get_info()
+
+                if info.model not in Devices:
+                    return self.async_abort(reason="unsupported_device")
+
                 if not await self._async_check_auth_required(user_input):
                     return await self._async_complete_entry(user_input)
 

--- a/homeassistant/components/smlight/config_flow.py
+++ b/homeassistant/components/smlight/config_flow.py
@@ -52,6 +52,11 @@ class SmlightConfigFlow(ConfigFlow, domain=DOMAIN):
             self.client = Api2(self.host, session=async_get_clientsession(self.hass))
 
             try:
+                info = await self.client.get_info()
+
+                if info.model not in Devices:
+                    return self.async_abort(reason="unsupported_device")
+
                 if not await self._async_check_auth_required(user_input):
                     return await self._async_complete_entry(user_input)
             except SmlightConnectionError:
@@ -71,6 +76,11 @@ class SmlightConfigFlow(ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             try:
+                info = await self.client.get_info()
+
+                if info.model not in Devices:
+                    return self.async_abort(reason="unsupported_device")
+
                 if not await self._async_check_auth_required(user_input):
                     return await self._async_complete_entry(user_input)
             except SmlightConnectionError:

--- a/homeassistant/components/smlight/strings.json
+++ b/homeassistant/components/smlight/strings.json
@@ -38,7 +38,8 @@
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "reauth_failed": "[%key:common::config_flow::error::invalid_auth%]",
-      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
+      "unsupported_device": "This device is not yet supported by the SMLIGHT integration"
     }
   },
   "entity": {

--- a/tests/components/smlight/test_config_flow.py
+++ b/tests/components/smlight/test_config_flow.py
@@ -97,7 +97,7 @@ async def test_zeroconf_flow(
     }
 
     assert len(mock_setup_entry.mock_calls) == 1
-    assert len(mock_smlight_client.get_info.mock_calls) == 1
+    assert len(mock_smlight_client.get_info.mock_calls) == 2
 
 
 async def test_zeroconf_flow_auth(
@@ -151,7 +151,7 @@ async def test_zeroconf_flow_auth(
     }
 
     assert len(mock_setup_entry.mock_calls) == 1
-    assert len(mock_smlight_client.get_info.mock_calls) == 1
+    assert len(mock_smlight_client.get_info.mock_calls) == 3
 
 
 @pytest.mark.usefixtures("mock_smlight_client")
@@ -239,7 +239,7 @@ async def test_user_invalid_auth(
     }
 
     assert len(mock_setup_entry.mock_calls) == 1
-    assert len(mock_smlight_client.get_info.mock_calls) == 1
+    assert len(mock_smlight_client.get_info.mock_calls) == 4
 
 
 async def test_user_cannot_connect(
@@ -276,7 +276,7 @@ async def test_user_cannot_connect(
     assert result2["title"] == "SLZB-06p7"
 
     assert len(mock_setup_entry.mock_calls) == 1
-    assert len(mock_smlight_client.get_info.mock_calls) == 1
+    assert len(mock_smlight_client.get_info.mock_calls) == 3
 
 
 async def test_auth_cannot_connect(
@@ -378,7 +378,7 @@ async def test_zeroconf_legacy_mac(
     }
 
     assert len(mock_setup_entry.mock_calls) == 1
-    assert len(mock_smlight_client.get_info.mock_calls) == 2
+    assert len(mock_smlight_client.get_info.mock_calls) == 3
 
 
 async def test_reauth_flow(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
If the user has a new device which hasnt had support added to the integration yet, we should abort the config flow with a message that the device is unsupported. This avoids the integration crashing on setup with an unknown device model.

This is a follow-up to previous PR comment:
https://github.com/home-assistant/core/pull/132045#issuecomment-2510822160

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
