### PR TITLE
Keep one backup per backup agent when executing retention policy

### DIFF
--- a/tests/components/backup/test_websocket.py
+++ b/tests/components/backup/test_websocket.py
@@ -20,6 +20,7 @@ from homeassistant.components.backup import (
 from homeassistant.components.backup.agent import BackupAgentUnreachableError
 from homeassistant.components.backup.const import DATA_MANAGER, DOMAIN
 from homeassistant.components.backup.manager import (
+    AgentBackupStatus,
     CreateBackupEvent,
     CreateBackupState,
     ManagerBackup,
@@ -1800,21 +1801,25 @@ async def test_config_schedule_logic(
             },
             {
                 "backup-1": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-10T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-2": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-11T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-3": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-12T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-4": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-12T04:45:00+01:00",
                     with_automatic_settings=False,
                     spec=ManagerBackup,
@@ -1839,21 +1844,25 @@ async def test_config_schedule_logic(
             },
             {
                 "backup-1": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-10T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-2": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-11T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-3": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-12T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-4": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-12T04:45:00+01:00",
                     with_automatic_settings=False,
                     spec=ManagerBackup,
@@ -1878,11 +1887,13 @@ async def test_config_schedule_logic(
             },
             {
                 "backup-1": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-10T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-2": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-11T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
@@ -1907,26 +1918,31 @@ async def test_config_schedule_logic(
             },
             {
                 "backup-1": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-09T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-2": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-10T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-3": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-11T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-4": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-12T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-5": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-12T04:45:00+01:00",
                     with_automatic_settings=False,
                     spec=ManagerBackup,
@@ -1940,7 +1956,7 @@ async def test_config_schedule_logic(
             1,
             1,
             1,
-            [call("backup-1")],
+            [call("backup-1", agent_ids=["test.test-agent"])],
         ),
         (
             {
@@ -1951,26 +1967,31 @@ async def test_config_schedule_logic(
             },
             {
                 "backup-1": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-09T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-2": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-10T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-3": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-11T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-4": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-12T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-5": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-12T04:45:00+01:00",
                     with_automatic_settings=False,
                     spec=ManagerBackup,
@@ -1984,7 +2005,10 @@ async def test_config_schedule_logic(
             1,
             1,
             2,
-            [call("backup-1"), call("backup-2")],
+            [
+                call("backup-1", agent_ids=["test.test-agent"]),
+                call("backup-2", agent_ids=["test.test-agent"]),
+            ],
         ),
         (
             {
@@ -1995,21 +2019,25 @@ async def test_config_schedule_logic(
             },
             {
                 "backup-1": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-10T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-2": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-11T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-3": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-12T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-4": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-12T04:45:00+01:00",
                     with_automatic_settings=False,
                     spec=ManagerBackup,
@@ -2023,7 +2051,7 @@ async def test_config_schedule_logic(
             1,
             1,
             1,
-            [call("backup-1")],
+            [call("backup-1", agent_ids=["test.test-agent"])],
         ),
         (
             {
@@ -2034,21 +2062,25 @@ async def test_config_schedule_logic(
             },
             {
                 "backup-1": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-10T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-2": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-11T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-3": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-12T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-4": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-12T04:45:00+01:00",
                     with_automatic_settings=False,
                     spec=ManagerBackup,
@@ -2062,7 +2094,7 @@ async def test_config_schedule_logic(
             1,
             1,
             1,
-            [call("backup-1")],
+            [call("backup-1", agent_ids=["test.test-agent"])],
         ),
         (
             {
@@ -2073,26 +2105,31 @@ async def test_config_schedule_logic(
             },
             {
                 "backup-1": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-09T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-2": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-10T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-3": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-11T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-4": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-12T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-5": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-12T04:45:00+01:00",
                     with_automatic_settings=False,
                     spec=ManagerBackup,
@@ -2106,7 +2143,11 @@ async def test_config_schedule_logic(
             1,
             1,
             3,
-            [call("backup-1"), call("backup-2"), call("backup-3")],
+            [
+                call("backup-1", agent_ids=["test.test-agent"]),
+                call("backup-2", agent_ids=["test.test-agent"]),
+                call("backup-3", agent_ids=["test.test-agent"]),
+            ],
         ),
         (
             {
@@ -2117,11 +2158,13 @@ async def test_config_schedule_logic(
             },
             {
                 "backup-1": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-12T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-2": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-12T04:45:00+01:00",
                     with_automatic_settings=False,
                     spec=ManagerBackup,
@@ -2261,21 +2304,25 @@ async def test_config_retention_copies_logic(
             },
             {
                 "backup-1": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-10T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-2": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-11T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-3": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-12T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-4": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-12T04:45:00+01:00",
                     with_automatic_settings=False,
                     spec=ManagerBackup,
@@ -2297,21 +2344,25 @@ async def test_config_retention_copies_logic(
             },
             {
                 "backup-1": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-10T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-2": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-11T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-3": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-12T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-4": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-12T04:45:00+01:00",
                     with_automatic_settings=False,
                     spec=ManagerBackup,
@@ -2333,26 +2384,31 @@ async def test_config_retention_copies_logic(
             },
             {
                 "backup-1": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-09T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-2": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-10T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-3": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-11T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-4": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-12T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-5": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-12T04:45:00+01:00",
                     with_automatic_settings=False,
                     spec=ManagerBackup,
@@ -2363,7 +2419,7 @@ async def test_config_retention_copies_logic(
             1,
             1,
             1,
-            [call("backup-1")],
+            [call("backup-1", agent_ids=["test.test-agent"])],
         ),
         (
             {
@@ -2374,26 +2430,31 @@ async def test_config_retention_copies_logic(
             },
             {
                 "backup-1": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-09T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-2": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-10T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-3": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-11T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-4": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-12T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-5": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-12T04:45:00+01:00",
                     with_automatic_settings=False,
                     spec=ManagerBackup,
@@ -2404,7 +2465,10 @@ async def test_config_retention_copies_logic(
             1,
             1,
             2,
-            [call("backup-1"), call("backup-2")],
+            [
+                call("backup-1", agent_ids=["test.test-agent"]),
+                call("backup-2", agent_ids=["test.test-agent"]),
+            ],
         ),
     ],
 )
@@ -2519,16 +2583,19 @@ async def test_config_retention_copies_logic_manual_backup(
             [],
             {
                 "backup-1": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-10T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-2": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-11T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-3": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-10T04:45:00+01:00",
                     with_automatic_settings=False,
                     spec=ManagerBackup,
@@ -2541,7 +2608,7 @@ async def test_config_retention_copies_logic_manual_backup(
             "2024-11-12T12:00:00+01:00",
             1,
             1,
-            [call("backup-1")],
+            [call("backup-1", agent_ids=["test.test-agent"])],
         ),
         # No config update - No cleanup
         (
@@ -2549,16 +2616,19 @@ async def test_config_retention_copies_logic_manual_backup(
             [],
             {
                 "backup-1": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-10T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-2": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-11T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-3": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-10T04:45:00+01:00",
                     with_automatic_settings=False,
                     spec=ManagerBackup,
@@ -2586,16 +2656,19 @@ async def test_config_retention_copies_logic_manual_backup(
             ],
             {
                 "backup-1": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-10T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-2": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-11T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-3": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-10T04:45:00+01:00",
                     with_automatic_settings=False,
                     spec=ManagerBackup,
@@ -2608,7 +2681,7 @@ async def test_config_retention_copies_logic_manual_backup(
             "2024-11-12T12:00:00+01:00",
             1,
             1,
-            [call("backup-1")],
+            [call("backup-1", agent_ids=["test.test-agent"])],
         ),
         (
             None,
@@ -2622,16 +2695,19 @@ async def test_config_retention_copies_logic_manual_backup(
             ],
             {
                 "backup-1": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-10T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-2": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-11T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-3": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-10T04:45:00+01:00",
                     with_automatic_settings=False,
                     spec=ManagerBackup,
@@ -2644,7 +2720,7 @@ async def test_config_retention_copies_logic_manual_backup(
             "2024-11-12T12:00:00+01:00",
             1,
             1,
-            [call("backup-1")],
+            [call("backup-1", agent_ids=["test.test-agent"])],
         ),
         (
             None,
@@ -2658,16 +2734,19 @@ async def test_config_retention_copies_logic_manual_backup(
             ],
             {
                 "backup-1": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-10T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-2": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-11T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-3": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-10T04:45:00+01:00",
                     with_automatic_settings=False,
                     spec=ManagerBackup,
@@ -2694,21 +2773,25 @@ async def test_config_retention_copies_logic_manual_backup(
             ],
             {
                 "backup-1": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-09T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-2": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-10T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-3": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-11T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-4": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-10T04:45:00+01:00",
                     with_automatic_settings=False,
                     spec=ManagerBackup,
@@ -2721,7 +2804,10 @@ async def test_config_retention_copies_logic_manual_backup(
             "2024-11-12T12:00:00+01:00",
             1,
             2,
-            [call("backup-1"), call("backup-2")],
+            [
+                call("backup-1", agent_ids=["test.test-agent"]),
+                call("backup-2", agent_ids=["test.test-agent"]),
+            ],
         ),
         (
             None,
@@ -2735,16 +2821,19 @@ async def test_config_retention_copies_logic_manual_backup(
             ],
             {
                 "backup-1": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-10T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-2": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-11T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-3": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-10T04:45:00+01:00",
                     with_automatic_settings=False,
                     spec=ManagerBackup,
@@ -2757,7 +2846,7 @@ async def test_config_retention_copies_logic_manual_backup(
             "2024-11-12T12:00:00+01:00",
             1,
             1,
-            [call("backup-1")],
+            [call("backup-1", agent_ids=["test.test-agent"])],
         ),
         (
             None,
@@ -2771,16 +2860,19 @@ async def test_config_retention_copies_logic_manual_backup(
             ],
             {
                 "backup-1": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-10T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-2": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-11T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-3": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-10T04:45:00+01:00",
                     with_automatic_settings=False,
                     spec=ManagerBackup,
@@ -2793,7 +2885,7 @@ async def test_config_retention_copies_logic_manual_backup(
             "2024-11-12T12:00:00+01:00",
             1,
             1,
-            [call("backup-1")],
+            [call("backup-1", agent_ids=["test.test-agent"])],
         ),
         (
             None,
@@ -2807,21 +2899,25 @@ async def test_config_retention_copies_logic_manual_backup(
             ],
             {
                 "backup-1": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-09T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-2": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-10T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-3": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-11T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-4": MagicMock(
+                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-10T04:45:00+01:00",
                     with_automatic_settings=False,
                     spec=ManagerBackup,
@@ -2834,7 +2930,10 @@ async def test_config_retention_copies_logic_manual_backup(
             "2024-11-12T12:00:00+01:00",
             1,
             2,
-            [call("backup-1"), call("backup-2")],
+            [
+                call("backup-1", agent_ids=["test.test-agent"]),
+                call("backup-2", agent_ids=["test.test-agent"]),
+            ],
         ),
     ],
 )

--- a/tests/components/backup/test_websocket.py
+++ b/tests/components/backup/test_websocket.py
@@ -6,6 +6,7 @@ from unittest.mock import ANY, AsyncMock, MagicMock, Mock, call, patch
 
 from freezegun.api import FrozenDateTimeFactory
 import pytest
+from pytest_unordered import unordered
 from syrupy import SnapshotAssertion
 
 from homeassistant.components.backup import (
@@ -1918,31 +1919,46 @@ async def test_config_schedule_logic(
             },
             {
                 "backup-1": MagicMock(
-                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    agents={
+                        "test.test-agent": MagicMock(spec=AgentBackupStatus),
+                        "test.test-agent2": MagicMock(spec=AgentBackupStatus),
+                    },
                     date="2024-11-09T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-2": MagicMock(
-                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    agents={
+                        "test.test-agent": MagicMock(spec=AgentBackupStatus),
+                        "test.test-agent2": MagicMock(spec=AgentBackupStatus),
+                    },
                     date="2024-11-10T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-3": MagicMock(
-                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    agents={
+                        "test.test-agent": MagicMock(spec=AgentBackupStatus),
+                        "test.test-agent2": MagicMock(spec=AgentBackupStatus),
+                    },
                     date="2024-11-11T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-4": MagicMock(
-                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    agents={
+                        "test.test-agent": MagicMock(spec=AgentBackupStatus),
+                        "test.test-agent2": MagicMock(spec=AgentBackupStatus),
+                    },
                     date="2024-11-12T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-5": MagicMock(
-                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    agents={
+                        "test.test-agent": MagicMock(spec=AgentBackupStatus),
+                        "test.test-agent2": MagicMock(spec=AgentBackupStatus),
+                    },
                     date="2024-11-12T04:45:00+01:00",
                     with_automatic_settings=False,
                     spec=ManagerBackup,
@@ -1956,7 +1972,80 @@ async def test_config_schedule_logic(
             1,
             1,
             1,
-            [call("backup-1", agent_ids=["test.test-agent"])],
+            [
+                call(
+                    "backup-1",
+                    agent_ids=unordered(["test.test-agent", "test.test-agent2"]),
+                )
+            ],
+        ),
+        (
+            {
+                "type": "backup/config/update",
+                "create_backup": {"agent_ids": ["test.test-agent"]},
+                "retention": {"copies": 3, "days": None},
+                "schedule": {"recurrence": "daily"},
+            },
+            {
+                "backup-1": MagicMock(
+                    agents={
+                        "test.test-agent": MagicMock(spec=AgentBackupStatus),
+                        "test.test-agent2": MagicMock(spec=AgentBackupStatus),
+                    },
+                    date="2024-11-09T04:45:00+01:00",
+                    with_automatic_settings=True,
+                    spec=ManagerBackup,
+                ),
+                "backup-2": MagicMock(
+                    agents={
+                        "test.test-agent": MagicMock(spec=AgentBackupStatus),
+                        "test.test-agent2": MagicMock(spec=AgentBackupStatus),
+                    },
+                    date="2024-11-10T04:45:00+01:00",
+                    with_automatic_settings=True,
+                    spec=ManagerBackup,
+                ),
+                "backup-3": MagicMock(
+                    agents={
+                        "test.test-agent": MagicMock(spec=AgentBackupStatus),
+                        "test.test-agent2": MagicMock(spec=AgentBackupStatus),
+                    },
+                    date="2024-11-11T04:45:00+01:00",
+                    with_automatic_settings=True,
+                    spec=ManagerBackup,
+                ),
+                "backup-4": MagicMock(
+                    agents={
+                        "test.test-agent": MagicMock(spec=AgentBackupStatus),
+                    },
+                    date="2024-11-12T04:45:00+01:00",
+                    with_automatic_settings=True,
+                    spec=ManagerBackup,
+                ),
+                "backup-5": MagicMock(
+                    agents={
+                        "test.test-agent": MagicMock(spec=AgentBackupStatus),
+                        "test.test-agent2": MagicMock(spec=AgentBackupStatus),
+                    },
+                    date="2024-11-12T04:45:00+01:00",
+                    with_automatic_settings=False,
+                    spec=ManagerBackup,
+                ),
+            },
+            {},
+            {},
+            "2024-11-11T04:45:00+01:00",
+            "2024-11-12T04:45:00+01:00",
+            "2024-11-12T04:45:00+01:00",
+            1,
+            1,
+            1,
+            [
+                call(
+                    "backup-1",
+                    agent_ids=unordered(["test.test-agent", "test.test-agent2"]),
+                )
+            ],
         ),
         (
             {
@@ -2105,31 +2194,46 @@ async def test_config_schedule_logic(
             },
             {
                 "backup-1": MagicMock(
-                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    agents={
+                        "test.test-agent": MagicMock(spec=AgentBackupStatus),
+                        "test.test-agent2": MagicMock(spec=AgentBackupStatus),
+                    },
                     date="2024-11-09T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-2": MagicMock(
-                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    agents={
+                        "test.test-agent": MagicMock(spec=AgentBackupStatus),
+                        "test.test-agent2": MagicMock(spec=AgentBackupStatus),
+                    },
                     date="2024-11-10T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-3": MagicMock(
-                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    agents={
+                        "test.test-agent": MagicMock(spec=AgentBackupStatus),
+                        "test.test-agent2": MagicMock(spec=AgentBackupStatus),
+                    },
                     date="2024-11-11T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-4": MagicMock(
-                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    agents={
+                        "test.test-agent": MagicMock(spec=AgentBackupStatus),
+                        "test.test-agent2": MagicMock(spec=AgentBackupStatus),
+                    },
                     date="2024-11-12T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-5": MagicMock(
-                    agents={"test.test-agent": MagicMock(spec=AgentBackupStatus)},
+                    agents={
+                        "test.test-agent": MagicMock(spec=AgentBackupStatus),
+                        "test.test-agent2": MagicMock(spec=AgentBackupStatus),
+                    },
                     date="2024-11-12T04:45:00+01:00",
                     with_automatic_settings=False,
                     spec=ManagerBackup,
@@ -2144,8 +2248,90 @@ async def test_config_schedule_logic(
             1,
             3,
             [
-                call("backup-1", agent_ids=["test.test-agent"]),
-                call("backup-2", agent_ids=["test.test-agent"]),
+                call(
+                    "backup-1",
+                    agent_ids=unordered(["test.test-agent", "test.test-agent2"]),
+                ),
+                call(
+                    "backup-2",
+                    agent_ids=unordered(["test.test-agent", "test.test-agent2"]),
+                ),
+                call(
+                    "backup-3",
+                    agent_ids=unordered(["test.test-agent", "test.test-agent2"]),
+                ),
+            ],
+        ),
+        (
+            {
+                "type": "backup/config/update",
+                "create_backup": {"agent_ids": ["test.test-agent"]},
+                "retention": {"copies": 0, "days": None},
+                "schedule": {"recurrence": "daily"},
+            },
+            {
+                "backup-1": MagicMock(
+                    agents={
+                        "test.test-agent": MagicMock(spec=AgentBackupStatus),
+                        "test.test-agent2": MagicMock(spec=AgentBackupStatus),
+                    },
+                    date="2024-11-09T04:45:00+01:00",
+                    with_automatic_settings=True,
+                    spec=ManagerBackup,
+                ),
+                "backup-2": MagicMock(
+                    agents={
+                        "test.test-agent": MagicMock(spec=AgentBackupStatus),
+                        "test.test-agent2": MagicMock(spec=AgentBackupStatus),
+                    },
+                    date="2024-11-10T04:45:00+01:00",
+                    with_automatic_settings=True,
+                    spec=ManagerBackup,
+                ),
+                "backup-3": MagicMock(
+                    agents={
+                        "test.test-agent": MagicMock(spec=AgentBackupStatus),
+                        "test.test-agent2": MagicMock(spec=AgentBackupStatus),
+                    },
+                    date="2024-11-11T04:45:00+01:00",
+                    with_automatic_settings=True,
+                    spec=ManagerBackup,
+                ),
+                "backup-4": MagicMock(
+                    agents={
+                        "test.test-agent": MagicMock(spec=AgentBackupStatus),
+                    },
+                    date="2024-11-12T04:45:00+01:00",
+                    with_automatic_settings=True,
+                    spec=ManagerBackup,
+                ),
+                "backup-5": MagicMock(
+                    agents={
+                        "test.test-agent": MagicMock(spec=AgentBackupStatus),
+                        "test.test-agent2": MagicMock(spec=AgentBackupStatus),
+                    },
+                    date="2024-11-12T04:45:00+01:00",
+                    with_automatic_settings=False,
+                    spec=ManagerBackup,
+                ),
+            },
+            {},
+            {},
+            "2024-11-11T04:45:00+01:00",
+            "2024-11-12T04:45:00+01:00",
+            "2024-11-12T04:45:00+01:00",
+            1,
+            1,
+            3,
+            [
+                call(
+                    "backup-1",
+                    agent_ids=unordered(["test.test-agent", "test.test-agent2"]),
+                ),
+                call(
+                    "backup-2",
+                    agent_ids=unordered(["test.test-agent", "test.test-agent2"]),
+                ),
                 call("backup-3", agent_ids=["test.test-agent"]),
             ],
         ),

--- a/tests/components/hassio/test_update.py
+++ b/tests/components/hassio/test_update.py
@@ -10,6 +10,9 @@ from aiohasupervisor.models import HomeAssistantUpdateOptions, StoreAddonUpdate
 import pytest
 
 from homeassistant.components.backup import BackupManagerError, ManagerBackup
+
+# pylint: disable-next=hass-component-root-import
+from homeassistant.components.backup.manager import AgentBackupStatus
 from homeassistant.components.hassio import DOMAIN
 from homeassistant.components.hassio.const import REQUEST_REFRESH_DELAY
 from homeassistant.const import __version__ as HAVERSION
@@ -348,34 +351,40 @@ async def test_update_addon_with_backup(
         (
             {
                 "backup-1": MagicMock(
+                    agents={"hassio.local": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-10T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-2": MagicMock(
+                    agents={"hassio.local": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-11T04:45:00+01:00",
                     with_automatic_settings=False,
                     spec=ManagerBackup,
                 ),
                 "backup-3": MagicMock(
+                    agents={"hassio.local": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-11T04:45:00+01:00",
                     extra_metadata={"supervisor.addon_update": "other"},
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-4": MagicMock(
+                    agents={"hassio.local": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-11T04:45:00+01:00",
                     extra_metadata={"supervisor.addon_update": "other"},
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-5": MagicMock(
+                    agents={"hassio.local": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-11T04:45:00+01:00",
                     extra_metadata={"supervisor.addon_update": "test"},
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-6": MagicMock(
+                    agents={"hassio.local": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-12T04:45:00+01:00",
                     extra_metadata={"supervisor.addon_update": "test"},
                     with_automatic_settings=True,

--- a/tests/components/hassio/test_websocket_api.py
+++ b/tests/components/hassio/test_websocket_api.py
@@ -9,6 +9,9 @@ from aiohasupervisor.models import HomeAssistantUpdateOptions, StoreAddonUpdate
 import pytest
 
 from homeassistant.components.backup import BackupManagerError, ManagerBackup
+
+# pylint: disable-next=hass-component-root-import
+from homeassistant.components.backup.manager import AgentBackupStatus
 from homeassistant.components.hassio import DOMAIN
 from homeassistant.components.hassio.const import (
     ATTR_DATA,
@@ -467,34 +470,40 @@ async def test_update_addon_with_backup(
         (
             {
                 "backup-1": MagicMock(
+                    agents={"hassio.local": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-10T04:45:00+01:00",
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-2": MagicMock(
+                    agents={"hassio.local": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-11T04:45:00+01:00",
                     with_automatic_settings=False,
                     spec=ManagerBackup,
                 ),
                 "backup-3": MagicMock(
+                    agents={"hassio.local": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-11T04:45:00+01:00",
                     extra_metadata={"supervisor.addon_update": "other"},
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-4": MagicMock(
+                    agents={"hassio.local": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-11T04:45:00+01:00",
                     extra_metadata={"supervisor.addon_update": "other"},
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-5": MagicMock(
+                    agents={"hassio.local": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-11T04:45:00+01:00",
                     extra_metadata={"supervisor.addon_update": "test"},
                     with_automatic_settings=True,
                     spec=ManagerBackup,
                 ),
                 "backup-6": MagicMock(
+                    agents={"hassio.local": MagicMock(spec=AgentBackupStatus)},
                     date="2024-11-12T04:45:00+01:00",
                     extra_metadata={"supervisor.addon_update": "test"},
                     with_automatic_settings=True,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Keep one backup per backup agent when executing retention policy

Without this, a backup agent may end up with no backups if we failed to upload to it

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
