### PR TITLE
Fix Home Connect actions keys

### DIFF
--- a/homeassistant/components/home_connect/__init__.py
+++ b/homeassistant/components/home_connect/__init__.py
@@ -50,8 +50,9 @@ CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 SERVICE_SETTING_SCHEMA = vol.Schema(
     {
         vol.Required(ATTR_DEVICE_ID): str,
-        vol.Required(ATTR_KEY): vol.In(
-            [setting.value for setting in SettingKey if setting != SettingKey.UNKNOWN]
+        vol.Required(ATTR_KEY): vol.All(
+            vol.Coerce(SettingKey),
+            vol.NotIn([SettingKey.UNKNOWN]),
         ),
         vol.Required(ATTR_VALUE): vol.Any(str, int, bool),
     }
@@ -60,8 +61,9 @@ SERVICE_SETTING_SCHEMA = vol.Schema(
 SERVICE_OPTION_SCHEMA = vol.Schema(
     {
         vol.Required(ATTR_DEVICE_ID): str,
-        vol.Required(ATTR_KEY): vol.In(
-            [option.value for option in OptionKey if option != OptionKey.UNKNOWN]
+        vol.Required(ATTR_KEY): vol.All(
+            vol.Coerce(OptionKey),
+            vol.NotIn([OptionKey.UNKNOWN]),
         ),
         vol.Required(ATTR_VALUE): vol.Any(str, int, bool),
         vol.Optional(ATTR_UNIT): str,
@@ -71,19 +73,22 @@ SERVICE_OPTION_SCHEMA = vol.Schema(
 SERVICE_PROGRAM_SCHEMA = vol.Any(
     {
         vol.Required(ATTR_DEVICE_ID): str,
-        vol.Required(ATTR_PROGRAM): vol.In(
-            [program.value for program in ProgramKey if program != ProgramKey.UNKNOWN]
+        vol.Required(ATTR_PROGRAM): vol.All(
+            vol.Coerce(ProgramKey),
+            vol.NotIn([ProgramKey.UNKNOWN]),
         ),
-        vol.Required(ATTR_KEY): vol.In(
-            [option.value for option in OptionKey if option != OptionKey.UNKNOWN]
+        vol.Required(ATTR_KEY): vol.All(
+            vol.Coerce(OptionKey),
+            vol.NotIn([OptionKey.UNKNOWN]),
         ),
         vol.Required(ATTR_VALUE): vol.Any(int, str),
         vol.Optional(ATTR_UNIT): str,
     },
     {
         vol.Required(ATTR_DEVICE_ID): str,
-        vol.Required(ATTR_PROGRAM): vol.In(
-            [program.value for program in ProgramKey if program != ProgramKey.UNKNOWN]
+        vol.Required(ATTR_PROGRAM): vol.All(
+            vol.Coerce(ProgramKey),
+            vol.NotIn([ProgramKey.UNKNOWN]),
         ),
     },
 )
@@ -144,14 +149,14 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     async def _async_service_program(call: ServiceCall, start: bool):
         """Execute calls to services taking a program."""
-        program = ProgramKey(call.data[ATTR_PROGRAM])
+        program = call.data[ATTR_PROGRAM]
         client, ha_id = await _get_client_and_ha_id(hass, call.data[ATTR_DEVICE_ID])
 
         option_key = call.data.get(ATTR_KEY)
         options = (
             [
                 Option(
-                    OptionKey(option_key),
+                    option_key,
                     call.data[ATTR_VALUE],
                     unit=call.data.get(ATTR_UNIT),
                 )
@@ -188,14 +193,14 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             if active:
                 await client.set_active_program_option(
                     ha_id,
-                    option_key=OptionKey(option_key),
+                    option_key=option_key,
                     value=value,
                     unit=unit,
                 )
             else:
                 await client.set_selected_program_option(
                     ha_id,
-                    option_key=OptionKey(option_key),
+                    option_key=option_key,
                     value=value,
                     unit=unit,
                 )
@@ -238,7 +243,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     async def async_service_setting(call: ServiceCall):
         """Service for changing a setting."""
-        key = SettingKey(call.data[ATTR_KEY])
+        key = call.data[ATTR_KEY]
         value = call.data[ATTR_VALUE]
         client, ha_id = await _get_client_and_ha_id(hass, call.data[ATTR_DEVICE_ID])
 

--- a/tests/components/home_connect/test_init.py
+++ b/tests/components/home_connect/test_init.py
@@ -5,7 +5,7 @@ from typing import Any
 from unittest.mock import MagicMock, patch
 
 from aiohomeconnect.const import OAUTH2_TOKEN
-from aiohomeconnect.model import SettingKey, StatusKey
+from aiohomeconnect.model import OptionKey, ProgramKey, SettingKey, StatusKey
 from aiohomeconnect.model.error import HomeConnectError
 import pytest
 import requests_mock
@@ -41,9 +41,9 @@ SERVICE_KV_CALL_PARAMS = [
         "service": "set_option_active",
         "service_data": {
             "device_id": "DEVICE_ID",
-            "key": "",
-            "value": "",
-            "unit": "",
+            "key": OptionKey.BSH_COMMON_FINISH_IN_RELATIVE.value,
+            "value": 43200,
+            "unit": "seconds",
         },
         "blocking": True,
     },
@@ -52,8 +52,8 @@ SERVICE_KV_CALL_PARAMS = [
         "service": "set_option_selected",
         "service_data": {
             "device_id": "DEVICE_ID",
-            "key": "",
-            "value": "",
+            "key": OptionKey.LAUNDRY_CARE_WASHER_TEMPERATURE.value,
+            "value": "LaundryCare.Washer.EnumType.Temperature.GC40",
         },
         "blocking": True,
     },
@@ -62,8 +62,8 @@ SERVICE_KV_CALL_PARAMS = [
         "service": "change_setting",
         "service_data": {
             "device_id": "DEVICE_ID",
-            "key": "",
-            "value": "",
+            "key": SettingKey.BSH_COMMON_CHILD_LOCK.value,
+            "value": True,
         },
         "blocking": True,
     },
@@ -95,9 +95,9 @@ SERVICE_PROGRAM_CALL_PARAMS = [
         "service": "select_program",
         "service_data": {
             "device_id": "DEVICE_ID",
-            "program": "",
-            "key": "",
-            "value": "",
+            "program": ProgramKey.LAUNDRY_CARE_WASHER_COTTON.value,
+            "key": OptionKey.LAUNDRY_CARE_WASHER_TEMPERATURE.value,
+            "value": "LaundryCare.Washer.EnumType.Temperature.GC40",
         },
         "blocking": True,
     },
@@ -106,10 +106,10 @@ SERVICE_PROGRAM_CALL_PARAMS = [
         "service": "start_program",
         "service_data": {
             "device_id": "DEVICE_ID",
-            "program": "",
-            "key": "",
-            "value": "",
-            "unit": "C",
+            "program": ProgramKey.LAUNDRY_CARE_WASHER_COTTON.value,
+            "key": OptionKey.BSH_COMMON_FINISH_IN_RELATIVE.value,
+            "value": 43200,
+            "unit": "seconds",
         },
         "blocking": True,
     },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Using program and option keys that aren't at the API documentation, will no longer work. To be able to use them, open an issue or submit a pull request with the required keys at [MartinHjelmare/aiohomeconnect](https://github.com/MartinHjelmare/aiohomeconnect).

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Actions weren't working because the method calls were done with raw strings instead of using instances of the respective key enumerations.
Now an instance of the respective keys is created, and the schema validation now validates that the given values are at the enumerations.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
