### PR TITLE
Add async_setup_config_entry_backup_listeners to backup utils

### DIFF
--- a/homeassistant/components/backup/__init__.py
+++ b/homeassistant/components/backup/__init__.py
@@ -39,9 +39,9 @@ from .manager import (
 )
 from .models import AddonInfo, AgentBackup, BackupNotFound, Folder
 from .util import (
+    async_setup_config_entry_backup_listeners,
     suggested_filename,
     suggested_filename_from_name_date,
-    async_setup_config_entry_backup_listeners,
 )
 from .websocket import async_register_websocket_handlers
 
@@ -135,4 +135,4 @@ def async_get_manager(hass: HomeAssistant) -> BackupManager:
     if DATA_MANAGER not in hass.data:
         raise HomeAssistantError("Backup integration is not available")
 
-    retur
+    return hass.data[DATA_MANAGER]

--- a/homeassistant/components/backup/__init__.py
+++ b/homeassistant/components/backup/__init__.py
@@ -38,7 +38,11 @@ from .manager import (
     WrittenBackup,
 )
 from .models import AddonInfo, AgentBackup, BackupNotFound, Folder
-from .util import suggested_filename, suggested_filename_from_name_date
+from .util import (
+    suggested_filename,
+    suggested_filename_from_name_date,
+    async_setup_config_entry_backup_listeners,
+)
 from .websocket import async_register_websocket_handlers
 
 __all__ = [
@@ -66,6 +70,7 @@ __all__ = [
     "RestoreBackupState",
     "WrittenBackup",
     "async_get_manager",
+    "async_setup_config_entry_backup_listeners",
     "suggested_filename",
     "suggested_filename_from_name_date",
 ]
@@ -130,4 +135,4 @@ def async_get_manager(hass: HomeAssistant) -> BackupManager:
     if DATA_MANAGER not in hass.data:
         raise HomeAssistantError("Backup integration is not available")
 
-    return hass.data[DATA_MANAGER]
+    retur

--- a/homeassistant/components/backup/__init__.py
+++ b/homeassistant/components/backup/__init__.py
@@ -39,7 +39,7 @@ from .manager import (
 )
 from .models import AddonInfo, AgentBackup, BackupNotFound, Folder
 from .util import (
-    async_setup_config_entry_backup_listeners,
+    async_setup_config_entry_backup_agents_listeners,
     suggested_filename,
     suggested_filename_from_name_date,
 )
@@ -70,7 +70,7 @@ __all__ = [
     "RestoreBackupState",
     "WrittenBackup",
     "async_get_manager",
-    "async_setup_config_entry_backup_listeners",
+    "async_setup_config_entry_backup_agents_listeners",
     "suggested_filename",
     "suggested_filename_from_name_date",
 ]

--- a/homeassistant/components/backup/util.py
+++ b/homeassistant/components/backup/util.py
@@ -606,7 +606,7 @@ async def receive_file(
 def async_setup_config_entry_backup_agents_listeners(
     hass: HomeAssistant,
     integration_domain: str,
-    hass_key: HassKey,
+    backup_agents_listeners: list[Callable[[], None]],
 ) -> None:
     """Set up backup listeners for a config entry.
 

--- a/homeassistant/components/backup/util.py
+++ b/homeassistant/components/backup/util.py
@@ -624,10 +624,14 @@ def async_setup_config_entry_backup_listeners(
     def async_on_config_entry_changed(
         change: ConfigEntryChange,
         entry: ConfigEntry,
+        old_state: ConfigEntryState | None,
     ) -> None:
         if change != ConfigEntryChange.UPDATED or entry.domain != integration_domain:
             return
-        if entry.state not in (ConfigEntryState.LOADED, ConfigEntryState.NOT_LOADED):
+        if entry.state is old_state or (
+            entry.state is not ConfigEntryState.LOADED
+            and old_state is not ConfigEntryState.LOADED
+        ):
             return
         async_notify_backup_listeners(hass)
 

--- a/homeassistant/components/backup/util.py
+++ b/homeassistant/components/backup/util.py
@@ -610,10 +610,7 @@ def async_setup_config_entry_backup_agents_listeners(
 ) -> None:
     """Set up backup listeners for a config entry.
 
-    We need a get the config entry during async_get_backup_agents through hass.config_entries.async_loaded_entries).
-    Since we want to ensure the entry is in that list during load and not in that list during unload.
-    Since we would call the listeners during setup_/unload_entry, this poses a race,
-    so we need to listen for config entry changes and notify the backup listeners when a config entry changes state from LOADED.
+    Integrations can't call the backup agents listeners from the integration's `async_setup_entry`, because the config entry's state is not changed to `ConfigEntryState.LOADED` until after `async_setup_entry` return. This helper listens to config entry state changes, and calls the listeners when a config entry changes to or from state `ConfigEntryState.LOADED`.
     """
 
     def async_notify_backup_listeners(hass: HomeAssistant) -> None:

--- a/homeassistant/components/backup/util.py
+++ b/homeassistant/components/backup/util.py
@@ -603,7 +603,7 @@ async def receive_file(
             await fut
 
 
-def async_setup_config_entry_backup_listeners(
+def async_setup_config_entry_backup_agents_listeners(
     hass: HomeAssistant,
     integration_domain: str,
     hass_key: HassKey,

--- a/homeassistant/components/backup/util.py
+++ b/homeassistant/components/backup/util.py
@@ -30,7 +30,6 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.util import dt as dt_util
-from homeassistant.util.hass_dict import HassKey
 from homeassistant.util.json import JsonObjectType, json_loads_object
 
 from .const import BUF_SIZE, LOGGER
@@ -608,14 +607,13 @@ def async_setup_config_entry_backup_agents_listeners(
     integration_domain: str,
     backup_agents_listeners: list[Callable[[], None]],
 ) -> None:
-    """Set up backup listeners for a config entry.
+    """Call backup agents listeners when a config entry is loaded or unloaded.
 
-    Integrations can't call the backup agents listeners from the integration's `async_setup_entry`, because the config entry's state is not changed to `ConfigEntryState.LOADED` until after `async_setup_entry` return. This helper listens to config entry state changes, and calls the listeners when a config entry changes to or from state `ConfigEntryState.LOADED`.
+    Integrations can't call the backup agents listeners from the integration's `async_setup_entry`,
+    because the config entry's state is not changed to `ConfigEntryState.LOADED` until after `async_setup_entry` return.
+    This helper listens to config entry state changes,
+    and calls the listeners when a config entry changes to or from state `ConfigEntryState.LOADED`.
     """
-
-    def async_notify_backup_listeners(hass: HomeAssistant) -> None:
-        for listener in hass.data.get(hass_key, []):
-            listener()
 
     @callback
     def async_on_config_entry_changed(
@@ -630,7 +628,8 @@ def async_setup_config_entry_backup_agents_listeners(
             and old_state is not ConfigEntryState.LOADED
         ):
             return
-        async_notify_backup_listeners(hass)
+        for listener in backup_agents_listeners:
+            listener()
 
     async_dispatcher_connect(
         hass,

--- a/homeassistant/components/config/config_entries.py
+++ b/homeassistant/components/config/config_entries.py
@@ -582,7 +582,9 @@ async def config_entries_subscribe(
 
     @callback
     def async_forward_config_entry_changes(
-        change: config_entries.ConfigEntryChange, entry: config_entries.ConfigEntry
+        change: config_entries.ConfigEntryChange,
+        entry: config_entries.ConfigEntry,
+        state: config_entries.ConfigEntryState | None = None,
     ) -> None:
         """Forward config entry state events to websocket."""
         if type_filter:

--- a/homeassistant/components/onedrive/__init__.py
+++ b/homeassistant/components/onedrive/__init__.py
@@ -15,7 +15,9 @@ from onedrive_personal_sdk.exceptions import (
 )
 from onedrive_personal_sdk.models.items import ItemUpdate
 
-from homeassistant.components.backup import async_setup_config_entry_backup_listeners
+from homeassistant.components.backup import (
+    async_setup_config_entry_backup_agents_listeners,
+)
 from homeassistant.const import CONF_ACCESS_TOKEN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
@@ -25,6 +27,7 @@ from homeassistant.helpers.config_entry_oauth2_flow import (
     async_get_config_entry_implementation,
 )
 from homeassistant.helpers.instance_id import async_get as async_get_instance_id
+from homeassistant.helpers.typing import ConfigType
 
 from .const import DATA_BACKUP_AGENT_LISTENERS, DOMAIN
 from .coordinator import (
@@ -37,6 +40,14 @@ PLATFORMS = [Platform.SENSOR]
 
 
 _LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up the OneDrive component."""
+    async_setup_config_entry_backup_agents_listeners(
+        hass, DOMAIN, hass.data.get(DATA_BACKUP_AGENT_LISTENERS, [])
+    )
+    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: OneDriveConfigEntry) -> bool:
@@ -98,7 +109,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: OneDriveConfigEntry) -> 
         ) from err
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-    async_setup_config_entry_backup_listeners(hass, DOMAIN, DATA_BACKUP_AGENT_LISTENERS)
 
     return True
 

--- a/homeassistant/components/onedrive/__init__.py
+++ b/homeassistant/components/onedrive/__init__.py
@@ -25,6 +25,8 @@ from homeassistant.helpers.config_entry_oauth2_flow import (
 )
 from homeassistant.helpers.instance_id import async_get as async_get_instance_id
 
+from homeassistant.components.backup import async_setup_config_entry_backup_listeners
+
 from .const import DATA_BACKUP_AGENT_LISTENERS, DOMAIN
 from .coordinator import (
     OneDriveConfigEntry,
@@ -96,54 +98,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: OneDriveConfigEntry) -> 
             translation_key="failed_to_migrate_files",
         ) from err
 
-    _async_notify_backup_listeners_soon(hass)
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    async_setup_config_entry_backup_listeners(hass, DOMAIN, DATA_BACKUP_AGENT_LISTENERS)
 
     return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: OneDriveConfigEntry) -> bool:
     """Unload a OneDrive config entry."""
-    _async_notify_backup_listeners_soon(hass)
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-
-
-def _async_notify_backup_listeners(hass: HomeAssistant) -> None:
-    for listener in hass.data.get(DATA_BACKUP_AGENT_LISTENERS, []):
-        listener()
-
-
-@callback
-def _async_notify_backup_listeners_soon(hass: HomeAssistant) -> None:
-    hass.loop.call_soon(_async_notify_backup_listeners, hass)
 
 
 async def _migrate_backup_files(client: OneDriveClient, backup_folder_id: str) -> None:
     """Migrate backup files to metadata version 2."""
     files = await client.list_drive_items(backup_folder_id)
-    for file in files:
-        if file.description and '"metadata_version": 1' in (
-            metadata_json := unescape(file.description)
-        ):
-            metadata = loads(metadata_json)
-            del metadata["metadata_version"]
-            metadata_filename = file.name.rsplit(".", 1)[0] + ".metadata.json"
-            metadata_file = await client.upload_file(
-                backup_folder_id,
-                metadata_filename,
-                dumps(metadata),
-            )
-            metadata_description = {
-                "metadata_version": 2,
-                "backup_id": metadata["backup_id"],
-                "backup_file_id": file.id,
-            }
-            await client.update_drive_item(
-                path_or_id=metadata_file.id,
-                data=ItemUpdate(description=dumps(metadata_description)),
-            )
-            await client.update_drive_item(
-                path_or_id=file.id,
-                data=ItemUpdate(description=""),
-            )
-            _LOGGER.debug("Migrated backup file %s", file.name)

--- a/homeassistant/components/onedrive/__init__.py
+++ b/homeassistant/components/onedrive/__init__.py
@@ -137,4 +137,3 @@ async def _migrate_backup_files(client: OneDriveClient, backup_folder_id: str) -
                 data=ItemUpdate(description=""),
             )
             _LOGGER.debug("Migrated backup file %s", file.name)
-    files = await client.list_drive_items(backup_folder_id)

--- a/homeassistant/components/onedrive/__init__.py
+++ b/homeassistant/components/onedrive/__init__.py
@@ -21,6 +21,7 @@ from homeassistant.components.backup import (
 from homeassistant.const import CONF_ACCESS_TOKEN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.config_entry_oauth2_flow import (
     OAuth2Session,
@@ -35,6 +36,8 @@ from .coordinator import (
     OneDriveRuntimeData,
     OneDriveUpdateCoordinator,
 )
+
+CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 PLATFORMS = [Platform.SENSOR]
 

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1253,9 +1253,7 @@ class ConfigEntry[_DataT = Any]:
         )
 
     @callback
-    def async_create_task[
-        _R
-    ](
+    def async_create_task[_R](
         self,
         hass: HomeAssistant,
         target: Coroutine[Any, Any, _R],
@@ -1279,9 +1277,7 @@ class ConfigEntry[_DataT = Any]:
         return task
 
     @callback
-    def async_create_background_task[
-        _R
-    ](
+    def async_create_background_task[_R](
         self,
         hass: HomeAssistant,
         target: Coroutine[Any, Any, _R],
@@ -1635,9 +1631,9 @@ class ConfigEntriesFlowManager(
         if existing_entry is not None:
             # Unload and remove the existing entry, but don't clean up devices and
             # entities until the new entry is added
-            await self.config_entries._async_remove(
+            await self.config_entries._async_remove(  # noqa: SLF001
                 existing_entry.entry_id
-            )  # noqa: SLF001
+            )
         await self.config_entries.async_add(entry)
 
         if existing_entry is not None:

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1253,7 +1253,9 @@ class ConfigEntry[_DataT = Any]:
         )
 
     @callback
-    def async_create_task[_R](
+    def async_create_task[
+        _R
+    ](
         self,
         hass: HomeAssistant,
         target: Coroutine[Any, Any, _R],
@@ -1277,7 +1279,9 @@ class ConfigEntry[_DataT = Any]:
         return task
 
     @callback
-    def async_create_background_task[_R](
+    def async_create_background_task[
+        _R
+    ](
         self,
         hass: HomeAssistant,
         target: Coroutine[Any, Any, _R],
@@ -1631,7 +1635,9 @@ class ConfigEntriesFlowManager(
         if existing_entry is not None:
             # Unload and remove the existing entry, but don't clean up devices and
             # entities until the new entry is added
-            await self.config_entries._async_remove(existing_entry.entry_id)
+            await self.config_entries._async_remove(
+                existing_entry.entry_id
+            )  # noqa: SLF001
         await self.config_entries.async_add(entry)
 
         if existing_entry is not None:
@@ -2516,7 +2522,7 @@ class ConfigEntries:
     ) -> None:
         """Dispatch a config entry change."""
         async_dispatcher_send_internal(
-            self.hass, SIGNAL_CONFIG_ENTRY_CHANGED, change_type, entry
+            self.hass, SIGNAL_CONFIG_ENTRY_CHANGED, change_type, entry, None
         )
 
     async def async_forward_entry_setups(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adding `async_setup_config_entry_backup_listeners` to make sure we avoid race conditions during backup setup / onloading in the call to `hass.config_entries.async_loaded_entries` in `async_get_backup_agents`. This is achieved by registering the listener calls with the dispatcher. 
Also, we're changing the `SIGNAL_CONFIG_ENTRY_CHANGED` in the config entry to be able to distinguish if the state change is one we want to trigger on.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
