### PR TITLE
Bump ZHA to 0.0.46

### DIFF
--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -21,7 +21,7 @@
     "zha",
     "universal_silabs_flasher"
   ],
-  "requirements": ["zha==0.0.45"],
+  "requirements": ["zha==0.0.46"],
   "usb": [
     {
       "vid": "10C4",

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -592,6 +592,24 @@
       },
       "window_detection": {
         "name": "Open window detection"
+      },
+      "silence_alarm": {
+        "name": "Silence alarm"
+      },
+      "preheat_active": {
+        "name": "Preheat active"
+      },
+      "fault_alarm": {
+        "name": "Fault alarm"
+      },
+      "led_indicator": {
+        "name": "LED indicator"
+      },
+      "error_or_battery_low": {
+        "name": "Error or battery low"
+      },
+      "flow_switch": {
+        "name": "Flow switch"
       }
     },
     "button": {
@@ -612,6 +630,9 @@
       },
       "restart_device": {
         "name": "Restart device"
+      },
+      "frost_lock_reset": {
+        "name": "Frost lock reset"
       }
     },
     "climate": {
@@ -885,6 +906,144 @@
       },
       "fading_time": {
         "name": "Fading time"
+      },
+      "temperature_offset": {
+        "name": "Temperature offset"
+      },
+      "humidity_offset": {
+        "name": "Humidity offset"
+      },
+      "comfort_temperature_min": {
+        "name": "Comfort temperature min"
+      },
+      "comfort_temperature_max": {
+        "name": "Comfort temperature max"
+      },
+      "comfort_humidity_min": {
+        "name": "Comfort humidity min"
+      },
+      "comfort_humidity_max": {
+        "name": "Comfort humidity max"
+      },
+      "measurement_interval": {
+        "name": "Measurement interval"
+      },
+      "on_time": {
+        "name": "On time"
+      },
+      "alarm_duration": {
+        "name": "Alarm duration"
+      },
+      "max_set": {
+        "name": "Liquid max percentage"
+      },
+      "mini_set": {
+        "name": "Liquid minimal percentage"
+      },
+      "installation_height": {
+        "name": "Height from sensor to tank bottom"
+      },
+      "liquid_depth_max": {
+        "name": "Height from sensor to liquid level"
+      },
+      "interval_time": {
+        "name": "Interval time"
+      },
+      "target_distance": {
+        "name": "Target distance"
+      },
+      "hold_delay_time": {
+        "name": "Hold delay time"
+      },
+      "breath_detection_max": {
+        "name": "Breath detection max"
+      },
+      "breath_detection_min": {
+        "name": "Breath detection min"
+      },
+      "small_move_detection_max": {
+        "name": "Small move detection max"
+      },
+      "small_move_detection_min": {
+        "name": "Small move detection min"
+      },
+      "small_move_sensitivity": {
+        "name": "Small move sensitivity"
+      },
+      "breath_sensitivity": {
+        "name": "Breath sensitivity"
+      },
+      "entry_sensitivity": {
+        "name": "Entry sensitivity"
+      },
+      "entry_distance_indentation": {
+        "name": "Entry distance indentation"
+      },
+      "illuminance_threshold": {
+        "name": "Illuminance threshold"
+      },
+      "block_time": {
+        "name": "Block time"
+      },
+      "motion_sensitivity": {
+        "name": "Motion sensitivity"
+      },
+      "radar_sensitivity": {
+        "name": "Radar sensitivity"
+      },
+      "motionless_detection": {
+        "name": "Motionless detection"
+      },
+      "motionless_sensitivity": {
+        "name": "Motionless detection sensitivity"
+      },
+      "output_time": {
+        "name": "Output time"
+      },
+      "illuminance_interval": {
+        "name": "Illuminance interval"
+      },
+      "temperature_report_interval": {
+        "name": "Temperature report interval"
+      },
+      "humidity_report_interval": {
+        "name": "Humidity report interval"
+      },
+      "alarm_temperature_max": {
+        "name": "Alarm temperature max"
+      },
+      "alarm_temperature_min": {
+        "name": "Alarm temperature min"
+      },
+      "temperature_sensitivity": {
+        "name": "Temperature sensitivity"
+      },
+      "alarm_humidity_max": {
+        "name": "Alarm humidity max"
+      },
+      "alarm_humidity_min": {
+        "name": "Alarm humidity min"
+      },
+      "humidity_sensitivity": {
+        "name": "Humidity sensitivity"
+      },
+      "deadzone_temperature": {
+        "name": "Deadzone temperature"
+      },
+      "min_temperature": {
+        "name": "Min temperature"
+      },
+      "max_temperature": {
+        "name": "Max temperature"
+      },
+      "valve_countdown": {
+        "name": "Irrigation time"
+      },
+      "quantitative_watering": {
+        "name": "Quantitative watering"
+      },
+      "valve_duration": {
+        "name": "Irrigation duration"
       }
     },
     "select": {
@@ -1034,6 +1193,48 @@
       },
       "pilot_wire_mode": {
         "name": "Pilot wire mode"
+      },
+      "alarm_ringtone": {
+        "name": "Alarm ringtone"
+      },
+      "liquid_state": {
+        "name": "Liquid state"
+      },
+      "breaker_mode": {
+        "name": "Breaker mode"
+      },
+      "breaker_status": {
+        "name": "Breaker status"
+      },
+      "status_indication": {
+        "name": "Status indication"
+      },
+      "breaker_polarity": {
+        "name": "Breaker polarity"
+      },
+      "work_mode": {
+        "name": "Work mode"
+      },
+      "presence_sensitivity": {
+        "name": "Presence sensitivity"
+      },
+      "fading_time": {
+        "name": "Fading time"
+      },
+      "display_unit": {
+        "name": "Display unit"
+      },
+      "alarm_mode": {
+        "name": "Alarm mode"
+      },
+      "alarm_volume": {
+        "name": "Alarm volume"
+      },
+      "working_day": {
+        "name": "Working day"
+      },
+      "eco_mode": {
+        "name": "Eco mode"
       }
     },
     "sensor": {
@@ -1276,6 +1477,90 @@
       },
       "self_test": {
         "name": "Self test result"
+      },
+      "voc_index": {
+        "name": "VOC index"
+      },
+      "energy_ph_a": {
+        "name": "Energy phase A"
+      },
+      "energy_ph_b": {
+        "name": "Energy phase B"
+      },
+      "energy_ph_c": {
+        "name": "Energy phase C"
+      },
+      "energy_produced": {
+        "name": "Energy produced"
+      },
+      "energy_produced_ph_a": {
+        "name": "Energy produced phase A"
+      },
+      "energy_produced_ph_b": {
+        "name": "Energy produced phase B"
+      },
+      "energy_produced_ph_c": {
+        "name": "Energy produced phase C"
+      },
+      "total_power_factor": {
+        "name": "Total power factor"
+      },
+      "self_test_result": {
+        "name": "Self test result"
+      },
+      "lower_explosive_limit": {
+        "name": "% Lower explosive limit"
+      },
+      "liquid_depth": {
+        "name": "Liquid depth"
+      },
+      "liquid_level_percent": {
+        "name": "Liquid level ratio"
+      },
+      "target_distance": {
+        "name": "Target distance"
+      },
+      "human_motion_state": {
+        "name": "Human motion state"
+      },
+      "temperature_alarm": {
+        "name": "Temperature alarm"
+      },
+      "humidity_alarm": {
+        "name": "Humidity alarm"
+      },
+      "alarm_state": {
+        "name": "Alarm state"
+      },
+      "power_type": {
+        "name": "Power type"
+      },
+      "valve_position": {
+        "name": "Valve position"
+      },
+      "time_left": {
+        "name": "Time left"
+      },
+      "valve_status": {
+        "name": "Valve status"
+      },
+      "valve_duration": {
+        "name": "Irrigation duration"
+      },
+      "smart_irrigation": {
+        "name": "Smart irrigation"
+      },
+      "surplus_flow": {
+        "name": "Surplus flow"
+      },
+      "single_watering_duration": {
+        "name": "Single watering duration"
+      },
+      "single_watering_amount": {
+        "name": "Single watering amount"
+      },
+      "error_status": {
+        "name": "Error status"
       }
     },
     "switch": {
@@ -1404,6 +1689,63 @@
       },
       "find_switch": {
         "name": "Distance switch"
+      },
+      "display_enabled": {
+        "name": "Display enabled"
+      },
+      "show_smiley": {
+        "name": "Show smiley"
+      },
+      "on_only_when_dark": {
+        "name": "On only when dark"
+      },
+      "mute_siren": {
+        "name": "Mute siren"
+      },
+      "self_test_switch": {
+        "name": "Self test"
+      },
+      "output_switch": {
+        "name": "Output switch"
+      },
+      "siren_on": {
+        "name": "Siren on"
+      },
+      "enable_tamper_alarm": {
+        "name": "Enable tamper alarm"
+      },
+      "temperature_alarm": {
+        "name": "Temperature alarm"
+      },
+      "humidity_alarm": {
+        "name": "Humidity alarm"
+      },
+      "silence_alarm": {
+        "name": "Silence alarm"
+      },
+      "frost_protection": {
+        "name": "Frost protection"
+      },
+      "factory_reset": {
+        "name": "Factory reset"
+      },
+      "away_mode": {
+        "name": "Away mode"
+      },
+      "schedule_enable": {
+        "name": "Schedule enable"
+      },
+      "scale_protection": {
+        "name": "Scale protection"
+      },
+      "frost_lock": {
+        "name": "Frost lock"
+      },
+      "switch_enabled": {
+        "name": "Switch enabled"
+      },
+      "total_flow_reset_switch": {
+        "name": "Total flow reset switch"
       }
     }
   }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3128,7 +3128,7 @@ zeroconf==0.141.0
 zeversolar==0.3.2
 
 # homeassistant.components.zha
-zha==0.0.45
+zha==0.0.46
 
 # homeassistant.components.zhong_hong
 zhong-hong-hvac==1.0.13

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2517,7 +2517,7 @@ zeroconf==0.141.0
 zeversolar==0.3.2
 
 # homeassistant.components.zha
-zha==0.0.45
+zha==0.0.46
 
 # homeassistant.components.zwave_js
 zwave-js-server-python==0.60.0


### PR DESCRIPTION
## Proposed change

This bumps ZHA to [0.0.46](https://github.com/zigpy/zha/releases/tag/0.0.46) (full diff: https://github.com/zigpy/zha/compare/0.0.45...0.0.46). These dependency upgrades are bundled with it: 
- `bellows` [0.43.0](https://github.com/zigpy/bellows/releases/tag/0.43.0)
full diff: https://github.com/zigpy/bellows/compare/0.42.6...0.43.0

- `zha-quirks` [0.0.131](https://github.com/zigpy/zha-device-handlers/releases/tag/0.0.131)
full diff: https://github.com/zigpy/zha-device-handlers/compare/0.0.130...0.0.131

- `zigpy` [0.76.0](https://github.com/zigpy/zigpy/releases/tag/0.76.0) (including [0.75.0](https://github.com/zigpy/zigpy/releases/tag/0.75.0), [0.75.1](https://github.com/zigpy/zigpy/releases/tag/0.75.1) changes)
full diff: https://github.com/zigpy/zigpy/compare/0.74.0...0.76.0

This zha-quirks release also adds a few entities via the quirks v2 API. The entity names are added to `strings.json`.

### Notes about these releases

With this quirks release, way more Tuya devices are supported properly thanks to @prairiesnpr. This is our biggest quirks release yet. See the [quirks changelog](https://github.com/zigpy/zha-device-handlers/releases/tag/0.0.131) for more details.

Some other longstanding device support PRs, like the IKEA VINDSTYRKA air quality sensor, have also been merged (or replaced with another PR) and finally get support. Support for the IKEA smart plug with INSPELNING has also been improved to fix incorrect power readings depending on the usage.
Both IKEA devices require a reconfiguration to set up updated attribute reporting (or re-pairing of the device).


## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #130270, fixes #126218, fixes #129723
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
