### PR TITLE
Correct the behavior of the Charge switch in Tessie/Teslemetry/Tesla Fleet

### DIFF
--- a/homeassistant/components/tesla_fleet/icons.json
+++ b/homeassistant/components/tesla_fleet/icons.json
@@ -298,7 +298,7 @@
       }
     },
     "switch": {
-      "charge_state_user_charge_enable_request": {
+      "charge_state_charging_state": {
         "default": "mdi:ev-station"
       },
       "climate_state_auto_seat_climate_left": {

--- a/homeassistant/components/tesla_fleet/strings.json
+++ b/homeassistant/components/tesla_fleet/strings.json
@@ -522,7 +522,7 @@
       }
     },
     "switch": {
-      "charge_state_user_charge_enable_request": {
+      "charge_state_charging_state": {
         "name": "Charge"
       },
       "climate_state_auto_seat_climate_left": {

--- a/homeassistant/components/tesla_fleet/switch.py
+++ b/homeassistant/components/tesla_fleet/switch.py
@@ -77,13 +77,12 @@ VEHICLE_DESCRIPTIONS: tuple[TeslaFleetSwitchEntityDescription, ...] = (
         ),
         scopes=[Scope.VEHICLE_CMDS],
     ),
-)
-
-VEHICLE_CHARGE_DESCRIPTION = TeslaFleetSwitchEntityDescription(
-    key="charge_state_user_charge_enable_request",
-    on_func=lambda api: api.charge_start(),
-    off_func=lambda api: api.charge_stop(),
-    scopes=[Scope.VEHICLE_CHARGING_CMDS, Scope.VEHICLE_CMDS],
+    TeslaFleetSwitchEntityDescription(
+        key="charge_state_charging_state",
+        on_func=lambda api: api.charge_start(),
+        off_func=lambda api: api.charge_stop(),
+        scopes=[Scope.VEHICLE_CHARGING_CMDS, Scope.VEHICLE_CMDS],
+    ),
 )
 
 
@@ -102,12 +101,6 @@ async def async_setup_entry(
                 )
                 for vehicle in entry.runtime_data.vehicles
                 for description in VEHICLE_DESCRIPTIONS
-            ),
-            (
-                TeslaFleetChargeSwitchEntity(
-                    vehicle, VEHICLE_CHARGE_DESCRIPTION, entry.runtime_data.scopes
-                )
-                for vehicle in entry.runtime_data.vehicles
             ),
             (
                 TeslaFleetChargeFromGridSwitchEntity(
@@ -170,17 +163,6 @@ class TeslaFleetVehicleSwitchEntity(TeslaFleetVehicleEntity, TeslaFleetSwitchEnt
         await handle_vehicle_command(self.entity_description.off_func(self.api))
         self._attr_is_on = False
         self.async_write_ha_state()
-
-
-class TeslaFleetChargeSwitchEntity(TeslaFleetVehicleSwitchEntity):
-    """Entity class for TeslaFleet charge switch."""
-
-    def _async_update_attrs(self) -> None:
-        """Update the attributes of the entity."""
-        if self._value is None:
-            self._attr_is_on = self.get("charge_state_charge_enable_request")
-        else:
-            self._attr_is_on = self._value
 
 
 class TeslaFleetChargeFromGridSwitchEntity(

--- a/homeassistant/components/tesla_fleet/switch.py
+++ b/homeassistant/components/tesla_fleet/switch.py
@@ -82,7 +82,7 @@ VEHICLE_DESCRIPTIONS: tuple[TeslaFleetSwitchEntityDescription, ...] = (
     ),
     TeslaFleetSwitchEntityDescription(
         key="charge_state_charging_state",
-        unique_id="charge_state_charge_enable_request",
+        unique_id="charge_state_user_charge_enable_request",
         on_func=lambda api: api.charge_start(),
         off_func=lambda api: api.charge_stop(),
         value_func=lambda state: state in {"Starting", "Charging"},

--- a/homeassistant/components/tesla_fleet/switch.py
+++ b/homeassistant/components/tesla_fleet/switch.py
@@ -16,6 +16,7 @@ from homeassistant.components.switch import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import StateType
 
 from . import TeslaFleetConfigEntry
 from .entity import TeslaFleetEnergyInfoEntity, TeslaFleetVehicleEntity
@@ -31,6 +32,7 @@ class TeslaFleetSwitchEntityDescription(SwitchEntityDescription):
 
     on_func: Callable
     off_func: Callable
+    value_func: Callable[[StateType], bool] = bool
     scopes: list[Scope]
 
 
@@ -39,6 +41,7 @@ VEHICLE_DESCRIPTIONS: tuple[TeslaFleetSwitchEntityDescription, ...] = (
         key="vehicle_state_sentry_mode",
         on_func=lambda api: api.set_sentry_mode(on=True),
         off_func=lambda api: api.set_sentry_mode(on=False),
+        value_func=lambda state: state in ("Starting", "Charging"),
         scopes=[Scope.VEHICLE_CMDS],
     ),
     TeslaFleetSwitchEntityDescription(
@@ -146,7 +149,7 @@ class TeslaFleetVehicleSwitchEntity(TeslaFleetVehicleEntity, TeslaFleetSwitchEnt
         if self._value is None:
             self._attr_is_on = None
         else:
-            self._attr_is_on = bool(self._value)
+            self._attr_is_on = self.entity_description.value_func(self._value)
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the Switch."""

--- a/homeassistant/components/teslemetry/icons.json
+++ b/homeassistant/components/teslemetry/icons.json
@@ -291,7 +291,7 @@
       }
     },
     "switch": {
-      "charge_state_user_charge_enable_request": {
+      "charge_state_charging_state": {
         "default": "mdi:ev-station"
       },
       "climate_state_auto_seat_climate_left": {

--- a/homeassistant/components/teslemetry/strings.json
+++ b/homeassistant/components/teslemetry/strings.json
@@ -608,7 +608,7 @@
       }
     },
     "switch": {
-      "charge_state_user_charge_enable_request": {
+      "charge_state_charging_state": {
         "name": "Charge"
       },
       "climate_state_auto_seat_climate_left": {

--- a/homeassistant/components/teslemetry/switch.py
+++ b/homeassistant/components/teslemetry/switch.py
@@ -42,7 +42,6 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetrySwitchEntityDescription, ...] = (
         key="vehicle_state_sentry_mode",
         on_func=lambda api: api.set_sentry_mode(on=True),
         off_func=lambda api: api.set_sentry_mode(on=False),
-        value_func=lambda state: state in ("Starting", "Charging"),
         scopes=[Scope.VEHICLE_CMDS],
     ),
     TeslemetrySwitchEntityDescription(
@@ -86,6 +85,7 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetrySwitchEntityDescription, ...] = (
         unique_id="charge_state_charge_enable_request",
         on_func=lambda api: api.charge_start(),
         off_func=lambda api: api.charge_stop(),
+        value_func=lambda state: state in ("Starting", "Charging"),
         scopes=[Scope.VEHICLE_CMDS, Scope.VEHICLE_CHARGING_CMDS],
     ),
 )
@@ -168,17 +168,6 @@ class TeslemetryVehicleSwitchEntity(TeslemetryVehicleEntity, TeslemetrySwitchEnt
         await handle_vehicle_command(self.entity_description.off_func(self.api))
         self._attr_is_on = False
         self.async_write_ha_state()
-
-
-class TeslemetryChargeSwitchEntity(TeslemetryVehicleSwitchEntity):
-    """Entity class for Teslemetry charge switch."""
-
-    def _async_update_attrs(self) -> None:
-        """Update the attributes of the entity."""
-        if self._value is None:
-            self._attr_is_on = self.get("charge_state_charge_enable_request")
-        else:
-            self._attr_is_on = self._value
 
 
 class TeslemetryChargeFromGridSwitchEntity(

--- a/homeassistant/components/teslemetry/switch.py
+++ b/homeassistant/components/teslemetry/switch.py
@@ -82,7 +82,7 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetrySwitchEntityDescription, ...] = (
     ),
     TeslemetrySwitchEntityDescription(
         key="charge_state_charging_state",
-        unique_id="charge_state_charge_enable_request",
+        unique_id="charge_state_user_charge_enable_request",
         on_func=lambda api: api.charge_start(),
         off_func=lambda api: api.charge_stop(),
         value_func=lambda state: state in {"Starting", "Charging"},

--- a/homeassistant/components/teslemetry/switch.py
+++ b/homeassistant/components/teslemetry/switch.py
@@ -77,13 +77,12 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetrySwitchEntityDescription, ...] = (
         ),
         scopes=[Scope.VEHICLE_CMDS],
     ),
-)
-
-VEHICLE_CHARGE_DESCRIPTION = TeslemetrySwitchEntityDescription(
-    key="charge_state_user_charge_enable_request",
-    on_func=lambda api: api.charge_start(),
-    off_func=lambda api: api.charge_stop(),
-    scopes=[Scope.VEHICLE_CMDS, Scope.VEHICLE_CHARGING_CMDS],
+    TeslemetrySwitchEntityDescription(
+        key="charge_state_charging_state",
+        on_func=lambda api: api.charge_start(),
+        off_func=lambda api: api.charge_stop(),
+        scopes=[Scope.VEHICLE_CMDS, Scope.VEHICLE_CHARGING_CMDS],
+    ),
 )
 
 
@@ -103,12 +102,6 @@ async def async_setup_entry(
                 for vehicle in entry.runtime_data.vehicles
                 for description in VEHICLE_DESCRIPTIONS
                 if description.key in vehicle.coordinator.data
-            ),
-            (
-                TeslemetryChargeSwitchEntity(
-                    vehicle, VEHICLE_CHARGE_DESCRIPTION, entry.runtime_data.scopes
-                )
-                for vehicle in entry.runtime_data.vehicles
             ),
             (
                 TeslemetryChargeFromGridSwitchEntity(

--- a/homeassistant/components/teslemetry/switch.py
+++ b/homeassistant/components/teslemetry/switch.py
@@ -32,8 +32,9 @@ class TeslemetrySwitchEntityDescription(SwitchEntityDescription):
 
     on_func: Callable
     off_func: Callable
-    value_func: Callable[[StateType], bool] = bool
     scopes: list[Scope]
+    value_func: Callable[[StateType], bool] = bool
+    unique_id: str | None = None
 
 
 VEHICLE_DESCRIPTIONS: tuple[TeslemetrySwitchEntityDescription, ...] = (
@@ -82,6 +83,7 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetrySwitchEntityDescription, ...] = (
     ),
     TeslemetrySwitchEntityDescription(
         key="charge_state_charging_state",
+        unique_id="charge_state_charge_enable_request",
         on_func=lambda api: api.charge_start(),
         off_func=lambda api: api.charge_stop(),
         scopes=[Scope.VEHICLE_CMDS, Scope.VEHICLE_CHARGING_CMDS],
@@ -141,9 +143,11 @@ class TeslemetryVehicleSwitchEntity(TeslemetryVehicleEntity, TeslemetrySwitchEnt
         scopes: list[Scope],
     ) -> None:
         """Initialize the Switch."""
-        super().__init__(data, description.key)
         self.entity_description = description
         self.scoped = any(scope in scopes for scope in description.scopes)
+        super().__init__(data, description.key)
+        if description.unique_id:
+            self._attr_unique_id = f"{data.vin}-{description.unique_id}"
 
     def _async_update_attrs(self) -> None:
         """Update the attributes of the sensor."""

--- a/homeassistant/components/teslemetry/switch.py
+++ b/homeassistant/components/teslemetry/switch.py
@@ -85,7 +85,7 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetrySwitchEntityDescription, ...] = (
         unique_id="charge_state_charge_enable_request",
         on_func=lambda api: api.charge_start(),
         off_func=lambda api: api.charge_stop(),
-        value_func=lambda state: state in ("Starting", "Charging"),
+        value_func=lambda state: state in {"Starting", "Charging"},
         scopes=[Scope.VEHICLE_CMDS, Scope.VEHICLE_CHARGING_CMDS],
     ),
 )

--- a/homeassistant/components/tessie/strings.json
+++ b/homeassistant/components/tessie/strings.json
@@ -459,7 +459,7 @@
       }
     },
     "switch": {
-      "charge_state_charge_enable_request": {
+      "charge_state_charging_state": {
         "name": "Charge"
       },
       "climate_state_defrost_mode": {

--- a/homeassistant/components/tessie/switch.py
+++ b/homeassistant/components/tessie/switch.py
@@ -50,7 +50,6 @@ DESCRIPTIONS: tuple[TessieSwitchEntityDescription, ...] = (
         key="climate_state_defrost_mode",
         on_func=lambda: start_defrost,
         off_func=lambda: stop_defrost,
-        value_func=lambda state: state in ("Starting", "Charging"),
     ),
     TessieSwitchEntityDescription(
         key="vehicle_state_sentry_mode",
@@ -72,6 +71,7 @@ DESCRIPTIONS: tuple[TessieSwitchEntityDescription, ...] = (
         unique_id="charge_state_charge_enable_request",
         on_func=lambda: start_charging,
         off_func=lambda: stop_charging,
+        value_func=lambda state: state in {"Starting", "Charging"},
     ),
 )
 

--- a/homeassistant/components/tessie/switch.py
+++ b/homeassistant/components/tessie/switch.py
@@ -63,12 +63,11 @@ DESCRIPTIONS: tuple[TessieSwitchEntityDescription, ...] = (
         on_func=lambda: start_steering_wheel_heater,
         off_func=lambda: stop_steering_wheel_heater,
     ),
-)
-
-CHARGE_DESCRIPTION: TessieSwitchEntityDescription = TessieSwitchEntityDescription(
-    key="charge_state_charge_enable_request",
-    on_func=lambda: start_charging,
-    off_func=lambda: stop_charging,
+    TessieSwitchEntityDescription(
+        key="charge_state_charge_enable_request",
+        on_func=lambda: start_charging,
+        off_func=lambda: stop_charging,
+    ),
 )
 
 PARALLEL_UPDATES = 0
@@ -88,10 +87,6 @@ async def async_setup_entry(
                 for vehicle in entry.runtime_data.vehicles
                 for description in DESCRIPTIONS
                 if description.key in vehicle.data_coordinator.data
-            ),
-            (
-                TessieChargeSwitchEntity(vehicle, CHARGE_DESCRIPTION)
-                for vehicle in entry.runtime_data.vehicles
             ),
             (
                 TessieChargeFromGridSwitchEntity(energysite)
@@ -137,18 +132,6 @@ class TessieSwitchEntity(TessieEntity, SwitchEntity):
         """Turn off the Switch."""
         await self.run(self.entity_description.off_func())
         self.set((self.entity_description.key, False))
-
-
-class TessieChargeSwitchEntity(TessieSwitchEntity):
-    """Entity class for Tessie charge switch."""
-
-    @property
-    def is_on(self) -> bool:
-        """Return the state of the Switch."""
-
-        if (charge := self.get("charge_state_user_charge_enable_request")) is not None:
-            return charge
-        return self._value
 
 
 class TessieChargeFromGridSwitchEntity(TessieEnergyEntity, SwitchEntity):

--- a/homeassistant/components/tessie/switch.py
+++ b/homeassistant/components/tessie/switch.py
@@ -42,6 +42,7 @@ class TessieSwitchEntityDescription(SwitchEntityDescription):
     on_func: Callable
     off_func: Callable
     value_func: Callable[[StateType], bool] = bool
+    unique_id: str | None = None
 
 
 DESCRIPTIONS: tuple[TessieSwitchEntityDescription, ...] = (
@@ -68,6 +69,7 @@ DESCRIPTIONS: tuple[TessieSwitchEntityDescription, ...] = (
     ),
     TessieSwitchEntityDescription(
         key="charge_state_charging_state",
+        unique_id="charge_state_charge_enable_request",
         on_func=lambda: start_charging,
         off_func=lambda: stop_charging,
     ),
@@ -118,8 +120,10 @@ class TessieSwitchEntity(TessieEntity, SwitchEntity):
         description: TessieSwitchEntityDescription,
     ) -> None:
         """Initialize the Switch."""
-        super().__init__(vehicle, description.key)
         self.entity_description = description
+        super().__init__(vehicle, description.key)
+        if description.unique_id:
+            self._attr_unique_id = f"{vehicle.vin}-{description.unique_id}"
 
     @property
     def is_on(self) -> bool:

--- a/homeassistant/components/tessie/switch.py
+++ b/homeassistant/components/tessie/switch.py
@@ -27,6 +27,7 @@ from homeassistant.components.switch import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import StateType
 
 from . import TessieConfigEntry
 from .entity import TessieEnergyEntity, TessieEntity
@@ -40,6 +41,7 @@ class TessieSwitchEntityDescription(SwitchEntityDescription):
 
     on_func: Callable
     off_func: Callable
+    value_func: Callable[[StateType], bool] = bool
 
 
 DESCRIPTIONS: tuple[TessieSwitchEntityDescription, ...] = (
@@ -47,6 +49,7 @@ DESCRIPTIONS: tuple[TessieSwitchEntityDescription, ...] = (
         key="climate_state_defrost_mode",
         on_func=lambda: start_defrost,
         off_func=lambda: stop_defrost,
+        value_func=lambda state: state in ("Starting", "Charging"),
     ),
     TessieSwitchEntityDescription(
         key="vehicle_state_sentry_mode",
@@ -121,7 +124,7 @@ class TessieSwitchEntity(TessieEntity, SwitchEntity):
     @property
     def is_on(self) -> bool:
         """Return the state of the Switch."""
-        return self._value
+        return self.entity_description.value_func(self._value)
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the Switch."""

--- a/homeassistant/components/tessie/switch.py
+++ b/homeassistant/components/tessie/switch.py
@@ -64,7 +64,7 @@ DESCRIPTIONS: tuple[TessieSwitchEntityDescription, ...] = (
         off_func=lambda: stop_steering_wheel_heater,
     ),
     TessieSwitchEntityDescription(
-        key="charge_state_charge_enable_request",
+        key="charge_state_charging_state",
         on_func=lambda: start_charging,
         off_func=lambda: stop_charging,
     ),

--- a/tests/components/tesla_fleet/snapshots/test_switch.ambr
+++ b/tests/components/tesla_fleet/snapshots/test_switch.ambr
@@ -263,7 +263,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'charge_state_charging_state',
-    'unique_id': 'LRWXF7EK4KC700000-charge_state_charge_enable_request',
+    'unique_id': 'LRWXF7EK4KC700000-charge_state_user_charge_enable_request',
     'unit_of_measurement': None,
   })
 # ---

--- a/tests/components/tesla_fleet/snapshots/test_switch.ambr
+++ b/tests/components/tesla_fleet/snapshots/test_switch.ambr
@@ -262,8 +262,8 @@
     'platform': 'tesla_fleet',
     'previous_unique_id': None,
     'supported_features': 0,
-    'translation_key': 'charge_state_user_charge_enable_request',
-    'unique_id': 'LRWXF7EK4KC700000-charge_state_user_charge_enable_request',
+    'translation_key': 'charge_state_charging_state',
+    'unique_id': 'LRWXF7EK4KC700000-charge_state_charging_state',
     'unit_of_measurement': None,
   })
 # ---

--- a/tests/components/tesla_fleet/snapshots/test_switch.ambr
+++ b/tests/components/tesla_fleet/snapshots/test_switch.ambr
@@ -263,7 +263,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'charge_state_charging_state',
-    'unique_id': 'LRWXF7EK4KC700000-charge_state_charging_state',
+    'unique_id': 'LRWXF7EK4KC700000-charge_state_charge_enable_request',
     'unit_of_measurement': None,
   })
 # ---
@@ -278,7 +278,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'on',
+    'state': 'off',
   })
 # ---
 # name: test_switch[switch.test_defrost-entry]
@@ -456,7 +456,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'on',
+    'state': 'off',
   })
 # ---
 # name: test_switch_alt[switch.test_defrost-statealt]

--- a/tests/components/teslemetry/snapshots/test_switch.ambr
+++ b/tests/components/teslemetry/snapshots/test_switch.ambr
@@ -263,7 +263,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'charge_state_charging_state',
-    'unique_id': 'LRW3F7EK4NC700000-charge_state_charge_enable_request',
+    'unique_id': 'LRW3F7EK4NC700000-charge_state_user_charge_enable_request',
     'unit_of_measurement': None,
   })
 # ---

--- a/tests/components/teslemetry/snapshots/test_switch.ambr
+++ b/tests/components/teslemetry/snapshots/test_switch.ambr
@@ -278,7 +278,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'on',
+    'state': 'off',
   })
 # ---
 # name: test_switch[switch.test_defrost-entry]
@@ -456,7 +456,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'on',
+    'state': 'off',
   })
 # ---
 # name: test_switch_alt[switch.test_defrost-statealt]

--- a/tests/components/teslemetry/snapshots/test_switch.ambr
+++ b/tests/components/teslemetry/snapshots/test_switch.ambr
@@ -263,7 +263,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'charge_state_charging_state',
-    'unique_id': 'LRW3F7EK4NC700000-charge_state_charging_state',
+    'unique_id': 'LRW3F7EK4NC700000-charge_state_charge_enable_request',
     'unit_of_measurement': None,
   })
 # ---

--- a/tests/components/teslemetry/snapshots/test_switch.ambr
+++ b/tests/components/teslemetry/snapshots/test_switch.ambr
@@ -262,8 +262,8 @@
     'platform': 'teslemetry',
     'previous_unique_id': None,
     'supported_features': 0,
-    'translation_key': 'charge_state_user_charge_enable_request',
-    'unique_id': 'LRW3F7EK4NC700000-charge_state_user_charge_enable_request',
+    'translation_key': 'charge_state_charging_state',
+    'unique_id': 'LRW3F7EK4NC700000-charge_state_charging_state',
     'unit_of_measurement': None,
   })
 # ---

--- a/tests/components/tessie/snapshots/test_switch.ambr
+++ b/tests/components/tessie/snapshots/test_switch.ambr
@@ -119,8 +119,8 @@
     'platform': 'tessie',
     'previous_unique_id': None,
     'supported_features': 0,
-    'translation_key': 'charge_state_charge_enable_request',
-    'unique_id': 'VINVINVIN-charge_state_charge_enable_request',
+    'translation_key': 'charge_state_charging_state',
+    'unique_id': 'VINVINVIN-charge_state_charging_state',
     'unit_of_measurement': None,
   })
 # ---

--- a/tests/components/tessie/snapshots/test_switch.ambr
+++ b/tests/components/tessie/snapshots/test_switch.ambr
@@ -120,7 +120,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'charge_state_charging_state',
-    'unique_id': 'VINVINVIN-charge_state_charging_state',
+    'unique_id': 'VINVINVIN-charge_state_charge_enable_request',
     'unit_of_measurement': None,
   })
 # ---

--- a/tests/components/tessie/snapshots/test_switch.ambr
+++ b/tests/components/tessie/snapshots/test_switch.ambr
@@ -351,6 +351,6 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'on',
+    'state': 'off',
   })
 # ---

--- a/tests/components/tessie/test_switch.py
+++ b/tests/components/tessie/test_switch.py
@@ -20,7 +20,7 @@ from .common import RESPONSE_OK, assert_entities, setup_platform
 async def test_switches(
     hass: HomeAssistant, snapshot: SnapshotAssertion, entity_registry: er.EntityRegistry
 ) -> None:
-    """Tests that the switche entities are correct."""
+    """Tests that the switch entities are correct."""
 
     entry = await setup_platform(hass, [Platform.SWITCH])
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Users are frequently confused by the "Charge" switch, since it did not show the state of charging, but instead the state of charging requests. However changes to the Tesla Fleet API mean its very costly to get the `user_charge_enable_request` value, and Tessie actually disabled this field a few weeks ago causing issues.

After discussions with @stx we decided the best outcome was to make the charge switch **directly** reflect the charge state, which means it does nothing when unplugged.

For consistency this PR fixes Tessie, Teslemetry, and Tesla Fleet at once.

Fixes https://github.com/home-assistant/core/issues/136236

Decoupled the unique id from the key to avoid making this a breaking change.

Targeting 2025.2

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #136236
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
