### PR TITLE
Remove v2 API support for HomeWizard P1 Meter

### DIFF
--- a/homeassistant/components/homewizard/__init__.py
+++ b/homeassistant/components/homewizard/__init__.py
@@ -25,7 +25,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: HomeWizardConfigEntry) -
 
     api: HomeWizardEnergy
 
-    if token := entry.data.get(CONF_TOKEN):
+    is_battery = entry.unique_id.startswith("HWE-BAT") if entry.unique_id else False
+
+    if (token := entry.data.get(CONF_TOKEN)) and is_battery:
         api = HomeWizardEnergyV2(
             entry.data[CONF_IP_ADDRESS],
             token=token,
@@ -37,7 +39,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: HomeWizardConfigEntry) -
             clientsession=async_get_clientsession(hass),
         )
 
-        await async_check_v2_support_and_create_issue(hass, entry)
+        if is_battery:
+            await async_check_v2_support_and_create_issue(hass, entry)
 
     coordinator = HWEnergyDeviceUpdateCoordinator(hass, api)
     try:

--- a/tests/components/homewizard/conftest.py
+++ b/tests/components/homewizard/conftest.py
@@ -160,7 +160,7 @@ def mock_config_entry_v2() -> MockConfigEntry:
             CONF_IP_ADDRESS: "127.0.0.1",
             CONF_TOKEN: "00112233445566778899ABCDEFABCDEF",
         },
-        unique_id="HWE-P1_5c2fafabcdef",
+        unique_id="HWE-BAT_5c2fafabcdef",
     )
 
 

--- a/tests/components/homewizard/test_init.py
+++ b/tests/components/homewizard/test_init.py
@@ -9,6 +9,7 @@ import pytest
 
 from homeassistant.components.homewizard.const import DOMAIN
 from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
+from homeassistant.const import CONF_IP_ADDRESS, CONF_TOKEN
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry, async_fire_time_changed
@@ -50,6 +51,36 @@ async def test_load_unload_v2(
     await hass.async_block_till_done()
 
     assert mock_config_entry_v2.state is ConfigEntryState.NOT_LOADED
+
+
+async def test_load_unload_v2_as_v1(
+    hass: HomeAssistant,
+    mock_homewizardenergy: MagicMock,
+) -> None:
+    """Test loading and unloading of integration with v2 config, but without using it."""
+
+    # Simulate v2 config but as a P1 Meter
+    mock_config_entry = MockConfigEntry(
+        title="Device",
+        domain=DOMAIN,
+        data={
+            CONF_IP_ADDRESS: "127.0.0.1",
+            CONF_TOKEN: "00112233445566778899ABCDEFABCDEF",
+        },
+        unique_id="HWE-P1_5c2fafabcdef",
+    )
+
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+    assert len(mock_homewizardenergy.combined.mock_calls) == 1
+
+    await hass.config_entries.async_unload(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
 
 
 async def test_load_failed_host_unavailable(

--- a/tests/components/homewizard/test_repair.py
+++ b/tests/components/homewizard/test_repair.py
@@ -36,6 +36,10 @@ async def test_repair_acquires_token(
     client = await hass_client()
 
     mock_config_entry.add_to_hass(hass)
+    hass.config_entries.async_update_entry(
+        mock_config_entry, unique_id="HWE-BAT_5c2fafabcdef"
+    )
+    await hass.async_block_till_done()
 
     with patch("homeassistant.components.homewizard.has_v2_api", return_value=True):
         await hass.config_entries.async_setup(mock_config_entry.entry_id)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove support for v2 API for HomeWizard P1 Meter. We have some stability issues when using 4 HomeWizard Plug-In Batteries in combination with the v2 API. We have to resolve that first. We prefer a stable experience instead of the 'more secure and feature rich' API.

This is related to https://github.com/home-assistant/core/issues/137237, but this is not the only cause. We have to tweak some things in the firmware.

Note: I did the minimal to remove the v2 support. The integration still follows the v2 flow, so new users will configure using v2 but use the v1 API. This works as expected. 
Also, the v1 to v2 migration cannot be triggered as the Battery has no v1 support.

We can remove the repair issue code, as it is not used. Let me know what is preferred.

Not marking this as breaking as this is PR is intended for the beta and the feature itself was not released.


> [!NOTE]
> this does not disable support for the Plug-In Battery implementation, which uses the v2 API 
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
