### PR TITLE
Migrate usb to use aiousbwatcher

### DIFF
--- a/homeassistant/components/keyboard_remote/manifest.json
+++ b/homeassistant/components/keyboard_remote/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_push",
   "loggers": ["aionotify", "evdev"],
   "quality_scale": "legacy",
-  "requirements": ["evdev==1.6.1", "asyncinotify==4.0.2"]
+  "requirements": ["evdev==1.6.1", "asyncinotify==4.2.0"]
 }

--- a/homeassistant/components/usb/__init__.py
+++ b/homeassistant/components/usb/__init__.py
@@ -315,7 +315,10 @@ class USBDiscovery:
         self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _stop_polling)
 
     async def _async_start_aiousbwatcher(self) -> None:
-        """Start monitoring hardware with aiousbwatcher. Returns True if successful."""
+        """Start monitoring hardware with aiousbwatcher.
+
+        Returns True if successful.
+        """
 
         @hass_callback
         def _usb_change_callback() -> None:

--- a/homeassistant/components/usb/__init__.py
+++ b/homeassistant/components/usb/__init__.py
@@ -296,8 +296,6 @@ class USBDiscovery:
                 ex,
             )
             self._async_start_monitor_polling()
-        except Exception:
-            _LOGGER.exception("Failed to start aiousbwatcher")
 
     @hass_callback
     def _async_start_monitor_polling(self) -> None:

--- a/homeassistant/components/usb/__init__.py
+++ b/homeassistant/components/usb/__init__.py
@@ -427,11 +427,13 @@ class USBDiscovery:
 
     async def _async_process_ports(self, ports: Sequence[ListPortInfo]) -> None:
         """Process each discovered port."""
+        _LOGGER.debug("Processing ports: %r", ports)
         usb_devices = {
             usb_device_from_port(port)
             for port in ports
             if port.vid is not None or port.pid is not None
         }
+        _LOGGER.debug("USB devices: %r", usb_devices)
 
         # CP2102N chips create *two* serial ports on macOS: `/dev/cu.usbserial-` and
         # `/dev/cu.SLAB_USBtoUART*`. The former does not work and we should ignore them.

--- a/homeassistant/components/usb/manifest.json
+++ b/homeassistant/components/usb/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "system",
   "iot_class": "local_push",
   "quality_scale": "internal",
-  "requirements": ["pyudev==0.24.1", "pyserial==3.5"]
+  "requirements": ["aiousbwatcher==1.1.0", "pyserial==3.5"]
 }

--- a/homeassistant/components/usb/manifest.json
+++ b/homeassistant/components/usb/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "system",
   "iot_class": "local_push",
   "quality_scale": "internal",
-  "requirements": ["aiousbwatcher==1.1.0", "pyserial==3.5"]
+  "requirements": ["aiousbwatcher==1.1.1", "pyserial==3.5"]
 }

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -8,7 +8,7 @@ aiohttp-asyncmdnsresolver==0.0.1
 aiohttp-fast-zlib==0.2.0
 aiohttp==3.11.11
 aiohttp_cors==0.7.0
-aiousbwatcher==1.1.0
+aiousbwatcher==1.1.1
 aiozoneinfo==0.2.1
 astral==2.2
 async-interrupt==1.2.0

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -8,6 +8,7 @@ aiohttp-asyncmdnsresolver==0.0.1
 aiohttp-fast-zlib==0.2.0
 aiohttp==3.11.11
 aiohttp_cors==0.7.0
+aiousbwatcher==1.1.0
 aiozoneinfo==0.2.1
 astral==2.2
 async-interrupt==1.2.0
@@ -57,7 +58,6 @@ pyserial==3.5
 pyspeex-noise==1.0.2
 python-slugify==8.0.4
 PyTurboJPEG==1.7.5
-pyudev==0.24.1
 PyYAML==6.0.2
 requests==2.32.3
 securetar==2025.1.4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -403,6 +403,9 @@ aiotractive==0.6.0
 # homeassistant.components.unifi
 aiounifi==81
 
+# homeassistant.components.usb
+aiousbwatcher==1.1.0
+
 # homeassistant.components.vlc_telnet
 aiovlc==0.5.1
 
@@ -2490,9 +2493,6 @@ pytrafikverket==1.1.1
 
 # homeassistant.components.v2c
 pytrydan==0.8.0
-
-# homeassistant.components.usb
-pyudev==0.24.1
 
 # homeassistant.components.uptimerobot
 pyuptimerobot==22.2.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -514,7 +514,7 @@ async-upnp-client==0.43.0
 asyncarve==0.1.1
 
 # homeassistant.components.keyboard_remote
-asyncinotify==4.0.2
+asyncinotify==4.2.0
 
 # homeassistant.components.supla
 asyncpysupla==0.0.5

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -404,7 +404,7 @@ aiotractive==0.6.0
 aiounifi==81
 
 # homeassistant.components.usb
-aiousbwatcher==1.1.0
+aiousbwatcher==1.1.1
 
 # homeassistant.components.vlc_telnet
 aiovlc==0.5.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -386,7 +386,7 @@ aiotractive==0.6.0
 aiounifi==81
 
 # homeassistant.components.usb
-aiousbwatcher==1.1.0
+aiousbwatcher==1.1.1
 
 # homeassistant.components.vlc_telnet
 aiovlc==0.5.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -385,6 +385,9 @@ aiotractive==0.6.0
 # homeassistant.components.unifi
 aiounifi==81
 
+# homeassistant.components.usb
+aiousbwatcher==1.1.0
+
 # homeassistant.components.vlc_telnet
 aiovlc==0.5.1
 
@@ -2014,9 +2017,6 @@ pytrafikverket==1.1.1
 
 # homeassistant.components.v2c
 pytrydan==0.8.0
-
-# homeassistant.components.usb
-pyudev==0.24.1
 
 # homeassistant.components.uptimerobot
 pyuptimerobot==22.2.0

--- a/tests/components/usb/test_init.py
+++ b/tests/components/usb/test_init.py
@@ -33,48 +33,8 @@ def aiousbwatcher_no_inotify():
         yield
 
 
-@pytest.fixture(name="operating_system")
-def mock_operating_system():
-    """Mock running Home Assistant Operating system."""
-    with patch(
-        "homeassistant.components.usb.system_info.async_get_system_info",
-        return_value={
-            "hassio": True,
-            "docker": True,
-        },
-    ):
-        yield
-
-
-@pytest.fixture(name="docker")
-def mock_docker():
-    """Mock running Home Assistant in docker container."""
-    with patch(
-        "homeassistant.components.usb.system_info.async_get_system_info",
-        return_value={
-            "hassio": False,
-            "docker": True,
-        },
-    ):
-        yield
-
-
-@pytest.fixture(name="venv")
-def mock_venv():
-    """Mock running Home Assistant in a venv container."""
-    with patch(
-        "homeassistant.components.usb.system_info.async_get_system_info",
-        return_value={
-            "hassio": False,
-            "docker": False,
-            "virtualenv": True,
-        },
-    ):
-        yield
-
-
 async def test_aiousbwatcher_discovery(
-    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, venv
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
     """Test that aiousbwatcher can discover a device without raising an exception."""
     new_usb = [{"domain": "test1", "vid": "3039"}, {"domain": "test2", "vid": "0FA0"}]
@@ -142,7 +102,7 @@ async def test_aiousbwatcher_discovery(
 
 @pytest.mark.usefixtures("aiousbwatcher_no_inotify")
 async def test_polling_discovery(
-    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, venv
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
     """Test that polling can discover a device without raising an exception."""
     new_usb = [{"domain": "test1", "vid": "3039"}]
@@ -197,9 +157,7 @@ async def test_polling_discovery(
 
 
 @pytest.mark.usefixtures("aiousbwatcher_no_inotify")
-async def test_removal_by_aiousbwatcher_before_started(
-    hass: HomeAssistant, operating_system
-) -> None:
+async def test_removal_by_aiousbwatcher_before_started(hass: HomeAssistant) -> None:
     """Test a device is removed by the aiousbwatcher before started."""
     new_usb = [{"domain": "test1", "vid": "3039", "pid": "3039"}]
 
@@ -739,7 +697,7 @@ async def test_non_matching_discovered_by_scanner_after_started(
 
 
 async def test_aiousbwatcher_on_wsl_fallback_without_throwing_exception(
-    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, venv
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
     """Test that aiousbwatcher on WSL failure results in fallback to scanning without raising an exception."""
     new_usb = [{"domain": "test1", "vid": "3039"}]
@@ -774,10 +732,8 @@ async def test_aiousbwatcher_on_wsl_fallback_without_throwing_exception(
     assert mock_config_flow.mock_calls[0][1][0] == "test1"
 
 
-async def test_discovered_by_aiousbwatcher_before_started_on_docker(
-    hass: HomeAssistant, docker
-) -> None:
-    """Test a device is discovered since aiousbwatcher is now running on bare docker."""
+async def test_discovered_by_aiousbwatcher_before_started(hass: HomeAssistant) -> None:
+    """Test a device is discovered since aiousbwatcher is now running."""
     new_usb = [{"domain": "test1", "vid": "3039", "pid": "3039"}]
 
     mock_comports = [


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
[aiousbwatcher](https://github.com/bluetooth-devices/aiousbwatcher) uses inotify on `/dev/bus/usb` to look for devices being added or removed which works on a lot more systems, and inside docker.  This should allow most container installs that don't have supervisor to discover new USB devices almost immediately.

Requires bumping asyncinotify to 4.2.0: https://github.com/ProCern/asyncinotify/compare/v4.0.2...v4.2.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
