### PR TITLE
Bump zeroconf to 0.143.0

### DIFF
--- a/homeassistant/components/zeroconf/manifest.json
+++ b/homeassistant/components/zeroconf/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "loggers": ["zeroconf"],
   "quality_scale": "internal",
-  "requirements": ["zeroconf==0.142.0"]
+  "requirements": ["zeroconf==0.143.0"]
 }

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -73,7 +73,7 @@ voluptuous-serialize==2.6.0
 voluptuous==0.15.2
 webrtc-models==0.3.0
 yarl==1.18.3
-zeroconf==0.142.0
+zeroconf==0.143.0
 
 # Constrain pycryptodome to avoid vulnerability
 # see https://github.com/home-assistant/core/pull/16238

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ dependencies    = [
     "voluptuous-openapi==0.0.6",
     "yarl==1.18.3",
     "webrtc-models==0.3.0",
-    "zeroconf==0.142.0"
+    "zeroconf==0.143.0"
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,4 +51,4 @@ voluptuous-serialize==2.6.0
 voluptuous-openapi==0.0.6
 yarl==1.18.3
 webrtc-models==0.3.0
-zeroconf==0.142.0
+zeroconf==0.143.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3125,7 +3125,7 @@ zamg==0.3.6
 zengge==0.2
 
 # homeassistant.components.zeroconf
-zeroconf==0.142.0
+zeroconf==0.143.0
 
 # homeassistant.components.zeversolar
 zeversolar==0.3.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2514,7 +2514,7 @@ yt-dlp[default]==2025.01.26
 zamg==0.3.6
 
 # homeassistant.components.zeroconf
-zeroconf==0.142.0
+zeroconf==0.143.0
 
 # homeassistant.components.zeversolar
 zeversolar==0.3.2


### PR DESCRIPTION
- [x] wheels https://github.com/home-assistant/core/actions/runs/13080154454 -- bthome-ble failure is unrelated --- see https://github.com/home-assistant/core/pull/137036



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
changelog: https://github.com/python-zeroconf/python-zeroconf/compare/0.142.0...0.143.0

Will hopefully fix the circular import seen on dev
```
Jan 31 18:41:37 homeassistant homeassistant[547]: Traceback (most recent call last):
Jan 31 18:41:37 homeassistant homeassistant[547]:   File "<frozen runpy>", line 198, in _run_module_as_main
Jan 31 18:41:37 homeassistant homeassistant[547]:   File "<frozen runpy>", line 88, in _run_code
Jan 31 18:41:37 homeassistant homeassistant[547]:   File "/usr/src/homeassistant/homeassistant/__main__.py", line 227, in <module>
Jan 31 18:41:37 homeassistant homeassistant[547]:     sys.exit(main())
Jan 31 18:41:37 homeassistant homeassistant[547]:              ~~~~^^
Jan 31 18:41:37 homeassistant homeassistant[547]:   File "/usr/src/homeassistant/homeassistant/__main__.py", line 192, in main
Jan 31 18:41:37 homeassistant homeassistant[547]:     from . import config, runner
Jan 31 18:41:37 homeassistant homeassistant[547]:   File "/usr/src/homeassistant/homeassistant/runner.py", line 16, in <module>
Jan 31 18:41:37 homeassistant homeassistant[547]:     from . import bootstrap
Jan 31 18:41:37 homeassistant homeassistant[547]:   File "/usr/src/homeassistant/homeassistant/bootstrap.py", line 41, in <module>
Jan 31 18:41:37 homeassistant homeassistant[547]:     from .components import (
Jan 31 18:41:37 homeassistant homeassistant[547]:     ...<21 lines>...
Jan 31 18:41:37 homeassistant homeassistant[547]:     )
Jan 31 18:41:37 homeassistant homeassistant[547]:   File "/usr/src/homeassistant/homeassistant/components/auth/__init__.py", line 158, in <module>
Jan 31 18:41:37 homeassistant homeassistant[547]:     from homeassistant.helpers.config_entry_oauth2_flow import OAuth2AuthorizeCallbackView
Jan 31 18:41:37 homeassistant homeassistant[547]:   File "/usr/src/homeassistant/homeassistant/helpers/config_entry_oauth2_flow.py", line 33, in <module>
Jan 31 18:41:37 homeassistant homeassistant[547]:     from .aiohttp_client import async_get_clientsession
Jan 31 18:41:37 homeassistant homeassistant[547]:   File "/usr/src/homeassistant/homeassistant/helpers/aiohttp_client.py", line 18, in <module>
Jan 31 18:41:37 homeassistant homeassistant[547]:     from aiohttp_asyncmdnsresolver.api import AsyncMDNSResolver
Jan 31 18:41:37 homeassistant homeassistant[547]:   File "/usr/local/lib/python3.13/site-packages/aiohttp_asyncmdnsresolver/api.py", line 3, in <module>
Jan 31 18:41:37 homeassistant homeassistant[547]:     from ._impl import AsyncMDNSResolver
Jan 31 18:41:37 homeassistant homeassistant[547]:   File "/usr/local/lib/python3.13/site-packages/aiohttp_asyncmdnsresolver/_impl.py", line 7, in <module>
Jan 31 18:41:37 homeassistant homeassistant[547]:     from zeroconf.asyncio import AsyncZeroconf
Jan 31 18:41:37 homeassistant homeassistant[547]:   File "/usr/local/lib/python3.13/site-packages/zeroconf/__init__.py", line 23, in <module>
Jan 31 18:41:37 homeassistant homeassistant[547]:     from ._cache import DNSCache  # noqa # import needed for backwards compat
Jan 31 18:41:37 homeassistant homeassistant[547]:     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jan 31 18:41:37 homeassistant homeassistant[547]:   File "src/zeroconf/_cache.py", line 1, in init zeroconf._cache
Jan 31 18:41:37 homeassistant homeassistant[547]:   File "/usr/local/lib/python3.13/site-packages/zeroconf/_protocol/incoming.py", line 27, in <module>
Jan 31 18:41:37 homeassistant homeassistant[547]:     from .._dns import (
Jan 31 18:41:37 homeassistant homeassistant[547]:     ...<8 lines>...
Jan 31 18:41:37 homeassistant homeassistant[547]:     )
Jan 31 18:41:37 homeassistant homeassistant[547]:   File "src/zeroconf/_dns.py", line 1, in init zeroconf._dns
Jan 31 18:41:37 homeassistant homeassistant[547]: AttributeError: partially initialized module 'zeroconf._protocol.incoming' from '/usr/local/lib/python3.13/site-packages/zeroconf/_protocol/incoming.py' has no attribute 'DNSIncoming' (most likely due to a circular import)
Jan 31 18:41:37 homeassistant homeassistant[547]: [18:41:37] INFO: Home Assistant Core finish process exit code 1
```
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
