### PR TITLE
Update Home Assistant base image to 2025.02.1

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,10 +1,10 @@
 image: ghcr.io/home-assistant/{arch}-homeassistant
 build_from:
-  aarch64: ghcr.io/home-assistant/aarch64-homeassistant-base:2024.12.0
-  armhf: ghcr.io/home-assistant/armhf-homeassistant-base:2024.12.0
-  armv7: ghcr.io/home-assistant/armv7-homeassistant-base:2024.12.0
-  amd64: ghcr.io/home-assistant/amd64-homeassistant-base:2024.12.0
-  i386: ghcr.io/home-assistant/i386-homeassistant-base:2024.12.0
+  aarch64: ghcr.io/home-assistant/aarch64-homeassistant-base:2025.02.1
+  armhf: ghcr.io/home-assistant/armhf-homeassistant-base:2025.02.1
+  armv7: ghcr.io/home-assistant/armv7-homeassistant-base:2025.02.1
+  amd64: ghcr.io/home-assistant/amd64-homeassistant-base:2025.02.1
+  i386: ghcr.io/home-assistant/i386-homeassistant-base:2025.02.1
 codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -28,8 +28,8 @@ MINOR_VERSION: Final = 3
 PATCH_VERSION: Final = "0.dev0"
 __short_version__: Final = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__: Final = f"{__short_version__}.{PATCH_VERSION}"
-REQUIRED_PYTHON_VER: Final[tuple[int, int, int]] = (3, 13, 0)
-REQUIRED_NEXT_PYTHON_VER: Final[tuple[int, int, int]] = (3, 13, 0)
+REQUIRED_PYTHON_VER: Final[tuple[int, int, int]] = (3, 13, 2)
+REQUIRED_NEXT_PYTHON_VER: Final[tuple[int, int, int]] = (3, 13, 2)
 # Truthy date string triggers showing related deprecation warning messages.
 REQUIRED_NEXT_PYTHON_HA_RELEASE: Final = ""
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Topic :: Home Automation",
 ]
-requires-python = ">=3.13.0"
+requires-python = ">=3.13.2"
 dependencies    = [
     "aiodns==3.2.0",
     # Integrations may depend on hassio integration without listing it to


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change

Home Assistant Core now requires at least Python 3.13.2.

This is a bump from Python 3.13.0 because of a critical issue with Python for our use case.
 
If you run Home Assistant OS, Home Assistant Supervised, or a Home Assistant Container (in, for example, Docker), **no action is needed**. In these cases, we take care of it for you.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Updates the Home Assistant base image to 2025.02.1

Main change is that the generic base image used is now on Python 3.13.2,
which we now also set at the min version.

Reason is that @emontnemery tracked down some really weird behavior (basically, the asyncio event loop went completely bananas) when backup uploads are interrupted to this CPython bug https://github.com/python/cpython/pull/128037 which is fixed in Python 3.13.2 

Release:
- https://github.com/home-assistant/docker/releases/tag/2025.02.0
- https://github.com/home-assistant/docker/releases/tag/2025.02.1

Build on the new generic base image: https://github.com/home-assistant/docker-base/releases/tag/2025.02.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
