### PR TITLE
Use separate metadata files for onedrive

### DIFF
--- a/homeassistant/components/onedrive/__init__.py
+++ b/homeassistant/components/onedrive/__init__.py
@@ -91,6 +91,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: OneDriveConfigEntry) -> 
         backup_folder_id=backup_folder.id,
     )
 
+    try:
+        await _migrate_backup_files(client, backup_folder.id)
+    except OneDriveException as err:
+        raise ConfigEntryNotReady(
+            translation_domain=DOMAIN,
+            translation_key="failed_to_migrate_files",
+        ) from err
+
     _async_notify_backup_listeners_soon(hass)
 
     return True
@@ -112,61 +120,32 @@ def _async_notify_backup_listeners_soon(hass: HomeAssistant) -> None:
     hass.loop.call_soon(_async_notify_backup_listeners, hass)
 
 
-async def async_migrate_entry(hass: HomeAssistant, entry: OneDriveConfigEntry) -> bool:
-    """Migrate config entry."""
-    if entry.version > 2:
-        # guard against downgrade from a future version
-        return False
-
-    if entry.version == 1:
-        implementation = await async_get_config_entry_implementation(hass, entry)
-        session = OAuth2Session(hass, entry, implementation)
-
-        async def get_access_token() -> str:
-            await session.async_ensure_token_valid()
-            return cast(str, session.token[CONF_ACCESS_TOKEN])
-
-        client = OneDriveClient(get_access_token, async_get_clientsession(hass))
-
-        async def migrate_backup_files(backup_folder_id: str) -> None:
-            files = await client.list_drive_items(backup_folder_id)
-            for file in files:
-                if file.description and "homeassistant_version" in file.description:
-                    metadata = loads(unescape(file.description))
-                    del metadata["metadata_version"]
-                    metadata_filename = file.name.rsplit(".", 1)[0] + ".metadata.json"
-                    metadata_file = await client.upload_file(
-                        backup_folder_id,
-                        metadata_filename,
-                        dumps(metadata),  # type: ignore[arg-type]
-                    )
-                    metadata_description = {
-                        "metadata_version": 2,
-                        "backup_id": metadata["backup_id"],
-                        "backup_file_id": file.id,
-                    }
-                    await client.update_drive_item(
-                        path_or_id=metadata_file.id,
-                        data=ItemUpdate(description=dumps(metadata_description)),
-                    )
-                    await client.update_drive_item(
-                        path_or_id=file.id,
-                        data=ItemUpdate(description=""),
-                    )
-                    _LOGGER.debug("Migrated backup file %s", file.name)
-
-        instance_id = await async_get_instance_id(hass)
-        backup_folder_name = f"backups_{instance_id[:8]}"
-        try:
-            approot = await client.get_approot()
-            backup_folder = await client.create_folder(
-                parent_id=approot.id, name=backup_folder_name
+async def _migrate_backup_files(client: OneDriveClient, backup_folder_id: str) -> None:
+    """Migrate backup files to metadata version 2."""
+    files = await client.list_drive_items(backup_folder_id)
+    for file in files:
+        if file.description and "homeassistant_version" in file.description:
+            metadata = loads(unescape(file.description))
+            if metadata["metadata_version"] != 1:
+                continue
+            del metadata["metadata_version"]
+            metadata_filename = file.name.rsplit(".", 1)[0] + ".metadata.json"
+            metadata_file = await client.upload_file(
+                backup_folder_id,
+                metadata_filename,
+                dumps(metadata),  # type: ignore[arg-type]
             )
-            await migrate_backup_files(backup_folder.id)
-        except OneDriveException as err:
-            _LOGGER.error("Migration failed with error %s", err)
-            return False
-
-        hass.config_entries.async_update_entry(entry, version=2)
-        _LOGGER.debug("Migrated OneDrive config entry to version 2")
-    return True
+            metadata_description = {
+                "metadata_version": 2,
+                "backup_id": metadata["backup_id"],
+                "backup_file_id": file.id,
+            }
+            await client.update_drive_item(
+                path_or_id=metadata_file.id,
+                data=ItemUpdate(description=dumps(metadata_description)),
+            )
+            await client.update_drive_item(
+                path_or_id=file.id,
+                data=ItemUpdate(description=""),
+            )
+            _LOGGER.debug("Migrated backup file %s", file.name)

--- a/homeassistant/components/onedrive/__init__.py
+++ b/homeassistant/components/onedrive/__init__.py
@@ -124,10 +124,10 @@ async def _migrate_backup_files(client: OneDriveClient, backup_folder_id: str) -
     """Migrate backup files to metadata version 2."""
     files = await client.list_drive_items(backup_folder_id)
     for file in files:
-        if file.description and "homeassistant_version" in file.description:
-            metadata = loads(unescape(file.description))
-            if metadata["metadata_version"] != 1:
-                continue
+        if file.description and '"metadata_version": 1' in (
+            metadata_json := unescape(file.description)
+        ):
+            metadata = loads(metadata_json)
             del metadata["metadata_version"]
             metadata_filename = file.name.rsplit(".", 1)[0] + ".metadata.json"
             metadata_file = await client.upload_file(

--- a/homeassistant/components/onedrive/backup.py
+++ b/homeassistant/components/onedrive/backup.py
@@ -170,8 +170,9 @@ class OneDriveBackupAgent(BackupAgent):
             description,  # type: ignore[arg-type]
         )
         metadata_description = {
+            "metadata_version": 2,
             "backup_id": backup.backup_id,
-            "file_id": backup_file.id,
+            "backup_file_id": backup_file.id,
         }
         await self._client.update_drive_item(
             path_or_id=item.id,

--- a/homeassistant/components/onedrive/backup.py
+++ b/homeassistant/components/onedrive/backup.py
@@ -124,14 +124,14 @@ class OneDriveBackupAgent(BackupAgent):
         if (
             metadata_item is None
             or metadata_item.description is None
-            or "file_id" not in metadata_item.description
+            or "backup_file_id" not in metadata_item.description
         ):
             raise BackupAgentError("Backup not found")
 
         metadata_info = json.loads(html.unescape(metadata_item.description))
 
         stream = await self._client.download_drive_item(
-            metadata_info["file_id"], timeout=TIMEOUT
+            metadata_info["backup_file_id"], timeout=TIMEOUT
         )
         return stream.iter_chunked(1024)
 
@@ -192,12 +192,12 @@ class OneDriveBackupAgent(BackupAgent):
         if (
             metadata_item is None
             or metadata_item.description is None
-            or "file_id" not in metadata_item.description
+            or "backup_file_id" not in metadata_item.description
         ):
             return
         metadata_info = json.loads(html.unescape(metadata_item.description))
 
-        await self._client.delete_drive_item(metadata_info["file_id"])
+        await self._client.delete_drive_item(metadata_info["backup_file_id"])
         await self._client.delete_drive_item(metadata_item.id)
 
     @handle_backup_errors
@@ -223,13 +223,6 @@ class OneDriveBackupAgent(BackupAgent):
         metadata_stream = await self._client.download_drive_item(metadata_file.id)
         metadata = json.loads(await metadata_stream.read())
         return AgentBackup.from_dict(metadata)
-
-    def _backup_from_description(self, description: str) -> AgentBackup:
-        """Create a backup object from a description."""
-        description = html.unescape(
-            description
-        )  # OneDrive encodes the description on save automatically
-        return AgentBackup.from_dict(json.loads(description))
 
     async def _find_item_by_backup_id(self, backup_id: str) -> File | Folder | None:
         """Find an item by backup ID."""

--- a/homeassistant/components/onedrive/backup.py
+++ b/homeassistant/components/onedrive/backup.py
@@ -160,22 +160,24 @@ class OneDriveBackupAgent(BackupAgent):
                 "Hash validation failed, backup file might be corrupt"
             ) from err
 
-        # store metadata in description
+        # store metadata in metadata file
         description = json.dumps(backup.as_dict())
         _LOGGER.debug("Creating metadata: %s", description)
         metadata_filename = filename.rsplit(".", 1)[0] + ".metadata.json"
-        item = await self._client.upload_file(
+        metadata_file = await self._client.upload_file(
             self._folder_id,
             metadata_filename,
             description,  # type: ignore[arg-type]
         )
+
+        # add metadata to the metadata file
         metadata_description = {
             "metadata_version": 2,
             "backup_id": backup.backup_id,
             "backup_file_id": backup_file.id,
         }
         await self._client.update_drive_item(
-            path_or_id=item.id,
+            path_or_id=metadata_file.id,
             data=ItemUpdate(description=json.dumps(metadata_description)),
         )
 

--- a/homeassistant/components/onedrive/config_flow.py
+++ b/homeassistant/components/onedrive/config_flow.py
@@ -19,7 +19,6 @@ class OneDriveConfigFlow(AbstractOAuth2FlowHandler, domain=DOMAIN):
     """Config flow to handle OneDrive OAuth2 authentication."""
 
     DOMAIN = DOMAIN
-    VERSION = 2
 
     @property
     def logger(self) -> logging.Logger:

--- a/homeassistant/components/onedrive/config_flow.py
+++ b/homeassistant/components/onedrive/config_flow.py
@@ -19,6 +19,7 @@ class OneDriveConfigFlow(AbstractOAuth2FlowHandler, domain=DOMAIN):
     """Config flow to handle OneDrive OAuth2 authentication."""
 
     DOMAIN = DOMAIN
+    VERSION = 2
 
     @property
     def logger(self) -> logging.Logger:

--- a/homeassistant/components/onedrive/strings.json
+++ b/homeassistant/components/onedrive/strings.json
@@ -35,9 +35,6 @@
     },
     "failed_to_get_folder": {
       "message": "Failed to get {folder} folder"
-    },
-    "metadata_migration_failed": {
-      "message": "Failed to migrate metadata from backup file to metadata file"
     }
   }
 }

--- a/homeassistant/components/onedrive/strings.json
+++ b/homeassistant/components/onedrive/strings.json
@@ -35,6 +35,9 @@
     },
     "failed_to_get_folder": {
       "message": "Failed to get {folder} folder"
+    },
+    "metadata_migration_failed": {
+      "message": "Failed to migrate metadata from backup file to metadata file"
     }
   }
 }

--- a/homeassistant/components/onedrive/strings.json
+++ b/homeassistant/components/onedrive/strings.json
@@ -35,6 +35,9 @@
     },
     "failed_to_get_folder": {
       "message": "Failed to get {folder} folder"
+    },
+    "failed_to_migrate_files": {
+      "message": "Failed to migrate metadata to separate files"
     }
   }
 }

--- a/tests/components/onedrive/conftest.py
+++ b/tests/components/onedrive/conftest.py
@@ -67,7 +67,6 @@ def mock_config_entry(expires_at: int, scopes: list[str]) -> MockConfigEntry:
             },
         },
         unique_id="mock_drive_id",
-        version=2,
     )
 
 

--- a/tests/components/onedrive/conftest.py
+++ b/tests/components/onedrive/conftest.py
@@ -67,6 +67,7 @@ def mock_config_entry(expires_at: int, scopes: list[str]) -> MockConfigEntry:
             },
         },
         unique_id="mock_drive_id",
+        version=2,
     )
 
 

--- a/tests/components/onedrive/const.py
+++ b/tests/components/onedrive/const.py
@@ -72,6 +72,29 @@ MOCK_BACKUP_FILE = File(
         quick_xor_hash="hash",
     ),
     mime_type="application/x-tar",
-    description=escape(dumps(BACKUP_METADATA)),
+    description="",
+    created_by=CONTRIBUTOR,
+)
+
+MOCK_METADATA_FILE = File(
+    id="id",
+    name="23e64aec.tar",
+    size=34519040,
+    parent_reference=ItemParentReference(
+        drive_id="mock_drive_id", id="id", path="path"
+    ),
+    hashes=Hashes(
+        quick_xor_hash="hash",
+    ),
+    mime_type="application/x-tar",
+    description=escape(
+        dumps(
+            {
+                "metadata_version": 2,
+                "backup_id": "23e64aec",
+                "backup_file_id": "id",
+            }
+        )
+    ),
     created_by=CONTRIBUTOR,
 )

--- a/tests/components/onedrive/test_backup.py
+++ b/tests/components/onedrive/test_backup.py
@@ -152,7 +152,7 @@ async def test_agents_delete(
 
     assert response["success"]
     assert response["result"] == {"agent_errors": {}}
-    mock_onedrive_client.delete_drive_item.assert_called_once()
+    assert mock_onedrive_client.delete_drive_item.call_count == 2
 
 
 async def test_agents_upload(

--- a/tests/components/onedrive/test_init.py
+++ b/tests/components/onedrive/test_init.py
@@ -20,6 +20,7 @@ async def test_load_unload_config_entry(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_onedrive_client_init: MagicMock,
+    mock_onedrive_client: MagicMock,
 ) -> None:
     """Test loading and unloading the integration."""
     await setup_integration(hass, mock_config_entry)
@@ -27,6 +28,10 @@ async def test_load_unload_config_entry(
     # Ensure the token callback is set up correctly
     token_callback = mock_onedrive_client_init.call_args[0][0]
     assert await token_callback() == "mock-access-token"
+
+    # make sure metadata migration is not called
+    assert mock_onedrive_client.upload_file.call_count == 0
+    assert mock_onedrive_client.update_drive_item.call_count == 0
 
     assert mock_config_entry.state is ConfigEntryState.LOADED
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

OneDrive is currently broken for a lot of users, because apparently some OneDrives have a 1kB limit for the description (where the metadata of the backup is stored). That was only noticed now, because it's not there for all users and only becomes a problem if the users also have multiple addons.

This PR changes the location where the metadata is stored to a separate metadata file and only keeps the reference to the backup file in the metadata file's description. Also, we migrate all existing backups to use the new metadata files.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #137467
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
