### PR TITLE
Preserve manually entered HEOS host

### DIFF
--- a/homeassistant/components/heos/__init__.py
+++ b/homeassistant/components/heos/__init__.py
@@ -74,13 +74,11 @@ async def async_unload_entry(hass: HomeAssistant, entry: HeosConfigEntry) -> boo
 
 async def async_migrate_entry(hass: HomeAssistant, entry: HeosConfigEntry) -> bool:
     """Migrate old entry."""
-    if entry.version > 1:
-        return False
-    if entry.minor_version > 0:
+    if entry.version > 1 or entry.minor_version > 1:
         return False
     data = {**entry.data}
     data[CONF_MANAGE_HOST] = not await is_custom_host(data[CONF_HOST])
-    hass.config_entries.async_update_entry(entry, data=data, version=1, minor_version=1)
+    hass.config_entries.async_update_entry(entry, data=data, version=1, minor_version=2)
     return True
 
 

--- a/homeassistant/components/heos/config_flow.py
+++ b/homeassistant/components/heos/config_flow.py
@@ -124,16 +124,16 @@ async def is_custom_host(host: str) -> bool:
         _LOGGER.debug(
             "Unable to determine if host '%s' is a custom", host, exc_info=True
         )
-        return False
+        return True
     else:
-        return host in [host.ip_address for host in system_info.hosts]
+        return host not in [host.ip_address for host in system_info.hosts]
 
 
 class HeosFlowHandler(ConfigFlow, domain=DOMAIN):
     """Define a flow for HEOS."""
 
     VERSION = 1
-    MINOR_VERSION = 1
+    MINOR_VERSION = 2
 
     def __init__(self) -> None:
         """Initialize the HEOS flow."""

--- a/homeassistant/components/heos/config_flow.py
+++ b/homeassistant/components/heos/config_flow.py
@@ -127,6 +127,8 @@ async def is_custom_host(host: str) -> bool:
         return True
     else:
         return host not in [host.ip_address for host in system_info.hosts]
+    finally:
+        await heos.disconnect()
 
 
 class HeosFlowHandler(ConfigFlow, domain=DOMAIN):

--- a/homeassistant/components/heos/const.py
+++ b/homeassistant/components/heos/const.py
@@ -2,6 +2,7 @@
 
 ATTR_PASSWORD = "password"
 ATTR_USERNAME = "username"
+CONF_MANAGE_HOST = "manage_host"
 DOMAIN = "heos"
 ENTRY_TITLE = "HEOS System"
 SERVICE_GROUP_VOLUME_SET = "group_volume_set"

--- a/homeassistant/components/heos/strings.json
+++ b/homeassistant/components/heos/strings.json
@@ -23,7 +23,7 @@
           "host": "[%key:common::config_flow::data::host%]"
         },
         "data_description": {
-          "manage_host": "Allow Home Assistant to automatically select the best device to connect to (recommended). Uncheck to the use the manual entry entered below.",
+          "manage_host": "Allow Home Assistant to automatically select the best device to connect to (recommended). Uncheck to preserve a manual host entered below.",
           "host": "[%key:component::heos::config::step::user::data_description::host%]"
         }
       },

--- a/homeassistant/components/heos/strings.json
+++ b/homeassistant/components/heos/strings.json
@@ -19,9 +19,11 @@
         "title": "Reconfigure HEOS",
         "description": "Change the host name or IP address of the HEOS-capable product used to access your HEOS System.",
         "data": {
+          "manage_host": "Manage automatically",
           "host": "[%key:common::config_flow::data::host%]"
         },
         "data_description": {
+          "manage_host": "Allow Home Assistant to automatically select the best device to connect to (recommended). Uncheck to the use the manual entry entered below.",
           "host": "[%key:component::heos::config::step::user::data_description::host%]"
         }
       },

--- a/homeassistant/components/heos/strings.json
+++ b/homeassistant/components/heos/strings.json
@@ -23,7 +23,7 @@
           "host": "[%key:common::config_flow::data::host%]"
         },
         "data_description": {
-          "manage_host": "Allow Home Assistant to automatically select the best device to connect to (recommended). Uncheck to preserve a manual host entered below.",
+          "manage_host": "Allow Home Assistant to automatically select the best device to connect to (recommended). Uncheck to preserve a manually entered host name below.",
           "host": "[%key:component::heos::config::step::user::data_description::host%]"
         }
       },

--- a/tests/components/heos/conftest.py
+++ b/tests/components/heos/conftest.py
@@ -24,7 +24,7 @@ from pyheos import (
 import pytest
 import pytest_asyncio
 
-from homeassistant.components.heos import DOMAIN
+from homeassistant.components.heos.const import CONF_MANAGE_HOST, DOMAIN, ENTRY_TITLE
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.helpers.service_info.ssdp import (
     ATTR_UPNP_DEVICE_TYPE,
@@ -47,9 +47,11 @@ def config_entry_fixture() -> MockConfigEntry:
     """Create a mock HEOS config entry."""
     return MockConfigEntry(
         domain=DOMAIN,
-        data={CONF_HOST: "127.0.0.1"},
-        title="HEOS System (via 127.0.0.1)",
+        data={CONF_HOST: "127.0.0.1", CONF_MANAGE_HOST: True},
+        title=ENTRY_TITLE,
         unique_id=DOMAIN,
+        version=1,
+        minor_version=1,
     )
 
 
@@ -58,10 +60,12 @@ def config_entry_options_fixture() -> MockConfigEntry:
     """Create a mock HEOS config entry with options."""
     return MockConfigEntry(
         domain=DOMAIN,
-        data={CONF_HOST: "127.0.0.1"},
-        title="HEOS System (via 127.0.0.1)",
+        data={CONF_HOST: "127.0.0.1", CONF_MANAGE_HOST: True},
+        title=ENTRY_TITLE,
         options={CONF_USERNAME: "user", CONF_PASSWORD: "pass"},
         unique_id=DOMAIN,
+        version=1,
+        minor_version=1,
     )
 
 

--- a/tests/components/heos/conftest.py
+++ b/tests/components/heos/conftest.py
@@ -44,20 +44,32 @@ from tests.common import MockConfigEntry
 
 @pytest.fixture(name="config_entry")
 def config_entry_fixture() -> MockConfigEntry:
-    """Create a mock HEOS config entry."""
+    """Create a mock HEOS config entry for the current version."""
     return MockConfigEntry(
         domain=DOMAIN,
         data={CONF_HOST: "127.0.0.1", CONF_MANAGE_HOST: True},
         title=ENTRY_TITLE,
         unique_id=DOMAIN,
         version=1,
-        minor_version=1,
+        minor_version=2,
+    )
+
+
+@pytest.fixture(name="config_entry_v1")
+def config_entry_v1_fixture() -> MockConfigEntry:
+    """Create a mock HEOS config entry for version 1."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: "127.0.0.1"},
+        title=ENTRY_TITLE,
+        unique_id=DOMAIN,
+        version=1,
     )
 
 
 @pytest.fixture(name="config_entry_options")
 def config_entry_options_fixture() -> MockConfigEntry:
-    """Create a mock HEOS config entry with options."""
+    """Create a mock HEOS config entry with options for the current version."""
     return MockConfigEntry(
         domain=DOMAIN,
         data={CONF_HOST: "127.0.0.1", CONF_MANAGE_HOST: True},
@@ -65,7 +77,7 @@ def config_entry_options_fixture() -> MockConfigEntry:
         options={CONF_USERNAME: "user", CONF_PASSWORD: "pass"},
         unique_id=DOMAIN,
         version=1,
-        minor_version=1,
+        minor_version=2,
     )
 
 

--- a/tests/components/heos/snapshots/test_config_flow.ambr
+++ b/tests/components/heos/snapshots/test_config_flow.ambr
@@ -1,0 +1,94 @@
+# serializer version: 1
+# name: test_create_entry_when_host_valid
+  FlowResultSnapshot({
+    'context': dict({
+      'source': 'user',
+      'unique_id': 'heos',
+    }),
+    'data': dict({
+      'host': '127.0.0.1',
+      'manage_host': False,
+    }),
+    'description': None,
+    'description_placeholders': None,
+    'flow_id': <ANY>,
+    'handler': 'heos',
+    'minor_version': 1,
+    'options': dict({
+    }),
+    'result': ConfigEntrySnapshot({
+      'data': dict({
+        'host': '127.0.0.1',
+        'manage_host': False,
+      }),
+      'disabled_by': None,
+      'discovery_keys': dict({
+      }),
+      'domain': 'heos',
+      'entry_id': <ANY>,
+      'minor_version': 1,
+      'options': dict({
+      }),
+      'pref_disable_new_entities': False,
+      'pref_disable_polling': False,
+      'source': 'user',
+      'subentries': list([
+      ]),
+      'title': 'HEOS System',
+      'unique_id': 'heos',
+      'version': 1,
+    }),
+    'subentries': tuple(
+    ),
+    'title': 'HEOS System',
+    'type': <FlowResultType.CREATE_ENTRY: 'create_entry'>,
+    'version': 1,
+  })
+# ---
+# name: test_discovery
+  FlowResultSnapshot({
+    'context': dict({
+      'confirm_only': True,
+      'source': 'ssdp',
+      'unique_id': 'heos',
+    }),
+    'data': dict({
+      'host': '127.0.0.1',
+      'manage_host': True,
+    }),
+    'description': None,
+    'description_placeholders': None,
+    'flow_id': <ANY>,
+    'handler': 'heos',
+    'minor_version': 1,
+    'options': dict({
+    }),
+    'result': ConfigEntrySnapshot({
+      'data': dict({
+        'host': '127.0.0.1',
+        'manage_host': True,
+      }),
+      'disabled_by': None,
+      'discovery_keys': dict({
+      }),
+      'domain': 'heos',
+      'entry_id': <ANY>,
+      'minor_version': 1,
+      'options': dict({
+      }),
+      'pref_disable_new_entities': False,
+      'pref_disable_polling': False,
+      'source': 'ssdp',
+      'subentries': list([
+      ]),
+      'title': 'HEOS System',
+      'unique_id': 'heos',
+      'version': 1,
+    }),
+    'subentries': tuple(
+    ),
+    'title': 'HEOS System',
+    'type': <FlowResultType.CREATE_ENTRY: 'create_entry'>,
+    'version': 1,
+  })
+# ---

--- a/tests/components/heos/snapshots/test_config_flow.ambr
+++ b/tests/components/heos/snapshots/test_config_flow.ambr
@@ -13,7 +13,7 @@
     'description_placeholders': None,
     'flow_id': <ANY>,
     'handler': 'heos',
-    'minor_version': 1,
+    'minor_version': 2,
     'options': dict({
     }),
     'result': ConfigEntrySnapshot({
@@ -26,7 +26,7 @@
       }),
       'domain': 'heos',
       'entry_id': <ANY>,
-      'minor_version': 1,
+      'minor_version': 2,
       'options': dict({
       }),
       'pref_disable_new_entities': False,
@@ -60,7 +60,7 @@
     'description_placeholders': None,
     'flow_id': <ANY>,
     'handler': 'heos',
-    'minor_version': 1,
+    'minor_version': 2,
     'options': dict({
     }),
     'result': ConfigEntrySnapshot({
@@ -73,7 +73,7 @@
       }),
       'domain': 'heos',
       'entry_id': <ANY>,
-      'minor_version': 1,
+      'minor_version': 2,
       'options': dict({
       }),
       'pref_disable_new_entities': False,

--- a/tests/components/heos/snapshots/test_diagnostics.ambr
+++ b/tests/components/heos/snapshots/test_diagnostics.ambr
@@ -10,7 +10,7 @@
       'discovery_keys': dict({
       }),
       'domain': 'heos',
-      'minor_version': 1,
+      'minor_version': 2,
       'options': dict({
       }),
       'pref_disable_new_entities': False,
@@ -158,7 +158,7 @@
       'discovery_keys': dict({
       }),
       'domain': 'heos',
-      'minor_version': 1,
+      'minor_version': 2,
       'options': dict({
       }),
       'pref_disable_new_entities': False,

--- a/tests/components/heos/snapshots/test_diagnostics.ambr
+++ b/tests/components/heos/snapshots/test_diagnostics.ambr
@@ -4,6 +4,7 @@
     'config_entry': dict({
       'data': dict({
         'host': '127.0.0.1',
+        'manage_host': True,
       }),
       'disabled_by': None,
       'discovery_keys': dict({
@@ -17,7 +18,7 @@
       'source': 'user',
       'subentries': list([
       ]),
-      'title': 'HEOS System (via 127.0.0.1)',
+      'title': 'HEOS System',
       'unique_id': 'heos',
       'version': 1,
     }),
@@ -151,6 +152,7 @@
     'config_entry': dict({
       'data': dict({
         'host': '127.0.0.1',
+        'manage_host': True,
       }),
       'disabled_by': None,
       'discovery_keys': dict({
@@ -164,7 +166,7 @@
       'source': 'user',
       'subentries': list([
       ]),
-      'title': 'HEOS System (via 127.0.0.1)',
+      'title': 'HEOS System',
       'unique_id': 'heos',
       'version': 1,
     }),

--- a/tests/components/heos/test_config_flow.py
+++ b/tests/components/heos/test_config_flow.py
@@ -220,6 +220,21 @@ async def test_reconfigure_validates_and_updates_config(
     assert result["type"] is FlowResultType.ABORT
 
 
+async def test_reconfigure_ignores_modified_host_when_managed(
+    hass: HomeAssistant, config_entry: MockConfigEntry
+) -> None:
+    """Test reconfigure ignores changed host when managed is enabled."""
+    config_entry.add_to_hass(hass)
+    result = await config_entry.start_reconfigure_flow(hass)
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_HOST: "new host", CONF_MANAGE_HOST: True},
+    )
+    assert config_entry.data == {CONF_HOST: "127.0.0.1", CONF_MANAGE_HOST: True}
+    assert result["reason"] == "reconfigure_successful"
+    assert result["type"] is FlowResultType.ABORT
+
+
 async def test_reconfigure_cannot_connect_recovers(
     hass: HomeAssistant, config_entry: MockConfigEntry, controller: MockHeos
 ) -> None:

--- a/tests/components/heos/test_init.py
+++ b/tests/components/heos/test_init.py
@@ -191,35 +191,27 @@ async def test_async_migrate_entry_newer_fails(
     assert config_entry.state is ConfigEntryState.MIGRATION_ERROR
 
 
+@pytest.mark.parametrize(
+    ("host", "expected_manage_host"), [("127.0.0.1", True), ("custom-host", False)]
+)
 async def test_async_migrate_entry_v1_1_to_v1_2(
     hass: HomeAssistant,
     config_entry_v1: MockConfigEntry,
     controller: MockHeos,
     system: HeosSystem,
+    host: str,
+    expected_manage_host: bool,
 ) -> None:
-    """Test migration from 1.1 to 1.2 with a non-customized host."""
+    """Test migration from 1.1 to 1.2."""
     controller.get_system_info.return_value = system
     config_entry_v1.add_to_hass(hass)
+    hass.config_entries.async_update_entry(config_entry_v1, data={CONF_HOST: host})
     assert await hass.config_entries.async_setup(config_entry_v1.entry_id)
     assert config_entry_v1.minor_version == 2
-    assert config_entry_v1.data == {CONF_HOST: "127.0.0.1", CONF_MANAGE_HOST: True}
-
-
-async def test_async_migrate_entry_v1_1_to_v1_2_custom_host(
-    hass: HomeAssistant,
-    config_entry_v1: MockConfigEntry,
-    controller: MockHeos,
-    system: HeosSystem,
-) -> None:
-    """Test migration from 1.1 to 1.2 with custom host turns off auto-manage."""
-    controller.get_system_info.return_value = system
-    config_entry_v1.add_to_hass(hass)
-    hass.config_entries.async_update_entry(
-        config_entry_v1, data={CONF_HOST: "custom-host"}
-    )
-    assert await hass.config_entries.async_setup(config_entry_v1.entry_id)
-    assert config_entry_v1.minor_version == 2
-    assert config_entry_v1.data == {CONF_HOST: "custom-host", CONF_MANAGE_HOST: False}
+    assert config_entry_v1.data == {
+        CONF_HOST: host,
+        CONF_MANAGE_HOST: expected_manage_host,
+    }
 
 
 async def test_async_migrate_entry_v1_1_to_v1_2_error(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Previous change (#138950) introduced functionality to automatically update the HEOS host from discovery. This has a side-effect of overwriting a custom host name, if configured by the user.

This change introduces a new config key (`manage_host: bool`) and exposes it in the reconfigure screen to allow the user to toggle automatic host management (and preserve a manually entered host name). The config entry minor version was incremented and migration determines if the host name is custom (best effort) and disables the functionality. For new adds of the integration, `manage_host` is set to `True` when setup from discovery and `False` when setup manually.

<img alt="New HEOS reconfigure screen" src="https://github.com/user-attachments/assets/61ab4ee8-384e-4702-a122-0ce8fe400c8c" />

This needs to be part of 2025.3 in order to not impact users.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: WIP
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository] 

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
