### PR TITLE
Refactor to-do list order and reordering in Habitica

### DIFF
--- a/homeassistant/components/habitica/todo.py
+++ b/homeassistant/components/habitica/todo.py
@@ -83,7 +83,7 @@ class BaseHabiticaListEntity(HabiticaBase, TodoListEntity):
 
     @tasks_order.setter
     @abstractmethod
-    def tasks_order(self, task_order: list[UUID]) -> None:
+    def tasks_order(self, tasks_order: list[UUID]) -> None:
         """Set the tasks order."""
 
     async def async_delete_todo_items(self, uids: list[str]) -> None:
@@ -269,9 +269,9 @@ class HabiticaTodosListEntity(BaseHabiticaListEntity):
         return self.coordinator.data.user.tasksOrder.todos
 
     @tasks_order.setter
-    def tasks_order(self, task_order: list[UUID]) -> None:
+    def tasks_order(self, tasks_order: list[UUID]) -> None:
         """Set the tasks order."""
-        self.coordinator.data.user.tasksOrder.todos = task_order
+        self.coordinator.data.user.tasksOrder.todos = tasks_order
 
     @property
     def todo_items(self) -> list[TodoItem]:
@@ -354,9 +354,9 @@ class HabiticaDailiesListEntity(BaseHabiticaListEntity):
         return self.coordinator.data.user.tasksOrder.dailys
 
     @tasks_order.setter
-    def tasks_order(self, task_order: list[UUID]) -> None:
+    def tasks_order(self, tasks_order: list[UUID]) -> None:
         """Set the tasks order."""
-        self.coordinator.data.user.tasksOrder.dailys = task_order
+        self.coordinator.data.user.tasksOrder.dailys = tasks_order
 
     @property
     def todo_items(self) -> list[TodoItem]:
@@ -393,8 +393,7 @@ class HabiticaDailiesListEntity(BaseHabiticaListEntity):
             tasks,
             key=lambda task: (
                 float("inf")
-                if (uid := (UUID(task.uid)))
-                not in (tasks_order := self.coordinator.data.user.tasksOrder.dailys)
-                else tasks_order.index(uid)
+                if (uid := (UUID(task.uid))) not in self.tasks_order
+                else self.tasks_order.index(uid)
             ),
         )

--- a/homeassistant/components/habitica/todo.py
+++ b/homeassistant/components/habitica/todo.py
@@ -132,7 +132,7 @@ class BaseHabiticaListEntity(HabiticaBase, TodoListEntity):
             pos = 0
 
         try:
-            tasks_order = (
+            tasks_order[:] = (
                 await self.coordinator.habitica.reorder_task(UUID(uid), pos)
             ).data
         except TooManyRequestsError as e:
@@ -282,7 +282,7 @@ class HabiticaTodosListEntity(BaseHabiticaListEntity):
             tasks,
             key=lambda task: (
                 float("inf")
-                if (uid := (UUID(task.uid)))
+                if (uid := UUID(task.uid))
                 not in (tasks_order := self.coordinator.data.user.tasksOrder.todos)
                 else tasks_order.index(uid)
             ),
@@ -368,7 +368,7 @@ class HabiticaDailiesListEntity(BaseHabiticaListEntity):
             tasks,
             key=lambda task: (
                 float("inf")
-                if (uid := (UUID(task.uid)))
+                if (uid := UUID(task.uid))
                 not in (tasks_order := self.coordinator.data.user.tasksOrder.dailys)
                 else tasks_order.index(uid)
             ),

--- a/tests/components/habitica/fixtures/reorder_dailies_response.json
+++ b/tests/components/habitica/fixtures/reorder_dailies_response.json
@@ -1,0 +1,15 @@
+{
+  "success": true,
+  "data": [
+    "f21fa608-cfc6-4413-9fc7-0eb1b48ca43a",
+    "2c6d136c-a1c3-4bef-b7c4-fa980784b1e1",
+    "bc1d1855-b2b8-4663-98ff-62e7b763dfc4",
+    "e97659e0-2c42-4599-a7bb-00282adc410d",
+    "564b9ac9-c53d-4638-9e7f-1cd96fe19baa",
+    "f2c85972-1a19-4426-bc6d-ce3337b9d99f",
+    "6e53f1f5-a315-4edd-984d-8d762e4a08ef"
+  ],
+  "notifications": [],
+  "userV": 589,
+  "appVersion": "5.28.6"
+}

--- a/tests/components/habitica/fixtures/reorder_todos_response.json
+++ b/tests/components/habitica/fixtures/reorder_todos_response.json
@@ -1,0 +1,12 @@
+{
+  "success": true,
+  "data": [
+    "88de7cd9-af2b-49ce-9afd-bf941d87336b",
+    "1aa3137e-ef72-4d1f-91ee-41933602f438",
+    "2f6fcabc-f670-4ec3-ba65-817e8deea490",
+    "86ea2475-d1b5-4020-bdcc-c188c7996afa"
+  ],
+  "notifications": [],
+  "userV": 589,
+  "appVersion": "5.28.6"
+}

--- a/tests/components/habitica/test_todo.py
+++ b/tests/components/habitica/test_todo.py
@@ -6,7 +6,13 @@ from typing import Any
 from unittest.mock import AsyncMock, patch
 from uuid import UUID
 
-from habiticalib import Direction, HabiticaTasksResponse, Task, TaskType
+from habiticalib import (
+    Direction,
+    HabiticaTaskOrderResponse,
+    HabiticaTasksResponse,
+    Task,
+    TaskType,
+)
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
@@ -601,19 +607,21 @@ async def test_delete_completed_todo_items_exception(
 
 
 @pytest.mark.parametrize(
-    ("entity_id", "uid", "second_pos", "third_pos"),
+    ("entity_id", "uid", "second_pos", "third_pos", "fixture"),
     [
         (
             "todo.test_user_to_do_s",
             "1aa3137e-ef72-4d1f-91ee-41933602f438",
             "88de7cd9-af2b-49ce-9afd-bf941d87336b",
             "2f6fcabc-f670-4ec3-ba65-817e8deea490",
+            "reorder_todos_response.json",
         ),
         (
             "todo.test_user_dailies",
             "2c6d136c-a1c3-4bef-b7c4-fa980784b1e1",
-            "564b9ac9-c53d-4638-9e7f-1cd96fe19baa",
-            "f2c85972-1a19-4426-bc6d-ce3337b9d99f",
+            "f21fa608-cfc6-4413-9fc7-0eb1b48ca43a",
+            "bc1d1855-b2b8-4663-98ff-62e7b763dfc4",
+            "reorder_dailies_response.json",
         ),
     ],
     ids=["todo", "daily"],
@@ -627,9 +635,12 @@ async def test_move_todo_item(
     uid: str,
     second_pos: str,
     third_pos: str,
+    fixture: str,
 ) -> None:
     """Test move todo items."""
-
+    habitica.reorder_task.return_value = HabiticaTaskOrderResponse.from_json(
+        load_fixture(fixture, DOMAIN)
+    )
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

- The Habitica user data already provides the data that defines the order of the tasks. This is used now to determine the order instead.
- The Habitica API endpoint for changing the position of a task already returns a list with the updated sort order. Instead of requesting a coordinator refresh, the data returned from the API is used to update the sort order. This makes it also unnecessary to move the tasks around in the coordinator, as this was done because the refresh takes some time due to a 5s debounce.
- Also a bug was fixed, where when moving a task down, it was off by one.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
