### PR TITLE
OTBR firmware API for Home Assistant Hardware

### DIFF
--- a/homeassistant/components/otbr/__init__.py
+++ b/homeassistant/components/otbr/__init__.py
@@ -7,6 +7,10 @@ import logging
 import aiohttp
 import python_otbr_api
 
+from homeassistant.components.homeassistant_hardware.helpers import (
+    async_notify_firmware_info,
+    async_register_firmware_info_provider,
+)
 from homeassistant.components.thread import async_add_dataset
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -15,7 +19,7 @@ from homeassistant.helpers import config_validation as cv, issue_registry as ir
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.typing import ConfigType
 
-from . import websocket_api
+from . import homeassistant_hardware, websocket_api
 from .const import DOMAIN
 from .util import (
     GetBorderAgentIdNotSupported,
@@ -34,6 +38,9 @@ type OTBRConfigEntry = ConfigEntry[OTBRData]
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the Open Thread Border Router component."""
     websocket_api.async_setup(hass)
+
+    async_register_firmware_info_provider(hass, DOMAIN, homeassistant_hardware)
+
     return True
 
 
@@ -76,6 +83,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: OTBRConfigEntry) -> bool
 
     entry.async_on_unload(entry.add_update_listener(async_reload_entry))
     entry.runtime_data = otbrdata
+
+    if fw_info := await homeassistant_hardware.async_get_firmware_info(hass, entry):
+        await async_notify_firmware_info(hass, DOMAIN, fw_info)
 
     return True
 

--- a/homeassistant/components/otbr/__init__.py
+++ b/homeassistant/components/otbr/__init__.py
@@ -98,3 +98,32 @@ async def async_unload_entry(hass: HomeAssistant, entry: OTBRConfigEntry) -> boo
 async def async_reload_entry(hass: HomeAssistant, entry: OTBRConfigEntry) -> None:
     """Handle an options update."""
     await hass.config_entries.async_reload(entry.entry_id)
+
+
+async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Migrate old entry."""
+    _LOGGER.debug("Migrating from version %s.%s", entry.version, entry.minor_version)
+
+    if entry.version == 1:
+        device = None
+
+        if (
+            fw_info := await homeassistant_hardware.async_get_firmware_info(hass, entry)
+        ) is not None:
+            device = fw_info.device
+
+        hass.config_entries.async_update_entry(
+            entry,
+            data={
+                **entry.data,
+                "device": device,
+            },
+            minor_version=2,
+        )
+
+    _LOGGER.debug(
+        "Migration to version %s.%s successful",
+        entry.version,
+        entry.minor_version,
+    )
+    return True

--- a/homeassistant/components/otbr/__init__.py
+++ b/homeassistant/components/otbr/__init__.py
@@ -98,32 +98,3 @@ async def async_unload_entry(hass: HomeAssistant, entry: OTBRConfigEntry) -> boo
 async def async_reload_entry(hass: HomeAssistant, entry: OTBRConfigEntry) -> None:
     """Handle an options update."""
     await hass.config_entries.async_reload(entry.entry_id)
-
-
-async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Migrate old entry."""
-    _LOGGER.debug("Migrating from version %s.%s", entry.version, entry.minor_version)
-
-    if entry.version == 1:
-        device = None
-
-        if (
-            fw_info := await homeassistant_hardware.async_get_firmware_info(hass, entry)
-        ) is not None:
-            device = fw_info.device
-
-        hass.config_entries.async_update_entry(
-            entry,
-            data={
-                **entry.data,
-                "device": device,
-            },
-            minor_version=2,
-        )
-
-    _LOGGER.debug(
-        "Migration to version %s.%s successful",
-        entry.version,
-        entry.minor_version,
-    )
-    return True

--- a/homeassistant/components/otbr/__init__.py
+++ b/homeassistant/components/otbr/__init__.py
@@ -12,7 +12,6 @@ from homeassistant.components.homeassistant_hardware.helpers import (
     async_register_firmware_info_provider,
 )
 from homeassistant.components.thread import async_add_dataset
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
 from homeassistant.helpers import config_validation as cv, issue_registry as ir
@@ -21,6 +20,7 @@ from homeassistant.helpers.typing import ConfigType
 
 from . import homeassistant_hardware, websocket_api
 from .const import DOMAIN
+from .types import OTBRConfigEntry
 from .util import (
     GetBorderAgentIdNotSupported,
     OTBRData,
@@ -31,8 +31,6 @@ from .util import (
 _LOGGER = logging.getLogger(__name__)
 
 CONFIG_SCHEMA = cv.empty_config_schema(DOMAIN)
-
-type OTBRConfigEntry = ConfigEntry[OTBRData]
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:

--- a/homeassistant/components/otbr/config_flow.py
+++ b/homeassistant/components/otbr/config_flow.py
@@ -218,7 +218,7 @@ class OTBRConfigFlow(ConfigFlow, domain=DOMAIN):
                     if current_entry.state == ConfigEntryState.LOADED:
                         assert current_entry.unique_id is not None
                         await self.hass.config_entries.async_reload(
-                            current_entry.unique_id
+                            current_entry.entry_id
                         )
 
                     continue

--- a/homeassistant/components/otbr/config_flow.py
+++ b/homeassistant/components/otbr/config_flow.py
@@ -16,7 +16,6 @@ import yarl
 from homeassistant.components.hassio import AddonError, AddonManager
 from homeassistant.components.homeassistant_yellow import hardware as yellow_hardware
 from homeassistant.components.thread import async_get_preferred_dataset
-from homeassistant.components.usb import get_serial_by_id
 from homeassistant.config_entries import SOURCE_HASSIO, ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_URL
 from homeassistant.core import HomeAssistant, callback
@@ -81,7 +80,6 @@ class OTBRConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Open Thread Border Router."""
 
     VERSION = 1
-    MINOR_VERSION = 2
 
     async def _set_dataset(self, api: python_otbr_api.OTBR, otbr_url: str) -> None:
         """Connect to the OTBR and create or apply a dataset if it doesn't have one."""
@@ -189,39 +187,33 @@ class OTBRConfigFlow(ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Handle hassio discovery."""
         config = discovery_info.config
-
-        if (device := config.get("device", None)) is not None:
-            device = await self.hass.async_add_executor_job(get_serial_by_id, device)
-
         url = f"http://{config['host']}:{config['port']}"
-        config_entry_data = {
-            "url": url,
-            "device": device,
-        }
+        config_entry_data = {"url": url}
 
-        for current_entry in self._async_current_entries():
-            if current_entry.source != SOURCE_HASSIO:
-                continue
-            current_url = yarl.URL(current_entry.data["url"])
-            if not (unique_id := current_entry.unique_id):
-                # The first version did not set a unique_id
-                # so if the entry does not have a unique_id
-                # we have to assume it's the first version
-                # This check can be removed in HA Core 2025.9
-                unique_id = discovery_info.uuid
-            if (
-                unique_id != discovery_info.uuid
-                or current_url.host != config["host"]
-                or config_entry_data == current_entry.data
-            ):
-                continue
-            # Update URL with the new port
-            self.hass.config_entries.async_update_entry(
-                current_entry,
-                data=config_entry_data,
-                unique_id=unique_id,  # Remove in HA Core 2025.9
-            )
-            return self.async_abort(reason="already_configured")
+        if current_entries := self._async_current_entries():
+            for current_entry in current_entries:
+                if current_entry.source != SOURCE_HASSIO:
+                    continue
+                current_url = yarl.URL(current_entry.data["url"])
+                if not (unique_id := current_entry.unique_id):
+                    # The first version did not set a unique_id
+                    # so if the entry does not have a unique_id
+                    # we have to assume it's the first version
+                    # This check can be removed in HA Core 2025.9
+                    unique_id = discovery_info.uuid
+                if (
+                    unique_id != discovery_info.uuid
+                    or current_url.host != config["host"]
+                    or current_url.port == config["port"]
+                ):
+                    continue
+                # Update URL with the new port
+                self.hass.config_entries.async_update_entry(
+                    current_entry,
+                    data=config_entry_data,
+                    unique_id=unique_id,  # Remove in HA Core 2025.9
+                )
+                return self.async_abort(reason="already_configured")
 
         try:
             await self._connect_and_configure_router(url)

--- a/homeassistant/components/otbr/config_flow.py
+++ b/homeassistant/components/otbr/config_flow.py
@@ -201,12 +201,19 @@ class OTBRConfigFlow(ConfigFlow, domain=DOMAIN):
                     # we have to assume it's the first version
                     # This check can be removed in HA Core 2025.9
                     unique_id = discovery_info.uuid
+
+                if unique_id != discovery_info.uuid:
+                    continue
+
                 if (
-                    unique_id != discovery_info.uuid
-                    or current_url.host != config["host"]
+                    current_url.host != config["host"]
                     or current_url.port == config["port"]
                 ):
+                    # Reload the entry since OTBR has restarted
+                    assert current_entry.unique_id is not None
+                    await self.hass.config_entries.async_reload(current_entry.unique_id)
                     continue
+
                 # Update URL with the new port
                 self.hass.config_entries.async_update_entry(
                     current_entry,

--- a/homeassistant/components/otbr/config_flow.py
+++ b/homeassistant/components/otbr/config_flow.py
@@ -16,7 +16,12 @@ import yarl
 from homeassistant.components.hassio import AddonError, AddonManager
 from homeassistant.components.homeassistant_yellow import hardware as yellow_hardware
 from homeassistant.components.thread import async_get_preferred_dataset
-from homeassistant.config_entries import SOURCE_HASSIO, ConfigFlow, ConfigFlowResult
+from homeassistant.config_entries import (
+    SOURCE_HASSIO,
+    ConfigEntryState,
+    ConfigFlow,
+    ConfigFlowResult,
+)
 from homeassistant.const import CONF_URL
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
@@ -210,8 +215,12 @@ class OTBRConfigFlow(ConfigFlow, domain=DOMAIN):
                     or current_url.port == config["port"]
                 ):
                     # Reload the entry since OTBR has restarted
-                    assert current_entry.unique_id is not None
-                    await self.hass.config_entries.async_reload(current_entry.unique_id)
+                    if current_entry.state == ConfigEntryState.LOADED:
+                        assert current_entry.unique_id is not None
+                        await self.hass.config_entries.async_reload(
+                            current_entry.unique_id
+                        )
+
                     continue
 
                 # Update URL with the new port

--- a/homeassistant/components/otbr/homeassistant_hardware.py
+++ b/homeassistant/components/otbr/homeassistant_hardware.py
@@ -43,7 +43,7 @@ async def async_get_firmware_info(
             hass=hass,
             logger=_LOGGER,
             addon_name="OpenThread Border Router",
-            addon_slug=host,
+            addon_slug=host.replace("-", "_"),
         )
 
         if (

--- a/homeassistant/components/otbr/homeassistant_hardware.py
+++ b/homeassistant/components/otbr/homeassistant_hardware.py
@@ -57,6 +57,8 @@ async def async_get_firmware_info(
     firmware_version = None
 
     if config_entry.state in (
+        # This function is called during OTBR config entry setup so we need to account
+        # for both config entry states
         ConfigEntryState.LOADED,
         ConfigEntryState.SETUP_IN_PROGRESS,
     ):

--- a/homeassistant/components/otbr/homeassistant_hardware.py
+++ b/homeassistant/components/otbr/homeassistant_hardware.py
@@ -1,0 +1,61 @@
+"""Home Assistant Hardware firmware utilities."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
+import voluptuous as vol
+from yarl import URL
+
+from homeassistant.components.hassio import valid_addon
+from homeassistant.components.homeassistant_hardware.util import (
+    ApplicationType,
+    FirmwareInfo,
+    OwningAddon,
+    OwningIntegration,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.hassio import is_hassio
+
+from .const import DOMAIN
+
+if TYPE_CHECKING:
+    from . import OTBRConfigEntry
+
+
+async def async_get_firmware_info(
+    hass: HomeAssistant, config_entry: ConfigEntry
+) -> FirmwareInfo | None:
+    """Return firmware information for the OpenThread Border Router."""
+    if TYPE_CHECKING:
+        config_entry = cast(OTBRConfigEntry, config_entry)
+
+    if (device := config_entry.data.get("device")) is None:
+        return None
+
+    owners: list[OwningIntegration | OwningAddon] = [
+        OwningIntegration(config_entry_id=config_entry.entry_id)
+    ]
+
+    if is_hassio(hass) and (host := URL(config_entry.data["url"]).host) is not None:
+        try:
+            valid_addon(host)
+        except vol.Invalid:
+            pass
+        else:
+            owners.append(OwningAddon(slug=host))
+
+    try:
+        firmware_version = await config_entry.runtime_data.get_coprocessor_version()
+    except HomeAssistantError:
+        firmware_version = None
+
+    return FirmwareInfo(
+        device=device,
+        firmware_type=ApplicationType.SPINEL,
+        firmware_version=firmware_version,
+        source=DOMAIN,
+        owners=owners,
+    )

--- a/homeassistant/components/otbr/homeassistant_hardware.py
+++ b/homeassistant/components/otbr/homeassistant_hardware.py
@@ -2,42 +2,40 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, cast
+import logging
+from typing import cast
 
 import voluptuous as vol
 from yarl import URL
 
-from homeassistant.components.hassio import valid_addon
+from homeassistant.components.hassio import AddonManager, valid_addon
 from homeassistant.components.homeassistant_hardware.util import (
     ApplicationType,
     FirmwareInfo,
     OwningAddon,
     OwningIntegration,
+    get_otbr_addon_firmware_info,
 )
-from homeassistant.config_entries import ConfigEntry
+from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.hassio import is_hassio
 
+from . import OTBRConfigEntry
 from .const import DOMAIN
 
-if TYPE_CHECKING:
-    from . import OTBRConfigEntry
+_LOGGER = logging.getLogger(__name__)
 
 
 async def async_get_firmware_info(
     hass: HomeAssistant, config_entry: ConfigEntry
 ) -> FirmwareInfo | None:
     """Return firmware information for the OpenThread Border Router."""
-    if TYPE_CHECKING:
-        config_entry = cast(OTBRConfigEntry, config_entry)
-
-    if (device := config_entry.data.get("device")) is None:
-        return None
-
     owners: list[OwningIntegration | OwningAddon] = [
         OwningIntegration(config_entry_id=config_entry.entry_id)
     ]
+
+    device = None
 
     if is_hassio(hass) and (host := URL(config_entry.data["url"]).host) is not None:
         try:
@@ -45,12 +43,34 @@ async def async_get_firmware_info(
         except vol.Invalid:
             pass
         else:
-            owners.append(OwningAddon(slug=host))
+            otbr_addon_manager = AddonManager(
+                hass=hass,
+                logger=_LOGGER,
+                addon_name="OpenThread Border Router",
+                addon_slug=host,
+            )
 
-    try:
-        firmware_version = await config_entry.runtime_data.get_coprocessor_version()
-    except HomeAssistantError:
-        firmware_version = None
+            if (
+                addon_fw_info := await get_otbr_addon_firmware_info(
+                    hass, otbr_addon_manager
+                )
+            ) is not None:
+                device = addon_fw_info.device
+                owners.extend(addon_fw_info.owners)
+
+    if config_entry.state == ConfigEntryState.LOADED:
+        config_entry = cast(OTBRConfigEntry, config_entry)
+
+        if device is None:
+            device = config_entry.data.get("device", None)
+
+        try:
+            firmware_version = await config_entry.runtime_data.get_coprocessor_version()
+        except HomeAssistantError:
+            firmware_version = None
+
+    if device is None:
+        return None
 
     return FirmwareInfo(
         device=device,

--- a/homeassistant/components/otbr/homeassistant_hardware.py
+++ b/homeassistant/components/otbr/homeassistant_hardware.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 import voluptuous as vol
 from yarl import URL
@@ -21,8 +21,10 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.hassio import is_hassio
 
-from . import OTBRConfigEntry
 from .const import DOMAIN
+
+if TYPE_CHECKING:
+    from . import OTBRConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -58,11 +60,14 @@ async def async_get_firmware_info(
                 device = addon_fw_info.device
                 owners.extend(addon_fw_info.owners)
 
-    if config_entry.state == ConfigEntryState.LOADED:
-        config_entry = cast(OTBRConfigEntry, config_entry)
+    firmware_version = None
 
-        if device is None:
-            device = config_entry.data.get("device", None)
+    if config_entry.state in (
+        ConfigEntryState.LOADED,
+        ConfigEntryState.SETUP_IN_PROGRESS,
+    ):
+        if TYPE_CHECKING:
+            config_entry = cast(OTBRConfigEntry, config_entry)
 
         try:
             firmware_version = await config_entry.runtime_data.get_coprocessor_version()

--- a/homeassistant/components/otbr/homeassistant_hardware.py
+++ b/homeassistant/components/otbr/homeassistant_hardware.py
@@ -5,10 +5,9 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, cast
 
-import voluptuous as vol
 from yarl import URL
 
-from homeassistant.components.hassio import AddonManager, valid_addon
+from homeassistant.components.hassio import AddonManager
 from homeassistant.components.homeassistant_hardware.util import (
     ApplicationType,
     FirmwareInfo,
@@ -40,25 +39,20 @@ async def async_get_firmware_info(
     device = None
 
     if is_hassio(hass) and (host := URL(config_entry.data["url"]).host) is not None:
-        try:
-            valid_addon(host)
-        except vol.Invalid:
-            pass
-        else:
-            otbr_addon_manager = AddonManager(
-                hass=hass,
-                logger=_LOGGER,
-                addon_name="OpenThread Border Router",
-                addon_slug=host,
-            )
+        otbr_addon_manager = AddonManager(
+            hass=hass,
+            logger=_LOGGER,
+            addon_name="OpenThread Border Router",
+            addon_slug=host,
+        )
 
-            if (
-                addon_fw_info := await get_otbr_addon_firmware_info(
-                    hass, otbr_addon_manager
-                )
-            ) is not None:
-                device = addon_fw_info.device
-                owners.extend(addon_fw_info.owners)
+        if (
+            addon_fw_info := await get_otbr_addon_firmware_info(
+                hass, otbr_addon_manager
+            )
+        ) is not None:
+            device = addon_fw_info.device
+            owners.extend(addon_fw_info.owners)
 
     firmware_version = None
 

--- a/homeassistant/components/otbr/homeassistant_hardware.py
+++ b/homeassistant/components/otbr/homeassistant_hardware.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, cast
 
 from yarl import URL
 
@@ -15,21 +14,19 @@ from homeassistant.components.homeassistant_hardware.util import (
     OwningIntegration,
     get_otbr_addon_firmware_info,
 )
-from homeassistant.config_entries import ConfigEntry, ConfigEntryState
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.hassio import is_hassio
 
 from .const import DOMAIN
-
-if TYPE_CHECKING:
-    from . import OTBRConfigEntry
+from .types import OTBRConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
 
 
 async def async_get_firmware_info(
-    hass: HomeAssistant, config_entry: ConfigEntry
+    hass: HomeAssistant, config_entry: OTBRConfigEntry
 ) -> FirmwareInfo | None:
     """Return firmware information for the OpenThread Border Router."""
     owners: list[OwningIntegration | OwningAddon] = [
@@ -62,9 +59,6 @@ async def async_get_firmware_info(
         ConfigEntryState.LOADED,
         ConfigEntryState.SETUP_IN_PROGRESS,
     ):
-        if TYPE_CHECKING:
-            config_entry = cast(OTBRConfigEntry, config_entry)
-
         try:
             firmware_version = await config_entry.runtime_data.get_coprocessor_version()
         except HomeAssistantError:

--- a/homeassistant/components/otbr/types.py
+++ b/homeassistant/components/otbr/types.py
@@ -1,0 +1,7 @@
+"""The Open Thread Border Router integration types."""
+
+from homeassistant.config_entries import ConfigEntry
+
+from .util import OTBRData
+
+type OTBRConfigEntry = ConfigEntry[OTBRData]

--- a/homeassistant/components/otbr/util.py
+++ b/homeassistant/components/otbr/util.py
@@ -163,6 +163,11 @@ class OTBRData:
         """Get extended address (EUI-64)."""
         return await self.api.get_extended_address()
 
+    @_handle_otbr_error
+    async def get_coprocessor_version(self) -> str:
+        """Get coprocessor firmware version."""
+        return await self.api.get_coprocessor_version()
+
 
 async def get_allowed_channel(hass: HomeAssistant, otbr_url: str) -> int | None:
     """Return the allowed channel, or None if there's no restriction."""

--- a/tests/components/otbr/__init__.py
+++ b/tests/components/otbr/__init__.py
@@ -33,6 +33,8 @@ TEST_BORDER_AGENT_EXTENDED_ADDRESS = bytes.fromhex("AEEB2F594B570BBF")
 TEST_BORDER_AGENT_ID = bytes.fromhex("230C6A1AC57F6F4BE262ACF32E5EF52C")
 TEST_BORDER_AGENT_ID_2 = bytes.fromhex("230C6A1AC57F6F4BE262ACF32E5EF52D")
 
+COPROCESSOR_VERSION = "OPENTHREAD/thread-reference-20200818-1740-g33cc75ed3; NRF52840; Jun 2 2022 14:25:49"
+
 ROUTER_DISCOVERY_HASS = {
     "type_": "_meshcop._udp.local.",
     "name": "HomeAssistant OpenThreadBorderRouter #0BBF._meshcop._udp.local.",
@@ -60,3 +62,7 @@ ROUTER_DISCOVERY_HASS = {
     },
     "interface_index": None,
 }
+
+TEST_COPROCESSOR_VERSION = (
+    "SL-OPENTHREAD/2.4.4.0_GitHub-7074a43e4; EFR32; Oct 21 2024 14:40:57"
+)

--- a/tests/components/otbr/conftest.py
+++ b/tests/components/otbr/conftest.py
@@ -15,6 +15,7 @@ from . import (
     DATASET_CH16,
     TEST_BORDER_AGENT_EXTENDED_ADDRESS,
     TEST_BORDER_AGENT_ID,
+    TEST_COPROCESSOR_VERSION,
 )
 
 from tests.common import MockConfigEntry
@@ -71,12 +72,23 @@ def get_extended_address_fixture() -> Generator[AsyncMock]:
         yield get_extended_address
 
 
+@pytest.fixture(name="get_coprocessor_version")
+def get_coprocessor_version_fixture() -> Generator[AsyncMock]:
+    """Mock get_coprocessor_version."""
+    with patch(
+        "python_otbr_api.OTBR.get_coprocessor_version",
+        return_value=TEST_COPROCESSOR_VERSION,
+    ) as get_coprocessor_version:
+        yield get_coprocessor_version
+
+
 @pytest.fixture(name="otbr_config_entry_multipan")
 async def otbr_config_entry_multipan_fixture(
     hass: HomeAssistant,
     get_active_dataset_tlvs: AsyncMock,
     get_border_agent_id: AsyncMock,
     get_extended_address: AsyncMock,
+    get_coprocessor_version: AsyncMock,
 ) -> str:
     """Mock Open Thread Border Router config entry."""
     config_entry = MockConfigEntry(
@@ -97,6 +109,7 @@ async def otbr_config_entry_thread_fixture(
     get_active_dataset_tlvs: AsyncMock,
     get_border_agent_id: AsyncMock,
     get_extended_address: AsyncMock,
+    get_coprocessor_version: AsyncMock,
 ) -> None:
     """Mock Open Thread Border Router config entry."""
     config_entry = MockConfigEntry(

--- a/tests/components/otbr/test_config_flow.py
+++ b/tests/components/otbr/test_config_flow.py
@@ -97,6 +97,7 @@ async def test_user_flow_additional_entry(
 @pytest.mark.usefixtures(
     "get_active_dataset_tlvs",
     "get_extended_address",
+    "get_coprocessor_version",
 )
 async def test_user_flow_additional_entry_fail_get_address(
     hass: HomeAssistant,
@@ -174,6 +175,7 @@ async def _finish_user_flow(
     "get_active_dataset_tlvs",
     "get_border_agent_id",
     "get_extended_address",
+    "get_coprocessor_version",
 )
 async def test_user_flow_additional_entry_same_address(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
@@ -563,7 +565,11 @@ async def test_hassio_discovery_flow_2x_addons(
     assert config_entry.unique_id == HASSIO_DATA_2.uuid
 
 
-@pytest.mark.usefixtures("get_active_dataset_tlvs", "get_extended_address")
+@pytest.mark.usefixtures(
+    "get_active_dataset_tlvs",
+    "get_extended_address",
+    "get_coprocessor_version",
+)
 async def test_hassio_discovery_flow_2x_addons_same_ext_address(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, otbr_addon_info
 ) -> None:

--- a/tests/components/otbr/test_config_flow.py
+++ b/tests/components/otbr/test_config_flow.py
@@ -10,9 +10,18 @@ import pytest
 import python_otbr_api
 
 from homeassistant.components import otbr
+from homeassistant.components.homeassistant_hardware.helpers import (
+    async_register_firmware_info_callback,
+)
+from homeassistant.components.homeassistant_hardware.util import (
+    ApplicationType,
+    FirmwareInfo,
+    OwningAddon,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers.service_info.hassio import HassioServiceInfo
+from homeassistant.setup import async_setup_component
 
 from . import DATASET_CH15, DATASET_CH16, TEST_BORDER_AGENT_ID, TEST_BORDER_AGENT_ID_2
 
@@ -30,6 +39,19 @@ HASSIO_DATA_2 = HassioServiceInfo(
     name="Silicon Labs Multiprotocol",
     slug="other_addon",
     uuid="23456",
+)
+
+HASSIO_DATA_OTBR = HassioServiceInfo(
+    config={
+        "host": "core-openthread-border-router",
+        "port": 8081,
+        "device": "/dev/ttyUSB1",
+        "firmware": "SL-OPENTHREAD/2.4.4.0_GitHub-7074a43e4; EFR32; Oct 21 2024 14:40:57\r",
+        "addon": "OpenThread Border Router",
+    },
+    name="OpenThread Border Router",
+    slug="core_openthread_border_router",
+    uuid="c58ba80fc88548008776bf8da903ef21",
 )
 
 
@@ -969,3 +991,55 @@ async def test_config_flow_additional_entry(
         )
 
     assert result["type"] is expected_result
+
+
+@pytest.mark.usefixtures(
+    "get_border_agent_id", "get_extended_address", "get_coprocessor_version"
+)
+async def test_hassio_discovery_reload(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, otbr_addon_info
+) -> None:
+    """Test the hassio discovery flow."""
+    await async_setup_component(hass, "homeassistant_hardware", {})
+
+    aioclient_mock.get(
+        "http://core-openthread-border-router:8081/node/dataset/active", text=""
+    )
+
+    callback = Mock()
+    async_register_firmware_info_callback(hass, "/dev/ttyUSB1", callback)
+
+    with (
+        patch(
+            "homeassistant.components.otbr.homeassistant_hardware.is_hassio",
+            return_value=True,
+        ),
+        patch(
+            "homeassistant.components.otbr.homeassistant_hardware.get_otbr_addon_firmware_info",
+            return_value=FirmwareInfo(
+                device="/dev/ttyUSB1",
+                firmware_type=ApplicationType.SPINEL,
+                firmware_version=None,
+                source="otbr",
+                owners=[
+                    OwningAddon(slug="core_openthread_border_router"),
+                ],
+            ),
+        ),
+    ):
+        await hass.config_entries.flow.async_init(
+            otbr.DOMAIN, context={"source": "hassio"}, data=HASSIO_DATA_OTBR
+        )
+
+        # OTBR is set up and calls the firmware info notification callback
+        assert len(callback.mock_calls) == 1
+        assert len(hass.config_entries.async_entries(otbr.DOMAIN)) == 1
+
+        # If we change discovery info and emit again, the integration will be reloaded
+        # and firmware information will be broadcast again
+        await hass.config_entries.flow.async_init(
+            otbr.DOMAIN, context={"source": "hassio"}, data=HASSIO_DATA_OTBR
+        )
+
+        assert len(callback.mock_calls) == 2
+        assert len(hass.config_entries.async_entries(otbr.DOMAIN)) == 1

--- a/tests/components/otbr/test_config_flow.py
+++ b/tests/components/otbr/test_config_flow.py
@@ -372,6 +372,7 @@ async def test_hassio_discovery_flow(
 
     expected_data = {
         "url": f"http://{HASSIO_DATA.config['host']}:{HASSIO_DATA.config['port']}",
+        "device": None,
     }
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
@@ -411,6 +412,7 @@ async def test_hassio_discovery_flow_yellow(
 
     expected_data = {
         "url": f"http://{HASSIO_DATA.config['host']}:{HASSIO_DATA.config['port']}",
+        "device": None,
     }
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
@@ -464,6 +466,7 @@ async def test_hassio_discovery_flow_sky_connect(
 
     expected_data = {
         "url": f"http://{HASSIO_DATA.config['host']}:{HASSIO_DATA.config['port']}",
+        "device": None,
     }
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
@@ -525,9 +528,11 @@ async def test_hassio_discovery_flow_2x_addons(
 
     expected_data = {
         "url": f"http://{HASSIO_DATA.config['host']}:{HASSIO_DATA.config['port']}",
+        "device": None,
     }
     expected_data_2 = {
         "url": f"http://{HASSIO_DATA_2.config['host']}:{HASSIO_DATA_2.config['port']}",
+        "device": None,
     }
 
     assert results[0]["type"] is FlowResultType.CREATE_ENTRY
@@ -609,6 +614,7 @@ async def test_hassio_discovery_flow_2x_addons_same_ext_address(
 
     expected_data = {
         "url": f"http://{HASSIO_DATA.config['host']}:{HASSIO_DATA.config['port']}",
+        "device": None,
     }
 
     assert results[0]["type"] is FlowResultType.CREATE_ENTRY
@@ -673,6 +679,7 @@ async def test_hassio_discovery_flow_router_not_setup(
 
     expected_data = {
         "url": f"http://{HASSIO_DATA.config['host']}:{HASSIO_DATA.config['port']}",
+        "device": None,
     }
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
@@ -726,6 +733,7 @@ async def test_hassio_discovery_flow_router_not_setup_has_preferred(
 
     expected_data = {
         "url": f"http://{HASSIO_DATA.config['host']}:{HASSIO_DATA.config['port']}",
+        "device": None,
     }
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
@@ -790,6 +798,7 @@ async def test_hassio_discovery_flow_router_not_setup_has_preferred_2(
 
     expected_data = {
         "url": f"http://{HASSIO_DATA.config['host']}:{HASSIO_DATA.config['port']}",
+        "device": None,
     }
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
@@ -850,6 +859,7 @@ async def test_hassio_discovery_flow_new_port_missing_unique_id(
 
     expected_data = {
         "url": f"http://{HASSIO_DATA.config['host']}:{HASSIO_DATA.config['port']}",
+        "device": None,
     }
     config_entry = hass.config_entries.async_entries(otbr.DOMAIN)[0]
     assert config_entry.data == expected_data
@@ -884,6 +894,7 @@ async def test_hassio_discovery_flow_new_port(hass: HomeAssistant) -> None:
 
     expected_data = {
         "url": f"http://{HASSIO_DATA.config['host']}:{HASSIO_DATA.config['port']}",
+        "device": None,
     }
     config_entry = hass.config_entries.async_entries(otbr.DOMAIN)[0]
     assert config_entry.data == expected_data
@@ -921,6 +932,7 @@ async def test_hassio_discovery_flow_new_port_other_addon(hass: HomeAssistant) -
     # Make sure the data of the existing entry was not updated
     expected_data = {
         "url": f"http://openthread_border_router:{HASSIO_DATA.config['port'] + 1}",
+        "device": None,
     }
     config_entry = hass.config_entries.async_get_entry(config_entry.entry_id)
     assert config_entry.data == expected_data

--- a/tests/components/otbr/test_config_flow.py
+++ b/tests/components/otbr/test_config_flow.py
@@ -372,7 +372,6 @@ async def test_hassio_discovery_flow(
 
     expected_data = {
         "url": f"http://{HASSIO_DATA.config['host']}:{HASSIO_DATA.config['port']}",
-        "device": None,
     }
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
@@ -412,7 +411,6 @@ async def test_hassio_discovery_flow_yellow(
 
     expected_data = {
         "url": f"http://{HASSIO_DATA.config['host']}:{HASSIO_DATA.config['port']}",
-        "device": None,
     }
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
@@ -466,7 +464,6 @@ async def test_hassio_discovery_flow_sky_connect(
 
     expected_data = {
         "url": f"http://{HASSIO_DATA.config['host']}:{HASSIO_DATA.config['port']}",
-        "device": None,
     }
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
@@ -528,11 +525,9 @@ async def test_hassio_discovery_flow_2x_addons(
 
     expected_data = {
         "url": f"http://{HASSIO_DATA.config['host']}:{HASSIO_DATA.config['port']}",
-        "device": None,
     }
     expected_data_2 = {
         "url": f"http://{HASSIO_DATA_2.config['host']}:{HASSIO_DATA_2.config['port']}",
-        "device": None,
     }
 
     assert results[0]["type"] is FlowResultType.CREATE_ENTRY
@@ -614,7 +609,6 @@ async def test_hassio_discovery_flow_2x_addons_same_ext_address(
 
     expected_data = {
         "url": f"http://{HASSIO_DATA.config['host']}:{HASSIO_DATA.config['port']}",
-        "device": None,
     }
 
     assert results[0]["type"] is FlowResultType.CREATE_ENTRY
@@ -679,7 +673,6 @@ async def test_hassio_discovery_flow_router_not_setup(
 
     expected_data = {
         "url": f"http://{HASSIO_DATA.config['host']}:{HASSIO_DATA.config['port']}",
-        "device": None,
     }
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
@@ -733,7 +726,6 @@ async def test_hassio_discovery_flow_router_not_setup_has_preferred(
 
     expected_data = {
         "url": f"http://{HASSIO_DATA.config['host']}:{HASSIO_DATA.config['port']}",
-        "device": None,
     }
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
@@ -798,7 +790,6 @@ async def test_hassio_discovery_flow_router_not_setup_has_preferred_2(
 
     expected_data = {
         "url": f"http://{HASSIO_DATA.config['host']}:{HASSIO_DATA.config['port']}",
-        "device": None,
     }
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
@@ -859,7 +850,6 @@ async def test_hassio_discovery_flow_new_port_missing_unique_id(
 
     expected_data = {
         "url": f"http://{HASSIO_DATA.config['host']}:{HASSIO_DATA.config['port']}",
-        "device": None,
     }
     config_entry = hass.config_entries.async_entries(otbr.DOMAIN)[0]
     assert config_entry.data == expected_data
@@ -894,7 +884,6 @@ async def test_hassio_discovery_flow_new_port(hass: HomeAssistant) -> None:
 
     expected_data = {
         "url": f"http://{HASSIO_DATA.config['host']}:{HASSIO_DATA.config['port']}",
-        "device": None,
     }
     config_entry = hass.config_entries.async_entries(otbr.DOMAIN)[0]
     assert config_entry.data == expected_data
@@ -932,7 +921,6 @@ async def test_hassio_discovery_flow_new_port_other_addon(hass: HomeAssistant) -
     # Make sure the data of the existing entry was not updated
     expected_data = {
         "url": f"http://openthread_border_router:{HASSIO_DATA.config['port'] + 1}",
-        "device": None,
     }
     config_entry = hass.config_entries.async_get_entry(config_entry.entry_id)
     assert config_entry.data == expected_data

--- a/tests/components/otbr/test_homeassistant_hardware.py
+++ b/tests/components/otbr/test_homeassistant_hardware.py
@@ -34,11 +34,9 @@ async def test_get_firmware_info(hass: HomeAssistant) -> None:
         domain="otbr",
         unique_id="some_unique_id",
         data={
-            "device": DEVICE_PATH,
             "url": "http://core_openthread_border_router:8888",
         },
         version=1,
-        minor_version=2,
     )
     otbr.add_to_hass(hass)
     otbr.mock_state(hass, ConfigEntryState.LOADED)
@@ -49,10 +47,6 @@ async def test_get_firmware_info(hass: HomeAssistant) -> None:
     with (
         patch(
             "homeassistant.components.otbr.homeassistant_hardware.is_hassio",
-            return_value=True,
-        ),
-        patch(
-            "homeassistant.components.otbr.homeassistant_hardware.valid_addon",
             return_value=True,
         ),
         patch(
@@ -93,7 +87,6 @@ async def test_get_firmware_info_ignored(hass: HomeAssistant) -> None:
         unique_id="some_unique_id",
         data={},
         version=1,
-        minor_version=2,
     )
     otbr.add_to_hass(hass)
 
@@ -108,11 +101,9 @@ async def test_get_firmware_info_no_coprocessor_version(hass: HomeAssistant) -> 
         domain="otbr",
         unique_id="some_unique_id",
         data={
-            "device": DEVICE_PATH,
             "url": "http://core_openthread_border_router:8888",
         },
         version=1,
-        minor_version=2,
     )
     otbr.add_to_hass(hass)
     otbr.mock_state(hass, ConfigEntryState.LOADED)
@@ -123,10 +114,6 @@ async def test_get_firmware_info_no_coprocessor_version(hass: HomeAssistant) -> 
     with (
         patch(
             "homeassistant.components.otbr.homeassistant_hardware.is_hassio",
-            return_value=True,
-        ),
-        patch(
-            "homeassistant.components.otbr.homeassistant_hardware.valid_addon",
             return_value=True,
         ),
         patch(
@@ -181,11 +168,9 @@ async def test_hardware_firmware_info_provider_notification(
         domain="otbr",
         unique_id="some_unique_id",
         data={
-            "device": DEVICE_PATH,
             "url": "http://core_openthread_border_router:8888",
         },
         version=1,
-        minor_version=2,
     )
     otbr.add_to_hass(hass)
 
@@ -197,10 +182,6 @@ async def test_hardware_firmware_info_provider_notification(
     with (
         patch(
             "homeassistant.components.otbr.homeassistant_hardware.is_hassio",
-            return_value=True,
-        ),
-        patch(
-            "homeassistant.components.otbr.homeassistant_hardware.valid_addon",
             return_value=True,
         ),
         patch(
@@ -245,11 +226,9 @@ async def test_get_firmware_info_remote_otbr(hass: HomeAssistant) -> None:
         domain="otbr",
         unique_id="some_unique_id",
         data={
-            "device": DEVICE_PATH,
             "url": "http://192.168.1.10:8888",
         },
         version=1,
-        minor_version=2,
     )
     otbr.add_to_hass(hass)
     otbr.mock_state(hass, ConfigEntryState.LOADED)

--- a/tests/components/otbr/test_homeassistant_hardware.py
+++ b/tests/components/otbr/test_homeassistant_hardware.py
@@ -1,0 +1,225 @@
+"""Test Home Assistant Hardware platform for OTBR."""
+
+from unittest.mock import AsyncMock, Mock, call, patch
+
+import pytest
+import voluptuous as vol
+
+from homeassistant.components.homeassistant_hardware.helpers import (
+    async_register_firmware_info_callback,
+)
+from homeassistant.components.homeassistant_hardware.util import (
+    ApplicationType,
+    FirmwareInfo,
+    OwningAddon,
+    OwningIntegration,
+)
+from homeassistant.components.otbr.homeassistant_hardware import async_get_firmware_info
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.setup import async_setup_component
+
+from . import TEST_COPROCESSOR_VERSION
+
+from tests.common import MockConfigEntry
+from tests.test_util.aiohttp import AiohttpClientMocker
+
+
+async def test_get_firmware_info(hass: HomeAssistant) -> None:
+    """Test `async_get_firmware_info`."""
+
+    otbr = MockConfigEntry(
+        domain="otbr",
+        unique_id="some_unique_id",
+        data={
+            "device": "/dev/ttyUSB1",
+            "url": "http://openthread_border_router:8888",
+        },
+        version=1,
+        minor_version=2,
+    )
+    otbr.add_to_hass(hass)
+    otbr.mock_state(hass, ConfigEntryState.LOADED)
+
+    otbr.runtime_data = AsyncMock()
+    otbr.runtime_data.get_coprocessor_version.return_value = TEST_COPROCESSOR_VERSION
+
+    with (
+        patch(
+            "homeassistant.components.otbr.homeassistant_hardware.is_hassio",
+            return_value=True,
+        ),
+        patch(
+            "homeassistant.components.otbr.homeassistant_hardware.valid_addon",
+            return_value=True,
+        ),
+    ):
+        fw_info = await async_get_firmware_info(hass, otbr)
+
+    assert fw_info == FirmwareInfo(
+        device="/dev/ttyUSB1",
+        firmware_type=ApplicationType.SPINEL,
+        firmware_version=TEST_COPROCESSOR_VERSION,
+        source="otbr",
+        owners=[
+            OwningIntegration(config_entry_id=otbr.entry_id),
+            OwningAddon(slug="openthread_border_router"),
+        ],
+    )
+
+
+async def test_get_firmware_info_ignored(hass: HomeAssistant) -> None:
+    """Test `async_get_firmware_info` with ignored entry."""
+
+    otbr = MockConfigEntry(
+        domain="otbr",
+        unique_id="some_unique_id",
+        data={},
+        version=1,
+        minor_version=2,
+    )
+    otbr.add_to_hass(hass)
+
+    fw_info = await async_get_firmware_info(hass, otbr)
+    assert fw_info is None
+
+
+async def test_get_firmware_info_bad_addon(hass: HomeAssistant) -> None:
+    """Test `async_get_firmware_info`."""
+
+    otbr = MockConfigEntry(
+        domain="otbr",
+        unique_id="some_unique_id",
+        data={
+            "device": "/dev/ttyUSB1",
+            "url": "http://openthread_border_router:8888",
+        },
+        version=1,
+        minor_version=2,
+    )
+    otbr.add_to_hass(hass)
+    otbr.mock_state(hass, ConfigEntryState.LOADED)
+
+    otbr.runtime_data = AsyncMock()
+    otbr.runtime_data.get_coprocessor_version.return_value = TEST_COPROCESSOR_VERSION
+
+    with (
+        patch(
+            "homeassistant.components.otbr.homeassistant_hardware.is_hassio",
+            return_value=True,
+        ),
+        patch(
+            "homeassistant.components.otbr.homeassistant_hardware.valid_addon",
+            side_effect=vol.Invalid("Bad addon name"),
+        ),
+    ):
+        fw_info = await async_get_firmware_info(hass, otbr)
+
+    assert fw_info == FirmwareInfo(
+        device="/dev/ttyUSB1",
+        firmware_type=ApplicationType.SPINEL,
+        firmware_version=TEST_COPROCESSOR_VERSION,
+        source="otbr",
+        owners=[
+            OwningIntegration(config_entry_id=otbr.entry_id),
+        ],
+    )
+
+
+async def test_get_firmware_info_no_coprocessor_version(hass: HomeAssistant) -> None:
+    """Test `async_get_firmware_info`."""
+
+    otbr = MockConfigEntry(
+        domain="otbr",
+        unique_id="some_unique_id",
+        data={
+            "device": "/dev/ttyUSB1",
+            "url": "http://openthread_border_router:8888",
+        },
+        version=1,
+        minor_version=2,
+    )
+    otbr.add_to_hass(hass)
+    otbr.mock_state(hass, ConfigEntryState.LOADED)
+
+    otbr.runtime_data = AsyncMock()
+    otbr.runtime_data.get_coprocessor_version.side_effect = HomeAssistantError()
+
+    with (
+        patch(
+            "homeassistant.components.otbr.homeassistant_hardware.is_hassio",
+            return_value=False,
+        ),
+    ):
+        fw_info = await async_get_firmware_info(hass, otbr)
+
+    assert fw_info == FirmwareInfo(
+        device="/dev/ttyUSB1",
+        firmware_type=ApplicationType.SPINEL,
+        firmware_version=None,
+        source="otbr",
+        owners=[
+            OwningIntegration(config_entry_id=otbr.entry_id),
+        ],
+    )
+
+
+@pytest.mark.parametrize(
+    ("version", "expected_version"),
+    [
+        (TEST_COPROCESSOR_VERSION, TEST_COPROCESSOR_VERSION),
+        (HomeAssistantError(), None),
+    ],
+)
+async def test_hardware_firmware_info_provider_notification(
+    hass: HomeAssistant,
+    version: str | Exception,
+    expected_version: str | None,
+    get_active_dataset_tlvs: AsyncMock,
+    get_border_agent_id: AsyncMock,
+    get_extended_address: AsyncMock,
+    get_coprocessor_version: AsyncMock,
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
+    """Test that the OTBR provides hardware and firmware information."""
+    otbr = MockConfigEntry(
+        domain="otbr",
+        unique_id="some_unique_id",
+        data={
+            "device": "/dev/ttyUSB1",
+            "url": "http://openthread_border_router:8888",
+        },
+        version=1,
+        minor_version=2,
+    )
+    otbr.add_to_hass(hass)
+
+    await async_setup_component(hass, "homeassistant_hardware", {})
+
+    callback = Mock()
+    async_register_firmware_info_callback(hass, "/dev/ttyUSB1", callback)
+
+    with (
+        patch(
+            "homeassistant.components.otbr.homeassistant_hardware.is_hassio",
+            return_value=True,
+        ),
+    ):
+        get_coprocessor_version.side_effect = version
+        await hass.config_entries.async_setup(otbr.entry_id)
+
+    assert callback.mock_calls == [
+        call(
+            FirmwareInfo(
+                device="/dev/ttyUSB1",
+                firmware_type=ApplicationType.SPINEL,
+                firmware_version=expected_version,
+                source="otbr",
+                owners=[
+                    OwningIntegration(config_entry_id=otbr.entry_id),
+                    OwningAddon(slug="openthread_border_router"),
+                ],
+            )
+        )
+    ]

--- a/tests/components/otbr/test_init.py
+++ b/tests/components/otbr/test_init.py
@@ -26,6 +26,7 @@ from . import (
     ROUTER_DISCOVERY_HASS,
     TEST_BORDER_AGENT_EXTENDED_ADDRESS,
     TEST_BORDER_AGENT_ID,
+    TEST_COPROCESSOR_VERSION,
 )
 
 from tests.common import MockConfigEntry
@@ -43,6 +44,7 @@ def enable_mocks_fixture(
     get_active_dataset_tlvs: AsyncMock,
     get_border_agent_id: AsyncMock,
     get_extended_address: AsyncMock,
+    get_coprocessor_version: AsyncMock,
 ) -> None:
     """Enable API mocks."""
 
@@ -298,6 +300,7 @@ async def test_config_entry_update(hass: HomeAssistant) -> None:
     mock_api.get_extended_address = AsyncMock(
         return_value=TEST_BORDER_AGENT_EXTENDED_ADDRESS
     )
+    mock_api.get_coprocessor_version = AsyncMock(return_value=TEST_COPROCESSOR_VERSION)
     with patch("python_otbr_api.OTBR", return_value=mock_api) as mock_otrb_api:
         assert await hass.config_entries.async_setup(config_entry.entry_id)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is a follow-up to #134598 and implements the `homeassistant_hardware` firmware push/pull API for the OTBR integration. It is currently implemented for just ZHA.

To support this, I've added `get_coprocessor_version` to the OTBR API object (https://github.com/home-assistant-libs/python-otbr-api/pull/166), which is supported by the most recent release of our OTBR addon.

I've decided against having the OTBR integration keep track of the serial port path. Instead, this information will be pulled entirely from the OTBR addon.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
