### PR TITLE
Add test fixture ignore_translations_for_mock_domains

### DIFF
--- a/tests/components/application_credentials/test_init.py
+++ b/tests/components/application_credentials/test_init.py
@@ -423,10 +423,7 @@ async def test_import_named_credential(
     ]
 
 
-@pytest.mark.parametrize(
-    "ignore_translations",
-    ["component.fake_integration.config.abort.missing_credentials"],
-)
+@pytest.mark.parametrize("ignore_translations_for_mock_domains", ["fake_integration"])
 async def test_config_flow_no_credentials(hass: HomeAssistant) -> None:
     """Test config flow base case with no credentials registered."""
     result = await hass.config_entries.flow.async_init(
@@ -436,10 +433,7 @@ async def test_config_flow_no_credentials(hass: HomeAssistant) -> None:
     assert result.get("reason") == "missing_credentials"
 
 
-@pytest.mark.parametrize(
-    "ignore_translations",
-    ["component.fake_integration.config.abort.missing_credentials"],
-)
+@pytest.mark.parametrize("ignore_translations_for_mock_domains", ["fake_integration"])
 async def test_config_flow_other_domain(
     hass: HomeAssistant,
     ws_client: ClientFixture,
@@ -567,10 +561,7 @@ async def test_config_flow_multiple_entries(
     )
 
 
-@pytest.mark.parametrize(
-    "ignore_translations",
-    ["component.fake_integration.config.abort.missing_credentials"],
-)
+@pytest.mark.parametrize("ignore_translations_for_mock_domains", ["fake_integration"])
 async def test_config_flow_create_delete_credential(
     hass: HomeAssistant,
     ws_client: ClientFixture,
@@ -616,10 +607,7 @@ async def test_config_flow_with_config_credential(
     assert result["data"].get("auth_implementation") == TEST_DOMAIN
 
 
-@pytest.mark.parametrize(
-    "ignore_translations",
-    ["component.fake_integration.config.abort.missing_configuration"],
-)
+@pytest.mark.parametrize("ignore_translations_for_mock_domains", ["fake_integration"])
 @pytest.mark.parametrize("mock_application_credentials_integration", [None])
 async def test_import_without_setup(hass: HomeAssistant, config_credential) -> None:
     """Test import of credentials without setting up the integration."""
@@ -635,10 +623,7 @@ async def test_import_without_setup(hass: HomeAssistant, config_credential) -> N
     assert result.get("reason") == "missing_configuration"
 
 
-@pytest.mark.parametrize(
-    "ignore_translations",
-    ["component.fake_integration.config.abort.missing_configuration"],
-)
+@pytest.mark.parametrize("ignore_translations_for_mock_domains", ["fake_integration"])
 @pytest.mark.parametrize("mock_application_credentials_integration", [None])
 async def test_websocket_without_platform(
     hass: HomeAssistant, ws_client: ClientFixture

--- a/tests/components/config/test_config_entries.py
+++ b/tests/components/config/test_config_entries.py
@@ -400,10 +400,7 @@ async def test_available_flows(
 ############################
 
 
-@pytest.mark.parametrize(
-    "ignore_translations",
-    ["component.test.config.error.Should be unique."],
-)
+@pytest.mark.parametrize("ignore_translations_for_mock_domains", ["test"])
 async def test_initialize_flow(hass: HomeAssistant, client: TestClient) -> None:
     """Test we can initialize a flow."""
     mock_platform(hass, "test.config_flow", None)
@@ -513,10 +510,7 @@ async def test_initialize_flow_unauth(
     assert resp.status == HTTPStatus.UNAUTHORIZED
 
 
-@pytest.mark.parametrize(
-    "ignore_translations",
-    ["component.test.config.abort.bla"],
-)
+@pytest.mark.parametrize("ignore_translations_for_mock_domains", ["test"])
 async def test_abort(hass: HomeAssistant, client: TestClient) -> None:
     """Test a flow that aborts."""
     mock_platform(hass, "test.config_flow", None)
@@ -826,10 +820,7 @@ async def test_get_progress_index_unauth(
     assert response["error"]["code"] == "unauthorized"
 
 
-@pytest.mark.parametrize(
-    "ignore_translations",
-    ["component.test.config.error.Should be unique."],
-)
+@pytest.mark.parametrize("ignore_translations_for_mock_domains", ["test"])
 async def test_get_progress_flow(hass: HomeAssistant, client: TestClient) -> None:
     """Test we can query the API for same result as we get from init a flow."""
     mock_platform(hass, "test.config_flow", None)
@@ -863,10 +854,7 @@ async def test_get_progress_flow(hass: HomeAssistant, client: TestClient) -> Non
     assert data == data2
 
 
-@pytest.mark.parametrize(
-    "ignore_translations",
-    ["component.test.config.error.Should be unique."],
-)
+@pytest.mark.parametrize("ignore_translations_for_mock_domains", ["test"])
 async def test_get_progress_flow_unauth(
     hass: HomeAssistant, client: TestClient, hass_admin_user: MockUser
 ) -> None:
@@ -2870,10 +2858,7 @@ async def test_flow_with_multiple_schema_errors_base(
         }
 
 
-@pytest.mark.parametrize(
-    "ignore_translations",
-    ["component.test.config.abort.reconfigure_successful"],
-)
+@pytest.mark.parametrize("ignore_translations_for_mock_domains", ["test"])
 @pytest.mark.usefixtures("freezer")
 async def test_supports_reconfigure(
     hass: HomeAssistant,

--- a/tests/components/conftest.py
+++ b/tests/components/conftest.py
@@ -618,7 +618,7 @@ async def _validate_translation(
     full_key = f"component.{component}.{category}.{key}"
     if component in ignore_translations_for_mock_domains:
         try:
-            loader.async_get_loaded_integration(hass, component)
+            await loader.async_get_integration(hass, component)
         except loader.IntegrationNotLoaded:
             return
         # If the integration exists, translation errors should be ignored via the
@@ -629,7 +629,7 @@ async def _validate_translation(
 
     translations = await async_get_translations(hass, "en", category, [component])
     try:
-        loader.async_get_loaded_integration(hass, component)
+        await loader.async_get_integration(hass, component)
     except loader.IntegrationNotLoaded:
         translation_errors[full_key] = (
             f"Translation not found for {component}: `{category}.{key}`. "

--- a/tests/components/conftest.py
+++ b/tests/components/conftest.py
@@ -747,6 +747,7 @@ async def _check_step_or_section_translations(
                 f"{translation_prefix}.sections.{data_key}",
                 description_placeholders,
                 data_value.schema,
+                ignore_translations_for_mock_domains,
             )
             continue
         iqs_config_flow = _get_integration_quality_scale_rule(

--- a/tests/components/homeassistant_hardware/test_config_flow_failures.py
+++ b/tests/components/homeassistant_hardware/test_config_flow_failures.py
@@ -35,8 +35,8 @@ async def fixture_mock_supervisor_client(supervisor_client: AsyncMock):
 
 
 @pytest.mark.parametrize(
-    "ignore_translations",
-    ["component.test_firmware_domain.config.abort.unsupported_firmware"],
+    "ignore_translations_for_mock_domains",
+    ["test_firmware_domain"],
 )
 @pytest.mark.parametrize(
     "next_step",
@@ -69,8 +69,8 @@ async def test_config_flow_cannot_probe_firmware(
 
 
 @pytest.mark.parametrize(
-    "ignore_translations",
-    ["component.test_firmware_domain.config.abort.not_hassio"],
+    "ignore_translations_for_mock_domains",
+    ["test_firmware_domain"],
 )
 async def test_config_flow_zigbee_not_hassio_wrong_firmware(
     hass: HomeAssistant,
@@ -98,8 +98,8 @@ async def test_config_flow_zigbee_not_hassio_wrong_firmware(
 
 
 @pytest.mark.parametrize(
-    "ignore_translations",
-    ["component.test_firmware_domain.config.abort.addon_already_running"],
+    "ignore_translations_for_mock_domains",
+    ["test_firmware_domain"],
 )
 async def test_config_flow_zigbee_flasher_addon_already_running(
     hass: HomeAssistant,
@@ -136,8 +136,8 @@ async def test_config_flow_zigbee_flasher_addon_already_running(
 
 
 @pytest.mark.parametrize(
-    "ignore_translations",
-    ["component.test_firmware_domain.config.abort.addon_info_failed"],
+    "ignore_translations_for_mock_domains",
+    ["test_firmware_domain"],
 )
 async def test_config_flow_zigbee_flasher_addon_info_fails(hass: HomeAssistant) -> None:
     """Test failure case when flasher addon cannot be installed."""
@@ -173,8 +173,8 @@ async def test_config_flow_zigbee_flasher_addon_info_fails(hass: HomeAssistant) 
 
 
 @pytest.mark.parametrize(
-    "ignore_translations",
-    ["component.test_firmware_domain.config.abort.addon_install_failed"],
+    "ignore_translations_for_mock_domains",
+    ["test_firmware_domain"],
 )
 async def test_config_flow_zigbee_flasher_addon_install_fails(
     hass: HomeAssistant,
@@ -207,8 +207,8 @@ async def test_config_flow_zigbee_flasher_addon_install_fails(
 
 
 @pytest.mark.parametrize(
-    "ignore_translations",
-    ["component.test_firmware_domain.config.abort.addon_set_config_failed"],
+    "ignore_translations_for_mock_domains",
+    ["test_firmware_domain"],
 )
 async def test_config_flow_zigbee_flasher_addon_set_config_fails(
     hass: HomeAssistant,
@@ -245,8 +245,8 @@ async def test_config_flow_zigbee_flasher_addon_set_config_fails(
 
 
 @pytest.mark.parametrize(
-    "ignore_translations",
-    ["component.test_firmware_domain.config.abort.addon_start_failed"],
+    "ignore_translations_for_mock_domains",
+    ["test_firmware_domain"],
 )
 async def test_config_flow_zigbee_flasher_run_fails(hass: HomeAssistant) -> None:
     """Test failure case when flasher addon fails to run."""
@@ -310,8 +310,8 @@ async def test_config_flow_zigbee_flasher_uninstall_fails(hass: HomeAssistant) -
 
 
 @pytest.mark.parametrize(
-    "ignore_translations",
-    ["component.test_firmware_domain.config.abort.unsupported_firmware"],
+    "ignore_translations_for_mock_domains",
+    ["test_firmware_domain"],
 )
 async def test_config_flow_zigbee_confirmation_fails(hass: HomeAssistant) -> None:
     """Test the config flow failing due to Zigbee firmware not being detected."""
@@ -346,8 +346,8 @@ async def test_config_flow_zigbee_confirmation_fails(hass: HomeAssistant) -> Non
 
 
 @pytest.mark.parametrize(
-    "ignore_translations",
-    ["component.test_firmware_domain.config.abort.not_hassio_thread"],
+    "ignore_translations_for_mock_domains",
+    ["test_firmware_domain"],
 )
 async def test_config_flow_thread_not_hassio(hass: HomeAssistant) -> None:
     """Test when the stick is used with a non-hassio setup and Thread is selected."""
@@ -373,8 +373,8 @@ async def test_config_flow_thread_not_hassio(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "ignore_translations",
-    ["component.test_firmware_domain.config.abort.addon_info_failed"],
+    "ignore_translations_for_mock_domains",
+    ["test_firmware_domain"],
 )
 async def test_config_flow_thread_addon_info_fails(hass: HomeAssistant) -> None:
     """Test failure case when flasher addon cannot be installed."""
@@ -401,8 +401,8 @@ async def test_config_flow_thread_addon_info_fails(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "ignore_translations",
-    ["component.test_firmware_domain.config.abort.otbr_addon_already_running"],
+    "ignore_translations_for_mock_domains",
+    ["test_firmware_domain"],
 )
 async def test_config_flow_thread_addon_already_running(hass: HomeAssistant) -> None:
     """Test failure case when the Thread addon is already running."""
@@ -440,8 +440,8 @@ async def test_config_flow_thread_addon_already_running(hass: HomeAssistant) -> 
 
 
 @pytest.mark.parametrize(
-    "ignore_translations",
-    ["component.test_firmware_domain.config.abort.addon_install_failed"],
+    "ignore_translations_for_mock_domains",
+    ["test_firmware_domain"],
 )
 async def test_config_flow_thread_addon_install_fails(hass: HomeAssistant) -> None:
     """Test failure case when flasher addon cannot be installed."""
@@ -471,8 +471,8 @@ async def test_config_flow_thread_addon_install_fails(hass: HomeAssistant) -> No
 
 
 @pytest.mark.parametrize(
-    "ignore_translations",
-    ["component.test_firmware_domain.config.abort.addon_set_config_failed"],
+    "ignore_translations_for_mock_domains",
+    ["test_firmware_domain"],
 )
 async def test_config_flow_thread_addon_set_config_fails(hass: HomeAssistant) -> None:
     """Test failure case when flasher addon cannot be configured."""
@@ -502,8 +502,8 @@ async def test_config_flow_thread_addon_set_config_fails(hass: HomeAssistant) ->
 
 
 @pytest.mark.parametrize(
-    "ignore_translations",
-    ["component.test_firmware_domain.config.abort.addon_start_failed"],
+    "ignore_translations_for_mock_domains",
+    ["test_firmware_domain"],
 )
 async def test_config_flow_thread_flasher_run_fails(hass: HomeAssistant) -> None:
     """Test failure case when flasher addon fails to run."""
@@ -567,8 +567,8 @@ async def test_config_flow_thread_flasher_uninstall_fails(hass: HomeAssistant) -
 
 
 @pytest.mark.parametrize(
-    "ignore_translations",
-    ["component.test_firmware_domain.config.abort.unsupported_firmware"],
+    "ignore_translations_for_mock_domains",
+    ["test_firmware_domain"],
 )
 async def test_config_flow_thread_confirmation_fails(hass: HomeAssistant) -> None:
     """Test the config flow failing due to OpenThread firmware not being detected."""
@@ -609,8 +609,8 @@ async def test_config_flow_thread_confirmation_fails(hass: HomeAssistant) -> Non
 
 
 @pytest.mark.parametrize(
-    "ignore_translations",
-    ["component.test_firmware_domain.options.abort.zha_still_using_stick"],
+    "ignore_translations_for_mock_domains",
+    ["test_firmware_domain"],
 )
 async def test_options_flow_zigbee_to_thread_zha_configured(
     hass: HomeAssistant,
@@ -657,8 +657,8 @@ async def test_options_flow_zigbee_to_thread_zha_configured(
 
 
 @pytest.mark.parametrize(
-    "ignore_translations",
-    ["component.test_firmware_domain.options.abort.otbr_still_using_stick"],
+    "ignore_translations_for_mock_domains",
+    ["test_firmware_domain"],
 )
 async def test_options_flow_thread_to_zigbee_otbr_configured(
     hass: HomeAssistant,

--- a/tests/components/homeassistant_hardware/test_silabs_multiprotocol_addon.py
+++ b/tests/components/homeassistant_hardware/test_silabs_multiprotocol_addon.py
@@ -450,10 +450,7 @@ async def test_option_flow_install_multi_pan_addon_zha_other_radio(
     }
 
 
-@pytest.mark.parametrize(
-    "ignore_translations",
-    ["component.test.options.abort.not_hassio"],
-)
+@pytest.mark.parametrize("ignore_translations_for_mock_domains", ["test"])
 async def test_option_flow_non_hassio(
     hass: HomeAssistant,
 ) -> None:
@@ -766,10 +763,7 @@ async def test_option_flow_addon_installed_same_device_do_not_uninstall_multi_pa
     assert result["type"] is FlowResultType.CREATE_ENTRY
 
 
-@pytest.mark.parametrize(
-    "ignore_translations",
-    ["component.test.options.abort.addon_already_running"],
-)
+@pytest.mark.parametrize("ignore_translations_for_mock_domains", ["test"])
 async def test_option_flow_flasher_already_running_failure(
     hass: HomeAssistant,
     addon_info,
@@ -881,10 +875,7 @@ async def test_option_flow_addon_installed_same_device_flasher_already_installed
     assert result["type"] is FlowResultType.CREATE_ENTRY
 
 
-@pytest.mark.parametrize(
-    "ignore_translations",
-    ["component.test.options.abort.addon_install_failed"],
-)
+@pytest.mark.parametrize("ignore_translations_for_mock_domains", ["test"])
 async def test_option_flow_flasher_install_failure(
     hass: HomeAssistant,
     addon_info,
@@ -951,10 +942,7 @@ async def test_option_flow_flasher_install_failure(
     assert result["reason"] == "addon_install_failed"
 
 
-@pytest.mark.parametrize(
-    "ignore_translations",
-    ["component.test.options.abort.addon_start_failed"],
-)
+@pytest.mark.parametrize("ignore_translations_for_mock_domains", ["test"])
 async def test_option_flow_flasher_addon_flash_failure(
     hass: HomeAssistant,
     addon_info,
@@ -1017,10 +1005,7 @@ async def test_option_flow_flasher_addon_flash_failure(
     assert result["description_placeholders"]["addon_name"] == "Silicon Labs Flasher"
 
 
-@pytest.mark.parametrize(
-    "ignore_translations",
-    ["component.test.options.abort.zha_migration_failed"],
-)
+@pytest.mark.parametrize("ignore_translations_for_mock_domains", ["test"])
 @patch(
     "homeassistant.components.zha.radio_manager.ZhaMultiPANMigrationHelper.async_initiate_migration",
     side_effect=Exception("Boom!"),
@@ -1082,10 +1067,7 @@ async def test_option_flow_uninstall_migration_initiate_failure(
     mock_initiate_migration.assert_called_once()
 
 
-@pytest.mark.parametrize(
-    "ignore_translations",
-    ["component.test.options.abort.zha_migration_failed"],
-)
+@pytest.mark.parametrize("ignore_translations_for_mock_domains", ["test"])
 @patch(
     "homeassistant.components.zha.radio_manager.ZhaMultiPANMigrationHelper.async_finish_migration",
     side_effect=Exception("Boom!"),
@@ -1187,10 +1169,7 @@ async def test_option_flow_do_not_install_multi_pan_addon(
     assert result["type"] is FlowResultType.CREATE_ENTRY
 
 
-@pytest.mark.parametrize(
-    "ignore_translations",
-    ["component.test.options.abort.addon_install_failed"],
-)
+@pytest.mark.parametrize("ignore_translations_for_mock_domains", ["test"])
 async def test_option_flow_install_multi_pan_addon_install_fails(
     hass: HomeAssistant,
     addon_store_info,
@@ -1234,10 +1213,7 @@ async def test_option_flow_install_multi_pan_addon_install_fails(
     assert result["reason"] == "addon_install_failed"
 
 
-@pytest.mark.parametrize(
-    "ignore_translations",
-    ["component.test.options.abort.addon_start_failed"],
-)
+@pytest.mark.parametrize("ignore_translations_for_mock_domains", ["test"])
 async def test_option_flow_install_multi_pan_addon_start_fails(
     hass: HomeAssistant,
     addon_store_info,
@@ -1299,10 +1275,7 @@ async def test_option_flow_install_multi_pan_addon_start_fails(
     assert result["reason"] == "addon_start_failed"
 
 
-@pytest.mark.parametrize(
-    "ignore_translations",
-    ["component.test.options.abort.addon_set_config_failed"],
-)
+@pytest.mark.parametrize("ignore_translations_for_mock_domains", ["test"])
 async def test_option_flow_install_multi_pan_addon_set_options_fails(
     hass: HomeAssistant,
     addon_store_info,
@@ -1346,10 +1319,7 @@ async def test_option_flow_install_multi_pan_addon_set_options_fails(
     assert result["reason"] == "addon_set_config_failed"
 
 
-@pytest.mark.parametrize(
-    "ignore_translations",
-    ["component.test.options.abort.addon_info_failed"],
-)
+@pytest.mark.parametrize("ignore_translations_for_mock_domains", ["test"])
 async def test_option_flow_addon_info_fails(
     hass: HomeAssistant,
     addon_store_info,
@@ -1373,10 +1343,7 @@ async def test_option_flow_addon_info_fails(
     assert result["reason"] == "addon_info_failed"
 
 
-@pytest.mark.parametrize(
-    "ignore_translations",
-    ["component.test.options.abort.zha_migration_failed"],
-)
+@pytest.mark.parametrize("ignore_translations_for_mock_domains", ["test"])
 @patch(
     "homeassistant.components.zha.radio_manager.ZhaMultiPANMigrationHelper.async_initiate_migration",
     side_effect=Exception("Boom!"),
@@ -1432,10 +1399,7 @@ async def test_option_flow_install_multi_pan_addon_zha_migration_fails_step_1(
     set_addon_options.assert_not_called()
 
 
-@pytest.mark.parametrize(
-    "ignore_translations",
-    ["component.test.options.abort.zha_migration_failed"],
-)
+@pytest.mark.parametrize("ignore_translations_for_mock_domains", ["test"])
 @patch(
     "homeassistant.components.zha.radio_manager.ZhaMultiPANMigrationHelper.async_finish_migration",
     side_effect=Exception("Boom!"),

--- a/tests/components/onkyo/test_config_flow.py
+++ b/tests/components/onkyo/test_config_flow.py
@@ -611,7 +611,7 @@ async def test_import_success(
 
 
 @pytest.mark.parametrize(
-    "ignore_translations",
+    "ignore_missing_translations",
     [
         [  # The schema is dynamically created from input sources
             "component.onkyo.options.step.names.sections.input_sources.data.TV",

--- a/tests/components/repairs/test_init.py
+++ b/tests/components/repairs/test_init.py
@@ -21,16 +21,7 @@ from tests.common import mock_platform
 from tests.typing import WebSocketGenerator
 
 
-@pytest.mark.parametrize(
-    "ignore_translations",
-    [
-        [
-            "component.test.issues.even_worse.title",
-            "component.test.issues.even_worse.description",
-            "component.test.issues.abc_123.title",
-        ]
-    ],
-)
+@pytest.mark.parametrize("ignore_translations_for_mock_domains", ["test"])
 @pytest.mark.freeze_time("2022-07-19 07:53:05")
 async def test_create_update_issue(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator
@@ -170,14 +161,7 @@ async def test_create_issue_invalid_version(
     assert msg["result"] == {"issues": []}
 
 
-@pytest.mark.parametrize(
-    "ignore_translations",
-    [
-        [
-            "component.test.issues.abc_123.title",
-        ]
-    ],
-)
+@pytest.mark.parametrize("ignore_translations_for_mock_domains", ["test"])
 @pytest.mark.freeze_time("2022-07-19 07:53:05")
 async def test_ignore_issue(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator
@@ -347,10 +331,7 @@ async def test_ignore_issue(
     }
 
 
-@pytest.mark.parametrize(
-    "ignore_translations",
-    ["component.fake_integration.issues.abc_123.title"],
-)
+@pytest.mark.parametrize("ignore_translations_for_mock_domains", ["fake_integration"])
 @pytest.mark.freeze_time("2022-07-19 07:53:05")
 async def test_delete_issue(
     hass: HomeAssistant,
@@ -505,10 +486,7 @@ async def test_non_compliant_platform(
     assert list(hass.data[DOMAIN]["platforms"].keys()) == ["fake_integration"]
 
 
-@pytest.mark.parametrize(
-    "ignore_translations",
-    ["component.fake_integration.issues.abc_123.title"],
-)
+@pytest.mark.parametrize("ignore_translations_for_mock_domains", ["fake_integration"])
 @pytest.mark.freeze_time("2022-07-21 08:22:00")
 async def test_sync_methods(
     hass: HomeAssistant,

--- a/tests/components/repairs/test_websocket_api.py
+++ b/tests/components/repairs/test_websocket_api.py
@@ -151,10 +151,7 @@ async def mock_repairs_integration(hass: HomeAssistant) -> None:
     )
 
 
-@pytest.mark.parametrize(
-    "ignore_translations",
-    ["component.fake_integration.issues.abc_123.title"],
-)
+@pytest.mark.parametrize("ignore_translations_for_mock_domains", ["fake_integration"])
 async def test_dismiss_issue(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
@@ -238,10 +235,7 @@ async def test_dismiss_issue(
     }
 
 
-@pytest.mark.parametrize(
-    "ignore_translations",
-    ["component.fake_integration.issues.abc_123.title"],
-)
+@pytest.mark.parametrize("ignore_translations_for_mock_domains", ["fake_integration"])
 async def test_fix_non_existing_issue(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
@@ -289,19 +283,19 @@ async def test_fix_non_existing_issue(
 
 
 @pytest.mark.parametrize(
-    ("domain", "step", "description_placeholders", "ignore_translations"),
+    (
+        "domain",
+        "step",
+        "description_placeholders",
+        "ignore_translations_for_mock_domains",
+    ),
     [
-        (
-            "fake_integration",
-            "custom_step",
-            None,
-            ["component.fake_integration.issues.abc_123.title"],
-        ),
+        ("fake_integration", "custom_step", None, ["fake_integration"]),
         (
             "fake_integration_default_handler",
             "confirm",
             {"abc": "123"},
-            ["component.fake_integration_default_handler.issues.abc_123.title"],
+            ["fake_integration_default_handler"],
         ),
     ],
 )
@@ -398,10 +392,7 @@ async def test_fix_issue_unauth(
     assert resp.status == HTTPStatus.UNAUTHORIZED
 
 
-@pytest.mark.parametrize(
-    "ignore_translations",
-    ["component.fake_integration.issues.abc_123.title"],
-)
+@pytest.mark.parametrize("ignore_translations_for_mock_domains", ["fake_integration"])
 async def test_get_progress_unauth(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
@@ -433,10 +424,7 @@ async def test_get_progress_unauth(
     assert resp.status == HTTPStatus.UNAUTHORIZED
 
 
-@pytest.mark.parametrize(
-    "ignore_translations",
-    ["component.fake_integration.issues.abc_123.title"],
-)
+@pytest.mark.parametrize("ignore_translations_for_mock_domains", ["fake_integration"])
 async def test_step_unauth(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
@@ -468,16 +456,7 @@ async def test_step_unauth(
     assert resp.status == HTTPStatus.UNAUTHORIZED
 
 
-@pytest.mark.parametrize(
-    "ignore_translations",
-    [
-        [
-            "component.test.issues.even_worse.title",
-            "component.test.issues.even_worse.description",
-            "component.test.issues.abc_123.title",
-        ]
-    ],
-)
+@pytest.mark.parametrize("ignore_translations_for_mock_domains", ["test"])
 @pytest.mark.freeze_time("2022-07-19 07:53:05")
 async def test_list_issues(
     hass: HomeAssistant,
@@ -569,15 +548,7 @@ async def test_list_issues(
     }
 
 
-@pytest.mark.parametrize(
-    "ignore_translations",
-    [
-        [
-            "component.fake_integration.issues.abc_123.title",
-            "component.fake_integration.issues.abc_123.fix_flow.abort.not_given",
-        ]
-    ],
-)
+@pytest.mark.parametrize("ignore_translations_for_mock_domains", ["fake_integration"])
 async def test_fix_issue_aborted(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
@@ -639,16 +610,7 @@ async def test_fix_issue_aborted(
     assert msg["result"]["issues"][0] == first_issue
 
 
-@pytest.mark.parametrize(
-    "ignore_translations",
-    [
-        [
-            "component.test.issues.abc_123.title",
-            "component.test.issues.even_worse.title",
-            "component.test.issues.even_worse.description",
-        ]
-    ],
-)
+@pytest.mark.parametrize("ignore_translations_for_mock_domains", ["test"])
 @pytest.mark.freeze_time("2022-07-19 07:53:05")
 async def test_get_issue_data(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator

--- a/tests/components/sensor/test_recorder.py
+++ b/tests/components/sensor/test_recorder.py
@@ -5449,12 +5449,11 @@ async def test_exclude_attributes(hass: HomeAssistant) -> None:
     assert ATTR_FRIENDLY_NAME in states[0].attributes
 
 
+@pytest.mark.parametrize("ignore_translations_for_mock_domains", ["test"])
 @pytest.mark.parametrize(
-    "ignore_translations",
+    "ignore_missing_translations",
     [
         [
-            "component.test.issues..title",
-            "component.test.issues..description",
             "component.sensor.issues..title",
             "component.sensor.issues..description",
         ]

--- a/tests/components/synology_dsm/test_repairs.py
+++ b/tests/components/synology_dsm/test_repairs.py
@@ -256,7 +256,7 @@ async def test_missing_backup_no_shares(
 
 
 @pytest.mark.parametrize(
-    "ignore_translations",
+    "ignore_missing_translations",
     ["component.synology_dsm.issues.other_issue.title"],
 )
 async def test_other_fixable_issues(

--- a/tests/components/websocket_api/test_commands.py
+++ b/tests/components/websocket_api/test_commands.py
@@ -540,10 +540,7 @@ async def test_call_service_schema_validation_error(
     assert len(calls) == 0
 
 
-@pytest.mark.parametrize(
-    "ignore_translations",
-    ["component.test.exceptions.custom_error.message"],
-)
+@pytest.mark.parametrize("ignore_translations_for_mock_domains", ["test"])
 async def test_call_service_error(
     hass: HomeAssistant, websocket_client: MockHAClientWebSocket
 ) -> None:
@@ -2394,9 +2391,7 @@ async def test_execute_script(
         ),
     ],
 )
-@pytest.mark.parametrize(
-    "ignore_translations", ["component.test.exceptions.test_error.message"]
-)
+@pytest.mark.parametrize("ignore_translations_for_mock_domains", ["test"])
 async def test_execute_script_err_localization(
     hass: HomeAssistant,
     websocket_client: MockHAClientWebSocket,

--- a/tests/components/workday/test_repairs.py
+++ b/tests/components/workday/test_repairs.py
@@ -430,7 +430,7 @@ async def test_bad_date_holiday(
 
 
 @pytest.mark.parametrize(
-    "ignore_translations",
+    "ignore_missing_translations",
     ["component.workday.issues.issue_1.title"],
 )
 async def test_other_fixable_issues(

--- a/tests/components/zwave_js/test_repairs.py
+++ b/tests/components/zwave_js/test_repairs.py
@@ -180,7 +180,7 @@ async def test_device_config_file_changed_ignore_step(
 
 
 @pytest.mark.parametrize(
-    "ignore_translations",
+    "ignore_missing_translations",
     ["component.zwave_js.issues.invalid_issue.title"],
 )
 async def test_invalid_issue(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add test fixture `ignore_translations_for_mock_domains` which should be used when ignoring missing translation keys for integrations which doesn't exist.

Also, rename the existing fixture `ignore_translations` to `ignore_missing_translations` and fail tests if it's used for an integration which exists.

Rationale:
When validating translations, the translation cache is populated. This is not a problem for real integrations, but for mocked integrations this means tests may interfere with each other if they test behavior related to translations.

When validating translations, we will not load translations for integrations added to `ignore_translations_for_mock_domains` to prevent this.

This fixes flaky test `tests/test_test_fixtures.py::test_evict_faked_translations`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
