### PR TITLE
Fix heos migration

### DIFF
--- a/homeassistant/components/heos/__init__.py
+++ b/homeassistant/components/heos/__init__.py
@@ -44,9 +44,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: HeosConfigEntry) -> bool
             player_id = int(ident[1])  # type: ignore[unreachable]
 
             # Create set of identifiers excluding this integration
-            identifiers = {
-                ident for domain, identifier in device.identifiers if ident[0] != DOMAIN
-            }
+            identifiers = {ident for ident in device.identifiers if ident[0] != DOMAIN}
             migrated_identifiers = {(DOMAIN, str(player_id))}
             # Add migrated if not already present in another device, which occurs if the user downgraded and then upgraded
             if not device_registry.async_get_device(migrated_identifiers):

--- a/homeassistant/components/heos/__init__.py
+++ b/homeassistant/components/heos/__init__.py
@@ -37,24 +37,26 @@ async def async_setup_entry(hass: HomeAssistant, entry: HeosConfigEntry) -> bool
     for device in device_registry.devices.get_devices_for_config_entry_id(
         entry.entry_id
     ):
-        for domain, player_id in device.identifiers:
-            if domain == DOMAIN and not isinstance(player_id, str):
-                # Create set of identifiers excluding this integration
-                identifiers = {  # type: ignore[unreachable]
-                    (domain, identifier)
-                    for domain, identifier in device.identifiers
-                    if domain != DOMAIN
-                }
-                migrated_identifiers = {(DOMAIN, str(player_id))}
-                # Add migrated if not already present in another device, which occurs if the user downgraded and then upgraded
-                if not device_registry.async_get_device(migrated_identifiers):
-                    identifiers.update(migrated_identifiers)
-                if len(identifiers) > 0:
-                    device_registry.async_update_device(
-                        device.id, new_identifiers=identifiers
-                    )
-                else:
-                    device_registry.async_remove_device(device.id)
+        for ident in device.identifiers:
+            if ident[0] != DOMAIN or isinstance(ident[1], str):
+                continue
+
+            player_id = int(ident[1])  # type: ignore[unreachable]
+
+            # Create set of identifiers excluding this integration
+            identifiers = {
+                ident for domain, identifier in device.identifiers if ident[0] != DOMAIN
+            }
+            migrated_identifiers = {(DOMAIN, str(player_id))}
+            # Add migrated if not already present in another device, which occurs if the user downgraded and then upgraded
+            if not device_registry.async_get_device(migrated_identifiers):
+                identifiers.update(migrated_identifiers)
+            if len(identifiers) > 0:
+                device_registry.async_update_device(
+                    device.id, new_identifiers=identifiers
+                )
+            else:
+                device_registry.async_remove_device(device.id)
             break
 
     coordinator = HeosCoordinator(hass, entry)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The HEOS migration would not work if device had 2 identifiers and the order was wrong, because the break was 1 level too high. This fixes that, which fixes the flakiness (read: fails 99%) of this test as the order of identifiers no longer matters.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
