### PR TITLE
Add HEOS entity service to set group volume level

### DIFF
--- a/homeassistant/components/heos/const.py
+++ b/homeassistant/components/heos/const.py
@@ -3,5 +3,6 @@
 ATTR_PASSWORD = "password"
 ATTR_USERNAME = "username"
 DOMAIN = "heos"
+SERVICE_GROUP_VOLUME_SET = "group_volume_set"
 SERVICE_SIGN_IN = "sign_in"
 SERVICE_SIGN_OUT = "sign_out"

--- a/homeassistant/components/heos/icons.json
+++ b/homeassistant/components/heos/icons.json
@@ -1,5 +1,8 @@
 {
   "services": {
+    "group_volume_set": {
+      "service": "mdi:volume-medium"
+    },
     "sign_in": {
       "service": "mdi:login"
     },

--- a/homeassistant/components/heos/media_player.py
+++ b/homeassistant/components/heos/media_player.py
@@ -17,10 +17,12 @@ from pyheos import (
     RepeatType,
     const as heos_const,
 )
+import voluptuous as vol
 
 from homeassistant.components import media_source
 from homeassistant.components.media_player import (
     ATTR_MEDIA_ENQUEUE,
+    ATTR_MEDIA_VOLUME_LEVEL,
     BrowseMedia,
     MediaPlayerEnqueue,
     MediaPlayerEntity,
@@ -33,13 +35,17 @@ from homeassistant.components.media_player import (
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import (
+    config_validation as cv,
+    entity_platform,
+    entity_registry as er,
+)
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util.dt import utcnow
 
-from .const import DOMAIN as HEOS_DOMAIN
+from .const import DOMAIN as HEOS_DOMAIN, SERVICE_GROUP_VOLUME_SET
 from .coordinator import HeosConfigEntry, HeosCoordinator
 
 PARALLEL_UPDATES = 0
@@ -93,6 +99,13 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Add media players for a config entry."""
+    # Register custom entity services
+    platform = entity_platform.async_get_current_platform()
+    platform.async_register_entity_service(
+        SERVICE_GROUP_VOLUME_SET,
+        {vol.Required(ATTR_MEDIA_VOLUME_LEVEL): cv.small_float},
+        "async_set_group_volume_level",
+    )
 
     def add_entities_callback(players: Sequence[HeosPlayer]) -> None:
         """Add entities for each player."""
@@ -345,6 +358,19 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
     async def async_set_volume_level(self, volume: float) -> None:
         """Set volume level, range 0..1."""
         await self._player.set_volume(int(volume * 100))
+
+    @catch_action_error("set group volume level")
+    async def async_set_group_volume_level(self, volume_level: float) -> None:
+        """Set group volume level."""
+        if self._player.group_id is None:
+            raise ServiceValidationError(
+                translation_domain=HEOS_DOMAIN,
+                translation_key="entity_not_grouped",
+                translation_placeholders={"entity_id": self.entity_id},
+            )
+        await self.coordinator.heos.set_group_volume(
+            self._player.group_id, int(volume_level * 100)
+        )
 
     @catch_action_error("join players")
     async def async_join_players(self, group_members: list[str]) -> None:

--- a/homeassistant/components/heos/services.yaml
+++ b/homeassistant/components/heos/services.yaml
@@ -1,3 +1,17 @@
+group_volume_set:
+  target:
+    entity:
+      integration: heos
+      domain: media_player
+  fields:
+    volume_level:
+      required: true
+      selector:
+        number:
+          min: 0
+          max: 1
+          step: 0.01
+
 sign_in:
   fields:
     username:

--- a/homeassistant/components/heos/strings.json
+++ b/homeassistant/components/heos/strings.json
@@ -71,6 +71,16 @@
     }
   },
   "services": {
+    "group_volume_set": {
+      "name": "Set group volume",
+      "description": "Sets the group's volume while preserving member volume ratios.",
+      "fields": {
+        "volume_level": {
+          "name": "Level",
+          "description": "The volume. 0 is inaudible, 1 is the maximum volume."
+        }
+      }
+    },
     "sign_in": {
       "name": "Sign in",
       "description": "Signs in to a HEOS account.",
@@ -93,6 +103,9 @@
   "exceptions": {
     "action_error": {
       "message": "Unable to {action}: {error}"
+    },
+    "entity_not_grouped": {
+      "message": "Entity {entity_id} is not joined to a group"
     },
     "entity_not_found": {
       "message": "Entity {entity_id} was not found"

--- a/tests/components/heos/__init__.py
+++ b/tests/components/heos/__init__.py
@@ -34,6 +34,7 @@ class MockHeos(Heos):
         self.player_set_play_state: AsyncMock = AsyncMock()
         self.player_set_volume: AsyncMock = AsyncMock()
         self.set_group: AsyncMock = AsyncMock()
+        self.set_group_volume: AsyncMock = AsyncMock()
         self.sign_in: AsyncMock = AsyncMock()
         self.sign_out: AsyncMock = AsyncMock()
 

--- a/tests/components/heos/test_media_player.py
+++ b/tests/components/heos/test_media_player.py
@@ -22,7 +22,7 @@ import pytest
 from syrupy.assertion import SnapshotAssertion
 from syrupy.filters import props
 
-from homeassistant.components.heos.const import DOMAIN
+from homeassistant.components.heos.const import DOMAIN, SERVICE_GROUP_VOLUME_SET
 from homeassistant.components.media_player import (
     ATTR_GROUP_MEMBERS,
     ATTR_INPUT_SOURCE,
@@ -722,6 +722,62 @@ async def test_volume_set_error(
             blocking=True,
         )
     controller.player_set_volume.assert_called_once_with(1, 100)
+
+
+async def test_group_volume_set(
+    hass: HomeAssistant, config_entry: MockConfigEntry, controller: MockHeos
+) -> None:
+    """Test the group volume set service."""
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_GROUP_VOLUME_SET,
+        {ATTR_ENTITY_ID: "media_player.test_player", ATTR_MEDIA_VOLUME_LEVEL: 1},
+        blocking=True,
+    )
+    controller.set_group_volume.assert_called_once_with(999, 100)
+
+
+async def test_group_volume_set_error(
+    hass: HomeAssistant, config_entry: MockConfigEntry, controller: MockHeos
+) -> None:
+    """Test the group volume set service errors."""
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    controller.set_group_volume.side_effect = CommandFailedError("", "Failure", 1)
+    with pytest.raises(
+        HomeAssistantError,
+        match=re.escape("Unable to set group volume level: Failure (1)"),
+    ):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_GROUP_VOLUME_SET,
+            {ATTR_ENTITY_ID: "media_player.test_player", ATTR_MEDIA_VOLUME_LEVEL: 1},
+            blocking=True,
+        )
+    controller.set_group_volume.assert_called_once_with(999, 100)
+
+
+async def test_group_volume_set_not_grouped_error(
+    hass: HomeAssistant, config_entry: MockConfigEntry, controller: MockHeos
+) -> None:
+    """Test the group volume set service when not grouped raises error."""
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    player = controller.players[1]
+    player.group_id = None
+    with pytest.raises(
+        ServiceValidationError,
+        match=re.escape("Entity media_player.test_player is not joined to a group"),
+    ):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_GROUP_VOLUME_SET,
+            {ATTR_ENTITY_ID: "media_player.test_player", ATTR_MEDIA_VOLUME_LEVEL: 1},
+            blocking=True,
+        )
+    controller.set_group_volume.assert_not_called()
 
 
 async def test_select_favorite(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds a new HEOS `media_player` entity service for setting the group volume level when the entity is joined to a group. Setting the group volume level adjusts the volume of it's members while preserving their relative ratios. This entity service can be called on any member of the group. If the entity is not joined to a group, a `ServiceValidationError` is raised.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/37536

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
