### PR TITLE
Add config flow to evohome

### DIFF
--- a/homeassistant/components/evohome/__init__.py
+++ b/homeassistant/components/evohome/__init__.py
@@ -23,6 +23,7 @@ from evohomeasync2.schemas.const import (
 )
 import voluptuous as vol
 
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     CONF_PASSWORD,
@@ -103,7 +104,15 @@ class EvoData:
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up evohome integration from YAML (deprecated)."""
+    # Return True but do nothing else to avoid old YAML configs interfering
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up the Evohome integration."""
+
+    config = {DOMAIN: dict(entry.data)}
 
     token_manager = TokenManager(
         hass,
@@ -135,6 +144,12 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         loc_idx=coordinator.loc_idx,
         tcs=coordinator.tcs,
     )
+
+    entry.runtime_data = coordinator
+
+    # await hass.config_entries.async_forward_entry_setups(
+    #     entry, (Platform.CLIMATE, Platform.WATER_HEATER)
+    # )
 
     hass.async_create_task(
         async_load_platform(hass, Platform.CLIMATE, DOMAIN, {}, config)

--- a/homeassistant/components/evohome/config_flow.py
+++ b/homeassistant/components/evohome/config_flow.py
@@ -1,0 +1,157 @@
+"""Config flow for the Evohome integration."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import evohomeasync2 as ec2
+import voluptuous as vol
+
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.const import CONF_PASSWORD, CONF_SCAN_INTERVAL, CONF_USERNAME
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+import homeassistant.helpers.config_validation as cv
+
+from .const import (
+    CONF_LOCATION_IDX,
+    DEFAULT_LOCATION_IDX,
+    DOMAIN,
+    SCAN_INTERVAL_DEFAULT,
+    SCAN_INTERVAL_MINIMUM,
+)
+from .storage import TokenManager
+
+STEP_USER_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_USERNAME): str,  # an email address
+        vol.Required(CONF_PASSWORD): str,
+    }
+)
+
+STEP_LOCATION_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_LOCATION_IDX, default=DEFAULT_LOCATION_IDX): vol.Coerce(int),
+    }
+)
+
+STEP_SCAN_INTERVAL_SCHEMA = vol.Schema(
+    {
+        vol.Optional(CONF_SCAN_INTERVAL, default=SCAN_INTERVAL_DEFAULT): vol.All(
+            cv.time_period, vol.Range(min=SCAN_INTERVAL_MINIMUM)
+        )
+    }
+)
+
+
+class EvohomeConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for evohome."""
+
+    VERSION = 1
+
+    _token_manager: TokenManager
+    _location_idx: int
+
+    def __init__(self) -> None:
+        """Initialize the flow."""
+        self._config: dict[str, Any] = {}
+
+    async def async_step_import(
+        self, import_config: dict[str, Any]
+    ) -> ConfigFlowResult:
+        """Handle a flow initiated by configuration file."""
+
+        import_config[CONF_LOCATION_IDX] = import_config.get(CONF_LOCATION_IDX, 0)
+        import_config[CONF_SCAN_INTERVAL] = import_config.get(
+            CONF_SCAN_INTERVAL, SCAN_INTERVAL_MINIMUM
+        )
+
+        self._token_manager = await self._test_credentials(**import_config)
+        self._location_idx = await self._test_location_idx(**import_config)
+
+        self._config.update(import_config)
+        return self.async_create_entry(title="Evohome", data=self._config)
+
+    async def async_step_user(self, user_input: dict | None = None) -> ConfigFlowResult:
+        """Handle the initial step (username/password)."""
+
+        if user_input is not None:
+            # Validate credentials, test connection, etc.
+            # If there's an error, show the form with errors
+            # e.g., raise an exception or return self.async_show_form(...)
+            self._token_manager = await self._test_credentials(**user_input)
+
+            self._config.update(user_input)
+            return await self.async_step_location()
+
+        return self.async_show_form(step_id="user", data_schema=STEP_USER_SCHEMA)
+
+    async def async_step_location(
+        self, user_input: dict | None = None
+    ) -> ConfigFlowResult:
+        """Handle the second step (location index)."""
+
+        if user_input is not None:
+            # Validate location as needed
+            await self._test_location_idx(**user_input)
+
+            self._config.update(user_input)
+            return await self.async_step_scan_interval()
+
+        return self.async_show_form(
+            step_id="location", data_schema=STEP_LOCATION_SCHEMA
+        )
+
+    async def async_step_scan_interval(
+        self, user_input: dict | None = None
+    ) -> ConfigFlowResult:
+        """Handle the final step (scan interval)."""
+
+        if user_input is not None:
+            # Validate the scan interval as needed
+            self._config.update(user_input)
+            return self.async_create_entry(title="Evohome", data=self._config)
+
+        return self.async_show_form(
+            step_id="scan_interval", data_schema=STEP_SCAN_INTERVAL_SCHEMA
+        )
+
+    async def _test_credentials(
+        self, /, username: str, password: str, **kwargs: Any
+    ) -> TokenManager:
+        """Test whether provided credentials are valid."""
+
+        token_manager = TokenManager(
+            self.hass,
+            username,
+            password,
+            async_get_clientsession(self.hass),
+        )
+
+        # fetch a new access token, using the credentials, not any refresh_token
+        assert not token_manager._refresh_token  # noqa: SLF001
+
+        await token_manager.fetch_access_token()  # ? raise ec2.BadUserCredentialsError:
+
+        return token_manager
+
+    async def _test_location_idx(self, /, location_idx: int, **kwargs: Any) -> int:
+        """Test whether provided credentials are valid."""
+
+        assert self._token_manager is not None  # mypy
+
+        client = ec2.EvohomeClient(self._token_manager)
+
+        await client.update(dont_update_status=True)  # ? raise ec2.EvohomeError:
+
+        try:
+            client.locations[location_idx]
+        except IndexError as err:
+            raise IndexError(
+                f"""
+                    Config error: 'location_idx' = {location_idx},
+                    but the valid range is 0-{len(client.locations) - 1}.
+                    Unable to continue. Fix any configuration errors and restart HA
+                """
+            ) from err
+
+        return location_idx

--- a/homeassistant/components/evohome/const.py
+++ b/homeassistant/components/evohome/const.py
@@ -12,11 +12,12 @@ STORAGE_VER: Final = 1
 STORAGE_KEY: Final = DOMAIN
 
 CONF_LOCATION_IDX: Final = "location_idx"
+DEFAULT_LOCATION_IDX: Final = 0
 
 USER_DATA: Final = "user_data"
 
 SCAN_INTERVAL_DEFAULT: Final = timedelta(seconds=300)
-SCAN_INTERVAL_MINIMUM: Final = timedelta(seconds=60)
+SCAN_INTERVAL_MINIMUM: Final = timedelta(seconds=180)  # NOTE: breaking change (was 60)
 
 ATTR_SYSTEM_MODE: Final = "mode"
 ATTR_DURATION_DAYS: Final = "period"

--- a/homeassistant/components/evohome/manifest.json
+++ b/homeassistant/components/evohome/manifest.json
@@ -2,9 +2,11 @@
   "domain": "evohome",
   "name": "Honeywell Total Connect Comfort (Europe)",
   "codeowners": ["@zxdavb"],
+  "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/evohome",
   "iot_class": "cloud_polling",
   "loggers": ["evohome", "evohomeasync", "evohomeasync2"],
   "quality_scale": "legacy",
-  "requirements": ["evohome-async==1.0.2"]
+  "requirements": ["evohome-async==1.0.2"],
+  "single_config_entry": true
 }

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -181,6 +181,7 @@ FLOWS = {
         "esphome",
         "eufylife_ble",
         "evil_genius_labs",
+        "evohome",
         "ezviz",
         "faa_delays",
         "fastdotcom",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -2663,7 +2663,7 @@
         },
         "evohome": {
           "integration_type": "hub",
-          "config_flow": false,
+          "config_flow": true,
           "iot_class": "cloud_polling",
           "name": "Honeywell Total Connect Comfort (Europe)"
         },

--- a/tests/components/evohome/test_config_flow.py
+++ b/tests/components/evohome/test_config_flow.py
@@ -1,0 +1,203 @@
+"""Tests for config flow for the Evohome integration."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant.components.evohome.const import (
+    CONF_LOCATION_IDX,
+    DEFAULT_LOCATION_IDX,
+    DOMAIN,
+    SCAN_INTERVAL_MINIMUM,
+)
+from homeassistant.config_entries import (
+    SOURCE_IMPORT,
+    SOURCE_USER,
+    ConfigEntryState,
+    ConfigFlowResult,
+)
+from homeassistant.const import CONF_PASSWORD, CONF_SCAN_INTERVAL, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+from .conftest import mock_make_request, mock_post_request
+
+
+@pytest.mark.parametrize("install", ["minimal"])
+async def test_import_flow(
+    hass: HomeAssistant,
+    config: dict[str, str],
+    install: str,
+) -> None:
+    """Test an import flow."""
+
+    # Mock the config data that would normally come from a YAML file or similar
+    import_config = config.copy()
+
+    with (
+        patch(
+            "evohomeasync2.auth.CredentialsManagerBase._post_request",
+            mock_post_request(install),
+        ),
+        patch("evohome.auth.AbstractAuth._make_request", mock_make_request(install)),
+        patch(
+            "homeassistant.components.evohome.async_setup_entry",
+            return_value=True,
+        ) as mock_setup_entry,
+    ):
+        result: ConfigFlowResult = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_IMPORT},
+            data=import_config,
+        )
+
+        await hass.async_block_till_done()
+
+        assert mock_setup_entry.await_count == 1
+
+    assert result["handler"] == DOMAIN
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+
+    entry = hass.config_entries.async_entries(DOMAIN)[0]
+
+    assert entry.source == SOURCE_IMPORT
+    assert entry.state is ConfigEntryState.LOADED
+
+    assert entry.domain == DOMAIN
+    assert entry.title == "Evohome"
+
+    assert entry.data == {
+        CONF_USERNAME: config[CONF_USERNAME],
+        CONF_PASSWORD: config[CONF_PASSWORD],
+        CONF_LOCATION_IDX: DEFAULT_LOCATION_IDX,
+        CONF_SCAN_INTERVAL: SCAN_INTERVAL_MINIMUM,
+    }
+
+
+@pytest.mark.parametrize("install", ["minimal"])
+async def test_form(
+    hass: HomeAssistant,
+    config: dict[str, str],
+    install: str,
+) -> None:
+    """Test a config flow."""
+
+    result: ConfigFlowResult = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+    )
+
+    assert result["handler"] == DOMAIN
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] is None  # == {}
+
+    with patch(
+        "evohomeasync2.auth.CredentialsManagerBase._post_request",
+        mock_post_request(install),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_USERNAME: config[CONF_USERNAME],
+                CONF_PASSWORD: config[CONF_PASSWORD],
+            },
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "location"
+    assert result["errors"] is None  # == {}
+
+    with patch("evohome.auth.AbstractAuth._make_request", mock_make_request(install)):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_LOCATION_IDX: DEFAULT_LOCATION_IDX,
+            },
+        )
+
+        # [
+        #     "type",
+        #     "flow_id",
+        #     "handler",
+        #     "data_schema",
+        #     "errors",
+        #     "description_placeholders",
+        #     "last_step",
+        #     "preview",
+        #     "step_id",
+        # ]
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "scan_interval"
+    assert result["errors"] is None  # == {}
+
+    with patch(
+        "homeassistant.components.evohome.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_SCAN_INTERVAL: SCAN_INTERVAL_MINIMUM,
+            },
+        )
+
+        # [
+        #     "type",
+        #     "flow_id",
+        #     "handler",
+        #     "data",
+        #     "description",
+        #     "description_placeholders",
+        #     "context",
+        #     "title",
+        #     "minor_version",
+        #     "options",
+        #     "version",
+        #     "result",
+        # ]
+
+        await hass.async_block_till_done()
+
+        assert mock_setup_entry.await_count == 1
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+
+    entry = hass.config_entries.async_entries(DOMAIN)[0]
+
+    assert entry.source == SOURCE_USER
+    assert entry.state is ConfigEntryState.LOADED
+
+    assert entry.domain == DOMAIN
+    assert entry.title == "Evohome"
+
+    assert entry.data == {
+        CONF_USERNAME: config[CONF_USERNAME],
+        CONF_PASSWORD: config[CONF_PASSWORD],
+        CONF_LOCATION_IDX: DEFAULT_LOCATION_IDX,
+        CONF_SCAN_INTERVAL: SCAN_INTERVAL_MINIMUM,
+    }
+
+
+# async def test_login_error(hass: HomeAssistant) -> None:
+#     """Test login error."""
+
+#     with patch(
+#         "homeassistant.components.airzone_cloud.AirzoneCloudApi.login",
+#         side_effect=LoginError,
+#     ):
+#         result = await hass.config_entries.flow.async_init(
+#             DOMAIN,
+#             context={"source": SOURCE_USER},
+#             data={
+#                 CONF_USERNAME: CONFIG[CONF_USERNAME],
+#                 CONF_PASSWORD: CONFIG[CONF_PASSWORD],
+#             },
+#         )
+
+#         assert result["errors"] == {"base": "cannot_connect"}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The following configuration options have changed:
 - the minimum `scan_interval` increased from 60 to 180 seconds
 - the high-resolution temperatures feature (0.1 °C instead of 0.5 °C) must now be explicitly enabled

A 60 second polling interval is unnecessarily aggressive (the zone temperatures simply don't get updated that often by the vendor), and amounts to abuse off the vendor API. 

The high resolution temperatures (to 0.01 °C, although displayed by HA to 0.1 °C) feature doubled the number of API calls per unit time, and lead to confusion under certain circumstances (e.g. temps jump value if the first API succeeds, but the high-resolution API fails).

The above changes will decrease the API request rate from 24-120 per hour to 12-24 per hour.  

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
