### PR TITLE
Add melcloud standard horizontal vane modes

### DIFF
--- a/homeassistant/components/melcloud/climate.py
+++ b/homeassistant/components/melcloud/climate.py
@@ -164,6 +164,7 @@ class AtaDeviceClimate(MelCloudClimate):
                     ATTR_VANE_HORIZONTAL_POSITIONS: self._device.vane_horizontal_positions,
                 }
             )
+            self._attr_supported_features |= ClimateEntityFeature.SWING_HORIZONTAL_MODE
 
         if vane_vertical := self._device.vane_vertical:
             attr.update(
@@ -274,14 +275,28 @@ class AtaDeviceClimate(MelCloudClimate):
         """Return vertical vane position or mode."""
         return self._device.vane_vertical
 
+    @property
+    def swing_horizontal_mode(self) -> str | None:
+        """Return vertical vane position or mode."""
+        return self._device.vane_horizontal
+
     async def async_set_swing_mode(self, swing_mode: str) -> None:
         """Set vertical vane position or mode."""
         await self.async_set_vane_vertical(swing_mode)
+
+    async def async_set_swing_horizontal_mode(self, swing_mode: str) -> None:
+        """Set vertical vane position or mode."""
+        await self.async_set_vane_horizontal(swing_mode)
 
     @property
     def swing_modes(self) -> list[str] | None:
         """Return a list of available vertical vane positions and modes."""
         return self._device.vane_vertical_positions
+
+    @property
+    def swing_horizontal_modes(self) -> list[str] | None:
+        """Return a list of available vertical vane positions and modes."""
+        return self._device.vane_horizontal_positions
 
     async def async_turn_on(self) -> None:
         """Turn the entity on."""

--- a/homeassistant/components/melcloud/climate.py
+++ b/homeassistant/components/melcloud/climate.py
@@ -284,7 +284,7 @@ class AtaDeviceClimate(MelCloudClimate):
 
     @property
     def swing_horizontal_mode(self) -> str | None:
-        """Return vertical vane position or mode."""
+        """Return horizontal vane position or mode."""
         return self._device.vane_horizontal
 
     async def async_set_swing_mode(self, swing_mode: str) -> None:
@@ -292,7 +292,7 @@ class AtaDeviceClimate(MelCloudClimate):
         await self.async_set_vane_vertical(swing_mode)
 
     async def async_set_swing_horizontal_mode(self, swing_horizontal_mode: str) -> None:
-        """Set vertical vane position or mode."""
+        """Set horizontal vane position or mode."""
         await self.async_set_vane_horizontal(swing_horizontal_mode)
 
     @property
@@ -302,7 +302,7 @@ class AtaDeviceClimate(MelCloudClimate):
 
     @property
     def swing_horizontal_modes(self) -> list[str] | None:
-        """Return a list of available vertical vane positions and modes."""
+        """Return a list of available horizontal vane positions and modes."""
         return self._device.vane_horizontal_positions
 
     async def async_turn_on(self) -> None:

--- a/homeassistant/components/melcloud/climate.py
+++ b/homeassistant/components/melcloud/climate.py
@@ -152,6 +152,14 @@ class AtaDeviceClimate(MelCloudClimate):
         self._attr_unique_id = f"{self.api.device.serial}-{self.api.device.mac}"
         self._attr_device_info = self.api.device_info
 
+    async def async_added_to_hass(self) -> None:
+        """When entity is added to hass."""
+        await super().async_added_to_hass()
+
+        # We can only check for vane_horizontal once we fetch the device data from the cloud
+        if self._device.vane_horizontal:
+            self._attr_supported_features |= ClimateEntityFeature.SWING_HORIZONTAL_MODE
+
     @property
     def extra_state_attributes(self) -> dict[str, Any] | None:
         """Return the optional state attributes with device specific additions."""
@@ -164,7 +172,6 @@ class AtaDeviceClimate(MelCloudClimate):
                     ATTR_VANE_HORIZONTAL_POSITIONS: self._device.vane_horizontal_positions,
                 }
             )
-            self._attr_supported_features |= ClimateEntityFeature.SWING_HORIZONTAL_MODE
 
         if vane_vertical := self._device.vane_vertical:
             attr.update(

--- a/homeassistant/components/melcloud/climate.py
+++ b/homeassistant/components/melcloud/climate.py
@@ -284,9 +284,9 @@ class AtaDeviceClimate(MelCloudClimate):
         """Set vertical vane position or mode."""
         await self.async_set_vane_vertical(swing_mode)
 
-    async def async_set_swing_horizontal_mode(self, swing_mode: str) -> None:
+    async def async_set_swing_horizontal_mode(self, swing_horizontal_mode: str) -> None:
         """Set vertical vane position or mode."""
-        await self.async_set_vane_horizontal(swing_mode)
+        await self.async_set_vane_horizontal(swing_horizontal_mode)
 
     @property
     def swing_modes(self) -> list[str] | None:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This commit allows users that have HVACs devices managed with melcloud to use the standard climate card to set the horizontal vane mode.

This just implements the standard methods added recently for horizontal vane support (as explained in https://developers.home-assistant.io/blog/2024/12/03/climate-horizontal-swing/ which was very helpful in knowing of this new support) in melcloud.



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

I tested this in my own melcloud devices.

In the future it would be interesting to remove the custom vane support in the melcloud integration and only use the standard services/methods but this would break existing automations so IMO it should be deprecated and cleaned up in a separate PR to be merged in a future version. In the meantime, it doesn't hurt to have both ways to access the same states. If someone points me to some documentation on how to deprecate services, I'll be glad to submit a PR too for that.




- This PR fixes or closes issue: fixes #123938
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
