### PR TITLE
Show new errors from the MotionMount

### DIFF
--- a/homeassistant/components/motionmount/sensor.py
+++ b/homeassistant/components/motionmount/sensor.py
@@ -10,6 +10,14 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from . import MotionMountConfigEntry
 from .entity import MotionMountEntity
 
+error_messages = {
+    MotionMountSystemError.MotorError: "motor",
+    MotionMountSystemError.ObstructionDetected: "obstruction",
+    MotionMountSystemError.TVWidthConstraintError: "tv_width_constraint",
+    MotionMountSystemError.HDMICECError: "hdmi_cec",
+    MotionMountSystemError.InternalError: "internal",
+}
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -47,14 +55,6 @@ class MotionMountErrorStatusSensor(MotionMountEntity, SensorEntity):
     def native_value(self) -> str:
         """Return error status."""
         status = self.mm.system_status
-
-        error_messages = {
-            MotionMountSystemError.MotorError: "motor",
-            MotionMountSystemError.ObstructionDetected: "obstruction",
-            MotionMountSystemError.TVWidthConstraintError: "tv_width_constraint",
-            MotionMountSystemError.HDMICECError: "hdmi_cec",
-            MotionMountSystemError.InternalError: "internal",
-        }
 
         for error, message in error_messages.items():
             if error in status:

--- a/homeassistant/components/motionmount/sensor.py
+++ b/homeassistant/components/motionmount/sensor.py
@@ -1,6 +1,7 @@
 """Support for MotionMount sensors."""
 
 import motionmount
+from motionmount import MotionMountSystemError
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
 from homeassistant.core import HomeAssistant
@@ -48,11 +49,11 @@ class MotionMountErrorStatusSensor(MotionMountEntity, SensorEntity):
         status = self.mm.system_status
 
         errorMessages = {
-            motionmount.MotionMountSystemError.MotorError: "motor",
-            motionmount.MotionMountSystemError.ObstructionDetected: "obstruction",
-            motionmount.MotionMountSystemError.TVWidthConstraintError: "tv_width_constraint",
-            motionmount.MotionMountSystemError.HDMICECError: "hdmi_cec",
-            motionmount.MotionMountSystemError.InternalError: "internal",
+            MotionMountSystemError.MotorError: "motor",
+            MotionMountSystemError.ObstructionDetected: "obstruction",
+            MotionMountSystemError.TVWidthConstraintError: "tv_width_constraint",
+            MotionMountSystemError.HDMICECError: "hdmi_cec",
+            MotionMountSystemError.InternalError: "internal",
         }
 
         for error, message in errorMessages.items():

--- a/homeassistant/components/motionmount/sensor.py
+++ b/homeassistant/components/motionmount/sensor.py
@@ -47,14 +47,16 @@ class MotionMountErrorStatusSensor(MotionMountEntity, SensorEntity):
         """Return error status."""
         status = self.mm.system_status
 
-        if motionmount.MotionMountSystemError.MotorError in status:
-            return "motor"
-        if motionmount.MotionMountSystemError.ObstructionDetected in status:
-            return "obstruction"
-        if motionmount.MotionMountSystemError.TVWidthConstraintError in status:
-            return "tv_width_constraint"
-        if motionmount.MotionMountSystemError.HDMICECError in status:
-            return "hdmi_cec"
-        if motionmount.MotionMountSystemError.InternalError in status:
-            return "internal"
+        errorMessages = {
+            motionmount.MotionMountSystemError.MotorError: "motor",
+            motionmount.MotionMountSystemError.ObstructionDetected: "obstruction",
+            motionmount.MotionMountSystemError.TVWidthConstraintError: "tv_width_constraint",
+            motionmount.MotionMountSystemError.HDMICECError: "hdmi_cec",
+            motionmount.MotionMountSystemError.InternalError: "internal",
+        }
+
+        for error, message in errorMessages.items():
+            if error in status:
+                return message
+
         return "none"

--- a/homeassistant/components/motionmount/sensor.py
+++ b/homeassistant/components/motionmount/sensor.py
@@ -48,7 +48,7 @@ class MotionMountErrorStatusSensor(MotionMountEntity, SensorEntity):
         """Return error status."""
         status = self.mm.system_status
 
-        errorMessages = {
+        error_messages = {
             MotionMountSystemError.MotorError: "motor",
             MotionMountSystemError.ObstructionDetected: "obstruction",
             MotionMountSystemError.TVWidthConstraintError: "tv_width_constraint",
@@ -56,7 +56,7 @@ class MotionMountErrorStatusSensor(MotionMountEntity, SensorEntity):
             MotionMountSystemError.InternalError: "internal",
         }
 
-        for error, message in errorMessages.items():
+        for error, message in error_messages.items():
             if error in status:
                 return message
 

--- a/homeassistant/components/motionmount/sensor.py
+++ b/homeassistant/components/motionmount/sensor.py
@@ -25,7 +25,14 @@ class MotionMountErrorStatusSensor(MotionMountEntity, SensorEntity):
     """The error status sensor of a MotionMount."""
 
     _attr_device_class = SensorDeviceClass.ENUM
-    _attr_options = ["none", "motor", "internal"]
+    _attr_options = [
+        "none",
+        "motor",
+        "hdmi_cec",
+        "obstruction",
+        "tv_width_constraint",
+        "internal",
+    ]
     _attr_translation_key = "motionmount_error_status"
 
     def __init__(
@@ -38,13 +45,16 @@ class MotionMountErrorStatusSensor(MotionMountEntity, SensorEntity):
     @property
     def native_value(self) -> str:
         """Return error status."""
-        errors = self.mm.error_status or 0
+        status = self.mm.system_status
 
-        if errors & (1 << 31):
-            # Only when but 31 is set are there any errors active at this moment
-            if errors & (1 << 10):
-                return "motor"
-
+        if motionmount.MotionMountSystemError.MotorError in status:
+            return "motor"
+        if motionmount.MotionMountSystemError.ObstructionDetected in status:
+            return "obstruction"
+        if motionmount.MotionMountSystemError.TVWidthConstraintError in status:
+            return "tv_width_constraint"
+        if motionmount.MotionMountSystemError.HDMICECError in status:
+            return "hdmi_cec"
+        if motionmount.MotionMountSystemError.InternalError in status:
             return "internal"
-
         return "none"

--- a/homeassistant/components/motionmount/sensor.py
+++ b/homeassistant/components/motionmount/sensor.py
@@ -1,5 +1,7 @@
 """Support for MotionMount sensors."""
 
+from typing import Final
+
 import motionmount
 from motionmount import MotionMountSystemError
 
@@ -10,7 +12,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from . import MotionMountConfigEntry
 from .entity import MotionMountEntity
 
-error_messages = {
+ERROR_MESSAGES: Final = {
     MotionMountSystemError.MotorError: "motor",
     MotionMountSystemError.ObstructionDetected: "obstruction",
     MotionMountSystemError.TVWidthConstraintError: "tv_width_constraint",
@@ -56,7 +58,7 @@ class MotionMountErrorStatusSensor(MotionMountEntity, SensorEntity):
         """Return error status."""
         status = self.mm.system_status
 
-        for error, message in error_messages.items():
+        for error, message in ERROR_MESSAGES.items():
             if error in status:
                 return message
 

--- a/homeassistant/components/motionmount/strings.json
+++ b/homeassistant/components/motionmount/strings.json
@@ -72,6 +72,9 @@
         "state": {
           "none": "None",
           "motor": "Motor",
+          "hdmi_cec": "HDMI CEC",
+          "obstruction": "Obstruction",
+          "tv_width_constraint": "TV width constraint",
           "internal": "Internal"
         }
       }

--- a/tests/components/motionmount/test_sensor.py
+++ b/tests/components/motionmount/test_sensor.py
@@ -2,7 +2,8 @@
 
 from unittest.mock import MagicMock, PropertyMock
 
-import motionmount
+from motionmount import MotionMountSystemError
+import pytest
 
 from homeassistant.core import HomeAssistant
 
@@ -13,51 +14,26 @@ from tests.common import MockConfigEntry
 MAC = bytes.fromhex("c4dd57f8a55f")
 
 
-async def test_error_status_sensor_none(
+@pytest.mark.parametrize(
+    "system_status",
+    [
+        (None, "none"),
+        (MotionMountSystemError.MotorError, "motor"),
+        (MotionMountSystemError.ObstructionDetected, "obstruction"),
+        (MotionMountSystemError.TVWidthConstraintError, "tv_width_constraint"),
+        (MotionMountSystemError.HDMICECError, "hdmi_cec"),
+        (MotionMountSystemError.InternalError, "internal"),
+    ],
+)
+async def test_error_status_sensor_states(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_motionmount_config_flow: MagicMock,
+    system_status: (MotionMountSystemError, str),
 ) -> None:
     """Tests the state attributes."""
-    mock_config_entry.add_to_hass(hass)
+    (status, state) = system_status
 
-    type(mock_motionmount_config_flow).name = PropertyMock(return_value=ZEROCONF_NAME)
-    type(mock_motionmount_config_flow).mac = PropertyMock(return_value=MAC)
-    type(mock_motionmount_config_flow).is_authenticated = PropertyMock(
-        return_value=True
-    )
-    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
-
-    assert hass.states.get("sensor.my_motionmount_error_status").state == "none"
-
-
-async def test_error_status_sensor_motor(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    mock_motionmount_config_flow: MagicMock,
-) -> None:
-    """Tests the state attributes."""
-    mock_config_entry.add_to_hass(hass)
-
-    type(mock_motionmount_config_flow).name = PropertyMock(return_value=ZEROCONF_NAME)
-    type(mock_motionmount_config_flow).mac = PropertyMock(return_value=MAC)
-    type(mock_motionmount_config_flow).is_authenticated = PropertyMock(
-        return_value=True
-    )
-    type(mock_motionmount_config_flow).system_status = PropertyMock(
-        return_value=[motionmount.MotionMountSystemError.MotorError]
-    )
-    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
-
-    assert hass.states.get("sensor.my_motionmount_error_status").state == "motor"
-
-
-async def test_error_status_sensor_obstruction(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    mock_motionmount_config_flow: MagicMock,
-) -> None:
-    """Tests the state attributes."""
     mock_config_entry.add_to_hass(hass)
 
     type(mock_motionmount_config_flow).name = PropertyMock(return_value=ZEROCONF_NAME)
@@ -66,74 +42,8 @@ async def test_error_status_sensor_obstruction(
         return_value=True
     )
     type(mock_motionmount_config_flow).system_status = PropertyMock(
-        return_value=[motionmount.MotionMountSystemError.ObstructionDetected]
+        return_value=[status]
     )
     assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
 
-    assert hass.states.get("sensor.my_motionmount_error_status").state == "obstruction"
-
-
-async def test_error_status_sensor_tv_width_constraint(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    mock_motionmount_config_flow: MagicMock,
-) -> None:
-    """Tests the state attributes."""
-    mock_config_entry.add_to_hass(hass)
-
-    type(mock_motionmount_config_flow).name = PropertyMock(return_value=ZEROCONF_NAME)
-    type(mock_motionmount_config_flow).mac = PropertyMock(return_value=MAC)
-    type(mock_motionmount_config_flow).is_authenticated = PropertyMock(
-        return_value=True
-    )
-    type(mock_motionmount_config_flow).system_status = PropertyMock(
-        return_value=[motionmount.MotionMountSystemError.TVWidthConstraintError]
-    )
-    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
-
-    assert (
-        hass.states.get("sensor.my_motionmount_error_status").state
-        == "tv_width_constraint"
-    )
-
-
-async def test_error_status_sensor_hdmi_cec(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    mock_motionmount_config_flow: MagicMock,
-) -> None:
-    """Tests the state attributes."""
-    mock_config_entry.add_to_hass(hass)
-
-    type(mock_motionmount_config_flow).name = PropertyMock(return_value=ZEROCONF_NAME)
-    type(mock_motionmount_config_flow).mac = PropertyMock(return_value=MAC)
-    type(mock_motionmount_config_flow).is_authenticated = PropertyMock(
-        return_value=True
-    )
-    type(mock_motionmount_config_flow).system_status = PropertyMock(
-        return_value=[motionmount.MotionMountSystemError.HDMICECError]
-    )
-    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
-
-    assert hass.states.get("sensor.my_motionmount_error_status").state == "hdmi_cec"
-
-
-async def test_error_status_sensor_internal(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    mock_motionmount_config_flow: MagicMock,
-) -> None:
-    """Tests the state attributes."""
-    mock_config_entry.add_to_hass(hass)
-
-    type(mock_motionmount_config_flow).name = PropertyMock(return_value=ZEROCONF_NAME)
-    type(mock_motionmount_config_flow).mac = PropertyMock(return_value=MAC)
-    type(mock_motionmount_config_flow).is_authenticated = PropertyMock(
-        return_value=True
-    )
-    type(mock_motionmount_config_flow).system_status = PropertyMock(
-        return_value=[motionmount.MotionMountSystemError.InternalError]
-    )
-    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
-
-    assert hass.states.get("sensor.my_motionmount_error_status").state == "internal"
+    assert hass.states.get("sensor.my_motionmount_error_status").state == state

--- a/tests/components/motionmount/test_sensor.py
+++ b/tests/components/motionmount/test_sensor.py
@@ -1,6 +1,6 @@
 """Tests for the MotionMount Sensor platform."""
 
-from unittest.mock import MagicMock, PropertyMock
+from unittest.mock import patch
 
 from motionmount import MotionMountSystemError
 import pytest
@@ -28,22 +28,22 @@ MAC = bytes.fromhex("c4dd57f8a55f")
 async def test_error_status_sensor_states(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_motionmount_config_flow: MagicMock,
     system_status: (MotionMountSystemError, str),
 ) -> None:
     """Tests the state attributes."""
     (status, state) = system_status
 
-    mock_config_entry.add_to_hass(hass)
+    with patch(
+        "homeassistant.components.motionmount.motionmount.MotionMount",
+        autospec=True,
+    ) as motionmount_mock:
+        motionmount_mock.return_value.name = ZEROCONF_NAME
+        motionmount_mock.return_value.mac = MAC
+        motionmount_mock.return_value.is_authenticated = True
+        motionmount_mock.return_value.system_status = [status]
 
-    type(mock_motionmount_config_flow).name = PropertyMock(return_value=ZEROCONF_NAME)
-    type(mock_motionmount_config_flow).mac = PropertyMock(return_value=MAC)
-    type(mock_motionmount_config_flow).is_authenticated = PropertyMock(
-        return_value=True
-    )
-    type(mock_motionmount_config_flow).system_status = PropertyMock(
-        return_value=[status]
-    )
-    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        mock_config_entry.add_to_hass(hass)
 
-    assert hass.states.get("sensor.my_motionmount_error_status").state == state
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+
+        assert hass.states.get("sensor.my_motionmount_error_status").state == state

--- a/tests/components/motionmount/test_sensor.py
+++ b/tests/components/motionmount/test_sensor.py
@@ -1,0 +1,139 @@
+"""Tests for the MotionMount Sensor platform."""
+
+from unittest.mock import MagicMock, PropertyMock
+
+import motionmount
+
+from homeassistant.core import HomeAssistant
+
+from . import ZEROCONF_NAME
+
+from tests.common import MockConfigEntry
+
+MAC = bytes.fromhex("c4dd57f8a55f")
+
+
+async def test_error_status_sensor_none(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_motionmount_config_flow: MagicMock,
+) -> None:
+    """Tests the state attributes."""
+    mock_config_entry.add_to_hass(hass)
+
+    type(mock_motionmount_config_flow).name = PropertyMock(return_value=ZEROCONF_NAME)
+    type(mock_motionmount_config_flow).mac = PropertyMock(return_value=MAC)
+    type(mock_motionmount_config_flow).is_authenticated = PropertyMock(
+        return_value=True
+    )
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+
+    assert hass.states.get("sensor.my_motionmount_error_status").state == "none"
+
+
+async def test_error_status_sensor_motor(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_motionmount_config_flow: MagicMock,
+) -> None:
+    """Tests the state attributes."""
+    mock_config_entry.add_to_hass(hass)
+
+    type(mock_motionmount_config_flow).name = PropertyMock(return_value=ZEROCONF_NAME)
+    type(mock_motionmount_config_flow).mac = PropertyMock(return_value=MAC)
+    type(mock_motionmount_config_flow).is_authenticated = PropertyMock(
+        return_value=True
+    )
+    type(mock_motionmount_config_flow).system_status = PropertyMock(
+        return_value=[motionmount.MotionMountSystemError.MotorError]
+    )
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+
+    assert hass.states.get("sensor.my_motionmount_error_status").state == "motor"
+
+
+async def test_error_status_sensor_obstruction(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_motionmount_config_flow: MagicMock,
+) -> None:
+    """Tests the state attributes."""
+    mock_config_entry.add_to_hass(hass)
+
+    type(mock_motionmount_config_flow).name = PropertyMock(return_value=ZEROCONF_NAME)
+    type(mock_motionmount_config_flow).mac = PropertyMock(return_value=MAC)
+    type(mock_motionmount_config_flow).is_authenticated = PropertyMock(
+        return_value=True
+    )
+    type(mock_motionmount_config_flow).system_status = PropertyMock(
+        return_value=[motionmount.MotionMountSystemError.ObstructionDetected]
+    )
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+
+    assert hass.states.get("sensor.my_motionmount_error_status").state == "obstruction"
+
+
+async def test_error_status_sensor_tv_width_constraint(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_motionmount_config_flow: MagicMock,
+) -> None:
+    """Tests the state attributes."""
+    mock_config_entry.add_to_hass(hass)
+
+    type(mock_motionmount_config_flow).name = PropertyMock(return_value=ZEROCONF_NAME)
+    type(mock_motionmount_config_flow).mac = PropertyMock(return_value=MAC)
+    type(mock_motionmount_config_flow).is_authenticated = PropertyMock(
+        return_value=True
+    )
+    type(mock_motionmount_config_flow).system_status = PropertyMock(
+        return_value=[motionmount.MotionMountSystemError.TVWidthConstraintError]
+    )
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+
+    assert (
+        hass.states.get("sensor.my_motionmount_error_status").state
+        == "tv_width_constraint"
+    )
+
+
+async def test_error_status_sensor_hdmi_cec(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_motionmount_config_flow: MagicMock,
+) -> None:
+    """Tests the state attributes."""
+    mock_config_entry.add_to_hass(hass)
+
+    type(mock_motionmount_config_flow).name = PropertyMock(return_value=ZEROCONF_NAME)
+    type(mock_motionmount_config_flow).mac = PropertyMock(return_value=MAC)
+    type(mock_motionmount_config_flow).is_authenticated = PropertyMock(
+        return_value=True
+    )
+    type(mock_motionmount_config_flow).system_status = PropertyMock(
+        return_value=[motionmount.MotionMountSystemError.HDMICECError]
+    )
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+
+    assert hass.states.get("sensor.my_motionmount_error_status").state == "hdmi_cec"
+
+
+async def test_error_status_sensor_internal(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_motionmount_config_flow: MagicMock,
+) -> None:
+    """Tests the state attributes."""
+    mock_config_entry.add_to_hass(hass)
+
+    type(mock_motionmount_config_flow).name = PropertyMock(return_value=ZEROCONF_NAME)
+    type(mock_motionmount_config_flow).mac = PropertyMock(return_value=MAC)
+    type(mock_motionmount_config_flow).is_authenticated = PropertyMock(
+        return_value=True
+    )
+    type(mock_motionmount_config_flow).system_status = PropertyMock(
+        return_value=[motionmount.MotionMountSystemError.InternalError]
+    )
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+
+    assert hass.states.get("sensor.my_motionmount_error_status").state == "internal"

--- a/tests/components/motionmount/test_sensor.py
+++ b/tests/components/motionmount/test_sensor.py
@@ -15,7 +15,7 @@ MAC = bytes.fromhex("c4dd57f8a55f")
 
 
 @pytest.mark.parametrize(
-    "system_status",
+    ("system_status", "state"),
     [
         (None, "none"),
         (MotionMountSystemError.MotorError, "motor"),
@@ -28,11 +28,10 @@ MAC = bytes.fromhex("c4dd57f8a55f")
 async def test_error_status_sensor_states(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    system_status: (MotionMountSystemError, str),
+    system_status: MotionMountSystemError,
+    state: str,
 ) -> None:
     """Tests the state attributes."""
-    (status, state) = system_status
-
     with patch(
         "homeassistant.components.motionmount.motionmount.MotionMount",
         autospec=True,
@@ -40,7 +39,7 @@ async def test_error_status_sensor_states(
         motionmount_mock.return_value.name = ZEROCONF_NAME
         motionmount_mock.return_value.mac = MAC
         motionmount_mock.return_value.is_authenticated = True
-        motionmount_mock.return_value.system_status = [status]
+        motionmount_mock.return_value.system_status = [system_status]
 
         mock_config_entry.add_to_hass(hass)
 


### PR DESCRIPTION
## Proposed change
This change updates the 'error sensor' that can now show the new errors that are generated by the MotionMount

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
