### PR TITLE
Test remember the milk configurator

### DIFF
--- a/tests/components/remember_the_milk/conftest.py
+++ b/tests/components/remember_the_milk/conftest.py
@@ -13,8 +13,16 @@ from .const import TOKEN
 @pytest.fixture(name="client")
 def client_fixture() -> Generator[MagicMock]:
     """Create a mock client."""
-    with patch("homeassistant.components.remember_the_milk.entity.Rtm") as client_class:
-        client = client_class.return_value
+    client = MagicMock()
+    with (
+        patch(
+            "homeassistant.components.remember_the_milk.entity.Rtm"
+        ) as entity_client_class,
+        patch("homeassistant.components.remember_the_milk.Rtm") as client_class,
+    ):
+        entity_client_class.return_value = client
+        client_class.return_value = client
+        client.token = TOKEN
         client.token_valid.return_value = True
         timelines = MagicMock()
         timelines.timeline.value = "1234"

--- a/tests/components/remember_the_milk/const.py
+++ b/tests/components/remember_the_milk/const.py
@@ -3,6 +3,11 @@
 import json
 
 PROFILE = "myprofile"
+CONFIG = {
+    "name": f"{PROFILE}",
+    "api_key": "test-api-key",
+    "shared_secret": "test-shared-secret",
+}
 TOKEN = "mytoken"
 JSON_STRING = json.dumps(
     {

--- a/tests/components/remember_the_milk/test_entity.py
+++ b/tests/components/remember_the_milk/test_entity.py
@@ -10,13 +10,7 @@ from homeassistant.components.remember_the_milk import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
-from .const import PROFILE
-
-CONFIG = {
-    "name": f"{PROFILE}",
-    "api_key": "test-api-key",
-    "shared_secret": "test-shared-secret",
-}
+from .const import CONFIG, PROFILE
 
 
 @pytest.mark.parametrize(

--- a/tests/components/remember_the_milk/test_init.py
+++ b/tests/components/remember_the_milk/test_init.py
@@ -1,0 +1,65 @@
+"""Test the Remember The Milk integration."""
+
+from collections.abc import Generator
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from homeassistant.components.remember_the_milk import DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+from .const import CONFIG, PROFILE, TOKEN
+
+
+@pytest.fixture(autouse=True)
+def configure_id() -> Generator[str]:
+    """Fixture to return a configure_id."""
+    mock_id = "1-1"
+    with patch(
+        "homeassistant.components.configurator.Configurator._generate_unique_id"
+    ) as generate_id:
+        generate_id.return_value = mock_id
+        yield mock_id
+
+
+@pytest.mark.parametrize(
+    ("token", "rtm_entity_exists", "configurator_end_state"),
+    [(TOKEN, True, "configured"), (None, False, "configure")],
+)
+async def test_configurator(
+    hass: HomeAssistant,
+    client: MagicMock,
+    storage: MagicMock,
+    configure_id: str,
+    token: str | None,
+    rtm_entity_exists: bool,
+    configurator_end_state: str,
+) -> None:
+    """Test configurator."""
+    storage.get_token.return_value = None
+    client.authenticate_desktop.return_value = ("test-url", "test-frob")
+    client.token = token
+    rtm_entity_id = f"{DOMAIN}.{PROFILE}"
+    configure_entity_id = f"configurator.{DOMAIN}_{PROFILE}"
+
+    assert await async_setup_component(hass, DOMAIN, {DOMAIN: CONFIG})
+    await hass.async_block_till_done()
+
+    assert hass.states.get(rtm_entity_id) is None
+    state = hass.states.get(configure_entity_id)
+    assert state
+    assert state.state == "configure"
+
+    await hass.services.async_call(
+        "configurator",
+        "configure",
+        {"configure_id": configure_id},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert bool(hass.states.get(rtm_entity_id)) == rtm_entity_exists
+    state = hass.states.get(configure_entity_id)
+    assert state
+    assert state.state == configurator_end_state


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Test this code to make sure the work until the config flow PR doesn't break anything.

```
Test session starts (platform: linux, Python 3.13.2, pytest 8.3.4, pytest-sugar 1.0.0)
rootdir: /home/martin/dev/home-assistant/core
configfile: pyproject.toml
plugins: typeguard-4.4.1, xdist-3.6.1, mock-3.14.0, timeout-2.3.1, pytest_freezer-0.4.9, picked-0.5.1, sugar-1.0.0, socket-0.7.0, respx-0.22.0, cov-6.0.0, syrupy-4.8.1, requests-mock-1.12.1, unordered-0.6.1, asyncio-0.25.3, anyio-4.8.0, github-actions-annotate-failures-0.3.0, aiohttp-1.1.0
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=function
collected 23 items                                                                                                                                                                                        

 tests/components/remember_the_milk/test_entity.py ✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓                                                                                                                           65% ██████▌   
 tests/components/remember_the_milk/test_init.py ✓✓                                                                                                                                          74% ███████▍  
 tests/components/remember_the_milk/test_storage.py ✓✓✓✓✓✓                                                                                                                                  100% ██████████

---------- coverage: platform linux, python 3.13.2-final-0 -----------
Name                                                     Stmts   Miss  Cover   Missing
--------------------------------------------------------------------------------------
homeassistant/components/remember_the_milk/__init__.py      56      0   100%
homeassistant/components/remember_the_milk/const.py          2      0   100%
homeassistant/components/remember_the_milk/entity.py        64      0   100%
homeassistant/components/remember_the_milk/storage.py       58      0   100%
--------------------------------------------------------------------------------------
TOTAL                                                      180      0   100%


Results (1.84s):
      23 passed
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
