### PR TITLE
Filter out certain intents from being matched in local fallback

### DIFF
--- a/homeassistant/components/assist_pipeline/pipeline.py
+++ b/homeassistant/components/assist_pipeline/pipeline.py
@@ -30,7 +30,7 @@ from homeassistant.components import (
 from homeassistant.components.tts import (
     generate_media_source_id as tts_generate_media_source_id,
 )
-from homeassistant.const import MATCH_ALL
+from homeassistant.const import ATTR_SUPPORTED_FEATURES, MATCH_ALL
 from homeassistant.core import Context, HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import chat_session, intent
@@ -1093,12 +1093,22 @@ class PipelineRun:
                     )
                     intent_response.async_set_speech(trigger_response_text)
 
+                intent_filter: Callable[[RecognizeResult], bool] | None = None
+                # If the LLM has API access, we filter out some sentences that are
+                # interfering with LLM operation.
+                if (
+                    intent_agent_state := self.hass.states.get(self.intent_agent)
+                ) and intent_agent_state.attributes.get(
+                    ATTR_SUPPORTED_FEATURES, 0
+                ) & conversation.ConversationEntityFeature.CONTROL:
+                    intent_filter = _async_local_fallback_intent_filter
+
                 # Try local intents first, if preferred.
                 elif self.pipeline.prefer_local_intents and (
                     intent_response := await conversation.async_handle_intents(
                         self.hass,
                         user_input,
-                        intent_filter=_async_local_fallback_intent_filter,
+                        intent_filter=intent_filter,
                     )
                 ):
                     # Local intent matched

--- a/homeassistant/components/conversation/__init__.py
+++ b/homeassistant/components/conversation/__init__.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 import logging
 import re
 from typing import Literal
 
+from hassil.recognize import RecognizeResult
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry
@@ -241,7 +243,10 @@ async def async_handle_sentence_triggers(
 
 
 async def async_handle_intents(
-    hass: HomeAssistant, user_input: ConversationInput
+    hass: HomeAssistant,
+    user_input: ConversationInput,
+    *,
+    intent_filter: Callable[[RecognizeResult], bool] | None = None,
 ) -> intent.IntentResponse | None:
     """Try to match input against registered intents and return response.
 
@@ -250,7 +255,9 @@ async def async_handle_intents(
     default_agent = async_get_agent(hass)
     assert isinstance(default_agent, DefaultAgent)
 
-    return await default_agent.async_handle_intents(user_input)
+    return await default_agent.async_handle_intents(
+        user_input, intent_filter=intent_filter
+    )
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:

--- a/homeassistant/components/conversation/default_agent.py
+++ b/homeassistant/components/conversation/default_agent.py
@@ -1324,6 +1324,8 @@ class DefaultAgent(ConversationEntity):
     async def async_handle_intents(
         self,
         user_input: ConversationInput,
+        *,
+        intent_filter: Callable[[RecognizeResult], bool] | None = None,
     ) -> intent.IntentResponse | None:
         """Try to match sentence against registered intents and return response.
 
@@ -1331,7 +1333,9 @@ class DefaultAgent(ConversationEntity):
         Returns None if no match or a matching error occurred.
         """
         result = await self.async_recognize_intent(user_input, strict_intents_only=True)
-        if not isinstance(result, RecognizeResult):
+        if not isinstance(result, RecognizeResult) or (
+            intent_filter is not None and intent_filter(result)
+        ):
             # No error message on failed match
             return None
 

--- a/tests/components/assist_pipeline/test_pipeline.py
+++ b/tests/components/assist_pipeline/test_pipeline.py
@@ -4,6 +4,7 @@ from collections.abc import AsyncGenerator
 from typing import Any
 from unittest.mock import ANY, patch
 
+from hassil.recognize import Intent, IntentData, RecognizeResult
 import pytest
 
 from homeassistant.components import conversation
@@ -16,6 +17,7 @@ from homeassistant.components.assist_pipeline.pipeline import (
     PipelineData,
     PipelineStorageCollection,
     PipelineStore,
+    _async_local_fallback_intent_filter,
     async_create_default_pipeline,
     async_get_pipeline,
     async_get_pipelines,
@@ -23,6 +25,7 @@ from homeassistant.components.assist_pipeline.pipeline import (
     async_update_pipeline,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import intent
 from homeassistant.setup import async_setup_component
 
 from . import MANY_LANGUAGES
@@ -657,3 +660,40 @@ async def test_migrate_after_load(hass: HomeAssistant) -> None:
 
     assert pipeline_updated.stt_engine == "stt.test"
     assert pipeline_updated.tts_engine == "tts.test"
+
+
+def test_fallback_intent_filter() -> None:
+    """Test that we filter the right things."""
+    assert (
+        _async_local_fallback_intent_filter(
+            RecognizeResult(
+                intent=Intent(intent.INTENT_GET_STATE),
+                intent_data=IntentData([]),
+                entities={},
+                entities_list=[],
+            )
+        )
+        is True
+    )
+    assert (
+        _async_local_fallback_intent_filter(
+            RecognizeResult(
+                intent=Intent(intent.INTENT_NEVERMIND),
+                intent_data=IntentData([]),
+                entities={},
+                entities_list=[],
+            )
+        )
+        is True
+    )
+    assert (
+        _async_local_fallback_intent_filter(
+            RecognizeResult(
+                intent=Intent(intent.INTENT_TURN_ON),
+                intent_data=IntentData([]),
+                entities={},
+                entities_list=[],
+            )
+        )
+        is False
+    )

--- a/tests/components/conversation/test_default_agent.py
+++ b/tests/components/conversation/test_default_agent.py
@@ -3155,6 +3155,79 @@ async def test_handle_intents_with_response_errors(
 
 
 @pytest.mark.usefixtures("init_components")
+async def test_handle_intents_filters_results(
+    hass: HomeAssistant,
+    init_components: None,
+    area_registry: ar.AreaRegistry,
+) -> None:
+    """Test that handle_intents can filter responses."""
+    assert await async_setup_component(hass, "climate", {})
+    area_registry.async_create("living room")
+
+    agent: default_agent.DefaultAgent = hass.data[DATA_DEFAULT_ENTITY]
+
+    user_input = ConversationInput(
+        text="What is the temperature in the living room?",
+        context=Context(),
+        conversation_id=None,
+        device_id=None,
+        language=hass.config.language,
+        agent_id=None,
+    )
+
+    mock_result = RecognizeResult(
+        intent=Intent("HassTurnOn"),
+        intent_data=IntentData([]),
+        entities={},
+        entities_list=[],
+    )
+    results = []
+
+    def _filter_intents(result):
+        results.append(result)
+        # We filter first, not 2nd.
+        return len(results) == 1
+
+    with (
+        patch(
+            "homeassistant.components.conversation.default_agent.DefaultAgent.async_recognize_intent",
+            return_value=mock_result,
+        ) as mock_recognize,
+        patch(
+            "homeassistant.components.conversation.default_agent.DefaultAgent._async_process_intent_result",
+        ) as mock_process,
+    ):
+        response = await agent.async_handle_intents(
+            user_input, intent_filter=_filter_intents
+        )
+
+        assert len(mock_recognize.mock_calls) == 1
+        assert len(mock_process.mock_calls) == 0
+
+        # It was ignored
+        assert response is None
+
+        # Check we filtered things
+        assert len(results) == 1
+        assert results[0] is mock_result
+
+        # Second time it is not filtered
+        response = await agent.async_handle_intents(
+            user_input, intent_filter=_filter_intents
+        )
+
+        assert len(mock_recognize.mock_calls) == 2
+        assert len(mock_process.mock_calls) == 2
+
+        # Check we filtered things
+        assert len(results) == 2
+        assert results[1] is mock_result
+
+        # It was ignored
+        assert response is not None
+
+
+@pytest.mark.usefixtures("init_components")
 async def test_state_names_are_not_translated(
     hass: HomeAssistant,
     init_components: None,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When using local fallback with LLMs, we don't want certain intents to match locally, as they can have double meaning, and the LLM knows better.

For example "Who is {location}" is locally matched for persons in a state, while for LLMs it could be "Who is the founder of Home Assitant".

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
