### PR TITLE
Revert "Clear statistics when you unload the Opower integration"

### DIFF
--- a/homeassistant/components/opower/__init__.py
+++ b/homeassistant/components/opower/__init__.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 
-from .coordinator import OpowerConfigEntry, OpowerCoordinator
+from .coordinator import OpowerCoordinator
 
 PLATFORMS: list[Platform] = [Platform.SENSOR]
+
+
+type OpowerConfigEntry = ConfigEntry[OpowerCoordinator]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: OpowerConfigEntry) -> bool:

--- a/homeassistant/components/opower/coordinator.py
+++ b/homeassistant/components/opower/coordinator.py
@@ -22,7 +22,6 @@ from homeassistant.components.recorder.statistics import (
     get_last_statistics,
     statistics_during_period,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, UnitOfEnergy, UnitOfVolume
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed
@@ -34,13 +33,9 @@ from .const import CONF_TOTP_SECRET, CONF_UTILITY, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
-type OpowerConfigEntry = ConfigEntry[OpowerCoordinator]
-
 
 class OpowerCoordinator(DataUpdateCoordinator[dict[str, Forecast]]):
     """Handle fetching Opower data, updating sensors and inserting statistics."""
-
-    config_entry: OpowerConfigEntry
 
     def __init__(
         self,
@@ -64,7 +59,6 @@ class OpowerCoordinator(DataUpdateCoordinator[dict[str, Forecast]]):
             config_entry.data[CONF_PASSWORD],
             config_entry.data.get(CONF_TOTP_SECRET),
         )
-        self._statistic_ids: set[str] = set()
 
         @callback
         def _dummy_listener() -> None:
@@ -75,12 +69,6 @@ class OpowerCoordinator(DataUpdateCoordinator[dict[str, Forecast]]):
         # forecast, which results to no sensors added, no registered listeners, and thus
         # _async_update_data not periodically getting called which is needed for _insert_statistics.
         self.async_add_listener(_dummy_listener)
-
-        self.config_entry.async_on_unload(self._clear_statistics)
-
-    def _clear_statistics(self) -> None:
-        """Clear statistics."""
-        get_instance(self.hass).async_clear_statistics(list(self._statistic_ids))
 
     async def _async_update_data(
         self,
@@ -127,8 +115,6 @@ class OpowerCoordinator(DataUpdateCoordinator[dict[str, Forecast]]):
             )
             cost_statistic_id = f"{DOMAIN}:{id_prefix}_energy_cost"
             consumption_statistic_id = f"{DOMAIN}:{id_prefix}_energy_consumption"
-            self._statistic_ids.add(cost_statistic_id)
-            self._statistic_ids.add(consumption_statistic_id)
             _LOGGER.debug(
                 "Updating Statistics for %s and %s",
                 cost_statistic_id,

--- a/homeassistant/components/opower/sensor.py
+++ b/homeassistant/components/opower/sensor.py
@@ -20,8 +20,9 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from . import OpowerConfigEntry
 from .const import DOMAIN
-from .coordinator import OpowerConfigEntry, OpowerCoordinator
+from .coordinator import OpowerCoordinator
 
 
 @dataclass(frozen=True, kw_only=True)


### PR DESCRIPTION
Reverts home-assistant/core#135908
I just realized this is also running when you reload the integration so it's not a good idea after all.