### PR TITLE
Revert breaking change "Auto select thermostat preset when selecting temperature

### DIFF
--- a/homeassistant/components/generic_thermostat/climate.py
+++ b/homeassistant/components/generic_thermostat/climate.py
@@ -271,7 +271,6 @@ class GenericThermostat(ClimateEntity, RestoreEntity):
         else:
             self._attr_preset_modes = [PRESET_NONE]
         self._presets = presets
-        self._presets_inv = {v: k for k, v in presets.items()}
 
     async def async_added_to_hass(self) -> None:
         """Run when entity about to be added."""
@@ -425,7 +424,6 @@ class GenericThermostat(ClimateEntity, RestoreEntity):
         """Set new target temperature."""
         if (temperature := kwargs.get(ATTR_TEMPERATURE)) is None:
             return
-        self._attr_preset_mode = self._presets_inv.get(temperature, PRESET_NONE)
         self._target_temp = temperature
         await self._async_control_heating(force=True)
         self.async_write_ha_state()

--- a/tests/components/generic_thermostat/test_climate.py
+++ b/tests/components/generic_thermostat/test_climate.py
@@ -318,20 +318,6 @@ async def test_set_target_temp(hass: HomeAssistant) -> None:
     assert state.attributes.get("temperature") == 30.0
 
 
-@pytest.mark.usefixtures("setup_comp_2")
-async def test_set_target_temp_change_preset(hass: HomeAssistant) -> None:
-    """Test the setting of the target temperature.
-
-    Verify that preset is changed.
-    """
-    await common.async_set_temperature(hass, 30)
-    state = hass.states.get(ENTITY)
-    assert state.attributes.get("preset_mode") == PRESET_NONE
-    await common.async_set_temperature(hass, 20)
-    state = hass.states.get(ENTITY)
-    assert state.attributes.get("preset_mode") == PRESET_COMFORT
-
-
 @pytest.mark.parametrize(
     ("preset", "temp"),
     [


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
This reverts a breaking change that was introduced with commit 8172afd9f4b5152d9c604fc41581983de6b302a7

> Auto select thermostat preset when selecting temperature (#134146)


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
There was a breaking change to the climate control system, which previously had multiple modes but now has only one mode with multiple set temperatures.

Before this change, it was possible to run the climate control in different modes (e.g., away, comfort). After the change (commit 8172afd), only one mode (none) remains. The other selections, such as comfort, now just set a preset temperature. If the temperature is changed on the climate control, the mode is lost and reverts to none.


Example:
I use the following modes:
* none: For daily use. The climate control changes depending on the time of day (lower temperature at night) and my location (lower temperature if away).
* away: For longer periods away from home. This mode also manages humidity by raising the temperature if humidity gets too high and lowering it again when humidity decreases.
* comfort: For when I have a friend over who is constantly cold. The apartment is heated more and ignores certain events, like leaving the house, but still allows for lowering the temperature at night (differently from the none mode).

With the change introduced in commit 8172afd9f4b5152d9c604fc41581983de6b302a7, this is no longer possible. The climate control will always revert to the none state the moment the temperature is changed (e.g., with the `action climate.set_temperature`).


I also like [the idea](https://github.com/home-assistant/core/pull/134146#issuecomment-2567865720) by @domingues, the author of 8172afd:
>  if for some reasons that I'm not aware this is considered a breaking change, we can transform this in a non breaking feature just adding a new setting to the integration "keep_preset_in_sync_with_temperate".

Work arounds:
Creating a new sensor to track the mode, instead of relying on the climate control's mode, is possible. However, this would require rewriting users' existing setups/automations. I believe tying the modes to the climate control is a cleaner solution, as it avoids additional sensors that wouldn't be visible in the climate control UI.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
