### PR TITLE
Shorten the integration name for `incomfort`

### DIFF
--- a/homeassistant/components/incomfort/manifest.json
+++ b/homeassistant/components/incomfort/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "incomfort",
-  "name": "Intergas InComfort/Intouch Lan2RF gateway",
+  "name": "Intergas gateway",
   "codeowners": ["@jbouwh"],
   "config_flow": true,
   "dhcp": [

--- a/homeassistant/components/incomfort/strings.json
+++ b/homeassistant/components/incomfort/strings.json
@@ -2,20 +2,20 @@
   "config": {
     "step": {
       "user": {
-        "description": "Set up new Intergas InComfort Lan2RF Gateway, some older systems might not need credentials to be set up. For newer devices authentication is required.",
+        "description": "Set up new Intergas gateway, some older systems might not need credentials to be set up. For newer devices authentication is required.",
         "data": {
           "host": "[%key:common::config_flow::data::host%]",
           "username": "[%key:common::config_flow::data::username%]",
           "password": "[%key:common::config_flow::data::password%]"
         },
         "data_description": {
-          "host": "Hostname or IP-address of the Intergas InComfort Lan2RF Gateway.",
+          "host": "Hostname or IP-address of the Intergas gateway.",
           "username": "The username to log into the gateway. This is `admin` in most cases.",
-          "password": "The password to log into the gateway, is printed at the bottom of the Lan2RF Gateway or is `intergas` for some older devices."
+          "password": "The password to log into the gateway, is printed at the bottom of the gateway or is `intergas` for some older devices."
         }
       },
       "dhcp_auth": {
-        "title": "Set up Intergas InComfort Lan2RF Gateway",
+        "title": "Set up Intergas gateway",
         "description": "Please enter authentication details for gateway {host}",
         "data": {
           "username": "[%key:common::config_flow::data::username%]",
@@ -23,12 +23,12 @@
         },
         "data_description": {
           "username": "The username to log into the gateway. This is `admin` in most cases.",
-          "password": "The password to log into the gateway, is printed at the bottom of the Lan2RF Gateway or is `intergas` for some older devices."
+          "password": "The password to log into the gateway, is printed at the bottom of the Gateway or is `intergas` for some older devices."
         }
       },
       "dhcp_confirm": {
-        "title": "Set up Intergas InComfort Lan2RF Gateway",
-        "description": "Do you want to set up the discovered Intergas InComfort Lan2RF Gateway ({host})?"
+        "title": "Set up Intergas gateway",
+        "description": "Do you want to set up the discovered Intergas gateway ({host})?"
       },
       "reauth_confirm": {
         "data": {
@@ -48,9 +48,9 @@
     "error": {
       "auth_error": "Invalid credentials.",
       "no_heaters": "No heaters found.",
-      "not_found": "No Lan2RF gateway found.",
-      "timeout_error": "Time out when connecting to Lan2RF gateway.",
-      "unknown": "Unknown error when connecting to Lan2RF gateway."
+      "not_found": "No gateway found.",
+      "timeout_error": "Time out when connecting to the gateway.",
+      "unknown": "Unknown error when connecting to the gateway."
     }
   },
   "exceptions": {
@@ -70,7 +70,7 @@
   "options": {
     "step": {
       "init": {
-        "title": "Intergas InComfort Lan2RF Gateway options",
+        "title": "Intergas gateway options",
         "data": {
           "legacy_setpoint_status": "Legacy setpoint handling"
         },

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -2866,7 +2866,7 @@
       "iot_class": "local_polling"
     },
     "incomfort": {
-      "name": "Intergas InComfort/Intouch Lan2RF gateway",
+      "name": "Intergas gateway",
       "integration_type": "hub",
       "config_flow": true,
       "iot_class": "local_polling"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Then curent name for the `incomfort` integration ("Intergas InComfort/Intouch Lan2RF gateway") is quite long and for no good reason. The device set up is a gateway called `Intergas gateway`. That should be enough. To be consequent the translation strings are updated consequently. Also the documentation will be updates.

The long names easily cause issues in the UI. E.g.:

![afbeelding](https://github.com/user-attachments/assets/7a65db53-b8c8-4236-b9b1-2290402e21dc)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/37211

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
