### PR TITLE
Don't use the current temperature from Shelly BLU TRV as a state for External Temperature number entity

### DIFF
--- a/homeassistant/components/shelly/number.py
+++ b/homeassistant/components/shelly/number.py
@@ -139,6 +139,24 @@ class RpcBluTrvNumber(RpcNumber):
         )
 
 
+class RpcBluTrvExtTempNumber(RpcBluTrvNumber):
+    """Represent a RPC BluTrv External Temperature number."""
+
+    _reported_value: float | None = None
+
+    @property
+    def native_value(self) -> float | None:
+        """Return value of number."""
+        return self._reported_value
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Change the value."""
+        await super().async_set_native_value(value)
+
+        self._reported_value = value
+        self.async_write_ha_state()
+
+
 NUMBERS: dict[tuple[str, str], BlockNumberDescription] = {
     ("device", "valvePos"): BlockNumberDescription(
         key="device|valvepos",
@@ -175,7 +193,7 @@ RPC_NUMBERS: Final = {
             "method": "Trv.SetExternalTemperature",
             "params": {"id": 0, "t_C": value},
         },
-        entity_class=RpcBluTrvNumber,
+        entity_class=RpcBluTrvExtTempNumber,
     ),
     "number": RpcNumberDescription(
         key="number",

--- a/tests/components/shelly/snapshots/test_number.ambr
+++ b/tests/components/shelly/snapshots/test_number.ambr
@@ -52,7 +52,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '15.2',
+    'state': 'unknown',
   })
 # ---
 # name: test_blu_trv_number_entity[number.trv_name_valve_position-entry]

--- a/tests/components/shelly/test_number.py
+++ b/tests/components/shelly/test_number.py
@@ -417,24 +417,23 @@ async def test_blu_trv_number_entity(
         assert entry == snapshot(name=f"{entity_id}-entry")
 
 
-async def test_blu_trv_set_value(
-    hass: HomeAssistant,
-    mock_blu_trv: Mock,
-    monkeypatch: pytest.MonkeyPatch,
+async def test_blu_trv_ext_temp_set_value(
+    hass: HomeAssistant, mock_blu_trv: Mock
 ) -> None:
-    """Test the set value action for BLU TRV number entity."""
+    """Test the set value action for BLU TRV External Temperature number entity."""
     await init_integration(hass, 3, model=MODEL_BLU_GATEWAY_GEN3)
 
     entity_id = f"{NUMBER_DOMAIN}.trv_name_external_temperature"
 
-    assert hass.states.get(entity_id).state == "15.2"
+    # After HA start the state should be unknown because there was no previous external
+    # temperature report
+    assert hass.states.get(entity_id).state is STATE_UNKNOWN
 
-    monkeypatch.setitem(mock_blu_trv.status["blutrv:200"], "current_C", 22.2)
     await hass.services.async_call(
         NUMBER_DOMAIN,
         SERVICE_SET_VALUE,
         {
-            ATTR_ENTITY_ID: f"{NUMBER_DOMAIN}.trv_name_external_temperature",
+            ATTR_ENTITY_ID: entity_id,
             ATTR_VALUE: 22.2,
         },
         blocking=True,
@@ -451,3 +450,44 @@ async def test_blu_trv_set_value(
     )
 
     assert hass.states.get(entity_id).state == "22.2"
+
+
+async def test_blu_trv_valve_pos_set_value(
+    hass: HomeAssistant,
+    mock_blu_trv: Mock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test the set value action for BLU TRV Valve Position number entity."""
+    # disable automatic temperature control to enable valve position entity
+    monkeypatch.setitem(mock_blu_trv.config["blutrv:200"], "enable", False)
+
+    await init_integration(hass, 3, model=MODEL_BLU_GATEWAY_GEN3)
+
+    entity_id = f"{NUMBER_DOMAIN}.trv_name_valve_position"
+
+    assert hass.states.get(entity_id).state == "0"
+
+    monkeypatch.setitem(mock_blu_trv.status["blutrv:200"], "pos", 20)
+    await hass.services.async_call(
+        NUMBER_DOMAIN,
+        SERVICE_SET_VALUE,
+        {
+            ATTR_ENTITY_ID: entity_id,
+            ATTR_VALUE: 20.0,
+        },
+        blocking=True,
+    )
+    mock_blu_trv.mock_update()
+    mock_blu_trv.call_rpc.assert_called_once_with(
+        "BluTRV.Call",
+        {
+            "id": 200,
+            "method": "Trv.SetPosition",
+            "params": {"id": 0, "pos": 20},
+        },
+        BLU_TRV_TIMEOUT,
+    )
+    # device only accepts int for 'pos' value
+    assert isinstance(mock_blu_trv.call_rpc.call_args[0][1]["params"]["pos"], int)
+
+    assert hass.states.get(entity_id).state == "20"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
If `underfloor heating` option is disabled, the device doesn't return exactly the same current temperature value that it receives via `SetExternalTemperature` (external temperature is used to calculate the correction for the internal measurement). As a result, the state of the External Temperature number entity is different than the value reported by user, which is confusing.

With this change the External Temperature number entity only uses the user value as a state (the state is `unknown` after HA start).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #137490
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
