### PR TITLE
Bumb python-homewizard-energy to 8.3.0

### DIFF
--- a/homeassistant/components/homewizard/manifest.json
+++ b/homeassistant/components/homewizard/manifest.json
@@ -12,6 +12,6 @@
   "iot_class": "local_polling",
   "loggers": ["homewizard_energy"],
   "quality_scale": "platinum",
-  "requirements": ["python-homewizard-energy==v8.2.0"],
+  "requirements": ["python-homewizard-energy==v8.3.0"],
   "zeroconf": ["_hwenergy._tcp.local.", "_homewizard._tcp.local."]
 }

--- a/homeassistant/components/homewizard/sensor.py
+++ b/homeassistant/components/homewizard/sensor.py
@@ -116,8 +116,15 @@ SENSORS: Final[tuple[HomeWizardSensorEntityDescription, ...]] = (
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
-        has_fn=lambda data: data.measurement.wifi_strength is not None,
-        value_fn=lambda data: data.measurement.wifi_strength,
+        has_fn=(
+            lambda data: data.system is not None
+            and data.system.wifi_strength_pct is not None
+        ),
+        value_fn=(
+            lambda data: data.system.wifi_strength_pct
+            if data.system is not None
+            else None
+        ),
     ),
     HomeWizardSensorEntityDescription(
         key="total_power_import_kwh",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2388,7 +2388,7 @@ python-gitlab==1.6.0
 python-homeassistant-analytics==0.8.1
 
 # homeassistant.components.homewizard
-python-homewizard-energy==v8.2.0
+python-homewizard-energy==v8.3.0
 
 # homeassistant.components.hp_ilo
 python-hpilo==4.4.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1933,7 +1933,7 @@ python-fullykiosk==0.0.14
 python-homeassistant-analytics==0.8.1
 
 # homeassistant.components.homewizard
-python-homewizard-energy==v8.2.0
+python-homewizard-energy==v8.3.0
 
 # homeassistant.components.izone
 python-izone==1.2.9

--- a/tests/components/homewizard/snapshots/test_diagnostics.ambr
+++ b/tests/components/homewizard/snapshots/test_diagnostics.ambr
@@ -79,6 +79,7 @@
         'uptime_s': 356,
         'wifi_rssi_db': -77,
         'wifi_ssid': '**REDACTED**',
+        'wifi_strength_pct': 100,
       }),
     }),
     'entry': dict({
@@ -169,6 +170,7 @@
         'uptime_s': None,
         'wifi_rssi_db': None,
         'wifi_ssid': '**REDACTED**',
+        'wifi_strength_pct': 92,
       }),
     }),
     'entry': dict({
@@ -259,6 +261,7 @@
         'uptime_s': None,
         'wifi_rssi_db': None,
         'wifi_ssid': '**REDACTED**',
+        'wifi_strength_pct': 92,
       }),
     }),
     'entry': dict({
@@ -385,6 +388,7 @@
         'uptime_s': None,
         'wifi_rssi_db': None,
         'wifi_ssid': '**REDACTED**',
+        'wifi_strength_pct': 100,
       }),
     }),
     'entry': dict({
@@ -479,6 +483,7 @@
         'uptime_s': None,
         'wifi_rssi_db': None,
         'wifi_ssid': '**REDACTED**',
+        'wifi_strength_pct': 94,
       }),
     }),
     'entry': dict({
@@ -573,6 +578,7 @@
         'uptime_s': None,
         'wifi_rssi_db': None,
         'wifi_ssid': '**REDACTED**',
+        'wifi_strength_pct': 100,
       }),
     }),
     'entry': dict({
@@ -663,6 +669,7 @@
         'uptime_s': None,
         'wifi_rssi_db': None,
         'wifi_ssid': '**REDACTED**',
+        'wifi_strength_pct': 84,
       }),
     }),
     'entry': dict({
@@ -753,6 +760,7 @@
         'uptime_s': None,
         'wifi_rssi_db': None,
         'wifi_ssid': '**REDACTED**',
+        'wifi_strength_pct': 92,
       }),
     }),
     'entry': dict({
@@ -843,6 +851,7 @@
         'uptime_s': None,
         'wifi_rssi_db': None,
         'wifi_ssid': '**REDACTED**',
+        'wifi_strength_pct': 92,
       }),
     }),
     'entry': dict({


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
python-homewizard-energy 8.3.0 adds a conversion from 'Wi-Fi RSSI' to the original Wi-Fi Strength, a value in percentage. Easier to understand for users and fully compatible with original sensor.

https://github.com/homewizard/python-homewizard-energy/releases/tag/v8.3.0
https://github.com/homewizard/python-homewizard-energy/compare/v8.2.0...v8.3.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
