### PR TITLE
Add exception handling for updating LetPot time entities

### DIFF
--- a/homeassistant/components/letpot/quality_scale.yaml
+++ b/homeassistant/components/letpot/quality_scale.yaml
@@ -63,7 +63,7 @@ rules:
   entity-device-class: todo
   entity-disabled-by-default: todo
   entity-translations: done
-  exception-translations: todo
+  exception-translations: done
   icon-translations: todo
   reconfiguration-flow: todo
   repair-issues: todo

--- a/homeassistant/components/letpot/quality_scale.yaml
+++ b/homeassistant/components/letpot/quality_scale.yaml
@@ -29,7 +29,7 @@ rules:
   unique-config-entry: done
 
   # Silver
-  action-exceptions: todo
+  action-exceptions: done
   config-entry-unloading:
     status: done
     comment: |

--- a/homeassistant/components/letpot/strings.json
+++ b/homeassistant/components/letpot/strings.json
@@ -40,5 +40,13 @@
         "name": "Light on"
       }
     }
+  },
+  "exceptions": {
+    "communication_error": {
+      "message": "An error occurred while communicating with the LetPot device: {exception}"
+    },
+    "unknown_error": {
+      "message": "An unknown error occurred while communicating with the LetPot device: {exception}"
+    }
   }
 }

--- a/homeassistant/components/letpot/time.py
+++ b/homeassistant/components/letpot/time.py
@@ -15,7 +15,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import LetPotConfigEntry
 from .coordinator import LetPotDeviceCoordinator
-from .entity import LetPotEntity
+from .entity import LetPotEntity, exception_handler
 
 # Each change pushes a 'full' device status with the change. The library will cache
 # pending changes to avoid overwriting, but try to avoid a lot of parallelism.
@@ -86,6 +86,7 @@ class LetPotTimeEntity(LetPotEntity, TimeEntity):
         """Return the time."""
         return self.entity_description.value_fn(self.coordinator.data)
 
+    @exception_handler
     async def async_set_value(self, value: time) -> None:
         """Set the time."""
         await self.entity_description.set_value_fn(

--- a/tests/components/letpot/test_time.py
+++ b/tests/components/letpot/test_time.py
@@ -1,0 +1,52 @@
+"""Test time entities for the LetPot integration."""
+
+from datetime import time
+from unittest.mock import MagicMock
+
+from letpot.exceptions import LetPotConnectionException, LetPotException
+import pytest
+
+from homeassistant.components.time import SERVICE_SET_VALUE
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+
+from . import setup_integration
+
+from tests.common import MockConfigEntry
+
+
+@pytest.mark.parametrize(
+    ("exception", "user_error"),
+    [
+        (
+            LetPotConnectionException("Connection failed"),
+            "An error occurred while communicating with the LetPot device: Connection failed",
+        ),
+        (
+            LetPotException("Random thing failed"),
+            "An unknown error occurred while communicating with the LetPot device: Random thing failed",
+        ),
+    ],
+)
+async def test_time_error(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_client: MagicMock,
+    mock_device_client: MagicMock,
+    exception: Exception,
+    user_error: str,
+) -> None:
+    """Test time entity exception handling."""
+    await setup_integration(hass, mock_config_entry)
+
+    mock_device_client.set_light_schedule.side_effect = exception
+
+    assert hass.states.get("time.garden_light_on") is not None
+    with pytest.raises(HomeAssistantError, match=user_error):
+        await hass.services.async_call(
+            "time",
+            SERVICE_SET_VALUE,
+            service_data={"time": time(hour=7, minute=0)},
+            blocking=True,
+            target={"entity_id": "time.garden_light_on"},
+        )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add exception handling for updating the time entities in the LetPot integration so it is better communicated to the user that it failed. Inspired by the AirGradient code to make it as easy as adding one decorator to do this for future platforms.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
