### PR TITLE
Make MockChatLog reusable for other integrations

### DIFF
--- a/tests/components/conversation/__init__.py
+++ b/tests/components/conversation/__init__.py
@@ -49,7 +49,7 @@ class MockAgent(conversation.AbstractConversationAgent):
 
 
 @pytest.fixture
-async def mock_chat_log(hass: HomeAssistant) -> conversation.MockChatLog:
+async def mock_chat_log(hass: HomeAssistant) -> MockChatLog:
     """Return mock chat logs."""
     # pylint: disable-next=contextmanager-generator-missing-cleanup
     with (

--- a/tests/components/conversation/__init__.py
+++ b/tests/components/conversation/__init__.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 from typing import Literal
+from unittest.mock import patch
+
+import pytest
 
 from homeassistant.components import conversation
 from homeassistant.components.conversation.models import (
@@ -14,7 +18,7 @@ from homeassistant.components.homeassistant.exposed_entities import (
     async_expose_entity,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import intent
+from homeassistant.helpers import chat_session, intent
 
 
 class MockAgent(conversation.AbstractConversationAgent):
@@ -42,6 +46,53 @@ class MockAgent(conversation.AbstractConversationAgent):
         return ConversationResult(
             response=response, conversation_id=user_input.conversation_id
         )
+
+
+@pytest.fixture
+async def mock_chat_log(hass: HomeAssistant) -> conversation.MockChatLog:
+    """Return mock chat logs."""
+    # pylint: disable-next=contextmanager-generator-missing-cleanup
+    with (
+        patch(
+            "homeassistant.components.conversation.chat_log.ChatLog",
+            MockChatLog,
+        ),
+        chat_session.async_get_chat_session(hass, "mock-conversation-id") as session,
+        conversation.async_get_chat_log(hass, session) as chat_log,
+    ):
+        yield chat_log
+
+
+@dataclass
+class MockChatLog(conversation.ChatLog):
+    """Mock chat log."""
+
+    _mock_tool_results: dict = field(default_factory=dict)
+
+    def mock_tool_results(self, results: dict) -> None:
+        """Set tool results."""
+        self._mock_tool_results = results
+
+    @property
+    def llm_api(self):
+        """Return LLM API."""
+        return self._llm_api
+
+    @llm_api.setter
+    def llm_api(self, value):
+        """Set LLM API."""
+        self._llm_api = value
+
+        if not value:
+            return
+
+        async def async_call_tool(tool_input):
+            """Call tool."""
+            if tool_input.id not in self._mock_tool_results:
+                raise ValueError(f"Tool {tool_input.id} not found")
+            return self._mock_tool_results[tool_input.id]
+
+        self._llm_api.async_call_tool = async_call_tool
 
 
 def expose_new(hass: HomeAssistant, expose_new: bool) -> None:

--- a/tests/components/openai_conversation/snapshots/test_conversation.ambr
+++ b/tests/components/openai_conversation/snapshots/test_conversation.ambr
@@ -2,20 +2,6 @@
 # name: test_function_call
   list([
     dict({
-      'content': '''
-        Current time is 16:00:00. Today's date is 2024-06-03.
-        You are a voice assistant for Home Assistant.
-        Answer questions about the world truthfully.
-        Answer in plain text. Keep it simple and to the point.
-        Only if the user wants to control a device, tell them to expose entities to their voice assistant in Home Assistant.
-      ''',
-      'role': 'system',
-    }),
-    dict({
-      'content': 'hello',
-      'role': 'user',
-    }),
-    dict({
       'content': 'Please call the test function',
       'role': 'user',
     }),

--- a/tests/components/openai_conversation/test_conversation.py
+++ b/tests/components/openai_conversation/test_conversation.py
@@ -1,10 +1,8 @@
 """Tests for the OpenAI integration."""
 
 from collections.abc import Generator
-from dataclasses import dataclass, field
 from unittest.mock import AsyncMock, patch
 
-from freezegun import freeze_time
 from httpx import Response
 from openai import RateLimitError
 from openai.types.chat.chat_completion_chunk import (
@@ -18,14 +16,17 @@ import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components import conversation
-from homeassistant.components.conversation import chat_log
 from homeassistant.components.homeassistant.exposed_entities import async_expose_entity
 from homeassistant.const import CONF_LLM_HASS_API
 from homeassistant.core import Context, HomeAssistant
-from homeassistant.helpers import chat_session, intent
+from homeassistant.helpers import intent
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
+from tests.components.conversation import (
+    MockChatLog,
+    mock_chat_log,  # noqa: F401
+)
 
 ASSIST_RESPONSE_FINISH = (
     # Assistant message
@@ -64,66 +65,6 @@ def mock_create_stream() -> Generator[AsyncMock]:
         )
 
         yield mock_create
-
-
-@dataclass
-class MockChatLog(chat_log.ChatLog):
-    """Mock chat log."""
-
-    _mock_tool_results: dict = field(default_factory=dict)
-
-    def mock_tool_results(self, results: dict) -> None:
-        """Set tool results."""
-        self._mock_tool_results = results
-
-    @property
-    def llm_api(self):
-        """Return LLM API."""
-        return self._llm_api
-
-    @llm_api.setter
-    def llm_api(self, value):
-        """Set LLM API."""
-        self._llm_api = value
-
-        if not value:
-            return
-
-        async def async_call_tool(tool_input):
-            """Call tool."""
-            if tool_input.id not in self._mock_tool_results:
-                raise ValueError(f"Tool {tool_input.id} not found")
-            return self._mock_tool_results[tool_input.id]
-
-        self._llm_api.async_call_tool = async_call_tool
-
-    def latest_content(self) -> list[conversation.Content]:
-        """Return content from latest version chat log.
-
-        The chat log makes copies until it's committed. Helper to get latest content.
-        """
-        with (
-            chat_session.async_get_chat_session(
-                self.hass, self.conversation_id
-            ) as session,
-            conversation.async_get_chat_log(self.hass, session) as chat_log,
-        ):
-            return chat_log.content
-
-
-@pytest.fixture
-async def mock_chat_log(hass: HomeAssistant) -> MockChatLog:
-    """Return mock chat logs."""
-    with (
-        patch(
-            "homeassistant.components.conversation.chat_log.ChatLog",
-            MockChatLog,
-        ),
-        chat_session.async_get_chat_session(hass, "mock-conversation-id") as session,
-        conversation.async_get_chat_log(hass, session) as chat_log,
-    ):
-        chat_log.async_add_user_content(conversation.UserContent("hello"))
-        return chat_log
 
 
 async def test_entity(
@@ -189,7 +130,7 @@ async def test_function_call(
     mock_config_entry_with_assist: MockConfigEntry,
     mock_init_component,
     mock_create_stream: AsyncMock,
-    mock_chat_log: MockChatLog,
+    mock_chat_log: MockChatLog,  # noqa: F811
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test function call from the assistant."""
@@ -309,17 +250,17 @@ async def test_function_call(
         }
     )
 
-    with freeze_time("2024-06-03 23:00:00"):
-        result = await conversation.async_converse(
-            hass,
-            "Please call the test function",
-            "mock-conversation-id",
-            Context(),
-            agent_id="conversation.openai",
-        )
+    result = await conversation.async_converse(
+        hass,
+        "Please call the test function",
+        mock_chat_log.conversation_id,
+        Context(),
+        agent_id="conversation.openai",
+    )
 
     assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
-    assert mock_chat_log.latest_content() == snapshot
+    # Don't test the prompt, as it's not deterministic
+    assert mock_chat_log.content[1:] == snapshot
 
 
 @pytest.mark.parametrize(
@@ -430,7 +371,7 @@ async def test_function_call_invalid(
     mock_config_entry_with_assist: MockConfigEntry,
     mock_init_component,
     mock_create_stream: AsyncMock,
-    mock_chat_log: MockChatLog,
+    mock_chat_log: MockChatLog,  # noqa: F811
     description: str,
     messages: tuple[ChatCompletionChunk],
 ) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This moves the MockChatLog class from `openai_conversation` to the `conversation` integration, to allow it to be reused by other conversation agents.

Requires https://github.com/home-assistant/core/pull/138173

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
