### PR TITLE
airq: add more verbose debug logging

### DIFF
--- a/homeassistant/components/airq/config_flow.py
+++ b/homeassistant/components/airq/config_flow.py
@@ -83,6 +83,7 @@ class AirQConfigFlow(ConfigFlow, domain=DOMAIN):
             await self.async_set_unique_id(device_info["id"])
             self._abort_if_unique_id_configured()
 
+            _LOGGER.debug("Creating an entry for %s", device_info["name"])
             return self.async_create_entry(title=device_info["name"], data=user_input)
 
         return self.async_show_form(

--- a/homeassistant/components/airq/coordinator.py
+++ b/homeassistant/components/airq/coordinator.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import timedelta
 import logging
 
-from aioairq import AirQ
+from aioairq.core import AirQ, identify_warming_up_sensors
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_IP_ADDRESS, CONF_PASSWORD
@@ -55,6 +55,9 @@ class AirQCoordinator(DataUpdateCoordinator):
     async def _async_update_data(self) -> dict:
         """Fetch the data from the device."""
         if "name" not in self.device_info:
+            _LOGGER.debug(
+                "'name' not found in AirQCoordinator.device_info, fetching from the device"
+            )
             info = await self.airq.fetch_device_info()
             self.device_info.update(
                 DeviceInfo(
@@ -64,7 +67,16 @@ class AirQCoordinator(DataUpdateCoordinator):
                     hw_version=info["hw_version"],
                 )
             )
-        return await self.airq.get_latest_data(  # type: ignore[no-any-return]
+            _LOGGER.debug(
+                "Updated AirQCoordinator.device_info for 'name' %s",
+                self.device_info.get("name"),
+            )
+        data: dict = await self.airq.get_latest_data(
             return_average=self.return_average,
             clip_negative_values=self.clip_negative,
         )
+        if warming_up_sensors := identify_warming_up_sensors(data):
+            _LOGGER.debug(
+                "Following sensors are still warming up: %s", warming_up_sensors
+            )
+        return data

--- a/tests/components/airq/test_config_flow.py
+++ b/tests/components/airq/test_config_flow.py
@@ -1,5 +1,6 @@
 """Test the air-Q config flow."""
 
+import logging
 from unittest.mock import patch
 
 from aioairq import DeviceInfo, InvalidAuth
@@ -37,8 +38,9 @@ DEFAULT_OPTIONS = {
 }
 
 
-async def test_form(hass: HomeAssistant) -> None:
+async def test_form(hass: HomeAssistant, caplog: pytest.LogCaptureFixture) -> None:
     """Test we get the form."""
+    caplog.set_level(logging.DEBUG)
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -54,6 +56,7 @@ async def test_form(hass: HomeAssistant) -> None:
             TEST_USER_DATA,
         )
         await hass.async_block_till_done()
+        assert f"Creating an entry for {TEST_DEVICE_INFO['name']}" in caplog.text
 
     assert result2["type"] is FlowResultType.CREATE_ENTRY
     assert result2["title"] == TEST_DEVICE_INFO["name"]

--- a/tests/components/airq/test_coordinator.py
+++ b/tests/components/airq/test_coordinator.py
@@ -1,0 +1,129 @@
+"""Test the air-Q coordinator."""
+
+import logging
+from unittest.mock import patch
+
+from aioairq import DeviceInfo as AirQDeviceInfo
+import pytest
+
+from homeassistant.components.airq import AirQCoordinator
+from homeassistant.components.airq.const import DOMAIN
+from homeassistant.const import CONF_IP_ADDRESS, CONF_PASSWORD
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+
+from tests.common import MockConfigEntry
+
+pytestmark = pytest.mark.usefixtures("mock_setup_entry")
+MOCKED_ENTRY = MockConfigEntry(
+    domain=DOMAIN,
+    data={
+        CONF_IP_ADDRESS: "192.168.0.0",
+        CONF_PASSWORD: "password",
+    },
+    unique_id="123-456",
+)
+
+TEST_DEVICE_INFO = AirQDeviceInfo(
+    id="id",
+    name="name",
+    model="model",
+    sw_version="sw",
+    hw_version="hw",
+)
+TEST_DEVICE_DATA = {"co2": 500.0, "Status": "OK"}
+STATUS_WARMUP = {
+    "co": "co sensor still in warm up phase; waiting time = 18 s",
+    "tvoc": "tvoc sensor still in warm up phase; waiting time = 18 s",
+    "so2": "so2 sensor still in warm up phase; waiting time = 17 s",
+}
+
+
+async def test_logging_in_coordinator_first_update_data(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test that the first AirQCoordinator._async_update_data call logs necessary setup.
+
+    The fields of AirQCoordinator.device_info that are specific to the device are only
+    populated upon the first call to AirQCoordinator._async_update_data. The one field
+    which is actually necessary is 'name', and its absence is checked and logged,
+    as well as its being set.
+    """
+    caplog.set_level(logging.DEBUG)
+    coordinator = AirQCoordinator(hass, MOCKED_ENTRY)
+
+    # check that the name _is_ missing
+    assert "name" not in coordinator.device_info
+
+    # First call: fetch missing device info
+    with (
+        patch("aioairq.AirQ.fetch_device_info", return_value=TEST_DEVICE_INFO),
+        patch("aioairq.AirQ.get_latest_data", return_value=TEST_DEVICE_DATA),
+    ):
+        await coordinator._async_update_data()
+
+    # check that the missing name is logged...
+    assert (
+        "'name' not found in AirQCoordinator.device_info, fetching from the device"
+        in caplog.text
+    )
+    # ...and fixed
+    assert coordinator.device_info.get("name") == TEST_DEVICE_INFO["name"]
+    assert (
+        f"Updated AirQCoordinator.device_info for 'name' {TEST_DEVICE_INFO['name']}"
+        in caplog.text
+    )
+
+    # Also that no warming up sensors is found as none are mocked
+    assert "Following sensors are still warming up" not in caplog.text
+
+
+async def test_logging_in_coordinator_subsequent_update_data(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test that the second AirQCoordinator._async_update_data call has nothing to log.
+
+    The second call is emulated by setting up AirQCoordinator.device_info correctly,
+    instead of actually calling the _async_update_data, which would populate the log
+    with the messages we want to see not being repeated.
+    """
+    caplog.set_level(logging.DEBUG)
+    coordinator = AirQCoordinator(hass, MOCKED_ENTRY)
+    coordinator.device_info.update(DeviceInfo(**TEST_DEVICE_INFO))
+
+    with (
+        patch("aioairq.AirQ.fetch_device_info", return_value=TEST_DEVICE_INFO),
+        patch("aioairq.AirQ.get_latest_data", return_value=TEST_DEVICE_DATA),
+    ):
+        await coordinator._async_update_data()
+    # check that the name _is not_ missing
+    assert "name" in coordinator.device_info
+    # and that nothing of the kind is logged
+    assert (
+        "'name' not found in AirQCoordinator.device_info, fetching from the device"
+        not in caplog.text
+    )
+    assert (
+        f"Updated AirQCoordinator.device_info for 'name' {TEST_DEVICE_INFO['name']}"
+        not in caplog.text
+    )
+
+
+async def test_logging_when_warming_up_sensor_present(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test that warming up sensors are logged."""
+    caplog.set_level(logging.DEBUG)
+    coordinator = AirQCoordinator(hass, MOCKED_ENTRY)
+    with (
+        patch("aioairq.AirQ.fetch_device_info", return_value=TEST_DEVICE_INFO),
+        patch(
+            "aioairq.AirQ.get_latest_data",
+            return_value=TEST_DEVICE_DATA | {"Status": STATUS_WARMUP},
+        ),
+    ):
+        await coordinator._async_update_data()
+    assert (
+        f"Following sensors are still warming up: {set(STATUS_WARMUP.keys())}"
+        in caplog.text
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

A follow up to the recent version bump PR #137454. This one adds a few more `DEBUG` level logging calls to the integration code itself.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/issues/82077
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
