### PR TITLE
Waze action support entities

### DIFF
--- a/homeassistant/components/waze_travel_time/__init__.py
+++ b/homeassistant/components/waze_travel_time/__init__.py
@@ -16,6 +16,7 @@ from homeassistant.core import (
     SupportsResponse,
 )
 from homeassistant.helpers.httpx_client import get_async_client
+from homeassistant.helpers.location import find_coordinates
 from homeassistant.helpers.selector import (
     BooleanSelector,
     SelectSelector,
@@ -99,6 +100,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
             region=service.data[CONF_REGION].upper(), client=httpx_client
         )
         response = await async_get_travel_times(
+            hass=hass,
             client=client,
             origin=service.data[CONF_ORIGIN],
             destination=service.data[CONF_DESTINATION],
@@ -121,6 +123,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
 
 
 async def async_get_travel_times(
+    hass: HomeAssistant,
     client: WazeRouteCalculator,
     origin: str,
     destination: str,
@@ -146,8 +149,8 @@ async def async_get_travel_times(
     vehicle_type = "" if vehicle_type.upper() == "CAR" else vehicle_type.upper()
     try:
         routes = await client.calc_routes(
-            origin,
-            destination,
+            find_coordinates(hass, origin),
+            find_coordinates(hass, destination),
             vehicle_type=vehicle_type,
             avoid_toll_roads=avoid_toll_roads,
             avoid_subscription_roads=avoid_subscription_roads,

--- a/homeassistant/components/waze_travel_time/__init__.py
+++ b/homeassistant/components/waze_travel_time/__init__.py
@@ -99,11 +99,21 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         client = WazeRouteCalculator(
             region=service.data[CONF_REGION].upper(), client=httpx_client
         )
+
+        origin_coordinates = find_coordinates(hass, service.data[CONF_ORIGIN])
+        destination_coordinates = find_coordinates(hass, service.data[CONF_DESTINATION])
+
+        origin = origin_coordinates if origin_coordinates else service.data[CONF_ORIGIN]
+        destination = (
+            destination_coordinates
+            if destination_coordinates
+            else service.data[CONF_DESTINATION]
+        )
+
         response = await async_get_travel_times(
-            hass=hass,
             client=client,
-            origin=service.data[CONF_ORIGIN],
-            destination=service.data[CONF_DESTINATION],
+            origin=origin,
+            destination=destination,
             vehicle_type=service.data[CONF_VEHICLE_TYPE],
             avoid_toll_roads=service.data[CONF_AVOID_TOLL_ROADS],
             avoid_subscription_roads=service.data[CONF_AVOID_SUBSCRIPTION_ROADS],
@@ -123,7 +133,6 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
 
 
 async def async_get_travel_times(
-    hass: HomeAssistant,
     client: WazeRouteCalculator,
     origin: str,
     destination: str,
@@ -149,8 +158,8 @@ async def async_get_travel_times(
     vehicle_type = "" if vehicle_type.upper() == "CAR" else vehicle_type.upper()
     try:
         routes = await client.calc_routes(
-            find_coordinates(hass, origin),
-            find_coordinates(hass, destination),
+            origin,
+            destination,
             vehicle_type=vehicle_type,
             avoid_toll_roads=avoid_toll_roads,
             avoid_subscription_roads=avoid_subscription_roads,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds support for providing entity IDs or friendly names as the origin and/or destination for the Waze travel time action. Aligning the usability with that of the sensor

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/37628
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
