### PR TITLE
Load `hassio` before `backup` at frontend stage

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -161,6 +161,12 @@ FRONTEND_INTEGRATIONS = {
     # integrations can be removed and database migration status is
     # visible in frontend
     "frontend",
+    # Hassio is an after dependency of backup, after dependencies
+    # are not promoted from stage 2 to earlier stages, so we need to
+    # add it here. Hassio needs to be setup before backup, otherwise
+    # the backup integration will think we are a container/core install
+    # when using HAOS or Supervised install.
+    "hassio",
     # Backup is an after dependency of frontend, after dependencies
     # are not promoted from stage 2 to earlier stages, so we need to
     # add it here.


### PR DESCRIPTION
## Proposed change
`backup` is loaded already before stage 1 as a dependency of `frontend` while `hassio` is loaded after that at stage 1.
This leads to `is_hassio` returning False when `backup` is loaded, thinking we are a container/core install and preventing backups on Supervised or HAOS installs.

This PR ensures that `hassio` is also loaded at the frontend stage as well. Fyi `hassio loaded:` is a debug from me.

Before:

```log
2025-02-01 10:13:10.825 INFO (MainThread) [homeassistant.bootstrap] Setting up frontend: {'backup', 'frontend'}
2025-02-01 10:13:10.841 DEBUG (MainThread) [homeassistant.components.backup] Scheduling next automatic delete of backups older than 7 in 1 day
2025-02-01 10:13:10.844 DEBUG (MainThread) [homeassistant.components.backup] Scheduling next automatic backup at 2025-02-02 05:02:57+01:00
2025-02-01 10:13:10.848 DEBUG (MainThread) [homeassistant.components.backup] Loaded 0 platforms
2025-02-01 10:13:10.848 DEBUG (MainThread) [homeassistant.components.backup] Loaded 0 agents
2025-02-01 10:13:10.849 DEBUG (MainThread) [homeassistant.components.backup] Loading backup agents for backup
2025-02-01 10:13:10.849 DEBUG (MainThread) [homeassistant.components.backup] hassio loaded: False
2025-02-01 10:13:10.849 DEBUG (MainThread) [homeassistant.components.backup] Backup platform backup loaded
2025-02-01 10:13:10.849 DEBUG (MainThread) [homeassistant.components.backup] 0 platforms loaded in total
2025-02-01 10:13:10.849 DEBUG (MainThread) [homeassistant.components.backup] 1 agents loaded in total
2025-02-01 10:13:10.849 DEBUG (MainThread) [homeassistant.components.backup] 1 local agents loaded in total
2025-02-01 10:13:10.858 INFO (MainThread) [homeassistant.bootstrap] Setting up recorder: {'recorder'}
2025-02-01 10:13:11.006 DEBUG (MainThread) [homeassistant.components.backup] Backup platform recorder loaded
2025-02-01 10:13:11.006 DEBUG (MainThread) [homeassistant.components.backup] 1 platforms loaded in total
2025-02-01 10:13:11.006 DEBUG (MainThread) [homeassistant.components.backup] 1 agents loaded in total
2025-02-01 10:13:11.006 DEBUG (MainThread) [homeassistant.components.backup] 1 local agents loaded in total
2025-02-01 10:13:11.006 INFO (MainThread) [homeassistant.bootstrap] Setting up debugger: {'debugpy'}
2025-02-01 10:13:11.006 INFO (MainThread) [homeassistant.bootstrap] Setting up stage 1: {'http', 'websocket_api', 'zeroconf', 'webhook', 'network', 'api', 'hassio', 'cloud', 'ssdp', 'auth', 'dhcp', 'usb', 'bluetooth', 'repairs'}
```

After:

```
2025-02-01 10:23:12.487 INFO (MainThread) [homeassistant.bootstrap] Setting up frontend: {'backup', 'frontend', 'hassio'}
2025-02-01 10:23:12.715 DEBUG (MainThread) [homeassistant.components.backup] Scheduling next automatic delete of backups older than 7 in 1 day
2025-02-01 10:23:12.715 DEBUG (MainThread) [homeassistant.components.backup] Scheduling next automatic backup at 2025-02-02 05:03:52+01:00
2025-02-01 10:23:12.716 DEBUG (MainThread) [homeassistant.components.backup] Loading backup agents for hassio
2025-02-01 10:23:12.717 DEBUG (MainThread) [homeassistant.components.backup] Backup platform hassio loaded
2025-02-01 10:23:12.717 DEBUG (MainThread) [homeassistant.components.backup] 0 platforms loaded in total
2025-02-01 10:23:12.717 DEBUG (MainThread) [homeassistant.components.backup] 0 agents loaded in total
2025-02-01 10:23:12.717 DEBUG (MainThread) [homeassistant.components.backup] 0 local agents loaded in total
2025-02-01 10:23:12.717 DEBUG (MainThread) [homeassistant.components.backup] Loaded 0 platforms
2025-02-01 10:23:12.717 DEBUG (MainThread) [homeassistant.components.backup] Loaded 0 agents
2025-02-01 10:23:12.718 DEBUG (MainThread) [homeassistant.components.backup] Loading backup agents for backup
2025-02-01 10:23:12.718 DEBUG (MainThread) [homeassistant.components.backup] hassio loaded: True
2025-02-01 10:23:12.718 DEBUG (MainThread) [homeassistant.components.backup] Backup platform backup loaded
2025-02-01 10:23:12.718 DEBUG (MainThread) [homeassistant.components.backup] 0 platforms loaded in total
2025-02-01 10:23:12.718 DEBUG (MainThread) [homeassistant.components.backup] 0 agents loaded in total
2025-02-01 10:23:12.718 DEBUG (MainThread) [homeassistant.components.backup] 0 local agents loaded in total
2025-02-01 10:23:12.730 INFO (MainThread) [homeassistant.bootstrap] Setting up recorder: {'recorder'}
2025-02-01 10:23:12.862 DEBUG (MainThread) [homeassistant.components.backup] Backup platform recorder loaded
2025-02-01 10:23:12.862 DEBUG (MainThread) [homeassistant.components.backup] 1 platforms loaded in total
2025-02-01 10:23:12.863 DEBUG (MainThread) [homeassistant.components.backup] 2 agents loaded in total
2025-02-01 10:23:12.863 DEBUG (MainThread) [homeassistant.components.backup] 0 local agents loaded in total
2025-02-01 10:23:12.863 INFO (MainThread) [homeassistant.bootstrap] Setting up debugger: {'debugpy'}
2025-02-01 10:23:12.863 INFO (MainThread) [homeassistant.bootstrap] Setting up stage 1: {'bluetooth', 'ssdp', 'http', 'usb', 'repairs', 'webhook', 'auth', 'network', 'cloud', 'api', 'zeroconf', 'websocket_api', 'dhcp', 'hassio'}
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #137055, fixes #137041
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
