### PR TITLE
Add more verbose debug logging to airq integration

### DIFF
--- a/homeassistant/components/airq/config_flow.py
+++ b/homeassistant/components/airq/config_flow.py
@@ -62,7 +62,7 @@ class AirQConfigFlow(ConfigFlow, domain=DOMAIN):
         try:
             await airq.validate()
         except ClientConnectionError:
-            _LOGGER.debug(
+            _LOGGER.error(
                 (
                     "Failed to connect to device %s. Check the IP address / device"
                     " ID as well as whether the device is connected to power and"
@@ -72,17 +72,18 @@ class AirQConfigFlow(ConfigFlow, domain=DOMAIN):
             )
             errors["base"] = "cannot_connect"
         except InvalidAuth:
-            _LOGGER.debug(
+            _LOGGER.error(
                 "Incorrect password for device %s", user_input[CONF_IP_ADDRESS]
             )
             errors["base"] = "invalid_auth"
         else:
-            _LOGGER.debug("Successfully connected to %s", user_input[CONF_IP_ADDRESS])
+            _LOGGER.info("Successfully connected to %s", user_input[CONF_IP_ADDRESS])
 
             device_info = await airq.fetch_device_info()
             await self.async_set_unique_id(device_info["id"])
             self._abort_if_unique_id_configured()
 
+            _LOGGER.debug("Creating an entry for %s", device_info["name"])
             return self.async_create_entry(title=device_info["name"], data=user_input)
 
         return self.async_show_form(

--- a/homeassistant/components/airq/coordinator.py
+++ b/homeassistant/components/airq/coordinator.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import timedelta
 import logging
 
-from aioairq import AirQ
+from aioairq.core import AirQ, identify_warming_up_sensors
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_IP_ADDRESS, CONF_PASSWORD
@@ -52,6 +52,9 @@ class AirQCoordinator(DataUpdateCoordinator):
     async def _async_update_data(self) -> dict:
         """Fetch the data from the device."""
         if "name" not in self.device_info:
+            _LOGGER.debug(
+                "'name' not found in AirQCoordinator.device_info, fetching from the device"
+            )
             info = await self.airq.fetch_device_info()
             self.device_info.update(
                 DeviceInfo(
@@ -61,7 +64,16 @@ class AirQCoordinator(DataUpdateCoordinator):
                     hw_version=info["hw_version"],
                 )
             )
-        return await self.airq.get_latest_data(  # type: ignore[no-any-return]
+            _LOGGER.debug(
+                "Updated AirQCoordinator.device_info for 'name' %s",
+                self.device_info.get("name"),
+            )
+        data: dict = await self.airq.get_latest_data(
             return_average=self.return_average,
             clip_negative_values=self.clip_negative,
         )
+        if warming_up_sensors := identify_warming_up_sensors(data):
+            _LOGGER.debug(
+                "Following sensors are still warming up: %s", warming_up_sensors
+            )
+        return data

--- a/homeassistant/components/airq/manifest.json
+++ b/homeassistant/components/airq/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "loggers": ["aioairq"],
-  "requirements": ["aioairq==0.4.3"]
+  "requirements": ["aioairq==0.4.4"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -176,7 +176,7 @@ aio-georss-gdacs==0.10
 aioacaia==0.1.14
 
 # homeassistant.components.airq
-aioairq==0.4.3
+aioairq==0.4.4
 
 # homeassistant.components.airzone_cloud
 aioairzone-cloud==0.6.10

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -164,7 +164,7 @@ aio-georss-gdacs==0.10
 aioacaia==0.1.14
 
 # homeassistant.components.airq
-aioairq==0.4.3
+aioairq==0.4.4
 
 # homeassistant.components.airzone_cloud
 aioairzone-cloud==0.6.10


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds a few more `_LOGGER.debug` calls to the integration and bumps the version of `aioairq` ([diff](https://github.com/CorantGmbH/aioairq/compare/v0.4.3...v0.4.4)) which in turns adds even more extensive debug logging.

There have been some [reports](https://github.com/home-assistant/core/issues/82077) of unexpected stalling of the integration which were very difficult to reproduce and the only remedy I could offer was a workaround with an automation that would restart the integration if needed. 
Recently, we received another report of a silent stalling, but only of a single entity / sensor. 
This is my best effort to allow the users to collect more information to debug such poorly reproducible issues.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/issues/82077
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/37197

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
