### PR TITLE
Fix write_registers calling after the upgrade of pymodbus to 3.8.x

### DIFF
--- a/homeassistant/components/modbus/modbus.py
+++ b/homeassistant/components/modbus/modbus.py
@@ -384,6 +384,11 @@ class ModbusHub:
             {ATTR_SLAVE: slave} if slave is not None else {ATTR_SLAVE: 1}
         )
         entry = self._pb_request[use_call]
+
+        if use_call in {"write_registers", "write_coils"}:
+            if not isinstance(value, list):
+                value = [value]
+
         kwargs[entry.value_attr_name] = value
         try:
             result: ModbusPDU = await entry.func(address, **kwargs)

--- a/tests/components/modbus/conftest.py
+++ b/tests/components/modbus/conftest.py
@@ -42,6 +42,7 @@ class ReadResult:
         self.registers = register_words
         self.bits = register_words
         self.value = register_words
+        self.count = len(register_words) if register_words is not None else 0
 
     def isError(self):
         """Set error state."""

--- a/tests/components/modbus/test_switch.py
+++ b/tests/components/modbus/test_switch.py
@@ -12,6 +12,7 @@ from homeassistant.components.modbus.const import (
     CALL_TYPE_DISCRETE,
     CALL_TYPE_REGISTER_HOLDING,
     CALL_TYPE_REGISTER_INPUT,
+    CALL_TYPE_X_REGISTER_HOLDINGS,
     CONF_DEVICE_ADDRESS,
     CONF_INPUT_TYPE,
     CONF_STATE_OFF,
@@ -50,6 +51,7 @@ from tests.common import async_fire_time_changed
 ENTITY_ID = f"{SWITCH_DOMAIN}.{TEST_ENTITY_NAME}".replace(" ", "_")
 ENTITY_ID2 = f"{ENTITY_ID}_2"
 ENTITY_ID3 = f"{ENTITY_ID}_3"
+ENTITY_ID4 = f"{ENTITY_ID}_4"
 
 
 @pytest.mark.parametrize(
@@ -330,6 +332,13 @@ async def test_restore_state_switch(
                     CONF_SCAN_INTERVAL: 0,
                     CONF_VERIFY: {CONF_STATE_ON: [1, 3]},
                 },
+                {
+                    CONF_NAME: f"{TEST_ENTITY_NAME} 4",
+                    CONF_ADDRESS: 19,
+                    CONF_WRITE_TYPE: CALL_TYPE_X_REGISTER_HOLDINGS,
+                    CONF_SCAN_INTERVAL: 0,
+                    CONF_VERIFY: {CONF_STATE_ON: [1, 3]},
+                },
             ],
         },
     ],
@@ -380,6 +389,20 @@ async def test_switch_service_turn(
     )
     await hass.async_block_till_done()
     assert hass.states.get(ENTITY_ID3).state == STATE_OFF
+
+    mock_modbus.read_holding_registers.return_value = ReadResult([0x03])
+    assert hass.states.get(ENTITY_ID4).state == STATE_OFF
+    await hass.services.async_call(
+        SWITCH_DOMAIN, SERVICE_TURN_ON, service_data={ATTR_ENTITY_ID: ENTITY_ID4}
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get(ENTITY_ID4).state == STATE_ON
+    mock_modbus.read_holding_registers.return_value = ReadResult([0x00])
+    await hass.services.async_call(
+        SWITCH_DOMAIN, SERVICE_TURN_OFF, service_data={ATTR_ENTITY_ID: ENTITY_ID4}
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get(ENTITY_ID4).state == STATE_OFF
 
     mock_modbus.write_register.side_effect = ModbusException("fail write_")
     await hass.services.async_call(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Pymodbus requires for [write_registers](https://github.com/pymodbus-dev/pymodbus/blob/7fc8d3e02d9d9011c25c80149eb88318e7f50d0e/pymodbus/client/mixin.py#L495) function a list of integer and a list of bool for[ write_coils](https://github.com/pymodbus-dev/pymodbus/blob/7fc8d3e02d9d9011c25c80149eb88318e7f50d0e/pymodbus/client/mixin.py#L472) 

Actually this requirements is satisfied only in the Climate component, where specific config parameters help the modbus climate to pass correctly the values to underlying pymodbus library. 
Switches, lights or fans, instead, use a different approach. I suppose that in the older version of the library this lack was fixed by the library itself, now instead this has generated the impossibility to use the modbus component in those users who need to use coils/holdings registers for switches/fans/lights as tracked in several issues. 

This PR before to call write_registers or write_coils, check if the value is correctly a list and it forces to a list in case it is not. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #138443
- This PR is related to issue: https://github.com/home-assistant/core/issues/138529#issuecomment-2661460214 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
