### PR TITLE
Mark non-installed EnergyFlip sensors as unavailable / don't report errors

### DIFF
--- a/homeassistant/components/huisbaasje/__init__.py
+++ b/homeassistant/components/huisbaasje/__init__.py
@@ -136,10 +136,6 @@ def _get_cumulative_value(
             and current_measurements[source_type][period_type] is not None
         ):
             return current_measurements[source_type][period_type]["value"]
-    else:
-        _LOGGER.error(
-            "Source type %s not present in %s", source_type, current_measurements
-        )
     return None
 
 
@@ -150,8 +146,4 @@ def _get_measurement_rate(current_measurements: dict, source_type: str):
             and current_measurements[source_type]["measurement"] is not None
         ):
             return current_measurements[source_type]["measurement"]["rate"]
-    else:
-        _LOGGER.error(
-            "Source type %s not present in %s", source_type, current_measurements
-        )
     return None

--- a/homeassistant/components/huisbaasje/sensor.py
+++ b/homeassistant/components/huisbaasje/sensor.py
@@ -230,6 +230,9 @@ async def async_setup_entry(
     async_add_entities(
         EnergyFlipSensor(coordinator, user_id, description)
         for description in SENSORS_INFO
+        if description.key in coordinator.data
+        and description.sensor_type in coordinator.data[description.key]
+        and coordinator.data[description.key][description.sensor_type] is not None
     )
 
 
@@ -274,5 +277,6 @@ class EnergyFlipSensor(
             super().available
             and self.coordinator.data
             and self._source_type in self.coordinator.data
-            and self.coordinator.data[self._source_type]
+            and self._sensor_type in self.coordinator.data[self._source_type]
+            and self.coordinator.data[self._source_type][self._sensor_type] is not None
         )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently the component energyflip reports errors when the API response does not contain certain fields. In my case, those fields are expected to be missing as I only have one hardware sensor (gas) installed, but not the other (electricity). As a result, my logs are spammed every few seconds, see #135204. With this PR only the sensors that are being reported through the API are marked as available / reported.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #135204
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass** _I suppose they succeed?_
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`) _(I think so)_
- [ ] Tests have been added to verify that the new code works. _Not sure what to do here, suggestions welcome._

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
