### PR TITLE
Fix Z-WaveJS inclusion in the background

### DIFF
--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -805,7 +805,7 @@ async def websocket_add_node(
     ]
     msg[DATA_UNSUBSCRIBE] = unsubs
 
-    if controller.inclusion_state == InclusionState.INCLUDING:
+    if controller.inclusion_state in (InclusionState.INCLUDING, InclusionState.BUSY):
         connection.send_result(
             msg[ID],
             True,  # Inclusion is already in progress

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -899,15 +899,8 @@ async def websocket_subscribe_s2_inclusion(
     @callback
     def handle_requested_grant(event: dict) -> None:
         """Accept the requested security classes without user interaction."""
-        inclusion_grant = InclusionGrant(
-            [
-                SecurityClass(sec_cls)
-                for sec_cls in event["requested_grant"]["security_classes"]
-            ],
-            event["requested_grant"]["client_side_auth"],
-        )
         hass.async_create_task(
-            driver.controller.async_grant_security_classes(inclusion_grant)
+            driver.controller.async_grant_security_classes(event["requested_grant"])
         )
 
     connection.subscriptions[msg["id"]] = async_cleanup

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -896,8 +896,9 @@ async def websocket_subscribe_s2_inclusion(
             )
         )
 
-    async def accept_requested_grant(event: dict) -> None:
-        # accept the requested security classes without user interaction
+    @callback
+    def handle_requested_grant(event: dict) -> None:
+        """Accept the requested security classes without user interaction."""
         inclusion_grant = InclusionGrant(
             [
                 SecurityClass(sec_cls)
@@ -905,11 +906,13 @@ async def websocket_subscribe_s2_inclusion(
             ],
             event["requested_grant"]["client_side_auth"],
         )
-        await driver.controller.async_grant_security_classes(inclusion_grant)
+        hass.async_create_task(
+            driver.controller.async_grant_security_classes(inclusion_grant)
+        )
 
     connection.subscriptions[msg["id"]] = async_cleanup
     msg[DATA_UNSUBSCRIBE] = unsubs = [
-        driver.controller.on("grant security classes", accept_requested_grant),
+        driver.controller.on("grant security classes", handle_requested_grant),
         driver.controller.on("validate dsk and enter pin", forward_dsk),
     ]
     connection.send_result(msg[ID])

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -5284,6 +5284,20 @@ async def test_subscribe_s2_inclusion(
     assert msg["success"]
     assert msg["result"] is None
 
+    # Test receiving requested grant event
+    event = Event(
+        type="grant security classes",
+        data={
+            "source": "controller",
+            "event": "grant security classes",
+            "requested": {
+                "securityClasses": [SecurityClass.S2_UNAUTHENTICATED],
+                "clientSideAuth": False,
+            },
+        },
+    )
+    client.driver.receive_event(event)
+
     # Test receiving DSK request event
     event = Event(
         type="validate dsk and enter pin",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow up to #132073
According to @AlCalzone we could receive the `grant security classes` event before `validate dsk and enter pin` and we must respond to it for the inclusion to continue.

To fully fix this https://github.com/home-assistant-libs/zwave-js-server-python/pull/1173 is required but this PR is not dependent on it

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
