### PR TITLE
Correct state and icon if fan is in standby mode in ViCare integration

### DIFF
--- a/homeassistant/components/vicare/fan.py
+++ b/homeassistant/components/vicare/fan.py
@@ -196,6 +196,9 @@ class ViCareFan(ViCareEntity, FanEntity):
     @property
     def is_on(self) -> bool | None:
         """Return true if the entity is on."""
+        if self._api.getVentilationQuickmode(VentilationQuickmode.STANDBY):
+            return False
+
         return self.percentage is not None and self.percentage > 0
 
     def turn_off(self, **kwargs: Any) -> None:
@@ -206,6 +209,8 @@ class ViCareFan(ViCareEntity, FanEntity):
     @property
     def icon(self) -> str | None:
         """Return the icon to use in the frontend."""
+        if self._api.getVentilationQuickmode(VentilationQuickmode.STANDBY):
+            return "mdi:fan-off"
         if hasattr(self, "_attr_preset_mode"):
             if self._attr_preset_mode == VentilationMode.VENTILATION:
                 return "mdi:fan-clock"

--- a/tests/components/vicare/snapshots/test_fan.ambr
+++ b/tests/components/vicare/snapshots/test_fan.ambr
@@ -1,68 +1,4 @@
 # serializer version: 1
-# name: test_all_entities[fan.model0_ventilation-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': dict({
-      'preset_modes': list([
-        <VentilationMode.PERMANENT: 'permanent'>,
-        <VentilationMode.VENTILATION: 'ventilation'>,
-        <VentilationMode.SENSOR_DRIVEN: 'sensor_driven'>,
-        <VentilationMode.SENSOR_OVERRIDE: 'sensor_override'>,
-      ]),
-    }),
-    'config_entry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'fan',
-    'entity_category': None,
-    'entity_id': 'fan.model0_ventilation',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': 'mdi:fan',
-    'original_name': 'Ventilation',
-    'platform': 'vicare',
-    'previous_unique_id': None,
-    'supported_features': <FanEntityFeature: 9>,
-    'translation_key': 'ventilation',
-    'unique_id': 'gateway0_deviceSerialViAir300F-ventilation',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_all_entities[fan.model0_ventilation-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'model0 Ventilation',
-      'icon': 'mdi:fan',
-      'percentage': 0,
-      'percentage_step': 25.0,
-      'preset_mode': None,
-      'preset_modes': list([
-        <VentilationMode.PERMANENT: 'permanent'>,
-        <VentilationMode.VENTILATION: 'ventilation'>,
-        <VentilationMode.SENSOR_DRIVEN: 'sensor_driven'>,
-        <VentilationMode.SENSOR_OVERRIDE: 'sensor_override'>,
-      ]),
-      'supported_features': <FanEntityFeature: 9>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'fan.model0_ventilation',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
 # name: test_all_entities[fan.model1_ventilation-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -92,7 +28,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:fan',
+    'original_icon': 'mdi:fan-off',
     'original_name': 'Ventilation',
     'platform': 'vicare',
     'previous_unique_id': None,
@@ -106,7 +42,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'model1 Ventilation',
-      'icon': 'mdi:fan',
+      'icon': 'mdi:fan-off',
       'percentage': 0,
       'percentage_step': 25.0,
       'preset_mode': None,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Correct the icon and state display when `standby` *quickmode* is active.

<img width="365" alt="Bildschirmfoto 2025-02-06 um 16 18 30" src="https://github.com/user-attachments/assets/d4edee08-f918-456b-ae46-1484c25e84e7" />



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
