### PR TITLE
Make Reolink reboot button always available

### DIFF
--- a/homeassistant/components/reolink/button.py
+++ b/homeassistant/components/reolink/button.py
@@ -135,9 +135,10 @@ BUTTON_ENTITIES = (
     ),
 )
 
-AVAILABILITY_HOST_BUTTON_ENTITIES = (
+HOST_BUTTON_ENTITIES = (
     ReolinkHostButtonEntityDescription(
         key="reboot",
+        always_available=True,
         device_class=ButtonDeviceClass.RESTART,
         entity_category=EntityCategory.CONFIG,
         entity_registry_enabled_default=False,
@@ -155,15 +156,15 @@ async def async_setup_entry(
     """Set up a Reolink button entities."""
     reolink_data: ReolinkData = config_entry.runtime_data
 
-    entities: list[ReolinkButtonEntity | ReolinkAvailabilityHostButtonEntity] = [
+    entities: list[ReolinkButtonEntity | ReolinkHostButtonEntity] = [
         ReolinkButtonEntity(reolink_data, channel, entity_description)
         for entity_description in BUTTON_ENTITIES
         for channel in reolink_data.host.api.channels
         if entity_description.supported(reolink_data.host.api, channel)
     ]
     entities.extend(
-        ReolinkAvailabilityHostButtonEntity(reolink_data, entity_description)
-        for entity_description in AVAILABILITY_HOST_BUTTON_ENTITIES
+        ReolinkHostButtonEntity(reolink_data, entity_description)
+        for entity_description in HOST_BUTTON_ENTITIES
         if entity_description.supported(reolink_data.host.api)
     )
     async_add_entities(entities)
@@ -235,12 +236,3 @@ class ReolinkHostButtonEntity(ReolinkHostCoordinatorEntity, ButtonEntity):
     async def async_press(self) -> None:
         """Execute the button action."""
         await self.entity_description.method(self._host.api)
-
-
-class ReolinkAvailabilityHostButtonEntity(ReolinkHostButtonEntity):
-    """Button entity class for Reolink hosts which will be available even if API is unavailable."""
-
-    @property
-    def available(self) -> bool:
-        """Return True if entity is available."""
-        return True

--- a/homeassistant/components/reolink/button.py
+++ b/homeassistant/components/reolink/button.py
@@ -135,7 +135,7 @@ BUTTON_ENTITIES = (
     ),
 )
 
-HOST_BUTTON_ENTITIES = (
+AVAILABILITY_HOST_BUTTON_ENTITIES = (
     ReolinkHostButtonEntityDescription(
         key="reboot",
         device_class=ButtonDeviceClass.RESTART,
@@ -155,15 +155,15 @@ async def async_setup_entry(
     """Set up a Reolink button entities."""
     reolink_data: ReolinkData = config_entry.runtime_data
 
-    entities: list[ReolinkButtonEntity | ReolinkHostButtonEntity] = [
+    entities: list[ReolinkButtonEntity | ReolinkAvailabilityHostButtonEntity] = [
         ReolinkButtonEntity(reolink_data, channel, entity_description)
         for entity_description in BUTTON_ENTITIES
         for channel in reolink_data.host.api.channels
         if entity_description.supported(reolink_data.host.api, channel)
     ]
     entities.extend(
-        ReolinkHostButtonEntity(reolink_data, entity_description)
-        for entity_description in HOST_BUTTON_ENTITIES
+        ReolinkAvailabilityHostButtonEntity(reolink_data, entity_description)
+        for entity_description in AVAILABILITY_HOST_BUTTON_ENTITIES
         if entity_description.supported(reolink_data.host.api)
     )
     async_add_entities(entities)
@@ -218,7 +218,7 @@ class ReolinkButtonEntity(ReolinkChannelCoordinatorEntity, ButtonEntity):
 
 
 class ReolinkHostButtonEntity(ReolinkHostCoordinatorEntity, ButtonEntity):
-    """Base button entity class for Reolink IP cameras."""
+    """Base button entity class for Reolink hosts."""
 
     entity_description: ReolinkHostButtonEntityDescription
 
@@ -235,3 +235,12 @@ class ReolinkHostButtonEntity(ReolinkHostCoordinatorEntity, ButtonEntity):
     async def async_press(self) -> None:
         """Execute the button action."""
         await self.entity_description.method(self._host.api)
+
+
+class ReolinkAvailabilityHostButtonEntity(ReolinkHostButtonEntity):
+    """Button entity class for Reolink hosts which will be available even if API is unavailable."""
+
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        return True

--- a/homeassistant/components/reolink/entity.py
+++ b/homeassistant/components/reolink/entity.py
@@ -25,6 +25,7 @@ class ReolinkEntityDescription(EntityDescription):
 
     cmd_key: str | None = None
     cmd_id: int | None = None
+    always_available: bool = False
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -92,6 +93,9 @@ class ReolinkHostCoordinatorEntity(CoordinatorEntity[DataUpdateCoordinator[None]
     @property
     def available(self) -> bool:
         """Return True if entity is available."""
+        if self.entity_description.always_available:
+            return True
+
         return (
             self._host.api.session_active
             and not self._host.api.baichuan.privacy_mode()

--- a/homeassistant/components/reolink/switch.py
+++ b/homeassistant/components/reolink/switch.py
@@ -206,11 +206,9 @@ SWITCH_ENTITIES = (
         value=lambda api, ch: api.pir_reduce_alarm(ch) is True,
         method=lambda api, ch, value: api.set_pir(ch, reduce_alarm=value),
     ),
-)
-
-AVAILABILITY_SWITCH_ENTITIES = (
     ReolinkSwitchEntityDescription(
         key="privacy_mode",
+        always_available=True,
         translation_key="privacy_mode",
         entity_category=EntityCategory.CONFIG,
         supported=lambda api, ch: api.supported(ch, "privacy_mode"),
@@ -355,12 +353,6 @@ async def async_setup_entry(
         for entity_description in CHIME_SWITCH_ENTITIES
         for chime in reolink_data.host.api.chime_list
     )
-    entities.extend(
-        ReolinkAvailabilitySwitchEntity(reolink_data, channel, entity_description)
-        for entity_description in AVAILABILITY_SWITCH_ENTITIES
-        for channel in reolink_data.host.api.channels
-        if entity_description.supported(reolink_data.host.api, channel)
-    )
 
     # Can be removed in HA 2025.4.0
     depricated_dict = {}
@@ -424,15 +416,6 @@ class ReolinkSwitchEntity(ReolinkChannelCoordinatorEntity, SwitchEntity):
         """Turn the entity off."""
         await self.entity_description.method(self._host.api, self._channel, False)
         self.async_write_ha_state()
-
-
-class ReolinkAvailabilitySwitchEntity(ReolinkSwitchEntity):
-    """Switch entity class for Reolink IP cameras which will be available even if API is unavailable."""
-
-    @property
-    def available(self) -> bool:
-        """Return True if entity is available."""
-        return self._host.api.camera_online(self._channel)
 
 
 class ReolinkNVRSwitchEntity(ReolinkHostCoordinatorEntity, SwitchEntity):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Make the Reolink reboot button always available.
Even if the HTTP API has crashed and is not working anymore causing all entities to become unavailable, the reboot button may still work: there is a fallback to the baichaun protocol over port 9000 which will still work even if the HTTP API has crashed.
Therefore do not mark the reboot button as unavailable.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
