### PR TITLE
Don't blow up when a backup doesn't exist on Synology DSM

### DIFF
--- a/homeassistant/components/synology_dsm/backup.py
+++ b/homeassistant/components/synology_dsm/backup.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import AsyncIterator, Callable, Coroutine
+from contextlib import suppress
 import logging
 from typing import TYPE_CHECKING, Any
 
@@ -161,15 +162,13 @@ class SynologyDSMBackupAgent(BackupAgent):
 
         :param backup_id: The ID of the backup that was returned in async_list_backups.
         """
-        try:
+        with suppress(SynologyDSMAPIErrorException):
             await self._file_station.delete_file(
                 path=self.path, filename=f"{backup_id}.tar"
             )
             await self._file_station.delete_file(
                 path=self.path, filename=f"{backup_id}_meta.json"
             )
-        except SynologyDSMAPIErrorException as err:
-            raise BackupAgentError("Failed to delete the backup") from err
 
     async def async_list_backups(self, **kwargs: Any) -> list[AgentBackup]:
         """List backups."""

--- a/tests/components/synology_dsm/test_backup.py
+++ b/tests/components/synology_dsm/test_backup.py
@@ -685,11 +685,7 @@ async def test_agents_delete_not_existing(
     response = await client.receive_json()
 
     assert response["success"]
-    assert response["result"] == {
-        "agent_errors": {
-            "synology_dsm.mocked_syno_dsm_entry": "Failed to delete the backup"
-        }
-    }
+    assert response["result"] == {"agent_errors": {}}
 
 
 async def test_agents_delete_error(
@@ -714,11 +710,7 @@ async def test_agents_delete_error(
     response = await client.receive_json()
 
     assert response["success"]
-    assert response["result"] == {
-        "agent_errors": {
-            "synology_dsm.mocked_syno_dsm_entry": "Failed to delete the backup"
-        }
-    }
+    assert response["result"] == {"agent_errors": {}}
     mock: AsyncMock = setup_dsm_with_filestation.file.delete_file
     assert len(mock.mock_calls) == 1
     assert mock.call_args_list[0].kwargs["filename"] == "abcd12ef.tar"

--- a/tests/components/synology_dsm/test_backup.py
+++ b/tests/components/synology_dsm/test_backup.py
@@ -673,7 +673,11 @@ async def test_agents_delete_not_existing(
     backup_id = "ef34ab12"
 
     setup_dsm_with_filestation.file.delete_file = AsyncMock(
-        side_effect=SynologyDSMAPIErrorException("api", "404", "not found")
+        side_effect=SynologyDSMAPIErrorException(
+            "api",
+            "900",
+            [{"code": 408, "path": f"/ha_backup/my_backup_path/{backup_id}.tar"}],
+        )
     )
 
     await client.send_json_auto_id(
@@ -688,19 +692,37 @@ async def test_agents_delete_not_existing(
     assert response["result"] == {"agent_errors": {}}
 
 
+@pytest.mark.parametrize(
+    ("error", "expected_log"),
+    [
+        (
+            SynologyDSMAPIErrorException("api", "100", "Unknown error"),
+            "{'api': 'api', 'code': '100', 'reason': 'Unknown', 'details': 'Unknown error'}",
+        ),
+        (
+            SynologyDSMAPIErrorException("api", "900", [{"code": 407}]),
+            "{'api': 'api', 'code': '900', 'reason': 'Unknown', 'details': [{'code': 407}]",
+        ),
+        (
+            SynologyDSMAPIErrorException("api", "900", [{"code": 417}]),
+            "{'api': 'api', 'code': '900', 'reason': 'Unknown', 'details': [{'code': 417}]",
+        ),
+    ],
+)
 async def test_agents_delete_error(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
+    caplog: pytest.LogCaptureFixture,
     setup_dsm_with_filestation: MagicMock,
+    error: SynologyDSMAPIErrorException,
+    expected_log: str,
 ) -> None:
     """Test error while delete backup."""
     client = await hass_ws_client(hass)
 
     # error while delete
     backup_id = "abcd12ef"
-    setup_dsm_with_filestation.file.delete_file.side_effect = (
-        SynologyDSMAPIErrorException("api", "404", "not found")
-    )
+    setup_dsm_with_filestation.file.delete_file.side_effect = error
     await client.send_json_auto_id(
         {
             "type": "backup/delete",
@@ -710,7 +732,12 @@ async def test_agents_delete_error(
     response = await client.receive_json()
 
     assert response["success"]
-    assert response["result"] == {"agent_errors": {}}
+    assert response["result"] == {
+        "agent_errors": {
+            "synology_dsm.mocked_syno_dsm_entry": "Failed to delete backup"
+        }
+    }
+    assert f"Failed to delete backup: {expected_log}" in caplog.text
     mock: AsyncMock = setup_dsm_with_filestation.file.delete_file
     assert len(mock.mock_calls) == 1
     assert mock.call_args_list[0].kwargs["filename"] == "abcd12ef.tar"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
