### PR TITLE
Add error handling to enphase_envoy switch platform action

### DIFF
--- a/homeassistant/components/enphase_envoy/entity.py
+++ b/homeassistant/components/enphase_envoy/entity.py
@@ -2,12 +2,21 @@
 
 from __future__ import annotations
 
-from pyenphase import EnvoyData
+from collections.abc import Callable, Coroutine
+from typing import Any, Concatenate
 
+from httpx import HTTPError
+from pyenphase import EnvoyData
+from pyenphase.exceptions import EnvoyError
+
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from .const import DOMAIN
 from .coordinator import EnphaseUpdateCoordinator
+
+ACTIONERRORS = (EnvoyError, HTTPError)
 
 
 class EnvoyBaseEntity(CoordinatorEntity[EnphaseUpdateCoordinator]):
@@ -33,3 +42,29 @@ class EnvoyBaseEntity(CoordinatorEntity[EnphaseUpdateCoordinator]):
         data = self.coordinator.envoy.data
         assert data is not None
         return data
+
+
+def exception_handler[_EntityT: EnvoyBaseEntity, **_P](
+    func: Callable[Concatenate[_EntityT, _P], Coroutine[Any, Any, Any]],
+) -> Callable[Concatenate[_EntityT, _P], Coroutine[Any, Any, None]]:
+    """Decorate Enphase Envoy calls to handle exceptions.
+
+    A decorator that wraps the passed in function, catches enphase_envoy errors.
+    """
+
+    async def handler(self: _EntityT, *args: _P.args, **kwargs: _P.kwargs) -> None:
+        try:
+            await func(self, *args, **kwargs)
+        except ACTIONERRORS as error:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="action_error",
+                translation_placeholders={
+                    "host": self.coordinator.envoy.host,
+                    "args": error.args[0],
+                    "action": func.__name__,
+                    "entity": self.entity_id,
+                },
+            ) from error
+
+    return handler

--- a/homeassistant/components/enphase_envoy/strings.json
+++ b/homeassistant/components/enphase_envoy/strings.json
@@ -400,6 +400,12 @@
     },
     "envoy_error": {
       "message": "Error communicating with Envoy API on {host}: {args}"
+    },
+    "switch_on_error": {
+      "message": "Failed to switch {switch} on, host: {host}: {args}"
+    },
+    "switch_off_error": {
+      "message": "Failed to switch {switch} off, host: {host}: {args}"
     }
   }
 }

--- a/homeassistant/components/enphase_envoy/strings.json
+++ b/homeassistant/components/enphase_envoy/strings.json
@@ -401,11 +401,8 @@
     "envoy_error": {
       "message": "Error communicating with Envoy API on {host}: {args}"
     },
-    "switch_on_error": {
-      "message": "Failed to switch {switch} on, host: {host}: {args}"
-    },
-    "switch_off_error": {
-      "message": "Failed to switch {switch} off, host: {host}: {args}"
+    "action_error": {
+      "message": "Failed to execute {action} for {entity}, host: {host}: {args}"
     }
   }
 }

--- a/tests/components/enphase_envoy/test_switch.py
+++ b/tests/components/enphase_envoy/test_switch.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import AsyncMock, patch
 
+from pyenphase.exceptions import EnvoyError
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
@@ -16,6 +17,7 @@ from homeassistant.const import (
     STATE_ON,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 
 from . import setup_integration
@@ -112,6 +114,46 @@ async def test_switch_grid_operation(
     mock_envoy.go_off_grid.reset_mock()
 
 
+@pytest.mark.parametrize("mock_envoy", ["envoy_metered_batt_relay"], indirect=True)
+async def test_switch_grid_operation_with_error(
+    hass: HomeAssistant,
+    mock_envoy: AsyncMock,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test switch platform operation for grid switches when error occurs."""
+    with patch("homeassistant.components.enphase_envoy.PLATFORMS", [Platform.SWITCH]):
+        await setup_integration(hass, config_entry)
+
+    sn = mock_envoy.data.enpower.serial_number
+    test_entity = f"{Platform.SWITCH}.enpower_{sn}_grid_enabled"
+
+    mock_envoy.go_off_grid.side_effect = EnvoyError("Test")
+    mock_envoy.go_on_grid.side_effect = EnvoyError("Test")
+
+    with pytest.raises(
+        HomeAssistantError,
+        match=f"Failed to switch {test_entity} off, host",
+    ):
+        # test grid status switch operation
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: test_entity},
+            blocking=True,
+        )
+
+    with pytest.raises(
+        HomeAssistantError,
+        match=f"Failed to switch {test_entity} on, host",
+    ):
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: test_entity},
+            blocking=True,
+        )
+
+
 @pytest.mark.parametrize(
     ("mock_envoy", "use_serial"),
     [
@@ -163,6 +205,53 @@ async def test_switch_charge_from_grid_operation(
     )
     mock_envoy.disable_charge_from_grid.assert_awaited_once_with()
     mock_envoy.disable_charge_from_grid.reset_mock()
+
+
+@pytest.mark.parametrize(
+    ("mock_envoy", "use_serial"),
+    [
+        ("envoy_metered_batt_relay", "enpower_654321"),
+        ("envoy_eu_batt", "envoy_1234"),
+    ],
+    indirect=["mock_envoy"],
+)
+async def test_switch_charge_from_grid_operation_with_error(
+    hass: HomeAssistant,
+    mock_envoy: AsyncMock,
+    config_entry: MockConfigEntry,
+    use_serial: str,
+) -> None:
+    """Test switch platform operation for charge from grid switches."""
+    with patch("homeassistant.components.enphase_envoy.PLATFORMS", [Platform.SWITCH]):
+        await setup_integration(hass, config_entry)
+
+    test_entity = f"{Platform.SWITCH}.{use_serial}_charge_from_grid"
+
+    mock_envoy.disable_charge_from_grid.side_effect = EnvoyError("Test")
+    mock_envoy.enable_charge_from_grid.side_effect = EnvoyError("Test")
+
+    with pytest.raises(
+        HomeAssistantError,
+        match=f"Failed to switch {test_entity} off, host",
+    ):
+        # test grid status switch operation
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: test_entity},
+            blocking=True,
+        )
+
+    with pytest.raises(
+        HomeAssistantError,
+        match=f"Failed to switch {test_entity} on, host",
+    ):
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: test_entity},
+            blocking=True,
+        )
 
 
 @pytest.mark.parametrize(
@@ -232,3 +321,51 @@ async def test_switch_relay_operation(
         assert mock_envoy.close_dry_contact.await_count == close_count
         mock_envoy.open_dry_contact.reset_mock()
         mock_envoy.close_dry_contact.reset_mock()
+
+
+@pytest.mark.parametrize(
+    ("mock_envoy", "relay"),
+    [("envoy_metered_batt_relay", "NC1")],
+    indirect=["mock_envoy"],
+)
+async def test_switch_relay_operation_with_error(
+    hass: HomeAssistant,
+    mock_envoy: AsyncMock,
+    config_entry: MockConfigEntry,
+    relay: str,
+) -> None:
+    """Test enphase_envoy switch relay entities operation."""
+    with patch("homeassistant.components.enphase_envoy.PLATFORMS", [Platform.SWITCH]):
+        await setup_integration(hass, config_entry)
+
+    entity_base = f"{Platform.SWITCH}."
+
+    assert (dry_contact := mock_envoy.data.dry_contact_settings[relay])
+    assert (name := dry_contact.load_name.lower().replace(" ", "_"))
+
+    test_entity = f"{entity_base}{name}"
+
+    mock_envoy.close_dry_contact.side_effect = EnvoyError("Test")
+    mock_envoy.open_dry_contact.side_effect = EnvoyError("Test")
+
+    with pytest.raises(
+        HomeAssistantError,
+        match=f"Failed to switch {relay} off, host",
+    ):
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: test_entity},
+            blocking=True,
+        )
+
+    with pytest.raises(
+        HomeAssistantError,
+        match=f"Failed to switch {relay} on, host",
+    ):
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: test_entity},
+            blocking=True,
+        )

--- a/tests/components/enphase_envoy/test_switch.py
+++ b/tests/components/enphase_envoy/test_switch.py
@@ -132,7 +132,7 @@ async def test_switch_grid_operation_with_error(
 
     with pytest.raises(
         HomeAssistantError,
-        match=f"Failed to switch {test_entity} off, host",
+        match=f"Failed to execute async_turn_off for {test_entity}, host",
     ):
         # test grid status switch operation
         await hass.services.async_call(
@@ -144,7 +144,7 @@ async def test_switch_grid_operation_with_error(
 
     with pytest.raises(
         HomeAssistantError,
-        match=f"Failed to switch {test_entity} on, host",
+        match=f"Failed to execute async_turn_on for {test_entity}, host",
     ):
         await hass.services.async_call(
             SWITCH_DOMAIN,
@@ -232,7 +232,7 @@ async def test_switch_charge_from_grid_operation_with_error(
 
     with pytest.raises(
         HomeAssistantError,
-        match=f"Failed to switch {test_entity} off, host",
+        match=f"Failed to execute async_turn_off for {test_entity}, host",
     ):
         # test grid status switch operation
         await hass.services.async_call(
@@ -244,7 +244,7 @@ async def test_switch_charge_from_grid_operation_with_error(
 
     with pytest.raises(
         HomeAssistantError,
-        match=f"Failed to switch {test_entity} on, host",
+        match=f"Failed to execute async_turn_on for {test_entity}, host",
     ):
         await hass.services.async_call(
             SWITCH_DOMAIN,
@@ -350,7 +350,7 @@ async def test_switch_relay_operation_with_error(
 
     with pytest.raises(
         HomeAssistantError,
-        match=f"Failed to switch {relay} off, host",
+        match=f"Failed to execute async_turn_off for {test_entity}, host",
     ):
         await hass.services.async_call(
             SWITCH_DOMAIN,
@@ -361,7 +361,7 @@ async def test_switch_relay_operation_with_error(
 
     with pytest.raises(
         HomeAssistantError,
-        match=f"Failed to switch {relay} on, host",
+        match=f"Failed to execute async_turn_on for {test_entity}, host",
     ):
         await hass.services.async_call(
             SWITCH_DOMAIN,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR adds translatable error handling to enphase_envoy switch platform actions. The UI will now popup an error similar to below error, which is also added to the log file.

```txt
Failed to switch switch.enpower_12345678901001_grid_enabled off, host: 192.168.3.102: All connection attempts failed
```
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
