### PR TITLE
Add sensor platform to LetPot integration

### DIFF
--- a/homeassistant/components/letpot/__init__.py
+++ b/homeassistant/components/letpot/__init__.py
@@ -22,7 +22,7 @@ from .const import (
 )
 from .coordinator import LetPotConfigEntry, LetPotDeviceCoordinator
 
-PLATFORMS: list[Platform] = [Platform.SWITCH, Platform.TIME]
+PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.SWITCH, Platform.TIME]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: LetPotConfigEntry) -> bool:

--- a/homeassistant/components/letpot/entity.py
+++ b/homeassistant/components/letpot/entity.py
@@ -1,16 +1,25 @@
 """Base class for LetPot entities."""
 
 from collections.abc import Callable, Coroutine
+from dataclasses import dataclass
 from typing import Any, Concatenate
 
 from letpot.exceptions import LetPotConnectionException, LetPotException
 
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .coordinator import LetPotDeviceCoordinator
+
+
+@dataclass(frozen=True, kw_only=True)
+class LetPotEntityDescription(EntityDescription):
+    """Description for all LetPot entities."""
+
+    supported_fn: Callable[[LetPotDeviceCoordinator], bool] = lambda _: True
 
 
 class LetPotEntity(CoordinatorEntity[LetPotDeviceCoordinator]):

--- a/homeassistant/components/letpot/icons.json
+++ b/homeassistant/components/letpot/icons.json
@@ -1,5 +1,10 @@
 {
   "entity": {
+    "sensor": {
+      "water_level": {
+        "default": "mdi:water-percent"
+      }
+    },
     "switch": {
       "alarm_sound": {
         "default": "mdi:bell-ring",

--- a/homeassistant/components/letpot/quality_scale.yaml
+++ b/homeassistant/components/letpot/quality_scale.yaml
@@ -59,8 +59,8 @@ rules:
   docs-troubleshooting: todo
   docs-use-cases: todo
   dynamic-devices: todo
-  entity-category: todo
-  entity-device-class: todo
+  entity-category: done
+  entity-device-class: done
   entity-disabled-by-default: todo
   entity-translations: done
   exception-translations: done

--- a/homeassistant/components/letpot/sensor.py
+++ b/homeassistant/components/letpot/sensor.py
@@ -40,7 +40,6 @@ class LetPotSensorEntityDescription(LetPotEntityDescription, SensorEntityDescrip
 SENSORS: tuple[LetPotSensorEntityDescription, ...] = (
     LetPotSensorEntityDescription(
         key="temperature",
-        translation_key="temperature",
         value_fn=lambda status: status.temperature_value,
         native_unit_of_measurement_fn=(
             lambda status: LETPOT_TEMPERATURE_UNIT_HA_UNIT[

--- a/homeassistant/components/letpot/sensor.py
+++ b/homeassistant/components/letpot/sensor.py
@@ -1,0 +1,105 @@
+"""Support for LetPot sensor entities."""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from letpot.models import DeviceFeature, LetPotDeviceStatus, TemperatureUnit
+
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorEntityDescription,
+    SensorStateClass,
+)
+from homeassistant.const import PERCENTAGE, UnitOfTemperature
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.typing import StateType
+
+from .coordinator import LetPotConfigEntry, LetPotDeviceCoordinator
+from .entity import LetPotEntity
+
+# Coordinator is used to centralize the data updates
+PARALLEL_UPDATES = 0
+
+
+LETPOT_TEMPERATURE_UNIT_HA_UNIT = {
+    TemperatureUnit.CELSIUS: UnitOfTemperature.CELSIUS,
+    TemperatureUnit.FAHRENHEIT: UnitOfTemperature.FAHRENHEIT,
+}
+
+
+@dataclass(frozen=True, kw_only=True)
+class LetPotSensorEntityDescription(SensorEntityDescription):
+    """Describes a LetPot sensor entity."""
+
+    native_unit_of_measurement_fn: Callable[[LetPotDeviceStatus], str | None]
+    value_fn: Callable[[LetPotDeviceStatus], StateType]
+
+
+TEMPERATURE_SENSOR: LetPotSensorEntityDescription = LetPotSensorEntityDescription(
+    key="temperature",
+    translation_key="temperature",
+    value_fn=lambda status: status.temperature_value,
+    native_unit_of_measurement_fn=lambda status: LETPOT_TEMPERATURE_UNIT_HA_UNIT[
+        status.temperature_unit or TemperatureUnit.CELSIUS
+    ],
+    device_class=SensorDeviceClass.TEMPERATURE,
+    state_class=SensorStateClass.MEASUREMENT,
+)
+WATER_LEVEL_SENSOR: LetPotSensorEntityDescription = LetPotSensorEntityDescription(
+    key="water_level",
+    translation_key="water_level",
+    value_fn=lambda status: status.water_level,
+    native_unit_of_measurement_fn=lambda _: PERCENTAGE,
+    state_class=SensorStateClass.MEASUREMENT,
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: LetPotConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up LetPot sensor entities based on a device features."""
+    coordinators = entry.runtime_data
+    entities: list[SensorEntity] = []
+    entities.extend(
+        LetPotSensorEntity(coordinator, TEMPERATURE_SENSOR)
+        for coordinator in coordinators
+        if DeviceFeature.TEMPERATURE in coordinator.device_client.device_features
+    )
+    entities.extend(
+        LetPotSensorEntity(coordinator, WATER_LEVEL_SENSOR)
+        for coordinator in coordinators
+        if DeviceFeature.WATER_LEVEL in coordinator.device_client.device_features
+    )
+    async_add_entities(entities)
+
+
+class LetPotSensorEntity(LetPotEntity, SensorEntity):
+    """Defines a LetPot sensor entity."""
+
+    entity_description: LetPotSensorEntityDescription
+
+    def __init__(
+        self,
+        coordinator: LetPotDeviceCoordinator,
+        description: LetPotSensorEntityDescription,
+    ) -> None:
+        """Initialize LetPot sensor entity."""
+        super().__init__(coordinator)
+        self.entity_description = description
+        self._attr_unique_id = f"{coordinator.config_entry.unique_id}_{coordinator.device.serial_number}_{description.key}"
+
+    @property
+    def native_unit_of_measurement(self) -> str | None:
+        """Return the native unit of measurement."""
+        return self.entity_description.native_unit_of_measurement_fn(
+            self.coordinator.data
+        )
+
+    @property
+    def native_value(self) -> StateType:
+        """Return the state of the sensor."""
+        return self.entity_description.value_fn(self.coordinator.data)

--- a/homeassistant/components/letpot/sensor.py
+++ b/homeassistant/components/letpot/sensor.py
@@ -42,13 +42,17 @@ SENSORS: tuple[LetPotSensorEntityDescription, ...] = (
         key="temperature",
         translation_key="temperature",
         value_fn=lambda status: status.temperature_value,
-        native_unit_of_measurement_fn=lambda status: LETPOT_TEMPERATURE_UNIT_HA_UNIT[
-            status.temperature_unit or TemperatureUnit.CELSIUS
-        ],
+        native_unit_of_measurement_fn=(
+            lambda status: LETPOT_TEMPERATURE_UNIT_HA_UNIT[
+                status.temperature_unit or TemperatureUnit.CELSIUS
+            ]
+        ),
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
-        supported_fn=lambda coordinator: DeviceFeature.TEMPERATURE
-        in coordinator.device_client.device_features,
+        supported_fn=(
+            lambda coordinator: DeviceFeature.TEMPERATURE
+            in coordinator.device_client.device_features
+        ),
     ),
     LetPotSensorEntityDescription(
         key="water_level",
@@ -56,8 +60,10 @@ SENSORS: tuple[LetPotSensorEntityDescription, ...] = (
         value_fn=lambda status: status.water_level,
         native_unit_of_measurement_fn=lambda _: PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,
-        supported_fn=lambda coordinator: DeviceFeature.WATER_LEVEL
-        in coordinator.device_client.device_features,
+        supported_fn=(
+            lambda coordinator: DeviceFeature.WATER_LEVEL
+            in coordinator.device_client.device_features
+        ),
     ),
 )
 

--- a/homeassistant/components/letpot/strings.json
+++ b/homeassistant/components/letpot/strings.json
@@ -34,7 +34,7 @@
   "entity": {
     "sensor": {
       "temperature": {
-        "name": "Temperature"
+        "name": "[%key:component::sensor::entity_component::temperature::name%]"
       },
       "water_level": {
         "name": "Water level"

--- a/homeassistant/components/letpot/strings.json
+++ b/homeassistant/components/letpot/strings.json
@@ -33,9 +33,6 @@
   },
   "entity": {
     "sensor": {
-      "temperature": {
-        "name": "[%key:component::sensor::entity_component::temperature::name%]"
-      },
       "water_level": {
         "name": "Water level"
       }

--- a/homeassistant/components/letpot/strings.json
+++ b/homeassistant/components/letpot/strings.json
@@ -32,6 +32,14 @@
     }
   },
   "entity": {
+    "sensor": {
+      "temperature": {
+        "name": "Temperature"
+      },
+      "water_level": {
+        "name": "Water level"
+      }
+    },
     "switch": {
       "alarm_sound": {
         "name": "Alarm sound"

--- a/homeassistant/components/letpot/switch.py
+++ b/homeassistant/components/letpot/switch.py
@@ -13,7 +13,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .coordinator import LetPotConfigEntry, LetPotDeviceCoordinator
-from .entity import LetPotEntity, exception_handler
+from .entity import LetPotEntity, LetPotEntityDescription, exception_handler
 
 # Each change pushes a 'full' device status with the change. The library will cache
 # pending changes to avoid overwriting, but try to avoid a lot of parallelism.
@@ -21,14 +21,31 @@ PARALLEL_UPDATES = 1
 
 
 @dataclass(frozen=True, kw_only=True)
-class LetPotSwitchEntityDescription(SwitchEntityDescription):
+class LetPotSwitchEntityDescription(LetPotEntityDescription, SwitchEntityDescription):
     """Describes a LetPot switch entity."""
 
     value_fn: Callable[[LetPotDeviceStatus], bool | None]
     set_value_fn: Callable[[LetPotDeviceClient, bool], Coroutine[Any, Any, None]]
 
 
-BASE_SWITCHES: tuple[LetPotSwitchEntityDescription, ...] = (
+SWITCHES: tuple[LetPotSwitchEntityDescription, ...] = (
+    LetPotSwitchEntityDescription(
+        key="alarm_sound",
+        translation_key="alarm_sound",
+        value_fn=lambda status: status.system_sound,
+        set_value_fn=lambda device_client, value: device_client.set_sound(value),
+        entity_category=EntityCategory.CONFIG,
+        supported_fn=lambda coordinator: coordinator.data.system_sound is not None,
+    ),
+    LetPotSwitchEntityDescription(
+        key="auto_mode",
+        translation_key="auto_mode",
+        value_fn=lambda status: status.water_mode == 1,
+        set_value_fn=lambda device_client, value: device_client.set_water_mode(value),
+        entity_category=EntityCategory.CONFIG,
+        supported_fn=lambda coordinator: DeviceFeature.PUMP_AUTO
+        in coordinator.device_client.device_features,
+    ),
     LetPotSwitchEntityDescription(
         key="power",
         translation_key="power",
@@ -44,20 +61,6 @@ BASE_SWITCHES: tuple[LetPotSwitchEntityDescription, ...] = (
         entity_category=EntityCategory.CONFIG,
     ),
 )
-ALARM_SWITCH: LetPotSwitchEntityDescription = LetPotSwitchEntityDescription(
-    key="alarm_sound",
-    translation_key="alarm_sound",
-    value_fn=lambda status: status.system_sound,
-    set_value_fn=lambda device_client, value: device_client.set_sound(value),
-    entity_category=EntityCategory.CONFIG,
-)
-AUTO_MODE_SWITCH: LetPotSwitchEntityDescription = LetPotSwitchEntityDescription(
-    key="auto_mode",
-    translation_key="auto_mode",
-    value_fn=lambda status: status.water_mode == 1,
-    set_value_fn=lambda device_client, value: device_client.set_water_mode(value),
-    entity_category=EntityCategory.CONFIG,
-)
 
 
 async def async_setup_entry(
@@ -69,19 +72,10 @@ async def async_setup_entry(
     coordinators = entry.runtime_data
     entities: list[SwitchEntity] = [
         LetPotSwitchEntity(coordinator, description)
-        for description in BASE_SWITCHES
+        for description in SWITCHES
         for coordinator in coordinators
+        if description.supported_fn(coordinator)
     ]
-    entities.extend(
-        LetPotSwitchEntity(coordinator, ALARM_SWITCH)
-        for coordinator in coordinators
-        if coordinator.data.system_sound is not None
-    )
-    entities.extend(
-        LetPotSwitchEntity(coordinator, AUTO_MODE_SWITCH)
-        for coordinator in coordinators
-        if DeviceFeature.PUMP_AUTO in coordinator.device_client.device_features
-    )
     async_add_entities(entities)
 
 

--- a/homeassistant/components/letpot/switch.py
+++ b/homeassistant/components/letpot/switch.py
@@ -43,8 +43,10 @@ SWITCHES: tuple[LetPotSwitchEntityDescription, ...] = (
         value_fn=lambda status: status.water_mode == 1,
         set_value_fn=lambda device_client, value: device_client.set_water_mode(value),
         entity_category=EntityCategory.CONFIG,
-        supported_fn=lambda coordinator: DeviceFeature.PUMP_AUTO
-        in coordinator.device_client.device_features,
+        supported_fn=(
+            lambda coordinator: DeviceFeature.PUMP_AUTO
+            in coordinator.device_client.device_features
+        ),
     ),
     LetPotSwitchEntityDescription(
         key="power",

--- a/tests/components/letpot/snapshots/test_sensor.ambr
+++ b/tests/components/letpot/snapshots/test_sensor.ambr
@@ -30,7 +30,7 @@
     'platform': 'letpot',
     'previous_unique_id': None,
     'supported_features': 0,
-    'translation_key': 'None',
+    'translation_key': None,
     'unique_id': 'a1b2c3d4e5f6a1b2c3d4e5f6_LPH63ABCD_temperature',
     'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })

--- a/tests/components/letpot/snapshots/test_sensor.ambr
+++ b/tests/components/letpot/snapshots/test_sensor.ambr
@@ -1,0 +1,104 @@
+# serializer version: 1
+# name: test_all_entities[sensor.garden_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.garden_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'Temperature',
+    'platform': 'letpot',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'temperature',
+    'unique_id': 'a1b2c3d4e5f6a1b2c3d4e5f6_LPH63ABCD_temperature',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_all_entities[sensor.garden_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'friendly_name': 'Garden Temperature',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.garden_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '18',
+  })
+# ---
+# name: test_all_entities[sensor.garden_water_level-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.garden_water_level',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Water level',
+    'platform': 'letpot',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'water_level',
+    'unique_id': 'a1b2c3d4e5f6a1b2c3d4e5f6_LPH63ABCD_water_level',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_all_entities[sensor.garden_water_level-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Garden Water level',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.garden_water_level',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '100',
+  })
+# ---

--- a/tests/components/letpot/snapshots/test_sensor.ambr
+++ b/tests/components/letpot/snapshots/test_sensor.ambr
@@ -30,7 +30,7 @@
     'platform': 'letpot',
     'previous_unique_id': None,
     'supported_features': 0,
-    'translation_key': 'temperature',
+    'translation_key': 'None',
     'unique_id': 'a1b2c3d4e5f6a1b2c3d4e5f6_LPH63ABCD_temperature',
     'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })

--- a/tests/components/letpot/test_sensor.py
+++ b/tests/components/letpot/test_sensor.py
@@ -1,0 +1,28 @@
+"""Test sensor entities for the LetPot integration."""
+
+from unittest.mock import MagicMock, patch
+
+from syrupy import SnapshotAssertion
+
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from . import setup_integration
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+
+async def test_all_entities(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    mock_client: MagicMock,
+    mock_device_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test sensor entities."""
+    with patch("homeassistant.components.letpot.PLATFORMS", [Platform.SENSOR]):
+        await setup_integration(hass, mock_config_entry)
+
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds the sensor platform to the LetPot integration, providing 2 sensors if you have a compatible device:
![Home Assistant screenshot showing 'Sensors' with 2 items: Temperature (20 °C) and Water level (90%)](https://github.com/user-attachments/assets/59d06f7e-6ef3-40e8-bcf6-a07d2d4a6fc8)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: home-assistant/home-assistant.io#37453
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
