### PR TITLE
Add config entry load/unload tests for LetPot

### DIFF
--- a/tests/components/letpot/__init__.py
+++ b/tests/components/letpot/__init__.py
@@ -1,6 +1,8 @@
 """Tests for the LetPot integration."""
 
-from letpot.models import AuthenticationInfo
+import datetime
+
+from letpot.models import AuthenticationInfo, LetPotDeviceStatus
 
 AUTHENTICATION = AuthenticationInfo(
     access_token="access_token",
@@ -9,4 +11,20 @@ AUTHENTICATION = AuthenticationInfo(
     refresh_token_expires=0,
     user_id="a1b2c3d4e5f6a1b2c3d4e5f6",
     email="email@example.com",
+)
+
+STATUS = LetPotDeviceStatus(
+    light_brightness=500,
+    light_mode=1,
+    light_schedule_end=datetime.time(12, 10),
+    light_schedule_start=datetime.time(12, 0),
+    online=True,
+    plant_days=1,
+    pump_mode=1,
+    pump_nutrient=None,
+    pump_status=0,
+    raw=[77, 0, 1, 18, 98, 1, 0, 0, 1, 1, 1, 0, 1, 12, 0, 12, 10, 1, 244, 0, 0, 0],
+    system_on=True,
+    system_sound=False,
+    system_state=0,
 )

--- a/tests/components/letpot/__init__.py
+++ b/tests/components/letpot/__init__.py
@@ -4,11 +4,23 @@ import datetime
 
 from letpot.models import AuthenticationInfo, LetPotDeviceStatus
 
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+async def setup_integration(hass: HomeAssistant, config_entry: MockConfigEntry) -> None:
+    """Fixture for setting up the component."""
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+
 AUTHENTICATION = AuthenticationInfo(
     access_token="access_token",
-    access_token_expires=0,
+    access_token_expires=1738368000,  # 2025-02-01 00:00:00 GMT
     refresh_token="refresh_token",
-    refresh_token_expires=0,
+    refresh_token_expires=1740441600,  # 2025-02-25 00:00:00 GMT
     user_id="a1b2c3d4e5f6a1b2c3d4e5f6",
     email="email@example.com",
 )

--- a/tests/components/letpot/conftest.py
+++ b/tests/components/letpot/conftest.py
@@ -3,6 +3,7 @@
 from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
+from letpot.models import LetPotDevice
 import pytest
 
 from homeassistant.components.letpot.const import (
@@ -26,6 +27,34 @@ def mock_setup_entry() -> Generator[AsyncMock]:
         "homeassistant.components.letpot.async_setup_entry", return_value=True
     ) as mock_setup_entry:
         yield mock_setup_entry
+
+
+@pytest.fixture
+def mock_client() -> Generator[AsyncMock]:
+    """Mock a LetPotClient."""
+    with (
+        patch(
+            "homeassistant.components.letpot.LetPotClient",
+            autospec=True,
+        ) as mock_client,
+        patch(
+            "homeassistant.components.letpot.config_flow.LetPotClient",
+            new=mock_client,
+        ),
+    ):
+        client = mock_client.return_value
+        client.login.return_value = AUTHENTICATION
+        client.refresh_token.return_value = AUTHENTICATION
+        client.get_devices.return_value = [
+            LetPotDevice(
+                serial_number="LPH21ABCD",
+                name="Garden",
+                device_type="LPH21",
+                is_online=True,
+                is_remote=False,
+            )
+        ]
+        yield client
 
 
 @pytest.fixture

--- a/tests/components/letpot/conftest.py
+++ b/tests/components/letpot/conftest.py
@@ -65,6 +65,8 @@ def mock_device_client() -> Generator[AsyncMock]:
         autospec=True,
     ) as mock_device_client:
         device_client = mock_device_client.return_value
+        device_client.device_model_code = "LPH21"
+        device_client.device_model_name = "LetPot Air"
         device_client.get_current_status.return_value = STATUS
         device_client.last_status.return_value = STATUS
         yield device_client

--- a/tests/components/letpot/conftest.py
+++ b/tests/components/letpot/conftest.py
@@ -15,7 +15,7 @@ from homeassistant.components.letpot.const import (
 )
 from homeassistant.const import CONF_ACCESS_TOKEN, CONF_EMAIL
 
-from . import AUTHENTICATION
+from . import AUTHENTICATION, STATUS
 
 from tests.common import MockConfigEntry
 
@@ -55,6 +55,19 @@ def mock_client() -> Generator[AsyncMock]:
             )
         ]
         yield client
+
+
+@pytest.fixture
+def mock_device_client() -> Generator[AsyncMock]:
+    """Mock a LetPotDeviceClient."""
+    with patch(
+        "homeassistant.components.letpot.coordinator.LetPotDeviceClient",
+        autospec=True,
+    ) as mock_device_client:
+        device_client = mock_device_client.return_value
+        device_client.get_current_status.return_value = STATUS
+        device_client.last_status.return_value = STATUS
+        yield device_client
 
 
 @pytest.fixture

--- a/tests/components/letpot/test_config_flow.py
+++ b/tests/components/letpot/test_config_flow.py
@@ -56,7 +56,6 @@ async def test_full_flow(
             CONF_PASSWORD: "test-password",
         },
     )
-    await hass.async_block_till_done()
 
     _assert_result_success(result)
     assert len(mock_setup_entry.mock_calls) == 1
@@ -103,7 +102,6 @@ async def test_flow_exceptions(
             CONF_PASSWORD: "test-password",
         },
     )
-    await hass.async_block_till_done()
 
     _assert_result_success(result)
     assert len(mock_setup_entry.mock_calls) == 1
@@ -133,7 +131,6 @@ async def test_flow_duplicate(
             CONF_PASSWORD: "test-password",
         },
     )
-    await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
@@ -163,7 +160,6 @@ async def test_reauth_flow(
         result["flow_id"],
         {CONF_PASSWORD: "new-password"},
     )
-    await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reauth_successful"
@@ -222,7 +218,6 @@ async def test_reauth_exceptions(
         result["flow_id"],
         {CONF_PASSWORD: "new-password"},
     )
-    await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reauth_successful"
@@ -259,7 +254,6 @@ async def test_reauth_different_user_id_new(
         result["flow_id"],
         {CONF_PASSWORD: "new-password"},
     )
-    await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reauth_successful"
@@ -299,7 +293,6 @@ async def test_reauth_different_user_id_existing(
         result["flow_id"],
         {CONF_PASSWORD: "new-password"},
     )
-    await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"

--- a/tests/components/letpot/test_config_flow.py
+++ b/tests/components/letpot/test_config_flow.py
@@ -2,7 +2,7 @@
 
 import dataclasses
 from typing import Any
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock
 
 from letpot.exceptions import LetPotAuthenticationException, LetPotConnectionException
 import pytest
@@ -39,7 +39,9 @@ def _assert_result_success(result: Any) -> None:
     assert result["result"].unique_id == AUTHENTICATION.user_id
 
 
-async def test_full_flow(hass: HomeAssistant, mock_setup_entry: AsyncMock) -> None:
+async def test_full_flow(
+    hass: HomeAssistant, mock_client: AsyncMock, mock_setup_entry: AsyncMock
+) -> None:
     """Test full flow with success."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
@@ -47,18 +49,14 @@ async def test_full_flow(hass: HomeAssistant, mock_setup_entry: AsyncMock) -> No
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {}
 
-    with patch(
-        "homeassistant.components.letpot.config_flow.LetPotClient.login",
-        return_value=AUTHENTICATION,
-    ):
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {
-                CONF_EMAIL: "email@example.com",
-                CONF_PASSWORD: "test-password",
-            },
-        )
-        await hass.async_block_till_done()
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_EMAIL: "email@example.com",
+            CONF_PASSWORD: "test-password",
+        },
+    )
+    await hass.async_block_till_done()
 
     _assert_result_success(result)
     assert len(mock_setup_entry.mock_calls) == 1
@@ -74,6 +72,7 @@ async def test_full_flow(hass: HomeAssistant, mock_setup_entry: AsyncMock) -> No
 )
 async def test_flow_exceptions(
     hass: HomeAssistant,
+    mock_client: AsyncMock,
     mock_setup_entry: AsyncMock,
     exception: Exception,
     error: str,
@@ -83,41 +82,38 @@ async def test_flow_exceptions(
         DOMAIN, context={"source": SOURCE_USER}
     )
 
-    with patch(
-        "homeassistant.components.letpot.config_flow.LetPotClient.login",
-        side_effect=exception,
-    ):
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {
-                CONF_EMAIL: "email@example.com",
-                CONF_PASSWORD: "test-password",
-            },
-        )
+    mock_client.login.side_effect = exception
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_EMAIL: "email@example.com",
+            CONF_PASSWORD: "test-password",
+        },
+    )
 
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": error}
 
     # Retry to show recovery.
-    with patch(
-        "homeassistant.components.letpot.config_flow.LetPotClient.login",
-        return_value=AUTHENTICATION,
-    ):
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {
-                CONF_EMAIL: "email@example.com",
-                CONF_PASSWORD: "test-password",
-            },
-        )
-        await hass.async_block_till_done()
+    mock_client.login.side_effect = None
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_EMAIL: "email@example.com",
+            CONF_PASSWORD: "test-password",
+        },
+    )
+    await hass.async_block_till_done()
 
     _assert_result_success(result)
     assert len(mock_setup_entry.mock_calls) == 1
 
 
 async def test_flow_duplicate(
-    hass: HomeAssistant, mock_setup_entry: AsyncMock, mock_config_entry: MockConfigEntry
+    hass: HomeAssistant,
+    mock_client: AsyncMock,
+    mock_setup_entry: AsyncMock,
+    mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test flow aborts when trying to add a previously added account."""
     mock_config_entry.add_to_hass(hass)
@@ -130,18 +126,14 @@ async def test_flow_duplicate(
     assert result["step_id"] == "user"
     assert result["errors"] == {}
 
-    with patch(
-        "homeassistant.components.letpot.config_flow.LetPotClient.login",
-        return_value=AUTHENTICATION,
-    ):
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {
-                CONF_EMAIL: "email@example.com",
-                CONF_PASSWORD: "test-password",
-            },
-        )
-        await hass.async_block_till_done()
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_EMAIL: "email@example.com",
+            CONF_PASSWORD: "test-password",
+        },
+    )
+    await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
@@ -149,7 +141,10 @@ async def test_flow_duplicate(
 
 
 async def test_reauth_flow(
-    hass: HomeAssistant, mock_setup_entry: AsyncMock, mock_config_entry: MockConfigEntry
+    hass: HomeAssistant,
+    mock_client: AsyncMock,
+    mock_setup_entry: AsyncMock,
+    mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test reauth flow with success."""
     mock_config_entry.add_to_hass(hass)
@@ -163,15 +158,12 @@ async def test_reauth_flow(
         access_token="new_access_token",
         refresh_token="new_refresh_token",
     )
-    with patch(
-        "homeassistant.components.letpot.config_flow.LetPotClient.login",
-        return_value=updated_auth,
-    ):
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {CONF_PASSWORD: "new-password"},
-        )
-        await hass.async_block_till_done()
+    mock_client.login.return_value = updated_auth
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_PASSWORD: "new-password"},
+    )
+    await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reauth_successful"
@@ -196,6 +188,7 @@ async def test_reauth_flow(
 )
 async def test_reauth_exceptions(
     hass: HomeAssistant,
+    mock_client: AsyncMock,
     mock_setup_entry: AsyncMock,
     mock_config_entry: MockConfigEntry,
     exception: Exception,
@@ -208,14 +201,11 @@ async def test_reauth_exceptions(
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "reauth_confirm"
 
-    with patch(
-        "homeassistant.components.letpot.config_flow.LetPotClient.login",
-        side_effect=exception,
-    ):
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {CONF_PASSWORD: "new-password"},
-        )
+    mock_client.login.side_effect = exception
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_PASSWORD: "new-password"},
+    )
 
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": error}
@@ -226,15 +216,13 @@ async def test_reauth_exceptions(
         access_token="new_access_token",
         refresh_token="new_refresh_token",
     )
-    with patch(
-        "homeassistant.components.letpot.config_flow.LetPotClient.login",
-        return_value=updated_auth,
-    ):
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {CONF_PASSWORD: "new-password"},
-        )
-        await hass.async_block_till_done()
+    mock_client.login.return_value = updated_auth
+    mock_client.login.side_effect = None
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_PASSWORD: "new-password"},
+    )
+    await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reauth_successful"
@@ -250,7 +238,10 @@ async def test_reauth_exceptions(
 
 
 async def test_reauth_different_user_id_new(
-    hass: HomeAssistant, mock_setup_entry: AsyncMock, mock_config_entry: MockConfigEntry
+    hass: HomeAssistant,
+    mock_client: AsyncMock,
+    mock_setup_entry: AsyncMock,
+    mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test reauth flow with different, new user ID updating the existing entry."""
     mock_config_entry.add_to_hass(hass)
@@ -263,15 +254,12 @@ async def test_reauth_different_user_id_new(
     assert result["step_id"] == "reauth_confirm"
 
     updated_auth = dataclasses.replace(AUTHENTICATION, user_id="new_user_id")
-    with patch(
-        "homeassistant.components.letpot.config_flow.LetPotClient.login",
-        return_value=updated_auth,
-    ):
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {CONF_PASSWORD: "new-password"},
-        )
-        await hass.async_block_till_done()
+    mock_client.login.return_value = updated_auth
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_PASSWORD: "new-password"},
+    )
+    await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reauth_successful"
@@ -289,7 +277,10 @@ async def test_reauth_different_user_id_new(
 
 
 async def test_reauth_different_user_id_existing(
-    hass: HomeAssistant, mock_setup_entry: AsyncMock, mock_config_entry: MockConfigEntry
+    hass: HomeAssistant,
+    mock_client: AsyncMock,
+    mock_setup_entry: AsyncMock,
+    mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test reauth flow with different, existing user ID aborting."""
     mock_config_entry.add_to_hass(hass)
@@ -303,15 +294,12 @@ async def test_reauth_different_user_id_existing(
     assert result["step_id"] == "reauth_confirm"
 
     updated_auth = dataclasses.replace(AUTHENTICATION, user_id="other_user_id")
-    with patch(
-        "homeassistant.components.letpot.config_flow.LetPotClient.login",
-        return_value=updated_auth,
-    ):
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {CONF_PASSWORD: "new-password"},
-        )
-        await hass.async_block_till_done()
+    mock_client.login.return_value = updated_auth
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_PASSWORD: "new-password"},
+    )
+    await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"

--- a/tests/components/letpot/test_init.py
+++ b/tests/components/letpot/test_init.py
@@ -1,0 +1,33 @@
+"""Test the LetPot integration initialization and setup."""
+
+from unittest.mock import MagicMock
+
+from homeassistant.components.letpot.const import DOMAIN
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+async def test_load_unload_config_entry(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_client: MagicMock,
+    mock_device_client: MagicMock,
+) -> None:
+    """Test the LetPot configuration entry loading/unloading."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+    assert len(mock_client.get_devices.mock_calls) == 1
+    assert len(mock_device_client.subscribe.mock_calls) == 1
+    assert len(mock_device_client.get_current_status.mock_calls) == 1
+
+    await hass.config_entries.async_unload(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert not hass.data.get(DOMAIN)
+    assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
+    assert len(mock_device_client.disconnect.mock_calls) == 1

--- a/tests/components/letpot/test_init.py
+++ b/tests/components/letpot/test_init.py
@@ -2,25 +2,30 @@
 
 from unittest.mock import MagicMock
 
+from letpot.exceptions import LetPotAuthenticationException, LetPotConnectionException
+import pytest
+
 from homeassistant.components.letpot.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 
+from . import setup_integration
+
 from tests.common import MockConfigEntry
 
 
+@pytest.mark.freeze_time("2025-01-31 00:00:00")
 async def test_load_unload_config_entry(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_client: MagicMock,
     mock_device_client: MagicMock,
 ) -> None:
-    """Test the LetPot configuration entry loading/unloading."""
-    mock_config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
+    """Test config entry loading/unloading."""
+    await setup_integration(hass, mock_config_entry)
 
     assert mock_config_entry.state is ConfigEntryState.LOADED
+    assert len(mock_client.refresh_token.mock_calls) == 0  # Didn't refresh valid token
     assert len(mock_client.get_devices.mock_calls) == 1
     assert len(mock_device_client.subscribe.mock_calls) == 1
     assert len(mock_device_client.get_current_status.mock_calls) == 1
@@ -31,3 +36,63 @@ async def test_load_unload_config_entry(
     assert not hass.data.get(DOMAIN)
     assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
     assert len(mock_device_client.disconnect.mock_calls) == 1
+
+
+@pytest.mark.freeze_time("2025-02-15 00:00:00")
+async def test_refresh_authentication_on_load(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_client: MagicMock,
+    mock_device_client: MagicMock,
+) -> None:
+    """Test expired access token refreshed when needed to load config entry."""
+    await setup_integration(hass, mock_config_entry)
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+    assert len(mock_client.refresh_token.mock_calls) == 1
+
+    # Check loading continued as expected after refreshing token
+    assert len(mock_client.get_devices.mock_calls) == 1
+    assert len(mock_device_client.subscribe.mock_calls) == 1
+    assert len(mock_device_client.get_current_status.mock_calls) == 1
+
+
+@pytest.mark.freeze_time("2025-03-01 00:00:00")
+async def test_refresh_token_error_aborts(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_client: MagicMock,
+) -> None:
+    """Test expired refresh token aborting config entry loading."""
+    mock_client.refresh_token.side_effect = LetPotAuthenticationException
+
+    await setup_integration(hass, mock_config_entry)
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
+    assert len(mock_client.refresh_token.mock_calls) == 1
+    assert len(mock_client.get_devices.mock_calls) == 0
+
+
+@pytest.mark.parametrize(
+    ("exception", "config_entry_state"),
+    [
+        (LetPotAuthenticationException, ConfigEntryState.SETUP_ERROR),
+        (LetPotConnectionException, ConfigEntryState.SETUP_RETRY),
+    ],
+)
+async def test_get_devices_exceptions(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_client: MagicMock,
+    mock_device_client: MagicMock,
+    exception: Exception,
+    config_entry_state: ConfigEntryState,
+) -> None:
+    """Test config entry errors if an exception is raised when getting devices."""
+    mock_client.get_devices.side_effect = exception
+
+    await setup_integration(hass, mock_config_entry)
+
+    assert mock_config_entry.state is config_entry_state
+    assert len(mock_client.get_devices.mock_calls) == 1
+    assert len(mock_device_client.subscribe.mock_calls) == 0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Expand testing for the LetPot integration by adding tests for the integration's `__init__.py` file.

A fixture is added to mock the client, and existing tests are updated to use it (first commit), which is why the number of changed lines is relatively high.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
