### PR TITLE
Add night light brightness level setting to VeSync

### DIFF
--- a/homeassistant/components/vesync/__init__.py
+++ b/homeassistant/components/vesync/__init__.py
@@ -27,6 +27,7 @@ PLATFORMS = [
     Platform.HUMIDIFIER,
     Platform.LIGHT,
     Platform.NUMBER,
+    Platform.SELECT,
     Platform.SENSOR,
     Platform.SWITCH,
 ]

--- a/homeassistant/components/vesync/const.py
+++ b/homeassistant/components/vesync/const.py
@@ -29,6 +29,10 @@ VS_HUMIDIFIER_MODE_HUMIDITY = "humidity"
 VS_HUMIDIFIER_MODE_MANUAL = "manual"
 VS_HUMIDIFIER_MODE_SLEEP = "sleep"
 
+NIGHT_LIGHT_LEVEL_BRIGHT = "bright"
+NIGHT_LIGHT_LEVEL_DIM = "dim"
+NIGHT_LIGHT_LEVEL_OFF = "off"
+
 VeSyncHumidifierDevice = VeSyncHumid200300S | VeSyncSuperior6000S
 """Humidifier device types"""
 

--- a/homeassistant/components/vesync/number.py
+++ b/homeassistant/components/vesync/number.py
@@ -5,7 +5,6 @@ from dataclasses import dataclass
 import logging
 
 from pyvesync.vesyncbasedevice import VeSyncBaseDevice
-from pyvesync.vesyncfan import VeSyncHumid200300S
 
 from homeassistant.components.number import (
     NumberEntity,
@@ -45,18 +44,7 @@ NUMBER_DESCRIPTIONS: list[VeSyncNumberEntityDescription] = [
         exists_fn=is_humidifier,
         set_value_fn=lambda device, value: device.set_mist_level(value),
         value_fn=lambda device: device.mist_level,
-    ),
-    VeSyncNumberEntityDescription(
-        key="night_light_brightness",
-        translation_key="night_light_brightness",
-        native_min_value=0,
-        native_max_value=100,
-        native_step=50,
-        mode=NumberMode.SLIDER,
-        exists_fn=lambda device: isinstance(device, VeSyncHumid200300S),
-        set_value_fn=lambda device, value: device.set_night_light_brightness(value),
-        value_fn=lambda device: device.details.get("night_light_brightness", 0),
-    ),
+    )
 ]
 
 

--- a/homeassistant/components/vesync/number.py
+++ b/homeassistant/components/vesync/number.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 import logging
 
 from pyvesync.vesyncbasedevice import VeSyncBaseDevice
+from pyvesync.vesyncfan import VeSyncHumid200300S
 
 from homeassistant.components.number import (
     NumberEntity,
@@ -44,7 +45,18 @@ NUMBER_DESCRIPTIONS: list[VeSyncNumberEntityDescription] = [
         exists_fn=is_humidifier,
         set_value_fn=lambda device, value: device.set_mist_level(value),
         value_fn=lambda device: device.mist_level,
-    )
+    ),
+    VeSyncNumberEntityDescription(
+        key="night_light_brightness",
+        translation_key="night_light_brightness",
+        native_min_value=0,
+        native_max_value=100,
+        native_step=50,
+        mode=NumberMode.SLIDER,
+        exists_fn=lambda device: isinstance(device, VeSyncHumid200300S),
+        set_value_fn=lambda device, value: device.set_night_light_brightness(value),
+        value_fn=lambda device: device.details.get("night_light_brightness", 0),
+    ),
 ]
 
 

--- a/homeassistant/components/vesync/select.py
+++ b/homeassistant/components/vesync/select.py
@@ -10,7 +10,7 @@ from homeassistant.components.select import SelectEntity, SelectEntityDescriptio
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .common import rgetattr
 from .const import (
@@ -70,7 +70,7 @@ SELECT_DESCRIPTIONS: list[VeSyncSelectEntityDescription] = [
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
-    async_add_entities: AddEntitiesCallback,
+    async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up select entities."""
 
@@ -91,7 +91,7 @@ async def async_setup_entry(
 @callback
 def _setup_entities(
     devices: list[VeSyncBaseDevice],
-    async_add_entities: AddEntitiesCallback,
+    async_add_entities: AddConfigEntryEntitiesCallback,
     coordinator: VeSyncDataCoordinator,
 ):
     """Add select entities."""

--- a/homeassistant/components/vesync/select.py
+++ b/homeassistant/components/vesync/select.py
@@ -32,10 +32,9 @@ VS_TO_HA_NIGHT_LIGHT_LEVEL_MAP = {
     50: NIGHT_LIGHT_LEVEL_DIM,
     0: NIGHT_LIGHT_LEVEL_OFF,
 }
+
 HA_TO_VS_NIGHT_LIGHT_LEVEL_MAP = {
-    NIGHT_LIGHT_LEVEL_BRIGHT: 100,
-    NIGHT_LIGHT_LEVEL_DIM: 50,
-    NIGHT_LIGHT_LEVEL_OFF: 0,
+    v: k for k, v in VS_TO_HA_NIGHT_LIGHT_LEVEL_MAP.items()
 }
 
 
@@ -52,7 +51,7 @@ SELECT_DESCRIPTIONS: list[VeSyncSelectEntityDescription] = [
     VeSyncSelectEntityDescription(
         key="night_light_level",
         translation_key="night_light_level",
-        options=["bright", "dim", "off"],
+        options=list(VS_TO_HA_NIGHT_LIGHT_LEVEL_MAP.values()),
         icon="mdi:brightness-6",
         exists_fn=lambda device: rgetattr(device, "night_light"),
         # The select_option service framework ensures that only options specified are
@@ -62,7 +61,7 @@ SELECT_DESCRIPTIONS: list[VeSyncSelectEntityDescription] = [
         ),
         # Reporting "off" as the choice for unhandled level.
         current_option_fn=lambda device: VS_TO_HA_NIGHT_LIGHT_LEVEL_MAP.get(
-            device.details.get("night_light_brightness"), "off"
+            device.details.get("night_light_brightness"), NIGHT_LIGHT_LEVEL_OFF
         ),
     ),
 ]

--- a/homeassistant/components/vesync/select.py
+++ b/homeassistant/components/vesync/select.py
@@ -1,0 +1,134 @@
+"""Support for VeSync numeric entities."""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+import logging
+
+from pyvesync.vesyncbasedevice import VeSyncBaseDevice
+
+from homeassistant.components.select import SelectEntity, SelectEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .common import rgetattr
+from .const import (
+    DOMAIN,
+    NIGHT_LIGHT_LEVEL_BRIGHT,
+    NIGHT_LIGHT_LEVEL_DIM,
+    NIGHT_LIGHT_LEVEL_OFF,
+    VS_COORDINATOR,
+    VS_DEVICES,
+    VS_DISCOVERY,
+)
+from .coordinator import VeSyncDataCoordinator
+from .entity import VeSyncBaseEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+VS_TO_HA_NIGHT_LIGHT_LEVEL_MAP = {
+    100: NIGHT_LIGHT_LEVEL_BRIGHT,
+    50: NIGHT_LIGHT_LEVEL_DIM,
+    0: NIGHT_LIGHT_LEVEL_OFF,
+}
+HA_TO_VS_NIGHT_LIGHT_LEVEL_MAP = {
+    NIGHT_LIGHT_LEVEL_BRIGHT: 100,
+    NIGHT_LIGHT_LEVEL_DIM: 50,
+    NIGHT_LIGHT_LEVEL_OFF: 0,
+}
+
+
+@dataclass(frozen=True, kw_only=True)
+class VeSyncSelectEntityDescription(SelectEntityDescription):
+    """Class to describe a Vesync select entity."""
+
+    exists_fn: Callable[[VeSyncBaseDevice], bool]
+    current_option_fn: Callable[[VeSyncBaseDevice], str]
+    select_option_fn: Callable[[VeSyncBaseDevice, str], bool]
+
+
+SELECT_DESCRIPTIONS: list[VeSyncSelectEntityDescription] = [
+    VeSyncSelectEntityDescription(
+        key="night_light_level",
+        translation_key="night_light_level",
+        options=["bright", "dim", "off"],
+        icon="mdi:brightness-6",
+        exists_fn=lambda device: rgetattr(device, "night_light"),
+        # The select_option service framework ensures that only options specified are
+        # accepted. ServiceValidationError gets raised for invalid value.
+        select_option_fn=lambda device, value: device.set_night_light_brightness(
+            HA_TO_VS_NIGHT_LIGHT_LEVEL_MAP.get(value, 0)
+        ),
+        # Reporting "off" as the choice for unhandled level.
+        current_option_fn=lambda device: VS_TO_HA_NIGHT_LIGHT_LEVEL_MAP.get(
+            device.details.get("night_light_brightness"), "off"
+        ),
+    ),
+]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up select entities."""
+
+    coordinator = hass.data[DOMAIN][VS_COORDINATOR]
+
+    @callback
+    def discover(devices):
+        """Add new devices to platform."""
+        _setup_entities(devices, async_add_entities, coordinator)
+
+    config_entry.async_on_unload(
+        async_dispatcher_connect(hass, VS_DISCOVERY.format(VS_DEVICES), discover)
+    )
+
+    _setup_entities(hass.data[DOMAIN][VS_DEVICES], async_add_entities, coordinator)
+
+
+@callback
+def _setup_entities(
+    devices: list[VeSyncBaseDevice],
+    async_add_entities: AddEntitiesCallback,
+    coordinator: VeSyncDataCoordinator,
+):
+    """Add select entities."""
+
+    async_add_entities(
+        VeSyncSelectEntity(dev, description, coordinator)
+        for dev in devices
+        for description in SELECT_DESCRIPTIONS
+        if description.exists_fn(dev)
+    )
+
+
+class VeSyncSelectEntity(VeSyncBaseEntity, SelectEntity):
+    """A class to set numeric options on Vesync device."""
+
+    entity_description: VeSyncSelectEntityDescription
+
+    def __init__(
+        self,
+        device: VeSyncBaseDevice,
+        description: VeSyncSelectEntityDescription,
+        coordinator: VeSyncDataCoordinator,
+    ) -> None:
+        """Initialize the VeSync select device."""
+        super().__init__(device, coordinator)
+        self.entity_description = description
+        self._attr_unique_id = f"{super().unique_id}-{description.key}"
+
+    @property
+    def current_option(self) -> str | None:
+        """Return an option."""
+        return self.entity_description.current_option_fn(self.device)
+
+    async def async_select_option(self, option: str) -> None:
+        """Set an option."""
+        if await self.hass.async_add_executor_job(
+            self.entity_description.select_option_fn, self.device, option
+        ):
+            await self.coordinator.async_request_refresh()

--- a/homeassistant/components/vesync/strings.json
+++ b/homeassistant/components/vesync/strings.json
@@ -56,6 +56,16 @@
         "name": "Mist level"
       }
     },
+    "select": {
+      "night_light_level": {
+        "name": "Night light level",
+        "state": {
+          "bright": "Bright",
+          "dim": "Dim",
+          "off": "[%key:common::state::off%]"
+        }
+      }
+    },
     "fan": {
       "vesync": {
         "state_attributes": {

--- a/homeassistant/components/vesync/strings.json
+++ b/homeassistant/components/vesync/strings.json
@@ -54,9 +54,6 @@
     "number": {
       "mist_level": {
         "name": "Mist level"
-      },
-      "night_light_brightness": {
-        "name": "Night brightness level"
       }
     },
     "fan": {

--- a/homeassistant/components/vesync/strings.json
+++ b/homeassistant/components/vesync/strings.json
@@ -54,6 +54,9 @@
     "number": {
       "mist_level": {
         "name": "Mist level"
+      },
+      "night_light_brightness": {
+        "name": "Night brightness level"
       }
     },
     "fan": {

--- a/tests/components/vesync/common.py
+++ b/tests/components/vesync/common.py
@@ -13,6 +13,7 @@ from tests.common import load_fixture, load_json_object_fixture
 ENTITY_HUMIDIFIER = "humidifier.humidifier_200s"
 ENTITY_HUMIDIFIER_MIST_LEVEL = "number.humidifier_200s_mist_level"
 ENTITY_HUMIDIFIER_HUMIDITY = "sensor.humidifier_200s_humidity"
+ENTITY_HUMIDIFIER_300S_NIGHT_LIGHT_SELECT = "select.humidifier_300s_night_light_level"
 
 ALL_DEVICES = load_json_object_fixture("vesync-devices.json", DOMAIN)
 ALL_DEVICE_NAMES: list[str] = [

--- a/tests/components/vesync/conftest.py
+++ b/tests/components/vesync/conftest.py
@@ -107,7 +107,7 @@ def outlet_fixture():
 
 @pytest.fixture(name="humidifier")
 def humidifier_fixture():
-    """Create a mock VeSync humidifier fixture."""
+    """Create a mock VeSync Classic200S humidifier fixture."""
     return Mock(
         VeSyncHumid200300S,
         cid="200s-humidifier",
@@ -126,6 +126,37 @@ def humidifier_fixture():
         mist_level=6,
         mist_modes=["auto", "manual"],
         mode=None,
+        sub_device_no=0,
+        config_module="configModule",
+        connection_status="online",
+        current_firm_version="1.0.0",
+        water_lacks=False,
+        water_tank_lifted=False,
+    )
+
+
+@pytest.fixture(name="humidifier_300s")
+def humidifier_300s_fixture():
+    """Create a mock VeSync Classic300S humidifier fixture."""
+    return Mock(
+        VeSyncHumid200300S,
+        cid="300s-humidifier",
+        config={
+            "auto_target_humidity": 40,
+            "display": "true",
+            "automatic_stop": "true",
+        },
+        details={
+            "humidity": 35,
+            "mode": "manual",
+        },
+        device_type="Classic300S",
+        device_name="Humidifier 300s",
+        device_status="on",
+        mist_level=6,
+        mist_modes=["auto", "manual"],
+        mode=None,
+        night_light=True,
         sub_device_no=0,
         config_module="configModule",
         connection_status="online",

--- a/tests/components/vesync/conftest.py
+++ b/tests/components/vesync/conftest.py
@@ -183,6 +183,21 @@ async def humidifier_config_entry(
     return entry
 
 
+@pytest.fixture
+async def install_humidifier_device(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    manager,
+    request: pytest.FixtureRequest,
+) -> None:
+    """Create a mock VeSync config entry with the specified humidifier device."""
+
+    # Install the defined humidifier
+    manager._dev_list["fans"].append(request.getfixturevalue(request.param))
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+
 @pytest.fixture(name="switch_old_id_config_entry")
 async def switch_old_id_config_entry(
     hass: HomeAssistant, requests_mock: requests_mock.Mocker, config

--- a/tests/components/vesync/conftest.py
+++ b/tests/components/vesync/conftest.py
@@ -146,10 +146,7 @@ def humidifier_300s_fixture():
             "display": "true",
             "automatic_stop": "true",
         },
-        details={
-            "humidity": 35,
-            "mode": "manual",
-        },
+        details={"humidity": 35, "mode": "manual", "night_light_brightness": 50},
         device_type="Classic300S",
         device_name="Humidifier 300s",
         device_status="on",

--- a/tests/components/vesync/test_init.py
+++ b/tests/components/vesync/test_init.py
@@ -56,6 +56,7 @@ async def test_async_setup_entry__no_devices(
             Platform.HUMIDIFIER,
             Platform.LIGHT,
             Platform.NUMBER,
+            Platform.SELECT,
             Platform.SENSOR,
             Platform.SWITCH,
         ]
@@ -87,6 +88,7 @@ async def test_async_setup_entry__loads_fans(
             Platform.HUMIDIFIER,
             Platform.LIGHT,
             Platform.NUMBER,
+            Platform.SELECT,
             Platform.SENSOR,
             Platform.SWITCH,
         ]

--- a/tests/components/vesync/test_select.py
+++ b/tests/components/vesync/test_select.py
@@ -1,0 +1,43 @@
+"""Tests for the select platform."""
+
+from unittest.mock import patch
+
+from homeassistant.components.select import (
+    ATTR_OPTION,
+    DOMAIN as SELECT_DOMAIN,
+    SERVICE_SELECT_OPTION,
+)
+from homeassistant.components.vesync.const import NIGHT_LIGHT_LEVEL_DIM
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import HomeAssistant
+
+from .common import ENTITY_HUMIDIFIER_300S_NIGHT_LIGHT_SELECT
+
+
+async def test_set_nightlight_level(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    humidifier_300s,
+    manager,
+) -> None:
+    """Test update of display for sleep mode."""
+
+    with patch(
+        "homeassistant.components.vesync.async_generate_device_list",
+        return_value=[humidifier_300s],
+    ):
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    with patch.object(humidifier_300s, "set_night_light_brightness") as method_mock:
+        await hass.services.async_call(
+            SELECT_DOMAIN,
+            SERVICE_SELECT_OPTION,
+            {
+                ATTR_ENTITY_ID: ENTITY_HUMIDIFIER_300S_NIGHT_LIGHT_SELECT,
+                ATTR_OPTION: NIGHT_LIGHT_LEVEL_DIM,
+            },
+            blocking=True,
+        )
+        method_mock.assert_called_once()

--- a/tests/components/vesync/test_select.py
+++ b/tests/components/vesync/test_select.py
@@ -1,6 +1,6 @@
 """Tests for the select platform."""
 
-from unittest.mock import patch
+import pytest
 
 from homeassistant.components.select import (
     ATTR_OPTION,
@@ -9,65 +9,46 @@ from homeassistant.components.select import (
 )
 from homeassistant.components.vesync.const import NIGHT_LIGHT_LEVEL_DIM
 from homeassistant.components.vesync.select import HA_TO_VS_NIGHT_LIGHT_LEVEL_MAP
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
 
 from .common import ENTITY_HUMIDIFIER_300S_NIGHT_LIGHT_SELECT
 
 
+@pytest.mark.parametrize(
+    "install_humidifier_device", ["humidifier_300s"], indirect=True
+)
 async def test_set_nightlight_level(
-    hass: HomeAssistant, config_entry: ConfigEntry, humidifier_300s, manager
+    hass: HomeAssistant, manager, humidifier_300s, install_humidifier_device
 ) -> None:
     """Test set of night light level."""
 
-    with (
-        patch(
-            "homeassistant.components.vesync.async_generate_device_list",
-            return_value=[humidifier_300s],
-        ),
-        patch(
-            "homeassistant.helpers.update_coordinator.DataUpdateCoordinator.async_request_refresh"
-        ) as coordinator_refresh,
-    ):
-        await hass.config_entries.async_setup(config_entry.entry_id)
-        await hass.async_block_till_done()
+    await hass.services.async_call(
+        SELECT_DOMAIN,
+        SERVICE_SELECT_OPTION,
+        {
+            ATTR_ENTITY_ID: ENTITY_HUMIDIFIER_300S_NIGHT_LIGHT_SELECT,
+            ATTR_OPTION: NIGHT_LIGHT_LEVEL_DIM,
+        },
+        blocking=True,
+    )
 
-    with patch.object(humidifier_300s, "set_night_light_brightness") as method_mock:
-        await hass.services.async_call(
-            SELECT_DOMAIN,
-            SERVICE_SELECT_OPTION,
-            {
-                ATTR_ENTITY_ID: ENTITY_HUMIDIFIER_300S_NIGHT_LIGHT_SELECT,
-                ATTR_OPTION: NIGHT_LIGHT_LEVEL_DIM,
-            },
-            blocking=True,
-        )
-
-        # Assert that setter API was invoked with the expected translated value
-        method_mock.assert_called_once_with(
-            HA_TO_VS_NIGHT_LIGHT_LEVEL_MAP[NIGHT_LIGHT_LEVEL_DIM]
-        )
-        # Assert that coordinator refresh was invoked
-        assert coordinator_refresh.assert_called
+    # Assert that setter API was invoked with the expected translated value
+    humidifier_300s.set_night_light_brightness.assert_called_once_with(
+        HA_TO_VS_NIGHT_LIGHT_LEVEL_MAP[NIGHT_LIGHT_LEVEL_DIM]
+    )
+    # Assert that devices were refreshed
+    manager.update_all_devices.assert_called_once()
 
 
-async def test_nightlight_level(
-    hass: HomeAssistant, config_entry: ConfigEntry, humidifier_300s, manager
-) -> None:
+@pytest.mark.parametrize(
+    "install_humidifier_device", ["humidifier_300s"], indirect=True
+)
+async def test_nightlight_level(hass: HomeAssistant, install_humidifier_device) -> None:
     """Test the state of night light level select entity."""
 
     # The mocked device has night_light_brightness=50 which is "dim"
-    with (
-        patch(
-            "homeassistant.components.vesync.async_generate_device_list",
-            return_value=[humidifier_300s],
-        ),
-    ):
-        await hass.config_entries.async_setup(config_entry.entry_id)
-        await hass.async_block_till_done()
-
-        assert (
-            hass.states.get(ENTITY_HUMIDIFIER_300S_NIGHT_LIGHT_SELECT).state
-            == NIGHT_LIGHT_LEVEL_DIM
-        )
+    assert (
+        hass.states.get(ENTITY_HUMIDIFIER_300S_NIGHT_LIGHT_SELECT).state
+        == NIGHT_LIGHT_LEVEL_DIM
+    )

--- a/tests/components/vesync/test_select.py
+++ b/tests/components/vesync/test_select.py
@@ -8,6 +8,7 @@ from homeassistant.components.select import (
     SERVICE_SELECT_OPTION,
 )
 from homeassistant.components.vesync.const import NIGHT_LIGHT_LEVEL_DIM
+from homeassistant.components.vesync.select import HA_TO_VS_NIGHT_LIGHT_LEVEL_MAP
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
@@ -16,12 +17,9 @@ from .common import ENTITY_HUMIDIFIER_300S_NIGHT_LIGHT_SELECT
 
 
 async def test_set_nightlight_level(
-    hass: HomeAssistant,
-    config_entry: ConfigEntry,
-    humidifier_300s,
-    manager,
+    hass: HomeAssistant, config_entry: ConfigEntry, humidifier_300s, manager
 ) -> None:
-    """Test update of display for sleep mode."""
+    """Test update of display for night light level."""
 
     with patch(
         "homeassistant.components.vesync.async_generate_device_list",
@@ -40,4 +38,8 @@ async def test_set_nightlight_level(
             },
             blocking=True,
         )
-        method_mock.assert_called_once()
+
+        # Assert that setter API was invoked with the expected translated value
+        method_mock.assert_called_once_with(
+            HA_TO_VS_NIGHT_LIGHT_LEVEL_MAP[NIGHT_LIGHT_LEVEL_DIM]
+        )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR introduces night light brightness level setting which can be set on VeSync Classic300S humidifier physically via  touch button.

Classic300S supports 3 brightness leves: 0, 50 and 100. This was determined by changing the level physically on the humidifier and examining the debug status. The set operation was physically cross checked on the humidifer.

The setting is limited to device type Classic300S since that is what I could use to physically verify the end result.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request:  https://github.com/home-assistant/home-assistant.io/pull/37332
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
