### PR TITLE
Feature Alert Events

### DIFF
--- a/homeassistant/components/alert/const.py
+++ b/homeassistant/components/alert/const.py
@@ -17,3 +17,5 @@ CONF_DATA = "data"
 
 DEFAULT_CAN_ACK = True
 DEFAULT_SKIP_FIRST = False
+
+ALERT_NOTIFY_EVENT = "alert_notify"

--- a/homeassistant/components/alert/entity.py
+++ b/homeassistant/components/alert/entity.py
@@ -33,7 +33,7 @@ class AlertNotifyAction(enum.StrEnum):
 
     generate = "generate"
     acknowledge = "acknowledge"
-    done = "clear"
+    done = "done"
     reset = "reset"
 
 

--- a/homeassistant/components/alert/entity.py
+++ b/homeassistant/components/alert/entity.py
@@ -195,8 +195,8 @@ class AlertEntity(Entity):
             self._async_fire_event(
                 AlertNotifyAction.generate,
                 message,
-                # The first notification that gets sent will have a repeat value of 0.
-                # So if the first repeat was skipped, offset the count by 1.
+                # The first notification that gets sent should have a repeat value of 0.
+                # Hence if the first repeat was skipped, offset the count by 1.
                 repeat=self._next_delay - int(self._skip_first),
             )
 

--- a/homeassistant/components/alert/entity.py
+++ b/homeassistant/components/alert/entity.py
@@ -195,7 +195,9 @@ class AlertEntity(Entity):
             self._async_fire_event(
                 AlertNotifyAction.generate,
                 message,
-                self._next_delay - int(self._skip_first),
+                # The first notification that gets sent will have a repeat value of 0.
+                # So if the first repeat was skipped, offset the count by 1.
+                repeat=self._next_delay - int(self._skip_first),
             )
 
             await self._send_notification_message(message)

--- a/tests/components/alert/snapshots/test_init.ambr
+++ b/tests/components/alert/snapshots/test_init.ambr
@@ -1,7 +1,7 @@
 # serializer version: 1
 # name: test_fire
   dict({
-    'action': <AlertAction.generate: 'generate'>,
+    'action': <AlertNotifyAction.generate: 'generate'>,
     'data': dict({
     }),
     'entity_id': 'alert.alert_test',
@@ -12,7 +12,7 @@
 # ---
 # name: test_notification
   dict({
-    'action': <AlertAction.done: 'clear'>,
+    'action': <AlertNotifyAction.done: 'done'>,
     'data': dict({
     }),
     'entity_id': 'alert.alert_test',
@@ -23,7 +23,7 @@
 # ---
 # name: test_notification_no_done_message
   dict({
-    'action': <AlertAction.done: 'clear'>,
+    'action': <AlertNotifyAction.done: 'done'>,
     'data': dict({
     }),
     'entity_id': 'alert.alert_test',
@@ -34,7 +34,7 @@
 # ---
 # name: test_reset
   dict({
-    'action': <AlertAction.acknowledge: 'acknowledge'>,
+    'action': <AlertNotifyAction.acknowledge: 'acknowledge'>,
     'data': dict({
     }),
     'entity_id': 'alert.alert_test',
@@ -45,7 +45,7 @@
 # ---
 # name: test_sending_data_notification
   dict({
-    'action': <AlertAction.generate: 'generate'>,
+    'action': <AlertNotifyAction.generate: 'generate'>,
     'data': dict({
       'data': dict({
         'inline_keyboard': list([
@@ -61,7 +61,7 @@
 # ---
 # name: test_silence
   dict({
-    'action': <AlertAction.acknowledge: 'acknowledge'>,
+    'action': <AlertNotifyAction.acknowledge: 'acknowledge'>,
     'data': dict({
     }),
     'entity_id': 'alert.alert_test',

--- a/tests/components/alert/snapshots/test_init.ambr
+++ b/tests/components/alert/snapshots/test_init.ambr
@@ -1,0 +1,62 @@
+# serializer version: 1
+# name: test_fire
+  dict({
+    'action': <AlertAction.generate: 'generate'>,
+    'entity_id': 'alert.alert_test',
+    'message': 'alert_test',
+    'repeat': 0,
+    'title': 'sensor.test',
+  })
+# ---
+# name: test_notification
+  dict({
+    'action': <AlertAction.done: 'clear'>,
+    'entity_id': 'alert.alert_test',
+    'message': 'alert_gone',
+    'repeat': None,
+    'title': 'sensor.test',
+  })
+# ---
+# name: test_notification_no_done_message
+  dict({
+    'action': <AlertAction.done: 'clear'>,
+    'entity_id': 'alert.alert_test',
+    'message': None,
+    'repeat': None,
+    'title': 'sensor.test',
+  })
+# ---
+# name: test_reset
+  dict({
+    'action': <AlertAction.acknowledge: 'acknowledge'>,
+    'entity_id': 'alert.alert_test',
+    'message': None,
+    'repeat': None,
+    'title': 'sensor.test',
+  })
+# ---
+# name: test_sending_data_notification
+  dict({
+    'action': <AlertAction.generate: 'generate'>,
+    'data': dict({
+      'data': dict({
+        'inline_keyboard': list([
+          'Close garage:/close_garage',
+        ]),
+      }),
+    }),
+    'entity_id': 'alert.alert_test',
+    'message': 'alert_test',
+    'repeat': 0,
+    'title': 'sensor.test',
+  })
+# ---
+# name: test_silence
+  dict({
+    'action': <AlertAction.acknowledge: 'acknowledge'>,
+    'entity_id': 'alert.alert_test',
+    'message': None,
+    'repeat': None,
+    'title': 'sensor.test',
+  })
+# ---

--- a/tests/components/alert/snapshots/test_init.ambr
+++ b/tests/components/alert/snapshots/test_init.ambr
@@ -2,6 +2,8 @@
 # name: test_fire
   dict({
     'action': <AlertAction.generate: 'generate'>,
+    'data': dict({
+    }),
     'entity_id': 'alert.alert_test',
     'message': 'alert_test',
     'repeat': 0,
@@ -11,6 +13,8 @@
 # name: test_notification
   dict({
     'action': <AlertAction.done: 'clear'>,
+    'data': dict({
+    }),
     'entity_id': 'alert.alert_test',
     'message': 'alert_gone',
     'repeat': None,
@@ -20,6 +24,8 @@
 # name: test_notification_no_done_message
   dict({
     'action': <AlertAction.done: 'clear'>,
+    'data': dict({
+    }),
     'entity_id': 'alert.alert_test',
     'message': None,
     'repeat': None,
@@ -29,6 +35,8 @@
 # name: test_reset
   dict({
     'action': <AlertAction.acknowledge: 'acknowledge'>,
+    'data': dict({
+    }),
     'entity_id': 'alert.alert_test',
     'message': None,
     'repeat': None,
@@ -54,6 +62,8 @@
 # name: test_silence
   dict({
     'action': <AlertAction.acknowledge: 'acknowledge'>,
+    'data': dict({
+    }),
     'entity_id': 'alert.alert_test',
     'message': None,
     'repeat': None,

--- a/tests/components/alert/test_init.py
+++ b/tests/components/alert/test_init.py
@@ -125,6 +125,7 @@ async def test_silence(
         {ATTR_ENTITY_ID: ENTITY_ID},
         blocking=True,
     )
+    await hass.async_block_till_done()
     assert hass.states.get(ENTITY_ID).state == STATE_OFF
     assert event_callback.event.data == snapshot
 

--- a/tests/components/alert/test_init.py
+++ b/tests/components/alert/test_init.py
@@ -76,10 +76,10 @@ ENTITY_ID = f"{DOMAIN}.{NAME}"
 
 
 class _EventCallback:
-    def __init__(self):
+    def __init__(self) -> None:
         self.event: Event | None = None
 
-    def listener(self, event: Event):
+    def listener(self, event: Event) -> None:
         self.event = event
 
 

--- a/tests/components/alert/test_init.py
+++ b/tests/components/alert/test_init.py
@@ -115,7 +115,6 @@ async def test_silence(
     assert await async_setup_component(hass, DOMAIN, TEST_CONFIG)
     hass.states.async_set("sensor.test", STATE_ON)
     await hass.async_block_till_done()
-
     event_callback = _EventCallback()
     hass.bus.async_listen_once(EVENT_ALERT_NOTIFY, event_callback.listener)
 
@@ -145,7 +144,6 @@ async def test_reset(
     assert await async_setup_component(hass, DOMAIN, TEST_CONFIG)
     hass.states.async_set("sensor.test", STATE_ON)
     await hass.async_block_till_done()
-
     event_callback = _EventCallback()
     hass.bus.async_listen_once(EVENT_ALERT_NOTIFY, event_callback.listener)
 
@@ -208,7 +206,6 @@ async def test_notification_no_done_message(
 
     event_callback = _EventCallback()
     hass.bus.async_listen_once(EVENT_ALERT_NOTIFY, event_callback.listener)
-
     hass.states.async_set("sensor.test", STATE_OFF)
     await hass.async_block_till_done()
     assert len(mock_notifier) == 1
@@ -228,7 +225,6 @@ async def test_notification(
 
     event_callback = _EventCallback()
     hass.bus.async_listen_once(EVENT_ALERT_NOTIFY, event_callback.listener)
-
     hass.states.async_set("sensor.test", STATE_OFF)
     await hass.async_block_till_done()
     assert len(mock_notifier) == 2
@@ -351,7 +347,6 @@ async def test_sending_data_notification(
     config = deepcopy(TEST_CONFIG)
     config[DOMAIN][NAME][CONF_DATA] = TEST_DATA
     assert await async_setup_component(hass, DOMAIN, config)
-
     event_callback = _EventCallback()
     hass.bus.async_listen_once(EVENT_ALERT_NOTIFY, event_callback.listener)
 


### PR DESCRIPTION
## Proposed change
The Alert integration provides functionality for managing the alert lifecycle (generate, done, reset, acknowledge) and sending notifications when alerts are generated or done. However, there is limited flexibility in managing where the notification get sent. For example, sending notifications to a device based on time of day or device location; or escalating the alert to send to other devices if it repeats more than 3 times.

With this enhancement, Alerts will generate events when the alert lifecycle changes and when alerts are repeated; allowing the user to create automations that listen to the events and perform custom notification routing.

Example event (new functionality)

```
event_type: alert_notify
data:
  entity_id: alert.al_ts_sensor_2_temperature_low
  action: generate
  title: Temperature Cold
  message: ALERT Yo dude its cold!
  repeat: 0
  data:
    title: Cold
    actions:
      - action: ACK_AL_TS_SENSOR_2_TEMPERATURE_LOW
        title: Acknowledge
      - action: NONE
        title: No Action
origin: LOCAL
time_fired: "2025-01-29T15:57:53.699782+00:00"
context:
  id: 01JJSCH1N32R660MEE5471M3EQ
  parent_id: null
  user_id: null

```

Example alert definition (existing functionality)

```
alert:
  al_ts_sensor_2_temperature_low:
    name: ts_sensor_2_temperature_low
    message: 'ALERT Yo dude it's cold'
    done_message: 'Cleared'
    title: Temperature Cold
    entity_id: input_boolean.alert_trigger
    state: "on"
    repeat:
      - 1
      - 1
      - 1
    can_acknowledge: true
    skip_first: false
    data:
      title: Cold
      actions:
        - action: ACK_AL_TS_SENSOR_2_TEMPERATURE_LOW
          title: Acknowledge
        - action: NONE
          title: No Action
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: TODO

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
