### PR TITLE
Add more tests/support for VeSync device variants

### DIFF
--- a/homeassistant/components/vesync/common.py
+++ b/homeassistant/components/vesync/common.py
@@ -9,7 +9,7 @@ from pyvesync.vesyncswitch import VeSyncWallSwitch
 
 from homeassistant.core import HomeAssistant
 
-from .const import VeSyncHumidifierDevice
+from .const import DEV_TYPE_TO_HA, SKU_TO_BASE_DEVICE
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -55,7 +55,10 @@ async def async_generate_device_list(
 def is_humidifier(device: VeSyncBaseDevice) -> bool:
     """Check if the device represents a humidifier."""
 
-    return isinstance(device, VeSyncHumidifierDevice)
+    return (
+        DEV_TYPE_TO_HA.get(SKU_TO_BASE_DEVICE.get(device.device_type, ""))
+        == "humidifier"
+    )
 
 
 def is_outlet(device: VeSyncBaseDevice) -> bool:

--- a/homeassistant/components/vesync/const.py
+++ b/homeassistant/components/vesync/const.py
@@ -1,6 +1,14 @@
 """Constants for VeSync Component."""
 
-from pyvesync.vesyncfan import VeSyncHumid200300S, VeSyncSuperior6000S
+from pyvesync.vesyncbulb import feature_dict as bulb_features
+from pyvesync.vesyncfan import (
+    VeSyncHumid200300S,
+    VeSyncSuperior6000S,
+    air_features,
+    humid_features,
+)
+from pyvesync.vesyncoutlet import outlet_config
+from pyvesync.vesyncswitch import feature_dict as switch_features
 
 DOMAIN = "vesync"
 VS_DISCOVERY = "vesync_discovery_{}"
@@ -32,69 +40,29 @@ VS_HUMIDIFIER_MODE_SLEEP = "sleep"
 VeSyncHumidifierDevice = VeSyncHumid200300S | VeSyncSuperior6000S
 """Humidifier device types"""
 
-DEV_TYPE_TO_HA = {
-    "wifi-switch-1.3": "outlet",
-    "ESW03-USA": "outlet",
-    "ESW01-EU": "outlet",
-    "ESW15-USA": "outlet",
-    "ESWL01": "switch",
-    "ESWL03": "switch",
-    "ESO15-TB": "outlet",
-    "LV-PUR131S": "fan",
-    "Core200S": "fan",
-    "Core300S": "fan",
-    "Core400S": "fan",
-    "Core600S": "fan",
-    "EverestAir": "fan",
-    "Vital200S": "fan",
-    "Vital100S": "fan",
-    "SmartTowerFan": "fan",
-    "ESD16": "walldimmer",
-    "ESWD16": "walldimmer",
-    "ESL100": "bulb-dimmable",
-    "ESL100CW": "bulb-tunable-white",
-}
+DEV_TYPE_TO_HA = {}
 
-SKU_TO_BASE_DEVICE = {
-    # Air Purifiers
-    "LV-PUR131S": "LV-PUR131S",
-    "LV-RH131S": "LV-PUR131S",  # Alt ID Model LV-PUR131S
-    "Core200S": "Core200S",
-    "LAP-C201S-AUSR": "Core200S",  # Alt ID Model Core200S
-    "LAP-C202S-WUSR": "Core200S",  # Alt ID Model Core200S
-    "Core300S": "Core300S",
-    "LAP-C301S-WJP": "Core300S",  # Alt ID Model Core300S
-    "LAP-C301S-WAAA": "Core300S",  # Alt ID Model Core300S
-    "LAP-C302S-WUSB": "Core300S",  # Alt ID Model Core300S
-    "Core400S": "Core400S",
-    "LAP-C401S-WJP": "Core400S",  # Alt ID Model Core400S
-    "LAP-C401S-WUSR": "Core400S",  # Alt ID Model Core400S
-    "LAP-C401S-WAAA": "Core400S",  # Alt ID Model Core400S
-    "Core600S": "Core600S",
-    "LAP-C601S-WUS": "Core600S",  # Alt ID Model Core600S
-    "LAP-C601S-WUSR": "Core600S",  # Alt ID Model Core600S
-    "LAP-C601S-WEU": "Core600S",  # Alt ID Model Core600S,
-    "Vital200S": "Vital200S",
-    "LAP-V201S-AASR": "Vital200S",  # Alt ID Model Vital200S
-    "LAP-V201S-WJP": "Vital200S",  # Alt ID Model Vital200S
-    "LAP-V201S-WEU": "Vital200S",  # Alt ID Model Vital200S
-    "LAP-V201S-WUS": "Vital200S",  # Alt ID Model Vital200S
-    "LAP-V201-AUSR": "Vital200S",  # Alt ID Model Vital200S
-    "LAP-V201S-AEUR": "Vital200S",  # Alt ID Model Vital200S
-    "LAP-V201S-AUSR": "Vital200S",  # Alt ID Model Vital200S
-    "Vital100S": "Vital100S",
-    "LAP-V102S-WUS": "Vital100S",  # Alt ID Model Vital100S
-    "LAP-V102S-AASR": "Vital100S",  # Alt ID Model Vital100S
-    "LAP-V102S-WEU": "Vital100S",  # Alt ID Model Vital100S
-    "LAP-V102S-WUK": "Vital100S",  # Alt ID Model Vital100S
-    "EverestAir": "EverestAir",
-    "LAP-EL551S-AUS": "EverestAir",  # Alt ID Model EverestAir
-    "LAP-EL551S-AEUR": "EverestAir",  # Alt ID Model EverestAir
-    "LAP-EL551S-WEU": "EverestAir",  # Alt ID Model EverestAir
-    "LAP-EL551S-WUS": "EverestAir",  # Alt ID Model EverestAir
-    "SmartTowerFan": "SmartTowerFan",
-    "LTF-F422S-KEU": "SmartTowerFan",  # Alt ID Model SmartTowerFan
-    "LTF-F422S-WUSR": "SmartTowerFan",  # Alt ID Model SmartTowerFan
-    "LTF-F422_WJP": "SmartTowerFan",  # Alt ID Model SmartTowerFan
-    "LTF-F422S-WUS": "SmartTowerFan",  # Alt ID Model SmartTowerFan
-}
+for device_name, device in bulb_features.items():
+    if "dimmable" in device["features"]:
+        DEV_TYPE_TO_HA[device_name] = "bulb-dimmable"
+
+    if "color_temp" in device["features"]:
+        DEV_TYPE_TO_HA[device_name] = "bulb-tunable-white"
+
+for device_name in air_features:
+    DEV_TYPE_TO_HA[device_name] = "fan"
+
+for device_name in outlet_config:
+    DEV_TYPE_TO_HA[device_name] = "outlet"
+
+for device_name, device in switch_features.items():
+    if "dimmable" in device["features"]:
+        DEV_TYPE_TO_HA[device_name] = "walldimmer"
+    else:
+        DEV_TYPE_TO_HA[device_name] = "switch"
+
+SKU_TO_BASE_DEVICE = {}
+
+for device_name, device_data in (air_features | humid_features).items():
+    for sku in device_data["models"]:
+        SKU_TO_BASE_DEVICE[sku] = device_name

--- a/homeassistant/components/vesync/const.py
+++ b/homeassistant/components/vesync/const.py
@@ -1,12 +1,7 @@
 """Constants for VeSync Component."""
 
 from pyvesync.vesyncbulb import feature_dict as bulb_features
-from pyvesync.vesyncfan import (
-    VeSyncHumid200300S,
-    VeSyncSuperior6000S,
-    air_features,
-    humid_features,
-)
+from pyvesync.vesyncfan import air_features, humid_features
 from pyvesync.vesyncoutlet import outlet_config
 from pyvesync.vesyncswitch import feature_dict as switch_features
 
@@ -37,9 +32,6 @@ VS_HUMIDIFIER_MODE_HUMIDITY = "humidity"
 VS_HUMIDIFIER_MODE_MANUAL = "manual"
 VS_HUMIDIFIER_MODE_SLEEP = "sleep"
 
-VeSyncHumidifierDevice = VeSyncHumid200300S | VeSyncSuperior6000S
-"""Humidifier device types"""
-
 DEV_TYPE_TO_HA = {}
 
 for device_name, device in bulb_features.items():
@@ -51,6 +43,9 @@ for device_name, device in bulb_features.items():
 
 for device_name in air_features:
     DEV_TYPE_TO_HA[device_name] = "fan"
+
+for device_name in humid_features:
+    DEV_TYPE_TO_HA[device_name] = "humidifier"
 
 for device_name in outlet_config:
     DEV_TYPE_TO_HA[device_name] = "outlet"

--- a/homeassistant/components/vesync/humidifier.py
+++ b/homeassistant/components/vesync/humidifier.py
@@ -28,7 +28,6 @@ from .const import (
     VS_HUMIDIFIER_MODE_HUMIDITY,
     VS_HUMIDIFIER_MODE_MANUAL,
     VS_HUMIDIFIER_MODE_SLEEP,
-    VeSyncHumidifierDevice,
 )
 from .coordinator import VeSyncDataCoordinator
 from .entity import VeSyncBaseEntity
@@ -96,8 +95,6 @@ class VeSyncHumidifierHA(VeSyncBaseEntity, HumidifierEntity):
     _attr_max_humidity = MAX_HUMIDITY
     _attr_min_humidity = MIN_HUMIDITY
     _attr_supported_features = HumidifierEntityFeature.MODES
-
-    device: VeSyncHumidifierDevice
 
     def __init__(
         self,

--- a/tests/components/vesync/common.py
+++ b/tests/components/vesync/common.py
@@ -22,6 +22,9 @@ DEVICE_FIXTURES: dict[str, list[tuple[str, str, str]]] = {
     "Humidifier 200s": [
         ("post", "/cloud/v2/deviceManaged/bypassV2", "humidifier-200s.json")
     ],
+    "Humidifier 300s": [
+        ("post", "/cloud/v2/deviceManaged/bypassV2", "device-detail.json")
+    ],
     "Humidifier 600S": [
         ("post", "/cloud/v2/deviceManaged/bypassV2", "device-detail.json")
     ],
@@ -29,6 +32,9 @@ DEVICE_FIXTURES: dict[str, list[tuple[str, str, str]]] = {
         ("post", "/131airPurifier/v1/device/deviceDetail", "purifier-detail.json")
     ],
     "Air Purifier 200s": [
+        ("post", "/cloud/v2/deviceManaged/bypassV2", "device-detail.json")
+    ],
+    "Air Purifier 300s": [
         ("post", "/cloud/v2/deviceManaged/bypassV2", "device-detail.json")
     ],
     "Air Purifier 400s": [
@@ -43,9 +49,21 @@ DEVICE_FIXTURES: dict[str, list[tuple[str, str, str]]] = {
     "Temperature Light": [
         ("post", "/cloud/v1/deviceManaged/bypass", "device-detail.json")
     ],
-    "Outlet": [
-        ("get", "/v1/device/outlet/detail", "outlet-detail.json"),
-        ("get", "/v1/device/outlet/energy/week", "outlet-energy-week.json"),
+    "Outlet 7A": [
+        ("get", "/v1/device/7a-outlet/detail", "outlet-detail.json"),
+        ("get", "/v1/device/7a-outlet/energy/week", "outlet-energy-week.json"),
+    ],
+    "Outlet 10A": [
+        ("post", "/10a/v1/device/devicedetail", "outlet-detail.json"),
+        ("post", "/10a/v1/device/energyweek", "outlet-energy-week.json"),
+    ],
+    "Outlet Outdoor Plug": [
+        (
+            "post",
+            "/outdoorsocket15a/v1/device/devicedetail",
+            "outlet-outdoor-detail.json",
+        ),
+        ("post", "/outdoorsocket15a/v1/device/energyweek", "outlet-energy-week.json"),
     ],
     "Wall Switch": [
         ("post", "/inwallswitch/v1/device/devicedetail", "device-detail.json")

--- a/tests/components/vesync/fixtures/outlet-detail.json
+++ b/tests/components/vesync/fixtures/outlet-detail.json
@@ -1,4 +1,5 @@
 {
+  "code": 0,
   "deviceStatus": "on",
   "activeTime": 10,
   "energy": 100,

--- a/tests/components/vesync/fixtures/outlet-outdoor-detail.json
+++ b/tests/components/vesync/fixtures/outlet-outdoor-detail.json
@@ -1,0 +1,25 @@
+{
+  "code": 0,
+  "msg": null,
+  "connectionStatus": "online",
+  "activeTime": 20,
+  "energy": 200,
+  "power": 50,
+  "voltage": 240,
+  "deviceStatus": "on",
+  "deviceName": "Outlet Outdoor Plug",
+  "subDevices": [
+    {
+      "subDeviceNo": 1,
+      "defaultName": "Socket A",
+      "subDeviceName": "Outlet Outdoor Plug",
+      "subDeviceStatus": "on"
+    },
+    {
+      "subDeviceNo": 2,
+      "defaultName": "Socket B",
+      "subDeviceName": "Outlet Outdoor Plug",
+      "subDeviceStatus": "on"
+    }
+  ]
+}

--- a/tests/components/vesync/fixtures/vesync-devices.json
+++ b/tests/components/vesync/fixtures/vesync-devices.json
@@ -13,6 +13,16 @@
         "configModule": "configModule"
       },
       {
+        "cid": "300s-humidifier",
+        "deviceType": "LUH-A601S-WUSB",
+        "deviceName": "Humidifier 300s",
+        "subDeviceNo": 4321,
+        "deviceStatus": "on",
+        "connectionStatus": "online",
+        "uuid": "00000000-1111-2222-3333-666666666666",
+        "configModule": "configModule"
+      },
+      {
         "cid": "600s-humidifier",
         "deviceType": "LUH-A602S-WUS",
         "deviceName": "Humidifier 600S",
@@ -45,6 +55,16 @@
         "configModule": "configModule"
       },
       {
+        "cid": "300s-purifier",
+        "deviceType": "LAP-C301S-WAAA",
+        "deviceName": "Air Purifier 300s",
+        "subDeviceNo": null,
+        "deviceStatus": "on",
+        "type": "wifi-air",
+        "connectionStatus": "online",
+        "configModule": "configModule"
+      },
+      {
         "cid": "400s-purifier",
         "deviceType": "LAP-C401S-WJP",
         "deviceName": "Air Purifier 400s",
@@ -60,6 +80,15 @@
         "deviceName": "Air Purifier 600s",
         "subDeviceNo": null,
         "type": "wifi-air",
+        "deviceStatus": "on",
+        "connectionStatus": "online",
+        "configModule": "configModule"
+      },
+      {
+        "cid": "smarttowerfan",
+        "deviceType": "LTF-F422S-KEU",
+        "deviceName": "SmartTowerFan",
+        "subDeviceNo": null,
         "deviceStatus": "on",
         "connectionStatus": "online",
         "configModule": "configModule"
@@ -83,10 +112,28 @@
         "configModule": "configModule"
       },
       {
-        "cid": "outlet",
+        "cid": "7a-outlet",
         "deviceType": "wifi-switch-1.3",
-        "deviceName": "Outlet",
+        "deviceName": "Outlet 7A",
         "subDeviceNo": null,
+        "deviceStatus": "on",
+        "connectionStatus": "online",
+        "configModule": "configModule"
+      },
+      {
+        "cid": "10a-outlet",
+        "deviceType": "ESW01-EU",
+        "deviceName": "Outlet 10A",
+        "subDeviceNo": null,
+        "deviceStatus": "on",
+        "connectionStatus": "online",
+        "configModule": "configModule"
+      },
+      {
+        "cid": "outdoor-outlet",
+        "deviceType": "ESO15-TB",
+        "deviceName": "Outlet Outdoor Plug",
+        "subDeviceNo": 1,
         "deviceStatus": "on",
         "connectionStatus": "online",
         "configModule": "configModule"
@@ -104,15 +151,6 @@
         "cid": "dimmable-switch",
         "deviceType": "ESWD16",
         "deviceName": "Dimmer Switch",
-        "subDeviceNo": null,
-        "deviceStatus": "on",
-        "connectionStatus": "online",
-        "configModule": "configModule"
-      },
-      {
-        "cid": "smarttowerfan",
-        "deviceType": "LTF-F422S-KEU",
-        "deviceName": "SmartTowerFan",
         "subDeviceNo": null,
         "deviceStatus": "on",
         "connectionStatus": "online",

--- a/tests/components/vesync/snapshots/test_fan.ambr
+++ b/tests/components/vesync/snapshots/test_fan.ambr
@@ -188,6 +188,105 @@
     'state': 'on',
   })
 # ---
+# name: test_fan_state[Air Purifier 300s][devices]
+  list([
+    DeviceRegistryEntrySnapshot({
+      'area_id': None,
+      'config_entries': <ANY>,
+      'configuration_url': None,
+      'connections': set({
+      }),
+      'disabled_by': None,
+      'entry_type': None,
+      'hw_version': None,
+      'id': <ANY>,
+      'identifiers': set({
+        tuple(
+          'vesync',
+          '300s-purifier',
+        ),
+      }),
+      'is_new': False,
+      'labels': set({
+      }),
+      'manufacturer': 'VeSync',
+      'model': 'LAP-C301S-WAAA',
+      'model_id': None,
+      'name': 'Air Purifier 300s',
+      'name_by_user': None,
+      'primary_config_entry': <ANY>,
+      'serial_number': None,
+      'suggested_area': None,
+      'sw_version': None,
+      'via_device_id': None,
+    }),
+  ])
+# ---
+# name: test_fan_state[Air Purifier 300s][entities]
+  list([
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'preset_modes': list([
+          'auto',
+          'sleep',
+        ]),
+      }),
+      'config_entry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'fan',
+      'entity_category': None,
+      'entity_id': 'fan.air_purifier_300s',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': None,
+      'original_name': None,
+      'platform': 'vesync',
+      'previous_unique_id': None,
+      'supported_features': <FanEntityFeature: 57>,
+      'translation_key': 'vesync',
+      'unique_id': '300s-purifier',
+      'unit_of_measurement': None,
+    }),
+  ])
+# ---
+# name: test_fan_state[Air Purifier 300s][fan.air_purifier_300s]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'child_lock': False,
+      'friendly_name': 'Air Purifier 300s',
+      'mode': 'manual',
+      'night_light': 'off',
+      'percentage': 33,
+      'percentage_step': 33.333333333333336,
+      'preset_mode': None,
+      'preset_modes': list([
+        'auto',
+        'sleep',
+      ]),
+      'screen_status': True,
+      'supported_features': <FanEntityFeature: 57>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'fan.air_purifier_300s',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
 # name: test_fan_state[Air Purifier 400s][devices]
   list([
     DeviceRegistryEntrySnapshot({
@@ -500,6 +599,44 @@
   list([
   ])
 # ---
+# name: test_fan_state[Humidifier 300s][devices]
+  list([
+    DeviceRegistryEntrySnapshot({
+      'area_id': None,
+      'config_entries': <ANY>,
+      'configuration_url': None,
+      'connections': set({
+      }),
+      'disabled_by': None,
+      'entry_type': None,
+      'hw_version': None,
+      'id': <ANY>,
+      'identifiers': set({
+        tuple(
+          'vesync',
+          '300s-humidifier4321',
+        ),
+      }),
+      'is_new': False,
+      'labels': set({
+      }),
+      'manufacturer': 'VeSync',
+      'model': 'LUH-A601S-WUSB',
+      'model_id': None,
+      'name': 'Humidifier 300s',
+      'name_by_user': None,
+      'primary_config_entry': <ANY>,
+      'serial_number': None,
+      'suggested_area': None,
+      'sw_version': None,
+      'via_device_id': None,
+    }),
+  ])
+# ---
+# name: test_fan_state[Humidifier 300s][entities]
+  list([
+  ])
+# ---
 # name: test_fan_state[Humidifier 600S][devices]
   list([
     DeviceRegistryEntrySnapshot({
@@ -538,7 +675,7 @@
   list([
   ])
 # ---
-# name: test_fan_state[Outlet][devices]
+# name: test_fan_state[Outlet 10A][devices]
   list([
     DeviceRegistryEntrySnapshot({
       'area_id': None,
@@ -553,16 +690,16 @@
       'identifiers': set({
         tuple(
           'vesync',
-          'outlet',
+          '10a-outlet',
         ),
       }),
       'is_new': False,
       'labels': set({
       }),
       'manufacturer': 'VeSync',
-      'model': 'wifi-switch-1.3',
+      'model': 'ESW01-EU',
       'model_id': None,
-      'name': 'Outlet',
+      'name': 'Outlet 10A',
       'name_by_user': None,
       'primary_config_entry': <ANY>,
       'serial_number': None,
@@ -572,7 +709,83 @@
     }),
   ])
 # ---
-# name: test_fan_state[Outlet][entities]
+# name: test_fan_state[Outlet 10A][entities]
+  list([
+  ])
+# ---
+# name: test_fan_state[Outlet 7A][devices]
+  list([
+    DeviceRegistryEntrySnapshot({
+      'area_id': None,
+      'config_entries': <ANY>,
+      'configuration_url': None,
+      'connections': set({
+      }),
+      'disabled_by': None,
+      'entry_type': None,
+      'hw_version': None,
+      'id': <ANY>,
+      'identifiers': set({
+        tuple(
+          'vesync',
+          '7a-outlet',
+        ),
+      }),
+      'is_new': False,
+      'labels': set({
+      }),
+      'manufacturer': 'VeSync',
+      'model': 'wifi-switch-1.3',
+      'model_id': None,
+      'name': 'Outlet 7A',
+      'name_by_user': None,
+      'primary_config_entry': <ANY>,
+      'serial_number': None,
+      'suggested_area': None,
+      'sw_version': None,
+      'via_device_id': None,
+    }),
+  ])
+# ---
+# name: test_fan_state[Outlet 7A][entities]
+  list([
+  ])
+# ---
+# name: test_fan_state[Outlet Outdoor Plug][devices]
+  list([
+    DeviceRegistryEntrySnapshot({
+      'area_id': None,
+      'config_entries': <ANY>,
+      'configuration_url': None,
+      'connections': set({
+      }),
+      'disabled_by': None,
+      'entry_type': None,
+      'hw_version': None,
+      'id': <ANY>,
+      'identifiers': set({
+        tuple(
+          'vesync',
+          'outdoor-outlet1',
+        ),
+      }),
+      'is_new': False,
+      'labels': set({
+      }),
+      'manufacturer': 'VeSync',
+      'model': 'ESO15-TB',
+      'model_id': None,
+      'name': 'Outlet Outdoor Plug',
+      'name_by_user': None,
+      'primary_config_entry': <ANY>,
+      'serial_number': None,
+      'suggested_area': None,
+      'sw_version': None,
+      'via_device_id': None,
+    }),
+  ])
+# ---
+# name: test_fan_state[Outlet Outdoor Plug][entities]
   list([
   ])
 # ---

--- a/tests/components/vesync/snapshots/test_light.ambr
+++ b/tests/components/vesync/snapshots/test_light.ambr
@@ -75,6 +75,44 @@
   list([
   ])
 # ---
+# name: test_light_state[Air Purifier 300s][devices]
+  list([
+    DeviceRegistryEntrySnapshot({
+      'area_id': None,
+      'config_entries': <ANY>,
+      'configuration_url': None,
+      'connections': set({
+      }),
+      'disabled_by': None,
+      'entry_type': None,
+      'hw_version': None,
+      'id': <ANY>,
+      'identifiers': set({
+        tuple(
+          'vesync',
+          '300s-purifier',
+        ),
+      }),
+      'is_new': False,
+      'labels': set({
+      }),
+      'manufacturer': 'VeSync',
+      'model': 'LAP-C301S-WAAA',
+      'model_id': None,
+      'name': 'Air Purifier 300s',
+      'name_by_user': None,
+      'primary_config_entry': <ANY>,
+      'serial_number': None,
+      'suggested_area': None,
+      'sw_version': None,
+      'via_device_id': None,
+    }),
+  ])
+# ---
+# name: test_light_state[Air Purifier 300s][entities]
+  list([
+  ])
+# ---
 # name: test_light_state[Air Purifier 400s][devices]
   list([
     DeviceRegistryEntrySnapshot({
@@ -371,6 +409,44 @@
   list([
   ])
 # ---
+# name: test_light_state[Humidifier 300s][devices]
+  list([
+    DeviceRegistryEntrySnapshot({
+      'area_id': None,
+      'config_entries': <ANY>,
+      'configuration_url': None,
+      'connections': set({
+      }),
+      'disabled_by': None,
+      'entry_type': None,
+      'hw_version': None,
+      'id': <ANY>,
+      'identifiers': set({
+        tuple(
+          'vesync',
+          '300s-humidifier4321',
+        ),
+      }),
+      'is_new': False,
+      'labels': set({
+      }),
+      'manufacturer': 'VeSync',
+      'model': 'LUH-A601S-WUSB',
+      'model_id': None,
+      'name': 'Humidifier 300s',
+      'name_by_user': None,
+      'primary_config_entry': <ANY>,
+      'serial_number': None,
+      'suggested_area': None,
+      'sw_version': None,
+      'via_device_id': None,
+    }),
+  ])
+# ---
+# name: test_light_state[Humidifier 300s][entities]
+  list([
+  ])
+# ---
 # name: test_light_state[Humidifier 600S][devices]
   list([
     DeviceRegistryEntrySnapshot({
@@ -409,7 +485,7 @@
   list([
   ])
 # ---
-# name: test_light_state[Outlet][devices]
+# name: test_light_state[Outlet 10A][devices]
   list([
     DeviceRegistryEntrySnapshot({
       'area_id': None,
@@ -424,16 +500,16 @@
       'identifiers': set({
         tuple(
           'vesync',
-          'outlet',
+          '10a-outlet',
         ),
       }),
       'is_new': False,
       'labels': set({
       }),
       'manufacturer': 'VeSync',
-      'model': 'wifi-switch-1.3',
+      'model': 'ESW01-EU',
       'model_id': None,
-      'name': 'Outlet',
+      'name': 'Outlet 10A',
       'name_by_user': None,
       'primary_config_entry': <ANY>,
       'serial_number': None,
@@ -443,7 +519,83 @@
     }),
   ])
 # ---
-# name: test_light_state[Outlet][entities]
+# name: test_light_state[Outlet 10A][entities]
+  list([
+  ])
+# ---
+# name: test_light_state[Outlet 7A][devices]
+  list([
+    DeviceRegistryEntrySnapshot({
+      'area_id': None,
+      'config_entries': <ANY>,
+      'configuration_url': None,
+      'connections': set({
+      }),
+      'disabled_by': None,
+      'entry_type': None,
+      'hw_version': None,
+      'id': <ANY>,
+      'identifiers': set({
+        tuple(
+          'vesync',
+          '7a-outlet',
+        ),
+      }),
+      'is_new': False,
+      'labels': set({
+      }),
+      'manufacturer': 'VeSync',
+      'model': 'wifi-switch-1.3',
+      'model_id': None,
+      'name': 'Outlet 7A',
+      'name_by_user': None,
+      'primary_config_entry': <ANY>,
+      'serial_number': None,
+      'suggested_area': None,
+      'sw_version': None,
+      'via_device_id': None,
+    }),
+  ])
+# ---
+# name: test_light_state[Outlet 7A][entities]
+  list([
+  ])
+# ---
+# name: test_light_state[Outlet Outdoor Plug][devices]
+  list([
+    DeviceRegistryEntrySnapshot({
+      'area_id': None,
+      'config_entries': <ANY>,
+      'configuration_url': None,
+      'connections': set({
+      }),
+      'disabled_by': None,
+      'entry_type': None,
+      'hw_version': None,
+      'id': <ANY>,
+      'identifiers': set({
+        tuple(
+          'vesync',
+          'outdoor-outlet1',
+        ),
+      }),
+      'is_new': False,
+      'labels': set({
+      }),
+      'manufacturer': 'VeSync',
+      'model': 'ESO15-TB',
+      'model_id': None,
+      'name': 'Outlet Outdoor Plug',
+      'name_by_user': None,
+      'primary_config_entry': <ANY>,
+      'serial_number': None,
+      'suggested_area': None,
+      'sw_version': None,
+      'via_device_id': None,
+    }),
+  ])
+# ---
+# name: test_light_state[Outlet Outdoor Plug][entities]
   list([
   ])
 # ---

--- a/tests/components/vesync/snapshots/test_sensor.ambr
+++ b/tests/components/vesync/snapshots/test_sensor.ambr
@@ -215,6 +215,185 @@
     'state': '99',
   })
 # ---
+# name: test_sensor_state[Air Purifier 300s][devices]
+  list([
+    DeviceRegistryEntrySnapshot({
+      'area_id': None,
+      'config_entries': <ANY>,
+      'configuration_url': None,
+      'connections': set({
+      }),
+      'disabled_by': None,
+      'entry_type': None,
+      'hw_version': None,
+      'id': <ANY>,
+      'identifiers': set({
+        tuple(
+          'vesync',
+          '300s-purifier',
+        ),
+      }),
+      'is_new': False,
+      'labels': set({
+      }),
+      'manufacturer': 'VeSync',
+      'model': 'LAP-C301S-WAAA',
+      'model_id': None,
+      'name': 'Air Purifier 300s',
+      'name_by_user': None,
+      'primary_config_entry': <ANY>,
+      'serial_number': None,
+      'suggested_area': None,
+      'sw_version': None,
+      'via_device_id': None,
+    }),
+  ])
+# ---
+# name: test_sensor_state[Air Purifier 300s][entities]
+  list([
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.air_purifier_300s_filter_lifetime',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': None,
+      'original_name': 'Filter lifetime',
+      'platform': 'vesync',
+      'previous_unique_id': None,
+      'supported_features': 0,
+      'translation_key': 'filter_life',
+      'unique_id': '300s-purifier-filter-life',
+      'unit_of_measurement': '%',
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.air_purifier_300s_air_quality',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': None,
+      'original_name': 'Air quality',
+      'platform': 'vesync',
+      'previous_unique_id': None,
+      'supported_features': 0,
+      'translation_key': 'air_quality',
+      'unique_id': '300s-purifier-air-quality',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.air_purifier_300s_pm2_5',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <SensorDeviceClass.PM25: 'pm25'>,
+      'original_icon': None,
+      'original_name': 'PM2.5',
+      'platform': 'vesync',
+      'previous_unique_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': '300s-purifier-pm25',
+      'unit_of_measurement': 'µg/m³',
+    }),
+  ])
+# ---
+# name: test_sensor_state[Air Purifier 300s][sensor.air_purifier_300s_air_quality]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Air Purifier 300s Air quality',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.air_purifier_300s_air_quality',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '5',
+  })
+# ---
+# name: test_sensor_state[Air Purifier 300s][sensor.air_purifier_300s_filter_lifetime]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Air Purifier 300s Filter lifetime',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.air_purifier_300s_filter_lifetime',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '99',
+  })
+# ---
+# name: test_sensor_state[Air Purifier 300s][sensor.air_purifier_300s_pm2_5]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pm25',
+      'friendly_name': 'Air Purifier 300s PM2.5',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': 'µg/m³',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.air_purifier_300s_pm2_5',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '1',
+  })
+# ---
 # name: test_sensor_state[Air Purifier 400s][devices]
   list([
     DeviceRegistryEntrySnapshot({
@@ -736,6 +915,93 @@
     'state': '35',
   })
 # ---
+# name: test_sensor_state[Humidifier 300s][devices]
+  list([
+    DeviceRegistryEntrySnapshot({
+      'area_id': None,
+      'config_entries': <ANY>,
+      'configuration_url': None,
+      'connections': set({
+      }),
+      'disabled_by': None,
+      'entry_type': None,
+      'hw_version': None,
+      'id': <ANY>,
+      'identifiers': set({
+        tuple(
+          'vesync',
+          '300s-humidifier4321',
+        ),
+      }),
+      'is_new': False,
+      'labels': set({
+      }),
+      'manufacturer': 'VeSync',
+      'model': 'LUH-A601S-WUSB',
+      'model_id': None,
+      'name': 'Humidifier 300s',
+      'name_by_user': None,
+      'primary_config_entry': <ANY>,
+      'serial_number': None,
+      'suggested_area': None,
+      'sw_version': None,
+      'via_device_id': None,
+    }),
+  ])
+# ---
+# name: test_sensor_state[Humidifier 300s][entities]
+  list([
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.humidifier_300s_humidity',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <SensorDeviceClass.HUMIDITY: 'humidity'>,
+      'original_icon': None,
+      'original_name': 'Humidity',
+      'platform': 'vesync',
+      'previous_unique_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': '300s-humidifier4321-humidity',
+      'unit_of_measurement': '%',
+    }),
+  ])
+# ---
+# name: test_sensor_state[Humidifier 300s][sensor.humidifier_300s_humidity]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'humidity',
+      'friendly_name': 'Humidifier 300s Humidity',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.humidifier_300s_humidity',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '35',
+  })
+# ---
 # name: test_sensor_state[Humidifier 600S][devices]
   list([
     DeviceRegistryEntrySnapshot({
@@ -823,7 +1089,7 @@
     'state': '35',
   })
 # ---
-# name: test_sensor_state[Outlet][devices]
+# name: test_sensor_state[Outlet 10A][devices]
   list([
     DeviceRegistryEntrySnapshot({
       'area_id': None,
@@ -838,16 +1104,16 @@
       'identifiers': set({
         tuple(
           'vesync',
-          'outlet',
+          '10a-outlet',
         ),
       }),
       'is_new': False,
       'labels': set({
       }),
       'manufacturer': 'VeSync',
-      'model': 'wifi-switch-1.3',
+      'model': 'ESW01-EU',
       'model_id': None,
-      'name': 'Outlet',
+      'name': 'Outlet 10A',
       'name_by_user': None,
       'primary_config_entry': <ANY>,
       'serial_number': None,
@@ -857,7 +1123,7 @@
     }),
   ])
 # ---
-# name: test_sensor_state[Outlet][entities]
+# name: test_sensor_state[Outlet 10A][entities]
   list([
     EntityRegistryEntrySnapshot({
       'aliases': set({
@@ -872,7 +1138,7 @@
       'disabled_by': None,
       'domain': 'sensor',
       'entity_category': None,
-      'entity_id': 'sensor.outlet_current_power',
+      'entity_id': 'sensor.outlet_10a_current_power',
       'has_entity_name': True,
       'hidden_by': None,
       'icon': None,
@@ -889,7 +1155,7 @@
       'previous_unique_id': None,
       'supported_features': 0,
       'translation_key': 'current_power',
-      'unique_id': 'outlet-power',
+      'unique_id': '10a-outlet-power',
       'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
     }),
     EntityRegistryEntrySnapshot({
@@ -905,7 +1171,7 @@
       'disabled_by': None,
       'domain': 'sensor',
       'entity_category': None,
-      'entity_id': 'sensor.outlet_energy_use_today',
+      'entity_id': 'sensor.outlet_10a_energy_use_today',
       'has_entity_name': True,
       'hidden_by': None,
       'icon': None,
@@ -922,7 +1188,7 @@
       'previous_unique_id': None,
       'supported_features': 0,
       'translation_key': 'energy_today',
-      'unique_id': 'outlet-energy',
+      'unique_id': '10a-outlet-energy',
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
     }),
     EntityRegistryEntrySnapshot({
@@ -938,7 +1204,7 @@
       'disabled_by': None,
       'domain': 'sensor',
       'entity_category': None,
-      'entity_id': 'sensor.outlet_energy_use_weekly',
+      'entity_id': 'sensor.outlet_10a_energy_use_weekly',
       'has_entity_name': True,
       'hidden_by': None,
       'icon': None,
@@ -955,7 +1221,7 @@
       'previous_unique_id': None,
       'supported_features': 0,
       'translation_key': 'energy_week',
-      'unique_id': 'outlet-energy-weekly',
+      'unique_id': '10a-outlet-energy-weekly',
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
     }),
     EntityRegistryEntrySnapshot({
@@ -971,7 +1237,7 @@
       'disabled_by': None,
       'domain': 'sensor',
       'entity_category': None,
-      'entity_id': 'sensor.outlet_energy_use_monthly',
+      'entity_id': 'sensor.outlet_10a_energy_use_monthly',
       'has_entity_name': True,
       'hidden_by': None,
       'icon': None,
@@ -988,7 +1254,7 @@
       'previous_unique_id': None,
       'supported_features': 0,
       'translation_key': 'energy_month',
-      'unique_id': 'outlet-energy-monthly',
+      'unique_id': '10a-outlet-energy-monthly',
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
     }),
     EntityRegistryEntrySnapshot({
@@ -1004,7 +1270,7 @@
       'disabled_by': None,
       'domain': 'sensor',
       'entity_category': None,
-      'entity_id': 'sensor.outlet_energy_use_yearly',
+      'entity_id': 'sensor.outlet_10a_energy_use_yearly',
       'has_entity_name': True,
       'hidden_by': None,
       'icon': None,
@@ -1021,7 +1287,7 @@
       'previous_unique_id': None,
       'supported_features': 0,
       'translation_key': 'energy_year',
-      'unique_id': 'outlet-energy-yearly',
+      'unique_id': '10a-outlet-energy-yearly',
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
     }),
     EntityRegistryEntrySnapshot({
@@ -1037,7 +1303,7 @@
       'disabled_by': None,
       'domain': 'sensor',
       'entity_category': None,
-      'entity_id': 'sensor.outlet_current_voltage',
+      'entity_id': 'sensor.outlet_10a_current_voltage',
       'has_entity_name': True,
       'hidden_by': None,
       'icon': None,
@@ -1054,101 +1320,765 @@
       'previous_unique_id': None,
       'supported_features': 0,
       'translation_key': 'current_voltage',
-      'unique_id': 'outlet-voltage',
+      'unique_id': '10a-outlet-voltage',
       'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
     }),
   ])
 # ---
-# name: test_sensor_state[Outlet][sensor.outlet_current_power]
+# name: test_sensor_state[Outlet 10A][sensor.outlet_10a_current_power]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'power',
-      'friendly_name': 'Outlet Current power',
+      'friendly_name': 'Outlet 10A Current power',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.outlet_current_power',
+    'entity_id': 'sensor.outlet_10a_current_power',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '25.0',
+    'state': '25',
   })
 # ---
-# name: test_sensor_state[Outlet][sensor.outlet_current_voltage]
+# name: test_sensor_state[Outlet 10A][sensor.outlet_10a_current_voltage]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'voltage',
-      'friendly_name': 'Outlet Current voltage',
+      'friendly_name': 'Outlet 10A Current voltage',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.outlet_current_voltage',
+    'entity_id': 'sensor.outlet_10a_current_voltage',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '120.0',
+    'state': '120',
   })
 # ---
-# name: test_sensor_state[Outlet][sensor.outlet_energy_use_monthly]
+# name: test_sensor_state[Outlet 10A][sensor.outlet_10a_energy_use_monthly]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Outlet Energy use monthly',
+      'friendly_name': 'Outlet 10A Energy use monthly',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.outlet_energy_use_monthly',
+    'entity_id': 'sensor.outlet_10a_energy_use_monthly',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '0',
   })
 # ---
-# name: test_sensor_state[Outlet][sensor.outlet_energy_use_today]
+# name: test_sensor_state[Outlet 10A][sensor.outlet_10a_energy_use_today]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Outlet Energy use today',
+      'friendly_name': 'Outlet 10A Energy use today',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.outlet_energy_use_today',
+    'entity_id': 'sensor.outlet_10a_energy_use_today',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '100',
   })
 # ---
-# name: test_sensor_state[Outlet][sensor.outlet_energy_use_weekly]
+# name: test_sensor_state[Outlet 10A][sensor.outlet_10a_energy_use_weekly]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Outlet Energy use weekly',
+      'friendly_name': 'Outlet 10A Energy use weekly',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.outlet_energy_use_weekly',
+    'entity_id': 'sensor.outlet_10a_energy_use_weekly',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '0',
   })
 # ---
-# name: test_sensor_state[Outlet][sensor.outlet_energy_use_yearly]
+# name: test_sensor_state[Outlet 10A][sensor.outlet_10a_energy_use_yearly]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Outlet Energy use yearly',
+      'friendly_name': 'Outlet 10A Energy use yearly',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.outlet_energy_use_yearly',
+    'entity_id': 'sensor.outlet_10a_energy_use_yearly',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_sensor_state[Outlet 7A][devices]
+  list([
+    DeviceRegistryEntrySnapshot({
+      'area_id': None,
+      'config_entries': <ANY>,
+      'configuration_url': None,
+      'connections': set({
+      }),
+      'disabled_by': None,
+      'entry_type': None,
+      'hw_version': None,
+      'id': <ANY>,
+      'identifiers': set({
+        tuple(
+          'vesync',
+          '7a-outlet',
+        ),
+      }),
+      'is_new': False,
+      'labels': set({
+      }),
+      'manufacturer': 'VeSync',
+      'model': 'wifi-switch-1.3',
+      'model_id': None,
+      'name': 'Outlet 7A',
+      'name_by_user': None,
+      'primary_config_entry': <ANY>,
+      'serial_number': None,
+      'suggested_area': None,
+      'sw_version': None,
+      'via_device_id': None,
+    }),
+  ])
+# ---
+# name: test_sensor_state[Outlet 7A][entities]
+  list([
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.outlet_7a_current_power',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <SensorDeviceClass.POWER: 'power'>,
+      'original_icon': None,
+      'original_name': 'Current power',
+      'platform': 'vesync',
+      'previous_unique_id': None,
+      'supported_features': 0,
+      'translation_key': 'current_power',
+      'unique_id': '7a-outlet-power',
+      'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      }),
+      'config_entry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.outlet_7a_energy_use_today',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
+      'original_icon': None,
+      'original_name': 'Energy use today',
+      'platform': 'vesync',
+      'previous_unique_id': None,
+      'supported_features': 0,
+      'translation_key': 'energy_today',
+      'unique_id': '7a-outlet-energy',
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      }),
+      'config_entry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.outlet_7a_energy_use_weekly',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
+      'original_icon': None,
+      'original_name': 'Energy use weekly',
+      'platform': 'vesync',
+      'previous_unique_id': None,
+      'supported_features': 0,
+      'translation_key': 'energy_week',
+      'unique_id': '7a-outlet-energy-weekly',
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      }),
+      'config_entry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.outlet_7a_energy_use_monthly',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
+      'original_icon': None,
+      'original_name': 'Energy use monthly',
+      'platform': 'vesync',
+      'previous_unique_id': None,
+      'supported_features': 0,
+      'translation_key': 'energy_month',
+      'unique_id': '7a-outlet-energy-monthly',
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      }),
+      'config_entry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.outlet_7a_energy_use_yearly',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
+      'original_icon': None,
+      'original_name': 'Energy use yearly',
+      'platform': 'vesync',
+      'previous_unique_id': None,
+      'supported_features': 0,
+      'translation_key': 'energy_year',
+      'unique_id': '7a-outlet-energy-yearly',
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.outlet_7a_current_voltage',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <SensorDeviceClass.VOLTAGE: 'voltage'>,
+      'original_icon': None,
+      'original_name': 'Current voltage',
+      'platform': 'vesync',
+      'previous_unique_id': None,
+      'supported_features': 0,
+      'translation_key': 'current_voltage',
+      'unique_id': '7a-outlet-voltage',
+      'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+    }),
+  ])
+# ---
+# name: test_sensor_state[Outlet 7A][sensor.outlet_7a_current_power]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power',
+      'friendly_name': 'Outlet 7A Current power',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.outlet_7a_current_power',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '25.0',
+  })
+# ---
+# name: test_sensor_state[Outlet 7A][sensor.outlet_7a_current_voltage]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'voltage',
+      'friendly_name': 'Outlet 7A Current voltage',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.outlet_7a_current_voltage',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '120.0',
+  })
+# ---
+# name: test_sensor_state[Outlet 7A][sensor.outlet_7a_energy_use_monthly]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy',
+      'friendly_name': 'Outlet 7A Energy use monthly',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.outlet_7a_energy_use_monthly',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_sensor_state[Outlet 7A][sensor.outlet_7a_energy_use_today]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy',
+      'friendly_name': 'Outlet 7A Energy use today',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.outlet_7a_energy_use_today',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '100',
+  })
+# ---
+# name: test_sensor_state[Outlet 7A][sensor.outlet_7a_energy_use_weekly]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy',
+      'friendly_name': 'Outlet 7A Energy use weekly',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.outlet_7a_energy_use_weekly',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_sensor_state[Outlet 7A][sensor.outlet_7a_energy_use_yearly]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy',
+      'friendly_name': 'Outlet 7A Energy use yearly',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.outlet_7a_energy_use_yearly',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_sensor_state[Outlet Outdoor Plug][devices]
+  list([
+    DeviceRegistryEntrySnapshot({
+      'area_id': None,
+      'config_entries': <ANY>,
+      'configuration_url': None,
+      'connections': set({
+      }),
+      'disabled_by': None,
+      'entry_type': None,
+      'hw_version': None,
+      'id': <ANY>,
+      'identifiers': set({
+        tuple(
+          'vesync',
+          'outdoor-outlet1',
+        ),
+      }),
+      'is_new': False,
+      'labels': set({
+      }),
+      'manufacturer': 'VeSync',
+      'model': 'ESO15-TB',
+      'model_id': None,
+      'name': 'Outlet Outdoor Plug',
+      'name_by_user': None,
+      'primary_config_entry': <ANY>,
+      'serial_number': None,
+      'suggested_area': None,
+      'sw_version': None,
+      'via_device_id': None,
+    }),
+  ])
+# ---
+# name: test_sensor_state[Outlet Outdoor Plug][entities]
+  list([
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.outlet_outdoor_plug_current_power',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <SensorDeviceClass.POWER: 'power'>,
+      'original_icon': None,
+      'original_name': 'Current power',
+      'platform': 'vesync',
+      'previous_unique_id': None,
+      'supported_features': 0,
+      'translation_key': 'current_power',
+      'unique_id': 'outdoor-outlet1-power',
+      'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      }),
+      'config_entry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.outlet_outdoor_plug_energy_use_today',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
+      'original_icon': None,
+      'original_name': 'Energy use today',
+      'platform': 'vesync',
+      'previous_unique_id': None,
+      'supported_features': 0,
+      'translation_key': 'energy_today',
+      'unique_id': 'outdoor-outlet1-energy',
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      }),
+      'config_entry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.outlet_outdoor_plug_energy_use_weekly',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
+      'original_icon': None,
+      'original_name': 'Energy use weekly',
+      'platform': 'vesync',
+      'previous_unique_id': None,
+      'supported_features': 0,
+      'translation_key': 'energy_week',
+      'unique_id': 'outdoor-outlet1-energy-weekly',
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      }),
+      'config_entry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.outlet_outdoor_plug_energy_use_monthly',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
+      'original_icon': None,
+      'original_name': 'Energy use monthly',
+      'platform': 'vesync',
+      'previous_unique_id': None,
+      'supported_features': 0,
+      'translation_key': 'energy_month',
+      'unique_id': 'outdoor-outlet1-energy-monthly',
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      }),
+      'config_entry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.outlet_outdoor_plug_energy_use_yearly',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
+      'original_icon': None,
+      'original_name': 'Energy use yearly',
+      'platform': 'vesync',
+      'previous_unique_id': None,
+      'supported_features': 0,
+      'translation_key': 'energy_year',
+      'unique_id': 'outdoor-outlet1-energy-yearly',
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.outlet_outdoor_plug_current_voltage',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <SensorDeviceClass.VOLTAGE: 'voltage'>,
+      'original_icon': None,
+      'original_name': 'Current voltage',
+      'platform': 'vesync',
+      'previous_unique_id': None,
+      'supported_features': 0,
+      'translation_key': 'current_voltage',
+      'unique_id': 'outdoor-outlet1-voltage',
+      'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+    }),
+  ])
+# ---
+# name: test_sensor_state[Outlet Outdoor Plug][sensor.outlet_outdoor_plug_current_power]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power',
+      'friendly_name': 'Outlet Outdoor Plug Current power',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.outlet_outdoor_plug_current_power',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '50',
+  })
+# ---
+# name: test_sensor_state[Outlet Outdoor Plug][sensor.outlet_outdoor_plug_current_voltage]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'voltage',
+      'friendly_name': 'Outlet Outdoor Plug Current voltage',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.outlet_outdoor_plug_current_voltage',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '240',
+  })
+# ---
+# name: test_sensor_state[Outlet Outdoor Plug][sensor.outlet_outdoor_plug_energy_use_monthly]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy',
+      'friendly_name': 'Outlet Outdoor Plug Energy use monthly',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.outlet_outdoor_plug_energy_use_monthly',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_sensor_state[Outlet Outdoor Plug][sensor.outlet_outdoor_plug_energy_use_today]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy',
+      'friendly_name': 'Outlet Outdoor Plug Energy use today',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.outlet_outdoor_plug_energy_use_today',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '200',
+  })
+# ---
+# name: test_sensor_state[Outlet Outdoor Plug][sensor.outlet_outdoor_plug_energy_use_weekly]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy',
+      'friendly_name': 'Outlet Outdoor Plug Energy use weekly',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.outlet_outdoor_plug_energy_use_weekly',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_sensor_state[Outlet Outdoor Plug][sensor.outlet_outdoor_plug_energy_use_yearly]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy',
+      'friendly_name': 'Outlet Outdoor Plug Energy use yearly',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.outlet_outdoor_plug_energy_use_yearly',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/vesync/snapshots/test_switch.ambr
+++ b/tests/components/vesync/snapshots/test_switch.ambr
@@ -75,6 +75,44 @@
   list([
   ])
 # ---
+# name: test_switch_state[Air Purifier 300s][devices]
+  list([
+    DeviceRegistryEntrySnapshot({
+      'area_id': None,
+      'config_entries': <ANY>,
+      'configuration_url': None,
+      'connections': set({
+      }),
+      'disabled_by': None,
+      'entry_type': None,
+      'hw_version': None,
+      'id': <ANY>,
+      'identifiers': set({
+        tuple(
+          'vesync',
+          '300s-purifier',
+        ),
+      }),
+      'is_new': False,
+      'labels': set({
+      }),
+      'manufacturer': 'VeSync',
+      'model': 'LAP-C301S-WAAA',
+      'model_id': None,
+      'name': 'Air Purifier 300s',
+      'name_by_user': None,
+      'primary_config_entry': <ANY>,
+      'serial_number': None,
+      'suggested_area': None,
+      'sw_version': None,
+      'via_device_id': None,
+    }),
+  ])
+# ---
+# name: test_switch_state[Air Purifier 300s][entities]
+  list([
+  ])
+# ---
 # name: test_switch_state[Air Purifier 400s][devices]
   list([
     DeviceRegistryEntrySnapshot({
@@ -265,6 +303,44 @@
   list([
   ])
 # ---
+# name: test_switch_state[Humidifier 300s][devices]
+  list([
+    DeviceRegistryEntrySnapshot({
+      'area_id': None,
+      'config_entries': <ANY>,
+      'configuration_url': None,
+      'connections': set({
+      }),
+      'disabled_by': None,
+      'entry_type': None,
+      'hw_version': None,
+      'id': <ANY>,
+      'identifiers': set({
+        tuple(
+          'vesync',
+          '300s-humidifier4321',
+        ),
+      }),
+      'is_new': False,
+      'labels': set({
+      }),
+      'manufacturer': 'VeSync',
+      'model': 'LUH-A601S-WUSB',
+      'model_id': None,
+      'name': 'Humidifier 300s',
+      'name_by_user': None,
+      'primary_config_entry': <ANY>,
+      'serial_number': None,
+      'suggested_area': None,
+      'sw_version': None,
+      'via_device_id': None,
+    }),
+  ])
+# ---
+# name: test_switch_state[Humidifier 300s][entities]
+  list([
+  ])
+# ---
 # name: test_switch_state[Humidifier 600S][devices]
   list([
     DeviceRegistryEntrySnapshot({
@@ -303,7 +379,7 @@
   list([
   ])
 # ---
-# name: test_switch_state[Outlet][devices]
+# name: test_switch_state[Outlet 10A][devices]
   list([
     DeviceRegistryEntrySnapshot({
       'area_id': None,
@@ -318,16 +394,16 @@
       'identifiers': set({
         tuple(
           'vesync',
-          'outlet',
+          '10a-outlet',
         ),
       }),
       'is_new': False,
       'labels': set({
       }),
       'manufacturer': 'VeSync',
-      'model': 'wifi-switch-1.3',
+      'model': 'ESW01-EU',
       'model_id': None,
-      'name': 'Outlet',
+      'name': 'Outlet 10A',
       'name_by_user': None,
       'primary_config_entry': <ANY>,
       'serial_number': None,
@@ -337,7 +413,7 @@
     }),
   ])
 # ---
-# name: test_switch_state[Outlet][entities]
+# name: test_switch_state[Outlet 10A][entities]
   list([
     EntityRegistryEntrySnapshot({
       'aliases': set({
@@ -350,7 +426,7 @@
       'disabled_by': None,
       'domain': 'switch',
       'entity_category': None,
-      'entity_id': 'switch.outlet',
+      'entity_id': 'switch.outlet_10a',
       'has_entity_name': True,
       'hidden_by': None,
       'icon': None,
@@ -367,19 +443,185 @@
       'previous_unique_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'outlet-device_status',
+      'unique_id': '10a-outlet-device_status',
       'unit_of_measurement': None,
     }),
   ])
 # ---
-# name: test_switch_state[Outlet][switch.outlet]
+# name: test_switch_state[Outlet 10A][switch.outlet_10a]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'outlet',
-      'friendly_name': 'Outlet',
+      'friendly_name': 'Outlet 10A',
     }),
     'context': <ANY>,
-    'entity_id': 'switch.outlet',
+    'entity_id': 'switch.outlet_10a',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_switch_state[Outlet 7A][devices]
+  list([
+    DeviceRegistryEntrySnapshot({
+      'area_id': None,
+      'config_entries': <ANY>,
+      'configuration_url': None,
+      'connections': set({
+      }),
+      'disabled_by': None,
+      'entry_type': None,
+      'hw_version': None,
+      'id': <ANY>,
+      'identifiers': set({
+        tuple(
+          'vesync',
+          '7a-outlet',
+        ),
+      }),
+      'is_new': False,
+      'labels': set({
+      }),
+      'manufacturer': 'VeSync',
+      'model': 'wifi-switch-1.3',
+      'model_id': None,
+      'name': 'Outlet 7A',
+      'name_by_user': None,
+      'primary_config_entry': <ANY>,
+      'serial_number': None,
+      'suggested_area': None,
+      'sw_version': None,
+      'via_device_id': None,
+    }),
+  ])
+# ---
+# name: test_switch_state[Outlet 7A][entities]
+  list([
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'switch',
+      'entity_category': None,
+      'entity_id': 'switch.outlet_7a',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <SwitchDeviceClass.OUTLET: 'outlet'>,
+      'original_icon': None,
+      'original_name': None,
+      'platform': 'vesync',
+      'previous_unique_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': '7a-outlet-device_status',
+      'unit_of_measurement': None,
+    }),
+  ])
+# ---
+# name: test_switch_state[Outlet 7A][switch.outlet_7a]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'outlet',
+      'friendly_name': 'Outlet 7A',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.outlet_7a',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_switch_state[Outlet Outdoor Plug][devices]
+  list([
+    DeviceRegistryEntrySnapshot({
+      'area_id': None,
+      'config_entries': <ANY>,
+      'configuration_url': None,
+      'connections': set({
+      }),
+      'disabled_by': None,
+      'entry_type': None,
+      'hw_version': None,
+      'id': <ANY>,
+      'identifiers': set({
+        tuple(
+          'vesync',
+          'outdoor-outlet1',
+        ),
+      }),
+      'is_new': False,
+      'labels': set({
+      }),
+      'manufacturer': 'VeSync',
+      'model': 'ESO15-TB',
+      'model_id': None,
+      'name': 'Outlet Outdoor Plug',
+      'name_by_user': None,
+      'primary_config_entry': <ANY>,
+      'serial_number': None,
+      'suggested_area': None,
+      'sw_version': None,
+      'via_device_id': None,
+    }),
+  ])
+# ---
+# name: test_switch_state[Outlet Outdoor Plug][entities]
+  list([
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'switch',
+      'entity_category': None,
+      'entity_id': 'switch.outlet_outdoor_plug',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <SwitchDeviceClass.OUTLET: 'outlet'>,
+      'original_icon': None,
+      'original_name': None,
+      'platform': 'vesync',
+      'previous_unique_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'outdoor-outlet1-device_status',
+      'unit_of_measurement': None,
+    }),
+  ])
+# ---
+# name: test_switch_state[Outlet Outdoor Plug][switch.outlet_outdoor_plug]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'outlet',
+      'friendly_name': 'Outlet Outdoor Plug',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.outlet_outdoor_plug',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/vesync/test_platform.py
+++ b/tests/components/vesync/test_platform.py
@@ -38,7 +38,7 @@ async def test_entity_update(
         entry_id="1",
     )
 
-    mock_multiple_device_responses(requests_mock, ["Air Purifier 400s", "Outlet"])
+    mock_multiple_device_responses(requests_mock, ["Air Purifier 400s", "Outlet 7A"])
 
     expected_entities = [
         # From "Air Purifier 400s"
@@ -46,14 +46,14 @@ async def test_entity_update(
         "sensor.air_purifier_400s_filter_lifetime",
         "sensor.air_purifier_400s_air_quality",
         "sensor.air_purifier_400s_pm2_5",
-        # From Outlet
-        "switch.outlet",
-        "sensor.outlet_current_power",
-        "sensor.outlet_energy_use_today",
-        "sensor.outlet_energy_use_weekly",
-        "sensor.outlet_energy_use_monthly",
-        "sensor.outlet_energy_use_yearly",
-        "sensor.outlet_current_voltage",
+        # From "Outlet 7A"
+        "switch.outlet_7a",
+        "sensor.outlet_7a_current_power",
+        "sensor.outlet_7a_energy_use_today",
+        "sensor.outlet_7a_energy_use_weekly",
+        "sensor.outlet_7a_energy_use_monthly",
+        "sensor.outlet_7a_energy_use_yearly",
+        "sensor.outlet_7a_current_voltage",
     ]
 
     config_entry.add_to_hass(hass)
@@ -66,20 +66,20 @@ async def test_entity_update(
         assert hass.states.get(entity_id).state != STATE_UNAVAILABLE
 
     assert hass.states.get("sensor.air_purifier_400s_air_quality").state == "5"
-    assert hass.states.get("sensor.outlet_current_voltage").state == "120.0"
-    assert hass.states.get("sensor.outlet_energy_use_weekly").state == "0"
+    assert hass.states.get("sensor.outlet_7a_current_voltage").state == "120.0"
+    assert hass.states.get("sensor.outlet_7a_energy_use_weekly").state == "0"
 
     # Update the mock responses
     mock_air_purifier_400s_update_response(requests_mock)
-    mock_outlet_energy_response(requests_mock, "Outlet", {"totalEnergy": 2.2})
-    mock_device_response(requests_mock, "Outlet", {"voltage": 129})
+    mock_outlet_energy_response(requests_mock, "Outlet 7A", {"totalEnergy": 2.2})
+    mock_device_response(requests_mock, "Outlet 7A", {"voltage": 129})
 
     freezer.tick(timedelta(seconds=UPDATE_INTERVAL))
     async_fire_time_changed(hass)
     await hass.async_block_till_done(True)
 
     assert hass.states.get("sensor.air_purifier_400s_air_quality").state == "15"
-    assert hass.states.get("sensor.outlet_current_voltage").state == "129.0"
+    assert hass.states.get("sensor.outlet_7a_current_voltage").state == "129.0"
 
     # Test energy update
     # pyvesync only updates energy parameters once every 6 hours.
@@ -88,5 +88,5 @@ async def test_entity_update(
     await hass.async_block_till_done(True)
 
     assert hass.states.get("sensor.air_purifier_400s_air_quality").state == "15"
-    assert hass.states.get("sensor.outlet_current_voltage").state == "129.0"
-    assert hass.states.get("sensor.outlet_energy_use_weekly").state == "2.2"
+    assert hass.states.get("sensor.outlet_7a_current_voltage").state == "129.0"
+    assert hass.states.get("sensor.outlet_7a_energy_use_weekly").state == "2.2"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The current VeSync plugin makes uses of long lists of hard-coded device SKUs and device types, which results in many issues and pull requests to support new devices after they are added to the underlying pyvesync library. This is further complicated by VeSync's love of adding new device SKUs for the same device, long after the original device was released.

In order to simplify handling within the Home Assistant integration for VeSync, this refactors the logic for detecting devices and SKUs to build the list based on the devices exposed by the pyvesync library. Additionally, this adds additional tests for newer VeSync devices that were previously supported by the integration but were not well-covered.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #128183
- Link to documentation pull request: N/A
- Link to developer documentation pull request:  N/A
- Link to frontend pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
