### PR TITLE
Use correct inputs for relative time and duration options

### DIFF
--- a/homeassistant/components/home_connect/__init__.py
+++ b/homeassistant/components/home_connect/__init__.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable
-from datetime import timedelta
 import logging
 from typing import Any, cast
 
@@ -74,6 +73,9 @@ PROGRAM_OPTIONS = {
         value,
     )
     for key, value in {
+        OptionKey.BSH_COMMON_DURATION: int,
+        OptionKey.BSH_COMMON_START_IN_RELATIVE: int,
+        OptionKey.BSH_COMMON_FINISH_IN_RELATIVE: int,
         OptionKey.CONSUMER_PRODUCTS_COFFEE_MAKER_FILL_QUANTITY: int,
         OptionKey.CONSUMER_PRODUCTS_COFFEE_MAKER_MULTIPLE_BEVERAGES: bool,
         OptionKey.DISHCARE_DISHWASHER_INTENSIV_ZONE: bool,
@@ -89,18 +91,6 @@ PROGRAM_OPTIONS = {
         OptionKey.COOKING_OVEN_FAST_PRE_HEAT: bool,
         OptionKey.LAUNDRY_CARE_WASHER_I_DOS_1_ACTIVE: bool,
         OptionKey.LAUNDRY_CARE_WASHER_I_DOS_2_ACTIVE: bool,
-    }.items()
-}
-
-TIME_PROGRAM_OPTIONS = {
-    bsh_key_to_translation_key(key): (
-        key,
-        value,
-    )
-    for key, value in {
-        OptionKey.BSH_COMMON_START_IN_RELATIVE: cv.time_period_str,
-        OptionKey.BSH_COMMON_DURATION: cv.time_period_str,
-        OptionKey.BSH_COMMON_FINISH_IN_RELATIVE: cv.time_period_str,
     }.items()
 }
 
@@ -156,10 +146,7 @@ SERVICE_PROGRAM_SCHEMA = vol.Any(
 
 def _require_program_or_at_least_one_option(data: dict) -> dict:
     if ATTR_PROGRAM not in data and not any(
-        option_key in data
-        for option_key in (
-            PROGRAM_ENUM_OPTIONS | PROGRAM_OPTIONS | TIME_PROGRAM_OPTIONS
-        )
+        option_key in data for option_key in (PROGRAM_ENUM_OPTIONS | PROGRAM_OPTIONS)
     ):
         raise ServiceValidationError(
             translation_domain=DOMAIN,
@@ -190,9 +177,7 @@ SERVICE_PROGRAM_AND_OPTIONS_SCHEMA = vol.All(
     .extend(
         {
             vol.Optional(translation_key): schema
-            for translation_key, (key, schema) in (
-                PROGRAM_OPTIONS | TIME_PROGRAM_OPTIONS
-            ).items()
+            for translation_key, (key, schema) in PROGRAM_OPTIONS.items()
         }
     ),
     _require_program_or_at_least_one_option,
@@ -486,13 +471,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:  # noqa:
             elif option in PROGRAM_OPTIONS:
                 option_key = PROGRAM_OPTIONS[option][0]
                 options.append(Option(option_key, value))
-            elif option in TIME_PROGRAM_OPTIONS:
-                options.append(
-                    Option(
-                        TIME_PROGRAM_OPTIONS[option][0],
-                        int(cast(timedelta, value).total_seconds()),
-                    )
-                )
+
         method_call: Awaitable[Any]
         exception_translation_key: str
         if program:

--- a/homeassistant/components/home_connect/services.yaml
+++ b/homeassistant/components/home_connect/services.yaml
@@ -387,10 +387,14 @@ set_program_and_options:
       collapsed: true
       fields:
         b_s_h_common_option_start_in_relative:
-          example: "30:00"
+          example: 3600
           required: false
           selector:
-            time:
+            number:
+              min: 0
+              step: 1
+              mode: box
+              unit_of_measurement: s
         dishcare_dishwasher_option_intensiv_zone:
           example: false
           required: false
@@ -493,10 +497,14 @@ set_program_and_options:
               mode: box
               unit_of_measurement: °C/°F
         b_s_h_common_option_duration:
-          example: "30:00"
+          example: 900
           required: false
           selector:
-            time:
+            number:
+              min: 0
+              step: 1
+              mode: box
+              unit_of_measurement: s
         cooking_oven_option_fast_pre_heat:
           example: false
           required: false
@@ -561,10 +569,14 @@ set_program_and_options:
                 - laundry_care_washer_enum_type_spin_speed_ul_medium
                 - laundry_care_washer_enum_type_spin_speed_ul_high
         b_s_h_common_option_finish_in_relative:
-          example: "30:00"
+          example: 3600
           required: false
           selector:
-            time:
+            number:
+              min: 0
+              step: 1
+              mode: box
+              unit_of_measurement: s
         laundry_care_washer_option_i_dos1_active:
           example: false
           required: false

--- a/tests/components/home_connect/test_init.py
+++ b/tests/components/home_connect/test_init.py
@@ -152,7 +152,7 @@ SERVICES_SET_PROGRAM_AND_OPTIONS = [
             "device_id": "DEVICE_ID",
             "affects_to": "selected_program",
             "program": "dishcare_dishwasher_program_eco_50",
-            "b_s_h_common_option_start_in_relative": "00:30:00",
+            "b_s_h_common_option_start_in_relative": 1800,
         },
         "blocking": True,
     },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Start/finish in and duration options where using a time entity, which represents a time in a day, not relative time or a duration.

Because of this, I switched these options to number inputs.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
