### PR TITLE
Migrate unique ID in vesync switches

### DIFF
--- a/homeassistant/components/vesync/__init__.py
+++ b/homeassistant/components/vesync/__init__.py
@@ -95,6 +95,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Migrate old entry."""
+    _LOGGER.debug("Migrating VeSync config entry: %s", config_entry.version)
     if config_entry.version == 1:
         # Migrate switch/outlets entity to a new unique ID
         _LOGGER.debug("Migrating VeSync config entry from version 1 to version 2")
@@ -103,18 +104,17 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
             entity_registry, config_entry.entry_id
         )
         for reg_entry in registry_entries:
-            if (
-                "--" not in reg_entry.unique_id
-                and reg_entry.platform == Platform.SWITCH
+            if "-" not in reg_entry.unique_id and reg_entry.entity_id.startswith(
+                Platform.SWITCH
             ):
                 _LOGGER.debug(
                     "Migrating switch/outlet entity from unique_id: %s to unique_id: %s",
                     reg_entry.unique_id,
-                    reg_entry.unique_id + "--device_status",
+                    reg_entry.unique_id + "-device_status",
                 )
                 entity_registry.async_update_entity(
                     reg_entry.entity_id,
-                    new_unique_id=reg_entry.unique_id + "--device_status",
+                    new_unique_id=reg_entry.unique_id + "-device_status",
                 )
             else:
                 _LOGGER.debug("Skipping entity with unique_id: %s", reg_entry.unique_id)

--- a/homeassistant/components/vesync/__init__.py
+++ b/homeassistant/components/vesync/__init__.py
@@ -90,3 +90,21 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass.data.pop(DOMAIN)
 
     return unload_ok
+
+
+async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+    """Migrate old entry."""
+    if config_entry.version == 1:
+        # Migrate switch/outlets entity to a new unique ID
+        # How do we get unique id of the switch entity?
+        old_unique_ids = config_entry.data.get("switches", [])
+        for old_unique_id in old_unique_ids:
+            new_unique_id = f"{old_unique_id}-device_status"
+            entity_registry = await hass.helpers.entity_registry.async_get_registry()
+            entity_entry = entity_registry.async_get(old_unique_id)
+            if entity_entry:
+                entity_registry.async_update_entity(
+                    entity_entry.entity_id, new_unique_id=new_unique_id
+                )
+        hass.config_entries.async_update_entry(config_entry, version=4)
+    return True

--- a/homeassistant/components/vesync/__init__.py
+++ b/homeassistant/components/vesync/__init__.py
@@ -95,8 +95,12 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Migrate old entry."""
-    _LOGGER.debug("Migrating VeSync config entry: %s", config_entry.version)
-    if config_entry.version == 1:
+    _LOGGER.debug(
+        "Migrating VeSync config entry: %s minor version: %s",
+        config_entry.version,
+        config_entry.minor_version,
+    )
+    if config_entry.minor_version == 1:
         # Migrate switch/outlets entity to a new unique ID
         _LOGGER.debug("Migrating VeSync config entry from version 1 to version 2")
         entity_registry = er.async_get(hass)
@@ -118,6 +122,6 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
                 )
             else:
                 _LOGGER.debug("Skipping entity with unique_id: %s", reg_entry.unique_id)
-        hass.config_entries.async_update_entry(config_entry, version=2)
+        hass.config_entries.async_update_entry(config_entry, minor_version=2)
 
     return True

--- a/homeassistant/components/vesync/__init__.py
+++ b/homeassistant/components/vesync/__init__.py
@@ -7,6 +7,7 @@ from pyvesync import VeSync
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, Platform
 from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
 from .common import async_generate_device_list
@@ -96,21 +97,27 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
     """Migrate old entry."""
     if config_entry.version == 1:
         # Migrate switch/outlets entity to a new unique ID
-        # How do we get unique id of the switch entity?
-        entity_registry = await hass.helpers.entity_registry.async_get_registry()
-        old_unique_ids = [
-            entry.unique_id
-            for entry in entity_registry.entities.values()
-            if DOMAIN in entry.platform and "--" not in entry.unique_id
-        ]
-
-        for old_unique_id in old_unique_ids:
-            new_unique_id = f"{old_unique_id}-device_status"
-            entity_registry = await hass.helpers.entity_registry.async_get_registry()
-            entity_entry = entity_registry.async_get(old_unique_id)
-            if entity_entry:
-                entity_registry.async_update_entity(
-                    entity_entry.entity_id, new_unique_id=new_unique_id
+        _LOGGER.debug("Migrating VeSync config entry from version 1 to version 2")
+        entity_registry = er.async_get(hass)
+        registry_entries = er.async_entries_for_config_entry(
+            entity_registry, config_entry.entry_id
+        )
+        for reg_entry in registry_entries:
+            if (
+                "--" not in reg_entry.unique_id
+                and reg_entry.platform == Platform.SWITCH
+            ):
+                _LOGGER.debug(
+                    "Migrating switch/outlet entity from unique_id: %s to unique_id: %s",
+                    reg_entry.unique_id,
+                    reg_entry.unique_id + "--device_status",
                 )
+                entity_registry.async_update_entity(
+                    reg_entry.entity_id,
+                    new_unique_id=reg_entry.unique_id + "--device_status",
+                )
+            else:
+                _LOGGER.debug("Skipping entity with unique_id: %s", reg_entry.unique_id)
         hass.config_entries.async_update_entry(config_entry, version=2)
+
     return True

--- a/homeassistant/components/vesync/__init__.py
+++ b/homeassistant/components/vesync/__init__.py
@@ -97,7 +97,13 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
     if config_entry.version == 1:
         # Migrate switch/outlets entity to a new unique ID
         # How do we get unique id of the switch entity?
-        old_unique_ids = config_entry.data.get("switches", [])
+        entity_registry = await hass.helpers.entity_registry.async_get_registry()
+        old_unique_ids = [
+            entry.unique_id
+            for entry in entity_registry.entities.values()
+            if DOMAIN in entry.platform and "--" not in entry.unique_id
+        ]
+
         for old_unique_id in old_unique_ids:
             new_unique_id = f"{old_unique_id}-device_status"
             entity_registry = await hass.helpers.entity_registry.async_get_registry()
@@ -106,5 +112,5 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
                 entity_registry.async_update_entity(
                     entity_entry.entity_id, new_unique_id=new_unique_id
                 )
-        hass.config_entries.async_update_entry(config_entry, version=4)
+        hass.config_entries.async_update_entry(config_entry, version=2)
     return True

--- a/homeassistant/components/vesync/config_flow.py
+++ b/homeassistant/components/vesync/config_flow.py
@@ -23,7 +23,8 @@ DATA_SCHEMA = vol.Schema(
 class VeSyncFlowHandler(ConfigFlow, domain=DOMAIN):
     """Handle a config flow."""
 
-    VERSION = 2
+    VERSION = 1
+    MINOR_VERSION = 2
 
     @callback
     def _show_form(self, errors: dict[str, str] | None = None) -> ConfigFlowResult:

--- a/homeassistant/components/vesync/config_flow.py
+++ b/homeassistant/components/vesync/config_flow.py
@@ -23,7 +23,7 @@ DATA_SCHEMA = vol.Schema(
 class VeSyncFlowHandler(ConfigFlow, domain=DOMAIN):
     """Handle a config flow."""
 
-    VERSION = 1
+    VERSION = 2
 
     @callback
     def _show_form(self, errors: dict[str, str] | None = None) -> ConfigFlowResult:

--- a/homeassistant/components/vesync/switch.py
+++ b/homeassistant/components/vesync/switch.py
@@ -83,6 +83,7 @@ class VeSyncSwitchHA(VeSyncBaseSwitch, SwitchEntity):
     ) -> None:
         """Initialize the VeSync switch device."""
         super().__init__(plug, coordinator)
+        self._attr_unique_id = f"{super().unique_id}-device_status"
         self.smartplug = plug
 
 
@@ -94,4 +95,5 @@ class VeSyncLightSwitch(VeSyncBaseSwitch, SwitchEntity):
     ) -> None:
         """Initialize Light Switch device class."""
         super().__init__(switch, coordinator)
+        self._attr_unique_id = f"{super().unique_id}-device_status"
         self.switch = switch

--- a/tests/components/vesync/conftest.py
+++ b/tests/components/vesync/conftest.py
@@ -168,7 +168,9 @@ async def switch_old_id_config_entry(
     )
     entry.add_to_hass(hass)
 
-    device_name = "Wall Switch"
-    mock_multiple_device_responses(requests_mock, [device_name])
+    wall_switch = "Wall Switch"
+    humidifer = "Humidifier 200s"
+
+    mock_multiple_device_responses(requests_mock, [wall_switch, humidifer])
 
     return entry

--- a/tests/components/vesync/conftest.py
+++ b/tests/components/vesync/conftest.py
@@ -153,3 +153,22 @@ async def humidifier_config_entry(
     await hass.async_block_till_done()
 
     return entry
+
+
+@pytest.fixture(name="switch_old_id_config_entry")
+async def switch_old_id_config_entry(
+    hass: HomeAssistant, requests_mock: requests_mock.Mocker, config
+) -> MockConfigEntry:
+    """Create a mock VeSync config entry for `switch` with the old unique ID approach."""
+    entry = MockConfigEntry(
+        title="VeSync",
+        domain=DOMAIN,
+        data=config[DOMAIN],
+        version=1,
+    )
+    entry.add_to_hass(hass)
+
+    device_name = "Wall Switch"
+    mock_multiple_device_responses(requests_mock, [device_name])
+
+    return entry

--- a/tests/components/vesync/conftest.py
+++ b/tests/components/vesync/conftest.py
@@ -165,6 +165,7 @@ async def switch_old_id_config_entry(
         domain=DOMAIN,
         data=config[DOMAIN],
         version=1,
+        minor_version=1,
     )
     entry.add_to_hass(hass)
 

--- a/tests/components/vesync/snapshots/test_switch.ambr
+++ b/tests/components/vesync/snapshots/test_switch.ambr
@@ -367,7 +367,7 @@
       'previous_unique_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'outlet',
+      'unique_id': 'outlet-device_status',
       'unit_of_measurement': None,
     }),
   ])
@@ -525,7 +525,7 @@
       'previous_unique_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'switch',
+      'unique_id': 'switch-device_status',
       'unit_of_measurement': None,
     }),
   ])

--- a/tests/components/vesync/test_init.py
+++ b/tests/components/vesync/test_init.py
@@ -151,7 +151,7 @@ async def test_migrate_config_entry(
     )
 
     assert switch.unique_id == "switch"
-    assert switch_old_id_config_entry.version == 1
+    assert switch_old_id_config_entry.minor_version == 1
     assert humidifer.unique_id == "humidifer"
 
     await hass.config_entries.async_setup(switch_old_id_config_entry.entry_id)

--- a/tests/components/vesync/test_init.py
+++ b/tests/components/vesync/test_init.py
@@ -134,8 +134,6 @@ async def test_migrate_config_entry(
     entity_registry: er.EntityRegistry,
 ) -> None:
     """Test migration of config entry. Only migrates switches to a new unique_id."""
-    entity_registry = er.async_get(hass)
-
     switch: er.RegistryEntry = entity_registry.async_get_or_create(
         domain="switch",
         platform="vesync",
@@ -159,7 +157,7 @@ async def test_migrate_config_entry(
     await hass.config_entries.async_setup(switch_old_id_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert switch_old_id_config_entry.version == 2
+    assert switch_old_id_config_entry.minor_version == 2
 
     migrated_switch = entity_registry.async_get(switch.entity_id)
     assert migrated_switch is not None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This preps for additional switch entities.  It migrates from switches not having a unique id to appending device status.   This aligns to PR https://github.com/home-assistant/core/pull/134409

I modeled this after: https://github.com/home-assistant/core/blob/5da9bfe0e3b658e12baa710948b99ae1cc5e7cb5/homeassistant/components/acmeda/__init__.py#L35-L46  

However I thought running the code on every start up is excessive.  This approach only migrates once. 


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
