### PR TITLE
Skip building wheels for electrickiwi-api

### DIFF
--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -50,6 +50,12 @@ INCLUDED_REQUIREMENTS_WHEELS = {
     "pyuserinput",
 }
 
+EXCLUDED_REQUIREMENTS_WHEELS = {
+    # Exclude 'electrickiwi-api' temporarily, until <3.13 pin is removed upstream.
+    # https://github.com/mikey0000/EK-API/pull/1
+    "electrickiwi-api",
+}
+
 
 # Requirements to exclude or include when running github actions.
 # Requirements listed in "exclude" will be commented-out in
@@ -64,7 +70,7 @@ OVERRIDDEN_REQUIREMENTS_ACTIONS = {
         "markers": {},
     },
     "wheels_aarch64": {
-        "exclude": set(),
+        "exclude": EXCLUDED_REQUIREMENTS_WHEELS,
         "include": INCLUDED_REQUIREMENTS_WHEELS,
         "markers": {},
     },
@@ -73,22 +79,23 @@ OVERRIDDEN_REQUIREMENTS_ACTIONS = {
     # "flimsy" on 386). The following packages depend on pandas,
     # so we comment them out.
     "wheels_armhf": {
-        "exclude": {"env-canada", "noaa-coops", "pyezviz", "pykrakenapi"},
+        "exclude": EXCLUDED_REQUIREMENTS_WHEELS
+        | {"env-canada", "noaa-coops", "pyezviz", "pykrakenapi"},
         "include": INCLUDED_REQUIREMENTS_WHEELS,
         "markers": {},
     },
     "wheels_armv7": {
-        "exclude": set(),
+        "exclude": EXCLUDED_REQUIREMENTS_WHEELS,
         "include": INCLUDED_REQUIREMENTS_WHEELS,
         "markers": {},
     },
     "wheels_amd64": {
-        "exclude": set(),
+        "exclude": EXCLUDED_REQUIREMENTS_WHEELS,
         "include": INCLUDED_REQUIREMENTS_WHEELS,
         "markers": {},
     },
     "wheels_i386": {
-        "exclude": set(),
+        "exclude": EXCLUDED_REQUIREMENTS_WHEELS,
         "include": INCLUDED_REQUIREMENTS_WHEELS,
         "markers": {},
     },


### PR DESCRIPTION
## Proposed change
`electrickiwi-api==0.9.12` pins `Python <3.13` which breaks the wheel builder.
_`uv` ignores upper bounds for Python versions which is why the CI tests were fine._
https://github.com/home-assistant/core/actions/runs/13171579271/job/36762816394#step:9:766

The library was updated in #135231

Exclude the library from the wheel builder until it's resolved upstream.
https://github.com/mikey0000/EK-API/pull/1

/CC @joostlek

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
