### PR TITLE
Fix home connect coffe-milk ratio option

### DIFF
--- a/homeassistant/components/home_connect/__init__.py
+++ b/homeassistant/components/home_connect/__init__.py
@@ -76,7 +76,6 @@ PROGRAM_OPTIONS = {
     for key, value in {
         OptionKey.CONSUMER_PRODUCTS_COFFEE_MAKER_FILL_QUANTITY: int,
         OptionKey.CONSUMER_PRODUCTS_COFFEE_MAKER_MULTIPLE_BEVERAGES: bool,
-        OptionKey.CONSUMER_PRODUCTS_COFFEE_MAKER_COFFEE_MILK_RATIO: int,
         OptionKey.DISHCARE_DISHWASHER_INTENSIV_ZONE: bool,
         OptionKey.DISHCARE_DISHWASHER_BRILLIANCE_DRY: bool,
         OptionKey.DISHCARE_DISHWASHER_VARIO_SPEED_PLUS: bool,
@@ -486,15 +485,6 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:  # noqa:
                 )
             elif option in PROGRAM_OPTIONS:
                 option_key = PROGRAM_OPTIONS[option][0]
-                if (
-                    option_key
-                    is OptionKey.CONSUMER_PRODUCTS_COFFEE_MAKER_COFFEE_MILK_RATIO
-                ):
-                    if value in (67, 68):
-                        value = 67
-                    else:
-                        value = round(value / 5) * 5
-                    value = f"ConsumerProducts.CoffeeMaker.EnumType.CoffeeMilkRatio.{int(value)}Percent"
                 options.append(Option(option_key, value))
             elif option in TIME_PROGRAM_OPTIONS:
                 options.append(

--- a/homeassistant/components/home_connect/__init__.py
+++ b/homeassistant/components/home_connect/__init__.py
@@ -486,6 +486,15 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:  # noqa:
                 )
             elif option in PROGRAM_OPTIONS:
                 option_key = PROGRAM_OPTIONS[option][0]
+                if (
+                    option_key
+                    is OptionKey.CONSUMER_PRODUCTS_COFFEE_MAKER_COFFEE_MILK_RATIO
+                ):
+                    if value in (67, 68):
+                        value = 67
+                    else:
+                        value = round(value / 5) * 5
+                    value = f"ConsumerProducts.CoffeeMaker.EnumType.CoffeeMilkRatio.{int(value)}Percent"
                 options.append(Option(option_key, value))
             elif option in TIME_PROGRAM_OPTIONS:
                 options.append(

--- a/homeassistant/components/home_connect/const.py
+++ b/homeassistant/components/home_connect/const.py
@@ -157,6 +157,27 @@ FLOW_RATE_OPTIONS = {
     )
 }
 
+COFFEE_MILK_RATIO_OPTIONS = {
+    bsh_key_to_translation_key(option): option
+    for option in (
+        "ConsumerProducts.CoffeeMaker.EnumType.CoffeeMilkRatio.10Percent",
+        "ConsumerProducts.CoffeeMaker.EnumType.CoffeeMilkRatio.20Percent",
+        "ConsumerProducts.CoffeeMaker.EnumType.CoffeeMilkRatio.25Percent",
+        "ConsumerProducts.CoffeeMaker.EnumType.CoffeeMilkRatio.30Percent",
+        "ConsumerProducts.CoffeeMaker.EnumType.CoffeeMilkRatio.40Percent",
+        "ConsumerProducts.CoffeeMaker.EnumType.CoffeeMilkRatio.50Percent",
+        "ConsumerProducts.CoffeeMaker.EnumType.CoffeeMilkRatio.55Percent",
+        "ConsumerProducts.CoffeeMaker.EnumType.CoffeeMilkRatio.60Percent",
+        "ConsumerProducts.CoffeeMaker.EnumType.CoffeeMilkRatio.65Percent",
+        "ConsumerProducts.CoffeeMaker.EnumType.CoffeeMilkRatio.67Percent",
+        "ConsumerProducts.CoffeeMaker.EnumType.CoffeeMilkRatio.70Percent",
+        "ConsumerProducts.CoffeeMaker.EnumType.CoffeeMilkRatio.75Percent",
+        "ConsumerProducts.CoffeeMaker.EnumType.CoffeeMilkRatio.80Percent",
+        "ConsumerProducts.CoffeeMaker.EnumType.CoffeeMilkRatio.85Percent",
+        "ConsumerProducts.CoffeeMaker.EnumType.CoffeeMilkRatio.90Percent",
+    )
+}
+
 HOT_WATER_TEMPERATURE_OPTIONS = {
     bsh_key_to_translation_key(option): option
     for option in (
@@ -300,6 +321,10 @@ PROGRAM_ENUM_OPTIONS = {
             BEAN_CONTAINER_OPTIONS,
         ),
         (OptionKey.CONSUMER_PRODUCTS_COFFEE_MAKER_FLOW_RATE, FLOW_RATE_OPTIONS),
+        (
+            OptionKey.CONSUMER_PRODUCTS_COFFEE_MAKER_COFFEE_MILK_RATIO,
+            COFFEE_MILK_RATIO_OPTIONS,
+        ),
         (
             OptionKey.CONSUMER_PRODUCTS_COFFEE_MAKER_HOT_WATER_TEMPERATURE,
             HOT_WATER_TEMPERATURE_OPTIONS,

--- a/homeassistant/components/home_connect/services.yaml
+++ b/homeassistant/components/home_connect/services.yaml
@@ -328,14 +328,28 @@ set_program_and_options:
           selector:
             boolean:
         consumer_products_coffee_maker_option_coffee_milk_ratio:
-          example: 50
+          example: consumer_products_coffee_maker_enum_type_coffee_milk_ratio_50_percent
           required: false
           selector:
-            number:
-              unit_of_measurement: "%"
-              step: 1
-              min: 10
-              max: 90
+            select:
+              mode: dropdown
+              translation_key: coffee_milk_ratio
+              options:
+                - consumer_products_coffee_maker_enum_type_coffee_milk_ratio_10_percent
+                - consumer_products_coffee_maker_enum_type_coffee_milk_ratio_20_percent
+                - consumer_products_coffee_maker_enum_type_coffee_milk_ratio_25_percent
+                - consumer_products_coffee_maker_enum_type_coffee_milk_ratio_30_percent
+                - consumer_products_coffee_maker_enum_type_coffee_milk_ratio_40_percent
+                - consumer_products_coffee_maker_enum_type_coffee_milk_ratio_50_percent
+                - consumer_products_coffee_maker_enum_type_coffee_milk_ratio_55_percent
+                - consumer_products_coffee_maker_enum_type_coffee_milk_ratio_60_percent
+                - consumer_products_coffee_maker_enum_type_coffee_milk_ratio_65_percent
+                - consumer_products_coffee_maker_enum_type_coffee_milk_ratio_67_percent
+                - consumer_products_coffee_maker_enum_type_coffee_milk_ratio_70_percent
+                - consumer_products_coffee_maker_enum_type_coffee_milk_ratio_75_percent
+                - consumer_products_coffee_maker_enum_type_coffee_milk_ratio_80_percent
+                - consumer_products_coffee_maker_enum_type_coffee_milk_ratio_85_percent
+                - consumer_products_coffee_maker_enum_type_coffee_milk_ratio_90_percent
         consumer_products_coffee_maker_option_hot_water_temperature:
           example: consumer_products_coffee_maker_enum_type_hot_water_temperature_50_c
           required: false

--- a/homeassistant/components/home_connect/services.yaml
+++ b/homeassistant/components/home_connect/services.yaml
@@ -333,7 +333,7 @@ set_program_and_options:
           selector:
             number:
               unit_of_measurement: "%"
-              step: 10
+              step: 1
               min: 10
               max: 90
         consumer_products_coffee_maker_option_hot_water_temperature:

--- a/homeassistant/components/home_connect/strings.json
+++ b/homeassistant/components/home_connect/strings.json
@@ -344,6 +344,25 @@
         "consumer_products_coffee_maker_enum_type_flow_rate_intense_plus": "Intense plus"
       }
     },
+    "coffee_milk_ratio": {
+      "options": {
+        "consumer_products_coffee_maker_enum_type_coffee_milk_ratio_10_percent": "10%",
+        "consumer_products_coffee_maker_enum_type_coffee_milk_ratio_20_percent": "20%",
+        "consumer_products_coffee_maker_enum_type_coffee_milk_ratio_25_percent": "25%",
+        "consumer_products_coffee_maker_enum_type_coffee_milk_ratio_30_percent": "30%",
+        "consumer_products_coffee_maker_enum_type_coffee_milk_ratio_40_percent": "40%",
+        "consumer_products_coffee_maker_enum_type_coffee_milk_ratio_50_percent": "50%",
+        "consumer_products_coffee_maker_enum_type_coffee_milk_ratio_55_percent": "55%",
+        "consumer_products_coffee_maker_enum_type_coffee_milk_ratio_60_percent": "60%",
+        "consumer_products_coffee_maker_enum_type_coffee_milk_ratio_65_percent": "65%",
+        "consumer_products_coffee_maker_enum_type_coffee_milk_ratio_67_percent": "67%",
+        "consumer_products_coffee_maker_enum_type_coffee_milk_ratio_70_percent": "70%",
+        "consumer_products_coffee_maker_enum_type_coffee_milk_ratio_75_percent": "75%",
+        "consumer_products_coffee_maker_enum_type_coffee_milk_ratio_80_percent": "80%",
+        "consumer_products_coffee_maker_enum_type_coffee_milk_ratio_85_percent": "85%",
+        "consumer_products_coffee_maker_enum_type_coffee_milk_ratio_90_percent": "90%"
+      }
+    },
     "hot_water_temperature": {
       "options": {
         "consumer_products_coffee_maker_enum_type_hot_water_temperature_white_tea": "White tea",

--- a/tests/components/home_connect/snapshots/test_init.ambr
+++ b/tests/components/home_connect/snapshots/test_init.ambr
@@ -50,14 +50,34 @@
             'key': <OptionKey.CONSUMER_PRODUCTS_COFFEE_MAKER_COFFEE_MILK_RATIO: 'ConsumerProducts.CoffeeMaker.Option.CoffeeMilkRatio'>,
             'name': None,
             'unit': None,
-            'value': 60,
+            'value': 'ConsumerProducts.CoffeeMaker.EnumType.CoffeeMilkRatio.60Percent',
           }),
         ]),
       }),
     }),
   )
 # ---
-# name: test_set_program_and_options[service_call3-set_selected_program_options]
+# name: test_set_program_and_options[service_call3-set_active_program_options]
+  _Call(
+    tuple(
+      'SIEMENS-HCS03WCH1-7BC6383CF794',
+    ),
+    dict({
+      'array_of_options': dict({
+        'options': list([
+          dict({
+            'display_value': None,
+            'key': <OptionKey.CONSUMER_PRODUCTS_COFFEE_MAKER_COFFEE_MILK_RATIO: 'ConsumerProducts.CoffeeMaker.Option.CoffeeMilkRatio'>,
+            'name': None,
+            'unit': None,
+            'value': 'ConsumerProducts.CoffeeMaker.EnumType.CoffeeMilkRatio.67Percent',
+          }),
+        ]),
+      }),
+    }),
+  )
+# ---
+# name: test_set_program_and_options[service_call4-set_selected_program_options]
   _Call(
     tuple(
       'SIEMENS-HCS03WCH1-7BC6383CF794',

--- a/tests/components/home_connect/snapshots/test_init.ambr
+++ b/tests/components/home_connect/snapshots/test_init.ambr
@@ -50,34 +50,14 @@
             'key': <OptionKey.CONSUMER_PRODUCTS_COFFEE_MAKER_COFFEE_MILK_RATIO: 'ConsumerProducts.CoffeeMaker.Option.CoffeeMilkRatio'>,
             'name': None,
             'unit': None,
-            'value': 'ConsumerProducts.CoffeeMaker.EnumType.CoffeeMilkRatio.60Percent',
+            'value': 'ConsumerProducts.CoffeeMaker.EnumType.CoffeeMilkRatio.50Percent',
           }),
         ]),
       }),
     }),
   )
 # ---
-# name: test_set_program_and_options[service_call3-set_active_program_options]
-  _Call(
-    tuple(
-      'SIEMENS-HCS03WCH1-7BC6383CF794',
-    ),
-    dict({
-      'array_of_options': dict({
-        'options': list([
-          dict({
-            'display_value': None,
-            'key': <OptionKey.CONSUMER_PRODUCTS_COFFEE_MAKER_COFFEE_MILK_RATIO: 'ConsumerProducts.CoffeeMaker.Option.CoffeeMilkRatio'>,
-            'name': None,
-            'unit': None,
-            'value': 'ConsumerProducts.CoffeeMaker.EnumType.CoffeeMilkRatio.67Percent',
-          }),
-        ]),
-      }),
-    }),
-  )
-# ---
-# name: test_set_program_and_options[service_call4-set_selected_program_options]
+# name: test_set_program_and_options[service_call3-set_selected_program_options]
   _Call(
     tuple(
       'SIEMENS-HCS03WCH1-7BC6383CF794',

--- a/tests/components/home_connect/test_init.py
+++ b/tests/components/home_connect/test_init.py
@@ -173,17 +173,7 @@ SERVICES_SET_PROGRAM_AND_OPTIONS = [
         "service_data": {
             "device_id": "DEVICE_ID",
             "affects_to": "active_program",
-            "consumer_products_coffee_maker_option_coffee_milk_ratio": 60,
-        },
-        "blocking": True,
-    },
-    {
-        "domain": DOMAIN,
-        "service": "set_program_and_options",
-        "service_data": {
-            "device_id": "DEVICE_ID",
-            "affects_to": "active_program",
-            "consumer_products_coffee_maker_option_coffee_milk_ratio": 68,
+            "consumer_products_coffee_maker_option_coffee_milk_ratio": "consumer_products_coffee_maker_enum_type_coffee_milk_ratio_50_percent",
         },
         "blocking": True,
     },
@@ -416,7 +406,6 @@ async def test_programs_and_options_actions_deprecation(
             "set_selected_program",
             "start_program",
             "set_active_program_options",
-            "set_active_program_options",
             "set_selected_program_options",
         ],
         strict=True,
@@ -459,7 +448,6 @@ async def test_set_program_and_options(
         [
             r"Error.*selecting.*program.*",
             r"Error.*starting.*program.*",
-            r"Error.*setting.*options.*active.*program.*",
             r"Error.*setting.*options.*active.*program.*",
             r"Error.*setting.*options.*selected.*program.*",
         ],

--- a/tests/components/home_connect/test_init.py
+++ b/tests/components/home_connect/test_init.py
@@ -182,6 +182,16 @@ SERVICES_SET_PROGRAM_AND_OPTIONS = [
         "service": "set_program_and_options",
         "service_data": {
             "device_id": "DEVICE_ID",
+            "affects_to": "active_program",
+            "consumer_products_coffee_maker_option_coffee_milk_ratio": 68,
+        },
+        "blocking": True,
+    },
+    {
+        "domain": DOMAIN,
+        "service": "set_program_and_options",
+        "service_data": {
+            "device_id": "DEVICE_ID",
             "affects_to": "selected_program",
             "consumer_products_coffee_maker_option_fill_quantity": 35,
         },
@@ -406,6 +416,7 @@ async def test_programs_and_options_actions_deprecation(
             "set_selected_program",
             "start_program",
             "set_active_program_options",
+            "set_active_program_options",
             "set_selected_program_options",
         ],
         strict=True,
@@ -448,6 +459,7 @@ async def test_set_program_and_options(
         [
             r"Error.*selecting.*program.*",
             r"Error.*starting.*program.*",
+            r"Error.*setting.*options.*active.*program.*",
             r"Error.*setting.*options.*active.*program.*",
             r"Error.*setting.*options.*selected.*program.*",
         ],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Added back the functionality that I missed at ac4e1e51f165317960cce2cde50a39a08b2cee38 which sets the coffee-milk ratio from an integer to the corresponding enum value.

Because there's a possible value `ConsumerProducts.CoffeeMaker.EnumType.CoffeeMilkRatio.67Percent`, I had to lower the step to 1, and round it to 5 if it is not 67 or 68, which would set it to 67.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
