### PR TITLE
Add a template function to access area attributes

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -1649,6 +1649,20 @@ def area_devices(hass: HomeAssistant, area_id_or_name: str) -> Iterable[str]:
     return [entry.id for entry in entries]
 
 
+def area_attr(hass: HomeAssistant, area_id_or_name: str, attr_name: str) -> Any:
+    """Get area specific attribute."""
+    area_reg = area_registry.async_get(hass)
+    area = area_reg.async_get_area(area_id_or_name)
+
+    if area is None:
+        return None
+
+    if not hasattr(area, attr_name):
+        return None
+
+    return getattr(area, attr_name)
+
+
 def labels(hass: HomeAssistant, lookup_value: Any = None) -> Iterable[str | None]:
     """Return all labels, or those from a area ID, device ID, or entity ID."""
     label_reg = label_registry.async_get(hass)
@@ -3035,6 +3049,9 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
 
         self.globals["area_devices"] = hassfunction(area_devices)
         self.filters["area_devices"] = self.globals["area_devices"]
+
+        self.globals["area_attr"] = hassfunction(area_attr)
+        self.filters["area_attr"] = self.globals["area_attr"]
 
         self.globals["floors"] = hassfunction(floors)
         self.filters["floors"] = self.globals["floors"]

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -1652,12 +1652,11 @@ def area_devices(hass: HomeAssistant, area_id_or_name: str) -> Iterable[str]:
 def area_attr(hass: HomeAssistant, area_id_or_name: str, attr_name: str) -> Any:
     """Get area specific attribute."""
     area_reg = area_registry.async_get(hass)
-    area = area_reg.async_get_area(area_id_or_name)
+    area = area_reg.async_get_area(area_id_or_name) or area_reg.async_get_area_by_name(
+        area_id_or_name
+    )
 
-    if area is None:
-        return None
-
-    if not hasattr(area, attr_name):
+    if area is None or not hasattr(area, attr_name):
         return None
 
     return getattr(area, attr_name)

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -4433,7 +4433,7 @@ async def test_area_attr(
     assert info.rate_limit is None
 
     # Test wrong value type (area_attr)
-    info = render_to_info(hass, "{{ area_attr(56, 'name') }}")
+    info = render_to_info(hass, "{{ area_attr('56', 'name') }}")
     assert_result_info(info, None)
     assert info.rate_limit is None
 
@@ -4461,6 +4461,12 @@ async def test_area_attr(
     # Test temperature_entity_id area attribute (area_attr)
     info = render_to_info(
         hass, f"{{{{ area_attr('{area_entry.id}', 'temperature_entity_id') }}}}"
+    )
+    assert_result_info(info, "sensor.mock_temperature")
+
+    # Test temperature_entity_id area attribute (area_attr)
+    info = render_to_info(
+        hass, f"{{{{ area_attr('{area_entry.name}', 'temperature_entity_id') }}}}"
     )
     assert_result_info(info, "sensor.mock_temperature")
 


### PR DESCRIPTION
## Proposed change
Add a new template function `area_attr` to access the attributes (e.g. `temperature_entity_id`) of an area. 

Tagged this for 2025.2, as there is no other possibility to use the new area attributes `temperature_entity_id` and `humidity_entity_id`.

~TODO: Docs~

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/37226

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
