### PR TITLE
Make Google Cloud STT/TTS timeout configurable

### DIFF
--- a/homeassistant/components/google_cloud/const.py
+++ b/homeassistant/components/google_cloud/const.py
@@ -19,7 +19,9 @@ CONF_PITCH = "pitch"
 CONF_GAIN = "gain"
 CONF_PROFILES = "profiles"
 CONF_TEXT_TYPE = "text_type"
+CONF_TIMEOUT= "TTS timeout, seconds"
 
+DEFAULT_TIMEOUT = 10
 DEFAULT_SPEED = 1.0
 DEFAULT_PITCH = 0
 DEFAULT_GAIN = 0

--- a/homeassistant/components/google_cloud/const.py
+++ b/homeassistant/components/google_cloud/const.py
@@ -19,7 +19,7 @@ CONF_PITCH = "pitch"
 CONF_GAIN = "gain"
 CONF_PROFILES = "profiles"
 CONF_TEXT_TYPE = "text_type"
-CONF_TIMEOUT= "TTS timeout, seconds"
+CONF_TIMEOUT= "tts_timeout"
 
 DEFAULT_TIMEOUT = 10
 DEFAULT_SPEED = 1.0

--- a/homeassistant/components/google_cloud/const.py
+++ b/homeassistant/components/google_cloud/const.py
@@ -19,7 +19,7 @@ CONF_PITCH = "pitch"
 CONF_GAIN = "gain"
 CONF_PROFILES = "profiles"
 CONF_TEXT_TYPE = "text_type"
-CONF_TIMEOUT= "tts_timeout"
+CONF_TIMEOUT = "timeout"
 
 DEFAULT_TIMEOUT = 10
 DEFAULT_SPEED = 1.0

--- a/homeassistant/components/google_cloud/helpers.py
+++ b/homeassistant/components/google_cloud/helpers.py
@@ -30,11 +30,13 @@ from .const import (
     CONF_PROFILES,
     CONF_SPEED,
     CONF_TEXT_TYPE,
+    CONF_TIMEOUT,
     CONF_VOICE,
     DEFAULT_GAIN,
     DEFAULT_LANG,
     DEFAULT_PITCH,
     DEFAULT_SPEED,
+    DEFAULT_TIMEOUT,
 )
 
 DEFAULT_VOICE = ""
@@ -150,6 +152,10 @@ def tts_options_schema(
                     )
                 ),
             ),
+            vol.Optional(
+                CONF_TIMEOUT,
+                default=defaults.get(CONF_TIMEOUT, DEFAULT_TIMEOUT),
+            ): NumberSelector(NumberSelectorConfig(min=1, max=60, step=1)),
         }
     )
 

--- a/homeassistant/components/google_cloud/strings.json
+++ b/homeassistant/components/google_cloud/strings.json
@@ -26,7 +26,7 @@
           "profiles": "Default audio profiles",
           "text_type": "Default text type",
           "stt_model": "STT model",
-          "tts_timeout": "TTS timeout, seconds"
+          "tts_timeout": "TTS timeout, seconds",
         }
       }
     }

--- a/homeassistant/components/google_cloud/strings.json
+++ b/homeassistant/components/google_cloud/strings.json
@@ -25,7 +25,8 @@
           "gain": "Default volume gain (in dB) of the voice",
           "profiles": "Default audio profiles",
           "text_type": "Default text type",
-          "stt_model": "STT model"
+          "stt_model": "STT model",
+          "tts_timeout": "TTS timeout, seconds"
         }
       }
     }

--- a/homeassistant/components/google_cloud/strings.json
+++ b/homeassistant/components/google_cloud/strings.json
@@ -26,7 +26,7 @@
           "profiles": "Default audio profiles",
           "text_type": "Default text type",
           "stt_model": "STT model",
-          "tts_timeout": "TTS timeout, seconds",
+          "timeout": "Timeout (in seconds)"
         }
       }
     }

--- a/homeassistant/components/google_cloud/stt.py
+++ b/homeassistant/components/google_cloud/stt.py
@@ -68,6 +68,7 @@ class GoogleCloudSpeechToTextEntity(SpeechToTextEntity):
         self._entry = entry
         self._client = client
         self._model = entry.options.get(CONF_STT_MODEL, DEFAULT_STT_MODEL)
+        self._timeout = entry.options.get(CONF_TIMEOUT, DEFAULT_TIMEOUT)
 
     @property
     def supported_languages(self) -> list[str]:
@@ -125,13 +126,10 @@ class GoogleCloudSpeechToTextEntity(SpeechToTextEntity):
             async for audio_content in stream:
                 yield speech_v1.StreamingRecognizeRequest(audio_content=audio_content)
                 
-        timeout = options[CONF_TIMEOUT]
-        if not timeout:
-            timeout = DEFAULT_TIMEOUT
         try:
             responses = await self._client.streaming_recognize(
                 requests=request_generator(),
-                timeout=timeout,
+                timeout=self._timeout,
             )
 
             transcript = ""

--- a/homeassistant/components/google_cloud/stt.py
+++ b/homeassistant/components/google_cloud/stt.py
@@ -125,7 +125,7 @@ class GoogleCloudSpeechToTextEntity(SpeechToTextEntity):
             # All subsequent requests must only contain audio_content
             async for audio_content in stream:
                 yield speech_v1.StreamingRecognizeRequest(audio_content=audio_content)
-                
+
         try:
             responses = await self._client.streaming_recognize(
                 requests=request_generator(),

--- a/homeassistant/components/google_cloud/stt.py
+++ b/homeassistant/components/google_cloud/stt.py
@@ -131,7 +131,7 @@ class GoogleCloudSpeechToTextEntity(SpeechToTextEntity):
         try:
             responses = await self._client.streaming_recognize(
                 requests=request_generator(),
-                timeout=10,
+                timeout=timeout,
             )
 
             transcript = ""

--- a/homeassistant/components/google_cloud/stt.py
+++ b/homeassistant/components/google_cloud/stt.py
@@ -30,6 +30,8 @@ from .const import (
     DEFAULT_STT_MODEL,
     DOMAIN,
     STT_LANGUAGES,
+    CONF_TIMEOUT,
+    DEFAULT_TIMEOUT,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -122,7 +124,10 @@ class GoogleCloudSpeechToTextEntity(SpeechToTextEntity):
             # All subsequent requests must only contain audio_content
             async for audio_content in stream:
                 yield speech_v1.StreamingRecognizeRequest(audio_content=audio_content)
-
+                
+        timeout = options[CONF_TIMEOUT]
+        if not timeout:
+            timeout = DEFAULT_TIMEOUT
         try:
             responses = await self._client.streaming_recognize(
                 requests=request_generator(),

--- a/homeassistant/components/google_cloud/stt.py
+++ b/homeassistant/components/google_cloud/stt.py
@@ -27,11 +27,11 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .const import (
     CONF_SERVICE_ACCOUNT_INFO,
     CONF_STT_MODEL,
+    CONF_TIMEOUT,
     DEFAULT_STT_MODEL,
+    DEFAULT_TIMEOUT,
     DOMAIN,
     STT_LANGUAGES,
-    CONF_TIMEOUT,
-    DEFAULT_TIMEOUT,
 )
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/google_cloud/tts.py
+++ b/homeassistant/components/google_cloud/tts.py
@@ -34,11 +34,13 @@ from .const import (
     CONF_SERVICE_ACCOUNT_INFO,
     CONF_SPEED,
     CONF_TEXT_TYPE,
+    CONF_TIMEOUT,
     CONF_VOICE,
     DEFAULT_GAIN,
     DEFAULT_LANG,
     DEFAULT_PITCH,
     DEFAULT_SPEED,
+    DEFAULT_TIMEOUT,
     DOMAIN,
 )
 from .helpers import async_tts_voices, tts_options_schema, tts_platform_schema
@@ -215,8 +217,11 @@ class BaseGoogleCloudProvider:
             ),
         )
 
-        response = await self._client.synthesize_speech(request, timeout=10)
-
+        tts_timeout = options[CONF_TIMEOUT]
+        if not tts_timeout:
+            tts_timeout = DEFAULT_TIMEOUT
+        response = await self._client.synthesize_speech(request, timeout=tts_timeout)
+        
         if encoding == texttospeech.AudioEncoding.MP3:
             extension = "mp3"
         elif encoding == texttospeech.AudioEncoding.OGG_OPUS:

--- a/homeassistant/components/google_cloud/tts.py
+++ b/homeassistant/components/google_cloud/tts.py
@@ -217,10 +217,10 @@ class BaseGoogleCloudProvider:
             ),
         )
 
-        tts_timeout = options[CONF_TIMEOUT]
-        if not tts_timeout:
-            tts_timeout = DEFAULT_TIMEOUT
-        response = await self._client.synthesize_speech(request, timeout=tts_timeout)
+        timeout = options[CONF_TIMEOUT]
+        if not timeout:
+            timeout = DEFAULT_TIMEOUT
+        response = await self._client.synthesize_speech(request, timeout=timeout)
         
         if encoding == texttospeech.AudioEncoding.MP3:
             extension = "mp3"

--- a/homeassistant/components/google_cloud/tts.py
+++ b/homeassistant/components/google_cloud/tts.py
@@ -217,10 +217,7 @@ class BaseGoogleCloudProvider:
             ),
         )
 
-        timeout = options[CONF_TIMEOUT]
-        if not timeout:
-            timeout = DEFAULT_TIMEOUT
-        response = await self._client.synthesize_speech(request, timeout=timeout)
+        response = await self._client.synthesize_speech(request, timeout=options.get(CONF_TIMEOUT, DEFAULT_TIMEOUT))
         
         if encoding == texttospeech.AudioEncoding.MP3:
             extension = "mp3"

--- a/homeassistant/components/google_cloud/tts.py
+++ b/homeassistant/components/google_cloud/tts.py
@@ -217,7 +217,9 @@ class BaseGoogleCloudProvider:
             ),
         )
 
-        response = await self._client.synthesize_speech(request, timeout=options.get(CONF_TIMEOUT, DEFAULT_TIMEOUT))
+        response = await self._client.synthesize_speech(
+            request, timeout=options.get(CONF_TIMEOUT, DEFAULT_TIMEOUT)
+        )
 
         if encoding == texttospeech.AudioEncoding.MP3:
             extension = "mp3"

--- a/homeassistant/components/google_cloud/tts.py
+++ b/homeassistant/components/google_cloud/tts.py
@@ -218,7 +218,7 @@ class BaseGoogleCloudProvider:
         )
 
         response = await self._client.synthesize_speech(request, timeout=options.get(CONF_TIMEOUT, DEFAULT_TIMEOUT))
-        
+
         if encoding == texttospeech.AudioEncoding.MP3:
             extension = "mp3"
         elif encoding == texttospeech.AudioEncoding.OGG_OPUS:

--- a/tests/components/google_cloud/test_config_flow.py
+++ b/tests/components/google_cloud/test_config_flow.py
@@ -162,6 +162,7 @@ async def test_options_flow(
         "profiles",
         "text_type",
         "stt_model",
+        "tts_timeout",
     }
     assert mock_api_tts_from_service_account_info.list_voices.call_count == 2
 
@@ -181,5 +182,6 @@ async def test_options_flow(
         "profiles": [],
         "text_type": "text",
         "stt_model": "latest_short",
+        "tts_timeout": 10,
     }
     assert mock_api_tts_from_service_account_info.list_voices.call_count == 3

--- a/tests/components/google_cloud/test_config_flow.py
+++ b/tests/components/google_cloud/test_config_flow.py
@@ -162,7 +162,7 @@ async def test_options_flow(
         "profiles",
         "text_type",
         "stt_model",
-        "tts_timeout",
+        "timeout",
     }
     assert mock_api_tts_from_service_account_info.list_voices.call_count == 2
 
@@ -182,6 +182,6 @@ async def test_options_flow(
         "profiles": [],
         "text_type": "text",
         "stt_model": "latest_short",
-        "tts_timeout": 10,
+        "timeout": 10,
     }
     assert mock_api_tts_from_service_account_info.list_voices.call_count == 3


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Hello, this is my first ever PR for Home Assistant - I sure hope I've done everything correctly, haha!

The existing implementation has a hard-coded 10s timeout when waiting for the generated speech from Google Cloud TTS.
Because of that, the integration fails (error "400 Request contains an invalid argument") when you try to generate outputs larger than roughly 600-800 characters, since it would take longer than that for Google Cloud TTS to return a response. I've been hitting this issue constantly when trying to announce long responses coming from my LLM, for example.

The proposed change makes TTS Timeout configurable in the UI. The default value is set at 10 seconds (same as the existing implementation), but now users can increase it if needed to generate longer output. The tests have been updated, too.
<img width="238" alt="2025-01-26 12_14_39-Settings – Home Assistant" src="https://github.com/user-attachments/assets/f3a6a36c-2704-4eee-bbca-079f41f5fdfe" />

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
- This PR is related to issue: Might be related to this https://github.com/home-assistant/core/issues/116983 (same error), but it's hard to say for sure since it was closed with little details.
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/37122

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`. (no changes)
- [X] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description. (no changes)

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
