### PR TITLE
Use the new hybrid Hydrawise client

### DIFF
--- a/homeassistant/components/hydrawise/__init__.py
+++ b/homeassistant/components/hydrawise/__init__.py
@@ -1,9 +1,9 @@
 """Support for Hydrawise cloud."""
 
-from pydrawise import auth, client
+from pydrawise import auth, hybrid
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, Platform
+from homeassistant.const import CONF_API_KEY, CONF_PASSWORD, CONF_USERNAME, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 
@@ -21,16 +21,21 @@ PLATFORMS: list[Platform] = [
     Platform.VALVE,
 ]
 
+_REQUIRED_AUTH_KEYS = (CONF_USERNAME, CONF_PASSWORD, CONF_API_KEY)
+
 
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Set up Hydrawise from a config entry."""
-    if CONF_USERNAME not in config_entry.data or CONF_PASSWORD not in config_entry.data:
-        # The GraphQL API requires username and password to authenticate. If either is
-        # missing, reauth is required.
+    if any(k not in config_entry.data for k in _REQUIRED_AUTH_KEYS):
+        # If we are missing any required authentication keys, trigger a reauth flow.
         raise ConfigEntryAuthFailed
 
-    hydrawise = client.Hydrawise(
-        auth.Auth(config_entry.data[CONF_USERNAME], config_entry.data[CONF_PASSWORD]),
+    hydrawise = hybrid.HybridClient(
+        auth.HybridAuth(
+            config_entry.data[CONF_USERNAME],
+            config_entry.data[CONF_PASSWORD],
+            config_entry.data[CONF_API_KEY],
+        ),
         app_id=APP_ID,
     )
 

--- a/homeassistant/components/hydrawise/coordinator.py
+++ b/homeassistant/components/hydrawise/coordinator.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
-from pydrawise import Hydrawise
+from pydrawise import HydrawiseBase
 from pydrawise.schema import Controller, ControllerWaterUseSummary, Sensor, User, Zone
 
 from homeassistant.core import HomeAssistant
@@ -38,7 +38,7 @@ class HydrawiseUpdateCoordinators:
 class HydrawiseDataUpdateCoordinator(DataUpdateCoordinator[HydrawiseData]):
     """Base class for Hydrawise Data Update Coordinators."""
 
-    api: Hydrawise
+    api: HydrawiseBase
 
 
 class HydrawiseMainDataUpdateCoordinator(HydrawiseDataUpdateCoordinator):
@@ -49,7 +49,7 @@ class HydrawiseMainDataUpdateCoordinator(HydrawiseDataUpdateCoordinator):
     integration are updated in a timely manner.
     """
 
-    def __init__(self, hass: HomeAssistant, api: Hydrawise) -> None:
+    def __init__(self, hass: HomeAssistant, api: HydrawiseBase) -> None:
         """Initialize HydrawiseDataUpdateCoordinator."""
         super().__init__(hass, LOGGER, name=DOMAIN, update_interval=MAIN_SCAN_INTERVAL)
         self.api = api
@@ -82,7 +82,7 @@ class HydrawiseWaterUseDataUpdateCoordinator(HydrawiseDataUpdateCoordinator):
     def __init__(
         self,
         hass: HomeAssistant,
-        api: Hydrawise,
+        api: HydrawiseBase,
         main_coordinator: HydrawiseMainDataUpdateCoordinator,
     ) -> None:
         """Initialize HydrawiseWaterUseDataUpdateCoordinator."""

--- a/homeassistant/components/hydrawise/strings.json
+++ b/homeassistant/components/hydrawise/strings.json
@@ -21,7 +21,7 @@
           "api_key": "[%key:common::config_flow::data::api_key%]"
         },
         "data_description": {
-          "api_key": "You can generate an API Key in the 'Account Details' section of the Hydrawise app"
+          "api_key": "[%key:component::hydrawise::config::step::user::data_description::api_key%]"
         }
       }
     },

--- a/homeassistant/components/hydrawise/strings.json
+++ b/homeassistant/components/hydrawise/strings.json
@@ -6,14 +6,22 @@
         "description": "Please provide the username and password for your Hydrawise cloud account:",
         "data": {
           "username": "[%key:common::config_flow::data::username%]",
-          "password": "[%key:common::config_flow::data::password%]"
+          "password": "[%key:common::config_flow::data::password%]",
+          "api_key": "[%key:common::config_flow::data::api_key%]"
+        },
+        "data_description": {
+          "api_key": "You can generate an API Key in the 'Account Details' section of the Hydrawise app"
         }
       },
       "reauth_confirm": {
         "title": "[%key:common::config_flow::title::reauth%]",
         "description": "The Hydrawise integration needs to re-authenticate your account",
         "data": {
-          "password": "[%key:common::config_flow::data::password%]"
+          "password": "[%key:common::config_flow::data::password%]",
+          "api_key": "[%key:common::config_flow::data::api_key%]"
+        },
+        "data_description": {
+          "api_key": "You can generate an API Key in the 'Account Details' section of the Hydrawise app"
         }
       }
     },

--- a/homeassistant/components/hydrawise/switch.py
+++ b/homeassistant/components/hydrawise/switch.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from datetime import timedelta
 from typing import Any
 
-from pydrawise import Hydrawise, Zone
+from pydrawise import HydrawiseBase, Zone
 
 from homeassistant.components.switch import (
     SwitchDeviceClass,
@@ -28,8 +28,8 @@ from .entity import HydrawiseEntity
 class HydrawiseSwitchEntityDescription(SwitchEntityDescription):
     """Describes Hydrawise binary sensor."""
 
-    turn_on_fn: Callable[[Hydrawise, Zone], Coroutine[Any, Any, None]]
-    turn_off_fn: Callable[[Hydrawise, Zone], Coroutine[Any, Any, None]]
+    turn_on_fn: Callable[[HydrawiseBase, Zone], Coroutine[Any, Any, None]]
+    turn_off_fn: Callable[[HydrawiseBase, Zone], Coroutine[Any, Any, None]]
     value_fn: Callable[[Zone], bool]
 
 

--- a/tests/components/hydrawise/conftest.py
+++ b/tests/components/hydrawise/conftest.py
@@ -63,7 +63,7 @@ def mock_pydrawise(
     controller_water_use_summary: ControllerWaterUseSummary,
 ) -> Generator[AsyncMock]:
     """Mock Hydrawise."""
-    with patch("pydrawise.client.Hydrawise", autospec=True) as mock_pydrawise:
+    with patch("pydrawise.hybrid.HybridClient", autospec=True) as mock_pydrawise:
         user.controllers = [controller]
         controller.sensors = sensors
         mock_pydrawise.return_value.get_user.return_value = user
@@ -76,8 +76,8 @@ def mock_pydrawise(
 
 @pytest.fixture
 def mock_auth() -> Generator[AsyncMock]:
-    """Mock pydrawise Auth."""
-    with patch("pydrawise.auth.Auth", autospec=True) as mock_auth:
+    """Mock pydrawise HybridAuth."""
+    with patch("pydrawise.auth.HybridAuth", autospec=True) as mock_auth:
         yield mock_auth.return_value
 
 
@@ -215,6 +215,7 @@ def mock_config_entry() -> MockConfigEntry:
         data={
             CONF_USERNAME: "asfd@asdf.com",
             CONF_PASSWORD: "__password__",
+            CONF_API_KEY: "abc123",
         },
         unique_id="hydrawise-customerid",
         version=1,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Hydrawise now requires an API key for authentication.

In order to alleviate API throttling issues, we now fall back on the REST API when polling for status updates. This requires an API key, which can be generated under the "Account Details" section of the Hydrawise app.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
After a lot of back-and-forth with a Hydrawise Product Manager, we have determined that we cannot poll the newer GraphQL API for updates, as it's not able to handle the load. (See https://github.com/home-assistant/core/issues/130857#issuecomment-2600919282 for a snippet of the conversation)

This PR changes the Hydrawise client to the new "hybrid" approach added in pydrawise 2025.1.0 (see https://github.com/dknowles2/pydrawise/pull/257 for details). This new client hides the details of which API we need to use for fetching data, allowing Home Assistant to use the same client interface. This should be a drop-in replacement, except for now requiring an API key for authenticating with the REST API.

The transition should be relatively smooth for a user: we simply trigger a reauth flow if the user is missing an API key, after which the integration should continue working normally.

(Note: I haven't updated the docs yet, I'll do that soon)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #130857
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
