### PR TITLE
Add support for fireplace mode control for flexit_bacnet integration

### DIFF
--- a/homeassistant/components/flexit_bacnet/icons.json
+++ b/homeassistant/components/flexit_bacnet/icons.json
@@ -30,6 +30,9 @@
       },
       "home_supply_fan_setpoint": {
         "default": "mdi:fan-plus"
+      },
+      "fireplace_mode_runtime": {
+        "default": "mdi:fireplace"
       }
     },
     "switch": {
@@ -37,6 +40,12 @@
         "default": "mdi:radiator",
         "state": {
           "off": "mdi:radiator-off"
+        }
+      },
+      "fireplace_mode": {
+        "default": "mdi:fireplace",
+        "state": {
+          "off": "mdi:fireplace-off"
         }
       }
     }

--- a/homeassistant/components/flexit_bacnet/number.py
+++ b/homeassistant/components/flexit_bacnet/number.py
@@ -14,7 +14,7 @@ from homeassistant.components.number import (
     NumberMode,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import PERCENTAGE
+from homeassistant.const import PERCENTAGE, UnitOfTime
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -25,6 +25,9 @@ from .entity import FlexitEntity
 
 _MAX_FAN_SETPOINT = 100
 _MIN_FAN_SETPOINT = 30
+
+_MAX_RUNTIME_DURATION = 360
+_MIN_RUNTIME_DURATION = 1
 
 
 @dataclass(kw_only=True, frozen=True)
@@ -175,6 +178,18 @@ NUMBERS: tuple[FlexitNumberEntityDescription, ...] = (
         native_unit_of_measurement=PERCENTAGE,
         native_max_value_fn=lambda _: _MAX_FAN_SETPOINT,
         native_min_value_fn=lambda device: int(device.fan_setpoint_supply_air_away),
+    ),
+    FlexitNumberEntityDescription(
+        key="fireplace_mode_runtime",
+        translation_key="fireplace_mode_runtime",
+        device_class=NumberDeviceClass.DURATION,
+        native_step=1,
+        mode=NumberMode.SLIDER,
+        native_value_fn=lambda device: device.fireplace_mode_runtime,
+        set_native_value_fn=lambda device: device.set_fireplace_mode_runtime,
+        native_unit_of_measurement=UnitOfTime.MINUTES,
+        native_max_value_fn=lambda _: _MAX_RUNTIME_DURATION,
+        native_min_value_fn=lambda _: _MIN_RUNTIME_DURATION,
     ),
 )
 

--- a/homeassistant/components/flexit_bacnet/strings.json
+++ b/homeassistant/components/flexit_bacnet/strings.json
@@ -52,6 +52,9 @@
       },
       "home_supply_fan_setpoint": {
         "name": "Home supply fan setpoint"
+      },
+      "fireplace_mode_runtime": {
+        "name": "Fireplace mode runtime"
       }
     },
     "sensor": {
@@ -104,6 +107,9 @@
     "switch": {
       "electric_heater": {
         "name": "Electric heater"
+      },
+      "fireplace_mode": {
+        "name": "Fireplace mode"
       }
     }
   }

--- a/homeassistant/components/flexit_bacnet/switch.py
+++ b/homeassistant/components/flexit_bacnet/switch.py
@@ -40,6 +40,13 @@ SWITCHES: tuple[FlexitSwitchEntityDescription, ...] = (
         turn_on_fn=lambda data: data.enable_electric_heater(),
         turn_off_fn=lambda data: data.disable_electric_heater(),
     ),
+    FlexitSwitchEntityDescription(
+        key="fireplace_mode",
+        translation_key="fireplace_mode",
+        is_on_fn=lambda data: data.fireplace_ventilation_status,
+        turn_on_fn=lambda data: data.trigger_fireplace_mode(),
+        turn_off_fn=lambda data: data.trigger_fireplace_mode(),
+    ),
 )
 
 

--- a/tests/components/flexit_bacnet/conftest.py
+++ b/tests/components/flexit_bacnet/conftest.py
@@ -67,6 +67,7 @@ def mock_flexit_bacnet() -> Generator[AsyncMock]:
         flexit_bacnet.air_filter_polluted = False
         flexit_bacnet.air_filter_exchange_interval = 8784
         flexit_bacnet.electric_heater = True
+        flexit_bacnet.fireplace_mode_runtime = 10
 
         # Mock fan setpoints
         flexit_bacnet.fan_setpoint_extract_air_fire = 56

--- a/tests/components/flexit_bacnet/snapshots/test_number.ambr
+++ b/tests/components/flexit_bacnet/snapshots/test_number.ambr
@@ -284,6 +284,63 @@
     'state': '56',
   })
 # ---
+# name: test_numbers[number.device_name_fireplace_mode_runtime-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'max': 360,
+      'min': 1,
+      'mode': <NumberMode.SLIDER: 'slider'>,
+      'step': 1,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': None,
+    'entity_id': 'number.device_name_fireplace_mode_runtime',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <NumberDeviceClass.DURATION: 'duration'>,
+    'original_icon': None,
+    'original_name': 'Fireplace mode runtime',
+    'platform': 'flexit_bacnet',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'fireplace_mode_runtime',
+    'unique_id': '0000-0001-fireplace_mode_runtime',
+    'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+  })
+# ---
+# name: test_numbers[number.device_name_fireplace_mode_runtime-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'duration',
+      'friendly_name': 'Device Name Fireplace mode runtime',
+      'max': 360,
+      'min': 1,
+      'mode': <NumberMode.SLIDER: 'slider'>,
+      'step': 1,
+      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.device_name_fireplace_mode_runtime',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '10',
+  })
+# ---
 # name: test_numbers[number.device_name_fireplace_supply_fan_setpoint-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({

--- a/tests/components/flexit_bacnet/snapshots/test_switch.ambr
+++ b/tests/components/flexit_bacnet/snapshots/test_switch.ambr
@@ -46,6 +46,53 @@
     'state': 'on',
   })
 # ---
+# name: test_switches[switch.device_name_fireplace_mode-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.device_name_fireplace_mode',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SwitchDeviceClass.SWITCH: 'switch'>,
+    'original_icon': None,
+    'original_name': 'Fireplace mode',
+    'platform': 'flexit_bacnet',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'fireplace_mode',
+    'unique_id': '0000-0001-fireplace_mode',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.device_name_fireplace_mode-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'switch',
+      'friendly_name': 'Device Name Fireplace mode',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.device_name_fireplace_mode',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
 # name: test_switches_implementation[switch.device_name_electric_heater-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This change introduces control over the fireplace mode for Flexit Nordic balanced ventilation units which should be used to properly balance ventilation in the house when a fireplace (without dedicated fresh air supply) is running.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
