### PR TITLE
Fix Reolink callback id collision

### DIFF
--- a/homeassistant/components/reolink/entity.py
+++ b/homeassistant/components/reolink/entity.py
@@ -118,7 +118,7 @@ class ReolinkHostCoordinatorEntity(CoordinatorEntity[DataUpdateCoordinator[None]
         await super().async_added_to_hass()
         cmd_key = self.entity_description.cmd_key
         cmd_id = self.entity_description.cmd_id
-        callback_id = f"{self._attr_unique_id}_{self.platform.domain}"
+        callback_id = f"{self.platform.domain}_{self._attr_unique_id}"
         if cmd_key is not None:
             self._host.async_register_update_cmd(cmd_key)
         if cmd_id is not None:
@@ -130,7 +130,7 @@ class ReolinkHostCoordinatorEntity(CoordinatorEntity[DataUpdateCoordinator[None]
         """Entity removed."""
         cmd_key = self.entity_description.cmd_key
         cmd_id = self.entity_description.cmd_id
-        callback_id = f"{self._attr_unique_id}_{self.platform.domain}"
+        callback_id = f"{self.platform.domain}_{self._attr_unique_id}"
         if cmd_key is not None:
             self._host.async_unregister_update_cmd(cmd_key)
         if cmd_id is not None:

--- a/homeassistant/components/reolink/entity.py
+++ b/homeassistant/components/reolink/entity.py
@@ -107,10 +107,10 @@ class ReolinkHostCoordinatorEntity(CoordinatorEntity[DataUpdateCoordinator[None]
         """Handle incoming TCP push event."""
         self.async_write_ha_state()
 
-    def register_callback(self, unique_id: str, cmd_id: int) -> None:
+    def register_callback(self, callback_id: str, cmd_id: int) -> None:
         """Register callback for TCP push events."""
         self._host.api.baichuan.register_callback(  # pragma: no cover
-            unique_id, self._push_callback, cmd_id
+            callback_id, self._push_callback, cmd_id
         )
 
     async def async_added_to_hass(self) -> None:
@@ -118,23 +118,25 @@ class ReolinkHostCoordinatorEntity(CoordinatorEntity[DataUpdateCoordinator[None]
         await super().async_added_to_hass()
         cmd_key = self.entity_description.cmd_key
         cmd_id = self.entity_description.cmd_id
+        callback_id = f"{self._attr_unique_id}_{self.platform.domain}"
         if cmd_key is not None:
             self._host.async_register_update_cmd(cmd_key)
         if cmd_id is not None:
-            self.register_callback(self._attr_unique_id, cmd_id)
+            self.register_callback(callback_id, cmd_id)
         # Privacy mode
-        self.register_callback(f"{self._attr_unique_id}_623", 623)
+        self.register_callback(f"{callback_id}_623", 623)
 
     async def async_will_remove_from_hass(self) -> None:
         """Entity removed."""
         cmd_key = self.entity_description.cmd_key
         cmd_id = self.entity_description.cmd_id
+        callback_id = f"{self._attr_unique_id}_{self.platform.domain}"
         if cmd_key is not None:
             self._host.async_unregister_update_cmd(cmd_key)
         if cmd_id is not None:
-            self._host.api.baichuan.unregister_callback(self._attr_unique_id)
+            self._host.api.baichuan.unregister_callback(callback_id)
         # Privacy mode
-        self._host.api.baichuan.unregister_callback(f"{self._attr_unique_id}_623")
+        self._host.api.baichuan.unregister_callback(f"{callback_id}_623")
 
         await super().async_will_remove_from_hass()
 

--- a/homeassistant/components/reolink/entity.py
+++ b/homeassistant/components/reolink/entity.py
@@ -195,10 +195,10 @@ class ReolinkChannelCoordinatorEntity(ReolinkHostCoordinatorEntity):
         """Return True if entity is available."""
         return super().available and self._host.api.camera_online(self._channel)
 
-    def register_callback(self, unique_id: str, cmd_id: int) -> None:
+    def register_callback(self, callback_id: str, cmd_id: int) -> None:
         """Register callback for TCP push events."""
         self._host.api.baichuan.register_callback(
-            unique_id, self._push_callback, cmd_id, self._channel
+            callback_id, self._push_callback, cmd_id, self._channel
         )
 
     async def async_added_to_hass(self) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
For a Reolink doorbell there are 2 entities with the same unique_id but a diffrent platform domain:
The light.status_led and the select.status_led (one is the wifi indicator, the other the doorbell ring light), those unique_ids have grown historically.

Home Assistant allows 2 identical unique ids as long as the platform is diffrent.
However the upstream reolink_aio library needs a completly unique callback_id, therfore raising this warning:

`2025-02-20 09:19:53.262 WARNING (MainThread) [reolink_aio.baichuan.baichuan] Baichuan host 192.168.1.IP: callback id 'XXXXXXXX_XXXXXXXXXX_status_led_623', cmd_id 623, ch 1 already registered, overwriting`

Add platform domain to Reolink callback_id to solve this and make the callback_id completly unique.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
