### PR TITLE
Add support for Tuya bitmap sensors

### DIFF
--- a/homeassistant/components/tuya/binary_sensor.py
+++ b/homeassistant/components/tuya/binary_sensor.py
@@ -28,7 +28,7 @@ class BitTest:
     """BitTest is used to encode the "on_value" for one bit in a bitmask.
 
     The mask is used to isolate the bit that should be
-    tested. By default 1 means "on" and 0 means "off", but setting the
+    tested. By default, 1 means "on" and 0 means "off", but setting the
     bit in xmask flips it so that 1 means "off" and 0 means "on".
     """
 

--- a/homeassistant/components/tuya/const.py
+++ b/homeassistant/components/tuya/const.py
@@ -87,6 +87,7 @@ class DPType(StrEnum):
     JSON = "Json"
     RAW = "Raw"
     STRING = "String"
+    BITMAP = "Bitmap"
 
 
 class DPCode(StrEnum):

--- a/homeassistant/components/tuya/entity.py
+++ b/homeassistant/components/tuya/entity.py
@@ -18,8 +18,8 @@ from .const import DOMAIN, LOGGER, TUYA_HA_SIGNAL_UPDATE_ENTITY, DPCode, DPType
 from .util import remap_value
 
 _DPTYPE_MAPPING: dict[str, DPType] = {
-    "Bitmap": DPType.RAW,
-    "bitmap": DPType.RAW,
+    "Bitmap": DPType.BITMAP,
+    "bitmap": DPType.BITMAP,
     "bool": DPType.BOOLEAN,
     "enum": DPType.ENUM,
     "json": DPType.JSON,

--- a/homeassistant/components/tuya/strings.json
+++ b/homeassistant/components/tuya/strings.json
@@ -56,6 +56,15 @@
       },
       "tilt": {
         "name": "Tilt"
+      },
+      "tankfull": {
+        "name": "Tank full"
+      },
+      "defrost": {
+        "name": "Defrost"
+      },
+      "wet": {
+        "name": "Wet"
       }
     },
     "button": {

--- a/tests/components/tuya/conftest.py
+++ b/tests/components/tuya/conftest.py
@@ -68,3 +68,26 @@ def mock_tuya_login_control() -> Generator[MagicMock]:
             },
         )
         yield login_control
+
+
+@pytest.fixture
+def mock_tuya_device() -> Generator[MagicMock]:
+    """Return a mocked Tuya device."""
+    with patch("tuya_sharing.CustomerDevice", autospec=True) as device_mock:
+        device = device_mock.return_value
+        # Meaningless UUIDs
+        device.id = "20b86c73-21d9-46de-81a4-9c06e4d9666b"
+        device.name = "c6065fba-eef6-48cc-a00d-113fa673ff98"
+        device.product_name = "f89c1e61-bf9e-46a0-aff0-7c749c405dfa"
+        device.product_id = "bd9ee8fe-e0dd-42f8-b3ce-8c8fad984fda"
+        yield device
+
+
+@pytest.fixture
+def mock_tuya_manager() -> Generator[MagicMock]:
+    """Return a mocked Tuya manager."""
+    with patch("tuya_sharing.Manager", autospec=True) as manager_mock:
+        manager = manager_mock.return_value
+        # Meaningless UUIDs
+        manager.terminal_id = "7cd96aff-6ec8-4006-b093-3dbff7947591"
+        yield manager

--- a/tests/components/tuya/test_binary_sensor.py
+++ b/tests/components/tuya/test_binary_sensor.py
@@ -1,0 +1,106 @@
+"""Tests for Tuya binary sensor platform."""
+
+from unittest.mock import Mock
+
+from tuya_sharing import DeviceStatusRange
+
+from homeassistant.components.tuya.binary_sensor import generate_binary_sensor_entities
+
+
+async def test_dehumidifier_binary_sensors(
+    mock_tuya_device: Mock, mock_tuya_manager: Mock
+) -> None:
+    """Test dehumidifier binary sensor."""
+    mock_tuya_device.category = "cs"
+    mock_tuya_device.status = {
+        "switch": True,
+        "dehumidify_set_value": 60,
+        "child_lock": False,
+        "humidity_indoor": 52,
+        "countdown_set": "cancel",
+        "countdown_left": 0,
+        "fault": 0,
+    }
+    mock_tuya_device.status_range = {
+        "switch": DeviceStatusRange(code="switch", type="Boolean", values="{}"),
+        "dehumidify_set_value": DeviceStatusRange(
+            code="dehumidify_set_value",
+            type="Integer",
+            values='{"unit":"%","min":35,"max":70,"scale":0,"step":5}',
+        ),
+        "child_lock": DeviceStatusRange(code="child_lock", type="Boolean", values="{}"),
+        "humidity_indoor": DeviceStatusRange(
+            code="humidity_indoor",
+            type="Integer",
+            values='{"unit":"%","min":0,"max":100,"scale":0,"step":1}',
+        ),
+        "countdown_set": DeviceStatusRange(
+            code="countdown_set",
+            type="Enum",
+            values='{"range":["cancel","1h","2h","3h"]}',
+        ),
+        "countdown_left": DeviceStatusRange(
+            code="countdown_left",
+            type="Integer",
+            values='{"unit":"h","min":0,"max":24,"scale":0,"step":1}',
+        ),
+        "fault": DeviceStatusRange(
+            code="fault",
+            type="Bitmap",
+            values='{"label":["tankfull","defrost","E1","E2","L2","L3","L4","wet"]}',
+        ),
+    }
+
+    entities = list(
+        generate_binary_sensor_entities(mock_tuya_device, mock_tuya_manager)
+    )
+    assert entities[0].entity_description.name == "tankfull"
+    assert not entities[0].is_on
+    assert entities[1].entity_description.name == "defrost"
+    assert not entities[1].is_on
+    assert entities[2].entity_description.name == "wet"
+    assert not entities[2].is_on
+
+    mock_tuya_device.status["fault"] = 0x1
+    entities = list(
+        generate_binary_sensor_entities(mock_tuya_device, mock_tuya_manager)
+    )
+    assert entities[0].entity_description.name == "tankfull"
+    assert entities[0].is_on
+    assert entities[1].entity_description.name == "defrost"
+    assert not entities[1].is_on
+    assert entities[2].entity_description.name == "wet"
+    assert not entities[2].is_on
+
+    mock_tuya_device.status["fault"] = 0x2
+    entities = list(
+        generate_binary_sensor_entities(mock_tuya_device, mock_tuya_manager)
+    )
+    assert entities[0].entity_description.name == "tankfull"
+    assert not entities[0].is_on
+    assert entities[1].entity_description.name == "defrost"
+    assert entities[1].is_on
+    assert entities[2].entity_description.name == "wet"
+    assert not entities[2].is_on
+
+    mock_tuya_device.status["fault"] = 0x80
+    entities = list(
+        generate_binary_sensor_entities(mock_tuya_device, mock_tuya_manager)
+    )
+    assert entities[0].entity_description.name == "tankfull"
+    assert not entities[0].is_on
+    assert entities[1].entity_description.name == "defrost"
+    assert not entities[1].is_on
+    assert entities[2].entity_description.name == "wet"
+    assert entities[2].is_on
+
+    mock_tuya_device.status["fault"] = 0x83
+    entities = list(
+        generate_binary_sensor_entities(mock_tuya_device, mock_tuya_manager)
+    )
+    assert entities[0].entity_description.name == "tankfull"
+    assert entities[0].is_on
+    assert entities[1].entity_description.name == "defrost"
+    assert entities[1].is_on
+    assert entities[2].entity_description.name == "wet"
+    assert entities[2].is_on


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

I have a [Meaco Arete Two dehumidifier](https://www.meaco.com/products/meacodry-arete-two-12l-dual-dehumidifier-hepa-air-purifier). This PR enables home assistant to detect when the water tank is full.

There is some discussion of the Meaco Arete Two [here](https://community.home-assistant.io/t/meacodry-arete-two-18l-dehumidifier-support/783710), which is where I learned that it uses Tuya. But after setting up the Tuya integration, I discovered that it couldn't read the "tank full" status, which is the main thing that I want to do. On further investigation, I discovered that the "tank full" is reported using the Bitmap type, which isn't currently supported by the Tuya integration. So the main contribution of this PR to add support for Bitmaps.

I don't think a Bitmap datatype would be convenient in home assistant because then the user would have to do bit twiddling to extract the information that they want. So I've set it up so that every bit that you're interested in gets converted into a separate binary sensor.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
