### PR TITLE
VOIP - handle ongoing calls for announce and start conversation

### DIFF
--- a/homeassistant/components/voip/__init__.py
+++ b/homeassistant/components/voip/__init__.py
@@ -8,14 +8,16 @@ from dataclasses import dataclass
 import logging
 
 from voip_utils import SIP_PORT
+from voip_utils.sip import get_sip_endpoint
 
 from homeassistant.auth.const import GROUP_ID_USER
+from homeassistant.components.network import async_get_source_ip
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
-from .const import CONF_SIP_PORT, DOMAIN
+from .const import CONF_SIP_PORT, CONF_SIP_USER, DEFAULT_SIP_USER, DOMAIN
 from .devices import VoIPDevices
 from .voip import HassVoipDatagramProtocol
 
@@ -59,12 +61,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             entry, data={**entry.data, "user": voip_user.id}
         )
 
+    sip_host = await async_get_source_ip(hass)
     sip_port = entry.options.get(CONF_SIP_PORT, SIP_PORT)
+    sip_user = entry.options.get(CONF_SIP_USER, DEFAULT_SIP_USER)
     devices = VoIPDevices(hass, entry)
     devices.async_setup()
+    local_endpoint = get_sip_endpoint(sip_host, port=sip_port, username=sip_user)
     transport, protocol = await _create_sip_server(
         hass,
-        lambda: HassVoipDatagramProtocol(hass, devices),
+        lambda: HassVoipDatagramProtocol(hass, devices, local_endpoint),
         sip_port,
     )
     _LOGGER.debug("Listening for VoIP calls on port %s", sip_port)

--- a/homeassistant/components/voip/binary_sensor.py
+++ b/homeassistant/components/voip/binary_sensor.py
@@ -92,5 +92,5 @@ class VoIPCallInProgress(VoIPEntity, BinarySensorEntity):
     @callback
     def _is_active_changed(self, device: VoIPDevice) -> None:
         """Call when active state changed."""
-        self._attr_is_on = self.voip_device.is_active
+        self._attr_is_on = self.voip_device.is_active()
         self.async_write_ha_state()

--- a/homeassistant/components/voip/config_flow.py
+++ b/homeassistant/components/voip/config_flow.py
@@ -16,7 +16,7 @@ from homeassistant.config_entries import (
 from homeassistant.core import callback
 from homeassistant.helpers import config_validation as cv
 
-from .const import CONF_SIP_PORT, DOMAIN
+from .const import CONF_SIP_PORT, CONF_SIP_USER, DEFAULT_SIP_USER, DOMAIN
 
 
 class VoIPConfigFlow(ConfigFlow, domain=DOMAIN):
@@ -58,6 +58,9 @@ class VoipOptionsFlowHandler(OptionsFlow):
     ) -> ConfigFlowResult:
         """Manage the options."""
         if user_input is not None:
+            if "enable_advanced" in user_input:
+                return await self.async_step_advanced()
+
             return self.async_create_entry(title="", data=user_input)
 
         return self.async_show_form(
@@ -70,7 +73,35 @@ class VoipOptionsFlowHandler(OptionsFlow):
                             CONF_SIP_PORT,
                             SIP_PORT,
                         ),
-                    ): cv.port
+                    ): cv.port,
+                    vol.Optional("enable_advanced"): bool,
+                }
+            ),
+            description_placeholders={
+                "note": "Enable advanced options by checking the box.",
+            },
+        )
+
+    async def async_step_advanced(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Manage the advanced options."""
+        if user_input is not None:
+            return self.async_create_entry(
+                title="", data={**self.config_entry.options, **user_input}
+            )
+
+        return self.async_show_form(
+            step_id="advanced",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(
+                        CONF_SIP_USER,
+                        default=self.config_entry.options.get(
+                            CONF_SIP_USER,
+                            DEFAULT_SIP_USER,
+                        ),
+                    ): str,
                 }
             ),
         )

--- a/homeassistant/components/voip/const.py
+++ b/homeassistant/components/voip/const.py
@@ -12,4 +12,7 @@ RTP_AUDIO_SETTINGS = {
     "sleep_ratio": 0.99,
 }
 
+DEFAULT_SIP_USER = "HA"
+
 CONF_SIP_PORT = "sip_port"
+CONF_SIP_USER = "sip_user"

--- a/homeassistant/components/voip/devices.py
+++ b/homeassistant/components/voip/devices.py
@@ -21,14 +21,18 @@ class VoIPDevice:
 
     voip_id: str
     device_id: str
-    is_active: bool = False
+    current_call: CallInfo | None = None
     update_listeners: list[Callable[[VoIPDevice], None]] = field(default_factory=list)
     protocol: VoipDatagramProtocol | None = None
 
+    def is_active(self) -> bool:
+        """Get active state."""
+        return self.current_call is not None
+
     @callback
-    def set_is_active(self, active: bool) -> None:
+    def set_is_active(self, call_info: CallInfo | None) -> None:
         """Set active state."""
-        self.is_active = active
+        self.current_call = call_info
         for listener in self.update_listeners:
             listener(self)
 

--- a/homeassistant/components/wyoming/stt.py
+++ b/homeassistant/components/wyoming/stt.py
@@ -1,5 +1,6 @@
 """Support for Wyoming speech-to-text services."""
 
+import asyncio
 from collections.abc import AsyncIterable
 import logging
 
@@ -116,7 +117,11 @@ class WyomingSttProvider(stt.SpeechToTextEntity):
                 await client.write_event(AudioStop().event())
 
                 while True:
-                    event = await client.read_event()
+                    try:
+                        event = await client.read_event()
+                    except asyncio.exceptions.CancelledError:
+                        _LOGGER.debug("Event read cancelled, retrying")
+                        continue
                     if event is None:
                         _LOGGER.debug("Connection lost")
                         return stt.SpeechResult(None, stt.SpeechResultState.ERROR)

--- a/tests/components/voip/test_binary_sensor.py
+++ b/tests/components/voip/test_binary_sensor.py
@@ -3,6 +3,8 @@
 from http import HTTPStatus
 
 import pytest
+from voip_utils import CallInfo
+from voip_utils.sip import SipEndpoint
 
 from homeassistant.components.repairs import DOMAIN as REPAIRS_DOMAIN
 from homeassistant.components.voip import DOMAIN
@@ -26,12 +28,20 @@ async def test_call_in_progress(
     assert state is not None
     assert state.state == "off"
 
-    voip_device.set_is_active(True)
+    call_info = CallInfo(
+        caller_endpoint=SipEndpoint("sip:192.168.1.2:5060"),
+        local_endpoint=SipEndpoint("sip:192.168.1.1:5060"),
+        caller_rtp_port=10000,
+        server_ip="127.0.0.1",
+        headers={},
+    )
+
+    voip_device.set_is_active(call_info)
 
     state = hass.states.get("binary_sensor.192_168_1_210_call_in_progress")
     assert state.state == "on"
 
-    voip_device.set_is_active(False)
+    voip_device.set_is_active(None)
 
     state = hass.states.get("binary_sensor.192_168_1_210_call_in_progress")
     assert state.state == "off"


### PR DESCRIPTION
Allow announcements and conversation starts to be queued up for an existing call. Also allow specifying a SIP username for the HA endpoint which is required for some VOIP servers.

I tried to combine elements from the current implementation and my original implementation to handle announcements and conversation start when there is already a call to the specified satellite.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allow announcements and conversation starts to be queued up for an existing call. Also allow specifying a SIP username for the HA endpoint which is required for some VOIP servers.

I tried to combine elements from the current implementation and my original implementation to handle announcements and conversation start when there is already a call to the specified satellite.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
