### PR TITLE
Use typed coordinator and runtime_data in eafm

### DIFF
--- a/homeassistant/components/eafm/__init__.py
+++ b/homeassistant/components/eafm/__init__.py
@@ -1,64 +1,22 @@
 """UK Environment Agency Flood Monitoring Integration."""
 
-import asyncio
-from datetime import timedelta
-import logging
-from typing import Any
-
-from aioeafm import get_station
-
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from .const import DOMAIN
+from .coordinator import EafmConfigEntry, EafmCoordinator
 
 PLATFORMS = [Platform.SENSOR]
 
-_LOGGER = logging.getLogger(__name__)
 
-
-def get_measures(station_data):
-    """Force measure key to always be a list."""
-    if "measures" not in station_data:
-        return []
-    if isinstance(station_data["measures"], dict):
-        return [station_data["measures"]]
-    return station_data["measures"]
-
-
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: EafmConfigEntry) -> bool:
     """Set up flood monitoring sensors for this config entry."""
-    station_key = entry.data["station"]
-    session = async_get_clientsession(hass=hass)
-
-    async def _async_update_data() -> dict[str, dict[str, Any]]:
-        # DataUpdateCoordinator will handle aiohttp ClientErrors and timeouts
-        async with asyncio.timeout(30):
-            data = await get_station(session, station_key)
-
-        measures = get_measures(data)
-        # Turn data.measures into a dict rather than a list so easier for entities to
-        # find themselves.
-        data["measures"] = {measure["@id"]: measure for measure in measures}
-        return data
-
-    coordinator = DataUpdateCoordinator[dict[str, dict[str, Any]]](
-        hass,
-        _LOGGER,
-        config_entry=entry,
-        name="sensor",
-        update_method=_async_update_data,
-        update_interval=timedelta(seconds=15 * 60),
-    )
+    coordinator = EafmCoordinator(hass, entry=entry)
     await coordinator.async_config_entry_first_refresh()
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
+    entry.runtime_data = coordinator
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: EafmConfigEntry) -> bool:
     """Unload flood monitoring sensors."""
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/eafm/coordinator.py
+++ b/homeassistant/components/eafm/coordinator.py
@@ -1,0 +1,57 @@
+"""UK Environment Agency Flood Monitoring Integration."""
+
+import asyncio
+from datetime import timedelta
+import logging
+from typing import Any
+
+from aioeafm import get_station
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+PLATFORMS = [Platform.SENSOR]
+
+_LOGGER = logging.getLogger(__name__)
+
+type EafmConfigEntry = ConfigEntry[EafmCoordinator]
+
+
+def _get_measures(station_data):
+    """Force measure key to always be a list."""
+    if "measures" not in station_data:
+        return []
+    if isinstance(station_data["measures"], dict):
+        return [station_data["measures"]]
+    return station_data["measures"]
+
+
+class EafmCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
+    """Class to manage fetching UK Flood Monitoring data."""
+
+    def __init__(self, hass: HomeAssistant, entry: EafmConfigEntry) -> None:
+        """Initialize."""
+        self._station_key = entry.data["station"]
+        self._session = async_get_clientsession(hass=hass)
+        super().__init__(
+            hass,
+            _LOGGER,
+            config_entry=entry,
+            name="sensor",
+            update_interval=timedelta(seconds=15 * 60),
+        )
+
+    async def _async_update_data(self) -> dict[str, dict[str, Any]]:
+        """Fetch the latest data from the source."""
+        # DataUpdateCoordinator will handle aiohttp ClientErrors and timeouts
+        async with asyncio.timeout(30):
+            data = await get_station(self._session, self._station_key)
+
+        measures = _get_measures(data)
+        # Turn data.measures into a dict rather than a list so easier for entities to
+        # find themselves.
+        data["measures"] = {measure["@id"]: measure for measure in measures}
+        return data

--- a/homeassistant/components/eafm/coordinator.py
+++ b/homeassistant/components/eafm/coordinator.py
@@ -20,7 +20,7 @@ _LOGGER = logging.getLogger(__name__)
 type EafmConfigEntry = ConfigEntry[EafmCoordinator]
 
 
-def _get_measures(station_data):
+def _get_measures(station_data: dict[str, Any]) -> list[dict[str, Any]]:
     """Force measure key to always be a list."""
     if "measures" not in station_data:
         return []

--- a/homeassistant/components/eafm/sensor.py
+++ b/homeassistant/components/eafm/sensor.py
@@ -3,17 +3,14 @@
 from typing import Any
 
 from homeassistant.components.sensor import SensorEntity, SensorStateClass
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfLength
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import (
-    CoordinatorEntity,
-    DataUpdateCoordinator,
-)
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
+from .coordinator import EafmConfigEntry, EafmCoordinator
 
 UNIT_MAPPING = {
     "http://qudt.org/1.1/vocab/unit#Meter": UnitOfLength.METERS,
@@ -22,11 +19,11 @@ UNIT_MAPPING = {
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: EafmConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up UK Flood Monitoring Sensors."""
-    coordinator: DataUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+    coordinator = config_entry.runtime_data
     created_entities: set[str] = set()
 
     @callback
@@ -70,7 +67,7 @@ class Measurement(CoordinatorEntity, SensorEntity):
     _attr_has_entity_name = True
     _attr_name = None
 
-    def __init__(self, coordinator, key):
+    def __init__(self, coordinator: EafmCoordinator, key: str) -> None:
         """Initialise the gauge with a data instance and station."""
         super().__init__(coordinator)
         self.key = key

--- a/tests/components/eafm/conftest.py
+++ b/tests/components/eafm/conftest.py
@@ -15,5 +15,5 @@ def mock_get_stations():
 @pytest.fixture
 def mock_get_station():
     """Mock aioeafm.get_station."""
-    with patch("homeassistant.components.eafm.get_station") as patched:
+    with patch("homeassistant.components.eafm.coordinator.get_station") as patched:
         yield patched


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
