### PR TITLE
Use the external URL set in Settings > System > Network if my is disabled as redirect URL for Google Drive instructions

### DIFF
--- a/homeassistant/components/google_drive/application_credentials.py
+++ b/homeassistant/components/google_drive/application_credentials.py
@@ -2,7 +2,10 @@
 
 from homeassistant.components.application_credentials import AuthorizationServer
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import config_entry_oauth2_flow
+from homeassistant.helpers.config_entry_oauth2_flow import (
+    AUTH_CALLBACK_PATH,
+    MY_AUTH_CALLBACK_PATH,
+)
 
 
 async def async_get_authorization_server(hass: HomeAssistant) -> AuthorizationServer:
@@ -15,9 +18,16 @@ async def async_get_authorization_server(hass: HomeAssistant) -> AuthorizationSe
 
 async def async_get_description_placeholders(hass: HomeAssistant) -> dict[str, str]:
     """Return description placeholders for the credentials dialog."""
+    redirect_url = (
+        MY_AUTH_CALLBACK_PATH
+        if "my" in hass.config.components
+        else f"{hass.config.external_url}{AUTH_CALLBACK_PATH}"
+        if hass.config.external_url
+        else "N/A"
+    )
     return {
         "oauth_consent_url": "https://console.cloud.google.com/apis/credentials/consent",
         "more_info_url": "https://www.home-assistant.io/integrations/google_drive/",
         "oauth_creds_url": "https://console.cloud.google.com/apis/credentials",
-        "redirect_url": config_entry_oauth2_flow.async_get_redirect_uri(hass),
+        "redirect_url": redirect_url,
     }

--- a/homeassistant/components/google_drive/application_credentials.py
+++ b/homeassistant/components/google_drive/application_credentials.py
@@ -18,13 +18,11 @@ async def async_get_authorization_server(hass: HomeAssistant) -> AuthorizationSe
 
 async def async_get_description_placeholders(hass: HomeAssistant) -> dict[str, str]:
     """Return description placeholders for the credentials dialog."""
-    redirect_url = (
-        MY_AUTH_CALLBACK_PATH
-        if "my" in hass.config.components
-        else f"{hass.config.external_url}{AUTH_CALLBACK_PATH}"
-        if hass.config.external_url
-        else "N/A"
-    )
+    if "my" in hass.config.components:
+        redirect_url = MY_AUTH_CALLBACK_PATH
+    else:
+        ha_host = hass.config.external_url or "https://YOUR_DOMAIN:PORT"
+        redirect_url = f"{ha_host}{AUTH_CALLBACK_PATH}"
     return {
         "oauth_consent_url": "https://console.cloud.google.com/apis/credentials/consent",
         "more_info_url": "https://www.home-assistant.io/integrations/google_drive/",

--- a/homeassistant/helpers/config_entry_oauth2_flow.py
+++ b/homeassistant/helpers/config_entry_oauth2_flow.py
@@ -62,13 +62,7 @@ def async_get_redirect_uri(hass: HomeAssistant) -> str:
         return MY_AUTH_CALLBACK_PATH
 
     if (req := http.current_request.get()) is None:
-        if hass.config.external_url is None:
-            raise RuntimeError(
-                "'my' integration disabled, no current request in context, and "
-                "no Home Assistant URL set in Settings > System > Network. "
-                "Either enable the 'my' integration or set the external URL."
-            )
-        return f"{hass.config.external_url}{AUTH_CALLBACK_PATH}"
+        raise RuntimeError("No current request in context")
 
     if (ha_host := req.headers.get(HEADER_FRONTEND_BASE)) is None:
         raise RuntimeError("No header in request")

--- a/homeassistant/helpers/config_entry_oauth2_flow.py
+++ b/homeassistant/helpers/config_entry_oauth2_flow.py
@@ -62,7 +62,13 @@ def async_get_redirect_uri(hass: HomeAssistant) -> str:
         return MY_AUTH_CALLBACK_PATH
 
     if (req := http.current_request.get()) is None:
-        raise RuntimeError("No current request in context")
+        if hass.config.external_url is None:
+            raise RuntimeError(
+                "'my' integration disabled, no current request in context, and "
+                "no Home Assistant URL set in Settings > System > Network. "
+                "Either enable the 'my' integration or set the external URL."
+            )
+        return f"{hass.config.external_url}{AUTH_CALLBACK_PATH}"
 
     if (ha_host := req.headers.get(HEADER_FRONTEND_BASE)) is None:
         raise RuntimeError("No header in request")

--- a/tests/components/google_drive/test_application_credentials.py
+++ b/tests/components/google_drive/test_application_credentials.py
@@ -1,0 +1,36 @@
+"""Test the Google Drive application_credentials."""
+
+import pytest
+
+from homeassistant import setup
+from homeassistant.components.google_drive.application_credentials import (
+    async_get_description_placeholders,
+)
+from homeassistant.core import HomeAssistant
+
+
+@pytest.mark.parametrize(
+    ("additional_components", "external_url", "expected_redirect_uri"),
+    [
+        ([], "https://example.com", "https://example.com/auth/external/callback"),
+        ([], None, "https://YOUR_DOMAIN:PORT/auth/external/callback"),
+        (["my"], "https://example.com", "https://my.home-assistant.io/redirect/oauth"),
+    ],
+)
+async def test_description_placeholders(
+    hass: HomeAssistant,
+    additional_components: list[str],
+    external_url: str | None,
+    expected_redirect_uri: str,
+) -> None:
+    """Test description placeholders."""
+    for component in additional_components:
+        assert await setup.async_setup_component(hass, component, {})
+    hass.config.external_url = external_url
+    placeholders = await async_get_description_placeholders(hass)
+    assert placeholders == {
+        "oauth_consent_url": "https://console.cloud.google.com/apis/credentials/consent",
+        "more_info_url": "https://www.home-assistant.io/integrations/google_drive/",
+        "oauth_creds_url": "https://console.cloud.google.com/apis/credentials",
+        "redirect_url": expected_redirect_uri,
+    }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Google Drive calls `config_entry_oauth2_flow.async_get_redirect_uri` to show the redirect URL users needs to setup.

https://github.com/home-assistant/core/blob/0e0129968bef32f35ccd1ad1bca55b22d4543bec/homeassistant/components/google_drive/application_credentials.py#L22

Unfortunately the context doesn't have a request to get the external URL from the header. Instead get it from the config.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #137491
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
