### PR TITLE
Fix Shelly mock initialization for sleepy RPC device in tests

### DIFF
--- a/tests/components/shelly/conftest.py
+++ b/tests/components/shelly/conftest.py
@@ -1,5 +1,6 @@
 """Test configuration for Shelly."""
 
+from copy import deepcopy
 from unittest.mock import AsyncMock, Mock, PropertyMock, patch
 
 from aioshelly.ble.const import (
@@ -592,8 +593,11 @@ def _mock_sleepy_not_initialized_rpc_device():
 
 def initialize_sleepy_rpc_device(device):
     """Initialize a sleepy RPC (Gen2+, Websocket) device."""
-    type(device).requires_auth = PropertyMock()
-    type(device).status = PropertyMock(return_value=MOCK_STATUS_RPC)
+    status = deepcopy(MOCK_STATUS_RPC)
+    status["sys"]["wakeup_period"] = 1000
+
+    type(device).requires_auth = PropertyMock(return_value=False)
+    type(device).status = PropertyMock(return_value=status)
     type(device).event = PropertyMock(return_value={})
     type(device).config = PropertyMock(return_value=MOCK_CONFIG)
     type(device).shelly = PropertyMock(return_value=MOCK_SHELLY_RPC)
@@ -601,14 +605,13 @@ def initialize_sleepy_rpc_device(device):
     type(device).firmware_version = PropertyMock(
         return_value="20240425-141520/1.3.0-ga3fdd3d"
     )
-    type(device).version = PropertyMock("1.3.0")
-    type(device).model = PropertyMock("SPSW-201PE16EU")
+    type(device).version = PropertyMock(return_value="1.3.0")
+    type(device).model = PropertyMock(return_value="SPSW-201PE16EU")
     type(device).xmod_info = PropertyMock(return_value={})
     type(device).hostname = PropertyMock(return_value="hostname")
     type(device).name = PropertyMock(return_value="Test Name")
     type(device).firmware_supported = PropertyMock(return_value=True)
 
-    device.status["sys"]["wakeup_period"] = 1000
     device.connected = True
     device.initialized = True
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix Shelly tests failure due to https://github.com/home-assistant/core/pull/138984

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
