### PR TITLE
Remove entity state from mcp-server prompt

### DIFF
--- a/homeassistant/components/mcp_server/__init__.py
+++ b/homeassistant/components/mcp_server/__init__.py
@@ -6,7 +6,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 
-from . import http
+from . import http, llm_api
 from .const import DOMAIN
 from .session import SessionManager
 from .types import MCPServerConfigEntry
@@ -25,6 +25,7 @@ CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the Model Context Protocol component."""
     http.async_register(hass)
+    llm_api.async_register_api(hass)
     return True
 
 

--- a/homeassistant/components/mcp_server/config_flow.py
+++ b/homeassistant/components/mcp_server/config_flow.py
@@ -42,8 +42,7 @@ class ModelContextServerProtocolConfigFlow(ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             return self.async_create_entry(
-                title=llm_apis[user_input[CONF_LLM_HASS_API]],
-                data=user_input,
+                title=llm_apis[user_input[CONF_LLM_HASS_API]], data=user_input
             )
 
         return self.async_show_form(

--- a/homeassistant/components/mcp_server/config_flow.py
+++ b/homeassistant/components/mcp_server/config_flow.py
@@ -10,13 +10,9 @@ import voluptuous as vol
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_LLM_HASS_API
 from homeassistant.helpers import llm
-from homeassistant.helpers.selector import (
-    SelectOptionDict,
-    SelectSelector,
-    SelectSelectorConfig,
-)
+from homeassistant.helpers.selector import SelectSelector, SelectSelectorConfig
 
-from .const import DOMAIN
+from .const import DOMAIN, LLM_API
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -32,11 +28,13 @@ class ModelContextServerProtocolConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle the initial step."""
-        llm_apis = {api.id: api.name for api in llm.async_get_apis(self.hass)}
+        # llm_apis = {api.id: api.name for api in llm.async_get_apis(self.hass)}
 
         if user_input is not None:
             return self.async_create_entry(
-                title=llm_apis[user_input[CONF_LLM_HASS_API]], data=user_input
+                # title=llm_apis[user_input[CONF_LLM_HASS_API]], data=user_input
+                title=user_input[CONF_LLM_HASS_API],
+                data=user_input,
             )
 
         return self.async_show_form(
@@ -48,13 +46,14 @@ class ModelContextServerProtocolConfigFlow(ConfigFlow, domain=DOMAIN):
                         default=llm.LLM_API_ASSIST,
                     ): SelectSelector(
                         SelectSelectorConfig(
-                            options=[
-                                SelectOptionDict(
-                                    label=name,
-                                    value=llm_api_id,
-                                )
-                                for llm_api_id, name in llm_apis.items()
-                            ]
+                            options=[LLM_API],
+                            # options=[
+                            #     SelectOptionDict(
+                            #         value=llm_api_id,
+                            #     )
+                            #     for llm_api_id in [LLM_API]
+                            # ],
+                            translation_key="llm_api",
                         )
                     ),
                 }

--- a/homeassistant/components/mcp_server/config_flow.py
+++ b/homeassistant/components/mcp_server/config_flow.py
@@ -60,7 +60,7 @@ class ModelContextServerProtocolConfigFlow(ConfigFlow, domain=DOMAIN):
                                     value=llm_api_id,
                                 )
                                 for llm_api_id, name in llm_apis.items()
-                            ],
+                            ]
                         )
                     ),
                 }

--- a/homeassistant/components/mcp_server/const.py
+++ b/homeassistant/components/mcp_server/const.py
@@ -2,3 +2,4 @@
 
 DOMAIN = "mcp_server"
 TITLE = "Model Context Protocol Server"
+LLM_API = "stateless_assist"

--- a/homeassistant/components/mcp_server/const.py
+++ b/homeassistant/components/mcp_server/const.py
@@ -3,3 +3,4 @@
 DOMAIN = "mcp_server"
 TITLE = "Model Context Protocol Server"
 LLM_API = "stateless_assist"
+LLM_API_NAME = "Stateless Assist"

--- a/homeassistant/components/mcp_server/llm_api.py
+++ b/homeassistant/components/mcp_server/llm_api.py
@@ -4,7 +4,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import intent, llm
 from homeassistant.util import yaml as yaml_util
 
-EXPOSED_ENTITY_FIELDS = {"name", "domain", "description", "area"}
+EXPOSED_ENTITY_FIELDS = {"name", "domain", "description", "area", "names"}
 
 
 def async_register_api(hass: HomeAssistant) -> None:

--- a/homeassistant/components/mcp_server/llm_api.py
+++ b/homeassistant/components/mcp_server/llm_api.py
@@ -1,0 +1,48 @@
+"""LLM API for MCP Server."""
+
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import intent, llm
+from homeassistant.util import yaml as yaml_util
+
+EXPOSED_ENTITY_FIELDS = {"name", "domain", "description", "area"}
+
+
+def async_register_api(hass: HomeAssistant) -> None:
+    """Register the LLM API."""
+    llm.async_register_api(hass, StatelessAssistAPI(hass))
+
+
+class StatelessAssistAPI(llm.AssistAPI):
+    """LLM API for MCP Server that provides the Assist API without state information in the prompt."""
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Initialize the StatelessAssistAPI."""
+        super().__init__(hass)
+        self.id = "stateless_assist"
+        self.name = "Stateless Assist API"
+
+    # Expose INTENT_GET_STATE
+    IGNORE_INTENTS = {
+        intent_name
+        for intent_name in llm.AssistAPI.IGNORE_INTENTS
+        if intent_name not in {intent.INTENT_GET_STATE}
+    }
+
+    @callback
+    def _async_get_exposed_entities_prompt(
+        self, llm_context: llm.LLMContext, exposed_entities: dict | None
+    ) -> list[str]:
+        """Return the prompt for the exposed entities."""
+        prompt = []
+
+        if exposed_entities:
+            prompt.append(
+                "An overview of the areas and the devices in this smart home:"
+            )
+            entities = [
+                {k: v for k, v in entity_info.items() if k in EXPOSED_ENTITY_FIELDS}
+                for entity_info in exposed_entities.values()
+            ]
+            prompt.append(yaml_util.dump(list(entities)))
+
+        return prompt

--- a/homeassistant/components/mcp_server/llm_api.py
+++ b/homeassistant/components/mcp_server/llm_api.py
@@ -1,8 +1,10 @@
 """LLM API for MCP Server."""
 
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import intent, llm
+from homeassistant.helpers import llm
 from homeassistant.util import yaml as yaml_util
+
+from .const import LLM_API, LLM_API_NAME
 
 EXPOSED_ENTITY_FIELDS = {"name", "domain", "description", "areas", "names"}
 
@@ -13,20 +15,18 @@ def async_register_api(hass: HomeAssistant) -> None:
 
 
 class StatelessAssistAPI(llm.AssistAPI):
-    """LLM API for MCP Server that provides the Assist API without state information in the prompt."""
+    """LLM API for MCP Server that provides the Assist API without state information in the prompt.
+
+    Syncing the state information is possible, but may put unnecessary load on
+    the system so we are instead providing the prompt without entity state. Since
+    actions don't care about the current state, there is little quality loss.
+    """
 
     def __init__(self, hass: HomeAssistant) -> None:
         """Initialize the StatelessAssistAPI."""
         super().__init__(hass)
-        self.id = "stateless_assist"
-        self.name = "Stateless Assist"
-
-    # Expose INTENT_GET_STATE
-    IGNORE_INTENTS = {
-        intent_name
-        for intent_name in llm.AssistAPI.IGNORE_INTENTS
-        if intent_name not in {intent.INTENT_GET_STATE}
-    }
+        self.id = LLM_API
+        self.name = LLM_API_NAME
 
     @callback
     def _async_get_exposed_entities_prompt(

--- a/homeassistant/components/mcp_server/llm_api.py
+++ b/homeassistant/components/mcp_server/llm_api.py
@@ -4,7 +4,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import intent, llm
 from homeassistant.util import yaml as yaml_util
 
-EXPOSED_ENTITY_FIELDS = {"name", "domain", "description", "area", "names"}
+EXPOSED_ENTITY_FIELDS = {"name", "domain", "description", "areas", "names"}
 
 
 def async_register_api(hass: HomeAssistant) -> None:

--- a/homeassistant/components/mcp_server/llm_api.py
+++ b/homeassistant/components/mcp_server/llm_api.py
@@ -19,7 +19,7 @@ class StatelessAssistAPI(llm.AssistAPI):
         """Initialize the StatelessAssistAPI."""
         super().__init__(hass)
         self.id = "stateless_assist"
-        self.name = "Stateless Assist API"
+        self.name = "Stateless Assist"
 
     # Expose INTENT_GET_STATE
     IGNORE_INTENTS = {

--- a/homeassistant/components/mcp_server/strings.json
+++ b/homeassistant/components/mcp_server/strings.json
@@ -14,12 +14,5 @@
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
     }
-  },
-  "selector": {
-    "llm_api": {
-      "options": {
-        "stateless_assist": "Stateless Assist"
-      }
-    }
   }
 }

--- a/homeassistant/components/mcp_server/strings.json
+++ b/homeassistant/components/mcp_server/strings.json
@@ -14,5 +14,12 @@
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
     }
+  },
+  "selector": {
+    "llm_api": {
+      "options": {
+        "stateless_assist": "Stateless Assist API"
+      }
+    }
   }
 }

--- a/homeassistant/components/mcp_server/strings.json
+++ b/homeassistant/components/mcp_server/strings.json
@@ -18,7 +18,7 @@
   "selector": {
     "llm_api": {
       "options": {
-        "stateless_assist": "Stateless Assist API"
+        "stateless_assist": "Stateless Assist"
       }
     }
   }

--- a/homeassistant/helpers/llm.py
+++ b/homeassistant/helpers/llm.py
@@ -316,14 +316,14 @@ class AssistAPI(API):
 
         return APIInstance(
             api=self,
-            api_prompt=self._async_get_prompt(llm_context, exposed_entities),
+            api_prompt=self._async_get_api_prompt(llm_context, exposed_entities),
             llm_context=llm_context,
             tools=self._async_get_tools(llm_context, exposed_entities),
             custom_serializer=_selector_serializer,
         )
 
     @callback
-    def _async_get_prompt(
+    def _async_get_api_prompt(
         self, llm_context: LLMContext, exposed_entities: dict | None
     ) -> str:
         if not exposed_entities:
@@ -333,13 +333,13 @@ class AssistAPI(API):
             )
         return "\n".join(
             [
-                *self._async_get_api_prompt(llm_context),
+                *self._async_get_preable(llm_context),
                 *self._async_get_exposed_entities_prompt(llm_context, exposed_entities),
             ]
         )
 
     @callback
-    def _async_get_api_prompt(self, llm_context: LLMContext) -> list[str]:
+    def _async_get_preable(self, llm_context: LLMContext) -> list[str]:
         """Return the prompt for the API."""
 
         prompt = [

--- a/tests/components/mcp_server/conftest.py
+++ b/tests/components/mcp_server/conftest.py
@@ -5,10 +5,9 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from homeassistant.components.mcp_server.const import DOMAIN
+from homeassistant.components.mcp_server.const import DOMAIN, LLM_API
 from homeassistant.const import CONF_LLM_HASS_API
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import llm
 
 from tests.common import MockConfigEntry
 
@@ -28,7 +27,7 @@ def mock_config_entry(hass: HomeAssistant) -> MockConfigEntry:
     config_entry = MockConfigEntry(
         domain=DOMAIN,
         data={
-            CONF_LLM_HASS_API: llm.LLM_API_ASSIST,
+            CONF_LLM_HASS_API: LLM_API,
         },
     )
     config_entry.add_to_hass(hass)

--- a/tests/components/mcp_server/test_http.py
+++ b/tests/components/mcp_server/test_http.py
@@ -20,7 +20,11 @@ from homeassistant.components.mcp_server.http import MESSAGES_API, SSE_API
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_LLM_HASS_API, STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers import (
+    area_registry as ar,
+    device_registry as dr,
+    entity_registry as er,
+)
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry, setup_test_component_platform
@@ -45,6 +49,11 @@ INITIALIZE_MESSAGE = {
 }
 EVENT_PREFIX = "event: "
 DATA_PREFIX = "data: "
+EXPECTED_PROMPT_SUFFIX = """
+- names: Kitchen Light
+  domain: light
+  areas: Kitchen
+"""
 
 
 @pytest.fixture
@@ -59,11 +68,13 @@ async def mock_entities(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
+    area_registry: ar.AreaRegistry,
     setup_integration: None,
 ) -> None:
     """Fixture to expose entities to the conversation agent."""
-    entity = MockLight("kitchen", STATE_OFF)
+    entity = MockLight("Kitchen Light", STATE_OFF)
     entity.entity_id = TEST_ENTITY
+    entity.unique_id = "test-light-unique-id"
     setup_test_component_platform(hass, LIGHT_DOMAIN, [entity])
 
     assert await async_setup_component(
@@ -71,6 +82,9 @@ async def mock_entities(
         LIGHT_DOMAIN,
         {LIGHT_DOMAIN: [{"platform": "test"}]},
     )
+    await hass.async_block_till_done()
+    kitchen = area_registry.async_get_or_create("Kitchen")
+    entity_registry.async_update_entity(TEST_ENTITY, area_id=kitchen.id)
 
     async_expose_entity(hass, CONVERSATION_DOMAIN, TEST_ENTITY, True)
 
@@ -320,7 +334,7 @@ async def test_mcp_tool_call(
     async with mcp_session(mcp_sse_url, hass_supervisor_access_token) as session:
         result = await session.call_tool(
             name="HassTurnOn",
-            arguments={"name": "kitchen"},
+            arguments={"name": "kitchen light"},
         )
 
     assert not result.isError
@@ -370,8 +384,11 @@ async def test_prompt_list(
 
     assert len(result.prompts) == 1
     prompt = result.prompts[0]
-    assert prompt.name == "Assist"
-    assert prompt.description == "Default prompt for the Home Assistant LLM API Assist"
+    assert prompt.name == "Stateless Assist"
+    assert (
+        prompt.description
+        == "Default prompt for the Home Assistant LLM API Stateless Assist"
+    )
 
 
 async def test_prompt_get(
@@ -383,13 +400,17 @@ async def test_prompt_get(
     """Test the get prompt endpoint."""
 
     async with mcp_session(mcp_sse_url, hass_supervisor_access_token) as session:
-        result = await session.get_prompt(name="Assist")
+        result = await session.get_prompt(name="Stateless Assist")
 
-    assert result.description == "Default prompt for the Home Assistant LLM API Assist"
+    assert (
+        result.description
+        == "Default prompt for the Home Assistant LLM API Stateless Assist"
+    )
     assert len(result.messages) == 1
     assert result.messages[0].role == "assistant"
     assert result.messages[0].content.type == "text"
     assert "When controlling Home Assistant" in result.messages[0].content.text
+    assert result.messages[0].content.text.endswith(EXPECTED_PROMPT_SUFFIX)
 
 
 async def test_get_unknwon_prompt(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add a new tool to use as an alternative to Assist API that does not contain state in the prompt. The problem is the model may get stuck thinking the prompt has the current state, but it is not correct after actions have been taken on the device. After some discussion and quality evaluation we see that the models still can perform well on actions (see [leaderboard](https://github.com/allenporter/home-assistant-datasets/tree/main/reports)).

We still may need to expose a way to retrieve state to further improve quality and parity for conversation agents for non-action commands.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
