### PR TITLE
Reduce requests made by webdav

### DIFF
--- a/homeassistant/components/webdav/backup.py
+++ b/homeassistant/components/webdav/backup.py
@@ -95,6 +95,23 @@ def suggested_filenames(backup: AgentBackup) -> tuple[str, str]:
     return f"{base_name}.tar", f"{base_name}.metadata.json"
 
 
+def _is_current_metadata_version(properties: list[Property]) -> bool:
+    """Check if is current metadata version."""
+    return any(
+        prop.value == METADATA_VERSION
+        for prop in properties
+        if prop.namespace == "homeassistant" and prop.name == "metadata_version"
+    )
+
+
+def _backup_id_from_properties(properties: list[Property]) -> str | None:
+    """Return the backup ID from properties."""
+    for prop in properties:
+        if prop.namespace == "homeassistant" and prop.name == "backup_id":
+            return prop.value
+    return None
+
+
 class WebDavBackupAgent(BackupAgent):
     """Backup agent interface."""
 
@@ -217,7 +234,7 @@ class WebDavBackupAgent(BackupAgent):
         metadata_files = await self._list_metadata_files()
         return [
             await self._download_metadata(metadata_file)
-            for metadata_file in metadata_files
+            for metadata_file in metadata_files.values()
         ]
 
     @handle_backup_errors
@@ -229,40 +246,33 @@ class WebDavBackupAgent(BackupAgent):
         """Return a backup."""
         return await self._find_backup_by_id(backup_id)
 
-    async def _list_metadata_files(self) -> list[str]:
+    async def _list_metadata_files(self) -> dict[str, str]:
         """List metadata files."""
-        files = await self._client.list_with_infos(self._backup_path)
-        return [
-            file["path"]
-            for file in files
-            if file["path"].endswith(".json")
-            and await self._is_current_metadata_version(file["path"])
-        ]
-
-    async def _is_current_metadata_version(self, path: str) -> bool:
-        """Check if is current metadata version."""
-        metadata_version = await self._client.get_property(
-            path,
-            PropertyRequest(
-                namespace="homeassistant",
-                name="metadata_version",
-            ),
-        )
-        return metadata_version.value == METADATA_VERSION if metadata_version else False
-
-    async def _find_backup_by_id(self, backup_id: str) -> AgentBackup | None:
-        """Find a backup by its backup ID on remote."""
-        metadata_files = await self._list_metadata_files()
-        for metadata_file in metadata_files:
-            remote_backup_id = await self._client.get_property(
-                metadata_file,
+        files = await self._client.list_with_properties(
+            self._backup_path,
+            [
+                PropertyRequest(
+                    namespace="homeassistant",
+                    name="metadata_version",
+                ),
                 PropertyRequest(
                     namespace="homeassistant",
                     name="backup_id",
                 ),
-            )
-            if remote_backup_id and remote_backup_id.value == backup_id:
-                return await self._download_metadata(metadata_file)
+            ],
+        )
+        return {
+            backup_id: file_name
+            for file_name, properties in files.items()
+            if file_name.endswith(".json") and _is_current_metadata_version(properties)
+            if (backup_id := _backup_id_from_properties(properties))
+        }
+
+    async def _find_backup_by_id(self, backup_id: str) -> AgentBackup | None:
+        """Find a backup by its backup ID on remote."""
+        metadata_files = await self._list_metadata_files()
+        if metadata_file := metadata_files.get(backup_id):
+            return await self._download_metadata(metadata_file)
 
         return None
 

--- a/homeassistant/components/webdav/backup.py
+++ b/homeassistant/components/webdav/backup.py
@@ -96,7 +96,7 @@ def suggested_filenames(backup: AgentBackup) -> tuple[str, str]:
 
 
 def _is_current_metadata_version(properties: list[Property]) -> bool:
-    """Check if is current metadata version."""
+    """Check if any property is of the current metadata version."""
     return any(
         prop.value == METADATA_VERSION
         for prop in properties

--- a/tests/components/webdav/conftest.py
+++ b/tests/components/webdav/conftest.py
@@ -4,18 +4,12 @@ from collections.abc import AsyncIterator, Generator
 from json import dumps
 from unittest.mock import AsyncMock, patch
 
-from aiowebdav2 import Property, PropertyRequest
 import pytest
 
 from homeassistant.components.webdav.const import DOMAIN
 from homeassistant.const import CONF_PASSWORD, CONF_URL, CONF_USERNAME
 
-from .const import (
-    BACKUP_METADATA,
-    MOCK_GET_PROPERTY_BACKUP_ID,
-    MOCK_GET_PROPERTY_METADATA_VERSION,
-    MOCK_LIST_WITH_INFOS,
-)
+from .const import BACKUP_METADATA, MOCK_LIST_WITH_PROPERTIES
 
 from tests.common import MockConfigEntry
 
@@ -44,14 +38,6 @@ def mock_config_entry() -> MockConfigEntry:
     )
 
 
-def _get_property(path: str, request: PropertyRequest) -> Property:
-    """Return the property of a file."""
-    if path.endswith(".json") and request.name == "metadata_version":
-        return MOCK_GET_PROPERTY_METADATA_VERSION
-
-    return MOCK_GET_PROPERTY_BACKUP_ID
-
-
 async def _download_mock(path: str, timeout=None) -> AsyncIterator[bytes]:
     """Mock the download function."""
     if path.endswith(".json"):
@@ -72,9 +58,8 @@ def mock_webdav_client() -> Generator[AsyncMock]:
         mock = mock_webdav_client.return_value
         mock.check.return_value = True
         mock.mkdir.return_value = True
-        mock.list_with_infos.return_value = MOCK_LIST_WITH_INFOS
+        mock.list_with_properties.return_value = MOCK_LIST_WITH_PROPERTIES
         mock.download_iter.side_effect = _download_mock
         mock.upload_iter.return_value = None
         mock.clean.return_value = None
-        mock.get_property.side_effect = _get_property
         yield mock

--- a/tests/components/webdav/const.py
+++ b/tests/components/webdav/const.py
@@ -16,37 +16,18 @@ BACKUP_METADATA = {
     "size": 34519040,
 }
 
-MOCK_LIST_WITH_INFOS = [
-    {
-        "content_type": "application/x-tar",
-        "created": "2025-02-10T17:47:22Z",
-        "etag": '"84d7d000-62dcd4ce886b4"',
-        "isdir": "False",
-        "modified": "Mon, 10 Feb 2025 17:47:22 GMT",
-        "name": "None",
-        "path": "/Automatic_backup_2025.2.1_2025-02-10_18.31_30202686.tar",
-        "size": "2228736000",
-    },
-    {
-        "content_type": "application/json",
-        "created": "2025-02-10T17:47:22Z",
-        "etag": '"8d0-62dcd4cec050a"',
-        "isdir": "False",
-        "modified": "Mon, 10 Feb 2025 17:47:22 GMT",
-        "name": "None",
-        "path": "/Automatic_backup_2025.2.1_2025-02-10_18.31_30202686.metadata.json",
-        "size": "2256",
-    },
-]
-
-MOCK_GET_PROPERTY_METADATA_VERSION = Property(
-    namespace="homeassistant",
-    name="metadata_version",
-    value="1",
-)
-
-MOCK_GET_PROPERTY_BACKUP_ID = Property(
-    namespace="homeassistant",
-    name="backup_id",
-    value="23e64aec",
-)
+MOCK_LIST_WITH_PROPERTIES = {
+    "/Automatic_backup_2025.2.1_2025-02-10_18.31_30202686.tar": [],
+    "/Automatic_backup_2025.2.1_2025-02-10_18.31_30202686.metadata.json": [
+        Property(
+            namespace="homeassistant",
+            name="backup_id",
+            value="23e64aec",
+        ),
+        Property(
+            namespace="homeassistant",
+            name="metadata_version",
+            value="1",
+        ),
+    ],
+}

--- a/tests/components/webdav/test_backup.py
+++ b/tests/components/webdav/test_backup.py
@@ -6,6 +6,7 @@ from collections.abc import AsyncGenerator
 from io import StringIO
 from unittest.mock import Mock, patch
 
+from aiowebdav2 import Property
 from aiowebdav2.exceptions import UnauthorizedError, WebDavError
 import pytest
 
@@ -15,7 +16,7 @@ from homeassistant.components.webdav.const import DATA_BACKUP_AGENT_LISTENERS, D
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
-from .const import BACKUP_METADATA, MOCK_LIST_WITH_INFOS
+from .const import BACKUP_METADATA, MOCK_LIST_WITH_PROPERTIES
 
 from tests.common import AsyncMock, MockConfigEntry
 from tests.typing import ClientSessionGenerator, WebSocketGenerator
@@ -208,7 +209,7 @@ async def test_error_on_agents_download(
     """Test we get not found on a not existing backup on download."""
     client = await hass_client()
     backup_id = BACKUP_METADATA["backup_id"]
-    webdav_client.list_with_infos.side_effect = [MOCK_LIST_WITH_INFOS, []]
+    webdav_client.list_with_properties.side_effect = [MOCK_LIST_WITH_PROPERTIES, {}]
 
     resp = await client.get(
         f"/api/backup/download/{backup_id}?agent_id={DOMAIN}.{mock_config_entry.entry_id}"
@@ -259,7 +260,7 @@ async def test_agents_delete_not_found_does_not_throw(
     webdav_client: AsyncMock,
 ) -> None:
     """Test agent delete backup."""
-    webdav_client.list_with_infos.return_value = []
+    webdav_client.list_with_properties.return_value = {}
     client = await hass_ws_client(hass)
 
     await client.send_json_auto_id(
@@ -280,7 +281,7 @@ async def test_agents_backup_not_found(
     webdav_client: AsyncMock,
 ) -> None:
     """Test backup not found."""
-    webdav_client.list_with_infos.return_value = []
+    webdav_client.list_with_properties.return_value = []
     backup_id = BACKUP_METADATA["backup_id"]
     client = await hass_ws_client(hass)
     await client.send_json_auto_id({"type": "backup/details", "backup_id": backup_id})
@@ -297,7 +298,7 @@ async def test_raises_on_403(
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test we raise on 403."""
-    webdav_client.list_with_infos.side_effect = UnauthorizedError(
+    webdav_client.list_with_properties.side_effect = UnauthorizedError(
         "https://webdav.example.com"
     )
     backup_id = BACKUP_METADATA["backup_id"]
@@ -321,3 +322,30 @@ async def test_listeners_get_cleaned_up(hass: HomeAssistant) -> None:
     remove_listener()
 
     assert hass.data.get(DATA_BACKUP_AGENT_LISTENERS) is None
+
+
+async def test_metadata_misses_backup_id(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    webdav_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test getting a backup when metadata has backup id property."""
+    MOCK_LIST_WITH_PROPERTIES[
+        "/Automatic_backup_2025.2.1_2025-02-10_18.31_30202686.metadata.json"
+    ] = [
+        Property(
+            namespace="homeassistant",
+            name="metadata_version",
+            value="1",
+        )
+    ]
+    webdav_client.list_with_properties.return_value = MOCK_LIST_WITH_PROPERTIES
+
+    backup_id = BACKUP_METADATA["backup_id"]
+    client = await hass_ws_client(hass)
+    await client.send_json_auto_id({"type": "backup/details", "backup_id": backup_id})
+    response = await client.receive_json()
+
+    assert response["success"]
+    assert response["result"]["backup"] is None


### PR DESCRIPTION
## Proposed change
Reduce the requests of the Webdav backup agent by requesting the file list together with the file properties instead of requesting the properties individually for each file.

Now we do a request to get a list of files with their properties (backup_id, metadata_version) and then a request to download the metadata file for each backup if needed.

/cc @MartinHjelmare  

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
