### PR TITLE
Fix recorder loading after base platforms

### DIFF
--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1556,11 +1556,13 @@ async def test_no_base_platforms_loaded_before_recorder(hass: HomeAssistant) -> 
             integration.all_dependencies
         )
         assert not domain_with_base_platforms_deps, (
-            f"{integration.domain} has base platforms in dependencies: {domain_with_base_platforms_deps}"
+            f"{integration.domain} has base platforms in dependencies: "
+            f"{domain_with_base_platforms_deps}"
         )
         integration_top_level_files = base_platform_py_files.intersection(
             integration._top_level_files
         )
         assert not integration_top_level_files, (
-            f"{integration.domain} has base platform files in top level files: {integration_top_level_files}"
+            f"{integration.domain} has base platform files in top level files: "
+            f"{integration_top_level_files}"
         )

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1523,3 +1523,44 @@ def test_should_rollover_is_always_false() -> None:
         ).shouldRollover(Mock())
         is False
     )
+
+
+async def test_no_base_platforms_loaded_before_recorder(hass: HomeAssistant) -> None:
+    """Verify stage 0 not load base platforms before recorder.
+
+    If a stage 0 integration has a base platform in its dependencies and
+    it loads before the recorder, it may load integrations that expect
+    the recorder to be loaded. We need to ensure that no stage 0 integration
+    has a base platform in its dependencies that loads before the recorder.
+    """
+    integrations_before_recorder: set[str] = set()
+    for _, integrations, _ in bootstrap.STAGE_0_INTEGRATIONS:
+        integrations_before_recorder |= integrations
+        if "recorder" in integrations:
+            break
+
+    integrations_or_execs = await loader.async_get_integrations(
+        hass, integrations_before_recorder
+    )
+    integrations: list[Integration] = []
+    resolve_deps_tasks: list[asyncio.Task[bool]] = []
+    for integration in integrations_or_execs.values():
+        assert not isinstance(integrations_or_execs, Exception)
+        integrations.append(integration)
+        resolve_deps_tasks.append(integration.resolve_dependencies())
+
+    await asyncio.gather(*resolve_deps_tasks)
+    base_platform_py_files = {f"{base_platform}.py" for base_platform in BASE_PLATFORMS}
+    for integration in integrations:
+        domain_with_base_platforms_deps = BASE_PLATFORMS.intersection(
+            integration.all_dependencies
+        )
+        assert not domain_with_base_platforms_deps, (
+            f"{integration.domain} has base platforms in dependencies: {domain_with_base_platforms_deps}"
+        )
+        integration_top_level_files = base_platform_py_files.intersection(
+            integration._top_level_files
+        )
+        assert not integration_top_level_files, (
+            f"{integration.domain} has base platform files in top level files: {integration_top_level_files}"
+        )


### PR DESCRIPTION

previous attempt to fix this was at https://github.com/home-assistant/core/pull/139037

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
#137067 made hassio load before the recorder which causes the sensor platform to be set up too soon. Reorder stage 0 to prevent this, and add a test to ensure we catch this in the future.

The problem now is this breaks #134534 
We have
`frontend` -> `backup` -> `hassio` -> `sensor`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
