### PR TITLE
Update roborock tests to patch client before test setup

### DIFF
--- a/tests/components/roborock/conftest.py
+++ b/tests/components/roborock/conftest.py
@@ -2,7 +2,8 @@
 
 from collections.abc import Generator
 from copy import deepcopy
-from unittest.mock import patch
+from typing import Any
+from unittest.mock import Mock, patch
 
 import pytest
 from roborock import RoborockCategory, RoomMapping
@@ -137,6 +138,22 @@ def bypass_api_fixture() -> None:
         patch("homeassistant.components.roborock.RoborockMqttClientA01", A01Mock),
     ):
         yield
+
+
+@pytest.fixture(name="send_message_side_effect")
+def send_message_side_effect_fixture() -> Any:
+    """Fixture to return a side effect for the send_message method."""
+    return None
+
+
+@pytest.fixture(name="mock_send_message")
+def mock_send_message_fixture(send_message_side_effect: Any) -> Mock:
+    """Fixture to mock the send_message method."""
+    with patch(
+        "homeassistant.components.roborock.coordinator.RoborockLocalClientV1._send_command",
+        side_effect=send_message_side_effect,
+    ) as mock_send_message:
+        yield mock_send_message
 
 
 @pytest.fixture

--- a/tests/components/roborock/test_switch.py
+++ b/tests/components/roborock/test_switch.py
@@ -1,6 +1,6 @@
 """Test Roborock Switch platform."""
 
-from unittest.mock import patch
+from unittest.mock import Mock
 
 import pytest
 import roborock
@@ -29,6 +29,7 @@ def platforms() -> list[Platform]:
 )
 async def test_update_success(
     hass: HomeAssistant,
+    mock_send_message: Mock,
     bypass_api_fixture,
     setup_entry: MockConfigEntry,
     entity_id: str,
@@ -36,27 +37,22 @@ async def test_update_success(
     """Test turning switch entities on and off."""
     # Ensure that the entity exist, as these test can pass even if there is no entity.
     assert hass.states.get(entity_id) is not None
-    with patch(
-        "homeassistant.components.roborock.coordinator.RoborockLocalClientV1._send_command"
-    ) as mock_send_message:
-        await hass.services.async_call(
-            "switch",
-            SERVICE_TURN_ON,
-            service_data=None,
-            blocking=True,
-            target={"entity_id": entity_id},
-        )
+    await hass.services.async_call(
+        "switch",
+        SERVICE_TURN_ON,
+        service_data=None,
+        blocking=True,
+        target={"entity_id": entity_id},
+    )
     assert mock_send_message.assert_called_once
-    with patch(
-        "homeassistant.components.roborock.coordinator.RoborockLocalClientV1.send_message"
-    ) as mock_send_message:
-        await hass.services.async_call(
-            "switch",
-            SERVICE_TURN_OFF,
-            service_data=None,
-            blocking=True,
-            target={"entity_id": entity_id},
-        )
+    mock_send_message.reset_mock()
+    await hass.services.async_call(
+        "switch",
+        SERVICE_TURN_OFF,
+        service_data=None,
+        blocking=True,
+        target={"entity_id": entity_id},
+    )
     assert mock_send_message.assert_called_once
 
 
@@ -67,8 +63,12 @@ async def test_update_success(
         ("switch.roborock_s7_maxv_status_indicator_light", SERVICE_TURN_OFF),
     ],
 )
+@pytest.mark.parametrize(
+    "send_message_side_effect", [roborock.exceptions.RoborockTimeout]
+)
 async def test_update_failed(
     hass: HomeAssistant,
+    mock_send_message: Mock,
     bypass_api_fixture,
     setup_entry: MockConfigEntry,
     entity_id: str,
@@ -78,10 +78,6 @@ async def test_update_failed(
     # Ensure that the entity exist, as these test can pass even if there is no entity.
     assert hass.states.get(entity_id) is not None
     with (
-        patch(
-            "homeassistant.components.roborock.coordinator.RoborockLocalClientV1._send_command",
-            side_effect=roborock.exceptions.RoborockTimeout,
-        ) as mock_send_message,
         pytest.raises(HomeAssistantError, match="Failed to update Roborock options"),
     ):
         await hass.services.async_call(

--- a/tests/components/roborock/test_time.py
+++ b/tests/components/roborock/test_time.py
@@ -1,7 +1,7 @@
 """Test Roborock Time platform."""
 
 from datetime import time
-from unittest.mock import patch
+from unittest.mock import Mock
 
 import pytest
 import roborock
@@ -29,6 +29,7 @@ def platforms() -> list[Platform]:
 )
 async def test_update_success(
     hass: HomeAssistant,
+    mock_send_message: Mock,
     bypass_api_fixture,
     setup_entry: MockConfigEntry,
     entity_id: str,
@@ -36,16 +37,13 @@ async def test_update_success(
     """Test turning switch entities on and off."""
     # Ensure that the entity exist, as these test can pass even if there is no entity.
     assert hass.states.get(entity_id) is not None
-    with patch(
-        "homeassistant.components.roborock.coordinator.RoborockLocalClientV1._send_command"
-    ) as mock_send_message:
-        await hass.services.async_call(
-            "time",
-            SERVICE_SET_VALUE,
-            service_data={"time": time(hour=1, minute=1)},
-            blocking=True,
-            target={"entity_id": entity_id},
-        )
+    await hass.services.async_call(
+        "time",
+        SERVICE_SET_VALUE,
+        service_data={"time": time(hour=1, minute=1)},
+        blocking=True,
+        target={"entity_id": entity_id},
+    )
     assert mock_send_message.assert_called_once
 
 
@@ -55,8 +53,12 @@ async def test_update_success(
         ("time.roborock_s7_maxv_do_not_disturb_begin"),
     ],
 )
+@pytest.mark.parametrize(
+    "send_message_side_effect", [roborock.exceptions.RoborockTimeout]
+)
 async def test_update_failure(
     hass: HomeAssistant,
+    mock_send_message: Mock,
     bypass_api_fixture,
     setup_entry: MockConfigEntry,
     entity_id: str,
@@ -64,13 +66,7 @@ async def test_update_failure(
     """Test turning switch entities on and off."""
     # Ensure that the entity exist, as these test can pass even if there is no entity.
     assert hass.states.get(entity_id) is not None
-    with (
-        patch(
-            "homeassistant.components.roborock.coordinator.RoborockLocalClientV1._send_command",
-            side_effect=roborock.exceptions.RoborockTimeout,
-        ) as mock_send_message,
-        pytest.raises(HomeAssistantError, match="Failed to update Roborock options"),
-    ):
+    with pytest.raises(HomeAssistantError, match="Failed to update Roborock options"):
         await hass.services.async_call(
             "time",
             SERVICE_SET_VALUE,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update roborock tests to patch client before test setup. This is required to keep the tests passing when bumping python-roborock (separate PR).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
