### PR TITLE
Handle previously migrated HEOS device identifier

### DIFF
--- a/homeassistant/components/heos/__init__.py
+++ b/homeassistant/components/heos/__init__.py
@@ -46,8 +46,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: HeosConfigEntry) -> bool
                     if domain != DOMAIN
                 }
                 migrated_identifiers = {(DOMAIN, str(player_id))}
+                # Add migrated if not already present in another device, which occurs if the user downgraded and then upgraded
                 if not device_registry.async_get_device(migrated_identifiers):
-                    # Add migrated if not already present in another device, which occurs if the user downgraded and then upgraded
                     identifiers.update(migrated_identifiers)
                 if len(identifiers) > 0:
                     device_registry.async_update_device(

--- a/homeassistant/components/heos/__init__.py
+++ b/homeassistant/components/heos/__init__.py
@@ -39,9 +39,22 @@ async def async_setup_entry(hass: HomeAssistant, entry: HeosConfigEntry) -> bool
     ):
         for domain, player_id in device.identifiers:
             if domain == DOMAIN and not isinstance(player_id, str):
-                device_registry.async_update_device(  # type: ignore[unreachable]
-                    device.id, new_identifiers={(DOMAIN, str(player_id))}
-                )
+                # Create set of identifiers excluding this integration
+                identifiers = {  # type: ignore[unreachable]
+                    (domain, identifier)
+                    for domain, identifier in device.identifiers
+                    if domain != DOMAIN
+                }
+                migrated_identifiers = {(DOMAIN, str(player_id))}
+                if not device_registry.async_get_device(migrated_identifiers):
+                    # Add migrated if not already present in another device, which occurs if the user downgraded and then upgraded
+                    identifiers.update(migrated_identifiers)
+                if len(identifiers) > 0:
+                    device_registry.async_update_device(
+                        device.id, new_identifiers=identifiers
+                    )
+                else:
+                    device_registry.async_remove_device(device.id)
             break
 
     coordinator = HeosCoordinator(hass, entry)

--- a/tests/components/heos/test_init.py
+++ b/tests/components/heos/test_init.py
@@ -193,7 +193,7 @@ async def test_device_id_migration(
     # Create a device with a legacy identifier
     device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,
-        identifiers={(DOMAIN, 1)},  # type: ignore[arg-type]
+        identifiers={(DOMAIN, 1), ("Other", "1")},  # type: ignore[arg-type]
     )
     device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,
@@ -201,5 +201,26 @@ async def test_device_id_migration(
     )
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     assert device_registry.async_get_device({("Other", 1)}) is not None  # type: ignore[arg-type]
+    assert device_registry.async_get_device({(DOMAIN, 1)}) is None  # type: ignore[arg-type]
+    assert device_registry.async_get_device({(DOMAIN, "1")}) is not None
+    assert device_registry.async_get_device({("Other", "1")}) is not None
+
+
+async def test_device_id_migration_both_present(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test that legacy non-string devices are removed when both devices present."""
+    config_entry.add_to_hass(hass)
+    # Create a device with a legacy identifier AND a new identifier
+    device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={(DOMAIN, 1)},  # type: ignore[arg-type]
+    )
+    device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id, identifiers={(DOMAIN, "1")}
+    )
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
     assert device_registry.async_get_device({(DOMAIN, 1)}) is None  # type: ignore[arg-type]
     assert device_registry.async_get_device({(DOMAIN, "1")}) is not None

--- a/tests/components/heos/test_init.py
+++ b/tests/components/heos/test_init.py
@@ -200,6 +200,7 @@ async def test_device_id_migration(
         identifiers={("Other", 1)},  # type: ignore[arg-type]
     )
     assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done(wait_background_tasks=True)
     assert device_registry.async_get_device({("Other", 1)}) is not None  # type: ignore[arg-type]
     assert device_registry.async_get_device({(DOMAIN, 1)}) is None  # type: ignore[arg-type]
     assert device_registry.async_get_device({(DOMAIN, "1")}) is not None
@@ -222,5 +223,6 @@ async def test_device_id_migration_both_present(
         config_entry_id=config_entry.entry_id, identifiers={(DOMAIN, "1")}
     )
     assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done(wait_background_tasks=True)
     assert device_registry.async_get_device({(DOMAIN, 1)}) is None  # type: ignore[arg-type]
     assert device_registry.async_get_device({(DOMAIN, "1")}) is not None


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Modifies the HEOS device identifier _type_ migration logic to handle a situation where the migrated device identifiers are already present in the registry.

This occurs when the user upgrades to 2025.2, downgrades without restoring their config data, then upgrades again. This results in the downgraded code adding new devices (under the old identifiers) alongside the migrated ones. The migration code now checks for this situation and deletes the old device instead of updating it. The full scenario is described in: #137558

Tests have been updated and added to verify this fix.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #137558
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X ] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
