### PR TITLE
Raise exceptions in HEOS custom actions

### DIFF
--- a/homeassistant/components/heos/services.py
+++ b/homeassistant/components/heos/services.py
@@ -7,7 +7,7 @@ import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant, ServiceCall
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import config_validation as cv, issue_registry as ir
 
 from .const import (
@@ -46,7 +46,6 @@ def register(hass: HomeAssistant):
 
 def _get_controller(hass: HomeAssistant) -> Heos:
     """Get the HEOS controller instance."""
-
     _LOGGER.warning(
         "Actions 'heos.sign_in' and 'heos.sign_out' are deprecated and will be removed in the 2025.8.0 release"
     )
@@ -79,16 +78,25 @@ async def _sign_in_handler(service: ServiceCall) -> None:
     try:
         await controller.sign_in(username, password)
     except CommandAuthenticationError as err:
-        _LOGGER.error("Sign in failed: %s", err)
+        raise ServiceValidationError(
+            translation_domain=DOMAIN, translation_key="sign_in_auth_error"
+        ) from err
     except HeosError as err:
-        _LOGGER.error("Unable to sign in: %s", err)
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="sign_in_error",
+            translation_placeholders={"error": str(err)},
+        ) from err
 
 
 async def _sign_out_handler(service: ServiceCall) -> None:
     """Sign out of the HEOS account."""
-
     controller = _get_controller(service.hass)
     try:
         await controller.sign_out()
     except HeosError as err:
-        _LOGGER.error("Unable to sign out: %s", err)
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="sign_out_error",
+            translation_placeholders={"error": str(err)},
+        ) from err

--- a/homeassistant/components/heos/strings.json
+++ b/homeassistant/components/heos/strings.json
@@ -100,6 +100,15 @@
     "integration_not_loaded": {
       "message": "The HEOS integration is not loaded"
     },
+    "sign_in_auth_error": {
+      "message": "Failed to sign in: Invalid username and/or password"
+    },
+    "sign_in_error": {
+      "message": "Unable to sign in: {error}"
+    },
+    "sign_out_error": {
+      "message": "Unable to sign out: {error}"
+    },
     "not_heos_media_player": {
       "message": "Entity {entity_id} is not a HEOS media player entity"
     },

--- a/tests/components/heos/test_services.py
+++ b/tests/components/heos/test_services.py
@@ -11,7 +11,7 @@ from homeassistant.components.heos.const import (
     SERVICE_SIGN_OUT,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 
 from tests.common import MockConfigEntry
 
@@ -34,10 +34,7 @@ async def test_sign_in(
 
 
 async def test_sign_in_failed(
-    hass: HomeAssistant,
-    config_entry: MockConfigEntry,
-    controller: Heos,
-    caplog: pytest.LogCaptureFixture,
+    hass: HomeAssistant, config_entry: MockConfigEntry, controller: Heos
 ) -> None:
     """Test sign-in service logs error when not connected."""
     config_entry.add_to_hass(hass)
@@ -47,22 +44,19 @@ async def test_sign_in_failed(
         "", "Invalid credentials", 6
     )
 
-    await hass.services.async_call(
-        DOMAIN,
-        SERVICE_SIGN_IN,
-        {ATTR_USERNAME: "test@test.com", ATTR_PASSWORD: "password"},
-        blocking=True,
-    )
+    with pytest.raises(ServiceValidationError):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SIGN_IN,
+            {ATTR_USERNAME: "test@test.com", ATTR_PASSWORD: "password"},
+            blocking=True,
+        )
 
     controller.sign_in.assert_called_once_with("test@test.com", "password")
-    assert "Sign in failed: Invalid credentials (6)" in caplog.text
 
 
 async def test_sign_in_unknown_error(
-    hass: HomeAssistant,
-    config_entry: MockConfigEntry,
-    controller: Heos,
-    caplog: pytest.LogCaptureFixture,
+    hass: HomeAssistant, config_entry: MockConfigEntry, controller: Heos
 ) -> None:
     """Test sign-in service logs error for failure."""
     config_entry.add_to_hass(hass)
@@ -70,15 +64,15 @@ async def test_sign_in_unknown_error(
 
     controller.sign_in.side_effect = HeosError()
 
-    await hass.services.async_call(
-        DOMAIN,
-        SERVICE_SIGN_IN,
-        {ATTR_USERNAME: "test@test.com", ATTR_PASSWORD: "password"},
-        blocking=True,
-    )
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SIGN_IN,
+            {ATTR_USERNAME: "test@test.com", ATTR_PASSWORD: "password"},
+            blocking=True,
+        )
 
     controller.sign_in.assert_called_once_with("test@test.com", "password")
-    assert "Unable to sign in" in caplog.text
 
 
 async def test_sign_in_not_loaded_raises(
@@ -123,17 +117,14 @@ async def test_sign_out_not_loaded_raises(
 
 
 async def test_sign_out_unknown_error(
-    hass: HomeAssistant,
-    config_entry: MockConfigEntry,
-    controller: Heos,
-    caplog: pytest.LogCaptureFixture,
+    hass: HomeAssistant, config_entry: MockConfigEntry, controller: Heos
 ) -> None:
     """Test the sign-out service."""
     config_entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     controller.sign_out.side_effect = HeosError()
 
-    await hass.services.async_call(DOMAIN, SERVICE_SIGN_OUT, {}, blocking=True)
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(DOMAIN, SERVICE_SIGN_OUT, {}, blocking=True)
 
     assert controller.sign_out.call_count == 1
-    assert "Unable to sign out" in caplog.text


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
The HEOS `sign_in` and `sign_out` services will now raise exceptions if the service call fails. Previously, failures were only logged. Note: These services are deprecated and will be removed in the HA release 2025.8.0.


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Removes logging and raises appropriate exception with translation when sign-in or sign-out fail.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [X] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
