### PR TITLE
Fix broken issue creation in econet

### DIFF
--- a/homeassistant/components/econet/climate.py
+++ b/homeassistant/components/econet/climate.py
@@ -23,7 +23,7 @@ from homeassistant.components.climate import (
 from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
-from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
+from homeassistant.helpers.issue_registry import IssueSeverity, create_issue
 
 from . import EconetConfigEntry
 from .const import DOMAIN
@@ -209,46 +209,30 @@ class EcoNetThermostat(EcoNetEntity[Thermostat], ClimateEntity):
 
     def turn_aux_heat_on(self) -> None:
         """Turn auxiliary heater on."""
-        # Ensure async_create_issue runs in the event loop
-        async def create_issue():
-            # Call async_create_issue without awaiting
-            async_create_issue(
-                self.hass,
-                DOMAIN,
-                "migrate_aux_heat",
-                breaks_in_ha_version="2025.4.0",
-                is_fixable=True,
-                is_persistent=True,
-                translation_key="migrate_aux_heat",
-                severity=IssueSeverity.WARNING,
-            )
-
-        # Schedule the async task
-        self.hass.loop.call_soon_threadsafe(lambda: self.hass.async_create_task(create_issue()))
-
-        # Set the heater mode
+        create_issue(
+            self.hass,
+            DOMAIN,
+            "migrate_aux_heat",
+            breaks_in_ha_version="2025.4.0",
+            is_fixable=True,
+            is_persistent=True,
+            translation_key="migrate_aux_heat",
+            severity=IssueSeverity.WARNING,
+        )
         self._econet.set_mode(ThermostatOperationMode.EMERGENCY_HEAT)
 
     def turn_aux_heat_off(self) -> None:
         """Turn auxiliary heater off."""
-        # Ensure async_create_issue runs in the event loop
-        async def create_issue():
-            # Call async_create_issue without awaiting
-            async_create_issue(
-                self.hass,
-                DOMAIN,
-                "migrate_aux_heat",
-                breaks_in_ha_version="2025.4.0",
-                is_fixable=True,
-                is_persistent=True,
-                translation_key="migrate_aux_heat",
-                severity=IssueSeverity.WARNING,
-            )
-
-        # Schedule the async task
-        self.hass.loop.call_soon_threadsafe(lambda: self.hass.async_create_task(create_issue()))
-
-        # Set the heater mode
+        create_issue(
+            self.hass,
+            DOMAIN,
+            "migrate_aux_heat",
+            breaks_in_ha_version="2025.4.0",
+            is_fixable=True,
+            is_persistent=True,
+            translation_key="migrate_aux_heat",
+            severity=IssueSeverity.WARNING,
+        )
         self._econet.set_mode(ThermostatOperationMode.HEATING)
 
     @property

--- a/homeassistant/components/econet/climate.py
+++ b/homeassistant/components/econet/climate.py
@@ -209,30 +209,46 @@ class EcoNetThermostat(EcoNetEntity[Thermostat], ClimateEntity):
 
     def turn_aux_heat_on(self) -> None:
         """Turn auxiliary heater on."""
-        async_create_issue(
-            self.hass,
-            DOMAIN,
-            "migrate_aux_heat",
-            breaks_in_ha_version="2025.4.0",
-            is_fixable=True,
-            is_persistent=True,
-            translation_key="migrate_aux_heat",
-            severity=IssueSeverity.WARNING,
-        )
+        # Ensure async_create_issue runs in the event loop
+        async def create_issue():
+            # Call async_create_issue without awaiting
+            async_create_issue(
+                self.hass,
+                DOMAIN,
+                "migrate_aux_heat",
+                breaks_in_ha_version="2025.4.0",
+                is_fixable=True,
+                is_persistent=True,
+                translation_key="migrate_aux_heat",
+                severity=IssueSeverity.WARNING,
+            )
+
+        # Schedule the async task
+        self.hass.loop.call_soon_threadsafe(lambda: self.hass.async_create_task(create_issue()))
+
+        # Set the heater mode
         self._econet.set_mode(ThermostatOperationMode.EMERGENCY_HEAT)
 
     def turn_aux_heat_off(self) -> None:
         """Turn auxiliary heater off."""
-        async_create_issue(
-            self.hass,
-            DOMAIN,
-            "migrate_aux_heat",
-            breaks_in_ha_version="2025.4.0",
-            is_fixable=True,
-            is_persistent=True,
-            translation_key="migrate_aux_heat",
-            severity=IssueSeverity.WARNING,
-        )
+        # Ensure async_create_issue runs in the event loop
+        async def create_issue():
+            # Call async_create_issue without awaiting
+            async_create_issue(
+                self.hass,
+                DOMAIN,
+                "migrate_aux_heat",
+                breaks_in_ha_version="2025.4.0",
+                is_fixable=True,
+                is_persistent=True,
+                translation_key="migrate_aux_heat",
+                severity=IssueSeverity.WARNING,
+            )
+
+        # Schedule the async task
+        self.hass.loop.call_soon_threadsafe(lambda: self.hass.async_create_task(create_issue()))
+
+        # Set the heater mode
         self._econet.set_mode(ThermostatOperationMode.HEATING)
 
     @property


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When econet aux_heat property is toggled (which should turn on emergency heat), there's an error related to the issue raising code added to warn about deprecation:

```
File "/srv/homeassistant/lib/python3.13/site-packages/homeassistant/helpers/frame.py", line 340, in _report_integration_frame
    raise RuntimeError(
    ...<5 lines>...
    )
RuntimeError: Detected that integration 'econet' calls issue_registry.async_get_or_create from a thread other than the event loop, which may cause Home Assistant to crash or data to corrupt. For more information, see https://developers.home-assistant.io/docs/asyncio_thread_safety/#issue_registryasync_get_or_create at homeassistant/components/econet/climate.py, line 213: async_create_issue(. Please create a bug report at https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue+label%3A%22integration%3A+econet%22
```
This issue was introduced by a7a219b. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #137772
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
