### PR TITLE
Remove name in Minecraft Server config entry

### DIFF
--- a/homeassistant/components/minecraft_server/__init__.py
+++ b/homeassistant/components/minecraft_server/__init__.py
@@ -9,7 +9,7 @@ import dns.rdata
 import dns.rdataclass
 import dns.rdatatype
 
-from homeassistant.const import CONF_ADDRESS, CONF_HOST, CONF_NAME, CONF_PORT, Platform
+from homeassistant.const import CONF_ADDRESS, CONF_HOST, CONF_PORT, Platform
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
@@ -126,23 +126,6 @@ async def async_migrate_entry(
         hass.config_entries.async_update_entry(config_entry, data=new_data, version=3)
 
         _LOGGER.debug("Migration to version 3 successful")
-
-    # 3 --> 4: Remove name in config entry.
-    if config_entry.version == 3:
-        _LOGGER.debug("Migrating from version 3")
-
-        config_data = config_entry.data
-
-        # Migrate config entry.
-        _LOGGER.debug(
-            "Migrating config entry, removing name '%s'", config_data.get("name", "")
-        )
-
-        new_data = config_data.copy()
-        del new_data[CONF_NAME]
-        hass.config_entries.async_update_entry(config_entry, data=new_data, version=4)
-
-        _LOGGER.debug("Migration to version 4 successful")
 
     return True
 

--- a/homeassistant/components/minecraft_server/__init__.py
+++ b/homeassistant/components/minecraft_server/__init__.py
@@ -9,7 +9,7 @@ import dns.rdata
 import dns.rdataclass
 import dns.rdatatype
 
-from homeassistant.const import CONF_ADDRESS, CONF_HOST, CONF_PORT, Platform
+from homeassistant.const import CONF_ADDRESS, CONF_HOST, CONF_NAME, CONF_PORT, Platform
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
@@ -126,6 +126,23 @@ async def async_migrate_entry(
         hass.config_entries.async_update_entry(config_entry, data=new_data, version=3)
 
         _LOGGER.debug("Migration to version 3 successful")
+
+    # 3 --> 4: Remove name in config entry.
+    if config_entry.version == 3:
+        _LOGGER.debug("Migrating from version 3")
+
+        config_data = config_entry.data
+
+        # Migrate config entry.
+        _LOGGER.debug(
+            "Migrating config entry, removing name '%s'", config_data.get("name", "")
+        )
+
+        new_data = config_data.copy()
+        del new_data[CONF_NAME]
+        hass.config_entries.async_update_entry(config_entry, data=new_data, version=4)
+
+        _LOGGER.debug("Migration to version 4 successful")
 
     return True
 

--- a/homeassistant/components/minecraft_server/config_flow.py
+++ b/homeassistant/components/minecraft_server/config_flow.py
@@ -21,7 +21,7 @@ _LOGGER = logging.getLogger(__name__)
 class MinecraftServerConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Minecraft Server."""
 
-    VERSION = 4
+    VERSION = 3
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None

--- a/homeassistant/components/minecraft_server/config_flow.py
+++ b/homeassistant/components/minecraft_server/config_flow.py
@@ -8,10 +8,10 @@ from typing import Any
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
-from homeassistant.const import CONF_ADDRESS, CONF_NAME, CONF_TYPE
+from homeassistant.const import CONF_ADDRESS, CONF_TYPE
 
 from .api import MinecraftServer, MinecraftServerAddressError, MinecraftServerType
-from .const import DEFAULT_NAME, DOMAIN
+from .const import DOMAIN
 
 DEFAULT_ADDRESS = "localhost:25565"
 
@@ -21,7 +21,7 @@ _LOGGER = logging.getLogger(__name__)
 class MinecraftServerConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Minecraft Server."""
 
-    VERSION = 3
+    VERSION = 4
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -37,7 +37,6 @@ class MinecraftServerConfigFlow(ConfigFlow, domain=DOMAIN):
 
             # Prepare config entry data.
             config_data = {
-                CONF_NAME: user_input[CONF_NAME],
                 CONF_ADDRESS: address,
             }
 
@@ -78,9 +77,6 @@ class MinecraftServerConfigFlow(ConfigFlow, domain=DOMAIN):
             step_id="user",
             data_schema=vol.Schema(
                 {
-                    vol.Required(
-                        CONF_NAME, default=user_input.get(CONF_NAME, DEFAULT_NAME)
-                    ): str,
                     vol.Required(
                         CONF_ADDRESS,
                         default=user_input.get(CONF_ADDRESS, DEFAULT_ADDRESS),

--- a/homeassistant/components/minecraft_server/const.py
+++ b/homeassistant/components/minecraft_server/const.py
@@ -1,7 +1,5 @@
 """Constants for the Minecraft Server integration."""
 
-DEFAULT_NAME = "Minecraft Server"
-
 DOMAIN = "minecraft_server"
 
 KEY_LATENCY = "latency"

--- a/homeassistant/components/minecraft_server/coordinator.py
+++ b/homeassistant/components/minecraft_server/coordinator.py
@@ -42,7 +42,7 @@ class MinecraftServerCoordinator(DataUpdateCoordinator[MinecraftServerData]):
 
         super().__init__(
             hass=hass,
-            name=config_entry.data[CONF_ADDRESS],
+            name=config_entry.title,
             config_entry=config_entry,
             logger=_LOGGER,
             update_interval=SCAN_INTERVAL,

--- a/homeassistant/components/minecraft_server/coordinator.py
+++ b/homeassistant/components/minecraft_server/coordinator.py
@@ -6,7 +6,7 @@ from datetime import timedelta
 import logging
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_ADDRESS, CONF_NAME, CONF_TYPE
+from homeassistant.const import CONF_ADDRESS, CONF_TYPE
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -42,7 +42,7 @@ class MinecraftServerCoordinator(DataUpdateCoordinator[MinecraftServerData]):
 
         super().__init__(
             hass=hass,
-            name=config_entry.data[CONF_NAME],
+            name=config_entry.data[CONF_ADDRESS],
             config_entry=config_entry,
             logger=_LOGGER,
             update_interval=SCAN_INTERVAL,

--- a/homeassistant/components/minecraft_server/diagnostics.py
+++ b/homeassistant/components/minecraft_server/diagnostics.py
@@ -5,12 +5,12 @@ from dataclasses import asdict
 from typing import Any
 
 from homeassistant.components.diagnostics import async_redact_data
-from homeassistant.const import CONF_ADDRESS, CONF_NAME
+from homeassistant.const import CONF_ADDRESS
 from homeassistant.core import HomeAssistant
 
 from .coordinator import MinecraftServerConfigEntry
 
-TO_REDACT: Iterable[Any] = {CONF_ADDRESS, CONF_NAME, "players_list"}
+TO_REDACT: Iterable[Any] = {CONF_ADDRESS, "players_list"}
 
 
 async def async_get_config_entry_diagnostics(

--- a/homeassistant/components/minecraft_server/quality_scale.yaml
+++ b/homeassistant/components/minecraft_server/quality_scale.yaml
@@ -6,9 +6,7 @@ rules:
   appropriate-polling: done
   brands: done
   common-modules: done
-  config-flow:
-    status: todo
-    comment: Check removal and replacement of name in config flow with the title (server address).
+  config-flow: done
   config-flow-test-coverage:
     status: todo
     comment: |

--- a/homeassistant/components/minecraft_server/strings.json
+++ b/homeassistant/components/minecraft_server/strings.json
@@ -5,7 +5,6 @@
         "title": "Link your Minecraft Server",
         "description": "Set up your Minecraft Server instance to allow monitoring.",
         "data": {
-          "name": "[%key:common::config_flow::data::name%]",
           "address": "Server address"
         }
       }

--- a/homeassistant/components/minecraft_server/strings.json
+++ b/homeassistant/components/minecraft_server/strings.json
@@ -2,11 +2,14 @@
   "config": {
     "step": {
       "user": {
-        "title": "Link your Minecraft Server",
-        "description": "Set up your Minecraft Server instance to allow monitoring.",
         "data": {
           "address": "Server address"
-        }
+        },
+        "data_description": {
+          "address": "The hostname, IP address or SRV record of your Minecraft server, optionally including the port."
+        },
+        "title": "Link your Minecraft Server",
+        "description": "Set up your Minecraft Server instance to allow monitoring."
       }
     },
     "abort": {

--- a/tests/components/minecraft_server/conftest.py
+++ b/tests/components/minecraft_server/conftest.py
@@ -18,6 +18,7 @@ def java_mock_config_entry() -> MockConfigEntry:
         domain=DOMAIN,
         unique_id=None,
         entry_id=TEST_CONFIG_ENTRY_ID,
+        title="mc.dummyserver.com:25566",
         data={
             CONF_ADDRESS: TEST_ADDRESS,
             CONF_TYPE: MinecraftServerType.JAVA_EDITION,
@@ -33,6 +34,7 @@ def bedrock_mock_config_entry() -> MockConfigEntry:
         domain=DOMAIN,
         unique_id=None,
         entry_id=TEST_CONFIG_ENTRY_ID,
+        title="mc.dummyserver.com:25566",
         data={
             CONF_ADDRESS: TEST_ADDRESS,
             CONF_TYPE: MinecraftServerType.BEDROCK_EDITION,

--- a/tests/components/minecraft_server/conftest.py
+++ b/tests/components/minecraft_server/conftest.py
@@ -3,8 +3,8 @@
 import pytest
 
 from homeassistant.components.minecraft_server.api import MinecraftServerType
-from homeassistant.components.minecraft_server.const import DEFAULT_NAME, DOMAIN
-from homeassistant.const import CONF_ADDRESS, CONF_NAME, CONF_TYPE
+from homeassistant.components.minecraft_server.const import DOMAIN
+from homeassistant.const import CONF_ADDRESS, CONF_TYPE
 
 from .const import TEST_ADDRESS, TEST_CONFIG_ENTRY_ID
 
@@ -19,11 +19,10 @@ def java_mock_config_entry() -> MockConfigEntry:
         unique_id=None,
         entry_id=TEST_CONFIG_ENTRY_ID,
         data={
-            CONF_NAME: DEFAULT_NAME,
             CONF_ADDRESS: TEST_ADDRESS,
             CONF_TYPE: MinecraftServerType.JAVA_EDITION,
         },
-        version=3,
+        version=4,
     )
 
 
@@ -35,9 +34,8 @@ def bedrock_mock_config_entry() -> MockConfigEntry:
         unique_id=None,
         entry_id=TEST_CONFIG_ENTRY_ID,
         data={
-            CONF_NAME: DEFAULT_NAME,
             CONF_ADDRESS: TEST_ADDRESS,
             CONF_TYPE: MinecraftServerType.BEDROCK_EDITION,
         },
-        version=3,
+        version=4,
     )

--- a/tests/components/minecraft_server/conftest.py
+++ b/tests/components/minecraft_server/conftest.py
@@ -18,7 +18,7 @@ def java_mock_config_entry() -> MockConfigEntry:
         domain=DOMAIN,
         unique_id=None,
         entry_id=TEST_CONFIG_ENTRY_ID,
-        title="mc.dummyserver.com:25566",
+        title=TEST_ADDRESS,
         data={
             CONF_ADDRESS: TEST_ADDRESS,
             CONF_TYPE: MinecraftServerType.JAVA_EDITION,
@@ -34,7 +34,7 @@ def bedrock_mock_config_entry() -> MockConfigEntry:
         domain=DOMAIN,
         unique_id=None,
         entry_id=TEST_CONFIG_ENTRY_ID,
-        title="mc.dummyserver.com:25566",
+        title=TEST_ADDRESS,
         data={
             CONF_ADDRESS: TEST_ADDRESS,
             CONF_TYPE: MinecraftServerType.BEDROCK_EDITION,

--- a/tests/components/minecraft_server/conftest.py
+++ b/tests/components/minecraft_server/conftest.py
@@ -22,7 +22,7 @@ def java_mock_config_entry() -> MockConfigEntry:
             CONF_ADDRESS: TEST_ADDRESS,
             CONF_TYPE: MinecraftServerType.JAVA_EDITION,
         },
-        version=4,
+        version=3,
     )
 
 
@@ -37,5 +37,5 @@ def bedrock_mock_config_entry() -> MockConfigEntry:
             CONF_ADDRESS: TEST_ADDRESS,
             CONF_TYPE: MinecraftServerType.BEDROCK_EDITION,
         },
-        version=4,
+        version=3,
     )

--- a/tests/components/minecraft_server/snapshots/test_binary_sensor.ambr
+++ b/tests/components/minecraft_server/snapshots/test_binary_sensor.ambr
@@ -3,10 +3,10 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'connectivity',
-      'friendly_name': 'Minecraft Server Status',
+      'friendly_name': 'mc.dummyserver.com:25566 Status',
     }),
     'context': <ANY>,
-    'entity_id': 'binary_sensor.minecraft_server_status',
+    'entity_id': 'binary_sensor.mc_dummyserver_com_25566_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -17,10 +17,10 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'connectivity',
-      'friendly_name': 'Minecraft Server Status',
+      'friendly_name': 'mc.dummyserver.com:25566 Status',
     }),
     'context': <ANY>,
-    'entity_id': 'binary_sensor.minecraft_server_status',
+    'entity_id': 'binary_sensor.mc_dummyserver_com_25566_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -31,10 +31,10 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'connectivity',
-      'friendly_name': 'Minecraft Server Status',
+      'friendly_name': 'mc.dummyserver.com:25566 Status',
     }),
     'context': <ANY>,
-    'entity_id': 'binary_sensor.minecraft_server_status',
+    'entity_id': 'binary_sensor.mc_dummyserver_com_25566_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -45,10 +45,10 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'connectivity',
-      'friendly_name': 'Minecraft Server Status',
+      'friendly_name': 'mc.dummyserver.com:25566 Status',
     }),
     'context': <ANY>,
-    'entity_id': 'binary_sensor.minecraft_server_status',
+    'entity_id': 'binary_sensor.mc_dummyserver_com_25566_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/minecraft_server/snapshots/test_diagnostics.ambr
+++ b/tests/components/minecraft_server/snapshots/test_diagnostics.ambr
@@ -4,7 +4,7 @@
     'config_entry': dict({
       'entry_id': '01234567890123456789012345678901',
       'unique_id': None,
-      'version': 4,
+      'version': 3,
     }),
     'config_entry_data': dict({
       'address': '**REDACTED**',
@@ -31,7 +31,7 @@
     'config_entry': dict({
       'entry_id': '01234567890123456789012345678901',
       'unique_id': None,
-      'version': 4,
+      'version': 3,
     }),
     'config_entry_data': dict({
       'address': '**REDACTED**',

--- a/tests/components/minecraft_server/snapshots/test_diagnostics.ambr
+++ b/tests/components/minecraft_server/snapshots/test_diagnostics.ambr
@@ -4,11 +4,10 @@
     'config_entry': dict({
       'entry_id': '01234567890123456789012345678901',
       'unique_id': None,
-      'version': 3,
+      'version': 4,
     }),
     'config_entry_data': dict({
       'address': '**REDACTED**',
-      'name': '**REDACTED**',
       'type': 'Bedrock Edition',
     }),
     'config_entry_options': dict({
@@ -32,11 +31,10 @@
     'config_entry': dict({
       'entry_id': '01234567890123456789012345678901',
       'unique_id': None,
-      'version': 3,
+      'version': 4,
     }),
     'config_entry_data': dict({
       'address': '**REDACTED**',
-      'name': '**REDACTED**',
       'type': 'Java Edition',
     }),
     'config_entry_options': dict({

--- a/tests/components/minecraft_server/snapshots/test_sensor.ambr
+++ b/tests/components/minecraft_server/snapshots/test_sensor.ambr
@@ -2,11 +2,11 @@
 # name: test_sensor[bedrock_mock_config_entry-BedrockServer-lookup-status_response1-entity_ids1]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Minecraft Server Latency',
+      'friendly_name': 'mc.dummyserver.com:25566 Latency',
       'unit_of_measurement': <UnitOfTime.MILLISECONDS: 'ms'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.minecraft_server_latency',
+    'entity_id': 'sensor.mc_dummyserver_com_25566_latency',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -16,11 +16,11 @@
 # name: test_sensor[bedrock_mock_config_entry-BedrockServer-lookup-status_response1-entity_ids1].1
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Minecraft Server Players online',
+      'friendly_name': 'mc.dummyserver.com:25566 Players online',
       'unit_of_measurement': 'players',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.minecraft_server_players_online',
+    'entity_id': 'sensor.mc_dummyserver_com_25566_players_online',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -30,11 +30,11 @@
 # name: test_sensor[bedrock_mock_config_entry-BedrockServer-lookup-status_response1-entity_ids1].2
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Minecraft Server Players max',
+      'friendly_name': 'mc.dummyserver.com:25566 Players max',
       'unit_of_measurement': 'players',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.minecraft_server_players_max',
+    'entity_id': 'sensor.mc_dummyserver_com_25566_players_max',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -44,10 +44,10 @@
 # name: test_sensor[bedrock_mock_config_entry-BedrockServer-lookup-status_response1-entity_ids1].3
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Minecraft Server World message',
+      'friendly_name': 'mc.dummyserver.com:25566 World message',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.minecraft_server_world_message',
+    'entity_id': 'sensor.mc_dummyserver_com_25566_world_message',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -57,10 +57,10 @@
 # name: test_sensor[bedrock_mock_config_entry-BedrockServer-lookup-status_response1-entity_ids1].4
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Minecraft Server Version',
+      'friendly_name': 'mc.dummyserver.com:25566 Version',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.minecraft_server_version',
+    'entity_id': 'sensor.mc_dummyserver_com_25566_version',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -70,10 +70,10 @@
 # name: test_sensor[bedrock_mock_config_entry-BedrockServer-lookup-status_response1-entity_ids1].5
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Minecraft Server Protocol version',
+      'friendly_name': 'mc.dummyserver.com:25566 Protocol version',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.minecraft_server_protocol_version',
+    'entity_id': 'sensor.mc_dummyserver_com_25566_protocol_version',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -83,10 +83,10 @@
 # name: test_sensor[bedrock_mock_config_entry-BedrockServer-lookup-status_response1-entity_ids1].6
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Minecraft Server Map name',
+      'friendly_name': 'mc.dummyserver.com:25566 Map name',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.minecraft_server_map_name',
+    'entity_id': 'sensor.mc_dummyserver_com_25566_map_name',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -96,10 +96,10 @@
 # name: test_sensor[bedrock_mock_config_entry-BedrockServer-lookup-status_response1-entity_ids1].7
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Minecraft Server Game mode',
+      'friendly_name': 'mc.dummyserver.com:25566 Game mode',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.minecraft_server_game_mode',
+    'entity_id': 'sensor.mc_dummyserver_com_25566_game_mode',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -109,10 +109,10 @@
 # name: test_sensor[bedrock_mock_config_entry-BedrockServer-lookup-status_response1-entity_ids1].8
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Minecraft Server Edition',
+      'friendly_name': 'mc.dummyserver.com:25566 Edition',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.minecraft_server_edition',
+    'entity_id': 'sensor.mc_dummyserver_com_25566_edition',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -122,11 +122,11 @@
 # name: test_sensor[java_mock_config_entry-JavaServer-async_lookup-status_response0-entity_ids0]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Minecraft Server Latency',
+      'friendly_name': 'mc.dummyserver.com:25566 Latency',
       'unit_of_measurement': <UnitOfTime.MILLISECONDS: 'ms'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.minecraft_server_latency',
+    'entity_id': 'sensor.mc_dummyserver_com_25566_latency',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -136,7 +136,7 @@
 # name: test_sensor[java_mock_config_entry-JavaServer-async_lookup-status_response0-entity_ids0].1
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Minecraft Server Players online',
+      'friendly_name': 'mc.dummyserver.com:25566 Players online',
       'players_list': list([
         'Player 1',
         'Player 2',
@@ -145,7 +145,7 @@
       'unit_of_measurement': 'players',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.minecraft_server_players_online',
+    'entity_id': 'sensor.mc_dummyserver_com_25566_players_online',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -155,11 +155,11 @@
 # name: test_sensor[java_mock_config_entry-JavaServer-async_lookup-status_response0-entity_ids0].2
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Minecraft Server Players max',
+      'friendly_name': 'mc.dummyserver.com:25566 Players max',
       'unit_of_measurement': 'players',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.minecraft_server_players_max',
+    'entity_id': 'sensor.mc_dummyserver_com_25566_players_max',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -169,10 +169,10 @@
 # name: test_sensor[java_mock_config_entry-JavaServer-async_lookup-status_response0-entity_ids0].3
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Minecraft Server World message',
+      'friendly_name': 'mc.dummyserver.com:25566 World message',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.minecraft_server_world_message',
+    'entity_id': 'sensor.mc_dummyserver_com_25566_world_message',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -182,10 +182,10 @@
 # name: test_sensor[java_mock_config_entry-JavaServer-async_lookup-status_response0-entity_ids0].4
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Minecraft Server Version',
+      'friendly_name': 'mc.dummyserver.com:25566 Version',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.minecraft_server_version',
+    'entity_id': 'sensor.mc_dummyserver_com_25566_version',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -195,10 +195,10 @@
 # name: test_sensor[java_mock_config_entry-JavaServer-async_lookup-status_response0-entity_ids0].5
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Minecraft Server Protocol version',
+      'friendly_name': 'mc.dummyserver.com:25566 Protocol version',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.minecraft_server_protocol_version',
+    'entity_id': 'sensor.mc_dummyserver_com_25566_protocol_version',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -208,11 +208,11 @@
 # name: test_sensor_update[bedrock_mock_config_entry-BedrockServer-lookup-status_response1-entity_ids1]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Minecraft Server Latency',
+      'friendly_name': 'mc.dummyserver.com:25566 Latency',
       'unit_of_measurement': <UnitOfTime.MILLISECONDS: 'ms'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.minecraft_server_latency',
+    'entity_id': 'sensor.mc_dummyserver_com_25566_latency',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -222,11 +222,11 @@
 # name: test_sensor_update[bedrock_mock_config_entry-BedrockServer-lookup-status_response1-entity_ids1].1
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Minecraft Server Players online',
+      'friendly_name': 'mc.dummyserver.com:25566 Players online',
       'unit_of_measurement': 'players',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.minecraft_server_players_online',
+    'entity_id': 'sensor.mc_dummyserver_com_25566_players_online',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -236,11 +236,11 @@
 # name: test_sensor_update[bedrock_mock_config_entry-BedrockServer-lookup-status_response1-entity_ids1].2
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Minecraft Server Players max',
+      'friendly_name': 'mc.dummyserver.com:25566 Players max',
       'unit_of_measurement': 'players',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.minecraft_server_players_max',
+    'entity_id': 'sensor.mc_dummyserver_com_25566_players_max',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -250,10 +250,10 @@
 # name: test_sensor_update[bedrock_mock_config_entry-BedrockServer-lookup-status_response1-entity_ids1].3
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Minecraft Server World message',
+      'friendly_name': 'mc.dummyserver.com:25566 World message',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.minecraft_server_world_message',
+    'entity_id': 'sensor.mc_dummyserver_com_25566_world_message',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -263,10 +263,10 @@
 # name: test_sensor_update[bedrock_mock_config_entry-BedrockServer-lookup-status_response1-entity_ids1].4
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Minecraft Server Version',
+      'friendly_name': 'mc.dummyserver.com:25566 Version',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.minecraft_server_version',
+    'entity_id': 'sensor.mc_dummyserver_com_25566_version',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -276,10 +276,10 @@
 # name: test_sensor_update[bedrock_mock_config_entry-BedrockServer-lookup-status_response1-entity_ids1].5
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Minecraft Server Protocol version',
+      'friendly_name': 'mc.dummyserver.com:25566 Protocol version',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.minecraft_server_protocol_version',
+    'entity_id': 'sensor.mc_dummyserver_com_25566_protocol_version',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -289,10 +289,10 @@
 # name: test_sensor_update[bedrock_mock_config_entry-BedrockServer-lookup-status_response1-entity_ids1].6
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Minecraft Server Map name',
+      'friendly_name': 'mc.dummyserver.com:25566 Map name',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.minecraft_server_map_name',
+    'entity_id': 'sensor.mc_dummyserver_com_25566_map_name',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -302,10 +302,10 @@
 # name: test_sensor_update[bedrock_mock_config_entry-BedrockServer-lookup-status_response1-entity_ids1].7
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Minecraft Server Game mode',
+      'friendly_name': 'mc.dummyserver.com:25566 Game mode',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.minecraft_server_game_mode',
+    'entity_id': 'sensor.mc_dummyserver_com_25566_game_mode',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -315,10 +315,10 @@
 # name: test_sensor_update[bedrock_mock_config_entry-BedrockServer-lookup-status_response1-entity_ids1].8
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Minecraft Server Edition',
+      'friendly_name': 'mc.dummyserver.com:25566 Edition',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.minecraft_server_edition',
+    'entity_id': 'sensor.mc_dummyserver_com_25566_edition',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -328,11 +328,11 @@
 # name: test_sensor_update[java_mock_config_entry-JavaServer-async_lookup-status_response0-entity_ids0]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Minecraft Server Latency',
+      'friendly_name': 'mc.dummyserver.com:25566 Latency',
       'unit_of_measurement': <UnitOfTime.MILLISECONDS: 'ms'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.minecraft_server_latency',
+    'entity_id': 'sensor.mc_dummyserver_com_25566_latency',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -342,7 +342,7 @@
 # name: test_sensor_update[java_mock_config_entry-JavaServer-async_lookup-status_response0-entity_ids0].1
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Minecraft Server Players online',
+      'friendly_name': 'mc.dummyserver.com:25566 Players online',
       'players_list': list([
         'Player 1',
         'Player 2',
@@ -351,7 +351,7 @@
       'unit_of_measurement': 'players',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.minecraft_server_players_online',
+    'entity_id': 'sensor.mc_dummyserver_com_25566_players_online',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -361,11 +361,11 @@
 # name: test_sensor_update[java_mock_config_entry-JavaServer-async_lookup-status_response0-entity_ids0].2
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Minecraft Server Players max',
+      'friendly_name': 'mc.dummyserver.com:25566 Players max',
       'unit_of_measurement': 'players',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.minecraft_server_players_max',
+    'entity_id': 'sensor.mc_dummyserver_com_25566_players_max',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -375,10 +375,10 @@
 # name: test_sensor_update[java_mock_config_entry-JavaServer-async_lookup-status_response0-entity_ids0].3
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Minecraft Server World message',
+      'friendly_name': 'mc.dummyserver.com:25566 World message',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.minecraft_server_world_message',
+    'entity_id': 'sensor.mc_dummyserver_com_25566_world_message',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -388,10 +388,10 @@
 # name: test_sensor_update[java_mock_config_entry-JavaServer-async_lookup-status_response0-entity_ids0].4
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Minecraft Server Version',
+      'friendly_name': 'mc.dummyserver.com:25566 Version',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.minecraft_server_version',
+    'entity_id': 'sensor.mc_dummyserver_com_25566_version',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -401,10 +401,10 @@
 # name: test_sensor_update[java_mock_config_entry-JavaServer-async_lookup-status_response0-entity_ids0].5
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Minecraft Server Protocol version',
+      'friendly_name': 'mc.dummyserver.com:25566 Protocol version',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.minecraft_server_protocol_version',
+    'entity_id': 'sensor.mc_dummyserver_com_25566_protocol_version',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/minecraft_server/test_binary_sensor.py
+++ b/tests/components/minecraft_server/test_binary_sensor.py
@@ -64,7 +64,9 @@ async def test_binary_sensor(
     ):
         assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
-        assert hass.states.get("binary_sensor.minecraft_server_status") == snapshot
+        assert (
+            hass.states.get("binary_sensor.mc_dummyserver_com_25566_status") == snapshot
+        )
 
 
 @pytest.mark.parametrize(
@@ -113,7 +115,9 @@ async def test_binary_sensor_update(
         freezer.tick(timedelta(minutes=1))
         async_fire_time_changed(hass)
         await hass.async_block_till_done()
-        assert hass.states.get("binary_sensor.minecraft_server_status") == snapshot
+        assert (
+            hass.states.get("binary_sensor.mc_dummyserver_com_25566_status") == snapshot
+        )
 
 
 @pytest.mark.parametrize(
@@ -167,5 +171,6 @@ async def test_binary_sensor_update_failure(
         async_fire_time_changed(hass)
         await hass.async_block_till_done()
         assert (
-            hass.states.get("binary_sensor.minecraft_server_status").state == STATE_OFF
+            hass.states.get("binary_sensor.mc_dummyserver_com_25566_status").state
+            == STATE_OFF
         )

--- a/tests/components/minecraft_server/test_config_flow.py
+++ b/tests/components/minecraft_server/test_config_flow.py
@@ -5,9 +5,9 @@ from unittest.mock import patch
 from mcstatus import BedrockServer, JavaServer
 
 from homeassistant.components.minecraft_server.api import MinecraftServerType
-from homeassistant.components.minecraft_server.const import DEFAULT_NAME, DOMAIN
+from homeassistant.components.minecraft_server.const import DOMAIN
 from homeassistant.config_entries import SOURCE_USER
-from homeassistant.const import CONF_ADDRESS, CONF_NAME, CONF_TYPE
+from homeassistant.const import CONF_ADDRESS, CONF_TYPE
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
@@ -22,7 +22,6 @@ from .const import (
 from tests.common import MockConfigEntry
 
 USER_INPUT = {
-    CONF_NAME: DEFAULT_NAME,
     CONF_ADDRESS: TEST_ADDRESS,
 }
 
@@ -146,7 +145,6 @@ async def test_java_connection(hass: HomeAssistant) -> None:
 
         assert result["type"] is FlowResultType.CREATE_ENTRY
         assert result["title"] == USER_INPUT[CONF_ADDRESS]
-        assert result["data"][CONF_NAME] == USER_INPUT[CONF_NAME]
         assert result["data"][CONF_ADDRESS] == TEST_ADDRESS
         assert result["data"][CONF_TYPE] == MinecraftServerType.JAVA_EDITION
 
@@ -169,7 +167,6 @@ async def test_bedrock_connection(hass: HomeAssistant) -> None:
 
         assert result["type"] is FlowResultType.CREATE_ENTRY
         assert result["title"] == USER_INPUT[CONF_ADDRESS]
-        assert result["data"][CONF_NAME] == USER_INPUT[CONF_NAME]
         assert result["data"][CONF_ADDRESS] == TEST_ADDRESS
         assert result["data"][CONF_TYPE] == MinecraftServerType.BEDROCK_EDITION
 
@@ -207,6 +204,5 @@ async def test_recovery(hass: HomeAssistant) -> None:
         )
         assert result2["type"] is FlowResultType.CREATE_ENTRY
         assert result2["title"] == USER_INPUT[CONF_ADDRESS]
-        assert result2["data"][CONF_NAME] == USER_INPUT[CONF_NAME]
         assert result2["data"][CONF_ADDRESS] == TEST_ADDRESS
         assert result2["data"][CONF_TYPE] == MinecraftServerType.BEDROCK_EDITION

--- a/tests/components/minecraft_server/test_init.py
+++ b/tests/components/minecraft_server/test_init.py
@@ -6,7 +6,7 @@ from mcstatus import JavaServer
 import pytest
 
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
-from homeassistant.components.minecraft_server.const import DEFAULT_NAME, DOMAIN
+from homeassistant.components.minecraft_server.const import DOMAIN
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_ADDRESS, CONF_HOST, CONF_NAME, CONF_PORT
@@ -22,6 +22,8 @@ from .const import (
 )
 
 from tests.common import MockConfigEntry
+
+DEFAULT_NAME = "Minecraft Server"
 
 TEST_UNIQUE_ID = f"{TEST_HOST}-{TEST_PORT}"
 
@@ -206,7 +208,7 @@ async def test_entry_migration(
     entity_registry: er.EntityRegistry,
     v1_mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test entry migration from version 1 to 3, where host and port is required for the connection to the server."""
+    """Test entry migration from version 1 to 4, where host and port is required for the connection to the server."""
     v1_mock_config_entry.add_to_hass(hass)
 
     device_entry_id = create_v1_mock_device_entry(hass, v1_mock_config_entry.entry_id)
@@ -240,10 +242,9 @@ async def test_entry_migration(
     # Test migrated config entry.
     assert migrated_config_entry.unique_id is None
     assert migrated_config_entry.data == {
-        CONF_NAME: DEFAULT_NAME,
         CONF_ADDRESS: TEST_ADDRESS,
     }
-    assert migrated_config_entry.version == 3
+    assert migrated_config_entry.version == 4
     assert migrated_config_entry.state is ConfigEntryState.LOADED
 
     # Test migrated device entry.
@@ -271,7 +272,7 @@ async def test_entry_migration(
 async def test_entry_migration_host_only(
     hass: HomeAssistant, v1_mock_config_entry: MockConfigEntry
 ) -> None:
-    """Test entry migration from version 1 to 3, where host alone is sufficient for the connection to the server."""
+    """Test entry migration from version 1 to 4, where host alone is sufficient for the connection to the server."""
     v1_mock_config_entry.add_to_hass(hass)
 
     device_entry_id = create_v1_mock_device_entry(hass, v1_mock_config_entry.entry_id)
@@ -299,10 +300,9 @@ async def test_entry_migration_host_only(
     # Test migrated config entry.
     assert v1_mock_config_entry.unique_id is None
     assert v1_mock_config_entry.data == {
-        CONF_NAME: DEFAULT_NAME,
         CONF_ADDRESS: TEST_HOST,
     }
-    assert v1_mock_config_entry.version == 3
+    assert v1_mock_config_entry.version == 4
     assert v1_mock_config_entry.state is ConfigEntryState.LOADED
 
 

--- a/tests/components/minecraft_server/test_init.py
+++ b/tests/components/minecraft_server/test_init.py
@@ -208,7 +208,7 @@ async def test_entry_migration(
     entity_registry: er.EntityRegistry,
     v1_mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test entry migration from version 1 to 4, where host and port is required for the connection to the server."""
+    """Test entry migration from version 1 to 3, where host and port is required for the connection to the server."""
     v1_mock_config_entry.add_to_hass(hass)
 
     device_entry_id = create_v1_mock_device_entry(hass, v1_mock_config_entry.entry_id)
@@ -242,9 +242,10 @@ async def test_entry_migration(
     # Test migrated config entry.
     assert migrated_config_entry.unique_id is None
     assert migrated_config_entry.data == {
+        CONF_NAME: DEFAULT_NAME,
         CONF_ADDRESS: TEST_ADDRESS,
     }
-    assert migrated_config_entry.version == 4
+    assert migrated_config_entry.version == 3
     assert migrated_config_entry.state is ConfigEntryState.LOADED
 
     # Test migrated device entry.
@@ -272,7 +273,7 @@ async def test_entry_migration(
 async def test_entry_migration_host_only(
     hass: HomeAssistant, v1_mock_config_entry: MockConfigEntry
 ) -> None:
-    """Test entry migration from version 1 to 4, where host alone is sufficient for the connection to the server."""
+    """Test entry migration from version 1 to 3, where host alone is sufficient for the connection to the server."""
     v1_mock_config_entry.add_to_hass(hass)
 
     device_entry_id = create_v1_mock_device_entry(hass, v1_mock_config_entry.entry_id)
@@ -300,9 +301,10 @@ async def test_entry_migration_host_only(
     # Test migrated config entry.
     assert v1_mock_config_entry.unique_id is None
     assert v1_mock_config_entry.data == {
+        CONF_NAME: DEFAULT_NAME,
         CONF_ADDRESS: TEST_HOST,
     }
-    assert v1_mock_config_entry.version == 4
+    assert v1_mock_config_entry.version == 3
     assert v1_mock_config_entry.state is ConfigEntryState.LOADED
 
 

--- a/tests/components/minecraft_server/test_sensor.py
+++ b/tests/components/minecraft_server/test_sensor.py
@@ -22,35 +22,35 @@ from .const import (
 from tests.common import async_fire_time_changed
 
 JAVA_SENSOR_ENTITIES: list[str] = [
-    "sensor.minecraft_server_latency",
-    "sensor.minecraft_server_players_online",
-    "sensor.minecraft_server_players_max",
-    "sensor.minecraft_server_world_message",
-    "sensor.minecraft_server_version",
-    "sensor.minecraft_server_protocol_version",
+    "sensor.mc_dummyserver_com_25566_latency",
+    "sensor.mc_dummyserver_com_25566_players_online",
+    "sensor.mc_dummyserver_com_25566_players_max",
+    "sensor.mc_dummyserver_com_25566_world_message",
+    "sensor.mc_dummyserver_com_25566_version",
+    "sensor.mc_dummyserver_com_25566_protocol_version",
 ]
 
 JAVA_SENSOR_ENTITIES_DISABLED_BY_DEFAULT: list[str] = [
-    "sensor.minecraft_server_players_max",
-    "sensor.minecraft_server_protocol_version",
+    "sensor.mc_dummyserver_com_25566_players_max",
+    "sensor.mc_dummyserver_com_25566_protocol_version",
 ]
 
 BEDROCK_SENSOR_ENTITIES: list[str] = [
-    "sensor.minecraft_server_latency",
-    "sensor.minecraft_server_players_online",
-    "sensor.minecraft_server_players_max",
-    "sensor.minecraft_server_world_message",
-    "sensor.minecraft_server_version",
-    "sensor.minecraft_server_protocol_version",
-    "sensor.minecraft_server_map_name",
-    "sensor.minecraft_server_game_mode",
-    "sensor.minecraft_server_edition",
+    "sensor.mc_dummyserver_com_25566_latency",
+    "sensor.mc_dummyserver_com_25566_players_online",
+    "sensor.mc_dummyserver_com_25566_players_max",
+    "sensor.mc_dummyserver_com_25566_world_message",
+    "sensor.mc_dummyserver_com_25566_version",
+    "sensor.mc_dummyserver_com_25566_protocol_version",
+    "sensor.mc_dummyserver_com_25566_map_name",
+    "sensor.mc_dummyserver_com_25566_game_mode",
+    "sensor.mc_dummyserver_com_25566_edition",
 ]
 
 BEDROCK_SENSOR_ENTITIES_DISABLED_BY_DEFAULT: list[str] = [
-    "sensor.minecraft_server_players_max",
-    "sensor.minecraft_server_protocol_version",
-    "sensor.minecraft_server_edition",
+    "sensor.mc_dummyserver_com_25566_players_max",
+    "sensor.mc_dummyserver_com_25566_protocol_version",
+    "sensor.mc_dummyserver_com_25566_edition",
 ]
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
CONF_NAME is removed from the config entry.
The user will now not be asked to enter a name while adding a new device. 
Instead of the name (default: "Minecraft Server"), the server address will be used instead (config flow title and coordinator name).
If wanted, the user can still manually rename the device afterwards.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: n.a.
- This PR is related to issue: n.a.
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/37641
- Link to developer documentation pull request: n.a.
- Link to frontend pull request: n.a.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
