### PR TITLE
Handle locked account error in Whirlpool

### DIFF
--- a/homeassistant/components/whirlpool/__init__.py
+++ b/homeassistant/components/whirlpool/__init__.py
@@ -5,7 +5,7 @@ import logging
 
 from aiohttp import ClientError
 from whirlpool.appliancesmanager import AppliancesManager
-from whirlpool.auth import Auth
+from whirlpool.auth import AccountLockedError as WhirlpoolAccountLocked, Auth
 from whirlpool.backendselector import BackendSelector
 
 from homeassistant.config_entries import ConfigEntry
@@ -39,6 +39,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: WhirlpoolConfigEntry) ->
         await auth.do_auth(store=False)
     except (ClientError, TimeoutError) as ex:
         raise ConfigEntryNotReady("Cannot connect") from ex
+    except WhirlpoolAccountLocked as ex:
+        raise ConfigEntryAuthFailed(
+            translation_domain=DOMAIN, translation_key="account_locked"
+        ) from ex
 
     if not auth.is_access_token_valid():
         _LOGGER.error("Authentication failed")

--- a/homeassistant/components/whirlpool/config_flow.py
+++ b/homeassistant/components/whirlpool/config_flow.py
@@ -9,7 +9,7 @@ from typing import Any
 from aiohttp import ClientError
 import voluptuous as vol
 from whirlpool.appliancesmanager import AppliancesManager
-from whirlpool.auth import Auth
+from whirlpool.auth import AccountLockedError as WhirlpoolAccountLocked, Auth
 from whirlpool.backendselector import BackendSelector
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
@@ -55,6 +55,8 @@ async def authenticate(
 
     try:
         await auth.do_auth()
+    except WhirlpoolAccountLocked:
+        return "account_locked"
     except (TimeoutError, ClientError):
         return "cannot_connect"
     except Exception:

--- a/homeassistant/components/whirlpool/strings.json
+++ b/homeassistant/components/whirlpool/strings.json
@@ -1,4 +1,7 @@
 {
+  "common": {
+    "account_locked_error": "The account is locked. Please follow the instructions in the manufacturer's app to unlock it"
+  },
   "config": {
     "step": {
       "user": {
@@ -31,6 +34,7 @@
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     },
     "error": {
+      "account_locked": "[%key:component::whirlpool::common::account_locked_error%]",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "unknown": "[%key:common::config_flow::error::unknown%]",
@@ -84,6 +88,11 @@
       "end_time": {
         "name": "End time"
       }
+    }
+  },
+  "exceptions": {
+    "account_locked": {
+      "message": "[%key:component::whirlpool::common::account_locked_error%]"
     }
   }
 }

--- a/tests/components/whirlpool/test_config_flow.py
+++ b/tests/components/whirlpool/test_config_flow.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 
 import aiohttp
 import pytest
+from whirlpool.auth import AccountLockedError
 
 from homeassistant import config_entries
 from homeassistant.components.whirlpool.const import CONF_BRAND, DOMAIN
@@ -82,6 +83,7 @@ async def test_form_invalid_auth(
 @pytest.mark.parametrize(
     ("exception", "expected_error"),
     [
+        (AccountLockedError, "account_locked"),
         (aiohttp.ClientConnectionError, "cannot_connect"),
         (TimeoutError, "cannot_connect"),
         (Exception, "unknown"),
@@ -249,6 +251,7 @@ async def test_reauth_flow_invalid_auth(
 @pytest.mark.parametrize(
     ("exception", "expected_error"),
     [
+        (AccountLockedError, "account_locked"),
         (aiohttp.ClientConnectionError, "cannot_connect"),
         (TimeoutError, "cannot_connect"),
         (Exception, "unknown"),

--- a/tests/components/whirlpool/test_init.py
+++ b/tests/components/whirlpool/test_init.py
@@ -3,6 +3,7 @@
 from unittest.mock import AsyncMock, MagicMock
 
 import aiohttp
+from whirlpool.auth import AccountLockedError
 from whirlpool.backendselector import Brand, Region
 
 from homeassistant.components.whirlpool.const import DOMAIN
@@ -99,6 +100,18 @@ async def test_setup_auth_failed(
     """Test setup with failed auth."""
     mock_auth_api.return_value.do_auth = AsyncMock()
     mock_auth_api.return_value.is_access_token_valid.return_value = False
+    entry = await init_integration(hass)
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 1
+    assert entry.state is ConfigEntryState.SETUP_ERROR
+
+
+async def test_setup_auth_account_locked(
+    hass: HomeAssistant,
+    mock_auth_api: MagicMock,
+    mock_aircon_api_instances: MagicMock,
+) -> None:
+    """Test setup with failed auth due to account being locked."""
+    mock_auth_api.return_value.do_auth.side_effect = AccountLockedError
     entry = await init_integration(hass)
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
     assert entry.state is ConfigEntryState.SETUP_ERROR


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
After a few authentication attemps with an invalid password, the account gets locked and a password reset is required. This change handles that error and informs the user about it. Previously, the user would only get a generic authentication error.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
