### PR TITLE
Make sure we always have agent_id in ConversationInput

### DIFF
--- a/homeassistant/components/conversation/agent_manager.py
+++ b/homeassistant/components/conversation/agent_manager.py
@@ -79,6 +79,9 @@ async def async_converse(
     extra_system_prompt: str | None = None,
 ) -> ConversationResult:
     """Process text and get intent."""
+    if agent_id is None:
+        agent_id = HOME_ASSISTANT_AGENT
+
     agent = async_get_agent(hass, agent_id)
 
     if agent is None:

--- a/homeassistant/components/conversation/default_agent.py
+++ b/homeassistant/components/conversation/default_agent.py
@@ -381,7 +381,7 @@ class DefaultAgent(ConversationEntity):
             speech: str = response.speech.get("plain", {}).get("speech", "")
             chat_log.async_add_assistant_content_without_tools(
                 AssistantContent(
-                    agent_id=user_input.agent_id,  # type: ignore[arg-type]
+                    agent_id=user_input.agent_id,
                     content=speech,
                 )
             )

--- a/homeassistant/components/conversation/http.py
+++ b/homeassistant/components/conversation/http.py
@@ -195,7 +195,7 @@ async def websocket_hass_agent_debug(
             conversation_id=None,
             device_id=msg.get("device_id"),
             language=msg.get("language", hass.config.language),
-            agent_id=None,
+            agent_id=agent.entity_id,
         )
         result_dict: dict[str, Any] | None = None
 

--- a/homeassistant/components/conversation/models.py
+++ b/homeassistant/components/conversation/models.py
@@ -37,7 +37,7 @@ class ConversationInput:
     language: str
     """Language of the request."""
 
-    agent_id: str | None = None
+    agent_id: str
     """Agent to use for processing."""
 
     extra_system_prompt: str | None = None

--- a/homeassistant/components/google_generative_ai_conversation/conversation.py
+++ b/homeassistant/components/google_generative_ai_conversation/conversation.py
@@ -261,8 +261,6 @@ class GoogleGenerativeAIConversationEntity(
         chat_log: conversation.ChatLog,
     ) -> conversation.ConversationResult:
         """Call the API."""
-
-        assert user_input.agent_id
         options = self.entry.options
 
         try:

--- a/homeassistant/components/openai_conversation/conversation.py
+++ b/homeassistant/components/openai_conversation/conversation.py
@@ -198,7 +198,6 @@ class OpenAIConversationEntity(
         chat_log: conversation.ChatLog,
     ) -> conversation.ConversationResult:
         """Call the API."""
-        assert user_input.agent_id
         options = self.entry.options
 
         try:

--- a/tests/components/conversation/test_init.py
+++ b/tests/components/conversation/test_init.py
@@ -271,6 +271,7 @@ async def test_async_handle_sentence_triggers(
             text="my trigger",
             context=Context(),
             conversation_id=None,
+            agent_id=conversation.HOME_ASSISTANT_AGENT,
             device_id=device_id,
             language=hass.config.language,
         ),
@@ -306,6 +307,7 @@ async def test_async_handle_intents(hass: HomeAssistant) -> None:
         ConversationInput(
             text="I'd like to order a stout",
             context=Context(),
+            agent_id=conversation.HOME_ASSISTANT_AGENT,
             conversation_id=None,
             device_id=None,
             language=hass.config.language,
@@ -321,6 +323,7 @@ async def test_async_handle_intents(hass: HomeAssistant) -> None:
         hass,
         ConversationInput(
             text="this sentence does not exist",
+            agent_id=conversation.HOME_ASSISTANT_AGENT,
             context=Context(),
             conversation_id=None,
             device_id=None,

--- a/tests/components/conversation/test_trigger.py
+++ b/tests/components/conversation/test_trigger.py
@@ -5,7 +5,7 @@ import logging
 import pytest
 import voluptuous as vol
 
-from homeassistant.components.conversation import default_agent
+from homeassistant.components.conversation import HOME_ASSISTANT_AGENT, default_agent
 from homeassistant.components.conversation.const import DATA_DEFAULT_ENTITY
 from homeassistant.components.conversation.models import ConversationInput
 from homeassistant.core import Context, HomeAssistant, ServiceCall
@@ -82,7 +82,7 @@ async def test_if_fires_on_event(
         "details": {},
         "device_id": None,
         "user_input": {
-            "agent_id": None,
+            "agent_id": HOME_ASSISTANT_AGENT,
             "context": context.as_dict(),
             "conversation_id": None,
             "device_id": None,
@@ -230,7 +230,7 @@ async def test_response_same_sentence(
         "details": {},
         "device_id": None,
         "user_input": {
-            "agent_id": None,
+            "agent_id": HOME_ASSISTANT_AGENT,
             "context": context.as_dict(),
             "conversation_id": None,
             "device_id": None,
@@ -408,7 +408,7 @@ async def test_same_trigger_multiple_sentences(
         "details": {},
         "device_id": None,
         "user_input": {
-            "agent_id": None,
+            "agent_id": HOME_ASSISTANT_AGENT,
             "context": context.as_dict(),
             "conversation_id": None,
             "device_id": None,
@@ -636,7 +636,7 @@ async def test_wildcards(hass: HomeAssistant, service_calls: list[ServiceCall]) 
         },
         "device_id": None,
         "user_input": {
-            "agent_id": None,
+            "agent_id": HOME_ASSISTANT_AGENT,
             "context": context.as_dict(),
             "conversation_id": None,
             "device_id": None,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
ConversationInput is only initialized inside the conversation integration. This allows us to ensure that the agent_id is always available (as someone has to process the input!). This makes typing inside OpenAI/Google a little easier.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
