### PR TITLE
Update HEOS host from discovery

### DIFF
--- a/homeassistant/components/heos/config_flow.py
+++ b/homeassistant/components/heos/config_flow.py
@@ -102,6 +102,18 @@ async def _validate_auth(
         return True
 
 
+def _get_current_hosts(entry: HeosConfigEntry) -> set[str]:
+    """Get a set of current hosts from the entry."""
+    hosts = set(entry.data[CONF_HOST])
+    if hasattr(entry, "runtime_data"):
+        hosts.update(
+            player.ip_address
+            for player in entry.runtime_data.heos.players.values()
+            if player.ip_address is not None
+        )
+    return hosts
+
+
 class HeosFlowHandler(ConfigFlow, domain=DOMAIN):
     """Define a flow for HEOS."""
 
@@ -125,10 +137,15 @@ class HeosFlowHandler(ConfigFlow, domain=DOMAIN):
         if TYPE_CHECKING:
             assert discovery_info.ssdp_location
 
-        await self.async_set_unique_id(DOMAIN)
-        # Connect to discovered host and get system information
+        entry: HeosConfigEntry | None = await self.async_set_unique_id(DOMAIN)
         hostname = urlparse(discovery_info.ssdp_location).hostname
         assert hostname is not None
+
+        # Abort early when discovered host is part of the current system
+        if entry and hostname in _get_current_hosts(entry):
+            return self.async_abort(reason="single_instance_allowed")
+
+        # Connect to discovered host and get system information
         heos = Heos(HeosOptions(hostname, events=False, heart_beat=False))
         try:
             await heos.connect()
@@ -146,8 +163,23 @@ class HeosFlowHandler(ConfigFlow, domain=DOMAIN):
         # Select the preferred host, if available
         if system_info.preferred_hosts:
             hostname = system_info.preferred_hosts[0].ip_address
-        self._discovered_host = hostname
-        return await self.async_step_confirm_discovery()
+
+        # Move to confirmation when not configured
+        if entry is None:
+            self._discovered_host = hostname
+            return await self.async_step_confirm_discovery()
+
+        # Only update if the configured host isn't part of the discovered hosts to ensure new players that come online don't trigger a reload
+        if entry.data[CONF_HOST] not in [host.ip_address for host in system_info.hosts]:
+            _LOGGER.debug(
+                "Updated host %s to discovered host %s", entry.data[CONF_HOST], hostname
+            )
+            return self.async_update_reload_and_abort(
+                entry,
+                data_updates={CONF_HOST: hostname},
+                reason="reconfigure_successful",
+            )
+        return self.async_abort(reason="single_instance_allowed")
 
     async def async_step_confirm_discovery(
         self, user_input: dict[str, Any] | None = None
@@ -167,6 +199,7 @@ class HeosFlowHandler(ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Obtain host and validate connection."""
         await self.async_set_unique_id(DOMAIN)
+        self._abort_if_unique_id_configured(error="single_instance_allowed")
         # Try connecting to host if provided
         errors: dict[str, str] = {}
         host = None

--- a/homeassistant/components/heos/manifest.json
+++ b/homeassistant/components/heos/manifest.json
@@ -9,7 +9,6 @@
   "loggers": ["pyheos"],
   "quality_scale": "silver",
   "requirements": ["pyheos==1.0.2"],
-  "single_config_entry": true,
   "ssdp": [
     {
       "st": "urn:schemas-denon-com:device:ACT-Denon:1"

--- a/homeassistant/components/heos/quality_scale.yaml
+++ b/homeassistant/components/heos/quality_scale.yaml
@@ -38,9 +38,7 @@ rules:
   # Gold
   devices: done
   diagnostics: done
-  discovery-update-info:
-    status: todo
-    comment: Explore if this is possible.
+  discovery-update-info: done
   discovery: done
   docs-data-update: done
   docs-examples: done

--- a/tests/components/heos/test_config_flow.py
+++ b/tests/components/heos/test_config_flow.py
@@ -7,7 +7,9 @@ from pyheos import (
     CommandFailedError,
     ConnectionState,
     HeosError,
+    HeosHost,
     HeosSystem,
+    NetworkType,
 )
 import pytest
 
@@ -118,17 +120,44 @@ async def test_discovery(
 
 
 async def test_discovery_flow_aborts_already_setup(
-    hass: HomeAssistant, discovery_data: SsdpServiceInfo, config_entry: MockConfigEntry
+    hass: HomeAssistant,
+    discovery_data_bedroom: SsdpServiceInfo,
+    config_entry: MockConfigEntry,
+    controller: MockHeos,
 ) -> None:
-    """Test discovery flow aborts when entry already setup."""
+    """Test discovery flow aborts when entry already setup and hosts didn't change."""
     config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    assert config_entry.data[CONF_HOST] == "127.0.0.1"
 
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_SSDP}, data=discovery_data
+        DOMAIN, context={"source": SOURCE_SSDP}, data=discovery_data_bedroom
     )
-
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "single_instance_allowed"
+    assert controller.get_system_info.call_count == 0
+    assert config_entry.data[CONF_HOST] == "127.0.0.1"
+
+
+async def test_discovery_aborts_same_system(
+    hass: HomeAssistant,
+    discovery_data_bedroom: SsdpServiceInfo,
+    controller: MockHeos,
+    config_entry: MockConfigEntry,
+    system: HeosSystem,
+) -> None:
+    """Test discovery does not update when current host is part of discovered's system."""
+    config_entry.add_to_hass(hass)
+    assert config_entry.data[CONF_HOST] == "127.0.0.1"
+
+    controller.get_system_info.return_value = system
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_SSDP}, data=discovery_data_bedroom
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "single_instance_allowed"
+    assert controller.get_system_info.call_count == 1
+    assert config_entry.data[CONF_HOST] == "127.0.0.1"
 
 
 async def test_discovery_fails_to_connect_aborts(
@@ -143,6 +172,26 @@ async def test_discovery_fails_to_connect_aborts(
     assert result["reason"] == "cannot_connect"
     assert controller.connect.call_count == 1
     assert controller.disconnect.call_count == 1
+
+
+async def test_discovery_updates(
+    hass: HomeAssistant,
+    discovery_data_bedroom: SsdpServiceInfo,
+    controller: MockHeos,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test discovery updates existing entry."""
+    config_entry.add_to_hass(hass)
+    assert config_entry.data[CONF_HOST] == "127.0.0.1"
+
+    host = HeosHost("Player", "Model", None, None, "127.0.0.2", NetworkType.WIRED, True)
+    controller.get_system_info.return_value = HeosSystem(None, host, [host])
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_SSDP}, data=discovery_data_bedroom
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert config_entry.data[CONF_HOST] == "127.0.0.2"
 
 
 async def test_reconfigure_validates_and_updates_config(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Updates the configured host from discovery when the device's IP address changes. In order for the discovery flows to be started after set up, `single_config_entry` was remove from the manifest and is manually enforced, per guidance from the core team. Lastly, this checks off the related quality scale item. Change are fully covered by tests.

CC @MartinHjelmare 


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
