### PR TITLE
Add trigger_variables to template trigger 'for' field

### DIFF
--- a/homeassistant/components/template/trigger.py
+++ b/homeassistant/components/template/trigger.py
@@ -48,7 +48,7 @@ async def async_attach_trigger(
 ) -> CALLBACK_TYPE:
     """Listen for state changes based on configuration."""
     trigger_data = trigger_info["trigger_data"]
-    _variables = trigger_info["variables"] or {}
+    variables = trigger_info["variables"] or {}
     value_template: Template = config[CONF_VALUE_TEMPLATE]
     time_delta = config.get(CONF_FOR)
     delay_cancel = None
@@ -57,7 +57,7 @@ async def async_attach_trigger(
 
     # Arm at setup if the template is already false.
     try:
-        if not result_as_boolean(value_template.async_render(_variables)):
+        if not result_as_boolean(value_template.async_render(variables)):
             armed = True
     except exceptions.TemplateError as ex:
         _LOGGER.warning(
@@ -134,11 +134,11 @@ async def async_attach_trigger(
             return
 
         data = {"trigger": template_variables}
-        variables = {**_variables, **data}
+        period_variables = {**variables, **data}
 
         try:
             period: timedelta = cv.positive_time_period(
-                template.render_complex(time_delta, variables)
+                template.render_complex(time_delta, period_variables)
             )
         except (exceptions.TemplateError, vol.Invalid) as ex:
             _LOGGER.error(
@@ -152,7 +152,7 @@ async def async_attach_trigger(
 
     info = async_track_template_result(
         hass,
-        [TrackTemplate(value_template, _variables)],
+        [TrackTemplate(value_template, variables)],
         template_listener,
     )
     unsub = info.async_remove

--- a/homeassistant/components/template/trigger.py
+++ b/homeassistant/components/template/trigger.py
@@ -48,6 +48,7 @@ async def async_attach_trigger(
 ) -> CALLBACK_TYPE:
     """Listen for state changes based on configuration."""
     trigger_data = trigger_info["trigger_data"]
+    _variables = trigger_info["variables"] or {}
     value_template: Template = config[CONF_VALUE_TEMPLATE]
     time_delta = config.get(CONF_FOR)
     delay_cancel = None
@@ -56,9 +57,7 @@ async def async_attach_trigger(
 
     # Arm at setup if the template is already false.
     try:
-        if not result_as_boolean(
-            value_template.async_render(trigger_info["variables"])
-        ):
+        if not result_as_boolean(value_template.async_render(_variables)):
             armed = True
     except exceptions.TemplateError as ex:
         _LOGGER.warning(
@@ -134,9 +133,12 @@ async def async_attach_trigger(
             call_action()
             return
 
+        data = {"trigger": template_variables}
+        variables = {**_variables, **data}
+
         try:
             period: timedelta = cv.positive_time_period(
-                template.render_complex(time_delta, {"trigger": template_variables})
+                template.render_complex(time_delta, variables)
             )
         except (exceptions.TemplateError, vol.Invalid) as ex:
             _LOGGER.error(
@@ -150,7 +152,7 @@ async def async_attach_trigger(
 
     info = async_track_template_result(
         hass,
-        [TrackTemplate(value_template, trigger_info["variables"])],
+        [TrackTemplate(value_template, _variables)],
         template_listener,
     )
     unsub = info.async_remove

--- a/tests/components/template/test_trigger.py
+++ b/tests/components/template/test_trigger.py
@@ -794,6 +794,39 @@ async def test_if_fires_on_change_with_for_template_3(
     [
         {
             automation.DOMAIN: {
+                "trigger_variables": {
+                    "seconds": 5,
+                    "entity": "test.entity",
+                },
+                "trigger": {
+                    "platform": "template",
+                    "value_template": "{{ is_state(entity, 'world') }}",
+                    "for": "{{ seconds }}",
+                },
+                "action": {"service": "test.automation"},
+            }
+        },
+    ],
+)
+@pytest.mark.usefixtures("start_ha")
+async def test_if_fires_on_change_with_for_template_4(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
+    """Test for firing on change with for template."""
+    hass.states.async_set("test.entity", "world")
+    await hass.async_block_till_done()
+    assert len(calls) == 0
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=10))
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+
+
+@pytest.mark.parametrize(("count", "domain"), [(1, automation.DOMAIN)])
+@pytest.mark.parametrize(
+    "config",
+    [
+        {
+            automation.DOMAIN: {
                 "trigger": {
                     "platform": "template",
                     "value_template": "{{ is_state('test.entity', 'world') }}",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Allows `trigger_variables` to be passed into template trigger's `for` templates.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes # https://github.com/home-assistant/core/issues/120191
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
