### PR TITLE
Flexit BACnet: Cooker hood mode support

### DIFF
--- a/homeassistant/components/flexit_bacnet/icons.json
+++ b/homeassistant/components/flexit_bacnet/icons.json
@@ -47,6 +47,12 @@
         "state": {
           "off": "mdi:fireplace-off"
         }
+      },
+      "cooker_hood_mode": {
+        "default": "mdi:kettle-steam",
+        "state": {
+          "off": "mdi:kettle"
+        }
       }
     }
   }

--- a/homeassistant/components/flexit_bacnet/strings.json
+++ b/homeassistant/components/flexit_bacnet/strings.json
@@ -110,6 +110,9 @@
       },
       "fireplace_mode": {
         "name": "Fireplace mode"
+      },
+      "cooker_hood_mode": {
+        "name": "Cooker hood mode"
       }
     }
   }

--- a/homeassistant/components/flexit_bacnet/switch.py
+++ b/homeassistant/components/flexit_bacnet/switch.py
@@ -47,6 +47,13 @@ SWITCHES: tuple[FlexitSwitchEntityDescription, ...] = (
         turn_on_fn=lambda data: data.trigger_fireplace_mode(),
         turn_off_fn=lambda data: data.trigger_fireplace_mode(),
     ),
+    FlexitSwitchEntityDescription(
+        key="cooker_hood_mode",
+        translation_key="cooker_hood_mode",
+        is_on_fn=lambda data: data.cooker_hood_status,
+        turn_on_fn=lambda data: data.activate_cooker_hood(),
+        turn_off_fn=lambda data: data.deactivate_cooker_hood(),
+    ),
 )
 
 

--- a/tests/components/flexit_bacnet/snapshots/test_switch.ambr
+++ b/tests/components/flexit_bacnet/snapshots/test_switch.ambr
@@ -1,4 +1,52 @@
 # serializer version: 1
+# name: test_switches[switch.device_name_cooker_hood_mode-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.device_name_cooker_hood_mode',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SwitchDeviceClass.SWITCH: 'switch'>,
+    'original_icon': None,
+    'original_name': 'Cooker hood mode',
+    'platform': 'flexit_bacnet',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'cooker_hood_mode',
+    'unique_id': '0000-0001-cooker_hood_mode',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.device_name_cooker_hood_mode-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'switch',
+      'friendly_name': 'Device Name Cooker hood mode',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.device_name_cooker_hood_mode',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
 # name: test_switches[switch.device_name_electric_heater-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add cooker hood mode support to Flexit BACnet integration.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
