### PR TITLE
Fix flakey onedrive tests

### DIFF
--- a/tests/components/onedrive/const.py
+++ b/tests/components/onedrive/const.py
@@ -1,15 +1,6 @@
 """Consts for OneDrive tests."""
 
-from html import escape
-from json import dumps
-
-from onedrive_personal_sdk.models.items import (
-    File,
-    Hashes,
-    IdentitySet,
-    ItemParentReference,
-    User,
-)
+from onedrive_personal_sdk.models.items import IdentitySet, User
 
 CLIENT_ID = "1234"
 CLIENT_SECRET = "5678"
@@ -37,41 +28,4 @@ IDENTITY_SET = IdentitySet(
         id="id",
         email="john@doe.com",
     )
-)
-
-MOCK_BACKUP_FILE = File(
-    id="id",
-    name="23e64aec.tar",
-    size=34519040,
-    parent_reference=ItemParentReference(
-        drive_id="mock_drive_id", id="id", path="path"
-    ),
-    hashes=Hashes(
-        quick_xor_hash="hash",
-    ),
-    mime_type="application/x-tar",
-    created_by=IDENTITY_SET,
-)
-
-MOCK_METADATA_FILE = File(
-    id="id",
-    name="23e64aec.tar",
-    size=34519040,
-    parent_reference=ItemParentReference(
-        drive_id="mock_drive_id", id="id", path="path"
-    ),
-    hashes=Hashes(
-        quick_xor_hash="hash",
-    ),
-    mime_type="application/x-tar",
-    description=escape(
-        dumps(
-            {
-                "metadata_version": 2,
-                "backup_id": "23e64aec",
-                "backup_file_id": "id",
-            }
-        )
-    ),
-    created_by=IDENTITY_SET,
 )

--- a/tests/components/onedrive/test_backup.py
+++ b/tests/components/onedrive/test_backup.py
@@ -11,6 +11,7 @@ from onedrive_personal_sdk.exceptions import (
     HashMismatchError,
     OneDriveException,
 )
+from onedrive_personal_sdk.models.items import File
 import pytest
 
 from homeassistant.components.backup import DOMAIN as BACKUP_DOMAIN, AgentBackup
@@ -23,7 +24,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from . import setup_integration
-from .const import BACKUP_METADATA, MOCK_BACKUP_FILE, MOCK_METADATA_FILE
+from .const import BACKUP_METADATA
 
 from tests.common import AsyncMock, MockConfigEntry
 from tests.typing import ClientSessionGenerator, MagicMock, WebSocketGenerator
@@ -248,12 +249,14 @@ async def test_error_on_agents_download(
     hass_client: ClientSessionGenerator,
     mock_onedrive_client: MagicMock,
     mock_config_entry: MockConfigEntry,
+    mock_backup_file: File,
+    mock_metadata_file: File,
 ) -> None:
     """Test we get not found on an not existing backup on download."""
     client = await hass_client()
     backup_id = BACKUP_METADATA["backup_id"]
     mock_onedrive_client.list_drive_items.side_effect = [
-        [MOCK_BACKUP_FILE, MOCK_METADATA_FILE],
+        [mock_backup_file, mock_metadata_file],
         [],
     ]
 

--- a/tests/components/onedrive/test_init.py
+++ b/tests/components/onedrive/test_init.py
@@ -11,7 +11,7 @@ from onedrive_personal_sdk.exceptions import (
     NotFoundError,
     OneDriveException,
 )
-from onedrive_personal_sdk.models.items import AppRoot, Drive, Folder, ItemUpdate
+from onedrive_personal_sdk.models.items import AppRoot, Drive, File, Folder, ItemUpdate
 import pytest
 from syrupy import SnapshotAssertion
 
@@ -25,7 +25,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, issue_registry as ir
 
 from . import setup_integration
-from .const import BACKUP_METADATA, INSTANCE_ID, MOCK_BACKUP_FILE
+from .const import BACKUP_METADATA, INSTANCE_ID
 
 from tests.common import MockConfigEntry
 
@@ -145,9 +145,10 @@ async def test_migrate_metadata_files(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_onedrive_client: MagicMock,
+    mock_backup_file: File,
 ) -> None:
     """Test migration of metadata files."""
-    MOCK_BACKUP_FILE.description = escape(
+    mock_backup_file.description = escape(
         dumps({**BACKUP_METADATA, "metadata_version": 1})
     )
     await setup_integration(hass, mock_config_entry)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fix flakey tests by using fixtures (that will reset between tests) instead of error prone object constants.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
