### PR TITLE
Enhancements to `flick_electric` integration

### DIFF
--- a/homeassistant/components/flick_electric/diagnostics.py
+++ b/homeassistant/components/flick_electric/diagnostics.py
@@ -1,0 +1,25 @@
+"""Diagnostics for the Flick Electric integration."""
+
+from typing import Any
+
+from homeassistant.const import CONF_CLIENT_SECRET, CONF_PASSWORD
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.redact import async_redact_data
+
+from .coordinator import FlickConfigEntry
+
+TO_REDACT = [
+    CONF_PASSWORD,
+    CONF_CLIENT_SECRET,
+]
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: FlickConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+
+    return {
+        "entry_data": async_redact_data(entry.data, TO_REDACT),
+        "data": entry.runtime_data.data,
+    }

--- a/homeassistant/components/flick_electric/icons.json
+++ b/homeassistant/components/flick_electric/icons.json
@@ -1,0 +1,9 @@
+{
+  "entity": {
+    "sensor": {
+      "power_price": {
+        "default": "mdi:currency-usd"
+      }
+    }
+  }
+}

--- a/homeassistant/components/flick_electric/quality_scale.yaml
+++ b/homeassistant/components/flick_electric/quality_scale.yaml
@@ -36,8 +36,8 @@ rules:
     comment: |
       This integration does not have any service actions.
   config-entry-unloading:
-    status: todo
-    comment: Can this be automatic via the coordinator?
+    status: done
+    comment: Handled by the coordinator
   docs-configuration-parameters:
     status: exempt
     comment: No options to configure

--- a/homeassistant/components/flick_electric/quality_scale.yaml
+++ b/homeassistant/components/flick_electric/quality_scale.yaml
@@ -1,0 +1,72 @@
+rules:
+  config-flow: done
+  test-before-configure: done
+  unique-config-entry: done
+  config-flow-test-coverage: done
+  runtime-data: done
+  test-before-setup: done
+  appropriate-polling: done
+  entity-unique-id: done
+  has-entity-name: done
+  entity-event-setup:
+    status: exempt
+    comment: does not use events
+  dependency-transparency: done
+  action-setup:
+    status: exempt
+    comment: no service actions
+  common-modules: done
+  docs-high-level-description: done
+  docs-installation-instructions: done
+  docs-removal-instructions:
+    status: todo
+    comment: Add removal instructions
+  docs-actions:
+    status: exempt
+    comment: no service actions
+  brands: done
+  config-entry-unloading:
+    status: todo
+    comment: Can this be automatic via the coordinator?
+  log-when-unavailable: done
+  entity-unavailable: done
+  action-exceptions:
+    status: exempt
+    comment: no service actions
+  reauthentication-flow: done
+  parallel-updates: done
+  test-coverage:
+    status: todo
+    comment: We are close to the goal of 95%
+  integration-owner: done
+  docs-installation-parameters:
+    status: todo
+    comment: Add the proper configuration_basic block
+  docs-configuration-parameters:
+    status: exempt
+    comment: No configuration parameters
+  entity-translations: done
+  entity-device-class:
+    status: exempt
+    comment: No applicable device class
+  devices:
+    status: todo
+    comment: Add device
+  entity-category: done
+  entity-disabled-by-default:
+    status: exempt
+    comment: No entities
+  discovery:
+    status: exempt
+    comment: Cannot be discovered
+  stale-devices:
+    status: exempt
+    comment: No devices
+  diagnostics: done
+  exception-translations:
+    status: exempt
+    comment: No service exceptions
+  icon-translations: done
+  reconfiguration-flow:
+    status: todo
+    comment: Add reconfiguration flow

--- a/homeassistant/components/flick_electric/quality_scale.yaml
+++ b/homeassistant/components/flick_electric/quality_scale.yaml
@@ -53,9 +53,7 @@ rules:
     comment: Handled by the coordinator
   parallel-updates: done
   reauthentication-flow: done
-  test-coverage:
-    status: todo
-    comment: We are close to the goal of 95%
+  test-coverage: done
 
   # Gold
   devices:

--- a/homeassistant/components/flick_electric/quality_scale.yaml
+++ b/homeassistant/components/flick_electric/quality_scale.yaml
@@ -1,68 +1,110 @@
 rules:
-  config-flow: done
-  test-before-configure: done
-  unique-config-entry: done
-  config-flow-test-coverage: done
-  runtime-data: done
-  test-before-setup: done
-  appropriate-polling: done
-  entity-unique-id: done
-  has-entity-name: done
-  entity-event-setup:
-    status: exempt
-    comment: does not use events
-  dependency-transparency: done
+  # Bronze
   action-setup:
     status: exempt
-    comment: no service actions
+    comment: |
+      This integration does not have any service actions.
+  appropriate-polling: done
+  brands: done
   common-modules: done
+  config-flow-test-coverage: done
+  config-flow: done
+  dependency-transparency: done
+  docs-actions:
+    status: exempt
+    comment: |
+      This integration does not have any service actions.
   docs-high-level-description: done
   docs-installation-instructions: done
   docs-removal-instructions:
     status: todo
     comment: Add removal instructions
-  docs-actions:
+  entity-event-setup:
     status: exempt
-    comment: no service actions
-  brands: done
+    comment: |
+      Entities of this integration do not explicitly subscribe to events.
+  entity-unique-id: done
+  has-entity-name: done
+  runtime-data: done
+  test-before-configure: done
+  test-before-setup: done
+  unique-config-entry: done
+
+  # Silver
+  action-exceptions:
+    status: exempt
+    comment: |
+      This integration does not have any service actions.
   config-entry-unloading:
     status: todo
     comment: Can this be automatic via the coordinator?
-  log-when-unavailable: done
-  entity-unavailable: done
-  action-exceptions:
+  docs-configuration-parameters:
     status: exempt
-    comment: no service actions
-  reauthentication-flow: done
-  parallel-updates: done
-  test-coverage:
-    status: todo
-    comment: We are close to the goal of 95%
-  integration-owner: done
+    comment: No options to configure
   docs-installation-parameters:
     status: todo
     comment: Add the proper configuration_basic block
-  docs-configuration-parameters:
-    status: exempt
-    comment: No configuration parameters
-  entity-translations: done
-  entity-device-class:
-    status: exempt
-    comment: No applicable device class
+  entity-unavailable:
+    status: done
+    comment: Handled by the coordinator
+  integration-owner: done
+  log-when-unavailable:
+    status: done
+    comment: Handled by the coordinator
+  parallel-updates: done
+  reauthentication-flow: done
+  test-coverage:
+    status: todo
+    comment: We are close to the goal of 95%
+
+  # Gold
   devices:
     status: todo
     comment: Add device
-  entity-category: done
-  entity-disabled-by-default:
+  diagnostics: done
+  discovery-update-info:
     status: exempt
-    comment: No entities
+    comment: |
+      This integration does not support discovery.
   discovery:
     status: exempt
-    comment: Cannot be discovered
-  stale-devices:
+    comment: |
+      This integration does not support discovery.
+  docs-data-update:
+    status: todo
+    comment: Add docs
+  docs-examples:
+    status: todo
+    comment: Add docs
+  docs-known-limitations:
+    status: todo
+    comment: Add docs
+  docs-supported-devices:
+    status: todo
+    comment: Add docs
+  docs-supported-functions:
+    status: todo
+    comment: Add docs
+  docs-troubleshooting:
+    status: todo
+    comment: Add docs
+  docs-use-cases:
+    status: todo
+    comment: Add docs
+  dynamic-devices:
     status: exempt
-    comment: No devices
-  diagnostics: done
+    comment: |
+      This integration has a fixed single device.
+  entity-category: done
+  entity-device-class:
+    status: exempt
+    comment: |
+      This integration has no relevant device class to use.
+  entity-disabled-by-default:
+    status: exempt
+    comment: |
+      This integration has no unpopular entities to disable.
+  entity-translations: done
   exception-translations:
     status: exempt
     comment: No service exceptions
@@ -70,3 +112,17 @@ rules:
   reconfiguration-flow:
     status: todo
     comment: Add reconfiguration flow
+  repair-issues:
+    status: exempt
+    comment: |
+      This integration doesn't have any cases where raising an issue is needed.
+  stale-devices:
+    status: exempt
+    comment: |
+      This integration has a fixed single device.
+
+  # Platinum
+  async-dependency: done
+  inject-websession: done
+  strict-typing:
+    status: todo

--- a/homeassistant/components/flick_electric/quality_scale.yaml
+++ b/homeassistant/components/flick_electric/quality_scale.yaml
@@ -16,9 +16,7 @@ rules:
       This integration does not have any service actions.
   docs-high-level-description: done
   docs-installation-instructions: done
-  docs-removal-instructions:
-    status: todo
-    comment: Add removal instructions
+  docs-removal-instructions: done
   entity-event-setup:
     status: exempt
     comment: |
@@ -41,9 +39,7 @@ rules:
   docs-configuration-parameters:
     status: exempt
     comment: No options to configure
-  docs-installation-parameters:
-    status: todo
-    comment: Add the proper configuration_basic block
+  docs-installation-parameters: done
   entity-unavailable:
     status: done
     comment: Handled by the coordinator
@@ -68,27 +64,19 @@ rules:
     status: exempt
     comment: |
       This integration does not support discovery.
-  docs-data-update:
-    status: todo
-    comment: Add docs
-  docs-examples:
-    status: todo
-    comment: Add docs
+  docs-data-update: done
+  docs-examples: done
   docs-known-limitations:
-    status: todo
-    comment: Add docs
+    status: exempt
+    comment: |
+      This integration has no known limitations.
   docs-supported-devices:
-    status: todo
-    comment: Add docs
-  docs-supported-functions:
-    status: todo
-    comment: Add docs
-  docs-troubleshooting:
-    status: todo
-    comment: Add docs
-  docs-use-cases:
-    status: todo
-    comment: Add docs
+    status: exempt
+    comment: |
+      This is an service, which doesn't integrate with any devices.
+  docs-supported-functions: done
+  docs-troubleshooting: done
+  docs-use-cases: done
   dynamic-devices:
     status: exempt
     comment: |

--- a/homeassistant/components/flick_electric/sensor.py
+++ b/homeassistant/components/flick_electric/sensor.py
@@ -16,6 +16,7 @@ from .coordinator import FlickConfigEntry, FlickElectricDataCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 SCAN_INTERVAL = timedelta(minutes=5)
+PARALLEL_UPDATES = 0
 
 
 async def async_setup_entry(

--- a/homeassistant/components/flick_electric/strings.json
+++ b/homeassistant/components/flick_electric/strings.json
@@ -8,12 +8,21 @@
           "password": "[%key:common::config_flow::data::password%]",
           "client_id": "Client ID (optional)",
           "client_secret": "Client Secret (optional)"
+        },
+        "data_description": {
+          "username": "Username used to login to Flick Electric",
+          "password": "Password used to login to Flick Electric",
+          "client_id": "Client ID (defaults to one used by Mobile App)",
+          "client_secret": "Client Secret (defaults to one used by Mobile App)"
         }
       },
       "select_account": {
         "title": "Select account",
         "data": {
           "account_id": "Account"
+        },
+        "data_description": {
+          "account_id": "Select the account to get pricing for"
         }
       }
     },

--- a/script/hassfest/quality_scale.py
+++ b/script/hassfest/quality_scale.py
@@ -393,7 +393,6 @@ INTEGRATIONS_WITHOUT_QUALITY_SCALE_FILE = [
     "flexit",
     "flexit_bacnet",
     "flic",
-    "flick_electric",
     "flipr",
     "flo",
     "flock",

--- a/tests/components/flick_electric/__init__.py
+++ b/tests/components/flick_electric/__init__.py
@@ -7,6 +7,9 @@ from homeassistant.components.flick_electric.const import (
     CONF_SUPPLY_NODE_REF,
 )
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
 
 CONF = {
     CONF_USERNAME: "test-username",
@@ -14,6 +17,14 @@ CONF = {
     CONF_ACCOUNT_ID: "1234",
     CONF_SUPPLY_NODE_REF: "123",
 }
+
+
+async def setup_integration(hass: HomeAssistant, config_entry: MockConfigEntry) -> None:
+    """Fixture for setting up the component."""
+    config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
 
 
 def _mock_flick_price():

--- a/tests/components/flick_electric/__init__.py
+++ b/tests/components/flick_electric/__init__.py
@@ -12,10 +12,10 @@ from homeassistant.core import HomeAssistant
 from tests.common import MockConfigEntry
 
 CONF = {
-    CONF_USERNAME: "test-username",
+    CONF_USERNAME: "9973debf-963f-49b0-9a73-ba9c3400cbed@anonymised.example.com",
     CONF_PASSWORD: "test-password",
-    CONF_ACCOUNT_ID: "1234",
-    CONF_SUPPLY_NODE_REF: "123",
+    CONF_ACCOUNT_ID: "134800",
+    CONF_SUPPLY_NODE_REF: "/network/nz/supply_nodes/ed7617df-4b10-4c8a-a05d-deadbeef8299",
 }
 
 

--- a/tests/components/flick_electric/conftest.py
+++ b/tests/components/flick_electric/conftest.py
@@ -7,7 +7,8 @@ import json_api_doc
 from pyflick import FlickPrice
 import pytest
 
-from homeassistant.components.flick_electric.const import DOMAIN
+from homeassistant.components.flick_electric.const import CONF_ACCOUNT_ID, DOMAIN
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 
 from . import CONF
 
@@ -23,7 +24,22 @@ def mock_config_entry() -> MockConfigEntry:
         data={**CONF},
         version=2,
         entry_id="974e52a5c0724d17b7ed876dd6ff4bc8",
-        unique_id="10123404",
+        unique_id=CONF[CONF_ACCOUNT_ID],
+    )
+
+
+@pytest.fixture
+def mock_old_config_entry() -> MockConfigEntry:
+    """Mock an outdated config entry."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_USERNAME: CONF[CONF_USERNAME],
+            CONF_PASSWORD: CONF[CONF_PASSWORD],
+        },
+        title=CONF[CONF_USERNAME],
+        unique_id=CONF[CONF_USERNAME],
+        version=1,
     )
 
 
@@ -38,6 +54,10 @@ def mock_flick_client() -> Generator[AsyncMock]:
         patch(
             "homeassistant.components.flick_electric.config_flow.FlickAPI",
             new=mock_api,
+        ),
+        patch(
+            "homeassistant.components.flick_electric.config_flow.SimpleFlickAuth.async_get_access_token",
+            return_value="123456789abcdef",
         ),
     ):
         api = mock_api.return_value
@@ -65,6 +85,10 @@ def mock_flick_client_multiple() -> Generator[AsyncMock]:
         patch(
             "homeassistant.components.flick_electric.config_flow.FlickAPI",
             new=mock_api,
+        ),
+        patch(
+            "homeassistant.components.flick_electric.config_flow.SimpleFlickAuth.async_get_access_token",
+            return_value="123456789abcdef",
         ),
     ):
         api = mock_api.return_value

--- a/tests/components/flick_electric/conftest.py
+++ b/tests/components/flick_electric/conftest.py
@@ -1,0 +1,69 @@
+"""Flick Electric tests configuration."""
+
+from collections.abc import Generator
+from unittest.mock import AsyncMock, patch
+
+import json_api_doc
+from pyflick import FlickPrice
+import pytest
+
+from homeassistant.components.flick_electric.const import (
+    CONF_ACCOUNT_ID,
+    CONF_SUPPLY_NODE_REF,
+    DOMAIN,
+)
+from homeassistant.const import (
+    CONF_CLIENT_ID,
+    CONF_CLIENT_SECRET,
+    CONF_PASSWORD,
+    CONF_USERNAME,
+)
+
+from tests.common import MockConfigEntry, load_json_value_fixture
+
+
+@pytest.fixture
+def mock_config_entry() -> MockConfigEntry:
+    """Mock a config entry."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        title="123 Fake Street, Newtown, Wellington 6021",
+        data={
+            CONF_USERNAME: "9973debf-963f-49b0-9a73-ba9c3400cbed@anonymised.example.com",
+            CONF_PASSWORD: "test-password",
+            CONF_ACCOUNT_ID: "10123404",
+            CONF_SUPPLY_NODE_REF: "/network/nz/supply_nodes/ed7617df-4b10-4c8a-a05d-deadbeef8299",
+            CONF_CLIENT_ID: "test-client-id",
+            CONF_CLIENT_SECRET: "test-client-secret",
+        },
+        version=2,
+        entry_id="974e52a5c0724d17b7ed876dd6ff4bc8",
+        unique_id="10123404",
+    )
+
+
+@pytest.fixture
+def mock_flick_client() -> Generator[AsyncMock]:
+    """Mock an Overseerr client."""
+    with (
+        patch(
+            "homeassistant.components.flick_electric.FlickAPI",
+            autospec=True,
+        ) as mock_api,
+        patch(
+            "homeassistant.components.flick_electric.config_flow.FlickAPI",
+            new=mock_api,
+        ),
+    ):
+        api = mock_api.return_value
+
+        api.getCustomerAccounts.return_value = json_api_doc.deserialize(
+            load_json_value_fixture("accounts.json", DOMAIN)
+        )
+        api.getPricing.return_value = FlickPrice(
+            json_api_doc.deserialize(
+                load_json_value_fixture("rated_period.json", DOMAIN)
+            )
+        )
+
+        yield api

--- a/tests/components/flick_electric/conftest.py
+++ b/tests/components/flick_electric/conftest.py
@@ -7,17 +7,9 @@ import json_api_doc
 from pyflick import FlickPrice
 import pytest
 
-from homeassistant.components.flick_electric.const import (
-    CONF_ACCOUNT_ID,
-    CONF_SUPPLY_NODE_REF,
-    DOMAIN,
-)
-from homeassistant.const import (
-    CONF_CLIENT_ID,
-    CONF_CLIENT_SECRET,
-    CONF_PASSWORD,
-    CONF_USERNAME,
-)
+from homeassistant.components.flick_electric.const import DOMAIN
+
+from . import CONF
 
 from tests.common import MockConfigEntry, load_json_value_fixture
 
@@ -28,14 +20,7 @@ def mock_config_entry() -> MockConfigEntry:
     return MockConfigEntry(
         domain=DOMAIN,
         title="123 Fake Street, Newtown, Wellington 6021",
-        data={
-            CONF_USERNAME: "9973debf-963f-49b0-9a73-ba9c3400cbed@anonymised.example.com",
-            CONF_PASSWORD: "test-password",
-            CONF_ACCOUNT_ID: "10123404",
-            CONF_SUPPLY_NODE_REF: "/network/nz/supply_nodes/ed7617df-4b10-4c8a-a05d-deadbeef8299",
-            CONF_CLIENT_ID: "test-client-id",
-            CONF_CLIENT_SECRET: "test-client-secret",
-        },
+        data={**CONF},
         version=2,
         entry_id="974e52a5c0724d17b7ed876dd6ff4bc8",
         unique_id="10123404",
@@ -44,7 +29,7 @@ def mock_config_entry() -> MockConfigEntry:
 
 @pytest.fixture
 def mock_flick_client() -> Generator[AsyncMock]:
-    """Mock an Overseerr client."""
+    """Mock a Flick Electric client."""
     with (
         patch(
             "homeassistant.components.flick_electric.FlickAPI",
@@ -59,6 +44,33 @@ def mock_flick_client() -> Generator[AsyncMock]:
 
         api.getCustomerAccounts.return_value = json_api_doc.deserialize(
             load_json_value_fixture("accounts.json", DOMAIN)
+        )
+        api.getPricing.return_value = FlickPrice(
+            json_api_doc.deserialize(
+                load_json_value_fixture("rated_period.json", DOMAIN)
+            )
+        )
+
+        yield api
+
+
+@pytest.fixture
+def mock_flick_client_multiple() -> Generator[AsyncMock]:
+    """Mock a Flick Electric with multiple accounts."""
+    with (
+        patch(
+            "homeassistant.components.flick_electric.FlickAPI",
+            autospec=True,
+        ) as mock_api,
+        patch(
+            "homeassistant.components.flick_electric.config_flow.FlickAPI",
+            new=mock_api,
+        ),
+    ):
+        api = mock_api.return_value
+
+        api.getCustomerAccounts.return_value = json_api_doc.deserialize(
+            load_json_value_fixture("accounts_multi.json", DOMAIN)
         )
         api.getPricing.return_value = FlickPrice(
             json_api_doc.deserialize(

--- a/tests/components/flick_electric/fixtures/accounts.json
+++ b/tests/components/flick_electric/fixtures/accounts.json
@@ -1,0 +1,105 @@
+{
+  "data": [
+    {
+      "id": "134800",
+      "type": "customer_account",
+      "attributes": {
+        "account_number": "10123404",
+        "billing_name": "9973debf-963f-49b0-9a73-Ba9c3400cbed@Anonymised Example",
+        "billing_email": null,
+        "address": "123 Fake Street, Newtown, Wellington 6021",
+        "brand": "flick",
+        "vulnerability_state": "none",
+        "medical_dependency": false,
+        "status": "active",
+        "start_at": "2023-03-02T00:00:00.000+13:00",
+        "end_at": null,
+        "application_id": "5dfc4978-07de-4d18-8ef7-055603805ba6",
+        "active": true,
+        "on_join_journey": false,
+        "placeholder": false
+      },
+      "relationships": {
+        "user": {
+          "data": {
+            "id": "106676",
+            "type": "customer_user"
+          }
+        },
+        "sign_up": {
+          "data": {
+            "id": "877039",
+            "type": "customer_sign_up"
+          }
+        },
+        "main_customer": {
+          "data": {
+            "id": "108335",
+            "type": "customer_customer"
+          }
+        },
+        "main_consumer": {
+          "data": {
+            "id": "108291",
+            "type": "customer_icp_consumer"
+          }
+        },
+        "primary_contact": {
+          "data": {
+            "id": "121953",
+            "type": "customer_contact"
+          }
+        },
+        "default_payment_method": {
+          "data": {
+            "id": "602801",
+            "type": "customer_payment_method"
+          }
+        },
+        "phone_numbers": {
+          "data": [
+            {
+              "id": "111604",
+              "type": "customer_phone_number"
+            }
+          ]
+        },
+        "payment_methods": {
+          "data": [
+            {
+              "id": "602801",
+              "type": "customer_payment_method"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "included": [
+    {
+      "id": "108291",
+      "type": "customer_icp_consumer",
+      "attributes": {
+        "start_date": "2023-03-02",
+        "end_date": null,
+        "icp_number": "0001234567UNB12",
+        "supply_node_ref": "/network/nz/supply_nodes/ed7617df-4b10-4c8a-a05d-deadbeef8299",
+        "physical_address": "123 FAKE STREET,NEWTOWN,WELLINGTON,6021"
+      }
+    }
+  ],
+  "meta": {
+    "verb": "get",
+    "type": "customer_account",
+    "params": [],
+    "permission": {
+      "uri": "flick:customer_app:resource:account:list",
+      "data_context": null
+    },
+    "host": "https://api.flickuat.com",
+    "service": "customer",
+    "path": "/accounts",
+    "description": "Returns the accounts viewable by the current user",
+    "respond_with_array": true
+  }
+}

--- a/tests/components/flick_electric/fixtures/accounts_multi.json
+++ b/tests/components/flick_electric/fixtures/accounts_multi.json
@@ -1,0 +1,144 @@
+{
+  "data": [
+    {
+      "id": "134800",
+      "type": "customer_account",
+      "attributes": {
+        "account_number": "10123404",
+        "billing_name": "9973debf-963f-49b0-9a73-Ba9c3400cbed@Anonymised Example",
+        "billing_email": null,
+        "address": "123 Fake Street, Newtown, Wellington 6021",
+        "brand": "flick",
+        "vulnerability_state": "none",
+        "medical_dependency": false,
+        "status": "active",
+        "start_at": "2023-03-02T00:00:00.000+13:00",
+        "end_at": null,
+        "application_id": "5dfc4978-07de-4d18-8ef7-055603805ba6",
+        "active": true,
+        "on_join_journey": false,
+        "placeholder": false
+      },
+      "relationships": {
+        "user": {
+          "data": {
+            "id": "106676",
+            "type": "customer_user"
+          }
+        },
+        "sign_up": {
+          "data": {
+            "id": "877039",
+            "type": "customer_sign_up"
+          }
+        },
+        "main_customer": {
+          "data": {
+            "id": "108335",
+            "type": "customer_customer"
+          }
+        },
+        "main_consumer": {
+          "data": {
+            "id": "108291",
+            "type": "customer_icp_consumer"
+          }
+        },
+        "primary_contact": {
+          "data": {
+            "id": "121953",
+            "type": "customer_contact"
+          }
+        },
+        "default_payment_method": {
+          "data": {
+            "id": "602801",
+            "type": "customer_payment_method"
+          }
+        },
+        "phone_numbers": {
+          "data": [
+            {
+              "id": "111604",
+              "type": "customer_phone_number"
+            }
+          ]
+        },
+        "payment_methods": {
+          "data": [
+            {
+              "id": "602801",
+              "type": "customer_payment_method"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "123456",
+      "type": "customer_account",
+      "attributes": {
+        "account_number": "123123123",
+        "billing_name": "9973debf-963f-49b0-9a73-Ba9c3400cbed@Anonymised Example",
+        "billing_email": null,
+        "address": "456 Fake Street, Newtown, Wellington 6021",
+        "brand": "flick",
+        "vulnerability_state": "none",
+        "medical_dependency": false,
+        "status": "active",
+        "start_at": "2023-03-02T00:00:00.000+13:00",
+        "end_at": null,
+        "application_id": "5dfc4978-07de-4d18-8ef7-055603805ba6",
+        "active": true,
+        "on_join_journey": false,
+        "placeholder": false
+      },
+      "relationships": {
+        "main_consumer": {
+          "data": {
+            "id": "11223344",
+            "type": "customer_icp_consumer"
+          }
+        }
+      }
+    }
+  ],
+  "included": [
+    {
+      "id": "108291",
+      "type": "customer_icp_consumer",
+      "attributes": {
+        "start_date": "2023-03-02",
+        "end_date": null,
+        "icp_number": "0001234567UNB12",
+        "supply_node_ref": "/network/nz/supply_nodes/ed7617df-4b10-4c8a-a05d-deadbeef8299",
+        "physical_address": "123 FAKE STREET,NEWTOWN,WELLINGTON,6021"
+      }
+    },
+    {
+      "id": "11223344",
+      "type": "customer_icp_consumer",
+      "attributes": {
+        "start_date": "2023-03-02",
+        "end_date": null,
+        "icp_number": "9991234567UNB12",
+        "supply_node_ref": "/network/nz/supply_nodes/ed7617df-4b10-4c8a-a05d-deadbeef1234",
+        "physical_address": "456 FAKE STREET,NEWTOWN,WELLINGTON,6021"
+      }
+    }
+  ],
+  "meta": {
+    "verb": "get",
+    "type": "customer_account",
+    "params": [],
+    "permission": {
+      "uri": "flick:customer_app:resource:account:list",
+      "data_context": null
+    },
+    "host": "https://api.flickuat.com",
+    "service": "customer",
+    "path": "/accounts",
+    "description": "Returns the accounts viewable by the current user",
+    "respond_with_array": true
+  }
+}

--- a/tests/components/flick_electric/fixtures/rated_period.json
+++ b/tests/components/flick_electric/fixtures/rated_period.json
@@ -1,0 +1,112 @@
+{
+  "data": {
+    "id": "_2025-02-09 05:30:00 UTC..2025-02-09 05:59:59 UTC",
+    "type": "rating_rated_period",
+    "attributes": {
+      "start_at": "2025-02-09T05:30:00.000Z",
+      "end_at": "2025-02-09T05:59:59.000Z",
+      "status": "final",
+      "cost": "0.20011",
+      "import_cost": "0.20011",
+      "export_cost": null,
+      "cost_unit": "NZD",
+      "quantity": "1.0",
+      "import_quantity": "1.0",
+      "export_quantity": null,
+      "quantity_unit": "kwh",
+      "renewable_quantity": null,
+      "generation_price_contract": null
+    },
+    "relationships": {
+      "components": {
+        "data": [
+          {
+            "id": "213507464_1_kwh_generation_UN_24_default_2025-02-09 05:30:00 UTC..2025-02-09 05:59:59 UTC",
+            "type": "rating_component"
+          },
+          {
+            "id": "213507464_1_kwh_network_UN_24_offpeak_2025-02-09 05:30:00 UTC..2025-02-09 05:59:59 UTC",
+            "type": "rating_component"
+          }
+        ]
+      }
+    }
+  },
+  "included": [
+    {
+      "id": "213507464_1_kwh_generation_UN_24_default_2025-02-09 05:30:00 UTC..2025-02-09 05:59:59 UTC",
+      "type": "rating_component",
+      "attributes": {
+        "charge_method": "kwh",
+        "charge_setter": "generation",
+        "value": "0.20011",
+        "quantity": "1.0",
+        "unit_code": "NZD",
+        "charge_per": "kwh",
+        "flow_direction": "import",
+        "content_code": "UN",
+        "hours_of_availability": 24,
+        "channel_number": 1,
+        "meter_serial_number": "213507464",
+        "price_name": "default",
+        "applicable_periods": [],
+        "single_unit_price": "0.20011",
+        "billable": true,
+        "renewable_quantity": null,
+        "generation_price_contract": "FLICK_FLAT_2024_04_01_midpoint"
+      }
+    },
+    {
+      "id": "213507464_1_kwh_network_UN_24_offpeak_2025-02-09 05:30:00 UTC..2025-02-09 05:59:59 UTC",
+      "type": "rating_component",
+      "attributes": {
+        "charge_method": "kwh",
+        "charge_setter": "network",
+        "value": "0.0406",
+        "quantity": "1.0",
+        "unit_code": "NZD",
+        "charge_per": "kwh",
+        "flow_direction": "import",
+        "content_code": "UN",
+        "hours_of_availability": 24,
+        "channel_number": 1,
+        "meter_serial_number": "213507464",
+        "price_name": "offpeak",
+        "applicable_periods": [],
+        "single_unit_price": "0.0406",
+        "billable": false,
+        "renewable_quantity": null,
+        "generation_price_contract": "FLICK_FLAT_2024_04_01_midpoint"
+      }
+    }
+  ],
+  "meta": {
+    "verb": "get",
+    "type": "rating_rated_period",
+    "params": [
+      {
+        "name": "supply_node_ref",
+        "type": "String",
+        "description": "The supply node to rate",
+        "example": "/network/nz/supply_nodes/bccd6f52-448b-4edf-a0c1-459ee67d215b",
+        "required": true
+      },
+      {
+        "name": "as_at",
+        "type": "DateTime",
+        "description": "The time to rate the supply node at; defaults to the current time",
+        "example": "2023-04-01T15:20:15-07:00",
+        "required": false
+      }
+    ],
+    "permission": {
+      "uri": "flick:rating:resource:rated_period:show",
+      "data_context": "supply_node"
+    },
+    "host": "https://api.flickuat.com",
+    "service": "rating",
+    "path": "/rated_period",
+    "description": "Fetch a rated period for a supply node in a specific point in time",
+    "respond_with_array": false
+  }
+}

--- a/tests/components/flick_electric/snapshots/test_diagnostics.ambr
+++ b/tests/components/flick_electric/snapshots/test_diagnostics.ambr
@@ -1,0 +1,17 @@
+# serializer version: 1
+# name: test_diagnostics
+  dict({
+    'data': dict({
+      '__type': "<class 'pyflick.types.FlickPrice'>",
+      'repr': "FlickPrice({'id': '_2025-02-09 05:30:00 UTC..2025-02-09 05:59:59 UTC', 'type': 'rating_rated_period', 'start_at': '2025-02-09T05:30:00.000Z', 'end_at': '2025-02-09T05:59:59.000Z', 'status': 'final', 'cost': '0.20011', 'import_cost': '0.20011', 'export_cost': None, 'cost_unit': 'NZD', 'quantity': '1.0', 'import_quantity': '1.0', 'export_quantity': None, 'quantity_unit': 'kwh', 'renewable_quantity': None, 'generation_price_contract': None, 'components': [{'id': '213507464_1_kwh_generation_UN_24_default_2025-02-09 05:30:00 UTC..2025-02-09 05:59:59 UTC', 'type': 'rating_component', 'charge_method': 'kwh', 'charge_setter': 'generation', 'value': '0.20011', 'quantity': '1.0', 'unit_code': 'NZD', 'charge_per': 'kwh', 'flow_direction': 'import', 'content_code': 'UN', 'hours_of_availability': 24, 'channel_number': 1, 'meter_serial_number': '213507464', 'price_name': 'default', 'applicable_periods': [], 'single_unit_price': '0.20011', 'billable': True, 'renewable_quantity': None, 'generation_price_contract': 'FLICK_FLAT_2024_04_01_midpoint'}, {'id': '213507464_1_kwh_network_UN_24_offpeak_2025-02-09 05:30:00 UTC..2025-02-09 05:59:59 UTC', 'type': 'rating_component', 'charge_method': 'kwh', 'charge_setter': 'network', 'value': '0.0406', 'quantity': '1.0', 'unit_code': 'NZD', 'charge_per': 'kwh', 'flow_direction': 'import', 'content_code': 'UN', 'hours_of_availability': 24, 'channel_number': 1, 'meter_serial_number': '213507464', 'price_name': 'offpeak', 'applicable_periods': [], 'single_unit_price': '0.0406', 'billable': False, 'renewable_quantity': None, 'generation_price_contract': 'FLICK_FLAT_2024_04_01_midpoint'}]})",
+    }),
+    'entry_data': dict({
+      'account_id': '10123404',
+      'client_id': 'test-client-id',
+      'client_secret': '**REDACTED**',
+      'password': '**REDACTED**',
+      'supply_node_ref': '/network/nz/supply_nodes/ed7617df-4b10-4c8a-a05d-deadbeef8299',
+      'username': '9973debf-963f-49b0-9a73-ba9c3400cbed@anonymised.example.com',
+    }),
+  })
+# ---

--- a/tests/components/flick_electric/snapshots/test_diagnostics.ambr
+++ b/tests/components/flick_electric/snapshots/test_diagnostics.ambr
@@ -6,9 +6,7 @@
       'repr': "FlickPrice({'id': '_2025-02-09 05:30:00 UTC..2025-02-09 05:59:59 UTC', 'type': 'rating_rated_period', 'start_at': '2025-02-09T05:30:00.000Z', 'end_at': '2025-02-09T05:59:59.000Z', 'status': 'final', 'cost': '0.20011', 'import_cost': '0.20011', 'export_cost': None, 'cost_unit': 'NZD', 'quantity': '1.0', 'import_quantity': '1.0', 'export_quantity': None, 'quantity_unit': 'kwh', 'renewable_quantity': None, 'generation_price_contract': None, 'components': [{'id': '213507464_1_kwh_generation_UN_24_default_2025-02-09 05:30:00 UTC..2025-02-09 05:59:59 UTC', 'type': 'rating_component', 'charge_method': 'kwh', 'charge_setter': 'generation', 'value': '0.20011', 'quantity': '1.0', 'unit_code': 'NZD', 'charge_per': 'kwh', 'flow_direction': 'import', 'content_code': 'UN', 'hours_of_availability': 24, 'channel_number': 1, 'meter_serial_number': '213507464', 'price_name': 'default', 'applicable_periods': [], 'single_unit_price': '0.20011', 'billable': True, 'renewable_quantity': None, 'generation_price_contract': 'FLICK_FLAT_2024_04_01_midpoint'}, {'id': '213507464_1_kwh_network_UN_24_offpeak_2025-02-09 05:30:00 UTC..2025-02-09 05:59:59 UTC', 'type': 'rating_component', 'charge_method': 'kwh', 'charge_setter': 'network', 'value': '0.0406', 'quantity': '1.0', 'unit_code': 'NZD', 'charge_per': 'kwh', 'flow_direction': 'import', 'content_code': 'UN', 'hours_of_availability': 24, 'channel_number': 1, 'meter_serial_number': '213507464', 'price_name': 'offpeak', 'applicable_periods': [], 'single_unit_price': '0.0406', 'billable': False, 'renewable_quantity': None, 'generation_price_contract': 'FLICK_FLAT_2024_04_01_midpoint'}]})",
     }),
     'entry_data': dict({
-      'account_id': '10123404',
-      'client_id': 'test-client-id',
-      'client_secret': '**REDACTED**',
+      'account_id': '134800',
       'password': '**REDACTED**',
       'supply_node_ref': '/network/nz/supply_nodes/ed7617df-4b10-4c8a-a05d-deadbeef8299',
       'username': '9973debf-963f-49b0-9a73-ba9c3400cbed@anonymised.example.com',

--- a/tests/components/flick_electric/test_config_flow.py
+++ b/tests/components/flick_electric/test_config_flow.py
@@ -1,6 +1,6 @@
 """Test the Flick Electric config flow."""
 
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 from pyflick.authentication import AuthException
 from pyflick.types import APIException
@@ -16,9 +16,15 @@ from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
-from . import CONF, _mock_flick_price
+from . import CONF, setup_integration
 
 from tests.common import MockConfigEntry
+
+# From test fixtures
+ACCOUNT_NAME_1 = "123 Fake Street, Newtown, Wellington 6021"
+ACCOUNT_NAME_2 = "456 Fake Street, Newtown, Wellington 6021"
+ACCOUNT_ID_2 = "123456"
+SUPPLY_NODE_REF_2 = "/network/nz/supply_nodes/ed7617df-4b10-4c8a-a05d-deadbeef1234"
 
 
 async def _flow_submit(hass: HomeAssistant) -> ConfigFlowResult:
@@ -32,7 +38,7 @@ async def _flow_submit(hass: HomeAssistant) -> ConfigFlowResult:
     )
 
 
-async def test_form(hass: HomeAssistant) -> None:
+async def test_form(hass: HomeAssistant, mock_flick_client: AsyncMock) -> None:
     """Test we get the form with only one, with no account picker."""
 
     result = await hass.config_entries.flow.async_init(
@@ -41,48 +47,24 @@ async def test_form(hass: HomeAssistant) -> None:
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {}
 
-    with (
-        patch(
-            "homeassistant.components.flick_electric.config_flow.SimpleFlickAuth.async_get_access_token",
-            return_value="123456789abcdef",
-        ),
-        patch(
-            "homeassistant.components.flick_electric.config_flow.FlickAPI.getCustomerAccounts",
-            return_value=[
-                {
-                    "id": "1234",
-                    "status": "active",
-                    "address": "123 Fake St",
-                    "main_consumer": {"supply_node_ref": "123"},
-                }
-            ],
-        ),
-        patch(
-            "homeassistant.components.flick_electric.config_flow.FlickAPI.getPricing",
-            return_value=_mock_flick_price(),
-        ),
-        patch(
-            "homeassistant.components.flick_electric.async_setup_entry",
-            return_value=True,
-        ) as mock_setup_entry,
-    ):
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {
-                CONF_USERNAME: "test-username",
-                CONF_PASSWORD: "test-password",
-            },
-        )
-        await hass.async_block_till_done()
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_USERNAME: CONF[CONF_USERNAME],
+            CONF_PASSWORD: CONF[CONF_PASSWORD],
+        },
+    )
+    await hass.async_block_till_done()
 
     assert result2["type"] is FlowResultType.CREATE_ENTRY
-    assert result2["title"] == "123 Fake St"
+    assert result2["title"] == ACCOUNT_NAME_1
     assert result2["data"] == CONF
-    assert result2["result"].unique_id == "1234"
-    assert len(mock_setup_entry.mock_calls) == 1
+    assert result2["result"].unique_id == CONF[CONF_ACCOUNT_ID]
 
 
-async def test_form_multi_account(hass: HomeAssistant) -> None:
+async def test_form_multi_account(
+    hass: HomeAssistant, mock_flick_client_multiple: AsyncMock
+) -> None:
     """Test the form when multiple accounts are available."""
 
     result = await hass.config_entries.flow.async_init(
@@ -91,272 +73,114 @@ async def test_form_multi_account(hass: HomeAssistant) -> None:
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {}
 
-    with (
-        patch(
-            "homeassistant.components.flick_electric.config_flow.SimpleFlickAuth.async_get_access_token",
-            return_value="123456789abcdef",
-        ),
-        patch(
-            "homeassistant.components.flick_electric.config_flow.FlickAPI.getCustomerAccounts",
-            return_value=[
-                {
-                    "id": "1234",
-                    "status": "active",
-                    "address": "123 Fake St",
-                    "main_consumer": {"supply_node_ref": "123"},
-                },
-                {
-                    "id": "5678",
-                    "status": "active",
-                    "address": "456 Fake St",
-                    "main_consumer": {"supply_node_ref": "456"},
-                },
-            ],
-        ),
-        patch(
-            "homeassistant.components.flick_electric.config_flow.FlickAPI.getPricing",
-            return_value=_mock_flick_price(),
-        ),
-        patch(
-            "homeassistant.components.flick_electric.async_setup_entry",
-            return_value=True,
-        ) as mock_setup_entry,
-    ):
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {
-                CONF_USERNAME: "test-username",
-                CONF_PASSWORD: "test-password",
-            },
-        )
-        await hass.async_block_till_done()
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_USERNAME: CONF[CONF_USERNAME],
+            CONF_PASSWORD: CONF[CONF_PASSWORD],
+        },
+    )
+    await hass.async_block_till_done()
 
-        assert result2["type"] is FlowResultType.FORM
-        assert result2["step_id"] == "select_account"
-        assert len(mock_setup_entry.mock_calls) == 0
+    assert result2["type"] is FlowResultType.FORM
+    assert result2["step_id"] == "select_account"
 
-        result3 = await hass.config_entries.flow.async_configure(
-            result2["flow_id"],
-            {"account_id": "5678"},
-        )
+    result3 = await hass.config_entries.flow.async_configure(
+        result2["flow_id"],
+        {CONF_ACCOUNT_ID: ACCOUNT_ID_2},
+    )
 
-        await hass.async_block_till_done()
+    await hass.async_block_till_done()
 
-        assert result3["type"] is FlowResultType.CREATE_ENTRY
-        assert result3["title"] == "456 Fake St"
-        assert result3["data"] == {
-            **CONF,
-            CONF_SUPPLY_NODE_REF: "456",
-            CONF_ACCOUNT_ID: "5678",
-        }
-        assert result3["result"].unique_id == "5678"
-        assert len(mock_setup_entry.mock_calls) == 1
+    assert result3["type"] is FlowResultType.CREATE_ENTRY
+    assert result3["title"] == ACCOUNT_NAME_2
+    assert result3["data"] == {
+        **CONF,
+        CONF_SUPPLY_NODE_REF: SUPPLY_NODE_REF_2,
+        CONF_ACCOUNT_ID: ACCOUNT_ID_2,
+    }
+    assert result3["result"].unique_id == ACCOUNT_ID_2
 
 
-async def test_reauth_token(hass: HomeAssistant) -> None:
+async def test_reauth_token(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_flick_client: AsyncMock,
+) -> None:
     """Test reauth flow when username/password is wrong."""
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={**CONF},
-        title="123 Fake St",
-        unique_id="1234",
-        version=2,
+    await setup_integration(hass, mock_config_entry)
+
+    with patch(
+        "homeassistant.components.flick_electric.config_flow.SimpleFlickAuth.async_get_access_token",
+        side_effect=AuthException,
+    ):
+        result = await mock_config_entry.start_reauth_flow(hass)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "invalid_auth"}
+    assert result["step_id"] == "user"
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_USERNAME: CONF[CONF_USERNAME], CONF_PASSWORD: CONF[CONF_PASSWORD]},
     )
-    entry.add_to_hass(hass)
 
-    with (
-        patch(
-            "homeassistant.components.flick_electric.config_flow.SimpleFlickAuth.async_get_access_token",
-            side_effect=AuthException,
-        ),
-    ):
-        result = await entry.start_reauth_flow(hass)
-
-        assert result["type"] is FlowResultType.FORM
-        assert result["errors"] == {"base": "invalid_auth"}
-        assert result["step_id"] == "user"
-
-    with (
-        patch(
-            "homeassistant.components.flick_electric.config_flow.SimpleFlickAuth.async_get_access_token",
-            return_value="123456789abcdef",
-        ),
-        patch(
-            "homeassistant.components.flick_electric.config_flow.FlickAPI.getCustomerAccounts",
-            return_value=[
-                {
-                    "id": "1234",
-                    "status": "active",
-                    "address": "123 Fake St",
-                    "main_consumer": {"supply_node_ref": "123"},
-                },
-            ],
-        ),
-        patch(
-            "homeassistant.components.flick_electric.config_flow.FlickAPI.getPricing",
-            return_value=_mock_flick_price(),
-        ),
-        patch(
-            "homeassistant.config_entries.ConfigEntries.async_update_entry",
-            return_value=True,
-        ) as mock_update_entry,
-    ):
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {
-                CONF_USERNAME: "test-username",
-                CONF_PASSWORD: "test-password",
-            },
-        )
-
-        assert result2["type"] is FlowResultType.ABORT
-        assert result2["reason"] == "reauth_successful"
-        assert len(mock_update_entry.mock_calls) > 0
+    assert result2["type"] is FlowResultType.ABORT
+    assert result2["reason"] == "reauth_successful"
 
 
-async def test_form_reauth_migrate(hass: HomeAssistant) -> None:
+async def test_form_reauth_migrate(
+    hass: HomeAssistant,
+    mock_old_config_entry: MockConfigEntry,
+    mock_flick_client: AsyncMock,
+) -> None:
     """Test reauth flow for v1 with single account."""
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={
-            CONF_USERNAME: "test-username",
-            CONF_PASSWORD: "test-password",
-        },
-        title="123 Fake St",
-        unique_id="test-username",
-        version=1,
-    )
-    entry.add_to_hass(hass)
+    mock_old_config_entry.add_to_hass(hass)
+    result = await mock_old_config_entry.start_reauth_flow(hass)
 
-    with (
-        patch(
-            "homeassistant.components.flick_electric.config_flow.SimpleFlickAuth.async_get_access_token",
-            return_value="123456789abcdef",
-        ),
-        patch(
-            "homeassistant.components.flick_electric.config_flow.FlickAPI.getCustomerAccounts",
-            return_value=[
-                {
-                    "id": "1234",
-                    "status": "active",
-                    "address": "123 Fake St",
-                    "main_consumer": {"supply_node_ref": "123"},
-                },
-            ],
-        ),
-        patch(
-            "homeassistant.components.flick_electric.config_flow.FlickAPI.getPricing",
-            return_value=_mock_flick_price(),
-        ),
-    ):
-        result = await entry.start_reauth_flow(hass)
-
-        assert result["type"] is FlowResultType.ABORT
-        assert result["reason"] == "reauth_successful"
-        assert entry.version == 2
-        assert entry.unique_id == "1234"
-        assert entry.data == CONF
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+    assert mock_old_config_entry.version == 2
+    assert mock_old_config_entry.unique_id == CONF[CONF_ACCOUNT_ID]
+    assert mock_old_config_entry.data == CONF
 
 
-async def test_form_reauth_migrate_multi_account(hass: HomeAssistant) -> None:
+async def test_form_reauth_migrate_multi_account(
+    hass: HomeAssistant,
+    mock_old_config_entry: MockConfigEntry,
+    mock_flick_client_multiple: AsyncMock,
+) -> None:
     """Test the form when multiple accounts are available."""
+    mock_old_config_entry.add_to_hass(hass)
+    result = await mock_old_config_entry.start_reauth_flow(hass)
 
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={
-            CONF_USERNAME: "test-username",
-            CONF_PASSWORD: "test-password",
-        },
-        title="123 Fake St",
-        unique_id="test-username",
-        version=1,
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "select_account"
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_ACCOUNT_ID: CONF[CONF_ACCOUNT_ID]},
     )
-    entry.add_to_hass(hass)
 
-    with (
-        patch(
-            "homeassistant.components.flick_electric.config_flow.SimpleFlickAuth.async_get_access_token",
-            return_value="123456789abcdef",
-        ),
-        patch(
-            "homeassistant.components.flick_electric.config_flow.FlickAPI.getCustomerAccounts",
-            return_value=[
-                {
-                    "id": "1234",
-                    "status": "active",
-                    "address": "123 Fake St",
-                    "main_consumer": {"supply_node_ref": "123"},
-                },
-                {
-                    "id": "5678",
-                    "status": "active",
-                    "address": "456 Fake St",
-                    "main_consumer": {"supply_node_ref": "456"},
-                },
-            ],
-        ),
-        patch(
-            "homeassistant.components.flick_electric.config_flow.FlickAPI.getPricing",
-            return_value=_mock_flick_price(),
-        ),
-    ):
-        result = await entry.start_reauth_flow(hass)
+    await hass.async_block_till_done()
 
-        assert result["type"] is FlowResultType.FORM
-        assert result["step_id"] == "select_account"
+    assert result2["type"] is FlowResultType.ABORT
+    assert result2["reason"] == "reauth_successful"
 
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {"account_id": "5678"},
-        )
-
-        await hass.async_block_till_done()
-
-        assert result2["type"] is FlowResultType.ABORT
-        assert result2["reason"] == "reauth_successful"
-
-        assert entry.version == 2
-        assert entry.unique_id == "5678"
-        assert entry.data == {
-            **CONF,
-            CONF_ACCOUNT_ID: "5678",
-            CONF_SUPPLY_NODE_REF: "456",
-        }
+    assert mock_old_config_entry.version == 2
+    assert mock_old_config_entry.unique_id == CONF[CONF_ACCOUNT_ID]
+    assert mock_old_config_entry.data == CONF
 
 
-async def test_form_duplicate_account(hass: HomeAssistant) -> None:
+async def test_form_duplicate_account(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_flick_client: AsyncMock,
+) -> None:
     """Test uniqueness for account_id."""
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={**CONF, CONF_ACCOUNT_ID: "1234", CONF_SUPPLY_NODE_REF: "123"},
-        title="123 Fake St",
-        unique_id="1234",
-        version=2,
-    )
-    entry.add_to_hass(hass)
+    await setup_integration(hass, mock_config_entry)
 
-    with (
-        patch(
-            "homeassistant.components.flick_electric.config_flow.SimpleFlickAuth.async_get_access_token",
-            return_value="123456789abcdef",
-        ),
-        patch(
-            "homeassistant.components.flick_electric.config_flow.FlickAPI.getCustomerAccounts",
-            return_value=[
-                {
-                    "id": "1234",
-                    "status": "active",
-                    "address": "123 Fake St",
-                    "main_consumer": {"supply_node_ref": "123"},
-                }
-            ],
-        ),
-        patch(
-            "homeassistant.components.flick_electric.config_flow.FlickAPI.getPricing",
-            return_value=_mock_flick_price(),
-        ),
-    ):
-        result = await _flow_submit(hass)
+    result = await _flow_submit(hass)
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
@@ -398,7 +222,9 @@ async def test_form_generic_exception(hass: HomeAssistant) -> None:
     assert result["errors"] == {"base": "unknown"}
 
 
-async def test_form_select_account_cannot_connect(hass: HomeAssistant) -> None:
+async def test_form_select_account_cannot_connect(
+    hass: HomeAssistant, mock_flick_client_multiple: AsyncMock
+) -> None:
     """Test we handle connection errors for select account."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -406,38 +232,16 @@ async def test_form_select_account_cannot_connect(hass: HomeAssistant) -> None:
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {}
 
-    with (
-        patch(
-            "homeassistant.components.flick_electric.config_flow.SimpleFlickAuth.async_get_access_token",
-            return_value="123456789abcdef",
-        ),
-        patch(
-            "homeassistant.components.flick_electric.config_flow.FlickAPI.getCustomerAccounts",
-            return_value=[
-                {
-                    "id": "1234",
-                    "status": "active",
-                    "address": "123 Fake St",
-                    "main_consumer": {"supply_node_ref": "123"},
-                },
-                {
-                    "id": "5678",
-                    "status": "active",
-                    "address": "456 Fake St",
-                    "main_consumer": {"supply_node_ref": "456"},
-                },
-            ],
-        ),
-        patch(
-            "homeassistant.components.flick_electric.config_flow.FlickAPI.getPricing",
-            side_effect=APIException,
-        ),
+    with patch.object(
+        mock_flick_client_multiple,
+        "getPricing",
+        side_effect=APIException,
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
-                CONF_USERNAME: "test-username",
-                CONF_PASSWORD: "test-password",
+                CONF_USERNAME: CONF[CONF_USERNAME],
+                CONF_PASSWORD: CONF[CONF_PASSWORD],
             },
         )
         await hass.async_block_till_done()
@@ -447,7 +251,7 @@ async def test_form_select_account_cannot_connect(hass: HomeAssistant) -> None:
 
         result3 = await hass.config_entries.flow.async_configure(
             result2["flow_id"],
-            {"account_id": "5678"},
+            {CONF_ACCOUNT_ID: CONF[CONF_ACCOUNT_ID]},
         )
 
         assert result3["type"] is FlowResultType.FORM
@@ -455,7 +259,9 @@ async def test_form_select_account_cannot_connect(hass: HomeAssistant) -> None:
         assert result3["errors"] == {"base": "cannot_connect"}
 
 
-async def test_form_select_account_invalid_auth(hass: HomeAssistant) -> None:
+async def test_form_select_account_invalid_auth(
+    hass: HomeAssistant, mock_flick_client_multiple: AsyncMock
+) -> None:
     """Test we handle auth errors for select account."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -463,65 +269,41 @@ async def test_form_select_account_invalid_auth(hass: HomeAssistant) -> None:
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {}
 
-    with (
-        patch(
-            "homeassistant.components.flick_electric.config_flow.SimpleFlickAuth.async_get_access_token",
-            return_value="123456789abcdef",
-        ),
-        patch(
-            "homeassistant.components.flick_electric.config_flow.FlickAPI.getCustomerAccounts",
-            return_value=[
-                {
-                    "id": "1234",
-                    "status": "active",
-                    "address": "123 Fake St",
-                    "main_consumer": {"supply_node_ref": "123"},
-                },
-                {
-                    "id": "5678",
-                    "status": "active",
-                    "address": "456 Fake St",
-                    "main_consumer": {"supply_node_ref": "456"},
-                },
-            ],
-        ),
-        patch(
-            "homeassistant.components.flick_electric.config_flow.FlickAPI.getPricing",
-            side_effect=AuthException,
-        ),
-    ):
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {
-                CONF_USERNAME: "test-username",
-                CONF_PASSWORD: "test-password",
-            },
-        )
-        await hass.async_block_till_done()
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_USERNAME: CONF[CONF_USERNAME],
+            CONF_PASSWORD: CONF[CONF_PASSWORD],
+        },
+    )
+    await hass.async_block_till_done()
 
-        assert result2["type"] is FlowResultType.FORM
-        assert result2["step_id"] == "select_account"
+    assert result2["type"] is FlowResultType.FORM
+    assert result2["step_id"] == "select_account"
 
     with (
         patch(
             "homeassistant.components.flick_electric.config_flow.SimpleFlickAuth.async_get_access_token",
             side_effect=AuthException,
         ),
-        patch(
-            "homeassistant.components.flick_electric.config_flow.FlickAPI.getCustomerAccounts",
+        patch.object(
+            mock_flick_client_multiple,
+            "getPricing",
             side_effect=AuthException,
         ),
     ):
         result3 = await hass.config_entries.flow.async_configure(
             result2["flow_id"],
-            {"account_id": "5678"},
+            {CONF_ACCOUNT_ID: CONF[CONF_ACCOUNT_ID]},
         )
 
         assert result3["type"] is FlowResultType.ABORT
         assert result3["reason"] == "no_permissions"
 
 
-async def test_form_select_account_failed_to_connect(hass: HomeAssistant) -> None:
+async def test_form_select_account_failed_to_connect(
+    hass: HomeAssistant, mock_flick_client_multiple: AsyncMock
+) -> None:
     """Test we handle connection errors for select account."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -529,115 +311,56 @@ async def test_form_select_account_failed_to_connect(hass: HomeAssistant) -> Non
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {}
 
-    with (
-        patch(
-            "homeassistant.components.flick_electric.config_flow.SimpleFlickAuth.async_get_access_token",
-            return_value="123456789abcdef",
-        ),
-        patch(
-            "homeassistant.components.flick_electric.config_flow.FlickAPI.getCustomerAccounts",
-            return_value=[
-                {
-                    "id": "1234",
-                    "status": "active",
-                    "address": "123 Fake St",
-                    "main_consumer": {"supply_node_ref": "123"},
-                },
-                {
-                    "id": "5678",
-                    "status": "active",
-                    "address": "456 Fake St",
-                    "main_consumer": {"supply_node_ref": "456"},
-                },
-            ],
-        ),
-        patch(
-            "homeassistant.components.flick_electric.config_flow.FlickAPI.getPricing",
-            side_effect=AuthException,
-        ),
-    ):
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {
-                CONF_USERNAME: "test-username",
-                CONF_PASSWORD: "test-password",
-            },
-        )
-        await hass.async_block_till_done()
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_USERNAME: CONF[CONF_USERNAME],
+            CONF_PASSWORD: CONF[CONF_PASSWORD],
+        },
+    )
+    await hass.async_block_till_done()
 
-        assert result2["type"] is FlowResultType.FORM
-        assert result2["step_id"] == "select_account"
+    assert result2["type"] is FlowResultType.FORM
+    assert result2["step_id"] == "select_account"
 
     with (
-        patch(
-            "homeassistant.components.flick_electric.config_flow.SimpleFlickAuth.async_get_access_token",
-            return_value="123456789abcdef",
-        ),
-        patch(
-            "homeassistant.components.flick_electric.config_flow.FlickAPI.getCustomerAccounts",
+        patch.object(
+            mock_flick_client_multiple,
+            "getCustomerAccounts",
             side_effect=APIException,
         ),
-        patch(
-            "homeassistant.components.flick_electric.config_flow.FlickAPI.getPricing",
+        patch.object(
+            mock_flick_client_multiple,
+            "getPricing",
             side_effect=APIException,
         ),
     ):
         result3 = await hass.config_entries.flow.async_configure(
             result2["flow_id"],
-            {"account_id": "5678"},
+            {CONF_ACCOUNT_ID: CONF[CONF_ACCOUNT_ID]},
         )
 
         assert result3["type"] is FlowResultType.FORM
         assert result3["errors"] == {"base": "cannot_connect"}
 
-    with (
-        patch(
-            "homeassistant.components.flick_electric.config_flow.SimpleFlickAuth.async_get_access_token",
-            return_value="123456789abcdef",
-        ),
-        patch(
-            "homeassistant.components.flick_electric.config_flow.FlickAPI.getCustomerAccounts",
-            return_value=[
-                {
-                    "id": "1234",
-                    "status": "active",
-                    "address": "123 Fake St",
-                    "main_consumer": {"supply_node_ref": "123"},
-                },
-                {
-                    "id": "5678",
-                    "status": "active",
-                    "address": "456 Fake St",
-                    "main_consumer": {"supply_node_ref": "456"},
-                },
-            ],
-        ),
-        patch(
-            "homeassistant.components.flick_electric.config_flow.FlickAPI.getPricing",
-            return_value=_mock_flick_price(),
-        ),
-        patch(
-            "homeassistant.components.flick_electric.async_setup_entry",
-            return_value=True,
-        ) as mock_setup_entry,
-    ):
-        result4 = await hass.config_entries.flow.async_configure(
-            result3["flow_id"],
-            {"account_id": "5678"},
-        )
+    result4 = await hass.config_entries.flow.async_configure(
+        result3["flow_id"],
+        {CONF_ACCOUNT_ID: ACCOUNT_ID_2},
+    )
 
-        assert result4["type"] is FlowResultType.CREATE_ENTRY
-        assert result4["title"] == "456 Fake St"
-        assert result4["data"] == {
-            **CONF,
-            CONF_SUPPLY_NODE_REF: "456",
-            CONF_ACCOUNT_ID: "5678",
-        }
-        assert result4["result"].unique_id == "5678"
-        assert len(mock_setup_entry.mock_calls) == 1
+    assert result4["type"] is FlowResultType.CREATE_ENTRY
+    assert result4["title"] == ACCOUNT_NAME_2
+    assert result4["data"] == {
+        **CONF,
+        CONF_SUPPLY_NODE_REF: SUPPLY_NODE_REF_2,
+        CONF_ACCOUNT_ID: ACCOUNT_ID_2,
+    }
+    assert result4["result"].unique_id == ACCOUNT_ID_2
 
 
-async def test_form_select_account_no_accounts(hass: HomeAssistant) -> None:
+async def test_form_select_account_no_accounts(
+    hass: HomeAssistant, mock_flick_client: AsyncMock
+) -> None:
     """Test we handle connection errors for select account."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -645,28 +368,23 @@ async def test_form_select_account_no_accounts(hass: HomeAssistant) -> None:
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {}
 
-    with (
-        patch(
-            "homeassistant.components.flick_electric.config_flow.SimpleFlickAuth.async_get_access_token",
-            return_value="123456789abcdef",
-        ),
-        patch(
-            "homeassistant.components.flick_electric.config_flow.FlickAPI.getCustomerAccounts",
-            return_value=[
-                {
-                    "id": "1234",
-                    "status": "closed",
-                    "address": "123 Fake St",
-                    "main_consumer": {"supply_node_ref": "123"},
-                },
-            ],
-        ),
+    with patch.object(
+        mock_flick_client,
+        "getCustomerAccounts",
+        return_value=[
+            {
+                "id": "1234",
+                "status": "closed",
+                "address": "123 Fake St",
+                "main_consumer": {"supply_node_ref": "123"},
+            },
+        ],
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
-                CONF_USERNAME: "test-username",
-                CONF_PASSWORD: "test-password",
+                CONF_USERNAME: CONF[CONF_USERNAME],
+                CONF_PASSWORD: CONF[CONF_PASSWORD],
             },
         )
         await hass.async_block_till_done()

--- a/tests/components/flick_electric/test_diagnostics.py
+++ b/tests/components/flick_electric/test_diagnostics.py
@@ -1,0 +1,29 @@
+"""Tests for the diagnostics data provided by the Overseerr integration."""
+
+from unittest.mock import AsyncMock
+
+from syrupy import SnapshotAssertion
+
+from homeassistant.core import HomeAssistant
+
+from . import setup_integration
+
+from tests.common import MockConfigEntry
+from tests.components.diagnostics import get_diagnostics_for_config_entry
+from tests.typing import ClientSessionGenerator
+
+
+async def test_diagnostics(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    mock_flick_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test diagnostics."""
+    await setup_integration(hass, mock_config_entry)
+
+    assert (
+        await get_diagnostics_for_config_entry(hass, hass_client, mock_config_entry)
+        == snapshot
+    )

--- a/tests/components/flick_electric/test_init.py
+++ b/tests/components/flick_electric/test_init.py
@@ -1,135 +1,83 @@
 """Test the Flick Electric config flow."""
 
-from unittest.mock import patch
+from unittest.mock import AsyncMock
 
-from pyflick.authentication import AuthException
+from pyflick.types import APIException, AuthException
+import pytest
 
 from homeassistant.components.flick_electric.const import CONF_ACCOUNT_ID, DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 
-from . import CONF, _mock_flick_price
+from . import CONF, setup_integration
 
 from tests.common import MockConfigEntry
 
 
-async def test_init_auth_failure_triggers_auth(hass: HomeAssistant) -> None:
-    """Test reauth flow is triggered when username/password is wrong."""
-    with (
-        patch(
-            "homeassistant.components.flick_electric.HassFlickAuth.async_get_access_token",
-            side_effect=AuthException,
-        ),
-    ):
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={**CONF},
-            title="123 Fake St",
-            unique_id="1234",
-            version=2,
-        )
-        entry.add_to_hass(hass)
+@pytest.mark.parametrize(
+    ("exception", "config_entry_state"),
+    [
+        (AuthException, ConfigEntryState.SETUP_ERROR),
+        (APIException, ConfigEntryState.SETUP_RETRY),
+    ],
+)
+async def test_init_auth_failure_triggers_auth(
+    hass: HomeAssistant,
+    mock_flick_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    exception: Exception,
+    config_entry_state: ConfigEntryState,
+) -> None:
+    """Test integration handles initialisation errors."""
+    mock_flick_client.getPricing.side_effect = exception
 
-        # Ensure setup fails
-        assert not await hass.config_entries.async_setup(entry.entry_id)
-        assert entry.state is ConfigEntryState.SETUP_ERROR
+    await setup_integration(hass, mock_config_entry)
 
-        # Ensure reauth flow is triggered
-        await hass.async_block_till_done()
-        assert len(hass.config_entries.flow.async_progress()) == 1
+    assert mock_config_entry.state == config_entry_state
 
 
-async def test_init_migration_single_account(hass: HomeAssistant) -> None:
+async def test_init_migration_single_account(
+    hass: HomeAssistant, mock_flick_client: AsyncMock
+) -> None:
     """Test migration with single account."""
-    with (
-        patch(
-            "homeassistant.components.flick_electric.HassFlickAuth.async_get_access_token",
-            return_value="123456789abcdef",
-        ),
-        patch(
-            "homeassistant.components.flick_electric.FlickAPI.getCustomerAccounts",
-            return_value=[
-                {
-                    "id": "1234",
-                    "status": "active",
-                    "address": "123 Fake St",
-                    "main_consumer": {"supply_node_ref": "123"},
-                }
-            ],
-        ),
-        patch(
-            "homeassistant.components.flick_electric.FlickAPI.getPricing",
-            return_value=_mock_flick_price(),
-        ),
-    ):
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={
-                CONF_USERNAME: CONF[CONF_USERNAME],
-                CONF_PASSWORD: CONF[CONF_PASSWORD],
-            },
-            title=CONF_USERNAME,
-            unique_id=CONF_USERNAME,
-            version=1,
-        )
-        entry.add_to_hass(hass)
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_USERNAME: CONF[CONF_USERNAME],
+            CONF_PASSWORD: CONF[CONF_PASSWORD],
+        },
+        title=CONF_USERNAME,
+        unique_id=CONF_USERNAME,
+        version=1,
+    )
+    await setup_integration(hass, entry)
 
-        assert await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-        assert len(hass.config_entries.flow.async_progress()) == 0
-        assert entry.state is ConfigEntryState.LOADED
-        assert entry.version == 2
-        assert entry.unique_id == CONF[CONF_ACCOUNT_ID]
-        assert entry.data == CONF
+    assert len(hass.config_entries.flow.async_progress()) == 0
+    assert entry.state is ConfigEntryState.LOADED
+    assert entry.version == 2
+    assert entry.unique_id == CONF[CONF_ACCOUNT_ID]
+    assert entry.data == CONF
 
 
-async def test_init_migration_multi_account_reauth(hass: HomeAssistant) -> None:
+async def test_init_migration_multi_account_reauth(
+    hass: HomeAssistant, mock_flick_client_multiple: AsyncMock
+) -> None:
     """Test migration triggers reauth with multiple accounts."""
-    with (
-        patch(
-            "homeassistant.components.flick_electric.HassFlickAuth.async_get_access_token",
-            return_value="123456789abcdef",
-        ),
-        patch(
-            "homeassistant.components.flick_electric.FlickAPI.getCustomerAccounts",
-            return_value=[
-                {
-                    "id": "1234",
-                    "status": "active",
-                    "address": "123 Fake St",
-                    "main_consumer": {"supply_node_ref": "123"},
-                },
-                {
-                    "id": "5678",
-                    "status": "active",
-                    "address": "456 Fake St",
-                    "main_consumer": {"supply_node_ref": "456"},
-                },
-            ],
-        ),
-        patch(
-            "homeassistant.components.flick_electric.FlickAPI.getPricing",
-            return_value=_mock_flick_price(),
-        ),
-    ):
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={
-                CONF_USERNAME: CONF[CONF_USERNAME],
-                CONF_PASSWORD: CONF[CONF_PASSWORD],
-            },
-            title=CONF_USERNAME,
-            unique_id=CONF_USERNAME,
-            version=1,
-        )
-        entry.add_to_hass(hass)
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_USERNAME: CONF[CONF_USERNAME],
+            CONF_PASSWORD: CONF[CONF_PASSWORD],
+        },
+        title=CONF_USERNAME,
+        unique_id=CONF_USERNAME,
+        version=1,
+    )
+    await setup_integration(hass, entry)
 
-        # ensure setup fails
-        assert not await hass.config_entries.async_setup(entry.entry_id)
-        assert entry.state is ConfigEntryState.MIGRATION_ERROR
-        await hass.async_block_till_done()
+    assert entry.state is ConfigEntryState.MIGRATION_ERROR
 
-        # Ensure reauth flow is triggered
-        await hass.async_block_till_done()
-        assert len(hass.config_entries.flow.async_progress()) == 1
+    # Ensure reauth flow is triggered
+    await hass.async_block_till_done()
+    assert len(hass.config_entries.flow.async_progress()) == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adds multiple enhancements to `flick_electric` integration, bringing it in line with the Silver quality scale:

- Adds diagnostics
- Entity icon translation
- Disable parallel updates
- Add data descriptions to the config flow
- Add fixtures to unit tests, to cover more of the API/integration surface

### Bronze
- [x] `action-setup` - Service actions are registered in async_setup
- [x] `appropriate-polling` - If it's a polling integration, set an appropriate polling interval
- [x] `brands` - Has branding assets available for the integration
- [x] `common-modules` - Place common patterns in common modules
- [x] `config-flow-test-coverage` - Full test coverage for the config flow
- [x] `config-flow` - Integration needs to be able to be set up via the UI
    - [x] Uses `data_description` to give context to fields
    - [x] Uses `ConfigEntry.data` and `ConfigEntry.options` correctly
- [x] `dependency-transparency` - Dependency transparency
- [ ] ~~`docs-actions` - The documentation describes the provided service actions that can be used~~
  - Not applicable
- [x] `docs-high-level-description` - The documentation includes a high-level description of the integration brand, product, or service
- [x] `docs-installation-instructions` - The documentation provides step-by-step installation instructions for the integration, including, if needed, prerequisites
- [x] `docs-removal-instructions` - The documentation provides removal instructions
- [ ] ~~`entity-event-setup` - Entities event setup~~
  - Entities of this integration do not explicitly subscribe to events.
- [x] `entity-unique-id` - Entities have a unique ID
- [x] `has-entity-name` - Entities use has_entity_name = True
- [x] `runtime-data` - Use ConfigEntry.runtime_data to store runtime data
- [x] `test-before-configure` - Test a connection in the config flow
- [x] `test-before-setup` - Check during integration initialization if we are able to set it up correctly
- [x] `unique-config-entry` - Don't allow the same device or service to be able to be set up twice

### Silver
- [ ] ~~`action-exceptions` - Service actions raise exceptions when encountering failures~~
  - This integration does not have any service actions.
- [x] `config-entry-unloading` - Support config entry unloading
- [x] `docs-configuration-parameters` - The documentation describes all integration configuration options
- [x] `docs-installation-parameters` - The documentation describes all integration installation parameters
- [x] `entity-unavailable` - Mark entity unavailable if appropriate
- [x] `integration-owner` - Has an integration owner
- [x] `log-when-unavailable` - If internet/device/service is unavailable, log once when unavailable and once when back connected
- [x] `parallel-updates` - Set Parallel updates
- [x] `reauthentication-flow` - Reauthentication flow
- [x] `test-coverage` - Above 95% test coverage for all integration modules



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/37373

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] ~~New or updated dependencies have been added to `requirements_all.txt`. Updated by running `python3 -m script.gen_requirements_all`.~~
- [ ] ~~For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.~~

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
