### PR TITLE
Add entity_category and is_entity_category to templates

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -1481,6 +1481,14 @@ def entity_category(hass: HomeAssistant, entity_id: str) -> str | None:
     return None
 
 
+def is_entity_category(hass: HomeAssistant, entity_id: str, category: Any) -> bool:
+    """Test if an entity is a specific entity category."""
+    return bool(
+        (_entity_category := entity_category(hass, entity_id)) == category
+        or (isinstance(category, list) and _entity_category in category)
+    )
+
+
 def is_device_attr(
     hass: HomeAssistant, device_or_entity_id: str, attr_name: str, attr_value: Any
 ) -> bool:
@@ -3257,6 +3265,10 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         self.globals["entity_category"] = hassfunction(entity_category)
         self.filters["entity_category"] = self.globals["entity_category"]
 
+        self.globals["is_entity_category"] = hassfunction(is_entity_category)
+        self.tests["is_entity_category"] = hassfunction(
+            is_entity_category, pass_eval_context
+        )
         # Config entry extensions
 
         self.globals["config_entry_attr"] = hassfunction(config_entry_attr)

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -1471,6 +1471,16 @@ def config_entry_attr(
     return getattr(config_entry, attr_name)
 
 
+def entity_category(hass: HomeAssistant, entity_id: str) -> str | None:
+    """Get the entity category for a specific entity."""
+    entity_reg = entity_registry.async_get(hass)
+
+    if entity := entity_reg.async_get(entity_id):
+        return str(entity.entity_category)
+
+    return None
+
+
 def is_device_attr(
     hass: HomeAssistant, device_or_entity_id: str, attr_name: str, attr_value: Any
 ) -> bool:
@@ -3241,6 +3251,11 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
 
         self.globals["integration_entities"] = hassfunction(integration_entities)
         self.filters["integration_entities"] = self.globals["integration_entities"]
+
+        # Entity extensions
+
+        self.globals["entity_category"] = hassfunction(entity_category)
+        self.filters["entity_category"] = self.globals["entity_category"]
 
         # Config entry extensions
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Filling a feature request for the ability to get the entity_category for a given entity_id.

https://community.home-assistant.io/t/add-the-entity-category-to-the-available-state-object-properties/378724

Listing the category
```
{{ label_entities('my_label') | map('entity_category') | list }} 
```

Checking the category(ies)
```
{{ label_entities('my_label') | select('is_entity_category', 'config') | list }}
{{ label_entities('my_label') | select('is_entity_category', ['config', 'diagnostic']) | list }} 
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
