### PR TITLE
Bump habluetooth to 3.22.1 and bleak-retry-connector to 3.9.0

### DIFF
--- a/homeassistant/components/bluetooth/manifest.json
+++ b/homeassistant/components/bluetooth/manifest.json
@@ -16,11 +16,11 @@
   "quality_scale": "internal",
   "requirements": [
     "bleak==0.22.3",
-    "bleak-retry-connector==3.8.1",
+    "bleak-retry-connector==3.9.0",
     "bluetooth-adapters==0.21.4",
     "bluetooth-auto-recovery==1.4.2",
     "bluetooth-data-tools==1.23.4",
     "dbus-fast==2.33.0",
-    "habluetooth==3.22.0"
+    "habluetooth==3.22.1"
   ]
 }

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -19,7 +19,7 @@ audioop-lts==0.2.1
 av==13.1.0
 awesomeversion==24.6.0
 bcrypt==4.2.0
-bleak-retry-connector==3.8.1
+bleak-retry-connector==3.9.0
 bleak==0.22.3
 bluetooth-adapters==0.21.4
 bluetooth-auto-recovery==1.4.2
@@ -33,7 +33,7 @@ dbus-fast==2.33.0
 fnv-hash-fast==1.2.2
 go2rtc-client==0.1.2
 ha-ffmpeg==3.2.2
-habluetooth==3.22.0
+habluetooth==3.22.1
 hass-nabucasa==0.92.0
 hassil==2.2.3
 home-assistant-bluetooth==1.13.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -600,7 +600,7 @@ bizkaibus==0.1.1
 bleak-esphome==2.7.1
 
 # homeassistant.components.bluetooth
-bleak-retry-connector==3.8.1
+bleak-retry-connector==3.9.0
 
 # homeassistant.components.bluetooth
 bleak==0.22.3
@@ -1103,7 +1103,7 @@ ha-philipsjs==3.2.2
 habiticalib==0.3.7
 
 # homeassistant.components.bluetooth
-habluetooth==3.22.0
+habluetooth==3.22.1
 
 # homeassistant.components.cloud
 hass-nabucasa==0.92.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -531,7 +531,7 @@ bimmer-connected[china]==0.17.2
 bleak-esphome==2.7.1
 
 # homeassistant.components.bluetooth
-bleak-retry-connector==3.8.1
+bleak-retry-connector==3.9.0
 
 # homeassistant.components.bluetooth
 bleak==0.22.3
@@ -944,7 +944,7 @@ ha-philipsjs==3.2.2
 habiticalib==0.3.7
 
 # homeassistant.components.bluetooth
-habluetooth==3.22.0
+habluetooth==3.22.1
 
 # homeassistant.components.cloud
 hass-nabucasa==0.92.0


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Must be bumped together since habluetooth 3.22.1 needs bleak-retry-connector 3.9.0+

bleak-retry-connector changelog: https://github.com/Bluetooth-Devices/bleak-retry-connector/compare/v3.8.1...v3.9.0
habluetooth changelog: https://github.com/Bluetooth-Devices/habluetooth/compare/v3.22.0...v3.22.1

If discovery is stuck on because something got out of sync (crash, cancellation, etc), `habluetooth` will try to turn it off before trying to start the scanner.

fixes #138864

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
