### PR TITLE
Netatmo add feature

### DIFF
--- a/homeassistant/components/netatmo/climate.py
+++ b/homeassistant/components/netatmo/climate.py
@@ -507,7 +507,7 @@ class NetatmoThermostat(NetatmoRoomEntity, ClimateEntity):
         )
 
         now_timestamp = dt_util.as_timestamp(dt_util.utcnow())
-        end_timestamp = int(now_timestamp + time_period.seconds)
+        end_timestamp = int(now_timestamp + time_period.total_seconds())
         await self.device.async_therm_manual(target_temperature, end_timestamp)
 
     async def _async_service_clear_temperature_setting(self, **kwargs: Any) -> None:

--- a/homeassistant/components/netatmo/climate.py
+++ b/homeassistant/components/netatmo/climate.py
@@ -147,7 +147,7 @@ async def async_setup_entry(
         SERVICE_SET_PRESET_MODE_WITH_END_DATETIME,
         {
             vol.Required(ATTR_PRESET_MODE): vol.In(THERM_MODES),
-            vol.Required(ATTR_END_DATETIME): cv.datetime,
+            vol.Optional(ATTR_END_DATETIME): cv.datetime,
         },
         "_async_service_set_preset_mode_with_end_datetime",
     )
@@ -462,8 +462,11 @@ class NetatmoThermostat(NetatmoRoomEntity, ClimateEntity):
         self, **kwargs: Any
     ) -> None:
         preset_mode = kwargs[ATTR_PRESET_MODE]
-        end_datetime = kwargs[ATTR_END_DATETIME]
-        end_timestamp = int(dt_util.as_timestamp(end_datetime))
+        end_datetime = kwargs.get(ATTR_END_DATETIME)
+        if end_datetime:
+            end_timestamp = int(dt_util.as_timestamp(end_datetime))
+        else:
+            end_timestamp = None
 
         await self.home.async_set_thermmode(
             mode=PRESET_MAP_NETATMO[preset_mode], end_time=end_timestamp

--- a/homeassistant/components/netatmo/services.yaml
+++ b/homeassistant/components/netatmo/services.yaml
@@ -40,8 +40,8 @@ set_preset_mode_with_end_datetime:
           options:
             - "away"
             - "frost_guard"
+            - "schedule"
     end_datetime:
-      required: true
       example: '"2019-04-20 05:04:20"'
       selector:
         datetime:

--- a/homeassistant/components/netatmo/strings.json
+++ b/homeassistant/components/netatmo/strings.json
@@ -129,8 +129,8 @@
           "description": "Climate preset mode such as Schedule, Away or Frost Guard."
         },
         "end_datetime": {
-          "name": "End date & time",
-          "description": "Date & time the preset will be active until."
+          "name": "End date & time (not used for Schedule mode)",
+          "description": "The preset will be active until this date & time. If unset, keep former endtime or indefinitely if none."
         }
       }
     },

--- a/tests/components/netatmo/test_climate.py
+++ b/tests/components/netatmo/test_climate.py
@@ -751,18 +751,6 @@ async def test_service_preset_mode_with_end_time_thermostats(
             blocking=True,
         )
 
-    # Test setting a valid preset mode (that allow an end datetime in Netatmo == THERM_MODES) without an end datetime
-    with pytest.raises(MultipleInvalid):
-        await hass.services.async_call(
-            "netatmo",
-            SERVICE_SET_PRESET_MODE_WITH_END_DATETIME,
-            {
-                ATTR_ENTITY_ID: climate_entity_livingroom,
-                ATTR_PRESET_MODE: PRESET_AWAY,
-            },
-            blocking=True,
-        )
-
 
 async def test_service_preset_mode_already_boost_valves(
     hass: HomeAssistant, config_entry: MockConfigEntry, netatmo_auth: AsyncMock


### PR DESCRIPTION
## Proposed change
* Add "schedule" choice in "set_preset_mode_with_end_datetime"
* Change "end_datetime" from Required to Optional : in Netatmo api it is optional
   - not used for schedule option
   - for other options (away and frost_guard) if left empty : keep former value of "end_time" if exists, else set to "forever"
* Fix bug in set_temperature_with_time_period when period > 1 min

![schedule](https://github.com/user-attachments/assets/9bbc78c5-33b1-4d69-9b10-4eef08daca06)


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
