### PR TITLE
Select preferred discovered HEOS host

### DIFF
--- a/homeassistant/components/heos/config_flow.py
+++ b/homeassistant/components/heos/config_flow.py
@@ -17,12 +17,9 @@ from homeassistant.config_entries import (
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import callback
 from homeassistant.helpers import selector
-from homeassistant.helpers.service_info.ssdp import (
-    ATTR_UPNP_FRIENDLY_NAME,
-    SsdpServiceInfo,
-)
+from homeassistant.helpers.service_info.ssdp import SsdpServiceInfo
 
-from .const import DOMAIN
+from .const import DOMAIN, ENTRY_TITLE
 from .coordinator import HeosConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
@@ -35,11 +32,6 @@ AUTH_SCHEMA = vol.Schema(
         ),
     }
 )
-
-
-def format_title(host: str) -> str:
-    """Format the title for config entries."""
-    return f"HEOS System (via {host})"
 
 
 async def _validate_host(host: str, errors: dict[str, str]) -> bool:
@@ -104,6 +96,10 @@ class HeosFlowHandler(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    def __init__(self) -> None:
+        """Initialize the HEOS flow."""
+        self._discovered_host: str | None = None
+
     @staticmethod
     @callback
     def async_get_options_flow(config_entry: HeosConfigEntry) -> OptionsFlow:
@@ -117,40 +113,63 @@ class HeosFlowHandler(ConfigFlow, domain=DOMAIN):
         # Store discovered host
         if TYPE_CHECKING:
             assert discovery_info.ssdp_location
-        hostname = urlparse(discovery_info.ssdp_location).hostname
-        friendly_name = f"{discovery_info.upnp[ATTR_UPNP_FRIENDLY_NAME]} ({hostname})"
-        self.hass.data.setdefault(DOMAIN, {})
-        self.hass.data[DOMAIN][friendly_name] = hostname
+
         await self.async_set_unique_id(DOMAIN)
-        # Show selection form
-        return self.async_show_form(step_id="user")
+        # Connect to discovered host and get system information
+        hostname = urlparse(discovery_info.ssdp_location).hostname
+        assert hostname is not None
+        heos = Heos(HeosOptions(hostname, events=False, heart_beat=False))
+        try:
+            await heos.connect()
+            system_info = await heos.get_system_info()
+        except HeosError as error:
+            _LOGGER.debug(
+                "Failed to retrieve system information from discovered HEOS device %s",
+                hostname,
+                exc_info=error,
+            )
+            return self.async_abort(reason="cannot_connect")
+        finally:
+            await heos.disconnect()
+
+        # Select the preferred host, if available
+        if system_info.preferred_hosts:
+            hostname = system_info.preferred_hosts[0].ip_address
+        self._discovered_host = hostname
+        return await self.async_step_confirm_discovery()
+
+    async def async_step_confirm_discovery(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Confirm discovered HEOS system."""
+        if user_input is not None:
+            assert self._discovered_host is not None
+            return self.async_create_entry(
+                title=ENTRY_TITLE, data={CONF_HOST: self._discovered_host}
+            )
+
+        self._set_confirm_only()
+        return self.async_show_form(step_id="confirm_discovery")
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Obtain host and validate connection."""
-        self.hass.data.setdefault(DOMAIN, {})
         await self.async_set_unique_id(DOMAIN)
         # Try connecting to host if provided
         errors: dict[str, str] = {}
         host = None
         if user_input is not None:
             host = user_input[CONF_HOST]
-            # Map host from friendly name if in discovered hosts
-            host = self.hass.data[DOMAIN].get(host, host)
             if await _validate_host(host, errors):
-                self.hass.data.pop(DOMAIN)  # Remove discovery data
                 return self.async_create_entry(
-                    title=format_title(host), data={CONF_HOST: host}
+                    title=ENTRY_TITLE, data={CONF_HOST: host}
                 )
 
         # Return form
-        host_type = (
-            str if not self.hass.data[DOMAIN] else vol.In(list(self.hass.data[DOMAIN]))
-        )
         return self.async_show_form(
             step_id="user",
-            data_schema=vol.Schema({vol.Required(CONF_HOST, default=host): host_type}),
+            data_schema=vol.Schema({vol.Required(CONF_HOST, default=host): str}),
             errors=errors,
         )
 

--- a/homeassistant/components/heos/const.py
+++ b/homeassistant/components/heos/const.py
@@ -3,6 +3,7 @@
 ATTR_PASSWORD = "password"
 ATTR_USERNAME = "username"
 DOMAIN = "heos"
+ENTRY_TITLE = "HEOS System"
 SERVICE_GROUP_VOLUME_SET = "group_volume_set"
 SERVICE_GROUP_VOLUME_DOWN = "group_volume_down"
 SERVICE_GROUP_VOLUME_UP = "group_volume_up"

--- a/homeassistant/components/heos/strings.json
+++ b/homeassistant/components/heos/strings.json
@@ -11,6 +11,10 @@
           "host": "Host name or IP address of a HEOS-capable product (preferably one connected via wire to the network)."
         }
       },
+      "confirm_discovery": {
+        "title": "Discovered HEOS System",
+        "description": "Do you want to add your HEOS devices to Home Assistant?"
+      },
       "reconfigure": {
         "title": "Reconfigure HEOS",
         "description": "Change the host name or IP address of the HEOS-capable product used to access your HEOS System.",
@@ -43,6 +47,7 @@
     },
     "abort": {
       "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
       "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]",
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"

--- a/tests/components/heos/__init__.py
+++ b/tests/components/heos/__init__.py
@@ -22,6 +22,7 @@ class MockHeos(Heos):
         self.get_players: AsyncMock = AsyncMock()
         self.group_volume_down: AsyncMock = AsyncMock()
         self.group_volume_up: AsyncMock = AsyncMock()
+        self.get_system_info: AsyncMock = AsyncMock()
         self.load_players: AsyncMock = AsyncMock()
         self.play_media: AsyncMock = AsyncMock()
         self.play_preset_station: AsyncMock = AsyncMock()

--- a/tests/components/heos/test_config_flow.py
+++ b/tests/components/heos/test_config_flow.py
@@ -129,7 +129,6 @@ async def test_discovery_fails_to_connect_aborts(
     hass: HomeAssistant, discovery_data: SsdpServiceInfo, controller: MockHeos
 ) -> None:
     """Test discovery aborts when trying to connect to host."""
-    # Single discovered, selects preferred host, shows confirm
     controller.connect.side_effect = HeosError()
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_SSDP}, data=discovery_data

--- a/tests/components/heos/test_config_flow.py
+++ b/tests/components/heos/test_config_flow.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from pyheos import CommandAuthenticationError, CommandFailedError, HeosError
+from pyheos import CommandAuthenticationError, CommandFailedError, HeosError, HeosSystem
 import pytest
 
 from homeassistant.components.heos.const import DOMAIN
@@ -69,57 +69,46 @@ async def test_create_entry_when_host_valid(
     )
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["result"].unique_id == DOMAIN
-    assert result["title"] == "HEOS System (via 127.0.0.1)"
+    assert result["title"] == "HEOS System"
     assert result["data"] == data
     assert controller.connect.call_count == 2  # Also called in async_setup_entry
     assert controller.disconnect.call_count == 1
 
 
-async def test_create_entry_when_friendly_name_valid(
-    hass: HomeAssistant, controller: MockHeos
-) -> None:
-    """Test result type is create entry when friendly name is valid."""
-    hass.data[DOMAIN] = {"Office (127.0.0.1)": "127.0.0.1"}
-    data = {CONF_HOST: "Office (127.0.0.1)"}
-
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_USER}, data=data
-    )
-
-    assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["result"].unique_id == DOMAIN
-    assert result["title"] == "HEOS System (via 127.0.0.1)"
-    assert result["data"] == {CONF_HOST: "127.0.0.1"}
-    assert controller.connect.call_count == 2  # Also called in async_setup_entry
-    assert controller.disconnect.call_count == 1
-    assert DOMAIN not in hass.data
-
-
-async def test_discovery_shows_create_form(
+async def test_discovery(
     hass: HomeAssistant,
     discovery_data: SsdpServiceInfo,
     discovery_data_bedroom: SsdpServiceInfo,
+    controller: MockHeos,
+    system: HeosSystem,
 ) -> None:
-    """Test discovery shows form to confirm setup."""
-
-    # Single discovered host shows form for user to finish setup.
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_SSDP}, data=discovery_data
-    )
-    assert hass.data[DOMAIN] == {"Office (127.0.0.1)": "127.0.0.1"}
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "user"
-
-    # Subsequent discovered hosts append to discovered hosts and abort.
+    """Test discovery shows form to confirm, then creates entry."""
+    # Single discovered, selects preferred host, shows confirm
+    controller.get_system_info.return_value = system
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_SSDP}, data=discovery_data_bedroom
     )
-    assert hass.data[DOMAIN] == {
-        "Office (127.0.0.1)": "127.0.0.1",
-        "Bedroom (127.0.0.2)": "127.0.0.2",
-    }
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "already_in_progress"
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "confirm_discovery"
+    assert controller.connect.call_count == 1
+    assert controller.get_system_info.call_count == 1
+    assert controller.disconnect.call_count == 1
+
+    # Subsequent discovered hosts abort.
+    subsequent_result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_SSDP}, data=discovery_data
+    )
+    assert subsequent_result["type"] is FlowResultType.ABORT
+    assert subsequent_result["reason"] == "already_in_progress"
+
+    # Confirm set up
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={}
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["result"].unique_id == DOMAIN
+    assert result["title"] == "HEOS System"
+    assert result["data"] == {CONF_HOST: "127.0.0.1"}
 
 
 async def test_discovery_flow_aborts_already_setup(
@@ -134,6 +123,21 @@ async def test_discovery_flow_aborts_already_setup(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "single_instance_allowed"
+
+
+async def test_discovery_fails_to_connect_aborts(
+    hass: HomeAssistant, discovery_data: SsdpServiceInfo, controller: MockHeos
+) -> None:
+    """Test discovery aborts when trying to connect to host."""
+    # Single discovered, selects preferred host, shows confirm
+    controller.connect.side_effect = HeosError()
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_SSDP}, data=discovery_data
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "cannot_connect"
+    assert controller.connect.call_count == 1
+    assert controller.disconnect.call_count == 1
 
 
 async def test_reconfigure_validates_and_updates_config(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Modifies the HEOS discovery flow to select a preferred host (when multiple are available) and show a simple confirmation to the user to add the integration. It does this by connecting to the first discovered host, retrieving the HEOS system information, and using a method from the library to identify the preferred host. Previously, the discovery flow would accumulate all discovered hosts and then present the list to the user. This provides a much better user experience, since we can determine the best host to use automatically. The user can still manually change the host via reconfigure later. This sets the stage for being able to automatically update the host from discovery in the future. Changes are fully tested.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
