### PR TITLE
Optimize enphase_envoy test integration setup.

### DIFF
--- a/tests/components/enphase_envoy/__init__.py
+++ b/tests/components/enphase_envoy/__init__.py
@@ -1,13 +1,19 @@
 """Tests for the Enphase Envoy integration."""
 
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
 
-async def setup_integration(hass: HomeAssistant, config_entry: MockConfigEntry) -> None:
-    """Fixture for setting up the component."""
+async def setup_integration(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    expected_state: ConfigEntryState = ConfigEntryState.LOADED,
+) -> None:
+    """Fixture for setting up the component and testing expected state."""
     config_entry.add_to_hass(hass)
 
     await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
+    await hass.async_block_till_done(wait_background_tasks=True)
+    assert config_entry.state is expected_state

--- a/tests/components/enphase_envoy/test_init.py
+++ b/tests/components/enphase_envoy/test_init.py
@@ -52,8 +52,6 @@ async def test_with_pre_v7_firmware(
     )
     await setup_integration(hass, config_entry)
 
-    assert config_entry.state is ConfigEntryState.LOADED
-
     assert (entity_state := hass.states.get("sensor.inverter_1"))
     assert entity_state.state == "1"
 
@@ -84,8 +82,6 @@ async def test_token_in_config_file(
     )
     mock_envoy.auth = EnvoyTokenAuth("127.0.0.1", token=token, envoy_serial="1234")
     await setup_integration(hass, entry)
-    await hass.async_block_till_done(wait_background_tasks=True)
-    assert entry.state is ConfigEntryState.LOADED
 
     assert (entity_state := hass.states.get("sensor.inverter_1"))
     assert entity_state.state == "1"
@@ -129,8 +125,6 @@ async def test_expired_token_in_config(
         cloud_password="test_password",
     )
     await setup_integration(hass, entry)
-    await hass.async_block_till_done(wait_background_tasks=True)
-    assert entry.state is ConfigEntryState.LOADED
 
     assert (entity_state := hass.states.get("sensor.inverter_1"))
     assert entity_state.state == "1"
@@ -230,9 +224,6 @@ async def test_coordinator_token_refresh_error(
     ):
         await setup_integration(hass, entry)
 
-    await hass.async_block_till_done(wait_background_tasks=True)
-    assert entry.state is ConfigEntryState.LOADED
-
     assert (entity_state := hass.states.get("sensor.inverter_1"))
     assert entity_state.state == "1"
 
@@ -255,7 +246,6 @@ async def test_config_no_unique_id(
         },
     )
     await setup_integration(hass, entry)
-    assert entry.state is ConfigEntryState.LOADED
     assert entry.unique_id == mock_envoy.serial_number
 
 
@@ -276,8 +266,7 @@ async def test_config_different_unique_id(
             CONF_PASSWORD: "test-password",
         },
     )
-    await setup_integration(hass, entry)
-    assert entry.state is ConfigEntryState.SETUP_RETRY
+    await setup_integration(hass, entry, expected_state=ConfigEntryState.SETUP_RETRY)
 
 
 @pytest.mark.parametrize(
@@ -298,7 +287,6 @@ async def test_remove_config_entry_device(
     """Test removing enphase_envoy config entry device."""
     assert await async_setup_component(hass, "config", {})
     await setup_integration(hass, config_entry)
-    assert config_entry.state is ConfigEntryState.LOADED
 
     # use client to send remove_device command
     hass_client = await hass_ws_client(hass)
@@ -349,8 +337,6 @@ async def test_option_change_reload(
 ) -> None:
     """Test options change will reload entity."""
     await setup_integration(hass, config_entry)
-    await hass.async_block_till_done(wait_background_tasks=True)
-    assert config_entry.state is ConfigEntryState.LOADED
     # By default neither option is available
     assert config_entry.options == {}
 
@@ -403,8 +389,6 @@ async def test_coordinator_firmware_refresh(
 ) -> None:
     """Test coordinator scheduled firmware check."""
     await setup_integration(hass, config_entry)
-    await hass.async_block_till_done(wait_background_tasks=True)
-    assert config_entry.state is ConfigEntryState.LOADED
 
     # Move time to next firmware check moment
     # SCAN_INTERVAL is patched to 1 day to disable it's firmware detection
@@ -447,8 +431,6 @@ async def test_coordinator_firmware_refresh_with_envoy_error(
 ) -> None:
     """Test coordinator scheduled firmware check."""
     await setup_integration(hass, config_entry)
-    await hass.async_block_till_done(wait_background_tasks=True)
-    assert config_entry.state is ConfigEntryState.LOADED
 
     caplog.set_level(logging.DEBUG)
     logging.getLogger("homeassistant.components.enphase_envoy.coordinator").setLevel(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Enphase_envoy tests use \_\_init\_\_.py::setup_integration(hass,conf_entry) to setup the test config_entry mock. Some tests then use 
```py
await hass.async_block_till_done(wait_background_tasks=True)
assert entry.state is ConfigEntryState.LOADED
```
and some don't, or only one of the two.

To unify all test code, and make sure all tests verify the config entry is in the expected state, this PR:

- Modifies setup_integration
  - Adds an optional parameter expected_state, defaulting to ConfigEntryState.LOADED
  - Adds wait_background_tasks=True
  - Adds expected state test to setup_integration

```py
await hass.config_entries.async_setup(config_entry.entry_id)
await hass.async_block_till_done(wait_background_tasks=True)
assert config_entry.state is expected_state
```
- updates test_init.py
  - test_config_different_unique_id  to specify  expected_state=ConfigEntryState.SETUP_RETRY
  - Remove the hass.async_block_till_done from individual tests
  - Remove the assert entry.state from individual tests


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
