### PR TITLE
Update nest config flow to create pub/sub topics

### DIFF
--- a/homeassistant/components/nest/config_flow.py
+++ b/homeassistant/components/nest/config_flow.py
@@ -206,7 +206,9 @@ class NestFlowHandler(
     ) -> ConfigFlowResult:
         """Handle cloud project in user input."""
         if user_input is not None:
-            self._data.update(user_input)
+            self._data[CONF_CLOUD_PROJECT_ID] = user_input[
+                CONF_CLOUD_PROJECT_ID
+            ].strip()
             return await self.async_step_device_project()
         return self.async_show_form(
             step_id="cloud_project",
@@ -227,7 +229,7 @@ class NestFlowHandler(
         """Collect device access project from user input."""
         errors = {}
         if user_input is not None:
-            project_id = user_input[CONF_PROJECT_ID]
+            project_id = user_input[CONF_PROJECT_ID].strip()
             if project_id == self._data[CONF_CLOUD_PROJECT_ID]:
                 _LOGGER.error(
                     "Device Access Project ID and Cloud Project ID must not be the"

--- a/homeassistant/components/nest/strings.json
+++ b/homeassistant/components/nest/strings.json
@@ -17,7 +17,7 @@
       },
       "device_project": {
         "title": "Nest: Create a Device Access Project",
-        "description": "Create a Nest Device Access project which **requires paying Google a US $5 fee** to set up.\n1. Go to the [Device Access Console]({device_access_console_url}), and through the payment flow.\n1. Select on **Create project**\n1. Give your Device Access project a name and select **Next**.\n1. Enter your OAuth Client ID\n1. Enable events by clicking **Enable** and **Create project**.\n\nEnter your Device Access Project ID below ([more info]({more_info_url})).",
+        "description": "Create a Nest Device Access project which **requires paying Google a US $5 fee** to set up.\n1. Go to the [Device Access Console]({device_access_console_url}), and through the payment flow.\n1. Select on **Create project**\n1. Give your Device Access project a name and select **Next**.\n1. Enter your OAuth Client ID\n1. Skip enabling events for now and click **Create project**.\n\nEnter your Device Access Project ID below ([more info]({more_info_url})).",
         "data": {
           "project_id": "Device Access Project ID"
         }
@@ -25,19 +25,17 @@
       "pick_implementation": {
         "title": "[%key:common::config_flow::title::oauth2_pick_implementation%]"
       },
-      "pubsub": {
-        "title": "Configure Google Cloud Pub/Sub",
-        "description": "Home Assistant uses Cloud Pub/Sub receive realtime Nest device updates. Nest servers publish updates to a Pub/Sub topic and Home Assistant receives the updates through a Pub/Sub subscription.\n\n1. Visit the [Device Access Console]({device_access_console_url}) and ensure a Pub/Sub topic is configured.\n2. Visit the [Cloud Console]({url}) to find your Google Cloud Project ID and confirm it is correct below.\n3. The next step will attempt to auto-discover Pub/Sub topics and subscriptions.\n\nSee the integration documentation for [more info]({more_info_url}).",
-        "data": {
-          "cloud_project_id": "[%key:component::nest::config::step::cloud_project::data::cloud_project_id%]"
-        }
-      },
       "pubsub_topic": {
         "title": "Configure Cloud Pub/Sub topic",
-        "description": "Nest devices publish updates on a Cloud Pub/Sub topic. Select the Pub/Sub topic below that is the same as the [Device Access Console]({device_access_console_url}). See the integration documentation for [more info]({more_info_url}).",
+        "description": "Nest devices publish updates on a Cloud Pub/Sub topic. You can select an existing topic if one exists, or choose to create a new topic and the next step will create it for you with the necessary permissions. See the integration documentation for [more info]({more_info_url}).",
         "data": {
           "topic_name": "Pub/Sub topic Name"
         }
+      },
+      "pubsub_topic_confirm": {
+        "title": "Enable Events",
+        "description": "The Nest Device Access Console needs to be configured to publish device events to your Pub/Sub topic.\n\n1. Visit the [Device Access Console]({device_access_console_url}).\n2. Open the project.\n3. Enable *Events* and set the Pub/Sub topic name to `{topic_name}`\n4. Click *Add & Validate* to verify the topic is configured correctly.\n\nSee the integration documentation for [more info]({more_info_url}).",
+        "submit": "Confirm"
       },
       "pubsub_subscription": {
         "title": "Configure Cloud Pub/Sub subscription",
@@ -70,7 +68,8 @@
       "oauth_error": "[%key:common::config_flow::abort::oauth2_error%]",
       "oauth_timeout": "[%key:common::config_flow::abort::oauth2_timeout%]",
       "oauth_unauthorized": "[%key:common::config_flow::abort::oauth2_unauthorized%]",
-      "oauth_failed": "[%key:common::config_flow::abort::oauth2_failed%]"
+      "oauth_failed": "[%key:common::config_flow::abort::oauth2_failed%]",
+      "pubsub_api_error": "[%key:component::nest::config::error::pubsub_api_error%]"
     },
     "create_entry": {
       "default": "[%key:common::config_flow::create_entry::authenticated%]"

--- a/homeassistant/components/nest/strings.json
+++ b/homeassistant/components/nest/strings.json
@@ -108,5 +108,17 @@
         }
       }
     }
+  },
+  "selector": {
+    "topic_name": {
+      "options": {
+        "create_new_topic": "Create new topic"
+      }
+    },
+    "subscription_name": {
+      "options": {
+        "create_new_subscription": "Create new subscription"
+      }
+    }
   }
 }

--- a/homeassistant/components/nest/strings.json
+++ b/homeassistant/components/nest/strings.json
@@ -17,7 +17,7 @@
       },
       "device_project": {
         "title": "Nest: Create a Device Access Project",
-        "description": "Create a Nest Device Access project which **requires paying Google a US $5 fee** to set up.\n1. Go to the [Device Access Console]({device_access_console_url}), and through the payment flow.\n1. Select on **Create project**\n1. Give your Device Access project a name and select **Next**.\n1. Enter your OAuth Client ID\n1. Skip enabling events for now and click **Create project**.\n\nEnter your Device Access Project ID below ([more info]({more_info_url})).",
+        "description": "Create a Nest Device Access project which **requires paying Google a US $5 fee** to set up.\n1. Go to the [Device Access Console]({device_access_console_url}), and through the payment flow.\n1. Select on **Create project**\n1. Give your Device Access project a name and select **Next**.\n1. Enter your OAuth Client ID\n1. Skip enabling events for now and select **Create project**.\n\nEnter your Device Access Project ID below ([more info]({more_info_url})).",
         "data": {
           "project_id": "Device Access Project ID"
         }
@@ -33,7 +33,7 @@
         }
       },
       "pubsub_topic_confirm": {
-        "title": "Enable Events",
+        "title": "Enable events",
         "description": "The Nest Device Access Console needs to be configured to publish device events to your Pub/Sub topic.\n\n1. Visit the [Device Access Console]({device_access_console_url}).\n2. Open the project.\n3. Enable *Events* and set the Pub/Sub topic name to `{topic_name}`\n4. Click *Add & Validate* to verify the topic is configured correctly.\n\nSee the integration documentation for [more info]({more_info_url}).",
         "submit": "Confirm"
       },

--- a/tests/components/nest/conftest.py
+++ b/tests/components/nest/conftest.py
@@ -74,20 +74,25 @@ class FakeAuth:
         self.json = None
         self.headers = None
         self.captured_requests = []
+        self._project_id = project_id
+        self._aioclient_mock = aioclient_mock
+        self.register_mock_requests()
 
+    def register_mock_requests(self) -> None:
+        """Register the mocks."""
         # API makes a call to request structures to initiate pubsub feed, but the
         # integration does not use this.
-        aioclient_mock.get(
-            f"{API_URL}/enterprises/{project_id}/structures",
+        self._aioclient_mock.get(
+            f"{API_URL}/enterprises/{self._project_id}/structures",
             side_effect=self.request_structures,
         )
-        aioclient_mock.get(
-            f"{API_URL}/enterprises/{project_id}/devices",
+        self._aioclient_mock.get(
+            f"{API_URL}/enterprises/{self._project_id}/devices",
             side_effect=self.request_devices,
         )
-        aioclient_mock.post(DEVICE_URL_MATCH, side_effect=self.request)
-        aioclient_mock.get(TEST_IMAGE_URL, side_effect=self.request)
-        aioclient_mock.get(TEST_CLIP_URL, side_effect=self.request)
+        self._aioclient_mock.post(DEVICE_URL_MATCH, side_effect=self.request)
+        self._aioclient_mock.get(TEST_IMAGE_URL, side_effect=self.request)
+        self._aioclient_mock.get(TEST_CLIP_URL, side_effect=self.request)
 
     async def request_structures(
         self, method: str, url: str, data: dict[str, Any]

--- a/tests/components/nest/test_config_flow.py
+++ b/tests/components/nest/test_config_flow.py
@@ -34,7 +34,7 @@ from tests.typing import ClientSessionGenerator
 
 WEB_REDIRECT_URL = "https://example.com/auth/external/callback"
 APP_REDIRECT_URL = "urn:ietf:wg:oauth:2.0:oob"
-RAND_SUBSCRIBER_SUFFIX = "ABCDEF"
+RAND_SUFFIX = "ABCDEF"
 
 FAKE_DHCP_DATA = DhcpServiceInfo(
     ip="127.0.0.2", macaddress="001122334455", hostname="fake_hostname"
@@ -52,7 +52,7 @@ def mock_rand_topic_name_fixture() -> None:
     """Set the topic name random string to a constant."""
     with patch(
         "homeassistant.components.nest.config_flow.get_random_string",
-        return_value=RAND_SUBSCRIBER_SUFFIX,
+        return_value=RAND_SUFFIX,
     ):
         yield
 
@@ -173,6 +173,7 @@ class OAuthFixture:
         selected_topic: str,
         selected_subscription: str = "create_new_subscription",
         user_input: dict | None = None,
+        existing_errors: dict | None = None,
     ) -> ConfigEntry:
         """Fixture to walk through the Pub/Sub topic and subscription steps.
 
@@ -192,6 +193,12 @@ class OAuthFixture:
                 "topic_name": selected_topic,
             },
         )
+        assert result.get("type") is FlowResultType.FORM
+        assert result.get("step_id") == "pubsub_topic_confirm"
+        assert not result.get("errors")
+
+        # ACK the topic selection. User is instructed to do some manual
+        result = await self.async_configure(result, {})
         assert result.get("type") is FlowResultType.FORM
         assert result.get("step_id") == "pubsub_subscription"
         assert not result.get("errors")
@@ -267,6 +274,12 @@ def mock_cloud_project_id() -> str:
     return CLOUD_PROJECT_ID
 
 
+@pytest.fixture(name="create_topic_status")
+def mock_create_topic_status() -> str:
+    """Fixture to configure the return code when creating the topic."""
+    return HTTPStatus.OK
+
+
 @pytest.fixture(name="create_subscription_status")
 def mock_create_subscription_status() -> str:
     """Fixture to configure the return code when creating the subscription."""
@@ -285,6 +298,64 @@ def mock_list_subscriptions_status() -> str:
     return HTTPStatus.OK
 
 
+def setup_mock_list_subscriptions_responses(
+    aioclient_mock: AiohttpClientMocker,
+    cloud_project_id: str,
+    subscriptions: list[tuple[str, str]],
+    list_subscriptions_status: HTTPStatus = HTTPStatus.OK,
+) -> None:
+    """Configure the mock responses for listing Pub/Sub subscriptions."""
+    aioclient_mock.get(
+        f"https://pubsub.googleapis.com/v1/projects/{cloud_project_id}/subscriptions",
+        json={
+            "subscriptions": [
+                {
+                    "name": subscription_name,
+                    "topic": topic,
+                    "pushConfig": {},
+                    "ackDeadlineSeconds": 10,
+                    "messageRetentionDuration": "604800s",
+                    "expirationPolicy": {"ttl": "2678400s"},
+                    "state": "ACTIVE",
+                }
+                for (subscription_name, topic) in subscriptions or ()
+            ]
+        },
+        status=list_subscriptions_status,
+    )
+
+
+def setup_mock_create_topic_responses(
+    aioclient_mock: AiohttpClientMocker,
+    cloud_project_id: str,
+    create_topic_status: HTTPStatus = HTTPStatus.OK,
+) -> None:
+    """Configure the mock responses for creating a Pub/Sub topic."""
+    aioclient_mock.put(
+        f"https://pubsub.googleapis.com/v1/projects/{cloud_project_id}/topics/home-assistant-{RAND_SUFFIX}",
+        json={},
+        status=create_topic_status,
+    )
+    aioclient_mock.post(
+        f"https://pubsub.googleapis.com/v1/projects/{cloud_project_id}/topics/home-assistant-{RAND_SUFFIX}:setIamPolicy",
+        json={},
+        status=create_topic_status,
+    )
+
+
+def setup_mock_create_subscription_responses(
+    aioclient_mock: AiohttpClientMocker,
+    cloud_project_id: str,
+    create_subscription_status: HTTPStatus = HTTPStatus.OK,
+) -> None:
+    """Configure the mock responses for creating a Pub/Sub subscription."""
+    aioclient_mock.put(
+        f"https://pubsub.googleapis.com/v1/projects/{cloud_project_id}/subscriptions/home-assistant-{RAND_SUFFIX}",
+        json={},
+        status=create_subscription_status,
+    )
+
+
 @pytest.fixture(autouse=True)
 def mock_pubsub_api_responses(
     aioclient_mock: AiohttpClientMocker,
@@ -293,6 +364,7 @@ def mock_pubsub_api_responses(
     subscriptions: list[tuple[str, str]],
     device_access_project_id: str,
     cloud_project_id: str,
+    create_topic_status: HTTPStatus,
     create_subscription_status: HTTPStatus,
     list_topics_status: HTTPStatus,
     list_subscriptions_status: HTTPStatus,
@@ -320,28 +392,14 @@ def mock_pubsub_api_responses(
     )
     # We check for a topic created by the SDM Device Access Console (but note we don't have permission to read it)
     # or the user has created one themselves in the Google Cloud Project.
-    aioclient_mock.get(
-        f"https://pubsub.googleapis.com/v1/projects/{cloud_project_id}/subscriptions",
-        json={
-            "subscriptions": [
-                {
-                    "name": subscription_name,
-                    "topic": topic,
-                    "pushConfig": {},
-                    "ackDeadlineSeconds": 10,
-                    "messageRetentionDuration": "604800s",
-                    "expirationPolicy": {"ttl": "2678400s"},
-                    "state": "ACTIVE",
-                }
-                for (subscription_name, topic) in subscriptions or ()
-            ]
-        },
-        status=list_subscriptions_status,
+    setup_mock_list_subscriptions_responses(
+        aioclient_mock, cloud_project_id, subscriptions, list_subscriptions_status
     )
-    aioclient_mock.put(
-        f"https://pubsub.googleapis.com/v1/projects/{cloud_project_id}/subscriptions/home-assistant-{RAND_SUBSCRIBER_SUFFIX}",
-        json={},
-        status=create_subscription_status,
+    setup_mock_create_topic_responses(
+        aioclient_mock, cloud_project_id, create_topic_status
+    )
+    setup_mock_create_subscription_responses(
+        aioclient_mock, cloud_project_id, create_subscription_status
     )
 
 
@@ -371,7 +429,7 @@ async def test_app_credentials(
         "auth_implementation": "imported-cred",
         "cloud_project_id": CLOUD_PROJECT_ID,
         "project_id": PROJECT_ID,
-        "subscription_name": f"projects/{CLOUD_PROJECT_ID}/subscriptions/home-assistant-{RAND_SUBSCRIBER_SUFFIX}",
+        "subscription_name": f"projects/{CLOUD_PROJECT_ID}/subscriptions/home-assistant-{RAND_SUFFIX}",
         "topic_name": f"projects/sdm-prod/topics/enterprise-{PROJECT_ID}",
         "token": {
             "refresh_token": "mock-refresh-token",
@@ -520,6 +578,11 @@ async def test_config_flow_pubsub_configuration_error(
         },
     )
     assert result.get("type") is FlowResultType.FORM
+    assert result.get("step_id") == "pubsub_topic_confirm"
+    assert not result.get("errors")
+
+    result = await oauth.async_configure(result, {})
+    assert result.get("type") is FlowResultType.FORM
     assert result.get("step_id") == "pubsub_subscription"
     assert result.get("data_schema")({}) == {
         "subscription_name": "create_new_subscription",
@@ -564,6 +627,11 @@ async def test_config_flow_pubsub_subscriber_error(
             "topic_name": f"projects/sdm-prod/topics/enterprise-{PROJECT_ID}",
         },
     )
+    assert result.get("type") is FlowResultType.FORM
+    assert result.get("step_id") == "pubsub_topic_confirm"
+    assert not result.get("errors")
+
+    result = await oauth.async_configure(result, {})
     assert result.get("type") is FlowResultType.FORM
     assert result.get("step_id") == "pubsub_subscription"
     assert result.get("data_schema")({}) == {
@@ -751,6 +819,11 @@ async def test_pubsub_subscription_auth_failure(
         },
     )
     assert result.get("type") is FlowResultType.FORM
+    assert result.get("step_id") == "pubsub_topic_confirm"
+    assert not result.get("errors")
+
+    result = await oauth.async_configure(result, {})
+    assert result.get("type") is FlowResultType.FORM
     assert result.get("step_id") == "pubsub_subscription"
     assert result.get("data_schema")({}) == {
         "subscription_name": "create_new_subscription",
@@ -833,7 +906,7 @@ async def test_config_entry_title_from_home(
     assert entry.data.get("cloud_project_id") == CLOUD_PROJECT_ID
     assert (
         entry.data.get("subscription_name")
-        == f"projects/{CLOUD_PROJECT_ID}/subscriptions/home-assistant-{RAND_SUBSCRIBER_SUFFIX}"
+        == f"projects/{CLOUD_PROJECT_ID}/subscriptions/home-assistant-{RAND_SUFFIX}"
     )
     assert (
         entry.data.get("topic_name")
@@ -905,7 +978,7 @@ async def test_title_failure_fallback(
     assert entry.data.get("cloud_project_id") == CLOUD_PROJECT_ID
     assert (
         entry.data.get("subscription_name")
-        == f"projects/{CLOUD_PROJECT_ID}/subscriptions/home-assistant-{RAND_SUBSCRIBER_SUFFIX}"
+        == f"projects/{CLOUD_PROJECT_ID}/subscriptions/home-assistant-{RAND_SUFFIX}"
     )
     assert (
         entry.data.get("topic_name")
@@ -997,7 +1070,7 @@ async def test_dhcp_discovery_with_creds(
         "auth_implementation": "imported-cred",
         "cloud_project_id": CLOUD_PROJECT_ID,
         "project_id": PROJECT_ID,
-        "subscription_name": f"projects/{CLOUD_PROJECT_ID}/subscriptions/home-assistant-{RAND_SUBSCRIBER_SUFFIX}",
+        "subscription_name": f"projects/{CLOUD_PROJECT_ID}/subscriptions/home-assistant-{RAND_SUFFIX}",
         "topic_name": f"projects/sdm-prod/topics/enterprise-{PROJECT_ID}",
         "token": {
             "refresh_token": "mock-refresh-token",
@@ -1092,7 +1165,7 @@ async def test_no_eligible_topics(
     hass: HomeAssistant,
     oauth: OAuthFixture,
 ) -> None:
-    """Test the case where there are no eligible pub/sub topics."""
+    """Test the case where there are no eligible pub/sub topics and the topic is created."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -1101,8 +1174,36 @@ async def test_no_eligible_topics(
 
     result = await oauth.async_configure(result, None)
     assert result.get("type") is FlowResultType.FORM
-    assert result.get("step_id") == "pubsub"
-    assert result.get("errors") == {"base": "no_pubsub_topics"}
+    assert result.get("step_id") == "pubsub_topic"
+    assert not result.get("errors")
+    # Option shown to create a new topic
+    assert result.get("data_schema")({}) == {
+        "topic_name": "create_new_topic",
+    }
+
+    entry = await oauth.async_complete_pubsub_flow(
+        result,
+        selected_topic="create_new_topic",
+        selected_subscription="create_new_subscription",
+    )
+
+    data = dict(entry.data)
+    assert "token" in data
+    data["token"].pop("expires_in")
+    data["token"].pop("expires_at")
+    assert data == {
+        "sdm": {},
+        "auth_implementation": "imported-cred",
+        "cloud_project_id": CLOUD_PROJECT_ID,
+        "project_id": PROJECT_ID,
+        "subscription_name": f"projects/{CLOUD_PROJECT_ID}/subscriptions/home-assistant-{RAND_SUFFIX}",
+        "topic_name": f"projects/{CLOUD_PROJECT_ID}/topics/home-assistant-{RAND_SUFFIX}",
+        "token": {
+            "refresh_token": "mock-refresh-token",
+            "access_token": "mock-access-token",
+            "type": "Bearer",
+        },
+    }
 
 
 @pytest.mark.parametrize(
@@ -1123,9 +1224,88 @@ async def test_list_topics_failure(
     oauth.async_mock_refresh()
 
     result = await oauth.async_configure(result, None)
+    assert result.get("type") is FlowResultType.ABORT
+    assert result.get("reason") == "pubsub_api_error"
+
+
+@pytest.mark.parametrize(
+    ("create_topic_status"),
+    [(HTTPStatus.INTERNAL_SERVER_ERROR)],
+)
+async def test_create_topic_failed(
+    hass: HomeAssistant,
+    oauth: OAuthFixture,
+    aioclient_mock: AiohttpClientMocker,
+    cloud_project_id: str,
+    subscriptions: list[tuple[str, str]],
+    auth: FakeAuth,
+) -> None:
+    """Test the case where there are no eligible pub/sub topics and the topic is created."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    await oauth.async_app_creds_flow(result)
+    oauth.async_mock_refresh()
+
+    result = await oauth.async_configure(result, None)
     assert result.get("type") is FlowResultType.FORM
-    assert result.get("step_id") == "pubsub"
+    assert result.get("step_id") == "pubsub_topic"
+    assert not result.get("errors")
+    # Option shown to create a new topic
+    assert result.get("data_schema")({}) == {
+        "topic_name": "create_new_topic",
+    }
+
+    result = await oauth.async_configure(result, {"topic_name": "create_new_topic"})
+    assert result.get("type") is FlowResultType.FORM
+    assert result.get("step_id") == "pubsub_topic"
     assert result.get("errors") == {"base": "pubsub_api_error"}
+
+    # Re-register mock requests needed for the rest of the test. The topic
+    # request will now succeed.
+    aioclient_mock.clear_requests()
+    setup_mock_create_topic_responses(aioclient_mock, cloud_project_id)
+    # Fix up other mock responses cleared above
+    auth.register_mock_requests()
+    setup_mock_list_subscriptions_responses(
+        aioclient_mock,
+        cloud_project_id,
+        subscriptions,
+    )
+    setup_mock_create_subscription_responses(aioclient_mock, cloud_project_id)
+
+    result = await oauth.async_configure(result, {"topic_name": "create_new_topic"})
+    assert result.get("type") is FlowResultType.FORM
+    assert result.get("step_id") == "pubsub_topic_confirm"
+    assert not result.get("errors")
+
+    result = await oauth.async_configure(result, {})
+    assert result.get("type") is FlowResultType.FORM
+    assert result.get("step_id") == "pubsub_subscription"
+    assert not result.get("errors")
+
+    # Create a subscription for the topic and end the flow
+    entry = await oauth.async_finish_setup(
+        result,
+        {"subscription_name": "create_new_subscription"},
+    )
+    data = dict(entry.data)
+    assert "token" in data
+    data["token"].pop("expires_in")
+    data["token"].pop("expires_at")
+    assert data == {
+        "sdm": {},
+        "auth_implementation": "imported-cred",
+        "cloud_project_id": CLOUD_PROJECT_ID,
+        "project_id": PROJECT_ID,
+        "subscription_name": f"projects/{CLOUD_PROJECT_ID}/subscriptions/home-assistant-{RAND_SUFFIX}",
+        "topic_name": f"projects/{CLOUD_PROJECT_ID}/topics/home-assistant-{RAND_SUFFIX}",
+        "token": {
+            "refresh_token": "mock-refresh-token",
+            "access_token": "mock-access-token",
+            "type": "Bearer",
+        },
+    }
 
 
 @pytest.mark.parametrize(
@@ -1157,6 +1337,11 @@ async def test_list_subscriptions_failure(
             "topic_name": f"projects/sdm-prod/topics/enterprise-{PROJECT_ID}",
         },
     )
+    assert result.get("type") is FlowResultType.FORM
+    assert result.get("step_id") == "pubsub_topic_confirm"
+    assert not result.get("errors")
+
+    result = await oauth.async_configure(result, {})
     assert result.get("type") is FlowResultType.FORM
     assert result.get("step_id") == "pubsub_subscription"
     assert result.get("errors") == {"base": "pubsub_api_error"}

--- a/tests/components/nest/test_config_flow.py
+++ b/tests/components/nest/test_config_flow.py
@@ -759,37 +759,6 @@ async def test_reauth_multiple_config_entries(
     assert entry.data.get("extra_data")
 
 
-@pytest.mark.parametrize(("sdm_managed_topic"), [(True)])
-async def test_pubsub_subscription_strip_whitespace(
-    hass: HomeAssistant,
-    oauth: OAuthFixture,
-) -> None:
-    """Check that project id has whitespace stripped on entry."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
-    await oauth.async_app_creds_flow(
-        result, cloud_project_id=" " + CLOUD_PROJECT_ID + " "
-    )
-    oauth.async_mock_refresh()
-    result = await oauth.async_configure(result, {"code": "1234"})
-    entry = await oauth.async_complete_pubsub_flow(
-        result, selected_topic="projects/sdm-prod/topics/enterprise-some-project-id"
-    )
-    assert entry.title == "Import from configuration.yaml"
-    assert "token" in entry.data
-    entry.data["token"].pop("expires_at")
-    assert entry.unique_id == PROJECT_ID
-    assert entry.data["token"] == {
-        "refresh_token": "mock-refresh-token",
-        "access_token": "mock-access-token",
-        "type": "Bearer",
-        "expires_in": 60,
-    }
-    assert "subscription_name" in entry.data
-    assert entry.data["cloud_project_id"] == CLOUD_PROJECT_ID
-
-
 @pytest.mark.parametrize(
     ("sdm_managed_topic", "create_subscription_status"),
     [(True, HTTPStatus.UNAUTHORIZED)],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update nest config flow to create pub/sub topics. The device access console used to manage this on behalf of users, but it has now changed to require users to create it themselves.

The manual instruction updates in https://github.com/home-assistant/home-assistant.io/pull/37130 have context for the steps involved of doing this manually.

The tests have been updated to fail once, then allow resuming the flow all the way to completion. This requires changing the fixtures around a lot since you can't reset the failure status of a single request and need to re-add all mock requests to the aiohttp request mocker. (This is a broader area that need to be updated for other tests as well from quality scale review)

Here is the history/rollout for this change:
- Nest always creates the topic before January 23rd 2025
- After [#128909](https://github.com/home-assistant/core/pull/128909) from  2024.11.X either nest or user can create the topic. However, nest still always creates the topic in prod until Jan 23rd. 
- Jan 23rd hits, now [#128909](https://github.com/home-assistant/core/pull/128909) is required as Nest no longer creates the topic.  Users may figure it out somehow, but there are a lot of steps.
- Documentation PR [#128909](https://github.com/home-assistant/home-assistant.io/pull/37130)  documents how to create the topic manually. hopefully users are slightly less confused
- This PR [#136609](https://github.com/home-assistant/core/pull/136609) automates topic creation in the config flow and we can try to make sure its in 2025.1.x

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
