### PR TITLE
Allow trigger based numeric sensors to be set to unknown

### DIFF
--- a/homeassistant/components/template/sensor.py
+++ b/homeassistant/components/template/sensor.py
@@ -385,12 +385,12 @@ class TriggerSensorEntity(TriggerEntity, RestoreSensor):
                 self._attr_last_reset = parsed_timestamp
 
         # Ensure that the state is set to None only if the rendered result is "None"
-        if (state := self._rendered.get(CONF_STATE)) is not None and state == "None":
+        state = self._rendered.get(CONF_STATE)
+        if state == "None":
             self._rendered[CONF_STATE] = None
+            return
 
-        if (
-            state := self._rendered.get(CONF_STATE)
-        ) is None or self.device_class not in (
+        if state is None or self.device_class not in (
             SensorDeviceClass.DATE,
             SensorDeviceClass.TIMESTAMP,
         ):

--- a/homeassistant/components/template/sensor.py
+++ b/homeassistant/components/template/sensor.py
@@ -384,6 +384,10 @@ class TriggerSensorEntity(TriggerEntity, RestoreSensor):
             else:
                 self._attr_last_reset = parsed_timestamp
 
+        # Ensure that the state is set to None only if the rendered result is "None"
+        if (state := self._rendered.get(CONF_STATE)) is not None and state == "None":
+            self._rendered[CONF_STATE] = None
+
         if (
             state := self._rendered.get(CONF_STATE)
         ) is None or self.device_class not in (

--- a/homeassistant/components/template/sensor.py
+++ b/homeassistant/components/template/sensor.py
@@ -386,7 +386,7 @@ class TriggerSensorEntity(TriggerEntity, RestoreSensor):
 
         # Ensure that the state is set to None only if the rendered result is "None"
         state = self._rendered.get(CONF_STATE)
-        if state == "None":
+        if state and state.lower() == "none":
             self._rendered[CONF_STATE] = None
             return
 

--- a/homeassistant/components/template/sensor.py
+++ b/homeassistant/components/template/sensor.py
@@ -339,6 +339,7 @@ class TriggerSensorEntity(TriggerEntity, RestoreSensor):
         """Initialize."""
         super().__init__(hass, coordinator, config)
 
+        self._parse_result.add(CONF_STATE)
         if (last_reset_template := config.get(ATTR_LAST_RESET)) is not None:
             if last_reset_template.is_static:
                 self._static_rendered[ATTR_LAST_RESET] = last_reset_template.template
@@ -384,13 +385,9 @@ class TriggerSensorEntity(TriggerEntity, RestoreSensor):
             else:
                 self._attr_last_reset = parsed_timestamp
 
-        # Ensure that the state is set to None only if the rendered result is "None"
-        state = self._rendered.get(CONF_STATE)
-        if state and state.lower() == "none":
-            self._rendered[CONF_STATE] = None
-            return
-
-        if state is None or self.device_class not in (
+        if (
+            state := self._rendered.get(CONF_STATE)
+        ) is None or self.device_class not in (
             SensorDeviceClass.DATE,
             SensorDeviceClass.TIMESTAMP,
         ):

--- a/tests/components/template/test_sensor.py
+++ b/tests/components/template/test_sensor.py
@@ -1527,7 +1527,7 @@ async def test_trigger_entity_available(hass: HomeAssistant) -> None:
     assert state.state == "unavailable"
 
 
-@pytest.mark.parametrize(("source_event_value"), [None, "None", "none"])
+@pytest.mark.parametrize(("source_event_value"), [None, "None"])
 async def test_numeric_trigger_entity_set_unknown(
     hass: HomeAssistant, source_event_value: str | None
 ) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix https://github.com/home-assistant/core/issues/117397

Currently when setting a numeric trigger based template sensor to `none`, the system errors because `"None"` is returned as the sensor state.  Now, we capture `"None"` and replace it with `None` to allow numeric sensors to be set `unknown`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
