### PR TITLE
Bump ZHA to 0.0.49 to fix Tuya TRV issues

### DIFF
--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -21,7 +21,7 @@
     "zha",
     "universal_silabs_flasher"
   ],
-  "requirements": ["zha==0.0.48"],
+  "requirements": ["zha==0.0.49"],
   "usb": [
     {
       "vid": "10C4",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3137,7 +3137,7 @@ zeroconf==0.144.1
 zeversolar==0.3.2
 
 # homeassistant.components.zha
-zha==0.0.48
+zha==0.0.49
 
 # homeassistant.components.zhong_hong
 zhong-hong-hvac==1.0.13

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2526,7 +2526,7 @@ zeroconf==0.144.1
 zeversolar==0.3.2
 
 # homeassistant.components.zha
-zha==0.0.48
+zha==0.0.49
 
 # homeassistant.components.zwave_js
 zwave-js-server-python==0.60.0


### PR DESCRIPTION
## Proposed change

This bumps ZHA to [0.0.49](https://github.com/zigpy/zha/releases/tag/0.0.49) (full diff: https://github.com/zigpy/zha/compare/0.0.48...0.0.49). These dependency upgrades are bundled with it: 

- `zha-quirks` [0.0.133](https://github.com/zigpy/zha-device-handlers/releases/tag/0.0.133)
full diff: https://github.com/zigpy/zha-device-handlers/compare/0.0.132...0.0.133


### Notes about these releases

This is a minor zha-quirks release, fixing issues with Tuya TRV devices and a Tuya motion sensor having inverted state.
I've opted to mention the "Tuya TRV fix" in the PR title (so changelog), as these are notable bugfixes.


## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #138269, fixes #138058
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
