### PR TITLE
Allow arbitrary Gemini attachments

### DIFF
--- a/homeassistant/components/google_generative_ai_conversation/__init__.py
+++ b/homeassistant/components/google_generative_ai_conversation/__init__.py
@@ -53,7 +53,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     async def generate_content(call: ServiceCall) -> ServiceResponse:
         """Generate content from text and optionally images."""
 
-        if CONF_IMAGE_FILENAME in call.data:
+        if call.data[CONF_IMAGE_FILENAME]:
             # Deprecated in 2025.3, to remove in 2025.9
             async_create_issue(
                 hass,

--- a/homeassistant/components/google_generative_ai_conversation/__init__.py
+++ b/homeassistant/components/google_generative_ai_conversation/__init__.py
@@ -26,6 +26,7 @@ from homeassistant.exceptions import (
     HomeAssistantError,
 )
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 from homeassistant.helpers.typing import ConfigType
 
 from .const import (
@@ -38,6 +39,7 @@ from .const import (
 
 SERVICE_GENERATE_CONTENT = "generate_content"
 CONF_IMAGE_FILENAME = "image_filename"
+CONF_FILENAMES = "filenames"
 
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 PLATFORMS = (Platform.CONVERSATION,)
@@ -50,23 +52,42 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     async def generate_content(call: ServiceCall) -> ServiceResponse:
         """Generate content from text and optionally images."""
+
+        if CONF_IMAGE_FILENAME in call.data:
+            # Deprecated in 2025.3, to remove in 2025.9
+            async_create_issue(
+                hass,
+                DOMAIN,
+                "deprecated_image_filename_parameter",
+                breaks_in_ha_version="2025.9.0",
+                is_fixable=False,
+                severity=IssueSeverity.WARNING,
+                translation_key="deprecated_image_filename_parameter",
+            )
+
         prompt_parts = [call.data[CONF_PROMPT]]
 
         def append_images_to_prompt():
             image_filenames = call.data[CONF_IMAGE_FILENAME]
-            for image_filename in image_filenames:
-                if not hass.config.is_allowed_path(image_filename):
+            filenames = call.data[CONF_FILENAMES]
+            for filename in image_filenames + filenames:
+                if not hass.config.is_allowed_path(filename):
                     raise HomeAssistantError(
-                        f"Cannot read `{image_filename}`, no access to path; "
+                        f"Cannot read `{filename}`, no access to path; "
                         "`allowlist_external_dirs` may need to be adjusted in "
                         "`configuration.yaml`"
                     )
-                if not Path(image_filename).exists():
-                    raise HomeAssistantError(f"`{image_filename}` does not exist")
-                mime_type, _ = mimetypes.guess_type(image_filename)
-                if mime_type is None or not mime_type.startswith("image"):
-                    raise HomeAssistantError(f"`{image_filename}` is not an image")
-                prompt_parts.append(Image.open(image_filename))
+                if not Path(filename).exists():
+                    raise HomeAssistantError(f"`{filename}` does not exist")
+                mime_type, _ = mimetypes.guess_type(filename)
+                if mime_type is None:
+                    raise HomeAssistantError(f"Cannot infer MIME type for `{filename}`")
+                if mime_type.startswith("image"):
+                    prompt_parts.append(Image.open(filename))
+                else:
+                    prompt_parts.append(
+                        {"mime_type": mime_type, "data": Path(filename).read_bytes()}
+                    )
 
         await hass.async_add_executor_job(append_images_to_prompt)
 
@@ -103,6 +124,9 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             {
                 vol.Required(CONF_PROMPT): cv.string,
                 vol.Optional(CONF_IMAGE_FILENAME, default=[]): vol.All(
+                    cv.ensure_list, [cv.string]
+                ),
+                vol.Optional(CONF_FILENAMES, default=[]): vol.All(
                     cv.ensure_list, [cv.string]
                 ),
             }

--- a/homeassistant/components/google_generative_ai_conversation/__init__.py
+++ b/homeassistant/components/google_generative_ai_conversation/__init__.py
@@ -74,7 +74,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         def append_files_to_prompt():
             image_filenames = call.data[CONF_IMAGE_FILENAME]
             filenames = call.data[CONF_FILENAMES]
-            for filename in image_filenames + filenames:
+            for filename in set(image_filenames + filenames):
                 if not hass.config.is_allowed_path(filename):
                     raise HomeAssistantError(
                         f"Cannot read `{filename}`, no access to path; "

--- a/homeassistant/components/google_generative_ai_conversation/services.yaml
+++ b/homeassistant/components/google_generative_ai_conversation/services.yaml
@@ -9,3 +9,8 @@ generate_content:
       required: false
       selector:
         object:
+    filenames:
+      required: false
+      selector:
+        text:
+          multiple: true

--- a/homeassistant/components/google_generative_ai_conversation/strings.json
+++ b/homeassistant/components/google_generative_ai_conversation/strings.json
@@ -56,10 +56,21 @@
         },
         "image_filename": {
           "name": "Image filename",
-          "description": "Images",
+          "description": "Deprecated. Use filenames instead.",
+          "example": "/config/www/image.jpg"
+        },
+        "filenames": {
+          "name": "Attachment filenames",
+          "description": "Attachments to add to the prompt (images, PDFs, etc)",
           "example": "/config/www/image.jpg"
         }
       }
+    }
+  },
+  "issues": {
+    "deprecated_image_filename_parameter": {
+      "title": "Deprecated 'image_filename' parameter",
+      "description": "The 'image_filename' parameter in Google Generative AI actions is deprecated. Please edit scripts and automations to use 'filenames' intead."
     }
   }
 }

--- a/tests/components/google_generative_ai_conversation/snapshots/test_init.ambr
+++ b/tests/components/google_generative_ai_conversation/snapshots/test_init.ambr
@@ -8,11 +8,8 @@
       dict({
         'contents': list([
           'Describe this image from my doorbell camera',
-          b'image bytes',
-          dict({
-            'data': b'context bytes',
-            'mime_type': 'text/plain',
-          }),
+          b'some file',
+          b'some file',
         ]),
         'model': 'models/gemini-2.0-flash',
       }),

--- a/tests/components/google_generative_ai_conversation/snapshots/test_init.ambr
+++ b/tests/components/google_generative_ai_conversation/snapshots/test_init.ambr
@@ -9,6 +9,10 @@
         'contents': list([
           'Describe this image from my doorbell camera',
           b'image bytes',
+          dict({
+            'data': b'context bytes',
+            'mime_type': 'text/plain',
+          }),
         ]),
         'model': 'models/gemini-2.0-flash',
       }),

--- a/tests/components/google_generative_ai_conversation/test_init.py
+++ b/tests/components/google_generative_ai_conversation/test_init.py
@@ -66,6 +66,10 @@ async def test_generate_content_service_with_image(
             ),
         ) as mock_generate,
         patch(
+            "homeassistant.components.google_generative_ai_conversation.Path.read_bytes",
+            return_value=b"context bytes",
+        ),
+        patch(
             "homeassistant.components.google_generative_ai_conversation.Image.open",
             return_value=b"image bytes",
         ),
@@ -77,7 +81,7 @@ async def test_generate_content_service_with_image(
             "generate_content",
             {
                 "prompt": "Describe this image from my doorbell camera",
-                "image_filename": "doorbell_snapshot.jpg",
+                "filenames": ["doorbell_snapshot.jpg", "context.txt"],
             },
             blocking=True,
             return_response=True,
@@ -161,7 +165,7 @@ async def test_generate_content_service_with_image_not_allowed_path(
             "generate_content",
             {
                 "prompt": "Describe this image from my doorbell camera",
-                "image_filename": "doorbell_snapshot.jpg",
+                "filenames": "doorbell_snapshot.jpg",
             },
             blocking=True,
             return_response=True,
@@ -186,30 +190,7 @@ async def test_generate_content_service_with_image_not_exists(
             "generate_content",
             {
                 "prompt": "Describe this image from my doorbell camera",
-                "image_filename": "doorbell_snapshot.jpg",
-            },
-            blocking=True,
-            return_response=True,
-        )
-
-
-@pytest.mark.usefixtures("mock_init_component")
-async def test_generate_content_service_with_non_image(hass: HomeAssistant) -> None:
-    """Test generate content service with a non image."""
-    with (
-        patch("pathlib.Path.exists", return_value=True),
-        patch.object(hass.config, "is_allowed_path", return_value=True),
-        patch("pathlib.Path.exists", return_value=True),
-        pytest.raises(
-            HomeAssistantError, match="`doorbell_snapshot.mp4` is not an image"
-        ),
-    ):
-        await hass.services.async_call(
-            "google_generative_ai_conversation",
-            "generate_content",
-            {
-                "prompt": "Describe this image from my doorbell camera",
-                "image_filename": "doorbell_snapshot.mp4",
+                "filenames": "doorbell_snapshot.jpg",
             },
             blocking=True,
             return_response=True,

--- a/tests/components/google_generative_ai_conversation/test_init.py
+++ b/tests/components/google_generative_ai_conversation/test_init.py
@@ -66,12 +66,8 @@ async def test_generate_content_service_with_image(
             ),
         ) as mock_generate,
         patch(
-            "homeassistant.components.google_generative_ai_conversation.Path.read_bytes",
-            return_value=b"context bytes",
-        ),
-        patch(
-            "homeassistant.components.google_generative_ai_conversation.Image.open",
-            return_value=b"image bytes",
+            "google.genai.files.Files.upload",
+            return_value=b"some file",
         ),
         patch("pathlib.Path.exists", return_value=True),
         patch.object(hass.config, "is_allowed_path", return_value=True),

--- a/tests/components/google_generative_ai_conversation/test_init.py
+++ b/tests/components/google_generative_ai_conversation/test_init.py
@@ -77,7 +77,7 @@ async def test_generate_content_service_with_image(
             "generate_content",
             {
                 "prompt": "Describe this image from my doorbell camera",
-                "filenames": ["doorbell_snapshot.jpg", "context.txt"],
+                "filenames": ["doorbell_snapshot.jpg", "context.txt", "context.txt"],
             },
             blocking=True,
             return_response=True,


### PR DESCRIPTION
This lets me use Gemini to extract information from PDFs in emails.

This is a followup of #128916, which I left alone for too long

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Allow arbitrary attachments, not just images.

This lets automations use Gemini to extract information from webpages or PDFs.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #128916
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/37520
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
