### PR TITLE
Add prefix path support to pyLoad integration

### DIFF
--- a/homeassistant/components/pyload/__init__.py
+++ b/homeassistant/components/pyload/__init__.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+import logging
+
 from aiohttp import CookieJar
 from pyloadapi import PyLoadAPI
+from yarl import URL
 
 from homeassistant.const import (
     CONF_HOST,
     CONF_PASSWORD,
+    CONF_PATH,
     CONF_PORT,
     CONF_SSL,
     CONF_USERNAME,
@@ -19,21 +23,24 @@ from homeassistant.helpers.aiohttp_client import async_create_clientsession
 
 from .coordinator import PyLoadConfigEntry, PyLoadCoordinator
 
+_LOGGER = logging.getLogger(__name__)
+
 PLATFORMS: list[Platform] = [Platform.BUTTON, Platform.SENSOR, Platform.SWITCH]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: PyLoadConfigEntry) -> bool:
     """Set up pyLoad from a config entry."""
 
-    url = (
-        f"{'https' if entry.data[CONF_SSL] else 'http'}://"
-        f"{entry.data[CONF_HOST]}:{entry.data[CONF_PORT]}/"
-    )
-
     session = async_create_clientsession(
         hass,
         verify_ssl=entry.data[CONF_VERIFY_SSL],
         cookie_jar=CookieJar(unsafe=True),
+    )
+    url = URL.build(
+        scheme="https" if entry.data[CONF_SSL] else "http",
+        host=entry.data[CONF_HOST],
+        port=entry.data[CONF_PORT],
+        path=entry.data[CONF_PATH],
     )
     pyloadapi = PyLoadAPI(
         session,
@@ -55,3 +62,22 @@ async def async_setup_entry(hass: HomeAssistant, entry: PyLoadConfigEntry) -> bo
 async def async_unload_entry(hass: HomeAssistant, entry: PyLoadConfigEntry) -> bool:
     """Unload a config entry."""
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+
+
+async def async_migrate_entry(hass: HomeAssistant, entry: PyLoadConfigEntry) -> bool:
+    """Migrate config entry."""
+    _LOGGER.debug(
+        "Migrating configuration from version %s.%s", entry.version, entry.minor_version
+    )
+
+    if entry.version == 1 and entry.minor_version == 0:
+        hass.config_entries.async_update_entry(
+            entry, data={**entry.data, CONF_PATH: "/"}, minor_version=1, version=1
+        )
+
+    _LOGGER.debug(
+        "Migration to configuration version %s.%s successful",
+        entry.version,
+        entry.minor_version,
+    )
+    return True

--- a/homeassistant/components/pyload/__init__.py
+++ b/homeassistant/components/pyload/__init__.py
@@ -11,9 +11,9 @@ from yarl import URL
 from homeassistant.const import (
     CONF_HOST,
     CONF_PASSWORD,
-    CONF_PATH,
     CONF_PORT,
     CONF_SSL,
+    CONF_URL,
     CONF_USERNAME,
     CONF_VERIFY_SSL,
     Platform,
@@ -36,15 +36,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: PyLoadConfigEntry) -> bo
         verify_ssl=entry.data[CONF_VERIFY_SSL],
         cookie_jar=CookieJar(unsafe=True),
     )
-    url = URL.build(
-        scheme="https" if entry.data[CONF_SSL] else "http",
-        host=entry.data[CONF_HOST],
-        port=entry.data[CONF_PORT],
-        path=entry.data[CONF_PATH],
-    )
     pyloadapi = PyLoadAPI(
         session,
-        api_url=url,
+        api_url=URL(entry.data[CONF_URL]),
         username=entry.data[CONF_USERNAME],
         password=entry.data[CONF_PASSWORD],
     )
@@ -71,8 +65,13 @@ async def async_migrate_entry(hass: HomeAssistant, entry: PyLoadConfigEntry) -> 
     )
 
     if entry.version == 1 and entry.minor_version == 0:
+        url = URL.build(
+            scheme="https" if entry.data[CONF_SSL] else "http",
+            host=entry.data[CONF_HOST],
+            port=entry.data[CONF_PORT],
+        ).human_repr()
         hass.config_entries.async_update_entry(
-            entry, data={**entry.data, CONF_PATH: "/"}, minor_version=1, version=1
+            entry, data={**entry.data, CONF_URL: url}, minor_version=1, version=1
         )
 
     _LOGGER.debug(

--- a/homeassistant/components/pyload/diagnostics.py
+++ b/homeassistant/components/pyload/diagnostics.py
@@ -5,13 +5,15 @@ from __future__ import annotations
 from dataclasses import asdict
 from typing import Any
 
-from homeassistant.components.diagnostics import async_redact_data
-from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
+from yarl import URL
+
+from homeassistant.components.diagnostics import REDACTED, async_redact_data
+from homeassistant.const import CONF_PASSWORD, CONF_URL, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 
 from .coordinator import PyLoadConfigEntry, PyLoadData
 
-TO_REDACT = {CONF_USERNAME, CONF_PASSWORD, CONF_HOST}
+TO_REDACT = {CONF_USERNAME, CONF_PASSWORD, CONF_URL}
 
 
 async def async_get_config_entry_diagnostics(
@@ -21,6 +23,9 @@ async def async_get_config_entry_diagnostics(
     pyload_data: PyLoadData = config_entry.runtime_data.data
 
     return {
-        "config_entry_data": async_redact_data(dict(config_entry.data), TO_REDACT),
+        "config_entry_data": {
+            **async_redact_data(dict(config_entry.data), TO_REDACT),
+            CONF_URL: URL(config_entry.data[CONF_URL]).with_host(REDACTED).human_repr(),
+        },
         "pyload_data": asdict(pyload_data),
     }

--- a/homeassistant/components/pyload/strings.json
+++ b/homeassistant/components/pyload/strings.json
@@ -3,38 +3,30 @@
     "step": {
       "user": {
         "data": {
-          "host": "[%key:common::config_flow::data::host%]",
+          "url": "[%key:common::config_flow::data::url%]",
           "username": "[%key:common::config_flow::data::username%]",
           "password": "[%key:common::config_flow::data::password%]",
-          "ssl": "[%key:common::config_flow::data::ssl%]",
-          "verify_ssl": "[%key:common::config_flow::data::verify_ssl%]",
-          "port": "[%key:common::config_flow::data::port%]"
+          "verify_ssl": "[%key:common::config_flow::data::verify_ssl%]"
         },
         "data_description": {
-          "host": "The hostname or IP address of the device running your pyLoad instance.",
+          "url": "Specify the full URL of your pyLoad web interface, including the protocol (http or https), hostname or IP address, port (pyLoad used 8000 by default), and any path prefix if applicable.\nExample: https://example.com:8000/path.",
           "username": "The username used to access the pyLoad instance.",
           "password": "The password associated with the pyLoad account.",
-          "port": "pyLoad uses port 8000 by default.",
-          "ssl": "If enabled, the connection to the pyLoad instance will use HTTPS.",
           "verify_ssl": "If checked, the SSL certificate will be validated to ensure a secure connection."
         }
       },
       "reconfigure": {
         "data": {
-          "host": "[%key:common::config_flow::data::host%]",
+          "url": "[%key:common::config_flow::data::url%]",
           "username": "[%key:common::config_flow::data::username%]",
           "password": "[%key:common::config_flow::data::password%]",
-          "ssl": "[%key:common::config_flow::data::ssl%]",
-          "verify_ssl": "[%key:common::config_flow::data::verify_ssl%]",
-          "port": "[%key:common::config_flow::data::port%]"
+          "verify_ssl": "[%key:common::config_flow::data::verify_ssl%]"
         },
         "data_description": {
-          "host": "[%key:component::pyload::config::step::user::data_description::host%]",
-          "verify_ssl": "[%key:component::pyload::config::step::user::data_description::verify_ssl%]",
+          "url": "[%key:component::pyload::config::step::user::data_description::url%]",
           "username": "[%key:component::pyload::config::step::user::data_description::username%]",
           "password": "[%key:component::pyload::config::step::user::data_description::password%]",
-          "port": "[%key:component::pyload::config::step::user::data_description::port%]",
-          "ssl": "[%key:component::pyload::config::step::user::data_description::ssl%]"
+          "verify_ssl": "[%key:component::pyload::config::step::user::data_description::verify_ssl%]"
         }
       },
       "reauth_confirm": {

--- a/homeassistant/components/pyload/strings.json
+++ b/homeassistant/components/pyload/strings.json
@@ -9,7 +9,7 @@
           "verify_ssl": "[%key:common::config_flow::data::verify_ssl%]"
         },
         "data_description": {
-          "url": "Specify the full URL of your pyLoad web interface, including the protocol (http or https), hostname or IP address, port (pyLoad used 8000 by default), and any path prefix if applicable.\nExample: https://example.com:8000/path.",
+          "url": "Specify the full URL of your pyLoad web interface, including the protocol (http or https), hostname or IP address, port (pyLoad uses 8000 by default), and any path prefix if applicable.\nExample: https://example.com:8000/path.",
           "username": "The username used to access the pyLoad instance.",
           "password": "The password associated with the pyLoad account.",
           "verify_ssl": "If checked, the SSL certificate will be validated to ensure a secure connection."

--- a/homeassistant/components/pyload/strings.json
+++ b/homeassistant/components/pyload/strings.json
@@ -9,7 +9,7 @@
           "verify_ssl": "[%key:common::config_flow::data::verify_ssl%]"
         },
         "data_description": {
-          "url": "Specify the full URL of your pyLoad web interface, including the protocol (http or https), hostname or IP address, port (pyLoad uses 8000 by default), and any path prefix if applicable.\nExample: `https://example.com:8000/path`",
+          "url": "Specify the full URL of your pyLoad web interface, including the protocol (HTTP or HTTPS), hostname or IP address, port (pyLoad uses 8000 by default), and any path prefix if applicable.\nExample: `https://example.com:8000/path`",
           "username": "The username used to access the pyLoad instance.",
           "password": "The password associated with the pyLoad account.",
           "verify_ssl": "If checked, the SSL certificate will be validated to ensure a secure connection."

--- a/homeassistant/components/pyload/strings.json
+++ b/homeassistant/components/pyload/strings.json
@@ -9,7 +9,7 @@
           "verify_ssl": "[%key:common::config_flow::data::verify_ssl%]"
         },
         "data_description": {
-          "url": "Specify the full URL of your pyLoad web interface, including the protocol (http or https), hostname or IP address, port (pyLoad uses 8000 by default), and any path prefix if applicable.\nExample: https://example.com:8000/path.",
+          "url": "Specify the full URL of your pyLoad web interface, including the protocol (http or https), hostname or IP address, port (pyLoad uses 8000 by default), and any path prefix if applicable.\nExample: `https://example.com:8000/path`",
           "username": "The username used to access the pyLoad instance.",
           "password": "The password associated with the pyLoad account.",
           "verify_ssl": "If checked, the SSL certificate will be validated to ensure a secure connection."

--- a/tests/components/pyload/conftest.py
+++ b/tests/components/pyload/conftest.py
@@ -10,7 +10,6 @@ from homeassistant.components.pyload.const import DEFAULT_NAME, DOMAIN
 from homeassistant.const import (
     CONF_HOST,
     CONF_PASSWORD,
-    CONF_PATH,
     CONF_PORT,
     CONF_SSL,
     CONF_URL,
@@ -26,15 +25,6 @@ USER_INPUT = {
     CONF_USERNAME: "test-username",
     CONF_VERIFY_SSL: False,
 }
-USER_INPUT_RESULT = {
-    CONF_HOST: "pyload.local",
-    CONF_PASSWORD: "test-password",
-    CONF_PORT: 8000,
-    CONF_PATH: "/prefix",
-    CONF_SSL: True,
-    CONF_USERNAME: "test-username",
-    CONF_VERIFY_SSL: False,
-}
 
 REAUTH_INPUT = {
     CONF_PASSWORD: "new-password",
@@ -42,11 +32,8 @@ REAUTH_INPUT = {
 }
 
 NEW_INPUT = {
-    CONF_HOST: "pyload.local",
+    CONF_URL: "https://pyload.local:8000/prefix",
     CONF_PASSWORD: "new-password",
-    CONF_PORT: 8000,
-    CONF_PATH: "/prefix",
-    CONF_SSL: True,
     CONF_USERNAME: "new-username",
     CONF_VERIFY_SSL: False,
 }
@@ -109,7 +96,7 @@ def mock_config_entry() -> MockConfigEntry:
     return MockConfigEntry(
         domain=DOMAIN,
         title=DEFAULT_NAME,
-        data=USER_INPUT_RESULT,
+        data=USER_INPUT,
         entry_id="XXXXXXXXXXXXXX",
     )
 

--- a/tests/components/pyload/conftest.py
+++ b/tests/components/pyload/conftest.py
@@ -10,8 +10,10 @@ from homeassistant.components.pyload.const import DEFAULT_NAME, DOMAIN
 from homeassistant.const import (
     CONF_HOST,
     CONF_PASSWORD,
+    CONF_PATH,
     CONF_PORT,
     CONF_SSL,
+    CONF_URL,
     CONF_USERNAME,
     CONF_VERIFY_SSL,
 )
@@ -19,9 +21,16 @@ from homeassistant.const import (
 from tests.common import MockConfigEntry
 
 USER_INPUT = {
+    CONF_URL: "https://pyload.local:8000/prefix",
+    CONF_PASSWORD: "test-password",
+    CONF_USERNAME: "test-username",
+    CONF_VERIFY_SSL: False,
+}
+USER_INPUT_RESULT = {
     CONF_HOST: "pyload.local",
     CONF_PASSWORD: "test-password",
     CONF_PORT: 8000,
+    CONF_PATH: "/prefix",
     CONF_SSL: True,
     CONF_USERNAME: "test-username",
     CONF_VERIFY_SSL: False,
@@ -36,6 +45,7 @@ NEW_INPUT = {
     CONF_HOST: "pyload.local",
     CONF_PASSWORD: "new-password",
     CONF_PORT: 8000,
+    CONF_PATH: "/prefix",
     CONF_SSL: True,
     CONF_USERNAME: "new-username",
     CONF_VERIFY_SSL: False,
@@ -97,5 +107,28 @@ def mock_pyloadapi() -> Generator[MagicMock]:
 def mock_config_entry() -> MockConfigEntry:
     """Mock pyLoad configuration entry."""
     return MockConfigEntry(
-        domain=DOMAIN, title=DEFAULT_NAME, data=USER_INPUT, entry_id="XXXXXXXXXXXXXX"
+        domain=DOMAIN,
+        title=DEFAULT_NAME,
+        data=USER_INPUT_RESULT,
+        entry_id="XXXXXXXXXXXXXX",
+    )
+
+
+@pytest.fixture(name="config_entry_migrate")
+def mock_config_entry_migrate() -> MockConfigEntry:
+    """Mock pyLoad configuration entry for migration."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        title=DEFAULT_NAME,
+        data={
+            CONF_HOST: "pyload.local",
+            CONF_PASSWORD: "test-password",
+            CONF_PORT: 8000,
+            CONF_SSL: True,
+            CONF_USERNAME: "test-username",
+            CONF_VERIFY_SSL: False,
+        },
+        version=1,
+        minor_version=0,
+        entry_id="XXXXXXXXXXXXXX",
     )

--- a/tests/components/pyload/snapshots/test_diagnostics.ambr
+++ b/tests/components/pyload/snapshots/test_diagnostics.ambr
@@ -2,11 +2,8 @@
 # name: test_diagnostics
   dict({
     'config_entry_data': dict({
-      'host': '**REDACTED**',
       'password': '**REDACTED**',
-      'path': '/prefix',
-      'port': 8000,
-      'ssl': True,
+      'url': 'https://pyload.local:8000/prefix',
       'username': '**REDACTED**',
       'verify_ssl': False,
     }),

--- a/tests/components/pyload/snapshots/test_diagnostics.ambr
+++ b/tests/components/pyload/snapshots/test_diagnostics.ambr
@@ -4,6 +4,7 @@
     'config_entry_data': dict({
       'host': '**REDACTED**',
       'password': '**REDACTED**',
+      'path': '/prefix',
       'port': 8000,
       'ssl': True,
       'username': '**REDACTED**',

--- a/tests/components/pyload/snapshots/test_diagnostics.ambr
+++ b/tests/components/pyload/snapshots/test_diagnostics.ambr
@@ -3,7 +3,7 @@
   dict({
     'config_entry_data': dict({
       'password': '**REDACTED**',
-      'url': 'https://pyload.local:8000/prefix',
+      'url': 'https://**redacted**:8000/prefix',
       'username': '**REDACTED**',
       'verify_ssl': False,
     }),

--- a/tests/components/pyload/test_config_flow.py
+++ b/tests/components/pyload/test_config_flow.py
@@ -10,7 +10,7 @@ from homeassistant.config_entries import SOURCE_USER
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
-from .conftest import NEW_INPUT, REAUTH_INPUT, USER_INPUT
+from .conftest import NEW_INPUT, REAUTH_INPUT, USER_INPUT, USER_INPUT_RESULT
 
 from tests.common import MockConfigEntry
 
@@ -34,7 +34,7 @@ async def test_form(
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == DEFAULT_NAME
-    assert result["data"] == USER_INPUT
+    assert result["data"] == USER_INPUT_RESULT
     assert len(mock_setup_entry.mock_calls) == 1
 
 
@@ -76,7 +76,7 @@ async def test_form_errors(
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == DEFAULT_NAME
-    assert result["data"] == USER_INPUT
+    assert result["data"] == USER_INPUT_RESULT
     assert len(mock_setup_entry.mock_calls) == 1
 
 
@@ -196,7 +196,7 @@ async def test_reconfiguration(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reconfigure_successful"
-    assert config_entry.data == USER_INPUT
+    assert config_entry.data == USER_INPUT_RESULT
     assert len(hass.config_entries.async_entries()) == 1
 
 
@@ -243,5 +243,5 @@ async def test_reconfigure_errors(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reconfigure_successful"
-    assert config_entry.data == USER_INPUT
+    assert config_entry.data == USER_INPUT_RESULT
     assert len(hass.config_entries.async_entries()) == 1

--- a/tests/components/pyload/test_config_flow.py
+++ b/tests/components/pyload/test_config_flow.py
@@ -10,7 +10,7 @@ from homeassistant.config_entries import SOURCE_USER
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
-from .conftest import NEW_INPUT, REAUTH_INPUT, USER_INPUT, USER_INPUT_RESULT
+from .conftest import NEW_INPUT, REAUTH_INPUT, USER_INPUT
 
 from tests.common import MockConfigEntry
 
@@ -34,7 +34,7 @@ async def test_form(
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == DEFAULT_NAME
-    assert result["data"] == USER_INPUT_RESULT
+    assert result["data"] == USER_INPUT
     assert len(mock_setup_entry.mock_calls) == 1
 
 
@@ -76,7 +76,7 @@ async def test_form_errors(
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == DEFAULT_NAME
-    assert result["data"] == USER_INPUT_RESULT
+    assert result["data"] == USER_INPUT
     assert len(mock_setup_entry.mock_calls) == 1
 
 
@@ -196,7 +196,7 @@ async def test_reconfiguration(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reconfigure_successful"
-    assert config_entry.data == USER_INPUT_RESULT
+    assert config_entry.data == USER_INPUT
     assert len(hass.config_entries.async_entries()) == 1
 
 
@@ -243,5 +243,5 @@ async def test_reconfigure_errors(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reconfigure_successful"
-    assert config_entry.data == USER_INPUT_RESULT
+    assert config_entry.data == USER_INPUT
     assert len(hass.config_entries.async_entries()) == 1

--- a/tests/components/pyload/test_init.py
+++ b/tests/components/pyload/test_init.py
@@ -8,7 +8,7 @@ from pyloadapi.exceptions import CannotConnect, InvalidAuth, ParserError
 import pytest
 
 from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
-from homeassistant.const import CONF_PATH
+from homeassistant.const import CONF_PATH, CONF_URL
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry, async_fire_time_changed
@@ -107,4 +107,4 @@ async def test_migration(
     assert config_entry_migrate.state is ConfigEntryState.LOADED
     assert config_entry_migrate.version == 1
     assert config_entry_migrate.minor_version == 1
-    assert config_entry_migrate.data.get(CONF_PATH) == "/"
+    assert config_entry_migrate.data[CONF_URL] == "https://pyload.local:8000/"

--- a/tests/components/pyload/test_init.py
+++ b/tests/components/pyload/test_init.py
@@ -8,6 +8,7 @@ from pyloadapi.exceptions import CannotConnect, InvalidAuth, ParserError
 import pytest
 
 from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
+from homeassistant.const import CONF_PATH
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry, async_fire_time_changed
@@ -88,3 +89,22 @@ async def test_coordinator_update_invalid_auth(
     await hass.async_block_till_done()
 
     assert any(config_entry.async_get_active_flows(hass, {SOURCE_REAUTH}))
+
+
+@pytest.mark.usefixtures("mock_pyloadapi")
+async def test_migration(
+    hass: HomeAssistant,
+    config_entry_migrate: MockConfigEntry,
+) -> None:
+    """Test config entry migration."""
+
+    config_entry_migrate.add_to_hass(hass)
+    assert config_entry_migrate.data.get(CONF_PATH) is None
+
+    await hass.config_entries.async_setup(config_entry_migrate.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry_migrate.state is ConfigEntryState.LOADED
+    assert config_entry_migrate.version == 1
+    assert config_entry_migrate.minor_version == 1
+    assert config_entry_migrate.data.get(CONF_PATH) == "/"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This update resolves a design limitation in the pyLoad integration. Previously, it was not possible to use the integration if pyLoad was configured with a path prefix. The setup required users to enter the protocol, hostname/IP, and port separately in three different input fields, without support for a path prefix.

Instead of adding an additional input field for the path prefix, the configuration process has been streamlined. Now, users only need to enter a single URL field. Internally, the URL components (protocol, hostname/IP, port, path) are still stored separately to prevent duplicate configurations for the same pyLoad instance.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/37680
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
