### PR TITLE
Add swing support for KNX climate entities

### DIFF
--- a/homeassistant/components/knx/climate.py
+++ b/homeassistant/components/knx/climate.py
@@ -19,6 +19,8 @@ from homeassistant.components.climate import (
     FAN_LOW,
     FAN_MEDIUM,
     FAN_ON,
+    SWING_OFF,
+    SWING_ON,
     ClimateEntity,
     ClimateEntityFeature,
     HVACAction,
@@ -136,6 +138,14 @@ def _create_climate(xknx: XKNX, config: ConfigType) -> XknxClimate:
             ClimateSchema.CONF_FAN_SPEED_STATE_ADDRESS
         ),
         fan_speed_mode=config[ClimateSchema.CONF_FAN_SPEED_MODE],
+        group_address_swing=config.get(ClimateSchema.CONF_SWING_ADDRESS),
+        group_address_swing_state=config.get(ClimateSchema.CONF_SWING_STATE_ADDRESS),
+        group_address_horizontal_swing=config.get(
+            ClimateSchema.CONF_SWING_HORIZONTAL_ADDRESS
+        ),
+        group_address_horizontal_swing_state=config.get(
+            ClimateSchema.CONF_SWING_HORIZONTAL_STATE_ADDRESS
+        ),
         group_address_humidity_state=config.get(
             ClimateSchema.CONF_HUMIDITY_STATE_ADDRESS
         ),
@@ -207,6 +217,16 @@ class KNXClimate(KnxYamlEntity, ClimateEntity):
                 self._attr_fan_modes = [self.fan_zero_mode] + [
                     f"{percentage}%" for percentage in self._fan_modes_percentages[1:]
                 ]
+        if self._device.swing is not None and self._device.swing.initialized:
+            self._attr_supported_features |= ClimateEntityFeature.SWING_MODE
+            self._attr_swing_modes = [SWING_ON, SWING_OFF]
+
+        if (
+            self._device.horizontal_swing is not None
+            and self._device.horizontal_swing.initialized
+        ):
+            self._attr_supported_features |= ClimateEntityFeature.SWING_HORIZONTAL_MODE
+            self._attr_swing_horizontal_modes = [SWING_ON, SWING_OFF]
 
         self._attr_target_temperature_step = self._device.temperature_step
         self._attr_unique_id = (
@@ -224,12 +244,12 @@ class KNXClimate(KnxYamlEntity, ClimateEntity):
     @property
     def current_temperature(self) -> float | None:
         """Return the current temperature."""
-        return self._device.temperature.value
+        return self._device.temperature.value  # type: ignore[no-any-return]
 
     @property
     def target_temperature(self) -> float | None:
         """Return the temperature we try to reach."""
-        return self._device.target_temperature.value
+        return self._device.target_temperature.value  # type: ignore[no-any-return]
 
     @property
     def min_temp(self) -> float:
@@ -350,7 +370,7 @@ class KNXClimate(KnxYamlEntity, ClimateEntity):
         Requires ClimateEntityFeature.PRESET_MODE.
         """
         if self._device.mode is not None and self._device.mode.supports_operation_mode:
-            return self._device.mode.operation_mode.name.lower()
+            return self._device.mode.operation_mode.name.lower()  # type: ignore[no-any-return]
         return None
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
@@ -374,7 +394,7 @@ class KNXClimate(KnxYamlEntity, ClimateEntity):
             return self.fan_zero_mode
 
         if self._device.fan_speed_mode == FanSpeedMode.STEP:
-            return self._attr_fan_modes[fan_speed]
+            return self._attr_fan_modes[fan_speed]  # type: ignore[no-any-return]
 
         # Find the closest fan mode percentage
         closest_percentage = min(
@@ -399,10 +419,32 @@ class KNXClimate(KnxYamlEntity, ClimateEntity):
 
         await self._device.set_fan_speed(self._fan_modes_percentages[fan_mode_index])
 
+    async def async_set_swing_mode(self, swing_mode: str) -> None:
+        """Set the swing setting."""
+        await self._device.set_swing(swing_mode == SWING_ON)
+
+    async def async_set_swing_horizontal_mode(self, swing_horizontal_mode: str) -> None:
+        """Set the horizontal swing setting."""
+        await self._device.set_horizontal_swing(swing_horizontal_mode == SWING_ON)
+
+    @property
+    def swing_mode(self) -> str | None:
+        """Return the swing setting."""
+        if self._device.swing is not None:
+            return SWING_ON if self._device.swing.value else SWING_OFF
+        return None
+
+    @property
+    def swing_horizontal_mode(self) -> str | None:
+        """Return the horizontal swing setting."""
+        if self._device.horizontal_swing is not None:
+            return SWING_ON if self._device.horizontal_swing.value else SWING_OFF
+        return None
+
     @property
     def current_humidity(self) -> float | None:
         """Return the current humidity."""
-        return self._device.humidity.value
+        return self._device.humidity.value  # type: ignore[no-any-return]
 
     @property
     def extra_state_attributes(self) -> dict[str, Any] | None:

--- a/homeassistant/components/knx/climate.py
+++ b/homeassistant/components/knx/climate.py
@@ -217,14 +217,11 @@ class KNXClimate(KnxYamlEntity, ClimateEntity):
                 self._attr_fan_modes = [self.fan_zero_mode] + [
                     f"{percentage}%" for percentage in self._fan_modes_percentages[1:]
                 ]
-        if self._device.swing is not None and self._device.swing.initialized:
+        if self._device.swing.initialized:
             self._attr_supported_features |= ClimateEntityFeature.SWING_MODE
             self._attr_swing_modes = [SWING_ON, SWING_OFF]
 
-        if (
-            self._device.horizontal_swing is not None
-            and self._device.horizontal_swing.initialized
-        ):
+        if self._device.horizontal_swing.initialized:
             self._attr_supported_features |= ClimateEntityFeature.SWING_HORIZONTAL_MODE
             self._attr_swing_horizontal_modes = [SWING_ON, SWING_OFF]
 
@@ -430,14 +427,14 @@ class KNXClimate(KnxYamlEntity, ClimateEntity):
     @property
     def swing_mode(self) -> str | None:
         """Return the swing setting."""
-        if self._device.swing is not None:
+        if self._device.swing.value is not None:
             return SWING_ON if self._device.swing.value else SWING_OFF
         return None
 
     @property
     def swing_horizontal_mode(self) -> str | None:
         """Return the horizontal swing setting."""
-        if self._device.horizontal_swing is not None:
+        if self._device.horizontal_swing.value is not None:
             return SWING_ON if self._device.horizontal_swing.value else SWING_OFF
         return None
 

--- a/homeassistant/components/knx/climate.py
+++ b/homeassistant/components/knx/climate.py
@@ -244,12 +244,12 @@ class KNXClimate(KnxYamlEntity, ClimateEntity):
     @property
     def current_temperature(self) -> float | None:
         """Return the current temperature."""
-        return self._device.temperature.value  # type: ignore[no-any-return]
+        return self._device.temperature.value
 
     @property
     def target_temperature(self) -> float | None:
         """Return the temperature we try to reach."""
-        return self._device.target_temperature.value  # type: ignore[no-any-return]
+        return self._device.target_temperature.value
 
     @property
     def min_temp(self) -> float:
@@ -370,7 +370,7 @@ class KNXClimate(KnxYamlEntity, ClimateEntity):
         Requires ClimateEntityFeature.PRESET_MODE.
         """
         if self._device.mode is not None and self._device.mode.supports_operation_mode:
-            return self._device.mode.operation_mode.name.lower()  # type: ignore[no-any-return]
+            return self._device.mode.operation_mode.name.lower()
         return None
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
@@ -394,7 +394,7 @@ class KNXClimate(KnxYamlEntity, ClimateEntity):
             return self.fan_zero_mode
 
         if self._device.fan_speed_mode == FanSpeedMode.STEP:
-            return self._attr_fan_modes[fan_speed]  # type: ignore[no-any-return]
+            return self._attr_fan_modes[fan_speed]
 
         # Find the closest fan mode percentage
         closest_percentage = min(
@@ -444,7 +444,7 @@ class KNXClimate(KnxYamlEntity, ClimateEntity):
     @property
     def current_humidity(self) -> float | None:
         """Return the current humidity."""
-        return self._device.humidity.value  # type: ignore[no-any-return]
+        return self._device.humidity.value
 
     @property
     def extra_state_attributes(self) -> dict[str, Any] | None:

--- a/homeassistant/components/knx/schema.py
+++ b/homeassistant/components/knx/schema.py
@@ -339,6 +339,10 @@ class ClimateSchema(KNXPlatformSchema):
     CONF_FAN_SPEED_MODE = "fan_speed_mode"
     CONF_FAN_ZERO_MODE = "fan_zero_mode"
     CONF_HUMIDITY_STATE_ADDRESS = "humidity_state_address"
+    CONF_SWING_ADDRESS = "swing_address"
+    CONF_SWING_STATE_ADDRESS = "swing_state_address"
+    CONF_SWING_HORIZONTAL_ADDRESS = "swing_horizontal_address"
+    CONF_SWING_HORIZONTAL_STATE_ADDRESS = "swing_horizontal_state_address"
 
     DEFAULT_NAME = "KNX Climate"
     DEFAULT_SETPOINT_SHIFT_MODE = "DPT6010"
@@ -427,6 +431,10 @@ class ClimateSchema(KNXPlatformSchema):
                 vol.Optional(CONF_FAN_ZERO_MODE, default=FAN_OFF): vol.Coerce(
                     FanZeroMode
                 ),
+                vol.Optional(CONF_SWING_ADDRESS): ga_list_validator,
+                vol.Optional(CONF_SWING_STATE_ADDRESS): ga_list_validator,
+                vol.Optional(CONF_SWING_HORIZONTAL_ADDRESS): ga_list_validator,
+                vol.Optional(CONF_SWING_HORIZONTAL_STATE_ADDRESS): ga_list_validator,
                 vol.Optional(CONF_HUMIDITY_STATE_ADDRESS): ga_list_validator,
             }
         ),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
Added support for swing in knx climate devices


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/37173

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
