### PR TITLE
Add option to ESPHome to subscribe to logs

### DIFF
--- a/homeassistant/components/esphome/config_flow.py
+++ b/homeassistant/components/esphome/config_flow.py
@@ -41,6 +41,7 @@ from .const import (
     CONF_ALLOW_SERVICE_CALLS,
     CONF_DEVICE_NAME,
     CONF_NOISE_PSK,
+    CONF_SUBSCRIBE_LOGS,
     DEFAULT_ALLOW_SERVICE_CALLS,
     DEFAULT_NEW_CONFIG_ALLOW_ALLOW_SERVICE_CALLS,
     DOMAIN,
@@ -507,6 +508,10 @@ class OptionsFlowHandler(OptionsFlow):
                     default=self.config_entry.options.get(
                         CONF_ALLOW_SERVICE_CALLS, DEFAULT_ALLOW_SERVICE_CALLS
                     ),
+                ): bool,
+                vol.Required(
+                    CONF_SUBSCRIBE_LOGS,
+                    default=self.config_entry.options.get(CONF_SUBSCRIBE_LOGS, False),
                 ): bool,
             }
         )

--- a/homeassistant/components/esphome/const.py
+++ b/homeassistant/components/esphome/const.py
@@ -5,6 +5,7 @@ from awesomeversion import AwesomeVersion
 DOMAIN = "esphome"
 
 CONF_ALLOW_SERVICE_CALLS = "allow_service_calls"
+CONF_SUBSCRIBE_LOGS = "subscribe_logs"
 CONF_DEVICE_NAME = "device_name"
 CONF_NOISE_PSK = "noise_psk"
 

--- a/homeassistant/components/esphome/manager.py
+++ b/homeassistant/components/esphome/manager.py
@@ -86,7 +86,7 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 LOG_LEVEL_TO_LOGGER = {
-    LogLevel.LOG_LEVEL_NONE: logging.NOTSET,
+    LogLevel.LOG_LEVEL_NONE: logging.DEBUG,
     LogLevel.LOG_LEVEL_ERROR: logging.ERROR,
     LogLevel.LOG_LEVEL_WARN: logging.WARNING,
     LogLevel.LOG_LEVEL_INFO: logging.INFO,

--- a/homeassistant/components/esphome/manager.py
+++ b/homeassistant/components/esphome/manager.py
@@ -388,9 +388,8 @@ class ESPHomeManager:
         hass = self.hass
         cli = self.cli
         stored_device_name = entry.data.get(CONF_DEVICE_NAME)
-        subscribe_logs = entry.options.get(CONF_SUBSCRIBE_LOGS)
         unique_id_is_mac_address = unique_id and ":" in unique_id
-        if subscribe_logs:
+        if entry.options.get(CONF_SUBSCRIBE_LOGS):
             cli.subscribe_logs(self._async_on_log, LogLevel.LOG_LEVEL_VERY_VERBOSE)
         results = await asyncio.gather(
             create_eager_task(cli.device_info()),

--- a/homeassistant/components/esphome/strings.json
+++ b/homeassistant/components/esphome/strings.json
@@ -54,7 +54,8 @@
     "step": {
       "init": {
         "data": {
-          "allow_service_calls": "Allow the device to perform Home Assistant actions."
+          "allow_service_calls": "Allow the device to perform Home Assistant actions.",
+          "subscribe_logs": "Subscribe to logs from the device. When enabled, the device will send logs to Home Assistant and you can view them in the logs panel."
         }
       }
     }

--- a/tests/components/esphome/conftest.py
+++ b/tests/components/esphome/conftest.py
@@ -6,7 +6,7 @@ import asyncio
 from asyncio import Event
 from collections.abc import AsyncGenerator, Awaitable, Callable, Coroutine
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 from aioesphomeapi import (
@@ -17,6 +17,7 @@ from aioesphomeapi import (
     EntityInfo,
     EntityState,
     HomeassistantServiceCall,
+    LogLevel,
     ReconnectLogic,
     UserService,
     VoiceAssistantAnnounceFinished,
@@ -41,6 +42,10 @@ from homeassistant.setup import async_setup_component
 from . import DASHBOARD_HOST, DASHBOARD_PORT, DASHBOARD_SLUG
 
 from tests.common import MockConfigEntry
+
+if TYPE_CHECKING:
+    from aioesphomeapi.api_pb2 import SubscribeLogsResponse
+
 
 _ONE_SECOND = 16000 * 2  # 16Khz 16-bit
 
@@ -154,6 +159,7 @@ def mock_client(mock_device_info) -> APIClient:
     mock_client.device_info = AsyncMock(return_value=mock_device_info)
     mock_client.connect = AsyncMock()
     mock_client.disconnect = AsyncMock()
+    mock_client.subscribe_logs = Mock()
     mock_client.list_entities_services = AsyncMock(return_value=([], []))
     mock_client.address = "127.0.0.1"
     mock_client.api_version = APIVersion(99, 99)
@@ -222,6 +228,7 @@ class MockESPHomeDevice:
             ]
             | None
         )
+        self.on_log_message: Callable[[SubscribeLogsResponse], None]
         self.device_info = device_info
 
     def set_state_callback(self, state_callback: Callable[[EntityState], None]) -> None:
@@ -249,6 +256,16 @@ class MockESPHomeDevice:
     async def mock_disconnect(self, expected_disconnect: bool) -> None:
         """Mock disconnecting."""
         await self.on_disconnect(expected_disconnect)
+
+    def set_on_log_message(
+        self, on_log_message: Callable[[SubscribeLogsResponse], None]
+    ) -> None:
+        """Set the log message callback."""
+        self.on_log_message = on_log_message
+
+    def mock_on_log_message(self, log_message: SubscribeLogsResponse) -> None:
+        """Mock on log message."""
+        self.on_log_message(log_message)
 
     def set_on_connect(self, on_connect: Callable[[], None]) -> None:
         """Set the connect callback."""
@@ -413,6 +430,12 @@ async def _mock_generic_device_entry(
             on_state_sub, on_state_request
         )
 
+    def _subscribe_logs(
+        on_log_message: Callable[[SubscribeLogsResponse], None], log_level: LogLevel
+    ) -> None:
+        """Subscribe to log messages."""
+        mock_device.set_on_log_message(on_log_message)
+
     def _subscribe_voice_assistant(
         *,
         handle_start: Callable[
@@ -453,6 +476,7 @@ async def _mock_generic_device_entry(
     mock_client.subscribe_states = _subscribe_states
     mock_client.subscribe_service_calls = _subscribe_service_calls
     mock_client.subscribe_home_assistant_states = _subscribe_home_assistant_states
+    mock_client.subscribe_logs = _subscribe_logs
 
     try_connect_done = Event()
 

--- a/tests/components/esphome/test_manager.py
+++ b/tests/components/esphome/test_manager.py
@@ -1279,6 +1279,7 @@ async def test_esphome_device_subscribe_logs(
         states=[],
     )
     await hass.async_block_till_done()
+    caplog.set_level(logging.DEBUG)
     device.mock_on_log_message(
         Mock(level=LogLevel.LOG_LEVEL_INFO, message=b"test_log_message")
     )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When something goes wrong on the device side, it's very difficult to get logs from the device because unless the user has an open log window, the logs are gone when the problem has been discovered.

The goal is to have them in the `home-assistant.log`. When we ask for logs in an issue, we can better understand what is going on with the device when we get an issue report since, in many cases, we never get logs, and the issue goes unsolved. It is too difficult for users to set up an external way to capture the logs or correlate the messages they see in HA with what is happening on the device because they must manually combine separate log files and timestamps or use [external components](https://github.com/TheStaticTurtle/esphome_syslog) to try to get the logs which means many issues that require careful examination of event order go unsolved.

This is implemented as an option because it can take days or weeks to track down an issue and we want to ensure the logging survives a restart.

While this problem applies in many cases, the proverbial straw and final motivation for this change is that we have had a [long-standing disconnect race bug in the BLE code](https://github.com/esphome/esphome/pull/8297) that has taken years to discover because we couldn't get good logs.

In most cases, you will still see very few messages in the log when this option is turned on. You'll need to enable debug logs in the UI as well, and then you'll be able to see a lot more about what's going on with the device. Example:
```
2025-02-22 13:51:31.441 DEBUG (MainThread) [homeassistant.components.esphome.manager] livingroomgliproxy: [D][esp32_ble_client:391]: [0] [BC:14:EF:7B:22:2A] Event 39
2025-02-22 13:51:31.444 INFO (MainThread) [homeassistant.components.esphome.manager] livingroomgliproxy: [I][esp32_ble_client:138]: [0] [BC:14:EF:7B:22:2A] Disconnecting (conn_id: 0).
2025-02-22 13:51:31.448 DEBUG (MainThread) [homeassistant.components.esphome.manager] livingroomgliproxy: [D][esp-idf:000][BTU_TASK]: W (4115275) BT_HCI: hci cmd send: disconnect: hdl 0x0, rsn:0x13
2025-02-22 13:51:31.450 DEBUG (MainThread) [homeassistant.components.esphome.manager] livingroomgliproxy: [D][esp-idf:000][BTU_TASK]: W (4115277) BT_APPL: gattc_conn_cb: if=3 st=0 id=3 rsn=0x16
2025-02-22 13:51:31.465 DEBUG (MainThread) [homeassistant.components.esphome.manager] livingroomgliproxy: [D][esp-idf:000][BTU_TASK]: W (4115278) BT_APPL: gattc_conn_cb: if=4 st=0 id=4 rsn=0x16
2025-02-22 13:51:31.475 DEBUG (MainThread) [homeassistant.components.esphome.manager] livingroomgliproxy: [D][esp-idf:000][BTU_TASK]: W (4115292) BT_APPL: gattc_conn_cb: if=5 st=0 id=5 rsn=0x16
2025-02-22 13:51:31.485 DEBUG (MainThread) [homeassistant.components.esphome.manager] livingroomgliproxy: [D][esp-idf:000][BTU_TASK]: W (4115305) BT_HCI: hcif disc complete: hdl 0x0, rsn 0x16
2025-02-22 13:51:31.489 INFO (MainThread) [homeassistant.components.esphome.manager] livingroomgliproxy: [I][bluetooth_proxy:282]: [0] [BC:14:EF:7B:22:2A] Connecting v3 with cache
2025-02-22 13:51:31.495 DEBUG (MainThread) [homeassistant.components.esphome.manager] livingroomgliproxy: [D][esp32_ble_tracker:115]: connecting: 0, discovered: 1, searching: 0, disconnecting: 0
2025-02-22 13:51:31.505 DEBUG (MainThread) [homeassistant.components.esphome.manager] livingroomgliproxy: [D][esp32_ble_tracker:231]: Pausing scan to make connection...
2025-02-22 13:51:31.517 INFO (MainThread) [homeassistant.components.esphome.manager] livingroomgliproxy: [I][esp32_ble_client:110]: [0] [BC:14:EF:7B:22:2A] 0x00 Attempting BLE connection
2025-02-22 13:51:31.528 DEBUG (MainThread) [homeassistant.components.esphome.manager] livingroomgliproxy: [D][esp32_ble_tracker:115]: connecting: 1, discovered: 0, searching: 0, disconnecting: 0
2025-02-22 13:51:31.635 DEBUG (MainThread) [homeassistant.components.esphome.manager] livingroomgliproxy: [D][esp32_ble_client:177]: [0] [BC:14:EF:7B:22:2A] ESP_GATTC_CONNECT_EVT
2025-02-22 13:51:31.639 DEBUG (MainThread) [homeassistant.components.esphome.manager] livingroomgliproxy: [D][esp32_ble_client:177]: [0] [BC:14:EF:7B:22:2A] ESP_GATTC_OPEN_EVT
2025-02-22 13:51:31.645 INFO (MainThread) [homeassistant.components.esphome.manager] livingroomgliproxy: [I][esp32_ble_client:231]: [0] [BC:14:EF:7B:22:2A] Connected
2025-02-22 13:51:31.650 DEBUG (MainThread) [homeassistant.components.esphome.manager] livingroomgliproxy: [D][esp32_ble_tracker:115]: connecting: 0, discovered: 0, searching: 0, disconnecting: 0
2025-02-22 13:51:31.654 DEBUG (MainThread) [homeassistant.components.esphome.manager] livingroomgliproxy: [D][esp32_ble_tracker:282]: Starting scan...
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
