### PR TITLE
Retry backup uploads in onedrive

### DIFF
--- a/homeassistant/components/onedrive/backup.py
+++ b/homeassistant/components/onedrive/backup.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import AsyncIterator, Callable, Coroutine
 from functools import wraps
 import html
@@ -9,7 +10,7 @@ import json
 import logging
 from typing import Any, Concatenate, cast
 
-from httpx import Response
+from httpx import Response, TimeoutException
 from kiota_abstractions.api_error import APIError
 from kiota_abstractions.authentication import AnonymousAuthenticationProvider
 from kiota_abstractions.headers_collection import HeadersCollection
@@ -42,6 +43,7 @@ from .const import DATA_BACKUP_AGENT_LISTENERS, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 UPLOAD_CHUNK_SIZE = 16 * 320 * 1024  # 5.2MB
+MAX_RETRIES = 5
 
 
 async def async_get_backup_agents(
@@ -96,7 +98,7 @@ def handle_backup_errors[_R, **P](
             )
             _LOGGER.debug("Full error: %s", err, exc_info=True)
             raise BackupAgentError("Backup operation failed") from err
-        except TimeoutError as err:
+        except TimeoutException as err:
             _LOGGER.error(
                 "Error during backup in %s: Timeout",
                 func.__name__,
@@ -268,6 +270,7 @@ class OneDriveBackupAgent(BackupAgent):
         start = 0
         buffer: list[bytes] = []
         buffer_size = 0
+        retries = 0
 
         async for chunk in stream:
             buffer.append(chunk)
@@ -279,11 +282,25 @@ class OneDriveBackupAgent(BackupAgent):
                     buffer_size > UPLOAD_CHUNK_SIZE
                 ):  # Loop in case the buffer is >= UPLOAD_CHUNK_SIZE * 2
                     slice_start = uploaded_chunks * UPLOAD_CHUNK_SIZE
-                    await async_upload(
-                        start,
-                        start + UPLOAD_CHUNK_SIZE - 1,
-                        chunk_data[slice_start : slice_start + UPLOAD_CHUNK_SIZE],
-                    )
+                    try:
+                        await async_upload(
+                            start,
+                            start + UPLOAD_CHUNK_SIZE - 1,
+                            chunk_data[slice_start : slice_start + UPLOAD_CHUNK_SIZE],
+                        )
+                    except (APIError, TimeoutException) as err:
+                        if (
+                            isinstance(err, APIError)
+                            and err.response_status_code
+                            and err.response_status_code < 500
+                        ):  # raise on 4xx errors
+                            raise
+                        if retries < MAX_RETRIES:
+                            await asyncio.sleep(2**retries)
+                            retries += 1
+                            continue
+                        raise
+                    retries = 0
                     start += UPLOAD_CHUNK_SIZE
                     uploaded_chunks += 1
                     buffer_size -= UPLOAD_CHUNK_SIZE

--- a/tests/components/onedrive/conftest.py
+++ b/tests/components/onedrive/conftest.py
@@ -176,3 +176,10 @@ def mock_instance_id() -> Generator[AsyncMock]:
         return_value="9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0",
     ):
         yield
+
+
+@pytest.fixture(autouse=True)
+def mock_asyncio_sleep() -> Generator[AsyncMock]:
+    """Mock asyncio.sleep."""
+    with patch("homeassistant.components.onedrive.backup.asyncio.sleep", AsyncMock()):
+        yield

--- a/tests/components/onedrive/test_backup.py
+++ b/tests/components/onedrive/test_backup.py
@@ -8,8 +8,10 @@ from io import StringIO
 from json import dumps
 from unittest.mock import Mock, patch
 
+from httpx import TimeoutException
 from kiota_abstractions.api_error import APIError
 from msgraph.generated.models.drive_item import DriveItem
+from msgraph_core.models import LargeFileUploadSession
 import pytest
 
 from homeassistant.components.backup import DOMAIN as BACKUP_DOMAIN, AgentBackup
@@ -255,6 +257,123 @@ async def test_broken_upload_session(
     assert "Failed to start backup upload" in caplog.text
 
 
+async def test_agents_upload_errors_retried(
+    hass_client: ClientSessionGenerator,
+    caplog: pytest.LogCaptureFixture,
+    mock_drive_items: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    mock_adapter: MagicMock,
+) -> None:
+    """Test agent upload backup."""
+    client = await hass_client()
+    test_backup = AgentBackup.from_dict(BACKUP_METADATA)
+
+    mock_adapter.send_async.side_effect = [
+        APIError(response_status_code=500),
+        LargeFileUploadSession(next_expected_ranges=["2-"]),
+        LargeFileUploadSession(next_expected_ranges=["2-"]),
+    ]
+
+    with (
+        patch(
+            "homeassistant.components.backup.manager.BackupManager.async_get_backup",
+        ) as fetch_backup,
+        patch(
+            "homeassistant.components.backup.manager.read_backup",
+            return_value=test_backup,
+        ),
+        patch("pathlib.Path.open") as mocked_open,
+        patch("homeassistant.components.onedrive.backup.UPLOAD_CHUNK_SIZE", 3),
+    ):
+        mocked_open.return_value.read = Mock(side_effect=[b"test", b""])
+        fetch_backup.return_value = test_backup
+        resp = await client.post(
+            f"/api/backup/upload?agent_id={DOMAIN}.{mock_config_entry.unique_id}",
+            data={"file": StringIO("test")},
+        )
+
+    assert resp.status == 201
+    assert mock_adapter.send_async.call_count == 3
+    assert f"Uploading backup {test_backup.backup_id}" in caplog.text
+    mock_drive_items.patch.assert_called_once()
+
+
+async def test_agents_upload_4xx_errors_not_retried(
+    hass_client: ClientSessionGenerator,
+    caplog: pytest.LogCaptureFixture,
+    mock_drive_items: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    mock_adapter: MagicMock,
+) -> None:
+    """Test agent upload backup."""
+    client = await hass_client()
+    test_backup = AgentBackup.from_dict(BACKUP_METADATA)
+
+    mock_adapter.send_async.side_effect = APIError(response_status_code=404)
+
+    with (
+        patch(
+            "homeassistant.components.backup.manager.BackupManager.async_get_backup",
+        ) as fetch_backup,
+        patch(
+            "homeassistant.components.backup.manager.read_backup",
+            return_value=test_backup,
+        ),
+        patch("pathlib.Path.open") as mocked_open,
+        patch("homeassistant.components.onedrive.backup.UPLOAD_CHUNK_SIZE", 3),
+    ):
+        mocked_open.return_value.read = Mock(side_effect=[b"test", b""])
+        fetch_backup.return_value = test_backup
+        resp = await client.post(
+            f"/api/backup/upload?agent_id={DOMAIN}.{mock_config_entry.unique_id}",
+            data={"file": StringIO("test")},
+        )
+
+    assert resp.status == 201
+    assert mock_adapter.send_async.call_count == 1
+    assert f"Uploading backup {test_backup.backup_id}" in caplog.text
+    assert mock_drive_items.patch.call_count == 0
+    assert "Backup operation failed" in caplog.text
+
+
+async def test_agents_upload_fails_after_max_retries(
+    hass_client: ClientSessionGenerator,
+    caplog: pytest.LogCaptureFixture,
+    mock_drive_items: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    mock_adapter: MagicMock,
+) -> None:
+    """Test agent upload backup."""
+    client = await hass_client()
+    test_backup = AgentBackup.from_dict(BACKUP_METADATA)
+
+    mock_adapter.send_async.side_effect = APIError(response_status_code=500)
+
+    with (
+        patch(
+            "homeassistant.components.backup.manager.BackupManager.async_get_backup",
+        ) as fetch_backup,
+        patch(
+            "homeassistant.components.backup.manager.read_backup",
+            return_value=test_backup,
+        ),
+        patch("pathlib.Path.open") as mocked_open,
+        patch("homeassistant.components.onedrive.backup.UPLOAD_CHUNK_SIZE", 3),
+    ):
+        mocked_open.return_value.read = Mock(side_effect=[b"test", b""])
+        fetch_backup.return_value = test_backup
+        resp = await client.post(
+            f"/api/backup/upload?agent_id={DOMAIN}.{mock_config_entry.unique_id}",
+            data={"file": StringIO("test")},
+        )
+
+    assert resp.status == 201
+    assert mock_adapter.send_async.call_count == 6
+    assert f"Uploading backup {test_backup.backup_id}" in caplog.text
+    assert mock_drive_items.patch.call_count == 0
+    assert "Backup operation failed" in caplog.text
+
+
 async def test_agents_download(
     hass_client: ClientSessionGenerator,
     mock_drive_items: MagicMock,
@@ -282,7 +401,7 @@ async def test_agents_download(
             APIError(response_status_code=500),
             "Backup operation failed",
         ),
-        (TimeoutError(), "Backup operation timed out"),
+        (TimeoutException("Timeout"), "Backup operation timed out"),
     ],
 )
 async def test_delete_error(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Make OneDrive backups less prone to intermittent failures by adding a retry mechanism. For 5xx errors use an exponential backoff strategy. Also catch the correct `TimeoutException` from `httpx`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #136959
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
