### PR TITLE
Reduce translations_once fixture scope to module

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -1867,23 +1867,6 @@ async def snapshot_platform(
         assert state == snapshot(name=f"{entity_entry.entity_id}-state")
 
 
-def reset_translation_cache(hass: HomeAssistant, components: list[str]) -> None:
-    """Reset translation cache for specified components.
-
-    Use this if you are mocking a core component (for example via
-    mock_integration), to ensure that the mocked translations are not
-    persisted in the shared session cache.
-    """
-    translations_cache = translation._async_get_translations_cache(hass)
-    for loaded_components in translations_cache.cache_data.loaded.values():
-        for component_to_unload in components:
-            loaded_components.discard(component_to_unload)
-    for loaded_categories in translations_cache.cache_data.cache.values():
-        for loaded_components in loaded_categories.values():
-            for component_to_unload in components:
-                loaded_components.pop(component_to_unload, None)
-
-
 @lru_cache
 def get_quality_scale(integration: str) -> dict[str, QualityScaleStatus]:
     """Load quality scale for integration."""

--- a/tests/components/stt/test_init.py
+++ b/tests/components/stt/test_init.py
@@ -34,7 +34,6 @@ from tests.common import (
     mock_integration,
     mock_platform,
     mock_restore_cache,
-    reset_translation_cache,
 )
 from tests.typing import ClientSessionGenerator, WebSocketGenerator
 
@@ -518,9 +517,6 @@ async def test_default_engine_prefer_cloud_entity(
     assert provider_engine is not None
     assert provider_engine.name == "test"
     assert async_default_engine(hass) == "stt.cloud_stt_entity"
-
-    # Reset the `cloud` translations cache to avoid flaky translation checks
-    reset_translation_cache(hass, ["cloud"])
 
 
 async def test_get_engine_legacy(

--- a/tests/components/tts/test_init.py
+++ b/tests/components/tts/test_init.py
@@ -44,7 +44,6 @@ from tests.common import (
     mock_integration,
     mock_platform,
     mock_restore_cache,
-    reset_translation_cache,
 )
 from tests.typing import ClientSessionGenerator, WebSocketGenerator
 
@@ -1987,6 +1986,3 @@ async def test_default_engine_prefer_cloud_entity(
     provider_engine = tts.async_resolve_engine(hass, "test")
     assert provider_engine == "test"
     assert tts.async_default_engine(hass) == "tts.cloud_tts_entity"
-
-    # Reset the `cloud` translations cache to avoid flaky translation checks
-    reset_translation_cache(hass, ["cloud"])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1230,13 +1230,13 @@ def mock_get_source_ip() -> Generator[_patch]:
         patcher.stop()
 
 
-@pytest.fixture(autouse=True, scope="session")
+@pytest.fixture(autouse=True, scope="module")
 def translations_once() -> Generator[_patch]:
-    """Only load translations once per session.
+    """Only load translations once per module.
 
-    Warning: having this as a session fixture can cause issues with tests that
-    create mock integrations, overriding the real integration translations
-    with empty ones. Translations should be reset after such tests (see #131628)
+    Note: This was previously a session scope fixture, but that made tests which
+    mock an integration interfere with tests which set up the real integration.
+    Unless we find a way to solve that, this needs to be module scope.
     """
     cache = _TranslationsCacheData({}, {})
     patcher = patch(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Reduce `translations_once` fixture scope from session to module; session scope causes very hard to track down issues where tests interfere with other tests

We can make it a session scope fixture if we can find a way where we evict fake entries from the cache inbetween tests:
- Maybe cache entries can be evicted when tearing down the fixture if there are no translations?
- Maybe we can evict the cache entry if translations were not loaded from the expected location (`homeassistant/components/{integration}/translations/en.json`)?

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
