### PR TITLE
Explicitly pass in the config_entry in nina coordinator

### DIFF
--- a/homeassistant/components/nina/__init__.py
+++ b/homeassistant/components/nina/__init__.py
@@ -11,7 +11,6 @@ from .const import (
     CONF_AREA_FILTER,
     CONF_FILTER_CORONA,
     CONF_HEADLINE_FILTER,
-    CONF_REGIONS,
     DOMAIN,
     NO_MATCH_REGEX,
 )
@@ -22,9 +21,6 @@ PLATFORMS: list[str] = [Platform.BINARY_SENSOR]
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up platform from a ConfigEntry."""
-
-    regions: dict[str, str] = entry.data[CONF_REGIONS]
-
     if CONF_HEADLINE_FILTER not in entry.data:
         filter_regex = NO_MATCH_REGEX
 
@@ -39,12 +35,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         new_data = {**entry.data, CONF_AREA_FILTER: ALL_MATCH_REGEX}
         hass.config_entries.async_update_entry(entry, data=new_data)
 
-    coordinator = NINADataUpdateCoordinator(
-        hass,
-        regions,
-        entry.data[CONF_HEADLINE_FILTER],
-        entry.data[CONF_AREA_FILTER],
-    )
+    coordinator = NINADataUpdateCoordinator(hass, entry)
 
     await coordinator.async_config_entry_first_refresh()
 

--- a/homeassistant/components/nina/coordinator.py
+++ b/homeassistant/components/nina/coordinator.py
@@ -59,7 +59,8 @@ class NINADataUpdateCoordinator(
         self.headline_filter: str = config_entry.data[CONF_HEADLINE_FILTER]
         self.area_filter: str = config_entry.data[CONF_AREA_FILTER]
 
-        for region in config_entry.data[CONF_REGIONS]:
+        regions: dict[str, str] = config_entry.data[CONF_REGIONS]
+        for region in regions:
             self._nina.addRegion(region)
 
         super().__init__(

--- a/homeassistant/components/nina/coordinator.py
+++ b/homeassistant/components/nina/coordinator.py
@@ -9,11 +9,19 @@ from typing import Any
 
 from pynina import ApiError, Nina
 
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import _LOGGER, DOMAIN, SCAN_INTERVAL
+from .const import (
+    _LOGGER,
+    CONF_AREA_FILTER,
+    CONF_HEADLINE_FILTER,
+    CONF_REGIONS,
+    DOMAIN,
+    SCAN_INTERVAL,
+)
 
 
 @dataclass
@@ -39,23 +47,28 @@ class NINADataUpdateCoordinator(
 ):
     """Class to manage fetching NINA data API."""
 
+    config_entry: ConfigEntry
+
     def __init__(
         self,
         hass: HomeAssistant,
-        regions: dict[str, str],
-        headline_filter: str,
-        area_filter: str,
+        config_entry: ConfigEntry,
     ) -> None:
         """Initialize."""
-        self._regions: dict[str, str] = regions
         self._nina: Nina = Nina(async_get_clientsession(hass))
-        self.headline_filter: str = headline_filter
-        self.area_filter: str = area_filter
+        self.headline_filter: str = config_entry.data[CONF_HEADLINE_FILTER]
+        self.area_filter: str = config_entry.data[CONF_AREA_FILTER]
 
-        for region in regions:
+        for region in config_entry.data[CONF_REGIONS]:
             self._nina.addRegion(region)
 
-        super().__init__(hass, _LOGGER, name=DOMAIN, update_interval=SCAN_INTERVAL)
+        super().__init__(
+            hass,
+            _LOGGER,
+            config_entry=config_entry,
+            name=DOMAIN,
+            update_interval=SCAN_INTERVAL,
+        )
 
     async def _async_update_data(self) -> dict[str, list[NinaWarningData]]:
         """Update data."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

related to #137484

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
