### PR TITLE
Reolink playback mutex

### DIFF
--- a/homeassistant/components/reolink/views.py
+++ b/homeassistant/components/reolink/views.py
@@ -47,6 +47,7 @@ class PlaybackProxyView(HomeAssistantView):
     def __init__(self, hass: HomeAssistant) -> None:
         """Initialize a proxy view."""
         self.hass = hass
+        _LOGGER.error("TEST")
         self.session = async_get_clientsession(
             hass,
             verify_ssl=False,
@@ -85,7 +86,7 @@ class PlaybackProxyView(HomeAssistantView):
 
         if _LOGGER.isEnabledFor(logging.DEBUG):
             _LOGGER.debug(
-                "Opening VOD stream from %s: %s",
+                "Opening proxy VOD stream from %s: %s",
                 host.api.camera_name(ch),
                 host.api.hide_password(reolink_url),
             )

--- a/homeassistant/components/reolink/views.py
+++ b/homeassistant/components/reolink/views.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
 from base64 import urlsafe_b64decode, urlsafe_b64encode
 from http import HTTPStatus
 import logging
-import asyncio
 
 from aiohttp import ClientError, ClientTimeout, web
 from reolink_aio.enums import VodRequestType
@@ -112,7 +112,13 @@ class PlaybackProxyView(HomeAssistantView):
                 await host.api.expire_session(unsubscribe=False)
                 self._download_mutex.release()
                 return await self.get(
-                    request, config_entry_id, channel, stream_res, vod_type, filename, retry
+                    request,
+                    config_entry_id,
+                    channel,
+                    stream_res,
+                    vod_type,
+                    filename,
+                    retry,
                 )
 
             # Reolink typo "apolication/octet-stream" instead of "application/octet-stream"
@@ -150,6 +156,6 @@ class PlaybackProxyView(HomeAssistantView):
             reolink_response.release()
             await response.write_eof()
         finally:
-            if self._download_mutex.locked()
+            if self._download_mutex.locked():
                 self._download_mutex.release()
         return response


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add a mutex to the downloading of playback files from a reolink camera.
Some Reolink cameras dont handle it well if mutiple files are downloaded simultaniously, besides it will not be faster to download in parralel vs sequentially since you are limited by the SD card speed and ethernet speed anyways.

If two playbacks are opend at the same time, one will start downloading emidiately (spinning icon in the UI with the playback bar filling up to fully grey), the other will wait (spinning icon) untill the first one finishes and then starts downloading (spinning icon with playback bar filling up).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/issues/137167
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
