### PR TITLE
Do not log at warning level when timestamp helpers return an empty string value (i.e. None)

### DIFF
--- a/homeassistant/components/sensor/helpers.py
+++ b/homeassistant/components/sensor/helpers.py
@@ -19,6 +19,10 @@ def async_parse_date_datetime(
 ) -> datetime | date | None:
     """Parse datetime string to a data or datetime."""
     if device_class == SensorDeviceClass.TIMESTAMP:
+        if value is "":
+            _LOGGER.debug("%s rendered timestamp unknown")
+            return None
+            
         if (parsed_timestamp := dt_util.parse_datetime(value)) is None:
             _LOGGER.warning("%s rendered invalid timestamp: %s", entity_id, value)
             return None


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR amends the helper sensor value validation to log empty string values at _debug_ rather than _warning_ log level.
None is a valid state for the `SensorDeviceClass.TIMESTAMP`: https://developers.home-assistant.io/docs/core/entity/sensor/

Currently the code logs a warning if the string fails to render a valid datetime, regardless as to whether it was an empty string.

Supporting empty/None values is useful for when you want to have a sensor that shows the next occurrence of something, for example the official Home Assistant app integration's `next_alarm` sensor renders `unknown` if no future alarm is set.

As a user this is preferrable to using a 0/unix epoch timestamp in the helper to avoid the warning, since users may want to trigger something when the time is after the timestamp sensor value (using 0 would falsely trigger this).

I'd suggest that given users are able to see the result of their template code in the helper builder UI, we don't need to log a warning of this state every time it occurs.

Handling of the value itself remains consistent with existing behaviour (i.e. the sensor renders the `unknown` state).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

Discussed previously in: https://community.home-assistant.io/t/what-to-return-in-timestamp-template-sensor-when-state-is-unknown/377152

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
