### PR TITLE
Cleanup stale devices on incomfort integration startup

### DIFF
--- a/homeassistant/components/incomfort/__init__.py
+++ b/homeassistant/components/incomfort/__init__.py
@@ -7,12 +7,12 @@ from incomfortclient import InvalidGateway, InvalidHeaterList
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers import device_registry as dr
 
 from .const import DOMAIN
-from .coordinator import InComfortDataCoordinator, async_connect_gateway
+from .coordinator import InComfortData, InComfortDataCoordinator, async_connect_gateway
 from .errors import InComfortTimeout, InComfortUnknownError, NoHeaters, NotFound
 
 PLATFORMS = (
@@ -25,6 +25,43 @@ PLATFORMS = (
 INTEGRATION_TITLE = "Intergas InComfort/Intouch Lan2RF gateway"
 
 type InComfortConfigEntry = ConfigEntry[InComfortDataCoordinator]
+
+
+@callback
+def async_cleanup_stale_devices(
+    hass: HomeAssistant,
+    entry: InComfortConfigEntry,
+    data: InComfortData,
+    gateway_device: dr.DeviceEntry,
+) -> None:
+    """Cleanup stale heater devices and climates."""
+    heater_serial_numbers = {heater.serial_no for heater in data.heaters}
+    device_registry = dr.async_get(hass)
+    device_entries = device_registry.devices.get_devices_for_config_entry_id(
+        entry.entry_id
+    )
+    stale_heater_serial_numbers: list[str] = [
+        device_entry.serial_number
+        for device_entry in device_entries
+        if device_entry.id != gateway_device.id
+        and device_entry.serial_number is not None
+        and device_entry.serial_number not in heater_serial_numbers
+    ]
+    if not stale_heater_serial_numbers:
+        return
+    cleanup_devices: list[str] = []
+    # Find stale heater and climate devices
+    for serial_number in stale_heater_serial_numbers:
+        cleanup_list = [f"{serial_number}_{index}" for index in range(1, 4)]
+        cleanup_list.append(serial_number)
+        cleanup_identifiers = [{(DOMAIN, cleanup_id)} for cleanup_id in cleanup_list]
+        cleanup_devices.extend(
+            device_entry.id
+            for device_entry in device_entries
+            if device_entry.identifiers in cleanup_identifiers
+        )
+    for device_id in cleanup_devices:
+        device_registry.async_remove_device(device_id)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: InComfortConfigEntry) -> bool:
@@ -46,7 +83,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: InComfortConfigEntry) ->
 
     # Register discovered gateway device
     device_registry = dr.async_get(hass)
-    device_registry.async_get_or_create(
+    gateway_device = device_registry.async_get_or_create(
         config_entry_id=entry.entry_id,
         identifiers={(DOMAIN, entry.entry_id)},
         connections={(dr.CONNECTION_NETWORK_MAC, entry.unique_id)}
@@ -55,6 +92,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: InComfortConfigEntry) ->
         manufacturer="Intergas",
         name="RFGateway",
     )
+    async_cleanup_stale_devices(hass, entry, data, gateway_device)
     coordinator = InComfortDataCoordinator(hass, data, entry.entry_id)
     entry.runtime_data = coordinator
     await coordinator.async_config_entry_first_refresh()

--- a/tests/components/incomfort/test_init.py
+++ b/tests/components/incomfort/test_init.py
@@ -1,6 +1,7 @@
 """Tests for Intergas InComfort integration."""
 
 from datetime import timedelta
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from aiohttp import ClientResponseError, RequestInfo
@@ -8,13 +9,17 @@ from freezegun.api import FrozenDateTimeFactory
 from incomfortclient import InvalidGateway, InvalidHeaterList
 import pytest
 
+from homeassistant.components.incomfort import DOMAIN
 from homeassistant.components.incomfort.coordinator import UPDATE_INTERVAL
 from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.device_registry import DeviceRegistry
 
-from tests.common import async_fire_time_changed
+from .conftest import MOCK_HEATER_STATUS
+
+from tests.common import MockConfigEntry, async_fire_time_changed
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
@@ -22,11 +27,60 @@ async def test_setup_platforms(
     hass: HomeAssistant,
     mock_incomfort: MagicMock,
     entity_registry: er.EntityRegistry,
-    mock_config_entry: ConfigEntry,
+    mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test the incomfort integration is set up correctly."""
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     assert mock_config_entry.state is ConfigEntryState.LOADED
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+@pytest.mark.parametrize(
+    "mock_heater_status", [MOCK_HEATER_STATUS | {"serial_no": "c01d00c0ffee"}]
+)
+async def test_stale_devices_cleanup(
+    hass: HomeAssistant,
+    device_registry: DeviceRegistry,
+    mock_incomfort: MagicMock,
+    entity_registry: er.EntityRegistry,
+    mock_config_entry: MockConfigEntry,
+    mock_heater_status: dict[str, Any],
+) -> None:
+    """Test the incomfort integration is cleaning up stale devices."""
+    # Setup an old heater with serial_no c01d00c0ffee
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+    await hass.config_entries.async_unload(mock_config_entry.entry_id)
+    old_entries = device_registry.devices.get_devices_for_config_entry_id(
+        mock_config_entry.entry_id
+    )
+    assert len(old_entries) == 3
+    old_heater = device_registry.async_get_device({(DOMAIN, "c01d00c0ffee")})
+    assert old_heater is not None
+    assert old_heater.serial_number == "c01d00c0ffee"
+    old_climate = device_registry.async_get_device({(DOMAIN, "c01d00c0ffee_1")})
+    assert old_heater is not None
+    old_climate = device_registry.async_get_device({(DOMAIN, "c01d00c0ffee_1")})
+    assert old_climate is not None
+
+    mock_heater_status["serial_no"] = "c0ffeec0ffee"
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+
+    new_entries = device_registry.devices.get_devices_for_config_entry_id(
+        mock_config_entry.entry_id
+    )
+    assert len(new_entries) == 3
+    new_heater = device_registry.async_get_device({(DOMAIN, "c0ffeec0ffee")})
+    assert new_heater is not None
+    assert new_heater.serial_number == "c0ffeec0ffee"
+    new_climate = device_registry.async_get_device({(DOMAIN, "c0ffeec0ffee_1")})
+    assert new_climate is not None
+
+    old_heater = device_registry.async_get_device({(DOMAIN, "c01d00c0ffee")})
+    assert old_heater is None
+    old_climate = device_registry.async_get_device({(DOMAIN, "c01d00c0ffee_1")})
+    assert old_climate is None
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Cleanup any stale devices when the incomfort integration starts up. When a heater is replaces and a new heater is connected, the old device entries for heater and climate are cleaned up.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
