### PR TITLE
Update codespell to 2.4.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
       - id: ruff-format
         files: ^((homeassistant|pylint|script|tests)/.+)?[^/]+\.(py|pyi)$
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.3.0
+    rev: v2.4.1
     hooks:
       - id: codespell
         args:

--- a/homeassistant/components/apple_tv/config_flow.py
+++ b/homeassistant/components/apple_tv/config_flow.py
@@ -134,7 +134,7 @@ class AppleTVConfigFlow(ConfigFlow, domain=DOMAIN):
         unique_id for said entry. When a new (zeroconf) service or device is
         discovered, the identifier is first used to look up if it belongs to an
         existing config entry. If that's the case, the unique_id from that entry is
-        re-used, otherwise the newly discovered identifier is used instead.
+        reused, otherwise the newly discovered identifier is used instead.
         """
         assert self.atv
         all_identifiers = set(self.atv.all_identifiers)

--- a/homeassistant/components/dwd_weather_warnings/sensor.py
+++ b/homeassistant/components/dwd_weather_warnings/sensor.py
@@ -3,7 +3,7 @@
 Data is fetched from DWD:
 https://rcccm.dwd.de/DE/wetter/warnungen_aktuell/objekt_einbindung/objekteinbindung.html
 
-Warnungen vor extremem Unwetter (Stufe 4)  # codespell:ignore vor
+Warnungen vor extremem Unwetter (Stufe 4)  # codespell:ignore vor,extremem
 Unwetterwarnungen (Stufe 3)
 Warnungen vor markantem Wetter (Stufe 2)  # codespell:ignore vor
 Wetterwarnungen (Stufe 1)

--- a/homeassistant/components/hue/v1/light.py
+++ b/homeassistant/components/hue/v1/light.py
@@ -408,7 +408,7 @@ class HueLight(CoordinatorEntity, LightEntity):
         if self._fixed_color_mode:
             return self._fixed_color_mode
 
-        # The light supports both hs/xy and white with adjustabe color_temperature
+        # The light supports both hs/xy and white with adjustable color_temperature
         mode = self._color_mode
         if mode in ("xy", "hs"):
             return ColorMode.HS

--- a/homeassistant/components/isy994/sensor.py
+++ b/homeassistant/components/isy994/sensor.py
@@ -73,7 +73,7 @@ ISY_CONTROL_TO_DEVICE_CLASS = {
     "CV": SensorDeviceClass.VOLTAGE,
     "DEWPT": SensorDeviceClass.TEMPERATURE,
     "DISTANC": SensorDeviceClass.DISTANCE,
-    "ETO": SensorDeviceClass.PRECIPITATION_INTENSITY,
+    "ETO": SensorDeviceClass.PRECIPITATION_INTENSITY,  # codespell:ignore eto
     "FATM": SensorDeviceClass.WEIGHT,
     "FREQ": SensorDeviceClass.FREQUENCY,
     "MUSCLEM": SensorDeviceClass.WEIGHT,

--- a/homeassistant/components/rflink/light.py
+++ b/homeassistant/components/rflink/light.py
@@ -101,7 +101,7 @@ def entity_class_for_type(entity_type):
     entity_device_mapping = {
         # sends only 'dim' commands not compatible with on/off switches
         TYPE_DIMMABLE: DimmableRflinkLight,
-        # sends only 'on/off' commands not advices with dimmers and signal
+        # sends only 'on/off' commands not advised with dimmers and signal
         # repetition
         TYPE_SWITCHABLE: RflinkLight,
         # sends 'dim' and 'on' command to support both dimmers and on/off

--- a/homeassistant/components/tuya/sensor.py
+++ b/homeassistant/components/tuya/sensor.py
@@ -45,7 +45,7 @@ class TuyaSensorEntityDescription(SensorEntityDescription):
     subkey: str | None = None
 
 
-# Commonly used battery sensors, that are re-used in the sensors down below.
+# Commonly used battery sensors, that are reused in the sensors down below.
 BATTERY_SENSORS: tuple[TuyaSensorEntityDescription, ...] = (
     TuyaSensorEntityDescription(
         key=DPCode.BATTERY_PERCENTAGE,

--- a/pylint/plugins/hass_enforce_class_module.py
+++ b/pylint/plugins/hass_enforce_class_module.py
@@ -140,7 +140,7 @@ class HassEnforceClassModule(BaseChecker):
 
             for ancestor in top_level_ancestors:
                 if ancestor.name in _BASE_ENTITY_MODULES and not any(
-                    anc.name in _MODULE_CLASSES for anc in ancestors
+                    parent.name in _MODULE_CLASSES for parent in ancestors
                 ):
                     self.add_message(
                         "hass-enforce-class-module",

--- a/requirements_test_pre_commit.txt
+++ b/requirements_test_pre_commit.txt
@@ -1,5 +1,5 @@
 # Automatically generated from .pre-commit-config.yaml by gen_requirements_all.py, do not edit
 
-codespell==2.3.0
+codespell==2.4.1
 ruff==0.9.1
 yamllint==1.35.1

--- a/tests/components/bluetooth_le_tracker/test_device_tracker.py
+++ b/tests/components/bluetooth_le_tracker/test_device_tracker.py
@@ -215,7 +215,7 @@ async def test_see_device_if_time_updated(hass: HomeAssistant) -> None:
 
 @pytest.mark.usefixtures("mock_bluetooth", "mock_device_tracker_conf")
 async def test_preserve_new_tracked_device_name(hass: HomeAssistant) -> None:
-    """Test preserving tracked device name across new seens."""
+    """Test preserving tracked device name across new seens."""  # codespell:ignore seens
 
     address = "DE:AD:BE:EF:13:37"
     name = "Mock device name"

--- a/tests/components/enphase_envoy/test_config_flow.py
+++ b/tests/components/enphase_envoy/test_config_flow.py
@@ -439,7 +439,7 @@ async def test_zero_conf_old_blank_entry(
     mock_setup_entry: AsyncMock,
     mock_envoy: AsyncMock,
 ) -> None:
-    """Test re-using old blank entry."""
+    """Test reusing old blank entry."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={
@@ -478,7 +478,7 @@ async def test_zero_conf_old_blank_entry_standard_title(
     mock_setup_entry: AsyncMock,
     mock_envoy: AsyncMock,
 ) -> None:
-    """Test re-using old blank entry was Envoy as title."""
+    """Test reusing old blank entry was Envoy as title."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={
@@ -519,7 +519,7 @@ async def test_zero_conf_old_blank_entry_user_title(
     mock_setup_entry: AsyncMock,
     mock_envoy: AsyncMock,
 ) -> None:
-    """Test re-using old blank entry with user title."""
+    """Test reusing old blank entry with user title."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={

--- a/tests/components/hue/test_light_v2.py
+++ b/tests/components/hue/test_light_v2.py
@@ -392,7 +392,7 @@ async def test_light_availability(
     assert test_light is not None
     assert test_light.state == "on"
 
-    # Change availability by modififying the zigbee_connectivity status
+    # Change availability by modifying the zigbee_connectivity status
     for status in ("connectivity_issue", "disconnected", "connected"):
         mock_bridge_v2.api.emit_event(
             "update",

--- a/tests/components/mqtt/test_util.py
+++ b/tests/components/mqtt/test_util.py
@@ -52,7 +52,7 @@ async def test_canceling_debouncer_on_shutdown(
         assert not mock_debouncer.is_set()
         mqtt_client_mock.subscribe.assert_not_called()
 
-        # Note thet the broker connection will not be disconnected gracefully
+        # Note that the broker connection will not be disconnected gracefully
         await hass.async_block_till_done()
         async_fire_time_changed(hass, utcnow() + timedelta(seconds=5))
         await asyncio.sleep(0)

--- a/tests/components/unifiprotect/test_camera.py
+++ b/tests/components/unifiprotect/test_camera.py
@@ -174,7 +174,7 @@ def validate_common_camera_state(
     entity_id: str,
     features: int = CameraEntityFeature.STREAM,
 ):
-    """Validate state that is common to all camera entity, regradless of type."""
+    """Validate state that is common to all camera entity, regardless of type."""
     entity_state = hass.states.get(entity_id)
     assert entity_state
     assert entity_state.attributes[ATTR_ATTRIBUTION] == DEFAULT_ATTRIBUTION


### PR DESCRIPTION
## Proposed change
https://github.com/codespell-project/codespell/releases/tag/v2.4.0
https://github.com/codespell-project/codespell/releases/tag/v2.4.1

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
