### PR TITLE
Fix minimum schema version to run event_id_post_migration

### DIFF
--- a/homeassistant/components/recorder/const.py
+++ b/homeassistant/components/recorder/const.py
@@ -53,7 +53,8 @@ LEGACY_STATES_EVENT_ID_INDEX_SCHEMA_VERSION = 28
 LEGACY_STATES_EVENT_FOREIGN_KEYS_FIXED_SCHEMA_VERSION = 34
 # https://github.com/home-assistant/core/pull/120779
 # fixed the foreign keys in the states table but it did
-# not bump the schema version
+# not bump the schema version which only databases created with
+# schema 35 and later do not need the rebuild.
 
 INTEGRATION_PLATFORM_COMPILE_STATISTICS = "compile_statistics"
 INTEGRATION_PLATFORM_LIST_STATISTIC_IDS = "list_statistic_ids"

--- a/homeassistant/components/recorder/const.py
+++ b/homeassistant/components/recorder/const.py
@@ -50,6 +50,10 @@ STATES_META_SCHEMA_VERSION = 38
 LAST_REPORTED_SCHEMA_VERSION = 43
 
 LEGACY_STATES_EVENT_ID_INDEX_SCHEMA_VERSION = 28
+LEGACY_STATES_EVENT_FOREIGN_KEYS_FIXED_SCHEMA_VERSION = 34
+# https://github.com/home-assistant/core/pull/120779
+# fixed the foreign keys in the states table but it did
+# not bump the schema version
 
 INTEGRATION_PLATFORM_COMPILE_STATISTICS = "compile_statistics"
 INTEGRATION_PLATFORM_LIST_STATISTIC_IDS = "list_statistic_ids"

--- a/homeassistant/components/recorder/const.py
+++ b/homeassistant/components/recorder/const.py
@@ -53,7 +53,7 @@ LEGACY_STATES_EVENT_ID_INDEX_SCHEMA_VERSION = 28
 LEGACY_STATES_EVENT_FOREIGN_KEYS_FIXED_SCHEMA_VERSION = 43
 # https://github.com/home-assistant/core/pull/120779
 # fixed the foreign keys in the states table but it did
-# not bump the schema version which means only databases 
+# not bump the schema version which means only databases
 # created with schema 44 and later do not need the rebuild.
 
 INTEGRATION_PLATFORM_COMPILE_STATISTICS = "compile_statistics"

--- a/homeassistant/components/recorder/const.py
+++ b/homeassistant/components/recorder/const.py
@@ -53,8 +53,8 @@ LEGACY_STATES_EVENT_ID_INDEX_SCHEMA_VERSION = 28
 LEGACY_STATES_EVENT_FOREIGN_KEYS_FIXED_SCHEMA_VERSION = 43
 # https://github.com/home-assistant/core/pull/120779
 # fixed the foreign keys in the states table but it did
-# not bump the schema version which only databases created with
-# schema 44 and later do not need the rebuild.
+# not bump the schema version which means only databases 
+# created with schema 44 and later do not need the rebuild.
 
 INTEGRATION_PLATFORM_COMPILE_STATISTICS = "compile_statistics"
 INTEGRATION_PLATFORM_LIST_STATISTIC_IDS = "list_statistic_ids"

--- a/homeassistant/components/recorder/const.py
+++ b/homeassistant/components/recorder/const.py
@@ -50,11 +50,11 @@ STATES_META_SCHEMA_VERSION = 38
 LAST_REPORTED_SCHEMA_VERSION = 43
 
 LEGACY_STATES_EVENT_ID_INDEX_SCHEMA_VERSION = 28
-LEGACY_STATES_EVENT_FOREIGN_KEYS_FIXED_SCHEMA_VERSION = 34
+LEGACY_STATES_EVENT_FOREIGN_KEYS_FIXED_SCHEMA_VERSION = 43
 # https://github.com/home-assistant/core/pull/120779
 # fixed the foreign keys in the states table but it did
 # not bump the schema version which only databases created with
-# schema 35 and later do not need the rebuild.
+# schema 44 and later do not need the rebuild.
 
 INTEGRATION_PLATFORM_COMPILE_STATISTICS = "compile_statistics"
 INTEGRATION_PLATFORM_LIST_STATISTIC_IDS = "list_statistic_ids"

--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -2872,10 +2872,10 @@ class EventIDPostMigration(BaseRunTimeMigration):
     migration_id = "event_id_post_migration"
     # Note we don't subtract 1 from the max_initial_schema_version
     # in this case because we need to run this migration on databases
-    # version 34 because the schema was not bumped when the table
+    # version 43 because the schema was not bumped when the table
     # rebuild was added in
     # https://github.com/home-assistant/core/pull/120779
-    # which means its only safe to assume version 35 and later
+    # which means its only safe to assume version 44 and later
     # do not need the table rebuild
     max_initial_schema_version = LEGACY_STATES_EVENT_FOREIGN_KEYS_FIXED_SCHEMA_VERSION
     task = MigrationTask

--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -52,6 +52,7 @@ from .auto_repairs.statistics.schema import (
 from .const import (
     CONTEXT_ID_AS_BINARY_SCHEMA_VERSION,
     EVENT_TYPE_IDS_SCHEMA_VERSION,
+    LEGACY_STATES_EVENT_FOREIGN_KEYS_FIXED_SCHEMA_VERSION,
     LEGACY_STATES_EVENT_ID_INDEX_SCHEMA_VERSION,
     STATES_META_SCHEMA_VERSION,
     SupportedDialect,
@@ -2490,9 +2491,10 @@ class BaseMigration(ABC):
         if self.initial_schema_version > self.max_initial_schema_version:
             _LOGGER.debug(
                 "Data migration '%s' not needed, database created with version %s "
-                "after migrator was added",
+                "after migrator was added in version %s",
                 self.migration_id,
                 self.initial_schema_version,
+                self.max_initial_schema_version,
             )
             return False
         if self.start_schema_version < self.required_schema_version:
@@ -2868,7 +2870,14 @@ class EventIDPostMigration(BaseRunTimeMigration):
     """Migration to remove old event_id index from states."""
 
     migration_id = "event_id_post_migration"
-    max_initial_schema_version = LEGACY_STATES_EVENT_ID_INDEX_SCHEMA_VERSION - 1
+    # Note we don't subtract 1 from the max_initial_schema_version
+    # in this case because we need to run this migration on databases
+    # version 34 because the schema was not bumped when the table
+    # rebuild was added in
+    # https://github.com/home-assistant/core/pull/120779 so its
+    # only safer to assume version 35 and later actually have the
+    # new schema.
+    max_initial_schema_version = LEGACY_STATES_EVENT_FOREIGN_KEYS_FIXED_SCHEMA_VERSION
     task = MigrationTask
     migration_version = 2
 

--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -2875,7 +2875,7 @@ class EventIDPostMigration(BaseRunTimeMigration):
     # version 34 because the schema was not bumped when the table
     # rebuild was added in
     # https://github.com/home-assistant/core/pull/120779 so its
-    # only safe to assume version 35 and later actually have the
+    # only safe to assume version 35 and later
     # do not need the table rebuild
     max_initial_schema_version = LEGACY_STATES_EVENT_FOREIGN_KEYS_FIXED_SCHEMA_VERSION
     task = MigrationTask

--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -2872,7 +2872,7 @@ class EventIDPostMigration(BaseRunTimeMigration):
     migration_id = "event_id_post_migration"
     # Note we don't subtract 1 from the max_initial_schema_version
     # in this case because we need to run this migration on databases
-    # version 43 because the schema was not bumped when the table
+    # version >= 43 because the schema was not bumped when the table
     # rebuild was added in
     # https://github.com/home-assistant/core/pull/120779
     # which means its only safe to assume version 44 and later

--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -2875,8 +2875,8 @@ class EventIDPostMigration(BaseRunTimeMigration):
     # version 34 because the schema was not bumped when the table
     # rebuild was added in
     # https://github.com/home-assistant/core/pull/120779 so its
-    # only safer to assume version 35 and later actually have the
-    # new schema.
+    # only safe to assume version 35 and later actually have the
+    # do not need the table rebuild
     max_initial_schema_version = LEGACY_STATES_EVENT_FOREIGN_KEYS_FIXED_SCHEMA_VERSION
     task = MigrationTask
     migration_version = 2

--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -2874,8 +2874,8 @@ class EventIDPostMigration(BaseRunTimeMigration):
     # in this case because we need to run this migration on databases
     # version 34 because the schema was not bumped when the table
     # rebuild was added in
-    # https://github.com/home-assistant/core/pull/120779 so its
-    # only safe to assume version 35 and later
+    # https://github.com/home-assistant/core/pull/120779
+    # which means its only safe to assume version 35 and later
     # do not need the table rebuild
     max_initial_schema_version = LEGACY_STATES_EVENT_FOREIGN_KEYS_FIXED_SCHEMA_VERSION
     task = MigrationTask

--- a/tests/components/recorder/test_migration_from_schema_32.py
+++ b/tests/components/recorder/test_migration_from_schema_32.py
@@ -225,6 +225,7 @@ async def test_migrate_events_context_ids(
         patch.object(recorder, "db_schema", old_db_schema),
         patch.object(migration, "SCHEMA_VERSION", old_db_schema.SCHEMA_VERSION),
         patch.object(migration.EventsContextIDMigration, "migrate_data"),
+        patch.object(migration.EventIDPostMigration, "migrate_data"),
         patch(CREATE_ENGINE_TARGET, new=_create_engine_test),
     ):
         async with (
@@ -282,6 +283,7 @@ async def test_migrate_events_context_ids(
             patch(
                 "sqlalchemy.schema.Index.create", autospec=True, wraps=Index.create
             ) as wrapped_idx_create,
+            patch.object(migration.EventIDPostMigration, "migrate_data"),
         ):
             async with async_test_recorder(
                 hass, wait_recorder=False, wait_recorder_setup=False
@@ -588,6 +590,7 @@ async def test_migrate_states_context_ids(
         patch.object(recorder, "db_schema", old_db_schema),
         patch.object(migration, "SCHEMA_VERSION", old_db_schema.SCHEMA_VERSION),
         patch.object(migration.StatesContextIDMigration, "migrate_data"),
+        patch.object(migration.EventIDPostMigration, "migrate_data"),
         patch(CREATE_ENGINE_TARGET, new=_create_engine_test),
     ):
         async with (
@@ -640,6 +643,7 @@ async def test_migrate_states_context_ids(
             patch(
                 "sqlalchemy.schema.Index.create", autospec=True, wraps=Index.create
             ) as wrapped_idx_create,
+            patch.object(migration.EventIDPostMigration, "migrate_data"),
         ):
             async with async_test_recorder(
                 hass, wait_recorder=False, wait_recorder_setup=False
@@ -1127,6 +1131,7 @@ async def test_post_migrate_entity_ids(
         patch.object(migration, "SCHEMA_VERSION", old_db_schema.SCHEMA_VERSION),
         patch.object(migration.EntityIDMigration, "migrate_data"),
         patch.object(migration.EntityIDPostMigration, "migrate_data"),
+        patch.object(migration.EventIDPostMigration, "migrate_data"),
         patch(CREATE_ENGINE_TARGET, new=_create_engine_test),
     ):
         async with (
@@ -1158,9 +1163,12 @@ async def test_post_migrate_entity_ids(
             return {state.state: state.entity_id for state in states}
 
     # Run again with new schema, let migration run
-    with patch(
-        "sqlalchemy.schema.Index.create", autospec=True, wraps=Index.create
-    ) as wrapped_idx_create:
+    with (
+        patch(
+            "sqlalchemy.schema.Index.create", autospec=True, wraps=Index.create
+        ) as wrapped_idx_create,
+        patch.object(migration.EventIDPostMigration, "migrate_data"),
+    ):
         async with (
             async_test_home_assistant() as hass,
             async_test_recorder(hass) as instance,
@@ -1168,7 +1176,6 @@ async def test_post_migrate_entity_ids(
             instance.recorder_and_worker_thread_ids.add(threading.get_ident())
 
             await hass.async_block_till_done()
-            await async_wait_recording_done(hass)
             await async_wait_recording_done(hass)
 
             states_by_state = await instance.async_add_executor_job(

--- a/tests/components/recorder/test_migration_run_time_migrations_remember.py
+++ b/tests/components/recorder/test_migration_run_time_migrations_remember.py
@@ -115,7 +115,7 @@ def _create_engine_test(
                 "event_context_id_as_binary": (0, 1),
                 "event_type_id_migration": (2, 1),
                 "entity_id_migration": (2, 1),
-                "event_id_post_migration": (0, 0),
+                "event_id_post_migration": (1, 1),
                 "entity_id_post_migration": (0, 1),
             },
             [
@@ -131,7 +131,7 @@ def _create_engine_test(
                 "event_context_id_as_binary": (0, 0),
                 "event_type_id_migration": (2, 1),
                 "entity_id_migration": (2, 1),
-                "event_id_post_migration": (0, 0),
+                "event_id_post_migration": (1, 1),
                 "entity_id_post_migration": (0, 1),
             },
             ["ix_states_entity_id_last_updated_ts"],
@@ -143,13 +143,43 @@ def _create_engine_test(
                 "event_context_id_as_binary": (0, 0),
                 "event_type_id_migration": (0, 0),
                 "entity_id_migration": (2, 1),
-                "event_id_post_migration": (0, 0),
+                "event_id_post_migration": (1, 1),
                 "entity_id_post_migration": (0, 1),
             },
             ["ix_states_entity_id_last_updated_ts"],
         ),
         (
             38,
+            {
+                "state_context_id_as_binary": (0, 0),
+                "event_context_id_as_binary": (0, 0),
+                "event_type_id_migration": (0, 0),
+                "entity_id_migration": (0, 0),
+                "event_id_post_migration": (1, 1),
+                "entity_id_post_migration": (0, 0),
+            },
+            [],
+        ),
+        (
+            43,
+            {
+                "state_context_id_as_binary": (0, 0),
+                "event_context_id_as_binary": (0, 0),
+                "event_type_id_migration": (0, 0),
+                "entity_id_migration": (0, 0),
+                # Schema was not bumped when the SQLite
+                # table rebuild was implemented so we need
+                # run event_id_post_migration up until
+                # schema 44 since its the first one we can
+                # be sure has the foreign key constraint removed
+                # via https://github.com/home-assistant/core/pull/120779
+                "event_id_post_migration": (1, 1),
+                "entity_id_post_migration": (0, 0),
+            },
+            [],
+        ),
+        (
+            44,
             {
                 "state_context_id_as_binary": (0, 0),
                 "event_context_id_as_binary": (0, 0),
@@ -266,8 +296,12 @@ async def test_data_migrator_logic(
     # the expected number of times.
     for migrator, mock in migrator_mocks.items():
         needs_migrate_calls, migrate_data_calls = expected_migrator_calls[migrator]
-        assert len(mock["needs_migrate"].mock_calls) == needs_migrate_calls
-        assert len(mock["migrate_data"].mock_calls) == migrate_data_calls
+        assert len(mock["needs_migrate"].mock_calls) == needs_migrate_calls, (
+            f"Expected {migrator} needs_migrate to be called {needs_migrate_calls} times, got {len(mock['needs_migrate'].mock_calls)}"
+        )
+        assert len(mock["migrate_data"].mock_calls) == migrate_data_calls, (
+            f"Expected {migrator} migrate_data to be called {migrate_data_calls} times, got {len(mock['migrate_data'].mock_calls)}"
+        )
 
 
 @pytest.mark.parametrize("enable_migrate_state_context_ids", [True])

--- a/tests/components/recorder/test_migration_run_time_migrations_remember.py
+++ b/tests/components/recorder/test_migration_run_time_migrations_remember.py
@@ -171,7 +171,7 @@ def _create_engine_test(
                 # table rebuild was implemented so we need
                 # run event_id_post_migration up until
                 # schema 44 since its the first one we can
-                # be sure has the foreign key constraint removed
+                # be sure has the foreign key constraint was removed
                 # via https://github.com/home-assistant/core/pull/120779
                 "event_id_post_migration": (1, 1),
                 "entity_id_post_migration": (0, 0),

--- a/tests/components/recorder/test_migration_run_time_migrations_remember.py
+++ b/tests/components/recorder/test_migration_run_time_migrations_remember.py
@@ -297,10 +297,12 @@ async def test_data_migrator_logic(
     for migrator, mock in migrator_mocks.items():
         needs_migrate_calls, migrate_data_calls = expected_migrator_calls[migrator]
         assert len(mock["needs_migrate"].mock_calls) == needs_migrate_calls, (
-            f"Expected {migrator} needs_migrate to be called {needs_migrate_calls} times, got {len(mock['needs_migrate'].mock_calls)}"
+            f"Expected {migrator} needs_migrate to be called {needs_migrate_calls} times,"
+            f" got {len(mock['needs_migrate'].mock_calls)}"
         )
         assert len(mock["migrate_data"].mock_calls) == migrate_data_calls, (
-            f"Expected {migrator} migrate_data to be called {migrate_data_calls} times, got {len(mock['migrate_data'].mock_calls)}"
+            f"Expected {migrator} migrate_data to be called {migrate_data_calls} times, "
+            f"got {len(mock['migrate_data'].mock_calls)}"
         )
 
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The table rebuild to fix the foreign key constraint was added in https://github.com/home-assistant/core/pull/120779 but the [schema version was not bumped](https://github.com/home-assistant/core/blob/e1f0c1d2c6f4e73eb90662c25565fb8e5fd28422/homeassistant/components/recorder/db_schema.py#L76) so we need to make sure any database that was created with schema 43 or older still has the migration run as otherwise they will not be able to purge the database with SQLite since each delete in the events table will due a full table scan of the states table to look for a foreign key that is not there

Note that everything works as expected with the migration, but the schema version was set too low so it simply didn't run. The only functional change here is the constant value used to run the migration for databases that were created with schema <= 43 and instead of schema < 28

fixes #138818 fixes #138649 fixes #137651

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
