### PR TITLE
Add ability to get callback when a config entry state changes

### DIFF
--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1184,7 +1184,6 @@ class ConfigEntry[_DataT = Any]:
         if self._on_state_change is None:
             self._on_state_change = []
         self._on_state_change.append(func)
-        assert self._on_state_change is not None
         return lambda: cast(list, self._on_state_change).remove(func)
 
     def _async_process_on_state_change(self) -> None:

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1658,9 +1658,7 @@ class ConfigEntriesFlowManager(
         if existing_entry is not None:
             # Unload and remove the existing entry, but don't clean up devices and
             # entities until the new entry is added
-            await self.config_entries._async_remove(  # noqa: SLF001
-                existing_entry.entry_id
-            )
+            await self.config_entries._async_remove(existing_entry.entry_id)  # noqa: SLF001
         await self.config_entries.async_add(entry)
 
         if existing_entry is not None:
@@ -2311,9 +2309,8 @@ class ConfigEntries:
         entry: ConfigEntry,
         *,
         data: Mapping[str, Any] | UndefinedType = UNDEFINED,
-        discovery_keys: (
-            MappingProxyType[str, tuple[DiscoveryKey, ...]] | UndefinedType
-        ) = UNDEFINED,
+        discovery_keys: MappingProxyType[str, tuple[DiscoveryKey, ...]]
+        | UndefinedType = UNDEFINED,
         minor_version: int | UndefinedType = UNDEFINED,
         options: Mapping[str, Any] | UndefinedType = UNDEFINED,
         pref_disable_new_entities: bool | UndefinedType = UNDEFINED,
@@ -2349,9 +2346,8 @@ class ConfigEntries:
         entry: ConfigEntry,
         *,
         data: Mapping[str, Any] | UndefinedType = UNDEFINED,
-        discovery_keys: (
-            MappingProxyType[str, tuple[DiscoveryKey, ...]] | UndefinedType
-        ) = UNDEFINED,
+        discovery_keys: MappingProxyType[str, tuple[DiscoveryKey, ...]]
+        | UndefinedType = UNDEFINED,
         minor_version: int | UndefinedType = UNDEFINED,
         options: Mapping[str, Any] | UndefinedType = UNDEFINED,
         pref_disable_new_entities: bool | UndefinedType = UNDEFINED,
@@ -2754,10 +2750,7 @@ class ConfigEntries:
                 continue
             issues.add(issue.issue_id)
 
-        for (
-            domain,
-            unique_ids,
-        ) in self._entries._domain_unique_id_index.items():  # noqa: SLF001
+        for domain, unique_ids in self._entries._domain_unique_id_index.items():  # noqa: SLF001
             # flipr creates duplicates during migration, and asks users to
             # remove the duplicate. We don't need warn about it here too.
             # We should remove the special case for "flipr" in HA Core 2025.4,

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -402,7 +402,7 @@ class ConfigEntry[_DataT = Any]:
     update_listeners: list[UpdateListenerType]
     _async_cancel_retry_setup: Callable[[], Any] | None
     _on_unload: list[Callable[[], Coroutine[Any, Any, None] | None]] | None
-    _on_state_change: list[Callable[[], Any | None]] | None
+    _on_state_change: list[CALLBACK_TYPE] | None
     setup_lock: asyncio.Lock
     _reauth_lock: asyncio.Lock
     _tasks: set[asyncio.Future[Any]]
@@ -1179,7 +1179,7 @@ class ConfigEntry[_DataT = Any]:
             )
 
     @callback
-    def async_on_state_change(self, func: Callable[[], Any | None]) -> CALLBACK_TYPE:
+    def async_on_state_change(self, func: CALLBACK_TYPE) -> CALLBACK_TYPE:
         """Add a function to call when a config entry changes its state."""
         if self._on_state_change is None:
             self._on_state_change = []

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -402,7 +402,7 @@ class ConfigEntry[_DataT = Any]:
     update_listeners: list[UpdateListenerType]
     _async_cancel_retry_setup: Callable[[], Any] | None
     _on_unload: list[Callable[[], Coroutine[Any, Any, None] | None]] | None
-    _on_state_change: list[Callable[[], Coroutine[Any, Any, None] | None]] | None
+    _on_state_change: list[Callable[[], Any | None]] | None
     setup_lock: asyncio.Lock
     _reauth_lock: asyncio.Lock
     _tasks: set[asyncio.Future[Any]]
@@ -1062,7 +1062,7 @@ class ConfigEntry[_DataT = Any]:
             hass, SIGNAL_CONFIG_ENTRY_CHANGED, ConfigEntryChange.UPDATED, self
         )
 
-        self._async_process_on_state_change(hass)
+        self._async_process_on_state_change()
 
     async def async_migrate(self, hass: HomeAssistant) -> bool:
         """Migrate an entry.
@@ -1179,20 +1179,25 @@ class ConfigEntry[_DataT = Any]:
             )
 
     @callback
-    def async_on_state_change(
-        self, func: Callable[[], Coroutine[Any, Any, None] | None]
-    ) -> None:
+    def async_on_state_change(self, func: Callable[[], Any | None]) -> None:
         """Add a function to call when a config entry changes its state."""
         if self._on_state_change is None:
             self._on_state_change = []
         self._on_state_change.append(func)
 
-    def _async_process_on_state_change(self, hass: HomeAssistant) -> None:
+    def _async_process_on_state_change(self) -> None:
         """Process the on_state_change callbacks and wait for pending tasks."""
         if self._on_state_change is not None:
-            while self._on_state_change:
-                if job := self._on_state_change.pop()():
-                    self.async_create_task(hass, job, eager_start=True)
+            for func in self._on_state_change:
+                if func is not None:
+                    try:
+                        func()
+                    except Exception:
+                        _LOGGER.exception(
+                            "Error calling on_state_change callback for %s (%s)",
+                            self.title,
+                            self.domain,
+                        )
 
     @callback
     def async_start_reauth(

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -402,7 +402,7 @@ class ConfigEntry[_DataT = Any]:
     update_listeners: list[UpdateListenerType]
     _async_cancel_retry_setup: Callable[[], Any] | None
     _on_unload: list[Callable[[], Coroutine[Any, Any, None] | None]] | None
-    _on_state_change: list[CALLBACK_TYPE] | None
+    _on_state_change: list[Callable[[], Any | None]] | None
     setup_lock: asyncio.Lock
     _reauth_lock: asyncio.Lock
     _tasks: set[asyncio.Future[Any]]
@@ -1179,11 +1179,13 @@ class ConfigEntry[_DataT = Any]:
             )
 
     @callback
-    def async_on_state_change(self, func: CALLBACK_TYPE) -> None:
+    def async_on_state_change(self, func: Callable[[], Any | None]) -> CALLBACK_TYPE:
         """Add a function to call when a config entry changes its state."""
         if self._on_state_change is None:
             self._on_state_change = []
         self._on_state_change.append(func)
+        assert self._on_state_change is not None
+        return lambda: cast(list, self._on_state_change).remove(func)
 
     def _async_process_on_state_change(self) -> None:
         """Process the on_state_change callbacks and wait for pending tasks."""

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1062,11 +1062,7 @@ class ConfigEntry[_DataT = Any]:
             hass, SIGNAL_CONFIG_ENTRY_CHANGED, ConfigEntryChange.UPDATED, self
         )
 
-        hass.async_create_task(
-            self._async_process_on_state_change(hass),
-            f"config entry state change {self.entry_id} {state}",
-            eager_start=True,
-        )
+        self._async_process_on_state_change(hass)
 
     async def async_migrate(self, hass: HomeAssistant) -> bool:
         """Migrate an entry.
@@ -1191,7 +1187,7 @@ class ConfigEntry[_DataT = Any]:
             self._on_state_change = []
         self._on_state_change.append(func)
 
-    async def _async_process_on_state_change(self, hass: HomeAssistant) -> None:
+    def _async_process_on_state_change(self, hass: HomeAssistant) -> None:
         """Process the on_state_change callbacks and wait for pending tasks."""
         if self._on_state_change is not None:
             while self._on_state_change:

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -4797,22 +4797,25 @@ async def test_entry_reload_calls_on_unload_listeners(
 
 
 @pytest.mark.parametrize(
-    ("source_state", "target_state", "transition_method_name"),
+    ("source_state", "target_state", "transition_method_name", "call_count"),
     [
         (
             config_entries.ConfigEntryState.NOT_LOADED,
             config_entries.ConfigEntryState.LOADED,
             "async_setup",
+            2,
         ),
         (
             config_entries.ConfigEntryState.LOADED,
             config_entries.ConfigEntryState.NOT_LOADED,
             "async_unload",
+            2,
         ),
         (
             config_entries.ConfigEntryState.LOADED,
             config_entries.ConfigEntryState.LOADED,
             "async_reload",
+            4,
         ),
     ],
 )
@@ -4822,6 +4825,7 @@ async def test_entry_state_change_calls_listener(
     source_state: config_entries.ConfigEntryState,
     target_state: config_entries.ConfigEntryState,
     transition_method_name: str,
+    call_count: int,
 ) -> None:
     """Test listeners get called on entry state changes."""
     entry = MockConfigEntry(domain="comp", state=source_state)
@@ -4845,7 +4849,7 @@ async def test_entry_state_change_calls_listener(
     transition_method = getattr(manager, transition_method_name)
     await transition_method(entry.entry_id)
 
-    assert len(mock_state_change_callback.mock_calls) == 1
+    assert len(mock_state_change_callback.mock_calls) == call_count
     assert entry.state is target_state
 
 

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -4853,6 +4853,45 @@ async def test_entry_state_change_calls_listener(
     assert entry.state is target_state
 
 
+async def test_entry_state_change_listener_removed(
+    hass: HomeAssistant,
+    manager: config_entries.ConfigEntries,
+) -> None:
+    """Test state_change listener can be removed."""
+    entry = MockConfigEntry(
+        domain="comp", state=config_entries.ConfigEntryState.NOT_LOADED
+    )
+    entry.add_to_hass(hass)
+
+    mock_integration(
+        hass,
+        MockModule(
+            "comp",
+            async_setup=AsyncMock(return_value=True),
+            async_setup_entry=AsyncMock(return_value=True),
+            async_unload_entry=AsyncMock(return_value=True),
+        ),
+    )
+    mock_platform(hass, "comp.config_flow", None)
+    hass.config.components.add("comp")
+
+    mock_state_change_callback = Mock()
+    remove = entry.async_on_state_change(mock_state_change_callback)
+
+    await manager.async_setup(entry.entry_id)
+
+    assert len(mock_state_change_callback.mock_calls) == 2
+    assert entry.state is config_entries.ConfigEntryState.LOADED
+
+    remove()
+
+    await manager.async_unload(entry.entry_id)
+
+    # the listener should no longer be called
+    assert len(mock_state_change_callback.mock_calls) == 2
+    assert entry.state is config_entries.ConfigEntryState.NOT_LOADED
+
+
 async def test_entry_state_change_error_does_not_block_transition(
     hass: HomeAssistant,
     manager: config_entries.ConfigEntries,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adding a callback method to the config entry that allows to register functions which are going to be called when the config entry changes its state.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/2576
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
