### PR TITLE
Fix typing errors in HEOS tests

### DIFF
--- a/tests/components/heos/__init__.py
+++ b/tests/components/heos/__init__.py
@@ -1,1 +1,45 @@
 """Tests for the Heos component."""
+
+from unittest.mock import AsyncMock
+
+from pyheos import Heos, HeosGroup, HeosOptions, HeosPlayer
+
+
+class MockHeos(Heos):
+    """Defines a mocked HEOS API."""
+
+    def __init__(self, options: HeosOptions) -> None:
+        """Initialize the mock."""
+        super().__init__(options)
+        # Overwrite the methods with async mocks, changing type
+        self.connect: AsyncMock = AsyncMock()
+        self.disconnect: AsyncMock = AsyncMock()
+        self.get_favorites: AsyncMock = AsyncMock()
+        self.get_groups: AsyncMock = AsyncMock()
+        self.get_input_sources: AsyncMock = AsyncMock()
+        self.get_playlists: AsyncMock = AsyncMock()
+        self.get_players: AsyncMock = AsyncMock()
+        self.load_players: AsyncMock = AsyncMock()
+        self.set_group: AsyncMock = AsyncMock()
+        self.sign_in: AsyncMock = AsyncMock()
+        self.sign_out: AsyncMock = AsyncMock()
+
+    def mock_set_players(self, players: dict[int, HeosPlayer]) -> None:
+        """Set the players on the mock instance."""
+        for player in players.values():
+            player.heos = self
+        self._players = players
+        self._players_loaded = bool(players)
+        self.get_players.return_value = players
+
+    def mock_set_groups(self, groups: dict[int, HeosGroup]) -> None:
+        """Set the groups on the mock instance."""
+        for group in groups.values():
+            group.heos = self
+        self._groups = groups
+        self._groups_loaded = bool(groups)
+        self.get_groups.return_value = groups
+
+    def mock_set_signed_in_username(self, signed_in_username: str | None) -> None:
+        """Set the signed in status on the mock instance."""
+        self._signed_in_username = signed_in_username

--- a/tests/components/heos/__init__.py
+++ b/tests/components/heos/__init__.py
@@ -24,6 +24,20 @@ class MockHeos(Heos):
         self.sign_in: AsyncMock = AsyncMock()
         self.sign_out: AsyncMock = AsyncMock()
 
+        self.add_to_queue: AsyncMock = AsyncMock()
+        self.player_clear_queue: AsyncMock = AsyncMock()
+        self.player_get_quick_selects: AsyncMock = AsyncMock()
+        self.player_set_mute: AsyncMock = AsyncMock()
+        self.player_set_play_state: AsyncMock = AsyncMock()
+        self.player_set_play_mode: AsyncMock = AsyncMock()
+        self.play_media: AsyncMock = AsyncMock()
+        self.player_play_next: AsyncMock = AsyncMock()
+        self.player_play_previous: AsyncMock = AsyncMock()
+        self.play_preset_station: AsyncMock = AsyncMock()
+        self.player_play_quick_select: AsyncMock = AsyncMock()
+        self.play_url: AsyncMock = AsyncMock()
+        self.player_set_volume: AsyncMock = AsyncMock()
+
     def mock_set_players(self, players: dict[int, HeosPlayer]) -> None:
         """Set the players on the mock instance."""
         for player in players.values():

--- a/tests/components/heos/__init__.py
+++ b/tests/components/heos/__init__.py
@@ -12,6 +12,7 @@ class MockHeos(Heos):
         """Initialize the mock."""
         super().__init__(options)
         # Overwrite the methods with async mocks, changing type
+        self.add_to_queue: AsyncMock = AsyncMock()
         self.connect: AsyncMock = AsyncMock()
         self.disconnect: AsyncMock = AsyncMock()
         self.get_favorites: AsyncMock = AsyncMock()
@@ -20,23 +21,21 @@ class MockHeos(Heos):
         self.get_playlists: AsyncMock = AsyncMock()
         self.get_players: AsyncMock = AsyncMock()
         self.load_players: AsyncMock = AsyncMock()
+        self.play_media: AsyncMock = AsyncMock()
+        self.play_preset_station: AsyncMock = AsyncMock()
+        self.play_url: AsyncMock = AsyncMock()
+        self.player_clear_queue: AsyncMock = AsyncMock()
+        self.player_get_quick_selects: AsyncMock = AsyncMock()
+        self.player_play_next: AsyncMock = AsyncMock()
+        self.player_play_previous: AsyncMock = AsyncMock()
+        self.player_play_quick_select: AsyncMock = AsyncMock()
+        self.player_set_mute: AsyncMock = AsyncMock()
+        self.player_set_play_mode: AsyncMock = AsyncMock()
+        self.player_set_play_state: AsyncMock = AsyncMock()
+        self.player_set_volume: AsyncMock = AsyncMock()
         self.set_group: AsyncMock = AsyncMock()
         self.sign_in: AsyncMock = AsyncMock()
         self.sign_out: AsyncMock = AsyncMock()
-
-        self.add_to_queue: AsyncMock = AsyncMock()
-        self.player_clear_queue: AsyncMock = AsyncMock()
-        self.player_get_quick_selects: AsyncMock = AsyncMock()
-        self.player_set_mute: AsyncMock = AsyncMock()
-        self.player_set_play_state: AsyncMock = AsyncMock()
-        self.player_set_play_mode: AsyncMock = AsyncMock()
-        self.play_media: AsyncMock = AsyncMock()
-        self.player_play_next: AsyncMock = AsyncMock()
-        self.player_play_previous: AsyncMock = AsyncMock()
-        self.play_preset_station: AsyncMock = AsyncMock()
-        self.player_play_quick_select: AsyncMock = AsyncMock()
-        self.play_url: AsyncMock = AsyncMock()
-        self.player_set_volume: AsyncMock = AsyncMock()
 
     def mock_set_players(self, players: dict[int, HeosPlayer]) -> None:
         """Set the players on the mock instance."""

--- a/tests/components/heos/conftest.py
+++ b/tests/components/heos/conftest.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterator
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import Mock, patch
 
 from pyheos import (
     HeosGroup,
@@ -84,6 +84,7 @@ async def controller_fixture(
     playlists: list[MediaItem],
     change_data: PlayerUpdateResult,
     group: dict[int, HeosGroup],
+    quick_selects: dict[int, str],
 ) -> MockHeos:
     """Create a mock Heos controller fixture."""
 
@@ -95,6 +96,7 @@ async def controller_fixture(
     mock_heos.get_input_sources.return_value = input_sources
     mock_heos.get_playlists.return_value = playlists
     mock_heos.load_players.return_value = change_data
+    mock_heos.player_get_quick_selects.return_value = quick_selects
     return mock_heos
 
 
@@ -127,7 +129,7 @@ def system_info_fixture() -> HeosSystem:
 
 
 @pytest.fixture(name="players")
-def players_fixture(quick_selects: dict[int, str]) -> dict[int, HeosPlayer]:
+def players_fixture() -> dict[int, HeosPlayer]:
     """Create two mock HeosPlayers."""
     players = {}
     for i in (1, 2):
@@ -160,24 +162,6 @@ def players_fixture(quick_selects: dict[int, str]) -> dict[int, HeosPlayer]:
             queue_id=1,
             source_id=10,
         )
-        player.add_to_queue = AsyncMock()
-        player.clear_queue = AsyncMock()
-        player.get_quick_selects = AsyncMock(return_value=quick_selects)
-        player.mute = AsyncMock()
-        player.pause = AsyncMock()
-        player.play = AsyncMock()
-        player.play_media = AsyncMock()
-        player.play_next = AsyncMock()
-        player.play_previous = AsyncMock()
-        player.play_preset_station = AsyncMock()
-        player.play_quick_select = AsyncMock()
-        player.play_url = AsyncMock()
-        player.set_mute = AsyncMock()
-        player.set_play_mode = AsyncMock()
-        player.set_quick_select = AsyncMock()
-        player.set_volume = AsyncMock()
-        player.stop = AsyncMock()
-        player.unmute = AsyncMock()
         players[player.player_id] = player
     return players
 

--- a/tests/components/heos/snapshots/test_diagnostics.ambr
+++ b/tests/components/heos/snapshots/test_diagnostics.ambr
@@ -98,8 +98,15 @@
       'Speaker - Line In 1',
     ]),
     'system': dict({
-      'connected_to_preferred_host': False,
-      'host': '127.0.0.1',
+      'connected_to_preferred_host': True,
+      'host': dict({
+        'ip_address': '127.0.0.1',
+        'model': 'HEOS Drive HS2',
+        'name': 'Test Player',
+        'network': 'wired',
+        'serial': '**REDACTED**',
+        'version': '1.0.0',
+      }),
       'hosts': list([
         dict({
           'ip_address': '127.0.0.1',

--- a/tests/components/heos/test_diagnostics.py
+++ b/tests/components/heos/test_diagnostics.py
@@ -2,14 +2,16 @@
 
 from unittest import mock
 
-from pyheos import Heos, HeosSystem
+from pyheos import HeosSystem
 import pytest
-from syrupy import SnapshotAssertion
+from syrupy.assertion import SnapshotAssertion
 from syrupy.filters import props
 
 from homeassistant.components.heos.const import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
+
+from . import MockHeos
 
 from tests.common import MockConfigEntry
 from tests.components.diagnostics import (
@@ -23,7 +25,7 @@ async def test_config_entry_diagnostics(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
     config_entry: MockConfigEntry,
-    controller: Heos,
+    controller: MockHeos,
     system: HeosSystem,
     snapshot: SnapshotAssertion,
 ) -> None:
@@ -77,7 +79,7 @@ async def test_device_diagnostics(
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     device_registry = dr.async_get(hass)
     device = device_registry.async_get_device({(DOMAIN, "1")})
-
+    assert device is not None
     diagnostics = await get_diagnostics_for_device(
         hass, hass_client, config_entry, device
     )

--- a/tests/components/heos/test_init.py
+++ b/tests/components/heos/test_init.py
@@ -1,8 +1,9 @@
 """Tests for the init module."""
 
 from typing import cast
+from unittest.mock import Mock
 
-from pyheos import Heos, HeosError, HeosOptions, SignalHeosEvent, SignalType
+from pyheos import HeosError, HeosOptions, SignalHeosEvent, SignalType
 import pytest
 
 from homeassistant.components.heos.const import DOMAIN
@@ -11,13 +12,15 @@ from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
+from . import MockHeos
+
 from tests.common import MockConfigEntry
 
 
 async def test_async_setup_entry_loads_platforms(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
-    controller: Heos,
+    controller: MockHeos,
 ) -> None:
     """Test load connects to heos, retrieves players, and loads platforms."""
     config_entry.add_to_hass(hass)
@@ -32,7 +35,10 @@ async def test_async_setup_entry_loads_platforms(
 
 
 async def test_async_setup_entry_with_options_loads_platforms(
-    hass: HomeAssistant, config_entry_options: MockConfigEntry, controller: Heos
+    hass: HomeAssistant,
+    config_entry_options: MockConfigEntry,
+    controller: MockHeos,
+    new_mock: Mock,
 ) -> None:
     """Test load connects to heos with options, retrieves players, and loads platforms."""
     config_entry_options.add_to_hass(hass)
@@ -40,8 +46,9 @@ async def test_async_setup_entry_with_options_loads_platforms(
 
     # Assert options passed and methods called
     assert config_entry_options.state is ConfigEntryState.LOADED
-    options = cast(HeosOptions, controller.new_mock.call_args[0][0])
+    options = cast(HeosOptions, new_mock.call_args[0][0])
     assert options.host == config_entry_options.data[CONF_HOST]
+    assert options.credentials is not None
     assert options.credentials.username == config_entry_options.options[CONF_USERNAME]
     assert options.credentials.password == config_entry_options.options[CONF_PASSWORD]
     assert controller.connect.call_count == 1
@@ -54,14 +61,14 @@ async def test_async_setup_entry_with_options_loads_platforms(
 async def test_async_setup_entry_auth_failure_starts_reauth(
     hass: HomeAssistant,
     config_entry_options: MockConfigEntry,
-    controller: Heos,
+    controller: MockHeos,
 ) -> None:
     """Test load with auth failure starts reauth, loads platforms."""
     config_entry_options.add_to_hass(hass)
 
     # Simulates what happens when the controller can't sign-in during connection
     async def connect_send_auth_failure() -> None:
-        controller._signed_in_username = None
+        controller.mock_set_signed_in_username(None)
         await controller.dispatcher.wait_send(
             SignalType.HEOS_EVENT, SignalHeosEvent.USER_CREDENTIALS_INVALID
         )
@@ -76,19 +83,19 @@ async def test_async_setup_entry_auth_failure_starts_reauth(
     controller.disconnect.assert_not_called()
     assert config_entry_options.state is ConfigEntryState.LOADED
     assert any(
-        config_entry_options.async_get_active_flows(hass, sources=[SOURCE_REAUTH])
+        config_entry_options.async_get_active_flows(hass, sources={SOURCE_REAUTH})
     )
 
 
 async def test_async_setup_entry_not_signed_in_loads_platforms(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
-    controller: Heos,
+    controller: MockHeos,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test setup does not retrieve favorites when not logged in."""
     config_entry.add_to_hass(hass)
-    controller._signed_in_username = None
+    controller.mock_set_signed_in_username(None)
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     assert controller.connect.call_count == 1
     assert controller.get_players.call_count == 1
@@ -102,7 +109,7 @@ async def test_async_setup_entry_not_signed_in_loads_platforms(
 
 
 async def test_async_setup_entry_connect_failure(
-    hass: HomeAssistant, config_entry: MockConfigEntry, controller: Heos
+    hass: HomeAssistant, config_entry: MockConfigEntry, controller: MockHeos
 ) -> None:
     """Connection failure raises ConfigEntryNotReady."""
     config_entry.add_to_hass(hass)
@@ -114,7 +121,7 @@ async def test_async_setup_entry_connect_failure(
 
 
 async def test_async_setup_entry_player_failure(
-    hass: HomeAssistant, config_entry: MockConfigEntry, controller: Heos
+    hass: HomeAssistant, config_entry: MockConfigEntry, controller: MockHeos
 ) -> None:
     """Failure to retrieve players raises ConfigEntryNotReady."""
     config_entry.add_to_hass(hass)
@@ -126,7 +133,7 @@ async def test_async_setup_entry_player_failure(
 
 
 async def test_async_setup_entry_favorites_failure(
-    hass: HomeAssistant, config_entry: MockConfigEntry, controller: Heos
+    hass: HomeAssistant, config_entry: MockConfigEntry, controller: MockHeos
 ) -> None:
     """Failure to retrieve favorites loads."""
     config_entry.add_to_hass(hass)
@@ -136,7 +143,7 @@ async def test_async_setup_entry_favorites_failure(
 
 
 async def test_async_setup_entry_inputs_failure(
-    hass: HomeAssistant, config_entry: MockConfigEntry, controller: Heos
+    hass: HomeAssistant, config_entry: MockConfigEntry, controller: MockHeos
 ) -> None:
     """Failure to retrieve inputs loads."""
     config_entry.add_to_hass(hass)
@@ -146,7 +153,7 @@ async def test_async_setup_entry_inputs_failure(
 
 
 async def test_unload_entry(
-    hass: HomeAssistant, config_entry: MockConfigEntry, controller: Heos
+    hass: HomeAssistant, config_entry: MockConfigEntry, controller: MockHeos
 ) -> None:
     """Test entries are unloaded correctly."""
     config_entry.add_to_hass(hass)
@@ -164,12 +171,14 @@ async def test_device_info(
     config_entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     device = device_registry.async_get_device({(DOMAIN, "1")})
+    assert device is not None
     assert device.manufacturer == "HEOS"
     assert device.model == "Drive HS2"
     assert device.name == "Test Player"
     assert device.serial_number == "123456"
     assert device.sw_version == "1.0.0"
     device = device_registry.async_get_device({(DOMAIN, "2")})
+    assert device is not None
     assert device.manufacturer == "HEOS"
     assert device.model == "Speaker"
 
@@ -183,12 +192,14 @@ async def test_device_id_migration(
     config_entry.add_to_hass(hass)
     # Create a device with a legacy identifier
     device_registry.async_get_or_create(
-        config_entry_id=config_entry.entry_id, identifiers={(DOMAIN, 1)}
+        config_entry_id=config_entry.entry_id,
+        identifiers={(DOMAIN, 1)},  # type: ignore[arg-type]
     )
     device_registry.async_get_or_create(
-        config_entry_id=config_entry.entry_id, identifiers={("Other", 1)}
+        config_entry_id=config_entry.entry_id,
+        identifiers={("Other", 1)},  # type: ignore[arg-type]
     )
     assert await hass.config_entries.async_setup(config_entry.entry_id)
-    assert device_registry.async_get_device({("Other", 1)}) is not None
-    assert device_registry.async_get_device({(DOMAIN, 1)}) is None
+    assert device_registry.async_get_device({("Other", 1)}) is not None  # type: ignore[arg-type]
+    assert device_registry.async_get_device({(DOMAIN, 1)}) is None  # type: ignore[arg-type]
     assert device_registry.async_get_device({(DOMAIN, "1")}) is not None

--- a/tests/components/heos/test_media_player.py
+++ b/tests/components/heos/test_media_player.py
@@ -372,14 +372,13 @@ async def test_clear_playlist(
     """Test the clear playlist service."""
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
-    player = controller.players[1]
     await hass.services.async_call(
         MEDIA_PLAYER_DOMAIN,
         SERVICE_CLEAR_PLAYLIST,
         {ATTR_ENTITY_ID: "media_player.test_player"},
         blocking=True,
     )
-    assert player.clear_queue.call_count == 1
+    assert controller.player_clear_queue.call_count == 1
 
 
 async def test_clear_playlist_error(
@@ -388,8 +387,7 @@ async def test_clear_playlist_error(
     """Test error raised when clear playlist fails."""
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
-    player = controller.players[1]
-    player.clear_queue.side_effect = CommandFailedError("", "Failure", 1)
+    controller.player_clear_queue.side_effect = CommandFailedError("", "Failure", 1)
     with pytest.raises(
         HomeAssistantError, match=re.escape("Unable to clear playlist: Failure (1)")
     ):
@@ -399,7 +397,7 @@ async def test_clear_playlist_error(
             {ATTR_ENTITY_ID: "media_player.test_player"},
             blocking=True,
         )
-    assert player.clear_queue.call_count == 1
+    assert controller.player_clear_queue.call_count == 1
 
 
 async def test_pause(
@@ -408,14 +406,13 @@ async def test_pause(
     """Test the pause service."""
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
-    player = controller.players[1]
     await hass.services.async_call(
         MEDIA_PLAYER_DOMAIN,
         SERVICE_MEDIA_PAUSE,
         {ATTR_ENTITY_ID: "media_player.test_player"},
         blocking=True,
     )
-    assert player.pause.call_count == 1
+    assert controller.player_set_play_state.call_count == 1
 
 
 async def test_pause_error(
@@ -424,8 +421,7 @@ async def test_pause_error(
     """Test the pause service raises error."""
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
-    player = controller.players[1]
-    player.pause.side_effect = CommandFailedError("", "Failure", 1)
+    controller.player_set_play_state.side_effect = CommandFailedError("", "Failure", 1)
     with pytest.raises(
         HomeAssistantError, match=re.escape("Unable to pause: Failure (1)")
     ):
@@ -435,7 +431,7 @@ async def test_pause_error(
             {ATTR_ENTITY_ID: "media_player.test_player"},
             blocking=True,
         )
-    assert player.pause.call_count == 1
+    assert controller.player_set_play_state.call_count == 1
 
 
 async def test_play(
@@ -444,14 +440,13 @@ async def test_play(
     """Test the play service."""
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
-    player = controller.players[1]
     await hass.services.async_call(
         MEDIA_PLAYER_DOMAIN,
         SERVICE_MEDIA_PLAY,
         {ATTR_ENTITY_ID: "media_player.test_player"},
         blocking=True,
     )
-    assert player.play.call_count == 1
+    assert controller.player_set_play_state.call_count == 1
 
 
 async def test_play_error(
@@ -460,8 +455,7 @@ async def test_play_error(
     """Test the play service raises error."""
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
-    player = controller.players[1]
-    player.play.side_effect = CommandFailedError("", "Failure", 1)
+    controller.player_set_play_state.side_effect = CommandFailedError("", "Failure", 1)
     with pytest.raises(
         HomeAssistantError, match=re.escape("Unable to play: Failure (1)")
     ):
@@ -471,7 +465,7 @@ async def test_play_error(
             {ATTR_ENTITY_ID: "media_player.test_player"},
             blocking=True,
         )
-    assert player.play.call_count == 1
+    assert controller.player_set_play_state.call_count == 1
 
 
 async def test_previous_track(
@@ -480,14 +474,13 @@ async def test_previous_track(
     """Test the previous track service."""
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
-    player = controller.players[1]
     await hass.services.async_call(
         MEDIA_PLAYER_DOMAIN,
         SERVICE_MEDIA_PREVIOUS_TRACK,
         {ATTR_ENTITY_ID: "media_player.test_player"},
         blocking=True,
     )
-    assert player.play_previous.call_count == 1
+    assert controller.player_play_previous.call_count == 1
 
 
 async def test_previous_track_error(
@@ -496,8 +489,7 @@ async def test_previous_track_error(
     """Test the previous track service raises error."""
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
-    player = controller.players[1]
-    player.play_previous.side_effect = CommandFailedError("", "Failure", 1)
+    controller.player_play_previous.side_effect = CommandFailedError("", "Failure", 1)
     with pytest.raises(
         HomeAssistantError,
         match=re.escape("Unable to move to previous track: Failure (1)"),
@@ -508,7 +500,7 @@ async def test_previous_track_error(
             {ATTR_ENTITY_ID: "media_player.test_player"},
             blocking=True,
         )
-    assert player.play_previous.call_count == 1
+    assert controller.player_play_previous.call_count == 1
 
 
 async def test_next_track(
@@ -517,14 +509,13 @@ async def test_next_track(
     """Test the next track service."""
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
-    player = controller.players[1]
     await hass.services.async_call(
         MEDIA_PLAYER_DOMAIN,
         SERVICE_MEDIA_NEXT_TRACK,
         {ATTR_ENTITY_ID: "media_player.test_player"},
         blocking=True,
     )
-    assert player.play_next.call_count == 1
+    assert controller.player_play_next.call_count == 1
 
 
 async def test_next_track_error(
@@ -533,8 +524,7 @@ async def test_next_track_error(
     """Test the next track service raises error."""
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
-    player = controller.players[1]
-    player.play_next.side_effect = CommandFailedError("", "Failure", 1)
+    controller.player_play_next.side_effect = CommandFailedError("", "Failure", 1)
     with pytest.raises(
         HomeAssistantError,
         match=re.escape("Unable to move to next track: Failure (1)"),
@@ -545,7 +535,7 @@ async def test_next_track_error(
             {ATTR_ENTITY_ID: "media_player.test_player"},
             blocking=True,
         )
-    assert player.play_next.call_count == 1
+    assert controller.player_play_next.call_count == 1
 
 
 async def test_stop(
@@ -554,14 +544,13 @@ async def test_stop(
     """Test the stop service."""
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
-    player = controller.players[1]
     await hass.services.async_call(
         MEDIA_PLAYER_DOMAIN,
         SERVICE_MEDIA_STOP,
         {ATTR_ENTITY_ID: "media_player.test_player"},
         blocking=True,
     )
-    assert player.stop.call_count == 1
+    assert controller.player_set_play_state.call_count == 1
 
 
 async def test_stop_error(
@@ -570,8 +559,7 @@ async def test_stop_error(
     """Test the stop service raises error."""
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
-    player = controller.players[1]
-    player.stop.side_effect = CommandFailedError("", "Failure", 1)
+    controller.player_set_play_state.side_effect = CommandFailedError("", "Failure", 1)
     with pytest.raises(
         HomeAssistantError,
         match=re.escape("Unable to stop: Failure (1)"),
@@ -582,7 +570,7 @@ async def test_stop_error(
             {ATTR_ENTITY_ID: "media_player.test_player"},
             blocking=True,
         )
-    assert player.stop.call_count == 1
+    assert controller.player_set_play_state.call_count == 1
 
 
 async def test_volume_mute(
@@ -591,14 +579,13 @@ async def test_volume_mute(
     """Test the volume mute service."""
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
-    player = controller.players[1]
     await hass.services.async_call(
         MEDIA_PLAYER_DOMAIN,
         SERVICE_VOLUME_MUTE,
         {ATTR_ENTITY_ID: "media_player.test_player", ATTR_MEDIA_VOLUME_MUTED: True},
         blocking=True,
     )
-    assert player.set_mute.call_count == 1
+    assert controller.player_set_mute.call_count == 1
 
 
 async def test_volume_mute_error(
@@ -607,8 +594,7 @@ async def test_volume_mute_error(
     """Test the volume mute service raises error."""
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
-    player = controller.players[1]
-    player.set_mute.side_effect = CommandFailedError("", "Failure", 1)
+    controller.player_set_mute.side_effect = CommandFailedError("", "Failure", 1)
     with pytest.raises(
         HomeAssistantError,
         match=re.escape("Unable to set mute: Failure (1)"),
@@ -619,7 +605,7 @@ async def test_volume_mute_error(
             {ATTR_ENTITY_ID: "media_player.test_player", ATTR_MEDIA_VOLUME_MUTED: True},
             blocking=True,
         )
-    assert player.set_mute.call_count == 1
+    assert controller.player_set_mute.call_count == 1
 
 
 async def test_shuffle_set(
@@ -635,7 +621,7 @@ async def test_shuffle_set(
         {ATTR_ENTITY_ID: "media_player.test_player", ATTR_MEDIA_SHUFFLE: True},
         blocking=True,
     )
-    player.set_play_mode.assert_called_once_with(player.repeat, True)
+    controller.player_set_play_mode.assert_called_once_with(1, player.repeat, True)
 
 
 async def test_shuffle_set_error(
@@ -645,7 +631,7 @@ async def test_shuffle_set_error(
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
     player = controller.players[1]
-    player.set_play_mode.side_effect = CommandFailedError("", "Failure", 1)
+    controller.player_set_play_mode.side_effect = CommandFailedError("", "Failure", 1)
     with pytest.raises(
         HomeAssistantError,
         match=re.escape("Unable to set shuffle: Failure (1)"),
@@ -656,7 +642,7 @@ async def test_shuffle_set_error(
             {ATTR_ENTITY_ID: "media_player.test_player", ATTR_MEDIA_SHUFFLE: True},
             blocking=True,
         )
-    player.set_play_mode.assert_called_once_with(player.repeat, True)
+    controller.player_set_play_mode.assert_called_once_with(1, player.repeat, True)
 
 
 async def test_repeat_set(
@@ -672,7 +658,9 @@ async def test_repeat_set(
         {ATTR_ENTITY_ID: "media_player.test_player", ATTR_MEDIA_REPEAT: RepeatMode.ONE},
         blocking=True,
     )
-    player.set_play_mode.assert_called_once_with(RepeatType.ON_ONE, player.shuffle)
+    controller.player_set_play_mode.assert_called_once_with(
+        1, RepeatType.ON_ONE, player.shuffle
+    )
 
 
 async def test_repeat_set_error(
@@ -682,7 +670,7 @@ async def test_repeat_set_error(
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
     player = controller.players[1]
-    player.set_play_mode.side_effect = CommandFailedError("", "Failure", 1)
+    controller.player_set_play_mode.side_effect = CommandFailedError("", "Failure", 1)
     with pytest.raises(
         HomeAssistantError,
         match=re.escape("Unable to set repeat: Failure (1)"),
@@ -696,7 +684,9 @@ async def test_repeat_set_error(
             },
             blocking=True,
         )
-    player.set_play_mode.assert_called_once_with(RepeatType.ON_ALL, player.shuffle)
+    controller.player_set_play_mode.assert_called_once_with(
+        1, RepeatType.ON_ALL, player.shuffle
+    )
 
 
 async def test_volume_set(
@@ -705,14 +695,13 @@ async def test_volume_set(
     """Test the volume set service."""
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
-    player = controller.players[1]
     await hass.services.async_call(
         MEDIA_PLAYER_DOMAIN,
         SERVICE_VOLUME_SET,
         {ATTR_ENTITY_ID: "media_player.test_player", ATTR_MEDIA_VOLUME_LEVEL: 1},
         blocking=True,
     )
-    player.set_volume.assert_called_once_with(100)
+    controller.player_set_volume.assert_called_once_with(1, 100)
 
 
 async def test_volume_set_error(
@@ -721,8 +710,7 @@ async def test_volume_set_error(
     """Test the volume set service raises error."""
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
-    player = controller.players[1]
-    player.set_volume.side_effect = CommandFailedError("", "Failure", 1)
+    controller.player_set_volume.side_effect = CommandFailedError("", "Failure", 1)
     with pytest.raises(
         HomeAssistantError,
         match=re.escape("Unable to set volume level: Failure (1)"),
@@ -733,7 +721,7 @@ async def test_volume_set_error(
             {ATTR_ENTITY_ID: "media_player.test_player", ATTR_MEDIA_VOLUME_LEVEL: 1},
             blocking=True,
         )
-    player.set_volume.assert_called_once_with(100)
+    controller.player_set_volume.assert_called_once_with(1, 100)
 
 
 async def test_select_favorite(
@@ -754,7 +742,7 @@ async def test_select_favorite(
         {ATTR_ENTITY_ID: "media_player.test_player", ATTR_INPUT_SOURCE: favorite.name},
         blocking=True,
     )
-    player.play_preset_station.assert_called_once_with(1)
+    controller.play_preset_station.assert_called_once_with(1, 1)
     # Test state is matched by station name
     player.now_playing_media.type = HeosMediaType.STATION
     player.now_playing_media.station = favorite.name
@@ -785,7 +773,7 @@ async def test_select_radio_favorite(
         {ATTR_ENTITY_ID: "media_player.test_player", ATTR_INPUT_SOURCE: favorite.name},
         blocking=True,
     )
-    player.play_preset_station.assert_called_once_with(2)
+    controller.play_preset_station.assert_called_once_with(1, 2)
     # Test state is matched by album id
     player.now_playing_media.type = HeosMediaType.STATION
     player.now_playing_media.station = "Classical"
@@ -808,10 +796,9 @@ async def test_select_radio_favorite_command_error(
     """Tests command error raises when playing favorite."""
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
-    player = controller.players[1]
     # Test set radio preset
     favorite = favorites[2]
-    player.play_preset_station.side_effect = CommandFailedError("", "Failure", 1)
+    controller.play_preset_station.side_effect = CommandFailedError("", "Failure", 1)
     with pytest.raises(
         HomeAssistantError,
         match=re.escape("Unable to select source: Failure (1)"),
@@ -825,7 +812,7 @@ async def test_select_radio_favorite_command_error(
             },
             blocking=True,
         )
-    player.play_preset_station.assert_called_once_with(2)
+    controller.play_preset_station.assert_called_once_with(1, 2)
 
 
 @pytest.mark.parametrize(
@@ -862,7 +849,9 @@ async def test_select_input_source(
         for input_sources in input_sources
         if input_sources.name == source_name
     )
-    player.play_media.assert_called_once_with(input_source)
+    controller.play_media.assert_called_once_with(
+        1, input_source, AddCriteriaType.PLAY_NOW
+    )
     # Update the now_playing_media to reflect play_media
     player.now_playing_media.source_id = const.MUSIC_SOURCE_AUX_INPUT
     player.now_playing_media.station = station
@@ -903,9 +892,8 @@ async def test_select_input_command_error(
     """Tests selecting an unknown input."""
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
-    player = controller.players[1]
     input_source = input_sources[0]
-    player.play_media.side_effect = CommandFailedError("", "Failure", 1)
+    controller.play_media.side_effect = CommandFailedError("", "Failure", 1)
     with pytest.raises(
         HomeAssistantError,
         match=re.escape("Unable to select source: Failure (1)"),
@@ -919,7 +907,9 @@ async def test_select_input_command_error(
             },
             blocking=True,
         )
-    player.play_media.assert_called_once_with(input_source)
+    controller.play_media.assert_called_once_with(
+        1, input_source, AddCriteriaType.PLAY_NOW
+    )
 
 
 async def test_unload_config_entry(
@@ -944,7 +934,6 @@ async def test_play_media(
     """Test the play media service with type url."""
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
-    player = controller.players[1]
     url = "http://news/podcast.mp3"
     await hass.services.async_call(
         MEDIA_PLAYER_DOMAIN,
@@ -956,7 +945,7 @@ async def test_play_media(
         },
         blocking=True,
     )
-    player.play_url.assert_called_once_with(url)
+    controller.play_url.assert_called_once_with(1, url)
 
 
 @pytest.mark.parametrize("media_type", [MediaType.URL, MediaType.MUSIC])
@@ -969,8 +958,7 @@ async def test_play_media_error(
     """Test the play media service with type url error raises."""
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
-    player = controller.players[1]
-    player.play_url.side_effect = CommandFailedError("", "Failure", 1)
+    controller.play_url.side_effect = CommandFailedError("", "Failure", 1)
     url = "http://news/podcast.mp3"
     with pytest.raises(
         HomeAssistantError,
@@ -986,7 +974,7 @@ async def test_play_media_error(
             },
             blocking=True,
         )
-    player.play_url.assert_called_once_with(url)
+    controller.play_url.assert_called_once_with(1, url)
 
 
 @pytest.mark.parametrize(
@@ -1002,7 +990,6 @@ async def test_play_media_quick_select(
     """Test the play media service with type quick_select."""
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
-    player = controller.players[1]
     await hass.services.async_call(
         MEDIA_PLAYER_DOMAIN,
         SERVICE_PLAY_MEDIA,
@@ -1013,7 +1000,7 @@ async def test_play_media_quick_select(
         },
         blocking=True,
     )
-    player.play_quick_select.assert_called_once_with(expected_index)
+    controller.player_play_quick_select.assert_called_once_with(1, expected_index)
 
 
 async def test_play_media_quick_select_error(
@@ -1022,7 +1009,6 @@ async def test_play_media_quick_select_error(
     """Test the play media service with invalid quick_select raises."""
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
-    player = controller.players[1]
     with pytest.raises(
         HomeAssistantError,
         match=re.escape("Unable to play media: Invalid quick select 'Invalid'"),
@@ -1037,7 +1023,7 @@ async def test_play_media_quick_select_error(
             },
             blocking=True,
         )
-    assert player.play_quick_select.call_count == 0
+    assert controller.player_play_quick_select.call_count == 0
 
 
 @pytest.mark.parametrize(
@@ -1059,7 +1045,6 @@ async def test_play_media_playlist(
     """Test the play media service with type playlist."""
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
-    player = controller.players[1]
     playlist = playlists[0]
     service_data = {
         ATTR_ENTITY_ID: "media_player.test_player",
@@ -1074,7 +1059,7 @@ async def test_play_media_playlist(
         service_data,
         blocking=True,
     )
-    player.play_media.assert_called_once_with(playlist, criteria)
+    controller.play_media.assert_called_once_with(1, playlist, criteria)
 
 
 async def test_play_media_playlist_error(
@@ -1083,7 +1068,6 @@ async def test_play_media_playlist_error(
     """Test the play media service with an invalid playlist name."""
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
-    player = controller.players[1]
     with pytest.raises(
         HomeAssistantError,
         match=re.escape("Unable to play media: Invalid playlist 'Invalid'"),
@@ -1098,7 +1082,7 @@ async def test_play_media_playlist_error(
             },
             blocking=True,
         )
-    assert player.add_to_queue.call_count == 0
+    assert controller.add_to_queue.call_count == 0
 
 
 @pytest.mark.parametrize(
@@ -1114,7 +1098,6 @@ async def test_play_media_favorite(
     """Test the play media service with type favorite."""
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
-    player = controller.players[1]
     await hass.services.async_call(
         MEDIA_PLAYER_DOMAIN,
         SERVICE_PLAY_MEDIA,
@@ -1125,7 +1108,7 @@ async def test_play_media_favorite(
         },
         blocking=True,
     )
-    player.play_preset_station.assert_called_once_with(expected_index)
+    controller.play_preset_station.assert_called_once_with(1, expected_index)
 
 
 async def test_play_media_favorite_error(
@@ -1134,7 +1117,6 @@ async def test_play_media_favorite_error(
     """Test the play media service with an invalid favorite raises."""
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
-    player = controller.players[1]
     with pytest.raises(
         HomeAssistantError,
         match=re.escape("Unable to play media: Invalid favorite 'Invalid'"),
@@ -1149,7 +1131,7 @@ async def test_play_media_favorite_error(
             },
             blocking=True,
         )
-    assert player.play_preset_station.call_count == 0
+    assert controller.play_preset_station.call_count == 0
 
 
 async def test_play_media_invalid_type(

--- a/tests/components/heos/test_services.py
+++ b/tests/components/heos/test_services.py
@@ -1,6 +1,6 @@
 """Tests for the services module."""
 
-from pyheos import CommandAuthenticationError, Heos, HeosError
+from pyheos import CommandAuthenticationError, HeosError
 import pytest
 
 from homeassistant.components.heos.const import (
@@ -13,11 +13,13 @@ from homeassistant.components.heos.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 
+from . import MockHeos
+
 from tests.common import MockConfigEntry
 
 
 async def test_sign_in(
-    hass: HomeAssistant, config_entry: MockConfigEntry, controller: Heos
+    hass: HomeAssistant, config_entry: MockConfigEntry, controller: MockHeos
 ) -> None:
     """Test the sign-in service."""
     config_entry.add_to_hass(hass)
@@ -34,7 +36,7 @@ async def test_sign_in(
 
 
 async def test_sign_in_failed(
-    hass: HomeAssistant, config_entry: MockConfigEntry, controller: Heos
+    hass: HomeAssistant, config_entry: MockConfigEntry, controller: MockHeos
 ) -> None:
     """Test sign-in service logs error when not connected."""
     config_entry.add_to_hass(hass)
@@ -56,7 +58,7 @@ async def test_sign_in_failed(
 
 
 async def test_sign_in_unknown_error(
-    hass: HomeAssistant, config_entry: MockConfigEntry, controller: Heos
+    hass: HomeAssistant, config_entry: MockConfigEntry, controller: MockHeos
 ) -> None:
     """Test sign-in service logs error for failure."""
     config_entry.add_to_hass(hass)
@@ -93,7 +95,7 @@ async def test_sign_in_not_loaded_raises(
 
 
 async def test_sign_out(
-    hass: HomeAssistant, config_entry: MockConfigEntry, controller: Heos
+    hass: HomeAssistant, config_entry: MockConfigEntry, controller: MockHeos
 ) -> None:
     """Test the sign-out service."""
     config_entry.add_to_hass(hass)
@@ -117,7 +119,7 @@ async def test_sign_out_not_loaded_raises(
 
 
 async def test_sign_out_unknown_error(
-    hass: HomeAssistant, config_entry: MockConfigEntry, controller: Heos
+    hass: HomeAssistant, config_entry: MockConfigEntry, controller: MockHeos
 ) -> None:
     """Test the sign-out service."""
     config_entry.add_to_hass(hass)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Introduced a `MockHeos` class to properly type mocked methods and encapsulate/centralize modifying internal data structures in the HEOS API instead of having it littered throughout tests. Most changed lines are updating the type in the test fixtures (`Heos` -> `MockHeos`). Fixed all typing errors found by running `mypy tests/components/heos --strict`. There were a couple of bugs in the tests this revealed, but nothing that ultimately affected the test accuracy. Tests are more tight and correct now.

TLDR: Ran `mypy` against the HEOS tests and fixed the issues. 😆 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
