### PR TITLE
Fix variable scopes in scripts

### DIFF
--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -12,7 +12,6 @@ from datetime import datetime, timedelta
 from functools import partial
 import itertools
 import logging
-from types import MappingProxyType
 from typing import Any, Literal, TypedDict, cast, overload
 
 import async_interrupt
@@ -90,7 +89,7 @@ from . import condition, config_validation as cv, service, template
 from .condition import ConditionCheckerType, trace_condition_function
 from .dispatcher import async_dispatcher_connect, async_dispatcher_send_internal
 from .event import async_call_later, async_track_template
-from .script_variables import ScriptVariables
+from .script_variables import ScriptRunVariables, ScriptVariables
 from .template import Template
 from .trace import (
     TraceElement,
@@ -177,7 +176,7 @@ def _set_result_unless_done(future: asyncio.Future[None]) -> None:
         future.set_result(None)
 
 
-def action_trace_append(variables: dict[str, Any], path: str) -> TraceElement:
+def action_trace_append(variables: TemplateVarsType, path: str) -> TraceElement:
     """Append a TraceElement to trace[path]."""
     trace_element = TraceElement(variables, path)
     trace_append_element(trace_element, ACTION_TRACE_NODE_MAX_LEN)
@@ -189,7 +188,7 @@ async def trace_action(
     hass: HomeAssistant,
     script_run: _ScriptRun,
     stop: asyncio.Future[None],
-    variables: dict[str, Any],
+    variables: TemplateVarsType,
 ) -> AsyncGenerator[TraceElement]:
     """Trace action execution."""
     path = trace_path_get()
@@ -411,7 +410,7 @@ class _ScriptRun:
         self,
         hass: HomeAssistant,
         script: Script,
-        variables: dict[str, Any],
+        variables: ScriptRunVariables,
         context: Context | None,
         log_exceptions: bool,
     ) -> None:
@@ -485,14 +484,16 @@ class _ScriptRun:
             script_stack.pop()
             self._finish()
 
-        return ScriptRunResult(self._conversation_response, response, self._variables)
+        return ScriptRunResult(
+            self._conversation_response, response, self._variables.local_scope
+        )
 
     async def _async_step(self, log_exceptions: bool) -> None:
         continue_on_error = self._action.get(CONF_CONTINUE_ON_ERROR, False)
 
         with trace_path(str(self._step)):
             async with trace_action(
-                self._hass, self, self._stop, self._variables
+                self._hass, self, self._stop, self._variables.non_parallel_scope
             ) as trace_element:
                 if self._stop.done():
                     return
@@ -526,7 +527,7 @@ class _ScriptRun:
                         ex, continue_on_error, self._log_exceptions or log_exceptions
                     )
                 finally:
-                    trace_element.update_variables(self._variables)
+                    trace_element.update_variables(self._variables.non_parallel_scope)
 
     def _finish(self) -> None:
         self._script._runs.remove(self)  # noqa: SLF001
@@ -624,11 +625,14 @@ class _ScriptRun:
         except ScriptStoppedError as ex:
             raise asyncio.CancelledError from ex
 
-    async def _async_run_script(self, script: Script) -> None:
+    async def _async_run_script(
+        self, script: Script, *, parallel: bool = False
+    ) -> None:
         """Execute a script."""
         result = await self._async_run_long_action(
             self._hass.async_create_task_internal(
-                script.async_run(self._variables, self._context), eager_start=True
+                script.async_run(self._variables.enter_scope(parallel), self._context),
+                eager_start=True,
             )
         )
         if result and result.conversation_response is not UNDEFINED:
@@ -647,7 +651,7 @@ class _ScriptRun:
             """Run a script with a trace path."""
             trace_path_stack_cv.set(copy(trace_path_stack_cv.get()))
             with trace_path([str(idx), "sequence"]):
-                await self._async_run_script(script)
+                await self._async_run_script(script, parallel=True)
 
         results = await asyncio.gather(
             *(async_run_with_trace(idx, script) for idx, script in enumerate(scripts)),
@@ -766,7 +770,7 @@ class _ScriptRun:
         description = self._action.get(CONF_ALIAS, "sequence")
         repeat = self._action[CONF_REPEAT]
 
-        saved_repeat_vars = self._variables.get("repeat")
+        self._variables = self._variables.enter_scope()
 
         def set_repeat_var(
             iteration: int, count: int | None = None, item: Any = None
@@ -776,7 +780,7 @@ class _ScriptRun:
                 repeat_vars["last"] = iteration == count
             if item is not None:
                 repeat_vars["item"] = item
-            self._variables["repeat"] = repeat_vars
+            self._variables.define_single("repeat", repeat_vars)
 
         script = self._script._get_repeat_script(self._step)  # noqa: SLF001
         warned_too_many_loops = False
@@ -927,10 +931,7 @@ class _ScriptRun:
                 # while all the cpu time is consumed.
                 await asyncio.sleep(0)
 
-        if saved_repeat_vars:
-            self._variables["repeat"] = saved_repeat_vars
-        else:
-            self._variables.pop("repeat", None)  # Not set if count = 0
+        self._variables = self._variables.exit_scope()
 
     ### Stop actions ###
 
@@ -959,11 +960,9 @@ class _ScriptRun:
     ## Variable actions ##
 
     async def _async_step_variables(self) -> None:
-        """Set a variable value."""
-        self._step_log("setting variables")
-        self._variables = self._action[CONF_VARIABLES].async_render(
-            self._hass, self._variables, render_as_defaults=False
-        )
+        """Define a local variable."""
+        self._step_log("defining local variables")
+        self._variables.define(self._action[CONF_VARIABLES])
 
     ## External actions ##
 
@@ -1016,7 +1015,7 @@ class _ScriptRun:
         """Perform the device automation specified in the action."""
         self._step_log("device automation")
         await device_action.async_call_action_from_config(
-            self._hass, self._action, self._variables, self._context
+            self._hass, self._action, dict(self._variables), self._context
         )
 
     async def _async_step_event(self) -> None:
@@ -1189,12 +1188,16 @@ class _ScriptRun:
 
         self._step_log("wait for trigger", timeout)
 
-        variables = {**self._variables}
-        self._variables["wait"] = {
-            "remaining": timeout,
-            "completed": False,
-            "trigger": None,
-        }
+        variables = dict(self._variables)
+        self._variables.assign_single(
+            "wait",
+            {
+                "remaining": timeout,
+                "completed": False,
+                "trigger": None,
+            },
+            parallel_copy=True,
+        )
         trace_set_result(wait=self._variables["wait"])
 
         if timeout == 0:
@@ -1240,7 +1243,9 @@ class _ScriptRun:
         timeout = self._get_timeout_seconds_from_action()
         self._step_log("wait template", timeout)
 
-        self._variables["wait"] = {"remaining": timeout, "completed": False}
+        self._variables.assign_single(
+            "wait", {"remaining": timeout, "completed": False}, parallel_copy=True
+        )
         trace_set_result(wait=self._variables["wait"])
 
         wait_template = self._action[CONF_WAIT_TEMPLATE]
@@ -1369,7 +1374,7 @@ async def _async_stop_scripts_at_shutdown(hass: HomeAssistant, event: Event) -> 
         )
 
 
-type _VarsType = dict[str, Any] | Mapping[str, Any] | MappingProxyType[str, Any]
+type _VarsType = dict[str, Any] | Mapping[str, Any] | ScriptRunVariables
 
 
 def _referenced_extract_ids(data: Any, key: str, found: set[str]) -> None:
@@ -1407,7 +1412,7 @@ class ScriptRunResult:
 
     conversation_response: str | None | UndefinedType
     service_response: ServiceResponse
-    variables: dict[str, Any]
+    variables: Mapping[str, Any]
 
 
 class Script:
@@ -1422,7 +1427,6 @@ class Script:
         *,
         # Used in "Running <running_description>" log message
         change_listener: Callable[[], Any] | None = None,
-        copy_variables: bool = False,
         log_exceptions: bool = True,
         logger: logging.Logger | None = None,
         max_exceeded: str = DEFAULT_MAX_EXCEEDED,
@@ -1476,8 +1480,6 @@ class Script:
         self._parallel_scripts: dict[int, list[Script]] = {}
         self._sequence_scripts: dict[int, Script] = {}
         self.variables = variables
-        self._variables_dynamic = template.is_complex(variables)
-        self._copy_variables_on_run = copy_variables
 
     @property
     def change_listener(self) -> Callable[..., Any] | None:
@@ -1755,25 +1757,19 @@ class Script:
         if self.top_level:
             if self.variables:
                 try:
-                    variables = self.variables.async_render(
+                    run_variables = self.variables.async_render(
                         self._hass,
                         run_variables,
                     )
                 except exceptions.TemplateError as err:
                     self._log("Error rendering variables: %s", err, level=logging.ERROR)
                     raise
-            elif run_variables:
-                variables = dict(run_variables)
-            else:
-                variables = {}
 
+            variables = ScriptRunVariables.create_top_level(run_variables)
             variables["context"] = context
-        elif self._copy_variables_on_run:
-            # This is not the top level script, variables have been turned to a dict
-            variables = cast(dict[str, Any], copy(run_variables))
         else:
-            # This is not the top level script, variables have been turned to a dict
-            variables = cast(dict[str, Any], run_variables)
+            # This is not the top level script, run_variables is an instance of ScriptRunVariables
+            variables = cast(ScriptRunVariables, run_variables)
 
         # Prevent non-allowed recursive calls which will cause deadlocks when we try to
         # stop (restart) or wait for (queued) our own script run.
@@ -1999,7 +1995,6 @@ class Script:
                 max_runs=self.max_runs,
                 logger=self._logger,
                 top_level=False,
-                copy_variables=True,
             )
             parallel_script.change_listener = partial(
                 self._chain_change_listener, parallel_script

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -766,9 +766,8 @@ class _ScriptRun:
             with trace_path("else"):
                 await self._async_run_script(if_data["if_else"])
 
-    @async_trace_path("repeat")
-    async def _async_step_repeat(self) -> None:  # noqa: C901
-        """Repeat a sequence."""
+    async def _async_do_step_repeat(self) -> None:  # noqa: C901
+        """Repeat a sequence helper."""
         description = self._action.get(CONF_ALIAS, "sequence")
         repeat = self._action[CONF_REPEAT]
 
@@ -780,7 +779,7 @@ class _ScriptRun:
                 repeat_vars["last"] = iteration == count
             if item is not None:
                 repeat_vars["item"] = item
-            self._variables.define_single("repeat", repeat_vars)
+            self._variables.define_local("repeat", repeat_vars)
 
         script = self._script._get_repeat_script(self._step)  # noqa: SLF001
         warned_too_many_loops = False
@@ -790,153 +789,153 @@ class _ScriptRun:
             with trace_path("sequence"):
                 await self._async_run_script(script)
 
-        self._variables = self._variables.enter_scope()
-        try:  # pylint: disable=too-many-nested-blocks
-            if CONF_COUNT in repeat:
-                count = repeat[CONF_COUNT]
-                if isinstance(count, template.Template):
-                    try:
-                        count = int(count.async_render(self._variables))
-                    except (exceptions.TemplateError, ValueError) as ex:
-                        self._log(
-                            "Error rendering %s repeat count template: %s",
-                            self._script.name,
-                            ex,
-                            level=logging.ERROR,
-                        )
-                        raise _AbortScript from ex
-                extra_msg = f" of {count}"
-                for iteration in range(1, count + 1):
-                    set_repeat_var(iteration, count)
-                    await async_run_sequence(iteration, extra_msg)
-                    if self._stop.done():
-                        break
-
-            elif CONF_FOR_EACH in repeat:
+        if CONF_COUNT in repeat:
+            count = repeat[CONF_COUNT]
+            if isinstance(count, template.Template):
                 try:
-                    items = template.render_complex(
-                        repeat[CONF_FOR_EACH], self._variables
-                    )
+                    count = int(count.async_render(self._variables))
                 except (exceptions.TemplateError, ValueError) as ex:
                     self._log(
-                        "Error rendering %s repeat for each items template: %s",
+                        "Error rendering %s repeat count template: %s",
                         self._script.name,
                         ex,
                         level=logging.ERROR,
                     )
                     raise _AbortScript from ex
+            extra_msg = f" of {count}"
+            for iteration in range(1, count + 1):
+                set_repeat_var(iteration, count)
+                await async_run_sequence(iteration, extra_msg)
+                if self._stop.done():
+                    break
 
-                if not isinstance(items, list):
-                    self._log(
-                        "Repeat 'for_each' must be a list of items in %s, got: %s",
-                        self._script.name,
-                        items,
-                        level=logging.ERROR,
-                    )
-                    raise _AbortScript("Repeat 'for_each' must be a list of items")
+        elif CONF_FOR_EACH in repeat:
+            try:
+                items = template.render_complex(repeat[CONF_FOR_EACH], self._variables)
+            except (exceptions.TemplateError, ValueError) as ex:
+                self._log(
+                    "Error rendering %s repeat for each items template: %s",
+                    self._script.name,
+                    ex,
+                    level=logging.ERROR,
+                )
+                raise _AbortScript from ex
 
-                count = len(items)
-                for iteration, item in enumerate(items, 1):
-                    set_repeat_var(iteration, count, item)
-                    extra_msg = f" of {count} with item: {item!r}"
+            if not isinstance(items, list):
+                self._log(
+                    "Repeat 'for_each' must be a list of items in %s, got: %s",
+                    self._script.name,
+                    items,
+                    level=logging.ERROR,
+                )
+                raise _AbortScript("Repeat 'for_each' must be a list of items")
+
+            count = len(items)
+            for iteration, item in enumerate(items, 1):
+                set_repeat_var(iteration, count, item)
+                extra_msg = f" of {count} with item: {item!r}"
+                if self._stop.done():
+                    break
+                await async_run_sequence(iteration, extra_msg)
+
+        elif CONF_WHILE in repeat:
+            conditions = [
+                await self._async_get_condition(config) for config in repeat[CONF_WHILE]
+            ]
+            for iteration in itertools.count(1):
+                set_repeat_var(iteration)
+                try:
                     if self._stop.done():
                         break
-                    await async_run_sequence(iteration, extra_msg)
-
-            elif CONF_WHILE in repeat:
-                conditions = [
-                    await self._async_get_condition(config)
-                    for config in repeat[CONF_WHILE]
-                ]
-                for iteration in itertools.count(1):
-                    set_repeat_var(iteration)
-                    try:
-                        if self._stop.done():
-                            break
-                        if not self._test_conditions(conditions, "while"):
-                            break
-                    except exceptions.ConditionError as ex:
-                        _LOGGER.warning("Error in 'while' evaluation:\n%s", ex)
+                    if not self._test_conditions(conditions, "while"):
                         break
+                except exceptions.ConditionError as ex:
+                    _LOGGER.warning("Error in 'while' evaluation:\n%s", ex)
+                    break
 
-                    if iteration > 1:
-                        if iteration > REPEAT_WARN_ITERATIONS:
-                            if not warned_too_many_loops:
-                                warned_too_many_loops = True
-                                _LOGGER.warning(
-                                    "While condition %s in script `%s` looped %s times",
-                                    repeat[CONF_WHILE],
-                                    self._script.name,
-                                    REPEAT_WARN_ITERATIONS,
-                                )
-
-                            if iteration > REPEAT_TERMINATE_ITERATIONS:
-                                _LOGGER.critical(
-                                    "While condition %s in script `%s` "
-                                    "terminated because it looped %s times",
-                                    repeat[CONF_WHILE],
-                                    self._script.name,
-                                    REPEAT_TERMINATE_ITERATIONS,
-                                )
-                                raise _AbortScript(
-                                    f"While condition {repeat[CONF_WHILE]} "
-                                    "terminated because it looped "
-                                    f" {REPEAT_TERMINATE_ITERATIONS} times"
-                                )
-
-                        # If the user creates a script with a tight loop,
-                        # yield to the event loop so the system stays
-                        # responsive while all the cpu time is consumed.
-                        await asyncio.sleep(0)
-
-                    await async_run_sequence(iteration)
-
-            elif CONF_UNTIL in repeat:
-                conditions = [
-                    await self._async_get_condition(config)
-                    for config in repeat[CONF_UNTIL]
-                ]
-                for iteration in itertools.count(1):
-                    set_repeat_var(iteration)
-                    await async_run_sequence(iteration)
-                    try:
-                        if self._stop.done():
-                            break
-                        if self._test_conditions(conditions, "until") in [True, None]:
-                            break
-                    except exceptions.ConditionError as ex:
-                        _LOGGER.warning("Error in 'until' evaluation:\n%s", ex)
-                        break
-
-                    if iteration >= REPEAT_WARN_ITERATIONS:
+                if iteration > 1:
+                    if iteration > REPEAT_WARN_ITERATIONS:
                         if not warned_too_many_loops:
                             warned_too_many_loops = True
                             _LOGGER.warning(
-                                "Until condition %s in script `%s` looped %s times",
-                                repeat[CONF_UNTIL],
+                                "While condition %s in script `%s` looped %s times",
+                                repeat[CONF_WHILE],
                                 self._script.name,
                                 REPEAT_WARN_ITERATIONS,
                             )
 
-                        if iteration >= REPEAT_TERMINATE_ITERATIONS:
+                        if iteration > REPEAT_TERMINATE_ITERATIONS:
                             _LOGGER.critical(
-                                "Until condition %s in script `%s` "
+                                "While condition %s in script `%s` "
                                 "terminated because it looped %s times",
-                                repeat[CONF_UNTIL],
+                                repeat[CONF_WHILE],
                                 self._script.name,
                                 REPEAT_TERMINATE_ITERATIONS,
                             )
                             raise _AbortScript(
-                                f"Until condition {repeat[CONF_UNTIL]} "
+                                f"While condition {repeat[CONF_WHILE]} "
                                 "terminated because it looped "
-                                f"{REPEAT_TERMINATE_ITERATIONS} times"
+                                f" {REPEAT_TERMINATE_ITERATIONS} times"
                             )
 
                     # If the user creates a script with a tight loop,
-                    # yield to the event loop so the system stays responsive
-                    # while all the cpu time is consumed.
+                    # yield to the event loop so the system stays
+                    # responsive while all the cpu time is consumed.
                     await asyncio.sleep(0)
 
+                await async_run_sequence(iteration)
+
+        elif CONF_UNTIL in repeat:
+            conditions = [
+                await self._async_get_condition(config) for config in repeat[CONF_UNTIL]
+            ]
+            for iteration in itertools.count(1):
+                set_repeat_var(iteration)
+                await async_run_sequence(iteration)
+                try:
+                    if self._stop.done():
+                        break
+                    if self._test_conditions(conditions, "until") in [True, None]:
+                        break
+                except exceptions.ConditionError as ex:
+                    _LOGGER.warning("Error in 'until' evaluation:\n%s", ex)
+                    break
+
+                if iteration >= REPEAT_WARN_ITERATIONS:
+                    if not warned_too_many_loops:
+                        warned_too_many_loops = True
+                        _LOGGER.warning(
+                            "Until condition %s in script `%s` looped %s times",
+                            repeat[CONF_UNTIL],
+                            self._script.name,
+                            REPEAT_WARN_ITERATIONS,
+                        )
+
+                    if iteration >= REPEAT_TERMINATE_ITERATIONS:
+                        _LOGGER.critical(
+                            "Until condition %s in script `%s` "
+                            "terminated because it looped %s times",
+                            repeat[CONF_UNTIL],
+                            self._script.name,
+                            REPEAT_TERMINATE_ITERATIONS,
+                        )
+                        raise _AbortScript(
+                            f"Until condition {repeat[CONF_UNTIL]} "
+                            "terminated because it looped "
+                            f"{REPEAT_TERMINATE_ITERATIONS} times"
+                        )
+
+                # If the user creates a script with a tight loop,
+                # yield to the event loop so the system stays responsive
+                # while all the cpu time is consumed.
+                await asyncio.sleep(0)
+
+    @async_trace_path("repeat")
+    async def _async_step_repeat(self) -> None:
+        """Repeat a sequence."""
+        self._variables = self._variables.enter_scope()
+        try:
+            await self._async_do_step_repeat()
         finally:
             self._variables = self._variables.exit_scope()
 
@@ -969,7 +968,10 @@ class _ScriptRun:
     async def _async_step_variables(self) -> None:
         """Define a local variable."""
         self._step_log("defining local variables")
-        self._variables.define(self._action[CONF_VARIABLES])
+        for key, value in (
+            self._action[CONF_VARIABLES].async_simple_render(self._variables).items()
+        ):
+            self._variables.define_local(key, value)
 
     ## External actions ##
 
@@ -1196,14 +1198,14 @@ class _ScriptRun:
         self._step_log("wait for trigger", timeout)
 
         variables = dict(self._variables)
-        self._variables.assign_single(
+        self._variables.assign(
             "wait",
             {
                 "remaining": timeout,
                 "completed": False,
                 "trigger": None,
             },
-            parallel_special=True,
+            parallel_protected=True,
         )
         trace_set_result(wait=self._variables["wait"])
 
@@ -1250,8 +1252,8 @@ class _ScriptRun:
         timeout = self._get_timeout_seconds_from_action()
         self._step_log("wait template", timeout)
 
-        self._variables.assign_single(
-            "wait", {"remaining": timeout, "completed": False}, parallel_special=True
+        self._variables.assign(
+            "wait", {"remaining": timeout, "completed": False}, parallel_protected=True
         )
         trace_set_result(wait=self._variables["wait"])
 

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -631,7 +631,9 @@ class _ScriptRun:
         """Execute a script."""
         result = await self._async_run_long_action(
             self._hass.async_create_task_internal(
-                script.async_run(self._variables.enter_scope(parallel), self._context),
+                script.async_run(
+                    self._variables.enter_scope(parallel=parallel), self._context
+                ),
                 eager_start=True,
             )
         )
@@ -1196,7 +1198,7 @@ class _ScriptRun:
                 "completed": False,
                 "trigger": None,
             },
-            parallel_copy=True,
+            parallel_special=True,
         )
         trace_set_result(wait=self._variables["wait"])
 
@@ -1244,7 +1246,7 @@ class _ScriptRun:
         self._step_log("wait template", timeout)
 
         self._variables.assign_single(
-            "wait", {"remaining": timeout, "completed": False}, parallel_copy=True
+            "wait", {"remaining": timeout, "completed": False}, parallel_special=True
         )
         trace_set_result(wait=self._variables["wait"])
 

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -1198,14 +1198,13 @@ class _ScriptRun:
         self._step_log("wait for trigger", timeout)
 
         variables = dict(self._variables)
-        self._variables.assign(
+        self._variables.assign_parallel_protected(
             "wait",
             {
                 "remaining": timeout,
                 "completed": False,
                 "trigger": None,
             },
-            parallel_protected=True,
         )
         trace_set_result(wait=self._variables["wait"])
 
@@ -1252,8 +1251,8 @@ class _ScriptRun:
         timeout = self._get_timeout_seconds_from_action()
         self._step_log("wait template", timeout)
 
-        self._variables.assign(
-            "wait", {"remaining": timeout, "completed": False}, parallel_protected=True
+        self._variables.assign_parallel_protected(
+            "wait", {"remaining": timeout, "completed": False}
         )
         trace_set_result(wait=self._variables["wait"])
 

--- a/homeassistant/helpers/script_variables.py
+++ b/homeassistant/helpers/script_variables.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+from collections import ChainMap, UserDict
 from collections.abc import Mapping
-from typing import Any
+from dataclasses import dataclass
+from typing import Any, cast
 
 from homeassistant.core import HomeAssistant, callback
 
@@ -24,30 +26,21 @@ class ScriptVariables:
         hass: HomeAssistant,
         run_variables: Mapping[str, Any] | None,
         *,
-        render_as_defaults: bool = True,
         limited: bool = False,
     ) -> dict[str, Any]:
         """Render script variables.
 
         The run variables are used to compute the static variables.
-
-        If `render_as_defaults` is True, the run variables will not be overridden.
-
+        The run variables will not be overridden.
         """
         if self._has_template is None:
             self._has_template = template.is_complex(self.variables)
 
         if not self._has_template:
-            if render_as_defaults:
-                rendered_variables = dict(self.variables)
+            rendered_variables = dict(self.variables)
 
-                if run_variables is not None:
-                    rendered_variables.update(run_variables)
-            else:
-                rendered_variables = (
-                    {} if run_variables is None else dict(run_variables)
-                )
-                rendered_variables.update(self.variables)
+            if run_variables is not None:
+                rendered_variables.update(run_variables)
 
             return rendered_variables
 
@@ -56,7 +49,7 @@ class ScriptVariables:
         for key, value in self.variables.items():
             # We can skip if we're going to override this key with
             # run variables anyway
-            if render_as_defaults and key in rendered_variables:
+            if key in rendered_variables:
                 continue
 
             rendered_variables[key] = template.render_complex(
@@ -65,6 +58,162 @@ class ScriptVariables:
 
         return rendered_variables
 
+    @callback
+    def async_simple_render(self, run_variables: Mapping[str, Any]) -> dict[str, Any]:
+        """Render script variables."""
+        if self._has_template is None:
+            self._has_template = template.is_complex(self.variables)
+
+        if not self._has_template:
+            return self.variables
+
+        run_variables = dict(run_variables)
+        rendered_variables = {}
+
+        for key, value in self.variables.items():
+            rendered_variable = template.render_complex(value, run_variables)
+            rendered_variables[key] = rendered_variable
+            run_variables[key] = rendered_variable
+
+        return rendered_variables
+
     def as_dict(self) -> dict[str, Any]:
         """Return dict version of this class."""
         return self.variables
+
+
+@dataclass(kw_only=True)
+class ScriptRunVariables(UserDict[str, Any]):
+    """Class to hold script run variables."""
+
+    _previous: ScriptRunVariables | None = None
+    _parent: ScriptRunVariables | None = None
+
+    _local_store: dict[str, Any] | None = None
+    _parallel_store: tuple[dict[str, Any], dict[str, Any]] | None = None
+
+    _non_parallel_scope: ChainMap[str, Any]
+    _full_scope: ChainMap[str, Any]
+
+    @classmethod
+    def create_top_level(
+        cls,
+        initial_data: Mapping[str, Any] | None = None,
+    ) -> ScriptRunVariables:
+        """Create a new ScriptRunVariables."""
+        local_store: dict[str, Any] = {}
+        non_parallel_scope = full_scope = ChainMap(local_store)
+        variables = cls(
+            _local_store=local_store,
+            _non_parallel_scope=non_parallel_scope,
+            _full_scope=full_scope,
+        )
+        if initial_data is not None:
+            variables.update(initial_data)
+        return variables
+
+    def enter_scope(self, parallel: bool = False) -> ScriptRunVariables:
+        """Enter a new scope."""
+        if self._local_store is not None or self._parallel_store is not None:
+            parent = self
+        else:
+            parent = cast(  # top level always has a local store, so we can cast safely
+                ScriptRunVariables, self._parent
+            )
+
+        if not parallel:
+            parallel_store: tuple[dict[str, Any], dict[str, Any]] | None = None
+            non_parallel_scope = self._non_parallel_scope
+            full_scope = self._full_scope
+        else:
+            parallel_store = ({}, {})
+            non_parallel_scope = ChainMap(parallel_store[1])
+            full_scope = self._full_scope.new_child(parallel_store[0])
+
+        return ScriptRunVariables(
+            _previous=self,
+            _parent=parent,
+            _parallel_store=parallel_store,
+            _non_parallel_scope=non_parallel_scope,
+            _full_scope=full_scope,
+        )
+
+    def exit_scope(self) -> ScriptRunVariables:
+        """Exit the current scope."""
+        if self._previous is None:
+            raise ValueError("Cannot exit root scope")
+        return self._previous
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        """Assign value to a variable."""
+        self.assign_single(key, value)
+
+    def __delitem__(self, key: str) -> None:
+        """Delete a variable."""
+        raise TypeError("Deleting items is not allowed in ScriptRunVariables.")
+
+    def assign_single(
+        self, key: str, value: Any, *, parallel_copy: bool = False
+    ) -> None:
+        """Assign a value to a variable."""
+        if self._local_store is not None and key in self._local_store:
+            self._local_store[key] = value
+            return
+
+        if self._parent is None:
+            assert self._local_store is not None  # top level always has a local store
+            self._local_store[key] = value
+            return
+
+        if self._parallel_store is not None:
+            self._parallel_store[1][key] = value
+            if parallel_copy:
+                self._parallel_store[0][key] = value
+            else:
+                self._parallel_store[0].pop(key, None)
+
+        self._parent.assign_single(key, value, parallel_copy=parallel_copy)
+
+    def assign(self, new_vars: ScriptVariables) -> None:
+        """Assign values to variables."""
+        for key, value in new_vars.async_simple_render(self).items():
+            self.assign_single(key, value)
+
+    def define_single(self, key: str, value: Any) -> None:
+        """Define a local variable."""
+        self._ensure_local()
+        assert self._local_store is not None
+        self._local_store[key] = value
+
+    def define(self, new_vars: ScriptVariables) -> None:
+        """Define local variables."""
+        self._ensure_local()
+        assert self._local_store is not None
+        for key, value in new_vars.async_simple_render(self).items():
+            self._local_store[key] = value
+
+    def _ensure_local(self) -> None:
+        if self._local_store is None:
+            self._local_store = {}
+            self._non_parallel_scope = self._non_parallel_scope.new_child(
+                self._local_store
+            )
+            self._full_scope = self._full_scope.new_child(self._local_store)
+
+    @property
+    def data(self) -> Mapping[str, Any]:  # type: ignore[override]
+        """Return variables in full scope.
+
+        Defined here for UserDict compatibility.
+        """
+        return self._full_scope
+
+    @property
+    def local_scope(self) -> Mapping[str, Any]:
+        """Return variables in local scope."""
+        return self._local_store if self._local_store is not None else {}
+
+    @property
+    def non_parallel_scope(self) -> Mapping[str, Any]:
+        """Return variables in non-parallel scope."""
+        return self._non_parallel_scope

--- a/homeassistant/helpers/script_variables.py
+++ b/homeassistant/helpers/script_variables.py
@@ -187,7 +187,7 @@ class ScriptRunVariables(UserDict[str, Any]):
         return self._previous
 
     def __setitem__(self, key: str, value: Any) -> None:
-        """Assign value to a variable. Equivalent to `assign_single`."""
+        """Assign value to a variable. Equivalent to `assign`."""
         self.assign(key, value)
 
     def __delitem__(self, key: str) -> None:

--- a/homeassistant/helpers/script_variables.py
+++ b/homeassistant/helpers/script_variables.py
@@ -166,7 +166,9 @@ class ScriptRunVariables(UserDict[str, Any]):
             full_scope = self._full_scope
         else:
             parallel_data = _ParallelData()
-            non_parallel_scope = ChainMap(parallel_data.outer_scope_writes)
+            non_parallel_scope = ChainMap(
+                parallel_data.protected, parallel_data.outer_scope_writes
+            )
             full_scope = self._full_scope.new_child(parallel_data.protected)
 
         return ScriptRunVariables(
@@ -212,11 +214,11 @@ class ScriptRunVariables(UserDict[str, Any]):
             return
 
         if self._parallel_data is not None:
-            self._parallel_data.outer_scope_writes[key] = value
             if parallel_protected:
                 self._parallel_data.protected[key] = value
-            else:
-                self._parallel_data.protected.pop(key, None)
+                return
+            self._parallel_data.protected.pop(key, None)
+            self._parallel_data.outer_scope_writes[key] = value
 
         self._parent.assign(key, value, parallel_protected=parallel_protected)
 

--- a/homeassistant/helpers/script_variables.py
+++ b/homeassistant/helpers/script_variables.py
@@ -95,7 +95,8 @@ class _ParallelData:
 
     # `protected` is for variables that need special protection in parallel sequences.
     # What this means is that such a variable defined in one parallel sequence will not be
-    # clobbered by the variable with the same name defined in another parallel sequence.
+    # clobbered by the variable with the same name assigned in another parallel sequence.
+    # It also means that such a variable will not be visible in the outer scope.
     # Currently the only such variable is `wait`.
     protected: dict[str, Any] = field(default_factory=dict)
     # `outer_scope_writes` is for variables that are written to the outer scope from
@@ -185,7 +186,7 @@ class ScriptRunVariables(UserDict[str, Any]):
         Does no clean-up, but simply returns the previous scope.
         """
         if self._previous is None:
-            raise ValueError("Cannot exit root scope")
+            raise ValueError("Cannot exit top-level scope")
         return self._previous
 
     def __setitem__(self, key: str, value: Any) -> None:

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -452,6 +452,68 @@ async def test_service_response_data_errors(
         await script_obj.async_run(context=context)
 
 
+async def test_calling_service_response_data_in_scopes(hass: HomeAssistant) -> None:
+    """Test response variable is still set after scopes end."""
+    expected_var = {"data": "value-12345"}
+
+    def mock_service(call: ServiceCall) -> ServiceResponse:
+        """Mock service call."""
+        if call.return_response:
+            return expected_var
+        return None
+
+    hass.services.async_register(
+        "test", "script", mock_service, supports_response=SupportsResponse.OPTIONAL
+    )
+
+    sequence = cv.SCRIPT_SCHEMA(
+        {
+            "parallel": [
+                {
+                    "alias": "Sequential group",
+                    "sequence": [
+                        {
+                            "alias": "variables",
+                            "variables": {"state": "off"},
+                        },
+                        {
+                            "alias": "service step1",
+                            "action": "test.script",
+                            "response_variable": "my_response",
+                        },
+                    ],
+                }
+            ]
+        }
+    )
+
+    script_obj = script.Script(hass, sequence, "Test Name", "test_domain")
+
+    result = await script_obj.async_run(context=Context())
+
+    assert result.variables["my_response"] == expected_var
+
+    expected_trace = {
+        "0": [{"variables": {"my_response": expected_var}}],
+        "0/parallel/0/sequence/0": [{"variables": {"state": "off"}}],
+        "0/parallel/0/sequence/1": [
+            {
+                "result": {
+                    "params": {
+                        "domain": "test",
+                        "service": "script",
+                        "service_data": {},
+                        "target": {},
+                    },
+                    "running_script": False,
+                },
+                "variables": {"my_response": expected_var},
+            }
+        ],
+    }
+    assert_action_trace(expected_trace)
+
+
 async def test_data_template_with_templated_key(hass: HomeAssistant) -> None:
     """Test the calling of a service with a data_template with a templated key."""
     context = Context()
@@ -1704,6 +1766,47 @@ async def test_wait_variables_out(hass: HomeAssistant, mode, action_type) -> Non
             assert 0.0 < float(remaining) < 5
         else:
             assert float(remaining) == 0.0
+
+
+async def test_wait_in_sequence(hass: HomeAssistant) -> None:
+    """Test wait variable is still set after sequence ends."""
+    sequence = cv.SCRIPT_SCHEMA(
+        [
+            {
+                "alias": "Sequential group",
+                "sequence": [
+                    {
+                        "alias": "variables",
+                        "variables": {"state": "off"},
+                    },
+                    {
+                        "alias": "wait template",
+                        "wait_template": "{{ state == 'off' }}",
+                    },
+                ],
+            },
+        ]
+    )
+
+    script_obj = script.Script(hass, sequence, "Test Name", "test_domain")
+
+    result = await script_obj.async_run(context=Context())
+
+    expected_var = {"completed": True, "remaining": None}
+
+    assert result.variables["wait"] == expected_var
+
+    expected_trace = {
+        "0": [{"variables": {"wait": expected_var}}],
+        "0/sequence/0": [{"variables": {"state": "off"}}],
+        "0/sequence/1": [
+            {
+                "result": {"wait": expected_var},
+                "variables": {"wait": expected_var},
+            }
+        ],
+    }
+    assert_action_trace(expected_trace)
 
 
 async def test_wait_for_trigger_bad(
@@ -3691,7 +3794,18 @@ async def test_parallel(hass: HomeAssistant, caplog: pytest.LogCaptureFixture) -
         "to_state": ANY,
     }
     expected_trace = {
-        "0": [{"variables": {"what": "world"}}],
+        "0": [
+            {
+                "variables": {
+                    "what": "world",
+                    "wait": {
+                        "completed": True,
+                        "remaining": None,
+                        "trigger": expected_trigger,
+                    },
+                }
+            }
+        ],
         "0/parallel/0/sequence/0": [
             {
                 "result": {

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -3794,18 +3794,7 @@ async def test_parallel(hass: HomeAssistant, caplog: pytest.LogCaptureFixture) -
         "to_state": ANY,
     }
     expected_trace = {
-        "0": [
-            {
-                "variables": {
-                    "what": "world",
-                    "wait": {
-                        "completed": True,
-                        "remaining": None,
-                        "trigger": expected_trigger,
-                    },
-                }
-            }
-        ],
+        "0": [{"variables": {"what": "world"}}],
         "0/parallel/0/sequence/0": [
             {
                 "result": {

--- a/tests/helpers/test_script_variables.py
+++ b/tests/helpers/test_script_variables.py
@@ -5,12 +5,13 @@ import pytest
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import TemplateError
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.script_variables import ScriptVariables
 
 
 async def test_static_vars() -> None:
     """Test static vars."""
     orig = {"hello": "world"}
-    var = cv.SCRIPT_VARIABLES_SCHEMA(orig)
+    var = ScriptVariables(orig)
     rendered = var.async_render(None, None)
     assert rendered is not orig
     assert rendered == orig
@@ -20,31 +21,28 @@ async def test_static_vars_run_args() -> None:
     """Test static vars."""
     orig = {"hello": "world"}
     orig_copy = dict(orig)
-    var = cv.SCRIPT_VARIABLES_SCHEMA(orig)
+    var = ScriptVariables(orig)
     rendered = var.async_render(None, {"hello": "override", "run": "var"})
     assert rendered == {"hello": "override", "run": "var"}
     # Make sure we don't change original vars
     assert orig == orig_copy
 
 
-async def test_static_vars_no_default() -> None:
+async def test_static_vars_simple() -> None:
     """Test static vars."""
     orig = {"hello": "world"}
-    var = cv.SCRIPT_VARIABLES_SCHEMA(orig)
-    rendered = var.async_render(None, None, render_as_defaults=False)
-    assert rendered is not orig
-    assert rendered == orig
+    var = ScriptVariables(orig)
+    rendered = var.async_simple_render({})
+    assert rendered is orig
 
 
-async def test_static_vars_run_args_no_default() -> None:
+async def test_static_vars_run_args_simple() -> None:
     """Test static vars."""
     orig = {"hello": "world"}
     orig_copy = dict(orig)
-    var = cv.SCRIPT_VARIABLES_SCHEMA(orig)
-    rendered = var.async_render(
-        None, {"hello": "override", "run": "var"}, render_as_defaults=False
-    )
-    assert rendered == {"hello": "world", "run": "var"}
+    var = ScriptVariables(orig)
+    rendered = var.async_simple_render({"hello": "override", "run": "var"})
+    assert rendered is orig
     # Make sure we don't change original vars
     assert orig == orig_copy
 
@@ -78,14 +76,14 @@ async def test_template_vars_run_args(hass: HomeAssistant) -> None:
     }
 
 
-async def test_template_vars_no_default(hass: HomeAssistant) -> None:
+async def test_template_vars_simple(hass: HomeAssistant) -> None:
     """Test template vars."""
     var = cv.SCRIPT_VARIABLES_SCHEMA({"hello": "{{ 1 + 1 }}"})
-    rendered = var.async_render(hass, None, render_as_defaults=False)
+    rendered = var.async_simple_render({})
     assert rendered == {"hello": 2}
 
 
-async def test_template_vars_run_args_no_default(hass: HomeAssistant) -> None:
+async def test_template_vars_run_args_simple(hass: HomeAssistant) -> None:
     """Test template vars."""
     var = cv.SCRIPT_VARIABLES_SCHEMA(
         {
@@ -93,16 +91,13 @@ async def test_template_vars_run_args_no_default(hass: HomeAssistant) -> None:
             "something_2": "{{ run_var_ex + 1 }}",
         }
     )
-    rendered = var.async_render(
-        hass,
+    rendered = var.async_simple_render(
         {
             "run_var_ex": 5,
             "something_2": 1,
-        },
-        render_as_defaults=False,
+        }
     )
     assert rendered == {
-        "run_var_ex": 5,
         "something": 6,
         "something_2": 6,
     }

--- a/tests/helpers/test_script_variables.py
+++ b/tests/helpers/test_script_variables.py
@@ -193,5 +193,5 @@ async def test_script_vars_parallel() -> None:
     assert script_vars_3b.exit_scope() is script_vars_2b
     assert script_vars_2b.exit_scope() is script_vars
 
-    assert script_vars._full_scope == {"x": "b", "y": "b", "z": 1}
-    assert script_vars.local_scope == {"x": "b", "y": "b", "z": 1}
+    assert script_vars._full_scope == {"x": "b", "y": 1, "z": 1}
+    assert script_vars.local_scope == {"x": "b", "y": 1, "z": 1}

--- a/tests/helpers/test_script_variables.py
+++ b/tests/helpers/test_script_variables.py
@@ -177,10 +177,10 @@ async def test_script_vars_parallel() -> None:
     script_vars_3b = script_vars_2b.enter_scope()
 
     script_vars_3a["x"] = "a"
-    script_vars_3a.assign("y", "a", parallel_protected=True)
+    script_vars_3a.assign_parallel_protected("y", "a")
 
     script_vars_3b["x"] = "b"
-    script_vars_3b.assign("y", "b", parallel_protected=True)
+    script_vars_3b.assign_parallel_protected("y", "b")
 
     assert script_vars_3a._full_scope == {"x": "b", "y": "a", "z": 1}
     assert script_vars_3a.non_parallel_scope == {"x": "a", "y": "a"}

--- a/tests/helpers/test_script_variables.py
+++ b/tests/helpers/test_script_variables.py
@@ -124,7 +124,7 @@ async def test_script_vars_delete_var() -> None:
         del script_vars["x"]
     with pytest.raises(TypeError):
         script_vars.pop("y")
-    assert script_vars.full_scope == {"x": 1, "y": 2}
+    assert script_vars._full_scope == {"x": 1, "y": 2}
 
 
 async def test_script_vars_scopes() -> None:
@@ -136,7 +136,7 @@ async def test_script_vars_scopes() -> None:
     assert script_vars["y"] == 1
 
     script_vars_2 = script_vars.enter_scope()
-    script_vars_2.define_single("x", 2)
+    script_vars_2.define_local("x", 2)
     assert script_vars_2["x"] == 2
     assert script_vars_2["y"] == 1
 
@@ -152,37 +152,18 @@ async def test_script_vars_scopes() -> None:
 
     assert script_vars_4.exit_scope() is script_vars_3
 
-    assert script_vars_3.full_scope == {"x": 3, "y": 3}
+    assert script_vars_3._full_scope == {"x": 3, "y": 3}
     assert script_vars_3.local_scope == {}
 
     assert script_vars_3.exit_scope() is script_vars_2
 
-    assert script_vars_2.full_scope == {"x": 3, "y": 3}
+    assert script_vars_2._full_scope == {"x": 3, "y": 3}
     assert script_vars_2.local_scope == {"x": 3}
 
     assert script_vars_2.exit_scope() is script_vars
 
-    assert script_vars.full_scope == {"x": 1, "y": 3}
+    assert script_vars._full_scope == {"x": 1, "y": 3}
     assert script_vars.local_scope == {"x": 1, "y": 3}
-
-
-async def test_script_vars_render(hass: HomeAssistant) -> None:
-    """Test script run variables render."""
-    script_vars = ScriptRunVariables.create_top_level()
-    script_vars_2 = script_vars.enter_scope()
-
-    script_vars_2["x"] = 1
-    script_vars_2.assign(cv.SCRIPT_VARIABLES_SCHEMA({"y": "{{ x }}", "z": 2}))
-    assert script_vars_2["y"] == 1
-    assert script_vars_2["z"] == 2
-
-    script_vars_2.define(cv.SCRIPT_VARIABLES_SCHEMA({"w": "{{ z }}", "y": "{{ w }}"}))
-    assert script_vars_2["w"] == 2
-    assert script_vars_2["y"] == 2
-    assert script_vars_2.full_scope == {"x": 1, "y": 2, "z": 2, "w": 2}
-
-    assert script_vars_2.exit_scope() is script_vars
-    assert script_vars.full_scope == {"x": 1, "y": 1, "z": 2}
 
 
 async def test_script_vars_parallel() -> None:
@@ -196,15 +177,15 @@ async def test_script_vars_parallel() -> None:
     script_vars_3b = script_vars_2b.enter_scope()
 
     script_vars_3a["x"] = "a"
-    script_vars_3a.assign_single("y", "a", parallel_special=True)
+    script_vars_3a.assign("y", "a", parallel_protected=True)
 
     script_vars_3b["x"] = "b"
-    script_vars_3b.assign_single("y", "b", parallel_special=True)
+    script_vars_3b.assign("y", "b", parallel_protected=True)
 
-    assert script_vars_3a.full_scope == {"x": "b", "y": "a", "z": 1}
+    assert script_vars_3a._full_scope == {"x": "b", "y": "a", "z": 1}
     assert script_vars_3a.non_parallel_scope == {"x": "a", "y": "a"}
 
-    assert script_vars_3b.full_scope == {"x": "b", "y": "b", "z": 1}
+    assert script_vars_3b._full_scope == {"x": "b", "y": "b", "z": 1}
     assert script_vars_3b.non_parallel_scope == {"x": "b", "y": "b"}
 
     assert script_vars_3a.exit_scope() is script_vars_2a
@@ -212,5 +193,5 @@ async def test_script_vars_parallel() -> None:
     assert script_vars_3b.exit_scope() is script_vars_2b
     assert script_vars_2b.exit_scope() is script_vars
 
-    assert script_vars.full_scope == {"x": "b", "y": "b", "z": 1}
+    assert script_vars._full_scope == {"x": "b", "y": "b", "z": 1}
     assert script_vars.local_scope == {"x": "b", "y": "b", "z": 1}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The `wait` variable and variables defined by a `response_variable` set in an inner scope of a script or automation now propagate to outer scopes also if a `variables` action is present in the inner scope. Furthermore, variables defined by a `response_variable` now also propagate out from `parallel` sequences. Scripts and automations which relied on the old buggy behavior need to be adjusted.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The scoping behavior of `wait` variable, as well as that of `response_variable` from action calls, had been buggy and was fixed.

To illustrate the bug, consider the following script:
```yaml
actions:
  - sequence:
      - action: weather.get_forecasts
        data:
          type: hourly
        target:
          entity_id: weather.home
        response_variable: result
  - action: persistent_notification.create
    data:
      message: "{{ result }}" # result contains the weather data.
```
Now consider:
```yaml
actions:
  - sequence:
      - variables:
          x: 4
      - action: weather.get_forecasts
        data:
          type: hourly
        target:
          entity_id: weather.home
        response_variable: result
  - action: persistent_notification.create
    data:
      message: "{{ result }}" # result is empty
```
This bug is now fixed and the variable always contains the weather data.
The reason it is technically a breaking change is that a user might have mistakenly relied on the variable not being properly set in this scenario.

The same bug and bugfix applies to the `wait` variable.
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/37720
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
