### PR TITLE
Fix Shelly model name for xmod devices

### DIFF
--- a/homeassistant/components/shelly/coordinator.py
+++ b/homeassistant/components/shelly/coordinator.py
@@ -68,11 +68,11 @@ from .utils import (
     async_create_issue_unsupported_firmware,
     get_block_device_sleep_period,
     get_device_entry_gen,
-    get_device_info_model,
     get_host,
     get_http_port,
     get_rpc_device_wakeup_period,
     get_rpc_ws_url,
+    get_shelly_model_name,
     update_device_fw_info,
 )
 
@@ -165,7 +165,7 @@ class ShellyCoordinatorBase[_DeviceT: BlockDevice | RpcDevice](
             connections={(CONNECTION_NETWORK_MAC, self.mac)},
             identifiers={(DOMAIN, self.mac)},
             manufacturer="Shelly",
-            model=get_device_info_model(self.device),
+            model=get_shelly_model_name(self.model, self.sleep_period, self.device),
             model_id=self.model,
             sw_version=self.sw_version,
             hw_version=f"gen{get_device_entry_gen(self.config_entry)}",

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -315,12 +315,25 @@ def get_model_name(info: dict[str, Any]) -> str:
     return cast(str, MODEL_NAMES.get(info["type"], info["type"]))
 
 
-def get_device_info_model(device: BlockDevice | RpcDevice) -> str | None:
-    """Return the device model for deviceinfo."""
-    if isinstance(device, RpcDevice) and (model := device.xmod_info.get("n")):
-        return cast(str, model)
+def get_shelly_model_name(
+    model: str,
+    sleep_period: int,
+    device: BlockDevice | RpcDevice,
+) -> str | None:
+    """Get Shelly model name.
 
-    return cast(str, MODEL_NAMES.get(device.model))
+    Assume that XMOD devices are not sleepy devices.
+    """
+    if (
+        sleep_period == 0
+        and isinstance(device, RpcDevice)
+        and (model_name := device.xmod_info.get("n"))
+    ):
+        # Use the model name from XMOD data
+        return cast(str, model_name)
+
+    # Use the model name from aioshelly
+    return cast(str, MODEL_NAMES.get(model))
 
 
 def get_rpc_channel_name(device: RpcDevice, key: str) -> str:

--- a/tests/components/shelly/conftest.py
+++ b/tests/components/shelly/conftest.py
@@ -13,6 +13,7 @@ from aioshelly.ble.const import (
 )
 from aioshelly.block_device import BlockDevice, BlockUpdateType
 from aioshelly.const import MODEL_1, MODEL_25, MODEL_PLUS_2PM
+from aioshelly.exceptions import NotInitialized
 from aioshelly.rpc_device import RpcDevice, RpcUpdateType
 import pytest
 
@@ -568,3 +569,97 @@ async def mock_blu_trv():
         blu_trv_device_mock.return_value.mock_update = Mock(side_effect=update)
 
         yield blu_trv_device_mock.return_value
+
+
+def _mock_sleepy_not_initialized_rpc_device():
+    """Mock sleepy NotInitialized rpc (Gen2+, Websocket) device."""
+    device = Mock(spec=RpcDevice, initialized=False, connected=False)
+    type(device).requires_auth = PropertyMock(side_effect=NotInitialized)
+    type(device).status = PropertyMock(side_effect=NotInitialized)
+    type(device).event = PropertyMock(side_effect=NotInitialized)
+    type(device).config = PropertyMock(side_effect=NotInitialized)
+    type(device).shelly = PropertyMock(side_effect=NotInitialized)
+    type(device).gen = PropertyMock(side_effect=NotInitialized)
+    type(device).firmware_version = PropertyMock(side_effect=NotInitialized)
+    type(device).version = PropertyMock(side_effect=NotInitialized)
+    type(device).model = PropertyMock(side_effect=NotInitialized)
+    type(device).xmod_info = PropertyMock(side_effect=NotInitialized)
+    type(device).hostname = PropertyMock(side_effect=NotInitialized)
+    type(device).name = PropertyMock(side_effect=NotInitialized)
+    type(device).firmware_supported = PropertyMock(side_effect=NotInitialized)
+    return device
+
+
+def initialize_sleepy_rpc_device(device):
+    """Initialize a sleepy RPC (Gen2+, Websocket) device."""
+    type(device).requires_auth = PropertyMock()
+    type(device).status = PropertyMock(return_value=MOCK_STATUS_RPC)
+    type(device).event = PropertyMock(return_value={})
+    type(device).config = PropertyMock(return_value=MOCK_CONFIG)
+    type(device).shelly = PropertyMock(return_value=MOCK_SHELLY_RPC)
+    type(device).gen = PropertyMock(return_value=2)
+    type(device).firmware_version = PropertyMock(
+        return_value="20240425-141520/1.3.0-ga3fdd3d"
+    )
+    type(device).version = PropertyMock("1.3.0")
+    type(device).model = PropertyMock("SPSW-201PE16EU")
+    type(device).xmod_info = PropertyMock(return_value={})
+    type(device).hostname = PropertyMock(return_value="hostname")
+    type(device).name = PropertyMock(return_value="Test Name")
+    type(device).firmware_supported = PropertyMock(return_value=True)
+
+    device.status["sys"]["wakeup_period"] = 1000
+    device.connected = True
+    device.initialized = True
+
+
+@pytest.fixture
+async def mock_sleepy_rpc_device():
+    """Mock sleepy RPC (Gen2+, Websocket) device.
+
+    Mock a RPC device that is not initialized and raises NotInitialized
+    when aioshelly properties are accessed.
+
+    Initialize the device when initialize() method is called.
+    """
+    with patch("aioshelly.rpc_device.RpcDevice.create") as rpc_device_mock:
+
+        def update():
+            rpc_device_mock.return_value.subscribe_updates.call_args[0][0](
+                {}, RpcUpdateType.STATUS
+            )
+
+        def event():
+            rpc_device_mock.return_value.subscribe_updates.call_args[0][0](
+                {}, RpcUpdateType.EVENT
+            )
+
+        def online():
+            rpc_device_mock.return_value.subscribe_updates.call_args[0][0](
+                {}, RpcUpdateType.ONLINE
+            )
+
+        def disconnected():
+            rpc_device_mock.return_value.subscribe_updates.call_args[0][0](
+                {}, RpcUpdateType.DISCONNECTED
+            )
+
+        def initialized():
+            rpc_device_mock.return_value.subscribe_updates.call_args[0][0](
+                {}, RpcUpdateType.INITIALIZED
+            )
+
+        def _initialize():
+            initialize_sleepy_rpc_device(device)
+
+        device = _mock_sleepy_not_initialized_rpc_device()
+        device.initialize = AsyncMock(side_effect=_initialize)
+        rpc_device_mock.return_value = device
+
+        rpc_device_mock.return_value.mock_disconnected = Mock(side_effect=disconnected)
+        rpc_device_mock.return_value.mock_update = Mock(side_effect=update)
+        rpc_device_mock.return_value.mock_event = Mock(side_effect=event)
+        rpc_device_mock.return_value.mock_online = Mock(side_effect=online)
+        rpc_device_mock.return_value.mock_initialized = Mock(side_effect=initialized)
+
+        yield rpc_device_mock.return_value

--- a/tests/components/shelly/test_init.py
+++ b/tests/components/shelly/test_init.py
@@ -312,13 +312,10 @@ async def test_sleeping_rpc_device_online_new_firmware(
 
 async def test_sleeping_rpc_device_online_during_setup(
     hass: HomeAssistant,
-    mock_rpc_device: Mock,
-    monkeypatch: pytest.MonkeyPatch,
+    mock_sleepy_rpc_device: Mock,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test sleeping device Gen2 woke up by user during setup."""
-    monkeypatch.setattr(mock_rpc_device, "connected", False)
-    monkeypatch.setitem(mock_rpc_device.status["sys"], "wakeup_period", 1000)
     await init_integration(hass, 2, sleep_period=1000)
     await hass.async_block_till_done(wait_background_tasks=True)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix Shelly model name for XMOD devices. This PR assumes that XMOD based devices will not be sleepy ones, it is safe to assume that because sleepy devices are very hardware/software tight and would be hard to support them on a generic device such as XMOD.
With this change even if a new XMOD will be a sleepy type it will not break, we will just not generate a model name for it which we can fix later.

Modified an existing test for a sleepy device to fail if a property of the device is accessed when the device is not initialized:

```
2025-02-21 11:11:01.674 ERROR    MainThread homeassistant.config_entries:config_entries.py:830 Error setting up entry Mock Title for shelly
Traceback (most recent call last):
  ...
  File "/workspaces/core/homeassistant/components/shelly/utils.py", line 320, in get_device_info_model
    if isinstance(device, RpcDevice) and (model := device.xmod_info.get("n")):
                                                   ^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/unittest/mock.py", line 3043, in __get__
    return self()
  File "/usr/local/lib/python3.13/unittest/mock.py", line 1167, in __call__
    return self._mock_call(*args, **kwargs)
           ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/unittest/mock.py", line 1171, in _mock_call
    return self._execute_mock_call(*args, **kwargs)
           ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/unittest/mock.py", line 1226, in _execute_mock_call
    raise effect
aioshelly.exceptions.NotInitialized
```

Reproduced before using Shelly Plus H&T and fixed with this change.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/138981
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
