### PR TITLE
Bump reolink-aio to 0.12.0

### DIFF
--- a/homeassistant/components/reolink/manifest.json
+++ b/homeassistant/components/reolink/manifest.json
@@ -19,5 +19,5 @@
   "iot_class": "local_push",
   "loggers": ["reolink_aio"],
   "quality_scale": "platinum",
-  "requirements": ["reolink-aio==0.11.10"]
+  "requirements": ["reolink-aio==0.12.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2612,7 +2612,7 @@ renault-api==0.2.9
 renson-endura-delta==1.7.2
 
 # homeassistant.components.reolink
-reolink-aio==0.11.10
+reolink-aio==0.12.0
 
 # homeassistant.components.idteck_prox
 rfk101py==0.0.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2115,7 +2115,7 @@ renault-api==0.2.9
 renson-endura-delta==1.7.2
 
 # homeassistant.components.reolink
-reolink-aio==0.11.10
+reolink-aio==0.12.0
 
 # homeassistant.components.rflink
 rflink==0.0.66


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump reolink-aio to 0.12.0:
**Core changes:**
- [Use Baichuan encryption offset as message_id to seperate push, host and channel responses](https://github.com/starkillerOG/reolink_aio/pull/106)
- [Use baichuan imediately when fallback already confirmed to be needed and working](https://github.com/starkillerOG/reolink_aio/commit/9218e2fcd382815ff54b1769025b1b35db5c2958)
- [Send baichuan commands concurrently using asyncio.gather](https://github.com/starkillerOG/reolink_aio/commit/1b3b30c967c655347433b0f0dbc3cab8d1e0051e)
- [Only GET specific channel after send_setting to not wake up other battery cams](https://github.com/starkillerOG/reolink_aio/commit/1d411e925d4362691a067ba1228d049469856254)
- [Split out parse_json from send and fix the case in which no body left after Baichuan filtering](https://github.com/starkillerOG/reolink_aio/commit/3845f9fb8f54ed6146fd9045a707f2a9a5e40f96)

**Bug fixes:**
- [Fix retry logic of Baichuan](https://github.com/starkillerOG/reolink_aio/commit/cd417f9c78cf8922c5187f26cbad8533697b2702)
- [Don't relay on login to obtain privacy mode supported](https://github.com/starkillerOG/reolink_aio/commit/f7cf187c973fb910c8f82eb3ff2031a07ad48be3)
- [Check privacy mode supported more thoroughly](https://github.com/starkillerOG/reolink_aio/commit/a5efa7a08ecd4df9698b6d3c7347ae021712bd90)
- [Add playback recording filename version 7](https://github.com/starkillerOG/reolink_aio/commit/148e4082d2f952457771691462972dba70fd457c)
- [Do not support Chime on battery doorbell for Home Hub](https://github.com/starkillerOG/reolink_aio/commit/5dfaf70e91c17503c070307884264c38038bb615)
- [Check channel of GetDingDongList to disregard wrong channels](https://github.com/starkillerOG/reolink_aio/commit/fd883bc0904308375f60fe3dd9a1823f3efafd1c)

**Optimizations:**
- [Add minimum firmware for E1 Pro IPC_NT1NA45MP](https://github.com/starkillerOG/reolink_aio/commit/1603c9cc3e023a4c15c6954b169f6bc6d989efb8)
- [Add Baichuan cmd_id to receive debug logs](https://github.com/starkillerOG/reolink_aio/commit/7ce8596df403885f26d87a720d6b6881e28b2056)

**Full Changelog**: https://github.com/starkillerOG/reolink_aio/compare/0.11.10...0.12.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/131017 fixes https://github.com/home-assistant/core/issues/137917
- This PR is related to issue: https://github.com/home-assistant/core/issues/138616 https://github.com/home-assistant/core/issues/138616 https://github.com/home-assistant/core/issues/138550
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
