### PR TITLE
Fix missing duration translation for Swiss public transport integration

### DIFF
--- a/homeassistant/components/swiss_public_transport/icons.json
+++ b/homeassistant/components/swiss_public_transport/icons.json
@@ -10,7 +10,7 @@
       "departure2": {
         "default": "mdi:bus-clock"
       },
-      "duration": {
+      "trip_duration": {
         "default": "mdi:timeline-clock"
       },
       "transfers": {

--- a/homeassistant/components/swiss_public_transport/sensor.py
+++ b/homeassistant/components/swiss_public_transport/sensor.py
@@ -56,6 +56,7 @@ SENSORS: tuple[SwissPublicTransportSensorEntityDescription, ...] = (
     ],
     SwissPublicTransportSensorEntityDescription(
         key="duration",
+        translation_key="duration",
         device_class=SensorDeviceClass.DURATION,
         native_unit_of_measurement=UnitOfTime.SECONDS,
         value_fn=lambda data_connection: data_connection["duration"],

--- a/homeassistant/components/swiss_public_transport/sensor.py
+++ b/homeassistant/components/swiss_public_transport/sensor.py
@@ -56,9 +56,10 @@ SENSORS: tuple[SwissPublicTransportSensorEntityDescription, ...] = (
     ],
     SwissPublicTransportSensorEntityDescription(
         key="duration",
-        translation_key="duration",
+        translation_key="trip_duration",
         device_class=SensorDeviceClass.DURATION,
         native_unit_of_measurement=UnitOfTime.SECONDS,
+        suggested_unit_of_measurement=UnitOfTime.HOURS,
         value_fn=lambda data_connection: data_connection["duration"],
     ),
     SwissPublicTransportSensorEntityDescription(

--- a/homeassistant/components/swiss_public_transport/strings.json
+++ b/homeassistant/components/swiss_public_transport/strings.json
@@ -64,8 +64,8 @@
       "departure2": {
         "name": "Departure +2"
       },
-      "duration": {
-        "name": "Duration"
+      "trip_duration": {
+        "name": "Trip duration"
       },
       "transfers": {
         "name": "Transfers"

--- a/tests/components/swiss_public_transport/snapshots/test_sensor.ambr
+++ b/tests/components/swiss_public_transport/snapshots/test_sensor.ambr
@@ -220,7 +220,7 @@
     'platform': 'swiss_public_transport',
     'previous_unique_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'duration',
     'unique_id': 'Zürich Bern_duration',
     'unit_of_measurement': <UnitOfTime.SECONDS: 's'>,
   })

--- a/tests/components/swiss_public_transport/snapshots/test_sensor.ambr
+++ b/tests/components/swiss_public_transport/snapshots/test_sensor.ambr
@@ -220,7 +220,7 @@
     'platform': 'swiss_public_transport',
     'previous_unique_id': None,
     'supported_features': 0,
-    'translation_key': 'duration',
+    'translation_key': 'trip_duration',
     'unique_id': 'Zürich Bern_duration',
     'unit_of_measurement': <UnitOfTime.SECONDS: 's'>,
   })
@@ -380,5 +380,57 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '0',
+  })
+# ---
+# name: test_all_entities[sensor.zurich_bern_trip_duration-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.zurich_bern_trip_duration',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfTime.HOURS: 'h'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.DURATION: 'duration'>,
+    'original_icon': None,
+    'original_name': 'Trip duration',
+    'platform': 'swiss_public_transport',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'trip_duration',
+    'unique_id': 'Zürich Bern_duration',
+    'unit_of_measurement': <UnitOfTime.HOURS: 'h'>,
+  })
+# ---
+# name: test_all_entities[sensor.zurich_bern_trip_duration-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by transport.opendata.ch',
+      'device_class': 'duration',
+      'friendly_name': 'Zürich Bern Trip duration',
+      'unit_of_measurement': <UnitOfTime.HOURS: 'h'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.zurich_bern_trip_duration',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.003',
   })
 # ---

--- a/tests/components/swiss_public_transport/snapshots/test_sensor.ambr
+++ b/tests/components/swiss_public_transport/snapshots/test_sensor.ambr
@@ -192,55 +192,6 @@
     'state': '2024-01-06T17:05:00+00:00',
   })
 # ---
-# name: test_all_entities[sensor.zurich_bern_duration-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.zurich_bern_duration',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': <SensorDeviceClass.DURATION: 'duration'>,
-    'original_icon': None,
-    'original_name': 'Duration',
-    'platform': 'swiss_public_transport',
-    'previous_unique_id': None,
-    'supported_features': 0,
-    'translation_key': 'trip_duration',
-    'unique_id': 'Zürich Bern_duration',
-    'unit_of_measurement': <UnitOfTime.SECONDS: 's'>,
-  })
-# ---
-# name: test_all_entities[sensor.zurich_bern_duration-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by transport.opendata.ch',
-      'device_class': 'duration',
-      'friendly_name': 'Zürich Bern Duration',
-      'unit_of_measurement': <UnitOfTime.SECONDS: 's'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.zurich_bern_duration',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '10',
-  })
-# ---
 # name: test_all_entities[sensor.zurich_bern_line-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({

--- a/tests/components/swiss_public_transport/test_sensor.py
+++ b/tests/components/swiss_public_transport/test_sensor.py
@@ -83,7 +83,7 @@ async def test_fetching_data(
         hass.states.get("sensor.zurich_bern_departure_2").state
         == "2024-01-06T17:05:00+00:00"
     )
-    assert hass.states.get("sensor.zurich_bern_duration").state == "10"
+    assert hass.states.get("sensor.zurich_bern_trip_duration").state == "0.003"
     assert hass.states.get("sensor.zurich_bern_platform").state == "0"
     assert hass.states.get("sensor.zurich_bern_transfers").state == "0"
     assert hass.states.get("sensor.zurich_bern_delay").state == "0"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix missing translation key for the duration sensor.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #136978
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
