### PR TITLE
Update mypy-dev to 1.16.0a1

### DIFF
--- a/homeassistant/components/flux_led/config_flow.py
+++ b/homeassistant/components/flux_led/config_flow.py
@@ -299,8 +299,7 @@ class FluxLedConfigFlow(ConfigFlow, domain=DOMAIN):
             # AKA `HF-LPB100-ZJ200`
             return device
         bulb = async_wifi_bulb_for_host(host, discovery=device)
-        if discovery is not None:
-            bulb.discovery = discovery
+        bulb.discovery = discovery  # type: ignore[assignment]
         try:
             await bulb.async_setup(lambda: None)
         finally:

--- a/homeassistant/components/flux_led/config_flow.py
+++ b/homeassistant/components/flux_led/config_flow.py
@@ -299,7 +299,8 @@ class FluxLedConfigFlow(ConfigFlow, domain=DOMAIN):
             # AKA `HF-LPB100-ZJ200`
             return device
         bulb = async_wifi_bulb_for_host(host, discovery=device)
-        bulb.discovery = discovery
+        if discovery is not None:
+            bulb.discovery = discovery
         try:
             await bulb.async_setup(lambda: None)
         finally:

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -12,7 +12,7 @@ coverage==7.6.8
 freezegun==1.5.1
 license-expression==30.4.0
 mock-open==1.4.0
-mypy-dev==1.15.0a2
+mypy-dev==1.16.0a1
 pre-commit==4.0.0
 pydantic==2.10.6
 pylint==3.3.3


### PR DESCRIPTION
## Proposed change
https://github.com/cdce8p/mypy-dev/releases/tag/1.15.0a2
https://github.com/cdce8p/mypy-dev/releases/tag/1.16.0a1
Compare: https://github.com/python/mypy/compare/5e119d0062ca425d927c0f036a63d95bf0cad367...1eb9d4ce36144d9e2e7c79dc35d517b4e1963dd7

- Typeshed updates
- Misc bugfixes
- Added support for properties with different getter and setter types

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
