### PR TITLE
Set PARALLEL_UPDATES for MotionMount integration

### DIFF
--- a/homeassistant/components/motionmount/binary_sensor.py
+++ b/homeassistant/components/motionmount/binary_sensor.py
@@ -12,6 +12,8 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from . import MotionMountConfigEntry
 from .entity import MotionMountEntity
 
+PARALLEL_UPDATES = 0
+
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/homeassistant/components/motionmount/number.py
+++ b/homeassistant/components/motionmount/number.py
@@ -14,6 +14,8 @@ from . import MotionMountConfigEntry
 from .const import DOMAIN
 from .entity import MotionMountEntity
 
+PARALLEL_UPDATES = 0
+
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/homeassistant/components/motionmount/quality_scale.yaml
+++ b/homeassistant/components/motionmount/quality_scale.yaml
@@ -37,7 +37,7 @@ rules:
   entity-unavailable: done
   integration-owner: done
   log-when-unavailable: done
-  parallel-updates: todo
+  parallel-updates: done
   reauthentication-flow: done
   test-coverage: todo
 

--- a/homeassistant/components/motionmount/select.py
+++ b/homeassistant/components/motionmount/select.py
@@ -17,6 +17,7 @@ from .entity import MotionMountEntity
 
 _LOGGER = logging.getLogger(__name__)
 SCAN_INTERVAL = timedelta(seconds=60)
+PARALLEL_UPDATES = 0
 
 
 async def async_setup_entry(

--- a/homeassistant/components/motionmount/sensor.py
+++ b/homeassistant/components/motionmount/sensor.py
@@ -12,6 +12,8 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from . import MotionMountConfigEntry
 from .entity import MotionMountEntity
 
+PARALLEL_UPDATES = 0
+
 ERROR_MESSAGES: Final = {
     MotionMountSystemError.MotorError: "motor",
     MotionMountSystemError.ObstructionDetected: "obstruction",


### PR DESCRIPTION
## Proposed change
This PR sets the PARALLEL_UPDATES for the entities.

Most entities are updated using push model and are not actively updated by HA. The select sensor does perform a (slow) poll, but as there is only a single device per sensor we can allow multiple updates at the same time as they will be directed to different devices.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
