### PR TITLE
Improve backup file naming in Synology DSM backup agent

### DIFF
--- a/homeassistant/components/synology_dsm/backup.py
+++ b/homeassistant/components/synology_dsm/backup.py
@@ -10,12 +10,16 @@ from aiohttp import StreamReader
 from synology_dsm.api.file_station import SynoFileStation
 from synology_dsm.exceptions import SynologyDSMAPIErrorException
 
-from homeassistant.components.backup import AgentBackup, BackupAgent, BackupAgentError
+from homeassistant.components.backup import (
+    AgentBackup,
+    BackupAgent,
+    BackupAgentError,
+    suggested_filename,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.aiohttp_client import ChunkAsyncStreamIterator
 from homeassistant.helpers.json import json_dumps
-from homeassistant.util.dt import parse_datetime
 from homeassistant.util.json import JsonObjectType, json_loads_object
 
 from .const import (
@@ -34,8 +38,7 @@ def suggested_filenames(backup: AgentBackup) -> tuple[str, str]:
 
     returns a tuple of tar_filename and meta_filename
     """
-    date = parse_datetime(backup.date, raise_on_error=True)
-    base_name = "_".join(f"{backup.name}-{date.strftime('%Y-%m-%d_%H-%M-%S')}".split())
+    base_name = suggested_filename(backup).rsplit(".", 1)[0]
     return (f"{base_name}.tar", f"{base_name}_meta.json")
 
 

--- a/tests/components/synology_dsm/test_backup.py
+++ b/tests/components/synology_dsm/test_backup.py
@@ -36,7 +36,7 @@ from .consts import HOST, MACS, PASSWORD, PORT, SERIAL, USE_SSL, USERNAME
 from tests.common import MockConfigEntry
 from tests.typing import ClientSessionGenerator, WebSocketGenerator
 
-BASE_FILENAME = "Automatic_backup_2025.2.0.dev0-2025-01-09_20-14-35"
+BASE_FILENAME = "Automatic_backup_2025.2.0.dev0_-_2025-01-09_20.14_35457323"
 
 
 class MockStreamReaderChunked(MockStreamReader):
@@ -523,7 +523,7 @@ async def test_agents_upload(
         protected=True,
         size=0,
     )
-    base_filename = "Test-1970-01-01_00-00-00"
+    base_filename = "Test_-_1970-01-01_00.00_00000000"
 
     with (
         patch(
@@ -574,7 +574,7 @@ async def test_agents_upload_error(
         protected=True,
         size=0,
     )
-    base_filename = "Test-1970-01-01_00-00-00"
+    base_filename = "Test_-_1970-01-01_00.00_00000000"
 
     # fail to upload the tar file
     with (

--- a/tests/components/synology_dsm/test_backup.py
+++ b/tests/components/synology_dsm/test_backup.py
@@ -36,6 +36,8 @@ from .consts import HOST, MACS, PASSWORD, PORT, SERIAL, USE_SSL, USERNAME
 from tests.common import MockConfigEntry
 from tests.typing import ClientSessionGenerator, WebSocketGenerator
 
+BASE_FILENAME = "Automatic_backup_2025.2.0.dev0-2025-01-09_20-14-35"
+
 
 class MockStreamReaderChunked(MockStreamReader):
     """Mock a stream reader with simulated chunked data."""
@@ -46,14 +48,14 @@ class MockStreamReaderChunked(MockStreamReader):
 
 
 async def _mock_download_file(path: str, filename: str) -> MockStreamReader:
-    if filename == "abcd12ef_meta.json":
+    if filename == f"{BASE_FILENAME}_meta.json":
         return MockStreamReader(
             b'{"addons":[],"backup_id":"abcd12ef","date":"2025-01-09T20:14:35.457323+01:00",'
             b'"database_included":true,"extra_metadata":{"instance_id":"36b3b7e984da43fc89f7bafb2645fa36",'
             b'"with_automatic_settings":true},"folders":[],"homeassistant_included":true,'
             b'"homeassistant_version":"2025.2.0.dev0","name":"Automatic backup 2025.2.0.dev0","protected":true,"size":13916160}'
         )
-    if filename == "abcd12ef.tar":
+    if filename == f"{BASE_FILENAME}.tar":
         return MockStreamReaderChunked(b"backup data")
     raise MockStreamReaderChunked(b"")
 
@@ -61,22 +63,22 @@ async def _mock_download_file(path: str, filename: str) -> MockStreamReader:
 async def _mock_download_file_meta_ok_tar_missing(
     path: str, filename: str
 ) -> MockStreamReader:
-    if filename == "abcd12ef_meta.json":
+    if filename == f"{BASE_FILENAME}_meta.json":
         return MockStreamReader(
             b'{"addons":[],"backup_id":"abcd12ef","date":"2025-01-09T20:14:35.457323+01:00",'
             b'"database_included":true,"extra_metadata":{"instance_id":"36b3b7e984da43fc89f7bafb2645fa36",'
             b'"with_automatic_settings":true},"folders":[],"homeassistant_included":true,'
             b'"homeassistant_version":"2025.2.0.dev0","name":"Automatic backup 2025.2.0.dev0","protected":true,"size":13916160}'
         )
-    if filename == "abcd12ef.tar":
-        raise SynologyDSMAPIErrorException("api", "404", "not found")
+    if filename == f"{BASE_FILENAME}.tar":
+        raise SynologyDSMAPIErrorException("api", "900", [{"code": 408}])
     raise MockStreamReaderChunked(b"")
 
 
 async def _mock_download_file_meta_defect(path: str, filename: str) -> MockStreamReader:
-    if filename == "abcd12ef_meta.json":
+    if filename == f"{BASE_FILENAME}_meta.json":
         return MockStreamReader(b"im not a json")
-    if filename == "abcd12ef.tar":
+    if filename == f"{BASE_FILENAME}.tar":
         return MockStreamReaderChunked(b"backup data")
     raise MockStreamReaderChunked(b"")
 
@@ -84,7 +86,6 @@ async def _mock_download_file_meta_defect(path: str, filename: str) -> MockStrea
 @pytest.fixture
 def mock_dsm_with_filestation():
     """Mock a successful service with filestation support."""
-
     with patch("homeassistant.components.synology_dsm.common.SynologyDSM") as dsm:
         dsm.login = AsyncMock(return_value=True)
         dsm.update = AsyncMock(return_value=True)
@@ -115,14 +116,14 @@ def mock_dsm_with_filestation():
                     SynoFileFile(
                         additional=None,
                         is_dir=False,
-                        name="abcd12ef_meta.json",
-                        path="/ha_backup/my_backup_path/abcd12ef_meta.json",
+                        name=f"{BASE_FILENAME}_meta.json",
+                        path=f"/ha_backup/my_backup_path/{BASE_FILENAME}_meta.json",
                     ),
                     SynoFileFile(
                         additional=None,
                         is_dir=False,
-                        name="abcd12ef.tar",
-                        path="/ha_backup/my_backup_path/abcd12ef.tar",
+                        name=f"{BASE_FILENAME}.tar",
+                        path=f"/ha_backup/my_backup_path/{BASE_FILENAME}.tar",
                     ),
                 ]
             ),
@@ -522,6 +523,7 @@ async def test_agents_upload(
         protected=True,
         size=0,
     )
+    base_filename = "Test-1970-01-01_00-00-00"
 
     with (
         patch(
@@ -544,9 +546,9 @@ async def test_agents_upload(
     assert f"Uploading backup {backup_id}" in caplog.text
     mock: AsyncMock = setup_dsm_with_filestation.file.upload_file
     assert len(mock.mock_calls) == 2
-    assert mock.call_args_list[0].kwargs["filename"] == "test-backup.tar"
+    assert mock.call_args_list[0].kwargs["filename"] == f"{base_filename}.tar"
     assert mock.call_args_list[0].kwargs["path"] == "/ha_backup/my_backup_path"
-    assert mock.call_args_list[1].kwargs["filename"] == "test-backup_meta.json"
+    assert mock.call_args_list[1].kwargs["filename"] == f"{base_filename}_meta.json"
     assert mock.call_args_list[1].kwargs["path"] == "/ha_backup/my_backup_path"
 
 
@@ -572,6 +574,7 @@ async def test_agents_upload_error(
         protected=True,
         size=0,
     )
+    base_filename = "Test-1970-01-01_00-00-00"
 
     # fail to upload the tar file
     with (
@@ -599,7 +602,7 @@ async def test_agents_upload_error(
     assert "Failed to upload backup" in caplog.text
     mock: AsyncMock = setup_dsm_with_filestation.file.upload_file
     assert len(mock.mock_calls) == 1
-    assert mock.call_args_list[0].kwargs["filename"] == "test-backup.tar"
+    assert mock.call_args_list[0].kwargs["filename"] == f"{base_filename}.tar"
     assert mock.call_args_list[0].kwargs["path"] == "/ha_backup/my_backup_path"
 
     # fail to upload the meta json file
@@ -630,9 +633,9 @@ async def test_agents_upload_error(
     assert "Failed to upload backup" in caplog.text
     mock: AsyncMock = setup_dsm_with_filestation.file.upload_file
     assert len(mock.mock_calls) == 3
-    assert mock.call_args_list[1].kwargs["filename"] == "test-backup.tar"
+    assert mock.call_args_list[1].kwargs["filename"] == f"{base_filename}.tar"
     assert mock.call_args_list[1].kwargs["path"] == "/ha_backup/my_backup_path"
-    assert mock.call_args_list[2].kwargs["filename"] == "test-backup_meta.json"
+    assert mock.call_args_list[2].kwargs["filename"] == f"{base_filename}_meta.json"
     assert mock.call_args_list[2].kwargs["path"] == "/ha_backup/my_backup_path"
 
 
@@ -657,9 +660,9 @@ async def test_agents_delete(
     assert response["result"] == {"agent_errors": {}}
     mock: AsyncMock = setup_dsm_with_filestation.file.delete_file
     assert len(mock.mock_calls) == 2
-    assert mock.call_args_list[0].kwargs["filename"] == "abcd12ef.tar"
+    assert mock.call_args_list[0].kwargs["filename"] == f"{BASE_FILENAME}.tar"
     assert mock.call_args_list[0].kwargs["path"] == "/ha_backup/my_backup_path"
-    assert mock.call_args_list[1].kwargs["filename"] == "abcd12ef_meta.json"
+    assert mock.call_args_list[1].kwargs["filename"] == f"{BASE_FILENAME}_meta.json"
     assert mock.call_args_list[1].kwargs["path"] == "/ha_backup/my_backup_path"
 
 
@@ -672,6 +675,9 @@ async def test_agents_delete_not_existing(
     client = await hass_ws_client(hass)
     backup_id = "ef34ab12"
 
+    setup_dsm_with_filestation.file.download_file = (
+        _mock_download_file_meta_ok_tar_missing
+    )
     setup_dsm_with_filestation.file.delete_file = AsyncMock(
         side_effect=SynologyDSMAPIErrorException(
             "api",
@@ -740,5 +746,5 @@ async def test_agents_delete_error(
     assert f"Failed to delete backup: {expected_log}" in caplog.text
     mock: AsyncMock = setup_dsm_with_filestation.file.delete_file
     assert len(mock.mock_calls) == 1
-    assert mock.call_args_list[0].kwargs["filename"] == "abcd12ef.tar"
+    assert mock.call_args_list[0].kwargs["filename"] == f"{BASE_FILENAME}.tar"
     assert mock.call_args_list[0].kwargs["path"] == "/ha_backup/my_backup_path"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This will include the name and the timestamp of the backup into the backup file names. Backups taken during beta of 2025.2 might not be readable anymore, but I do not consider this as a breaking change, since it is the beta phase :grimacing: 

resulting files on the NAS:
![image](https://github.com/user-attachments/assets/bf80a4cf-8c6b-430e-ac59-e0dab5095cc2)


- [x] needs rebase after #136913

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
