### PR TITLE
Don't overwrite setup state in async_set_domains_to_be_loaded

### DIFF
--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -132,7 +132,13 @@ def async_set_domains_to_be_loaded(hass: core.HomeAssistant, domains: set[str]) 
      - Keep track of domains which will load but have not yet finished loading
     """
     setup_done_futures = hass.data.setdefault(DATA_SETUP_DONE, {})
-    setup_done_futures.update({domain: hass.loop.create_future() for domain in domains})
+    setup_futures = hass.data.setdefault(DATA_SETUP, {})
+    old_domains = set(setup_futures) | set(setup_done_futures) | hass.config.components
+    if overlap := old_domains & domains:
+        _LOGGER.debug("Domains to be loaded %s already loaded or pending", overlap)
+    setup_done_futures.update(
+        {domain: hass.loop.create_future() for domain in domains - old_domains}
+    )
 
 
 def setup_component(hass: core.HomeAssistant, domain: str, config: ConfigType) -> bool:

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -363,20 +363,24 @@ async def test_component_failing_setup(hass: HomeAssistant) -> None:
 
 async def test_component_exception_setup(hass: HomeAssistant) -> None:
     """Test component that raises exception during setup."""
-    setup.async_set_domains_to_be_loaded(hass, {"comp"})
+    domain = "comp"
+    setup.async_set_domains_to_be_loaded(hass, {domain})
 
     def exception_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         """Raise exception."""
         raise Exception("fail!")  # noqa: TRY002
 
-    mock_integration(hass, MockModule("comp", setup=exception_setup))
+    mock_integration(hass, MockModule(domain, setup=exception_setup))
 
-    assert not await setup.async_setup_component(hass, "comp", {})
-    assert "comp" not in hass.config.components
+    assert not await setup.async_setup_component(hass, domain, {})
+    assert domain in hass.data[setup.DATA_SETUP]
+    assert domain not in hass.data[setup.DATA_SETUP_DONE]
+    assert domain not in hass.config.components
 
 
 async def test_component_base_exception_setup(hass: HomeAssistant) -> None:
     """Test component that raises exception during setup."""
+    domain = "comp"
     setup.async_set_domains_to_be_loaded(hass, {"comp"})
 
     def exception_setup(hass: HomeAssistant, config: ConfigType) -> bool:
@@ -389,7 +393,69 @@ async def test_component_base_exception_setup(hass: HomeAssistant) -> None:
         await setup.async_setup_component(hass, "comp", {})
     assert str(exc_info.value) == "fail!"
 
-    assert "comp" not in hass.config.components
+    assert domain in hass.data[setup.DATA_SETUP]
+    assert domain not in hass.data[setup.DATA_SETUP_DONE]
+    assert domain not in hass.config.components
+
+
+async def test_set_domains_to_be_loaded(hass: HomeAssistant) -> None:
+    """Test async_set_domains_to_be_loaded."""
+    domain_good = "comp_good"
+    domain_bad = "comp_bad"
+    domain_base_exception = "comp_base_exception"
+    domain_exception = "comp_exception"
+    domains = {domain_good, domain_bad, domain_exception, domain_base_exception}
+    setup.async_set_domains_to_be_loaded(hass, domains)
+
+    assert set(hass.data[setup.DATA_SETUP_DONE]) == domains
+    setup_done = dict(hass.data[setup.DATA_SETUP_DONE])
+
+    # Calling async_set_domains_to_be_loaded again should not create new futures
+    setup.async_set_domains_to_be_loaded(hass, domains)
+    assert setup_done == hass.data[setup.DATA_SETUP_DONE]
+
+    def good_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+        """Success."""
+        return True
+
+    def bad_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+        """Fail."""
+        return False
+
+    def base_exception_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+        """Raise exception."""
+        raise BaseException("fail!")  # noqa: TRY002
+
+    def exception_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+        """Raise exception."""
+        raise Exception("fail!")  # noqa: TRY002
+
+    mock_integration(hass, MockModule(domain_good, setup=good_setup))
+    mock_integration(hass, MockModule(domain_bad, setup=bad_setup))
+    mock_integration(
+        hass, MockModule(domain_base_exception, setup=base_exception_setup)
+    )
+    mock_integration(hass, MockModule(domain_exception, setup=exception_setup))
+
+    # Set up the four components
+    assert await setup.async_setup_component(hass, domain_good, {})
+    assert not await setup.async_setup_component(hass, domain_bad, {})
+    assert not await setup.async_setup_component(hass, domain_exception, {})
+    with pytest.raises(BaseException, match="fail!"):
+        await setup.async_setup_component(hass, domain_base_exception, {})
+
+    # Check the result of the setup
+    assert not hass.data[setup.DATA_SETUP_DONE]
+    assert set(hass.data[setup.DATA_SETUP]) == {
+        domain_bad,
+        domain_exception,
+        domain_base_exception,
+    }
+    assert set(hass.config.components) == {domain_good}
+
+    # Calling async_set_domains_to_be_loaded again should not create any new futures
+    setup.async_set_domains_to_be_loaded(hass, domains)
+    assert not hass.data[setup.DATA_SETUP_DONE]
 
 
 async def test_component_setup_with_validation_and_dependency(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Don't overwrite setup state in `async_set_domains_to_be_loaded`

During startup, `async_set_domains_to_be_loaded` is called multiple times with sets of domains to indicate domains which will be loaded in each stage.
If a domain is passed in more than once, we need to ensure we don't overwrite the previously created future, or create a future for a domain which has already been set up to prevent the startup process from deadlocking.

CC @jpbede 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
