### PR TITLE
Fix Nederlandse Spoorwegen to ignore trains in the past

### DIFF
--- a/homeassistant/components/nederlandse_spoorwegen/sensor.py
+++ b/homeassistant/components/nederlandse_spoorwegen/sensor.py
@@ -241,7 +241,6 @@ class NSDepartureSensor(SensorEntity):
             )
         else:
             trip_time = datetime.now().strftime("%d-%m-%Y %H:%M")
-            _LOGGER.debug(trip_time)
 
         try:
             self._trips = self._nsapi.get_trips(

--- a/homeassistant/components/nederlandse_spoorwegen/sensor.py
+++ b/homeassistant/components/nederlandse_spoorwegen/sensor.py
@@ -20,7 +20,7 @@ from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
-from homeassistant.util import Throttle
+from homeassistant.util import Throttle, dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -119,6 +119,8 @@ class NSDepartureSensor(SensorEntity):
         self._time = time
         self._state = None
         self._trips = None
+        self._first_trip = None
+        self._next_trip = None
 
     @property
     def name(self):
@@ -136,41 +138,41 @@ class NSDepartureSensor(SensorEntity):
         if not self._trips:
             return None
 
-        if self._trips[0].trip_parts:
-            route = [self._trips[0].departure]
-            route.extend(k.destination for k in self._trips[0].trip_parts)
+        if self._first_trip.trip_parts:
+            route = [self._first_trip.departure]
+            route.extend(k.destination for k in self._first_trip.trip_parts)
 
         # Static attributes
         attributes = {
-            "going": self._trips[0].going,
+            "going": self._first_trip.going,
             "departure_time_planned": None,
             "departure_time_actual": None,
             "departure_delay": False,
-            "departure_platform_planned": self._trips[0].departure_platform_planned,
-            "departure_platform_actual": self._trips[0].departure_platform_actual,
+            "departure_platform_planned": self._first_trip.departure_platform_planned,
+            "departure_platform_actual": self._first_trip.departure_platform_actual,
             "arrival_time_planned": None,
             "arrival_time_actual": None,
             "arrival_delay": False,
-            "arrival_platform_planned": self._trips[0].arrival_platform_planned,
-            "arrival_platform_actual": self._trips[0].arrival_platform_actual,
+            "arrival_platform_planned": self._first_trip.arrival_platform_planned,
+            "arrival_platform_actual": self._first_trip.arrival_platform_actual,
             "next": None,
-            "status": self._trips[0].status.lower(),
-            "transfers": self._trips[0].nr_transfers,
+            "status": self._first_trip.status.lower(),
+            "transfers": self._first_trip.nr_transfers,
             "route": route,
             "remarks": None,
         }
 
         # Planned departure attributes
-        if self._trips[0].departure_time_planned is not None:
-            attributes["departure_time_planned"] = self._trips[
-                0
-            ].departure_time_planned.strftime("%H:%M")
+        if self._first_trip.departure_time_planned is not None:
+            attributes["departure_time_planned"] = (
+                self._first_trip.departure_time_planned.strftime("%H:%M:%S")
+            )
 
         # Actual departure attributes
-        if self._trips[0].departure_time_actual is not None:
-            attributes["departure_time_actual"] = self._trips[
-                0
-            ].departure_time_actual.strftime("%H:%M")
+        if self._first_trip.departure_time_actual is not None:
+            attributes["departure_time_actual"] = (
+                self._first_trip.departure_time_actual.strftime("%H:%M:%S")
+            )
 
         # Delay departure attributes
         if (
@@ -182,16 +184,16 @@ class NSDepartureSensor(SensorEntity):
             attributes["departure_delay"] = True
 
         # Planned arrival attributes
-        if self._trips[0].arrival_time_planned is not None:
-            attributes["arrival_time_planned"] = self._trips[
-                0
-            ].arrival_time_planned.strftime("%H:%M")
+        if self._first_trip.arrival_time_planned is not None:
+            attributes["arrival_time_planned"] = (
+                self._first_trip.arrival_time_planned.strftime("%H:%M:%S")
+            )
 
         # Actual arrival attributes
-        if self._trips[0].arrival_time_actual is not None:
-            attributes["arrival_time_actual"] = self._trips[
-                0
-            ].arrival_time_actual.strftime("%H:%M")
+        if self._first_trip.arrival_time_actual is not None:
+            attributes["arrival_time_actual"] = (
+                self._first_trip.arrival_time_actual.strftime("%H:%M:%S")
+            )
 
         # Delay arrival attributes
         if (
@@ -202,15 +204,14 @@ class NSDepartureSensor(SensorEntity):
             attributes["arrival_delay"] = True
 
         # Next attributes
-        if len(self._trips) > 1:
-            if self._trips[1].departure_time_actual is not None:
-                attributes["next"] = self._trips[1].departure_time_actual.strftime(
-                    "%H:%M"
-                )
-            elif self._trips[1].departure_time_planned is not None:
-                attributes["next"] = self._trips[1].departure_time_planned.strftime(
-                    "%H:%M"
-                )
+        if self._next_trip.departure_time_actual is not None:
+            attributes["next"] = self._next_trip.departure_time_actual.strftime(
+                "%H:%M:%S"
+            )
+        elif self._next_trip.departure_time_planned is not None:
+            attributes["next"] = self._next_trip.departure_time_planned.strftime(
+                "%H:%M:%S"
+            )
 
         return attributes
 
@@ -225,6 +226,7 @@ class NSDepartureSensor(SensorEntity):
         ):
             self._state = None
             self._trips = None
+            self._first_trip = None
             return
 
         # Set the search parameter to search from a specific trip time
@@ -237,18 +239,43 @@ class NSDepartureSensor(SensorEntity):
             )
         else:
             trip_time = datetime.now().strftime("%d-%m-%Y %H:%M")
+            _LOGGER.debug(trip_time)
 
         try:
             self._trips = self._nsapi.get_trips(
                 trip_time, self._departure, self._via, self._heading, True, 0, 2
             )
             if self._trips:
-                if self._trips[0].departure_time_actual is None:
-                    planned_time = self._trips[0].departure_time_planned
-                    self._state = planned_time.strftime("%H:%M")
-                else:
-                    actual_time = self._trips[0].departure_time_actual
-                    self._state = actual_time.strftime("%H:%M")
+                all_times = []
+
+                # If a train is delayed we can observe this through departure_time_actual.
+                for trip in self._trips:
+                    if trip.departure_time_actual is None:
+                        all_times.append(trip.departure_time_planned)
+                    else:
+                        all_times.append(trip.departure_time_actual)
+
+                # Remove all trains that already left.
+                filtered_times = [
+                    (i, time)
+                    for i, time in enumerate(all_times)
+                    if time
+                    > datetime.now().replace(tzinfo=dt_util.get_default_time_zone())
+                ]
+
+                sorted_times = sorted(filtered_times, key=lambda x: x[1])
+                self._first_trip = self._trips[sorted_times[0][0]]
+                self._state = sorted_times[0][1].strftime("%H:%M:%S")
+
+                # Filter again to remove trains that leave at the exact same time.
+                filtered_times = [
+                    (i, time)
+                    for i, time in enumerate(all_times)
+                    if time > sorted_times[0][1]
+                ]
+                sorted_times = sorted(filtered_times, key=lambda x: x[1])
+                self._next_trip = self._trips[sorted_times[0][0]]
+
         except (
             requests.exceptions.ConnectionError,
             requests.exceptions.HTTPError,

--- a/homeassistant/components/nederlandse_spoorwegen/sensor.py
+++ b/homeassistant/components/nederlandse_spoorwegen/sensor.py
@@ -238,7 +238,7 @@ class NSDepartureSensor(SensorEntity):
                 .strftime("%d-%m-%Y %H:%M")
             )
         else:
-            trip_time = datetime.now().strftime("%d-%m-%Y %H:%M")
+            trip_time = dt_util.now().strftime("%d-%m-%Y %H:%M")
 
         try:
             self._trips = self._nsapi.get_trips(
@@ -258,8 +258,7 @@ class NSDepartureSensor(SensorEntity):
                 filtered_times = [
                     (i, time)
                     for i, time in enumerate(all_times)
-                    if time
-                    > datetime.now().replace(tzinfo=dt_util.get_default_time_zone())
+                    if time > dt_util.now()
                 ]
 
                 if len(filtered_times) > 0:

--- a/homeassistant/components/nederlandse_spoorwegen/sensor.py
+++ b/homeassistant/components/nederlandse_spoorwegen/sensor.py
@@ -165,13 +165,13 @@ class NSDepartureSensor(SensorEntity):
         # Planned departure attributes
         if self._first_trip.departure_time_planned is not None:
             attributes["departure_time_planned"] = (
-                self._first_trip.departure_time_planned.strftime("%H:%M:%S")
+                self._first_trip.departure_time_planned.strftime("%H:%M")
             )
 
         # Actual departure attributes
         if self._first_trip.departure_time_actual is not None:
             attributes["departure_time_actual"] = (
-                self._first_trip.departure_time_actual.strftime("%H:%M:%S")
+                self._first_trip.departure_time_actual.strftime("%H:%M")
             )
 
         # Delay departure attributes
@@ -186,13 +186,13 @@ class NSDepartureSensor(SensorEntity):
         # Planned arrival attributes
         if self._first_trip.arrival_time_planned is not None:
             attributes["arrival_time_planned"] = (
-                self._first_trip.arrival_time_planned.strftime("%H:%M:%S")
+                self._first_trip.arrival_time_planned.strftime("%H:%M")
             )
 
         # Actual arrival attributes
         if self._first_trip.arrival_time_actual is not None:
             attributes["arrival_time_actual"] = (
-                self._first_trip.arrival_time_actual.strftime("%H:%M:%S")
+                self._first_trip.arrival_time_actual.strftime("%H:%M")
             )
 
         # Delay arrival attributes
@@ -205,12 +205,10 @@ class NSDepartureSensor(SensorEntity):
 
         # Next attributes
         if self._next_trip.departure_time_actual is not None:
-            attributes["next"] = self._next_trip.departure_time_actual.strftime(
-                "%H:%M:%S"
-            )
+            attributes["next"] = self._next_trip.departure_time_actual.strftime("%H:%M")
         elif self._next_trip.departure_time_planned is not None:
             attributes["next"] = self._next_trip.departure_time_planned.strftime(
-                "%H:%M:%S"
+                "%H:%M"
             )
         else:
             attributes["next"] = None
@@ -267,7 +265,7 @@ class NSDepartureSensor(SensorEntity):
                 if len(filtered_times) > 0:
                     sorted_times = sorted(filtered_times, key=lambda x: x[1])
                     self._first_trip = self._trips[sorted_times[0][0]]
-                    self._state = sorted_times[0][1].strftime("%H:%M:%S")
+                    self._state = sorted_times[0][1].strftime("%H:%M")
                 else:
                     self._first_trip = None
                     self._state = None

--- a/homeassistant/components/nederlandse_spoorwegen/sensor.py
+++ b/homeassistant/components/nederlandse_spoorwegen/sensor.py
@@ -265,22 +265,23 @@ class NSDepartureSensor(SensorEntity):
                     sorted_times = sorted(filtered_times, key=lambda x: x[1])
                     self._first_trip = self._trips[sorted_times[0][0]]
                     self._state = sorted_times[0][1].strftime("%H:%M")
+
+                    # Filter again to remove trains that leave at the exact same time.
+                    filtered_times = [
+                        (i, time)
+                        for i, time in enumerate(all_times)
+                        if time > sorted_times[0][1]
+                    ]
+
+                    if len(filtered_times) > 0:
+                        sorted_times = sorted(filtered_times, key=lambda x: x[1])
+                        self._next_trip = self._trips[sorted_times[0][0]]
+                    else:
+                        self._next_trip = None
+
                 else:
                     self._first_trip = None
                     self._state = None
-
-                # Filter again to remove trains that leave at the exact same time.
-                filtered_times = [
-                    (i, time)
-                    for i, time in enumerate(all_times)
-                    if time > sorted_times[0][1]
-                ]
-
-                if len(filtered_times) > 0:
-                    sorted_times = sorted(filtered_times, key=lambda x: x[1])
-                    self._next_trip = self._trips[sorted_times[0][0]]
-                else:
-                    self._next_trip = None
 
         except (
             requests.exceptions.ConnectionError,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
No

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The Nederlandse Spoorwegen (NS) integration is supposed to provide information on when the next train leaves. However, it often does not provide the correct information because the integration takes the first train in the API response, due to one of two reasons the first train is usually not the one we need:
1. The API of NS does not provide information of just future trains. It also provides trains that have left recently (approx up 30 minutes ago).
2. Trains can get delayed which is not taken into account.

This is resolved by 1) determining per train which time to use (planned or actual/delayed), 2) ignoring all trains that left already.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/104754
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

_Not applicable since no changes made in intended functionality._
- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

_Not applicable since no changes in communication with devices, web services, or third-party tools._
- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
