### PR TITLE
Fix race configuring zeroconf

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -155,7 +155,6 @@ LOGGING_AND_HTTP_DEPS_INTEGRATIONS = {
     # Ensure network config is available
     # before hassio or any other integration is
     # loaded and creates an aiohttp client session
-    # an aiohttp client session
     "network",
     # Error logging
     "system_log",

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -152,10 +152,6 @@ LOGGING_AND_HTTP_DEPS_INTEGRATIONS = {
     "isal",
     # Set log levels
     "logger",
-    # Ensure network config is available
-    # before hassio is loaded and creates
-    # an aiohttp client session
-    "network",
     # Error logging
     "system_log",
     "sentry",

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -152,6 +152,9 @@ LOGGING_AND_HTTP_DEPS_INTEGRATIONS = {
     "isal",
     # Set log levels
     "logger",
+    # Ensure network config is available
+    # before hassio is loaded
+    "network",
     # Error logging
     "system_log",
     "sentry",

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -152,6 +152,10 @@ LOGGING_AND_HTTP_DEPS_INTEGRATIONS = {
     "isal",
     # Set log levels
     "logger",
+    # Ensure network config is available
+    # before hassio is loaded and creates
+    # an aiohttp client session
+    "network",
     # Error logging
     "system_log",
     "sentry",

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -153,7 +153,8 @@ LOGGING_AND_HTTP_DEPS_INTEGRATIONS = {
     # Set log levels
     "logger",
     # Ensure network config is available
-    # before hassio is loaded and creates
+    # before hassio or any other integration is
+    # loaded and creates an aiohttp client session
     # an aiohttp client session
     "network",
     # Error logging

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -154,7 +154,7 @@ LOGGING_AND_HTTP_DEPS_INTEGRATIONS = {
     "logger",
     # Ensure network config is available
     # before hassio or any other integration is
-    # loaded and creates an aiohttp client session
+    # loaded that might create an aiohttp client session
     "network",
     # Error logging
     "system_log",

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -153,7 +153,8 @@ LOGGING_AND_HTTP_DEPS_INTEGRATIONS = {
     # Set log levels
     "logger",
     # Ensure network config is available
-    # before hassio is loaded
+    # before hassio is loaded and creates
+    # an aiohttp client session
     "network",
     # Error logging
     "system_log",

--- a/homeassistant/components/http/manifest.json
+++ b/homeassistant/components/http/manifest.json
@@ -2,7 +2,6 @@
   "domain": "http",
   "name": "HTTP",
   "codeowners": ["@home-assistant/core"],
-  "dependencies": ["network"],
   "documentation": "https://www.home-assistant.io/integrations/http",
   "integration_type": "system",
   "iot_class": "local_push",

--- a/homeassistant/components/http/manifest.json
+++ b/homeassistant/components/http/manifest.json
@@ -2,6 +2,7 @@
   "domain": "http",
   "name": "HTTP",
   "codeowners": ["@home-assistant/core"],
+  "dependencies": ["network"],
   "documentation": "https://www.home-assistant.io/integrations/http",
   "integration_type": "system",
   "iot_class": "local_push",

--- a/homeassistant/components/network/__init__.py
+++ b/homeassistant/components/network/__init__.py
@@ -20,7 +20,7 @@ from .const import (
     PUBLIC_TARGET_IP,
 )
 from .models import Adapter
-from .network import Network, async_get_network
+from .network import Network, async_get_loaded_network, async_get_network
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -32,6 +32,12 @@ async def async_get_adapters(hass: HomeAssistant) -> list[Adapter]:
     """Get the network adapter configuration."""
     network: Network = await async_get_network(hass)
     return network.adapters
+
+
+@callback
+def async_get_loaded_adapters(hass: HomeAssistant) -> list[Adapter]:
+    """Get the network adapter configuration."""
+    return async_get_loaded_network(hass).adapters
 
 
 @bind_hass
@@ -74,7 +80,14 @@ async def async_get_enabled_source_ips(
     hass: HomeAssistant,
 ) -> list[IPv4Address | IPv6Address]:
     """Build the list of enabled source ips."""
-    adapters = await async_get_adapters(hass)
+    return async_get_enabled_source_ips_from_adapters(await async_get_adapters(hass))
+
+
+@callback
+def async_get_enabled_source_ips_from_adapters(
+    adapters: list[Adapter],
+) -> list[IPv4Address | IPv6Address]:
+    """Build the list of enabled source ips."""
     sources: list[IPv4Address | IPv6Address] = []
     for adapter in adapters:
         if not adapter["enabled"]:
@@ -150,6 +163,8 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     from .websocket import (  # pylint: disable=import-outside-toplevel
         async_register_websocket_commands,
     )
+
+    await async_get_network(hass)
 
     async_register_websocket_commands(hass)
     return True

--- a/homeassistant/components/network/const.py
+++ b/homeassistant/components/network/const.py
@@ -12,8 +12,6 @@ DOMAIN: Final = "network"
 STORAGE_KEY: Final = "core.network"
 STORAGE_VERSION: Final = 1
 
-DATA_NETWORK: Final = "network"
-
 ATTR_ADAPTERS: Final = "adapters"
 ATTR_CONFIGURED_ADAPTERS: Final = "configured_adapters"
 DEFAULT_CONFIGURED_ADAPTERS: list[str] = []

--- a/homeassistant/components/network/network.py
+++ b/homeassistant/components/network/network.py
@@ -9,11 +9,12 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.singleton import singleton
 from homeassistant.helpers.storage import Store
 from homeassistant.util.async_ import create_eager_task
+from homeassistant.util.hass_dict import HassKey
 
 from .const import (
     ATTR_CONFIGURED_ADAPTERS,
-    DATA_NETWORK,
     DEFAULT_CONFIGURED_ADAPTERS,
+    DOMAIN,
     STORAGE_KEY,
     STORAGE_VERSION,
 )
@@ -22,8 +23,16 @@ from .util import async_load_adapters, enable_adapters, enable_auto_detected_ada
 
 _LOGGER = logging.getLogger(__name__)
 
+DATA_NETWORK: HassKey[Network] = HassKey(DOMAIN)
 
-@singleton(DATA_NETWORK)
+
+@callback
+def async_get_loaded_network(hass: HomeAssistant) -> Network:
+    """Get network singleton."""
+    return hass.data[DATA_NETWORK]
+
+
+@singleton(DOMAIN)
 async def async_get_network(hass: HomeAssistant) -> Network:
     """Get network singleton."""
     network = Network(hass)

--- a/tests/components/zeroconf/test_init.py
+++ b/tests/components/zeroconf/test_init.py
@@ -1314,7 +1314,7 @@ async def test_async_detect_interfaces_explicitly_set_ipv6_freebsd(
 async def test_async_detect_interfaces_explicitly_before_setup(
     hass: HomeAssistant,
 ) -> None:
-    """Test interfaces are explicitly set when IPv6 before setup is called."""
+    """Test interfaces are explicitly set with IPv6 before setup is called."""
     with (
         patch("homeassistant.components.zeroconf.sys.platform", "linux"),
         patch("homeassistant.components.zeroconf.HaZeroconf") as mock_zc,

--- a/tests/components/zeroconf/test_init.py
+++ b/tests/components/zeroconf/test_init.py
@@ -1090,7 +1090,7 @@ async def test_async_detect_interfaces_setting_non_loopback_route(
         patch.object(hass.config_entries.flow, "async_init"),
         patch.object(zeroconf, "AsyncServiceBrowser", side_effect=service_update_mock),
         patch(
-            "homeassistant.components.zeroconf.network.async_get_adapters",
+            "homeassistant.components.zeroconf.network.async_get_loaded_adapters",
             return_value=_ADAPTER_WITH_DEFAULT_ENABLED,
         ),
         patch(
@@ -1178,7 +1178,7 @@ async def test_async_detect_interfaces_setting_empty_route_linux(
         patch.object(hass.config_entries.flow, "async_init"),
         patch.object(zeroconf, "AsyncServiceBrowser", side_effect=service_update_mock),
         patch(
-            "homeassistant.components.zeroconf.network.async_get_adapters",
+            "homeassistant.components.zeroconf.network.async_get_loaded_adapters",
             return_value=_ADAPTERS_WITH_MANUAL_CONFIG,
         ),
         patch(
@@ -1212,7 +1212,7 @@ async def test_async_detect_interfaces_setting_empty_route_freebsd(
         patch.object(hass.config_entries.flow, "async_init"),
         patch.object(zeroconf, "AsyncServiceBrowser", side_effect=service_update_mock),
         patch(
-            "homeassistant.components.zeroconf.network.async_get_adapters",
+            "homeassistant.components.zeroconf.network.async_get_loaded_adapters",
             return_value=_ADAPTERS_WITH_MANUAL_CONFIG,
         ),
         patch(
@@ -1263,7 +1263,7 @@ async def test_async_detect_interfaces_explicitly_set_ipv6_linux(
         patch.object(hass.config_entries.flow, "async_init"),
         patch.object(zeroconf, "AsyncServiceBrowser", side_effect=service_update_mock),
         patch(
-            "homeassistant.components.zeroconf.network.async_get_adapters",
+            "homeassistant.components.zeroconf.network.async_get_loaded_adapters",
             return_value=_ADAPTER_WITH_DEFAULT_ENABLED_AND_IPV6,
         ),
         patch(
@@ -1292,7 +1292,7 @@ async def test_async_detect_interfaces_explicitly_set_ipv6_freebsd(
         patch.object(hass.config_entries.flow, "async_init"),
         patch.object(zeroconf, "AsyncServiceBrowser", side_effect=service_update_mock),
         patch(
-            "homeassistant.components.zeroconf.network.async_get_adapters",
+            "homeassistant.components.zeroconf.network.async_get_loaded_adapters",
             return_value=_ADAPTER_WITH_DEFAULT_ENABLED_AND_IPV6,
         ),
         patch(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1180,15 +1180,31 @@ async def mqtt_mock_entry(
 @pytest.fixture(autouse=True, scope="session")
 def mock_network() -> Generator[None]:
     """Mock network."""
-    with patch(
-        "homeassistant.components.network.util.ifaddr.get_adapters",
-        return_value=[
-            Mock(
-                nice_name="eth0",
-                ips=[Mock(is_IPv6=False, ip="10.10.10.10", network_prefix=24)],
-                index=0,
-            )
-        ],
+    with (
+        patch(
+            "homeassistant.components.network.util.ifaddr.get_adapters",
+            return_value=[
+                Mock(
+                    nice_name="eth0",
+                    ips=[Mock(is_IPv6=False, ip="10.10.10.10", network_prefix=24)],
+                    index=0,
+                )
+            ],
+        ),
+        patch(
+            "homeassistant.components.network.async_get_loaded_adapters",
+            return_value=[
+                {
+                    "auto": True,
+                    "default": True,
+                    "enabled": True,
+                    "index": 0,
+                    "ipv4": [{"address": "10.10.10.10", "network_prefix": 24}],
+                    "ipv6": [],
+                    "name": "eth0",
+                }
+            ],
+        ),
     ):
         yield
 


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
There was a race where, if the `zeroconf` instance was created before `async_setup` was called it would be created with defaults.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #138421
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
