### PR TITLE
Use runtime_data in motionmount integration

### DIFF
--- a/homeassistant/components/motionmount/__init__.py
+++ b/homeassistant/components/motionmount/__init__.py
@@ -14,6 +14,8 @@ from homeassistant.helpers.device_registry import format_mac
 
 from .const import DOMAIN, EMPTY_MAC
 
+type MotionMountConfigEntry = ConfigEntry[motionmount.MotionMount]
+
 PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
     Platform.NUMBER,
@@ -22,7 +24,7 @@ PLATFORMS: list[Platform] = [
 ]
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: MotionMountConfigEntry) -> bool:
     """Set up Vogel's MotionMount from a config entry."""
 
     host = entry.data[CONF_HOST]
@@ -65,17 +67,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             )
 
     # Store an API object for your platforms to access
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = mm
+    entry.runtime_data = mm
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(
+    hass: HomeAssistant, entry: MotionMountConfigEntry
+) -> bool:
     """Unload a config entry."""
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        mm: motionmount.MotionMount = hass.data[DOMAIN].pop(entry.entry_id)
+        mm = entry.runtime_data
         await mm.disconnect()
 
     return unload_ok

--- a/homeassistant/components/motionmount/binary_sensor.py
+++ b/homeassistant/components/motionmount/binary_sensor.py
@@ -6,19 +6,20 @@ from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN
+from . import MotionMountConfigEntry
 from .entity import MotionMountEntity
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+    hass: HomeAssistant,
+    entry: MotionMountConfigEntry,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Vogel's MotionMount from a config entry."""
-    mm = hass.data[DOMAIN][entry.entry_id]
+    mm = entry.runtime_data
 
     async_add_entities([MotionMountMovingSensor(mm, entry)])
 
@@ -29,7 +30,9 @@ class MotionMountMovingSensor(MotionMountEntity, BinarySensorEntity):
     _attr_device_class = BinarySensorDeviceClass.MOVING
     _attr_translation_key = "motionmount_is_moving"
 
-    def __init__(self, mm: motionmount.MotionMount, config_entry: ConfigEntry) -> None:
+    def __init__(
+        self, mm: motionmount.MotionMount, config_entry: MotionMountConfigEntry
+    ) -> None:
         """Initialize moving binary sensor entity."""
         super().__init__(mm, config_entry)
         self._attr_unique_id = f"{self._base_unique_id}-moving"

--- a/homeassistant/components/motionmount/entity.py
+++ b/homeassistant/components/motionmount/entity.py
@@ -5,12 +5,12 @@ from typing import TYPE_CHECKING
 
 import motionmount
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_CONNECTIONS, ATTR_IDENTIFIERS, CONF_PIN
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo, format_mac
 from homeassistant.helpers.entity import Entity
 
+from . import MotionMountConfigEntry
 from .const import DOMAIN, EMPTY_MAC
 
 _LOGGER = logging.getLogger(__name__)
@@ -22,7 +22,9 @@ class MotionMountEntity(Entity):
     _attr_should_poll = False
     _attr_has_entity_name = True
 
-    def __init__(self, mm: motionmount.MotionMount, config_entry: ConfigEntry) -> None:
+    def __init__(
+        self, mm: motionmount.MotionMount, config_entry: MotionMountConfigEntry
+    ) -> None:
         """Initialize general MotionMount entity."""
         self.mm = mm
         self.config_entry = config_entry

--- a/homeassistant/components/motionmount/number.py
+++ b/homeassistant/components/motionmount/number.py
@@ -5,21 +5,23 @@ import socket
 import motionmount
 
 from homeassistant.components.number import NumberEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import PERCENTAGE
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from . import MotionMountConfigEntry
 from .const import DOMAIN
 from .entity import MotionMountEntity
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+    hass: HomeAssistant,
+    entry: MotionMountConfigEntry,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Vogel's MotionMount from a config entry."""
-    mm: motionmount.MotionMount = hass.data[DOMAIN][entry.entry_id]
+    mm = entry.runtime_data
 
     async_add_entities(
         (
@@ -37,7 +39,9 @@ class MotionMountExtension(MotionMountEntity, NumberEntity):
     _attr_native_unit_of_measurement = PERCENTAGE
     _attr_translation_key = "motionmount_extension"
 
-    def __init__(self, mm: motionmount.MotionMount, config_entry: ConfigEntry) -> None:
+    def __init__(
+        self, mm: motionmount.MotionMount, config_entry: MotionMountConfigEntry
+    ) -> None:
         """Initialize Extension number."""
         super().__init__(mm, config_entry)
         self._attr_unique_id = f"{self._base_unique_id}-extension"
@@ -66,7 +70,9 @@ class MotionMountTurn(MotionMountEntity, NumberEntity):
     _attr_native_unit_of_measurement = PERCENTAGE
     _attr_translation_key = "motionmount_turn"
 
-    def __init__(self, mm: motionmount.MotionMount, config_entry: ConfigEntry) -> None:
+    def __init__(
+        self, mm: motionmount.MotionMount, config_entry: MotionMountConfigEntry
+    ) -> None:
         """Initialize Turn number."""
         super().__init__(mm, config_entry)
         self._attr_unique_id = f"{self._base_unique_id}-turn"

--- a/homeassistant/components/motionmount/select.py
+++ b/homeassistant/components/motionmount/select.py
@@ -7,11 +7,11 @@ import socket
 import motionmount
 
 from homeassistant.components.select import SelectEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from . import MotionMountConfigEntry
 from .const import DOMAIN, WALL_PRESET_NAME
 from .entity import MotionMountEntity
 
@@ -20,10 +20,12 @@ SCAN_INTERVAL = timedelta(seconds=60)
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+    hass: HomeAssistant,
+    entry: MotionMountConfigEntry,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Vogel's MotionMount from a config entry."""
-    mm = hass.data[DOMAIN][entry.entry_id]
+    mm = entry.runtime_data
 
     async_add_entities([MotionMountPresets(mm, entry)], True)
 
@@ -37,7 +39,7 @@ class MotionMountPresets(MotionMountEntity, SelectEntity):
     def __init__(
         self,
         mm: motionmount.MotionMount,
-        config_entry: ConfigEntry,
+        config_entry: MotionMountConfigEntry,
     ) -> None:
         """Initialize Preset selector."""
         super().__init__(mm, config_entry)

--- a/homeassistant/components/motionmount/sensor.py
+++ b/homeassistant/components/motionmount/sensor.py
@@ -3,19 +3,20 @@
 import motionmount
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN
+from . import MotionMountConfigEntry
 from .entity import MotionMountEntity
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+    hass: HomeAssistant,
+    entry: MotionMountConfigEntry,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Vogel's MotionMount from a config entry."""
-    mm = hass.data[DOMAIN][entry.entry_id]
+    mm = entry.runtime_data
 
     async_add_entities((MotionMountErrorStatusSensor(mm, entry),))
 
@@ -27,7 +28,9 @@ class MotionMountErrorStatusSensor(MotionMountEntity, SensorEntity):
     _attr_options = ["none", "motor", "internal"]
     _attr_translation_key = "motionmount_error_status"
 
-    def __init__(self, mm: motionmount.MotionMount, config_entry: ConfigEntry) -> None:
+    def __init__(
+        self, mm: motionmount.MotionMount, config_entry: MotionMountConfigEntry
+    ) -> None:
         """Initialize sensor entiry."""
         super().__init__(mm, config_entry)
         self._attr_unique_id = f"{self._base_unique_id}-error-status"


### PR DESCRIPTION
## Proposed change
Use the ConfigEntry's runtime_data to store the client object.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
