### PR TITLE
Allow configuration of generic thermostat helper precision and step in UI

### DIFF
--- a/homeassistant/components/generic_thermostat/climate.py
+++ b/homeassistant/components/generic_thermostat/climate.py
@@ -69,8 +69,10 @@ from .const import (
     CONF_MAX_TEMP,
     CONF_MIN_DUR,
     CONF_MIN_TEMP,
+    CONF_PRECISION,
     CONF_PRESETS,
     CONF_SENSOR,
+    CONF_TEMP_STEP,
     DEFAULT_TOLERANCE,
     DOMAIN,
     PLATFORMS,
@@ -82,9 +84,7 @@ DEFAULT_NAME = "Generic Thermostat"
 
 CONF_INITIAL_HVAC_MODE = "initial_hvac_mode"
 CONF_KEEP_ALIVE = "keep_alive"
-CONF_PRECISION = "precision"
 CONF_TARGET_TEMP = "target_temp"
-CONF_TEMP_STEP = "target_temp_step"
 
 
 PRESETS_SCHEMA: VolDictType = {
@@ -112,7 +112,8 @@ PLATFORM_SCHEMA_COMMON = vol.Schema(
             vol.In([PRECISION_TENTHS, PRECISION_HALVES, PRECISION_WHOLE]),
         ),
         vol.Optional(CONF_TEMP_STEP): vol.All(
-            vol.In([PRECISION_TENTHS, PRECISION_HALVES, PRECISION_WHOLE])
+            vol.Coerce(float),
+            vol.In([PRECISION_TENTHS, PRECISION_HALVES, PRECISION_WHOLE]),
         ),
         vol.Optional(CONF_UNIQUE_ID): cv.string,
         **PRESETS_SCHEMA,

--- a/homeassistant/components/generic_thermostat/const.py
+++ b/homeassistant/components/generic_thermostat/const.py
@@ -32,5 +32,7 @@ CONF_PRESETS = {
         PRESET_ACTIVITY,
     )
 }
+CONF_PRECISION = "precision"
 CONF_SENSOR = "target_sensor"
+CONF_TEMP_STEP = "target_temp_step"
 DEFAULT_TOLERANCE = 0.3

--- a/homeassistant/components/generic_thermostat/strings.json
+++ b/homeassistant/components/generic_thermostat/strings.json
@@ -14,7 +14,9 @@
           "cold_tolerance": "Cold tolerance",
           "hot_tolerance": "Hot tolerance",
           "min_temp": "Minimum target temperature",
-          "max_temp": "Maximum target temperature"
+          "max_temp": "Maximum target temperature",
+          "precision": "Precision",
+          "target_temp_step": "Target temperature step"
         },
         "data_description": {
           "ac_mode": "Set the actuator specified to be treated as a cooling device instead of a heating device.",
@@ -22,7 +24,9 @@
           "target_sensor": "Temperature sensor that reflects the current temperature.",
           "min_cycle_duration": "Set a minimum amount of time that the switch specified must be in its current state prior to being switched either off or on.",
           "cold_tolerance": "Minimum amount of difference between the temperature read by the temperature sensor the target temperature that must change prior to being switched on. For example, if the target temperature is 25 and the tolerance is 0.5 the heater will start when the sensor equals or goes below 24.5.",
-          "hot_tolerance": "Minimum amount of difference between the temperature read by the temperature sensor the target temperature that must change prior to being switched off. For example, if the target temperature is 25 and the tolerance is 0.5 the heater will stop when the sensor equals or goes above 25.5."
+          "hot_tolerance": "Minimum amount of difference between the temperature read by the temperature sensor the target temperature that must change prior to being switched off. For example, if the target temperature is 25 and the tolerance is 0.5 the heater will stop when the sensor equals or goes above 25.5.",
+          "precision": "Can be used to match your actual thermostat's precision.",
+          "target_temp_step": "The desired step size for setting the target temperature."
         }
       },
       "presets": {
@@ -49,7 +53,9 @@
           "cold_tolerance": "[%key:component::generic_thermostat::config::step::user::data::cold_tolerance%]",
           "hot_tolerance": "[%key:component::generic_thermostat::config::step::user::data::hot_tolerance%]",
           "min_temp": "[%key:component::generic_thermostat::config::step::user::data::min_temp%]",
-          "max_temp": "[%key:component::generic_thermostat::config::step::user::data::max_temp%]"
+          "max_temp": "[%key:component::generic_thermostat::config::step::user::data::max_temp%]",
+          "precision": "[%key:component::generic_thermostat::config::step::user::data::precision%]",
+          "target_temp_step": "[%key:component::generic_thermostat::config::step::user::data::target_temp_step%]"
         },
         "data_description": {
           "heater": "[%key:component::generic_thermostat::config::step::user::data_description::heater%]",
@@ -57,7 +63,9 @@
           "ac_mode": "[%key:component::generic_thermostat::config::step::user::data_description::ac_mode%]",
           "min_cycle_duration": "[%key:component::generic_thermostat::config::step::user::data_description::min_cycle_duration%]",
           "cold_tolerance": "[%key:component::generic_thermostat::config::step::user::data_description::cold_tolerance%]",
-          "hot_tolerance": "[%key:component::generic_thermostat::config::step::user::data_description::hot_tolerance%]"
+          "hot_tolerance": "[%key:component::generic_thermostat::config::step::user::data_description::hot_tolerance%]",
+          "precision": "[%key:component::generic_thermostat::config::step::user::data_description::precision%]",
+          "target_temp_step": "[%key:component::generic_thermostat::config::step::user::data_description::target_temp_step%]"
         }
       },
       "presets": {

--- a/tests/components/generic_thermostat/snapshots/test_config_flow.ambr
+++ b/tests/components/generic_thermostat/snapshots/test_config_flow.ambr
@@ -56,23 +56,23 @@
 # name: test_options[with_away]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_temperature': 15.0,
+      'current_temperature': 15.5,
       'friendly_name': 'My thermostat',
       'hvac_action': <HVACAction.OFF: 'off'>,
       'hvac_modes': list([
         <HVACMode.HEAT: 'heat'>,
         <HVACMode.OFF: 'off'>,
       ]),
-      'max_temp': 35,
-      'min_temp': 7,
+      'max_temp': 35.0,
+      'min_temp': 7.0,
       'preset_mode': 'none',
       'preset_modes': list([
         'none',
         'away',
       ]),
       'supported_features': <ClimateEntityFeature: 401>,
-      'target_temp_step': 0.1,
-      'temperature': 7,
+      'target_temp_step': 1.0,
+      'temperature': 7.0,
     }),
     'context': <ANY>,
     'entity_id': 'climate.my_thermostat',
@@ -85,7 +85,7 @@
 # name: test_options[without_away]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'current_temperature': 15.0,
+      'current_temperature': 15.6,
       'friendly_name': 'My thermostat',
       'hvac_action': <HVACAction.OFF: 'off'>,
       'hvac_modes': list([

--- a/tests/components/generic_thermostat/test_config_flow.py
+++ b/tests/components/generic_thermostat/test_config_flow.py
@@ -11,8 +11,10 @@ from homeassistant.components.generic_thermostat.const import (
     CONF_COLD_TOLERANCE,
     CONF_HEATER,
     CONF_HOT_TOLERANCE,
+    CONF_PRECISION,
     CONF_PRESETS,
     CONF_SENSOR,
+    CONF_TEMP_STEP,
     DOMAIN,
 )
 from homeassistant.components.sensor import SensorDeviceClass
@@ -85,6 +87,8 @@ async def test_options(hass: HomeAssistant, snapshot: SnapshotAssertion) -> None
             CONF_AC_MODE: False,
             CONF_COLD_TOLERANCE: 0.3,
             CONF_HOT_TOLERANCE: 0.3,
+            CONF_PRECISION: 0.5,
+            CONF_TEMP_STEP: 1.0,
             CONF_PRESETS[PRESET_AWAY]: 20,
         },
         title="My dehumidifier",
@@ -93,7 +97,7 @@ async def test_options(hass: HomeAssistant, snapshot: SnapshotAssertion) -> None
 
     hass.states.async_set(
         "sensor.temperature",
-        "15",
+        "15.6",
         {
             ATTR_UNIT_OF_MEASUREMENT: UnitOfTemperature.CELSIUS,
             ATTR_DEVICE_CLASS: SensorDeviceClass.TEMPERATURE,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The generic thermostat helper allows the precision and target temp step to be configured when using YAML, but not via the UI. This exposes those two settings in the UI as well.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
