### PR TITLE
Only refresh advanced Hydrawise data when entities are enabled

### DIFF
--- a/homeassistant/components/hydrawise/__init__.py
+++ b/homeassistant/components/hydrawise/__init__.py
@@ -52,6 +52,8 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         )
     )
     await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
+    # The initial refresh will not pull data, so we need to manually refresh again.
+    await water_use_coordinator.async_refresh()
     return True
 
 

--- a/homeassistant/components/hydrawise/coordinator.py
+++ b/homeassistant/components/hydrawise/coordinator.py
@@ -110,12 +110,17 @@ class HydrawiseWaterUseDataUpdateCoordinator(HydrawiseDataUpdateCoordinator):
     async def _async_update_data(self) -> HydrawiseData:
         """Fetch the latest data from Hydrawise."""
         daily_water_summary: dict[int, ControllerWaterUseSummary] = {}
+        listening_entities = set(self.async_contexts())
         for controller in self._main_coordinator.data.controllers.values():
-            daily_water_summary[controller.id] = await self.api.get_water_use_summary(
-                controller,
-                now().replace(hour=0, minute=0, second=0, microsecond=0),
-                now(),
-            )
+            summary = ControllerWaterUseSummary()
+            if listening_entities:
+                summary = await self.api.get_water_use_summary(
+                    controller,
+                    now().replace(hour=0, minute=0, second=0, microsecond=0),
+                    now(),
+                )
+            daily_water_summary[controller.id] = summary
+
         main_data = self._main_coordinator.data
         return HydrawiseData(
             user=main_data.user,

--- a/homeassistant/components/hydrawise/entity.py
+++ b/homeassistant/components/hydrawise/entity.py
@@ -29,12 +29,12 @@ class HydrawiseEntity(CoordinatorEntity[HydrawiseDataUpdateCoordinator]):
         sensor_id: int | None = None,
     ) -> None:
         """Initialize the Hydrawise entity."""
-        super().__init__(coordinator=coordinator)
+        self._device_id = str(zone_id) if zone_id is not None else str(controller.id)
+        super().__init__(coordinator=coordinator, context=self._device_id)
         self.entity_description = description
         self.controller = controller
         self.zone_id = zone_id
         self.sensor_id = sensor_id
-        self._device_id = str(zone_id) if zone_id is not None else str(controller.id)
         self._attr_unique_id = f"{self._device_id}_{description.key}"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self._device_id)},

--- a/tests/components/hydrawise/snapshots/test_sensor.ambr
+++ b/tests/components/hydrawise/snapshots/test_sensor.ambr
@@ -242,7 +242,7 @@
       }),
     }),
     'original_device_class': <SensorDeviceClass.VOLUME: 'volume'>,
-    'original_icon': None,
+    'original_icon': 'mdi:water-outline',
     'original_name': 'Daily active water use',
     'platform': 'hydrawise',
     'previous_unique_id': None,


### PR DESCRIPTION
## Proposed change
This prevents the `HydrawiseWaterUseDataUpdateCoordinator` from refreshing data if there are no entities subscribed to updates. The API calls that this coordinator makes are expensive (both server-side and client-side) so there's no reason to make them if nothing needs the data.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
