### PR TITLE
Fix data update coordinator garbage collection

### DIFF
--- a/homeassistant/helpers/debounce.py
+++ b/homeassistant/helpers/debounce.py
@@ -146,6 +146,9 @@ class Debouncer[_R_co]:
         """Cancel any scheduled call, and prevent new runs."""
         self._shutdown_requested = True
         self.async_cancel()
+        # Release hard reference to parent function
+        # https://github.com/home-assistant/core/issues/137237
+        self._function = None
 
     @callback
     def async_cancel(self) -> None:

--- a/homeassistant/helpers/debounce.py
+++ b/homeassistant/helpers/debounce.py
@@ -146,9 +146,10 @@ class Debouncer[_R_co]:
         """Cancel any scheduled call, and prevent new runs."""
         self._shutdown_requested = True
         self.async_cancel()
-        # Release hard reference to parent function
+        # Release hard references to parent function
         # https://github.com/home-assistant/core/issues/137237
         self._function = None
+        self._job = None
 
     @callback
     def async_cancel(self) -> None:

--- a/tests/helpers/test_debounce.py
+++ b/tests/helpers/test_debounce.py
@@ -4,6 +4,7 @@ import asyncio
 from datetime import timedelta
 import logging
 from unittest.mock import AsyncMock, Mock
+import weakref
 
 import pytest
 
@@ -529,3 +530,37 @@ async def test_background(
     async_fire_time_changed(hass, utcnow() + timedelta(seconds=1))
     await hass.async_block_till_done(wait_background_tasks=False)
     assert len(calls) == 2
+
+
+async def test_shutdown_releases_parent_class(hass: HomeAssistant) -> None:
+    """Test shutdown releases parent class.
+
+    See https://github.com/home-assistant/core/issues/137237
+    """
+    calls = []
+
+    class SomeClass:
+        def run_func(self) -> None:
+            calls.append(None)
+
+    my_class = SomeClass()
+    my_class_weak_ref = weakref.ref(my_class)
+
+    debouncer = debounce.Debouncer(
+        hass,
+        _LOGGER,
+        cooldown=0.01,
+        immediate=True,
+        function=my_class.run_func,
+    )
+
+    # Debouncer keeps a reference to the function, prevening GC
+    del my_class
+    await debouncer.async_call()
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+    assert my_class_weak_ref() is not None
+
+    # Debouncer shutdown releases the class
+    debouncer.async_shutdown()
+    assert my_class_weak_ref() is None


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When unloading a config entry, coordinators are automatically "shut down" via
https://github.com/home-assistant/core/blob/f9cc3361e34b5174e66443b10000f36d905ffde6/homeassistant/helpers/update_coordinator.py#L126-L127

The linked debouncer is also automatically "shut down" via
https://github.com/home-assistant/core/blob/f9cc3361e34b5174e66443b10000f36d905ffde6/homeassistant/helpers/update_coordinator.py#L178

However, the debouncer holds a hard reference to the coordinator via the coordinator function, both directly and via the HassJob wrapper
https://github.com/home-assistant/core/blob/f9cc3361e34b5174e66443b10000f36d905ffde6/homeassistant/helpers/debounce.py#L57-L62

These hard references prevent both the coordinator and the debouncer from being garbage collected.

Related to https://github.com/home-assistant/core/issues/137237

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
