### PR TITLE
Make default dim level configurable in Lutron

### DIFF
--- a/homeassistant/components/lutron/config_flow.py
+++ b/homeassistant/components/lutron/config_flow.py
@@ -85,7 +85,7 @@ class LutronConfigFlow(ConfigFlow, domain=DOMAIN):
 
 
 class OptionsFlowHandler(OptionsFlow):
-    """Handle a option flow for esphome."""
+    """Handle option flow for lutron."""
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None

--- a/homeassistant/components/lutron/config_flow.py
+++ b/homeassistant/components/lutron/config_flow.py
@@ -6,10 +6,15 @@ import logging
 from typing import Any
 from urllib.error import HTTPError
 
-import voluptuous as vol
 from pylutron import Lutron
+import voluptuous as vol
 
-from homeassistant.config_entries import ConfigFlow, ConfigFlowResult, OptionsFlow
+from homeassistant.config_entries import (
+    ConfigEntry,
+    ConfigFlow,
+    ConfigFlowResult,
+    OptionsFlow,
+)
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import callback
 
@@ -76,15 +81,11 @@ class LutronConfigFlow(ConfigFlow, domain=DOMAIN):
         config_entry: ConfigEntry,
     ) -> OptionsFlowHandler:
         """Get the options flow for this handler."""
-        return OptionsFlowHandler(config_entry)
+        return OptionsFlowHandler()
 
 
 class OptionsFlowHandler(OptionsFlow):
     """Handle a option flow for esphome."""
-
-    def __init__(self, config_entry: ConfigEntry) -> None:
-        """Initialize options flow."""
-        self.config_entry = config_entry
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None

--- a/homeassistant/components/lutron/config_flow.py
+++ b/homeassistant/components/lutron/config_flow.py
@@ -17,6 +17,11 @@ from homeassistant.config_entries import (
 )
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import callback
+from homeassistant.helpers.selector import (
+    NumberSelector,
+    NumberSelectorConfig,
+    NumberSelectorMode,
+)
 
 from .const import CONF_DEFAULT_DIMMER_LEVEL, DEFAULT_DIMMER_LEVEL, DOMAIN
 
@@ -101,7 +106,9 @@ class OptionsFlowHandler(OptionsFlow):
                     default=self.config_entry.options.get(
                         CONF_DEFAULT_DIMMER_LEVEL, DEFAULT_DIMMER_LEVEL
                     ),
-                ): vol.All(vol.Coerce(int), vol.Range(min=1, max=255)),
+                ): NumberSelector(
+                    NumberSelectorConfig(min=1, max=255, mode=NumberSelectorMode.SLIDER)
+                )
             }
         )
         return self.async_show_form(step_id="init", data_schema=data_schema)

--- a/homeassistant/components/lutron/const.py
+++ b/homeassistant/components/lutron/const.py
@@ -1,3 +1,7 @@
 """Lutron constants."""
 
 DOMAIN = "lutron"
+
+CONF_DEFAULT_DIMMER_LEVEL = "default_dimmer_level"
+
+DEFAULT_DIMMER_LEVEL = 255 / 2

--- a/homeassistant/components/lutron/light.py
+++ b/homeassistant/components/lutron/light.py
@@ -20,6 +20,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import DOMAIN, LutronData
+from .const import CONF_DEFAULT_DIMMER_LEVEL, DEFAULT_DIMMER_LEVEL
 from .entity import LutronDevice
 
 
@@ -72,7 +73,9 @@ class LutronLight(LutronDevice, LightEntity):
             if ATTR_BRIGHTNESS in kwargs and self._lutron_device.is_dimmable:
                 brightness = kwargs[ATTR_BRIGHTNESS]
             elif self._prev_brightness == 0:
-                brightness = 255 / 2
+                brightness = self.platform.config_entry.options.get(
+                    CONF_DEFAULT_DIMMER_LEVEL, DEFAULT_DIMMER_LEVEL
+                )
             else:
                 brightness = self._prev_brightness
             self._prev_brightness = brightness

--- a/homeassistant/components/lutron/strings.json
+++ b/homeassistant/components/lutron/strings.json
@@ -19,6 +19,15 @@
       }
     }
   },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "default_dimmer_level": "Default light level when first turning on a light from HomeAssistant"
+        }
+      }
+    }
+  },
   "entity": {
     "event": {
       "button": {

--- a/homeassistant/components/lutron/strings.json
+++ b/homeassistant/components/lutron/strings.json
@@ -23,7 +23,7 @@
     "step": {
       "init": {
         "data": {
-          "default_dimmer_level": "Default light level when first turning on a light from HomeAssistant"
+          "default_dimmer_level": "Default light level when first turning on a light from Home Assistant"
         }
       }
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Re-submitting #126160 after changing branch name to pass commit checks.

Make the default dim setting user configurable as requested in issue #122805 

On docs, I'll submit a doc PR assuming this change looks ok.

On tests, the existing tests pass but I'm not sure how to update the tests to test options. I was mostly following what ESPHome does and I didn't see any examples of them testing options. I'm happy to add if I can get a pointer on how to test them.

thanks!


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #122805 
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x	] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
