### PR TITLE
Adjust 'Install all test requirements' task to include base requirements

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -148,7 +148,7 @@
     {
       "label": "Install all Test Requirements",
       "type": "shell",
-      "command": "uv pip install -r requirements_test_all.txt",
+      "command": "uv pip install -r requirements.txt -r requirements_test_all.txt",
       "group": {
         "kind": "build",
         "isDefault": true

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -6,6 +6,7 @@
 # contain hints for available should be kept in sync with them
 
 -c homeassistant/package_constraints.txt
+-r requirements.txt
 -r requirements_test_pre_commit.txt
 astroid==3.3.8
 coverage==7.6.10

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -6,7 +6,6 @@
 # contain hints for available should be kept in sync with them
 
 -c homeassistant/package_constraints.txt
--r requirements.txt
 -r requirements_test_pre_commit.txt
 astroid==3.3.8
 coverage==7.6.10


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Running the "Install all test requirements" task doesn't currently install updated core dependencies.

```
pytest tests/components/foscam
ImportError while loading conftest '/workspaces/core/tests/conftest.py'.
tests/conftest.py:50: in <module>
    from . import patch_time  # noqa: F401, isort:skip
tests/patch_time.py:31: in <module>
    from homeassistant import runner  # noqa: E402
homeassistant/runner.py:16: in <module>
    from . import bootstrap
homeassistant/bootstrap.py:41: in <module>
    from .components import (
homeassistant/components/auth/__init__.py:158: in <module>
    from homeassistant.helpers.config_entry_oauth2_flow import OAuth2AuthorizeCallbackView
homeassistant/helpers/config_entry_oauth2_flow.py:33: in <module>
    from .aiohttp_client import async_get_clientsession
homeassistant/helpers/aiohttp_client.py:18: in <module>
    from aiohttp_asyncmdnsresolver.api import AsyncDualMDNSResolver
E   ImportError: cannot import name 'AsyncDualMDNSResolver' from 'aiohttp_asyncmdnsresolver.api' (/home/vscode/.local/ha-venv/lib/python3.13/site-packages/aiohttp_asyncmdnsresolver/api.py)
```

I had to run `uv pip install requirements.txt` manually to install these updated dependencies:
```
 - aiohttp-asyncmdnsresolver==0.0.1
 + aiohttp-asyncmdnsresolver==0.1.0
 - aiohttp-fast-zlib==0.2.0
 + aiohttp-fast-zlib==0.2.2
 - ulid-transform==1.0.2
 + ulid-transform==1.2.0
 - uv==0.5.8
 + uv==0.5.27
 - voluptuous-openapi==0.0.5
 + voluptuous-openapi==0.0.6
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
