### PR TITLE
Add repair-issue that backup location setup is missing in Synology DSM

### DIFF
--- a/homeassistant/components/synology_dsm/const.py
+++ b/homeassistant/components/synology_dsm/const.py
@@ -35,6 +35,8 @@ PLATFORMS = [
 EXCEPTION_DETAILS = "details"
 EXCEPTION_UNKNOWN = "unknown"
 
+ISSUE_MISSING_BACKUP_SETUP = "missing_backup_setup"
+
 # Configuration
 CONF_SERIAL = "serial"
 CONF_VOLUMES = "volumes"

--- a/homeassistant/components/synology_dsm/repairs.py
+++ b/homeassistant/components/synology_dsm/repairs.py
@@ -1,0 +1,127 @@
+"""Repair flows for the Synology DSM integration."""
+
+from __future__ import annotations
+
+from contextlib import suppress
+import logging
+from typing import cast
+
+from synology_dsm.api.file_station.models import SynoFileSharedFolder
+import voluptuous as vol
+
+from homeassistant import data_entry_flow
+from homeassistant.components.repairs import ConfirmRepairFlow, RepairsFlow
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import issue_registry as ir
+from homeassistant.helpers.selector import (
+    SelectOptionDict,
+    SelectSelector,
+    SelectSelectorConfig,
+    SelectSelectorMode,
+)
+
+from .const import (
+    CONF_BACKUP_PATH,
+    CONF_BACKUP_SHARE,
+    DOMAIN,
+    ISSUE_MISSING_BACKUP_SETUP,
+    SYNOLOGY_CONNECTION_EXCEPTIONS,
+)
+from .models import SynologyDSMData
+
+LOGGER = logging.getLogger(__name__)
+
+
+class MissingBackupSetupRepairFlow(RepairsFlow):
+    """Handler for an issue fixing flow."""
+
+    def __init__(self, entry: ConfigEntry, issue_id: str) -> None:
+        """Create flow."""
+        self.entry = entry
+        self.issue_id = issue_id
+        super().__init__()
+
+    async def async_step_init(
+        self, user_input: dict[str, str] | None = None
+    ) -> data_entry_flow.FlowResult:
+        """Handle the first step of a fix flow."""
+
+        return self.async_show_menu(
+            menu_options=["confirm", "ignore"],
+            description_placeholders={
+                "docs_url": "https://www.home-assistant.io/integrations/synology_dsm/#backup-location"
+            },
+        )
+
+    async def async_step_confirm(
+        self, user_input: dict[str, str] | None = None
+    ) -> data_entry_flow.FlowResult:
+        """Handle the confirm step of a fix flow."""
+
+        syno_data: SynologyDSMData = self.hass.data[DOMAIN][self.entry.unique_id]
+
+        if user_input is not None:
+            self.hass.config_entries.async_update_entry(
+                self.entry, options={**dict(self.entry.options), **user_input}
+            )
+            return self.async_create_entry(data={})
+
+        shares: list[SynoFileSharedFolder] | None = None
+        if syno_data.api.file_station:
+            with suppress(*SYNOLOGY_CONNECTION_EXCEPTIONS):
+                shares = await syno_data.api.file_station.get_shared_folders(
+                    only_writable=True
+                )
+        else:
+            return self.async_abort(reason="no_file_station")
+
+        if not shares:
+            return self.async_abort(reason="no_shares")
+
+        return self.async_show_form(
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_BACKUP_SHARE,
+                        default=self.entry.options[CONF_BACKUP_SHARE],
+                    ): SelectSelector(
+                        SelectSelectorConfig(
+                            options=[
+                                SelectOptionDict(value=s.path, label=s.name)
+                                for s in shares
+                            ],
+                            mode=SelectSelectorMode.DROPDOWN,
+                        ),
+                    ),
+                    vol.Required(
+                        CONF_BACKUP_PATH,
+                        default=self.entry.options[CONF_BACKUP_PATH],
+                    ): str,
+                }
+            ),
+        )
+
+    async def async_step_ignore(
+        self, _: dict[str, str] | None = None
+    ) -> data_entry_flow.FlowResult:
+        """Handle the confirm step of a fix flow."""
+        ir.async_ignore_issue(self.hass, DOMAIN, self.issue_id, True)
+        return self.async_abort(reason="ignored")
+
+
+async def async_create_fix_flow(
+    hass: HomeAssistant,
+    issue_id: str,
+    data: dict[str, str | int | float | None] | None,
+) -> RepairsFlow:
+    """Create flow."""
+    entry = None
+    if data and (entry_id := data.get("entry_id")):
+        entry_id = cast(str, entry_id)
+        entry = hass.config_entries.async_get_entry(entry_id)
+
+    if entry and issue_id.startswith(ISSUE_MISSING_BACKUP_SETUP):
+        return MissingBackupSetupRepairFlow(entry, issue_id)
+
+    return ConfirmRepairFlow()

--- a/homeassistant/components/synology_dsm/repairs.py
+++ b/homeassistant/components/synology_dsm/repairs.py
@@ -73,8 +73,6 @@ class MissingBackupSetupRepairFlow(RepairsFlow):
                 shares = await syno_data.api.file_station.get_shared_folders(
                     only_writable=True
                 )
-        else:
-            return self.async_abort(reason="no_file_station")
 
         if not shares:
             return self.async_abort(reason="no_shares")

--- a/homeassistant/components/synology_dsm/strings.json
+++ b/homeassistant/components/synology_dsm/strings.json
@@ -193,10 +193,10 @@
       "fix_flow": {
         "step": {
           "init": {
-            "description": "The backup location for {title} is not configured. Do you want to set it up now?\nDetails can be found in the integration documenation under [Backup Location]({docs_url})",
+            "description": "The backup location for {title} is not configured. Do you want to set it up now? Details can be found in the integration documentation under [Backup Location]({docs_url})",
             "menu_options": {
-              "ignore": "Don't set it up now",
-              "confirm": "Set up the backup location now"
+              "confirm": "Set up the backup location now",
+              "ignore": "Don't set it up now"
             }
           },
           "confirm": {
@@ -213,7 +213,7 @@
         },
         "abort": {
           "no_file_station": "The user seems to have not the correct permissions.\nPlease check the documentation.",
-          "no_shares": "There are no shared folders availbe for the user.\nPlease check the documentation.",
+          "no_shares": "There are no shared folders available for the user.\nPlease check the documentation.",
           "ignored": "The backup location has not been configured.\nYou can still set it up later via the integration options."
         }
       }

--- a/homeassistant/components/synology_dsm/strings.json
+++ b/homeassistant/components/synology_dsm/strings.json
@@ -212,7 +212,6 @@
           }
         },
         "abort": {
-          "no_file_station": "The user seems to have not the correct permissions.\nPlease check the documentation.",
           "no_shares": "There are no shared folders available for the user.\nPlease check the documentation.",
           "ignored": "The backup location has not been configured.\nYou can still set it up later via the integration options."
         }

--- a/homeassistant/components/synology_dsm/strings.json
+++ b/homeassistant/components/synology_dsm/strings.json
@@ -187,6 +187,38 @@
       }
     }
   },
+  "issues": {
+    "missing_backup_setup": {
+      "title": "Backup location not configured for {title}",
+      "fix_flow": {
+        "step": {
+          "init": {
+            "description": "The backup location for {title} is not configured. Do you want to set it up now?\nDetails can be found in the integration documenation under [Backup Location]({docs_url})",
+            "menu_options": {
+              "ignore": "Don't set it up now",
+              "confirm": "Set up the backup location now"
+            }
+          },
+          "confirm": {
+            "title": "[%key:component::synology_dsm::config::step::backup_share::title%]",
+            "data": {
+              "backup_share": "[%key:component::synology_dsm::config::step::backup_share::data::backup_share%]",
+              "backup_path": "[%key:component::synology_dsm::config::step::backup_share::data::backup_path%]"
+            },
+            "data_description": {
+              "backup_share": "[%key:component::synology_dsm::config::step::backup_share::data_description::backup_share%]",
+              "backup_path": "[%key:component::synology_dsm::config::step::backup_share::data_description::backup_path%]"
+            }
+          }
+        },
+        "abort": {
+          "no_file_station": "The user seems to have not the correct permissions.\nPlease check the documentation.",
+          "no_shares": "There are no shared folders availbe for the user.\nPlease check the documentation.",
+          "ignored": "The backup location has not been configured.\nYou can still set it up later via the integration options."
+        }
+      }
+    }
+  },
   "services": {
     "reboot": {
       "name": "Reboot",

--- a/tests/components/synology_dsm/test_repairs.py
+++ b/tests/components/synology_dsm/test_repairs.py
@@ -1,0 +1,253 @@
+"""Test repairs for synology dsm."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import pytest
+from synology_dsm.api.file_station.models import SynoFileSharedFolder
+
+from homeassistant.components.repairs import DOMAIN as REPAIRS_DOMAIN
+from homeassistant.components.synology_dsm.const import (
+    CONF_BACKUP_PATH,
+    CONF_BACKUP_SHARE,
+    DOMAIN,
+)
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_MAC,
+    CONF_PASSWORD,
+    CONF_PORT,
+    CONF_SSL,
+    CONF_USERNAME,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+from .consts import HOST, MACS, PASSWORD, PORT, SERIAL, USE_SSL, USERNAME
+
+from tests.common import MockConfigEntry
+from tests.components.repairs import process_repair_fix_flow, start_repair_fix_flow
+from tests.typing import ClientSessionGenerator, WebSocketGenerator
+
+
+@pytest.fixture
+def mock_dsm_with_filestation():
+    """Mock a successful service with filestation support."""
+    with patch("homeassistant.components.synology_dsm.common.SynologyDSM") as dsm:
+        dsm.login = AsyncMock(return_value=True)
+        dsm.update = AsyncMock(return_value=True)
+
+        dsm.surveillance_station.update = AsyncMock(return_value=True)
+        dsm.upgrade.update = AsyncMock(return_value=True)
+        dsm.utilisation = Mock(cpu_user_load=1, update=AsyncMock(return_value=True))
+        dsm.network = Mock(update=AsyncMock(return_value=True), macs=MACS)
+        dsm.storage = Mock(
+            disks_ids=["sda", "sdb", "sdc"],
+            volumes_ids=["volume_1"],
+            update=AsyncMock(return_value=True),
+        )
+        dsm.information = Mock(serial=SERIAL)
+        dsm.file = AsyncMock(
+            get_shared_folders=AsyncMock(
+                return_value=[
+                    SynoFileSharedFolder(
+                        additional=None,
+                        is_dir=True,
+                        name="HA Backup",
+                        path="/ha_backup",
+                    )
+                ]
+            ),
+        )
+        dsm.logout = AsyncMock(return_value=True)
+        yield dsm
+
+
+@pytest.fixture
+async def setup_dsm_with_filestation(
+    hass: HomeAssistant,
+    mock_dsm_with_filestation: MagicMock,
+):
+    """Mock setup of synology dsm config entry."""
+    with (
+        patch(
+            "homeassistant.components.synology_dsm.common.SynologyDSM",
+            return_value=mock_dsm_with_filestation,
+        ),
+        patch("homeassistant.components.synology_dsm.PLATFORMS", return_value=[]),
+    ):
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            data={
+                CONF_HOST: HOST,
+                CONF_PORT: PORT,
+                CONF_SSL: USE_SSL,
+                CONF_USERNAME: USERNAME,
+                CONF_PASSWORD: PASSWORD,
+                CONF_MAC: MACS[0],
+            },
+            options={
+                CONF_BACKUP_PATH: None,
+                CONF_BACKUP_SHARE: None,
+            },
+            unique_id="my_serial",
+        )
+        entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        assert await async_setup_component(hass, REPAIRS_DOMAIN, {})
+        await hass.async_block_till_done()
+
+        yield mock_dsm_with_filestation
+
+
+async def test_create_issue(
+    hass: HomeAssistant,
+    setup_dsm_with_filestation: MagicMock,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test the issue is created."""
+    ws_client = await hass_ws_client(hass)
+    await ws_client.send_json({"id": 1, "type": "repairs/list_issues"})
+    msg = await ws_client.receive_json()
+
+    assert msg["success"]
+    assert len(msg["result"]["issues"]) == 1
+    issue = msg["result"]["issues"][0]
+    assert issue["breaks_in_ha_version"] is None
+    assert issue["domain"] == DOMAIN
+    assert issue["issue_id"] == "missing_backup_setup_my_serial"
+    assert issue["translation_key"] == "missing_backup_setup"
+
+
+async def test_missing_backup_ignore(
+    hass: HomeAssistant,
+    setup_dsm_with_filestation: MagicMock,
+    hass_client: ClientSessionGenerator,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test missing backup location setup issue is ignored by the user."""
+    ws_client = await hass_ws_client(hass)
+    client = await hass_client()
+
+    # get repair issues
+    await ws_client.send_json({"id": 1, "type": "repairs/list_issues"})
+    msg = await ws_client.receive_json()
+    assert msg["success"]
+    assert len(msg["result"]["issues"]) == 1
+    issue = msg["result"]["issues"][0]
+    assert not issue["ignored"]
+
+    # start repair flow
+    data = await start_repair_fix_flow(client, DOMAIN, "missing_backup_setup_my_serial")
+
+    flow_id = data["flow_id"]
+    assert data["description_placeholders"] == {
+        "docs_url": "https://www.home-assistant.io/integrations/synology_dsm/#backup-location"
+    }
+    assert data["step_id"] == "init"
+    assert data["menu_options"] == ["confirm", "ignore"]
+
+    # seelct to ignore the flow
+    data = await process_repair_fix_flow(
+        client, flow_id, json={"next_step_id": "ignore"}
+    )
+    assert data["type"] == "abort"
+    assert data["reason"] == "ignored"
+
+    # check issue is ignored
+    await ws_client.send_json({"id": 2, "type": "repairs/list_issues"})
+    msg = await ws_client.receive_json()
+    assert msg["success"]
+    assert len(msg["result"]["issues"]) == 1
+    issue = msg["result"]["issues"][0]
+    assert issue["ignored"]
+
+
+async def test_missing_backup_success(
+    hass: HomeAssistant,
+    setup_dsm_with_filestation: MagicMock,
+    hass_client: ClientSessionGenerator,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test the missing backup location setup repair flow is fully processed by the user."""
+    ws_client = await hass_ws_client(hass)
+    client = await hass_client()
+    entries = hass.config_entries.async_entries(DOMAIN)
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry.options == {"backup_path": None, "backup_share": None}
+
+    # get repair issues
+    await ws_client.send_json({"id": 1, "type": "repairs/list_issues"})
+    msg = await ws_client.receive_json()
+    assert msg["success"]
+    assert len(msg["result"]["issues"]) == 1
+    issue = msg["result"]["issues"][0]
+    assert not issue["ignored"]
+
+    # start repair flow
+    data = await start_repair_fix_flow(client, DOMAIN, "missing_backup_setup_my_serial")
+
+    flow_id = data["flow_id"]
+    assert data["description_placeholders"] == {
+        "docs_url": "https://www.home-assistant.io/integrations/synology_dsm/#backup-location"
+    }
+    assert data["step_id"] == "init"
+    assert data["menu_options"] == ["confirm", "ignore"]
+
+    # seelct to confirm the flow
+    data = await process_repair_fix_flow(
+        client, flow_id, json={"next_step_id": "confirm"}
+    )
+    assert data["step_id"] == "confirm"
+    assert data["type"] == "form"
+
+    # fill out the form and submit
+    data = await process_repair_fix_flow(
+        client,
+        flow_id,
+        json={"backup_share": "/ha_backup", "backup_path": "backup_ha_dev"},
+    )
+    assert data["type"] == "create_entry"
+    assert entry.options == {
+        "backup_path": "backup_ha_dev",
+        "backup_share": "/ha_backup",
+    }
+
+
+async def test_missing_backup_no_shares(
+    hass: HomeAssistant,
+    setup_dsm_with_filestation: MagicMock,
+    hass_client: ClientSessionGenerator,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test the missing backup location setup repair flow errors out."""
+    ws_client = await hass_ws_client(hass)
+    client = await hass_client()
+
+    # get repair issues
+    await ws_client.send_json({"id": 1, "type": "repairs/list_issues"})
+    msg = await ws_client.receive_json()
+    assert msg["success"]
+    assert len(msg["result"]["issues"]) == 1
+
+    # start repair flow
+    data = await start_repair_fix_flow(client, DOMAIN, "missing_backup_setup_my_serial")
+
+    flow_id = data["flow_id"]
+    assert data["description_placeholders"] == {
+        "docs_url": "https://www.home-assistant.io/integrations/synology_dsm/#backup-location"
+    }
+    assert data["step_id"] == "init"
+    assert data["menu_options"] == ["confirm", "ignore"]
+
+    # inject error
+    setup_dsm_with_filestation.file.get_shared_folders.return_value = []
+
+    # select to confirm the flow
+    data = await process_repair_fix_flow(
+        client, flow_id, json={"next_step_id": "confirm"}
+    )
+    assert data["type"] == "abort"
+    assert data["reason"] == "no_shares"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adds a repair-issue which informs the user, that the backup location has not been set up yet. It also provides a repair-flow, so the user can immediately setup the backup location. Thanks @joostlek for giving me this idea :partying_face: 

repair notification
![image](https://github.com/user-attachments/assets/e4b2292e-9716-4f9c-a7b9-11894be9f8c8)

repair menu
![image](https://github.com/user-attachments/assets/e9574213-dd86-44d5-b086-baed5a7cdc2a)

repair-flow
![image](https://github.com/user-attachments/assets/b24b42b7-af2f-464b-8267-b36411a00802)

repair ignored
![image](https://github.com/user-attachments/assets/ebc1bb66-d94e-4adc-ade5-6278050e625e)



- [x] TODO add tests

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
