### PR TITLE
Improve Minecraft Server config flow tests

### DIFF
--- a/homeassistant/components/minecraft_server/quality_scale.yaml
+++ b/homeassistant/components/minecraft_server/quality_scale.yaml
@@ -7,12 +7,7 @@ rules:
   brands: done
   common-modules: done
   config-flow: done
-  config-flow-test-coverage:
-    status: todo
-    comment: |
-      Merge test_show_config_form with full flow test.
-      Move full flow test to the top of all tests.
-      All test cases should end in either CREATE_ENTRY or ABORT.
+  config-flow-test-coverage: done
   dependency-transparency: done
   docs-actions:
     status: exempt

--- a/tests/components/minecraft_server/test_config_flow.py
+++ b/tests/components/minecraft_server/test_config_flow.py
@@ -88,10 +88,37 @@ async def test_full_flow_bedrock(hass: HomeAssistant) -> None:
         assert result["data"][CONF_TYPE] == MinecraftServerType.BEDROCK_EDITION
 
 
-async def test_service_already_configured(
+async def test_service_already_configured_java(
+    hass: HomeAssistant, java_mock_config_entry: MockConfigEntry
+) -> None:
+    """Test config flow abort if a Java Edition server is already configured."""
+    java_mock_config_entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "homeassistant.components.minecraft_server.api.BedrockServer.lookup",
+            side_effect=ValueError,
+        ),
+        patch(
+            "homeassistant.components.minecraft_server.api.JavaServer.async_lookup",
+            return_value=JavaServer(host=TEST_HOST, port=TEST_PORT),
+        ),
+        patch(
+            "homeassistant.components.minecraft_server.api.JavaServer.async_status",
+            return_value=TEST_JAVA_STATUS_RESPONSE,
+        ),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_USER}, data=USER_INPUT
+        )
+        assert result["type"] is FlowResultType.ABORT
+        assert result["reason"] == "already_configured"
+
+
+async def test_service_already_configured_bedrock(
     hass: HomeAssistant, bedrock_mock_config_entry: MockConfigEntry
 ) -> None:
-    """Test config flow abort if service is already configured."""
+    """Test config flow abort if a Bedrock Edition server is already configured."""
     bedrock_mock_config_entry.add_to_hass(hass)
 
     with (
@@ -112,7 +139,7 @@ async def test_service_already_configured(
 
 
 async def test_recovery_java(hass: HomeAssistant) -> None:
-    """Test config flow recovery (successful connection after a failed connection)."""
+    """Test config flow recovery with a Java Edition server (successful connection after a failed connection)."""
     with (
         patch(
             "homeassistant.components.minecraft_server.api.BedrockServer.lookup",
@@ -157,7 +184,7 @@ async def test_recovery_java(hass: HomeAssistant) -> None:
 
 
 async def test_recovery_bedrock(hass: HomeAssistant) -> None:
-    """Test config flow recovery (successful connection after a failed connection)."""
+    """Test config flow recovery with a Bedrock Edition server (successful connection after a failed connection)."""
     with (
         patch(
             "homeassistant.components.minecraft_server.api.BedrockServer.lookup",

--- a/tests/components/minecraft_server/test_config_flow.py
+++ b/tests/components/minecraft_server/test_config_flow.py
@@ -26,14 +26,66 @@ USER_INPUT = {
 }
 
 
-async def test_show_config_form(hass: HomeAssistant) -> None:
-    """Test if initial configuration form is shown."""
+async def test_full_flow_java(hass: HomeAssistant) -> None:
+    """Test config entry in case of a successful connection to a Java Edition server."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
+
+    with (
+        patch(
+            "homeassistant.components.minecraft_server.api.BedrockServer.lookup",
+            side_effect=ValueError,
+        ),
+        patch(
+            "homeassistant.components.minecraft_server.api.JavaServer.async_lookup",
+            return_value=JavaServer(host=TEST_HOST, port=TEST_PORT),
+        ),
+        patch(
+            "homeassistant.components.minecraft_server.api.JavaServer.async_status",
+            return_value=TEST_JAVA_STATUS_RESPONSE,
+        ),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_USER}, data=USER_INPUT
+        )
+
+        assert result["type"] is FlowResultType.CREATE_ENTRY
+        assert result["title"] == USER_INPUT[CONF_ADDRESS]
+        assert result["data"][CONF_ADDRESS] == TEST_ADDRESS
+        assert result["data"][CONF_TYPE] == MinecraftServerType.JAVA_EDITION
+
+
+async def test_full_flow_bedrock(hass: HomeAssistant) -> None:
+    """Test config entry in case of a successful connection to a Bedrock Edition server."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    with (
+        patch(
+            "homeassistant.components.minecraft_server.api.BedrockServer.lookup",
+            return_value=BedrockServer(host=TEST_HOST, port=TEST_PORT),
+        ),
+        patch(
+            "homeassistant.components.minecraft_server.api.BedrockServer.async_status",
+            return_value=TEST_BEDROCK_STATUS_RESPONSE,
+        ),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_USER}, data=USER_INPUT
+        )
+
+        assert result["type"] is FlowResultType.CREATE_ENTRY
+        assert result["title"] == USER_INPUT[CONF_ADDRESS]
+        assert result["data"][CONF_ADDRESS] == TEST_ADDRESS
+        assert result["data"][CONF_TYPE] == MinecraftServerType.BEDROCK_EDITION
 
 
 async def test_service_already_configured(
@@ -59,28 +111,8 @@ async def test_service_already_configured(
         assert result["reason"] == "already_configured"
 
 
-async def test_address_validation_failure(hass: HomeAssistant) -> None:
-    """Test error in case of a failed connection."""
-    with (
-        patch(
-            "homeassistant.components.minecraft_server.api.BedrockServer.lookup",
-            side_effect=ValueError,
-        ),
-        patch(
-            "homeassistant.components.minecraft_server.api.JavaServer.async_lookup",
-            side_effect=ValueError,
-        ),
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_USER}, data=USER_INPUT
-        )
-
-        assert result["type"] is FlowResultType.FORM
-        assert result["errors"] == {"base": "cannot_connect"}
-
-
-async def test_java_connection_failure(hass: HomeAssistant) -> None:
-    """Test error in case of a failed connection to a Java Edition server."""
+async def test_recovery_java(hass: HomeAssistant) -> None:
+    """Test config flow recovery (successful connection after a failed connection)."""
     with (
         patch(
             "homeassistant.components.minecraft_server.api.BedrockServer.lookup",
@@ -98,33 +130,9 @@ async def test_java_connection_failure(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}, data=USER_INPUT
         )
-
         assert result["type"] is FlowResultType.FORM
         assert result["errors"] == {"base": "cannot_connect"}
 
-
-async def test_bedrock_connection_failure(hass: HomeAssistant) -> None:
-    """Test error in case of a failed connection to a Bedrock Edition server."""
-    with (
-        patch(
-            "homeassistant.components.minecraft_server.api.BedrockServer.lookup",
-            return_value=BedrockServer(host=TEST_HOST, port=TEST_PORT),
-        ),
-        patch(
-            "homeassistant.components.minecraft_server.api.BedrockServer.async_status",
-            side_effect=OSError,
-        ),
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_USER}, data=USER_INPUT
-        )
-
-        assert result["type"] is FlowResultType.FORM
-        assert result["errors"] == {"base": "cannot_connect"}
-
-
-async def test_java_connection(hass: HomeAssistant) -> None:
-    """Test config entry in case of a successful connection to a Java Edition server."""
     with (
         patch(
             "homeassistant.components.minecraft_server.api.BedrockServer.lookup",
@@ -139,18 +147,17 @@ async def test_java_connection(hass: HomeAssistant) -> None:
             return_value=TEST_JAVA_STATUS_RESPONSE,
         ),
     ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_USER}, data=USER_INPUT
+        result2 = await hass.config_entries.flow.async_configure(
+            flow_id=result["flow_id"], user_input=USER_INPUT
         )
+        assert result2["type"] is FlowResultType.CREATE_ENTRY
+        assert result2["title"] == USER_INPUT[CONF_ADDRESS]
+        assert result2["data"][CONF_ADDRESS] == TEST_ADDRESS
+        assert result2["data"][CONF_TYPE] == MinecraftServerType.JAVA_EDITION
 
-        assert result["type"] is FlowResultType.CREATE_ENTRY
-        assert result["title"] == USER_INPUT[CONF_ADDRESS]
-        assert result["data"][CONF_ADDRESS] == TEST_ADDRESS
-        assert result["data"][CONF_TYPE] == MinecraftServerType.JAVA_EDITION
 
-
-async def test_bedrock_connection(hass: HomeAssistant) -> None:
-    """Test config entry in case of a successful connection to a Bedrock Edition server."""
+async def test_recovery_bedrock(hass: HomeAssistant) -> None:
+    """Test config flow recovery (successful connection after a failed connection)."""
     with (
         patch(
             "homeassistant.components.minecraft_server.api.BedrockServer.lookup",
@@ -158,29 +165,7 @@ async def test_bedrock_connection(hass: HomeAssistant) -> None:
         ),
         patch(
             "homeassistant.components.minecraft_server.api.BedrockServer.async_status",
-            return_value=TEST_BEDROCK_STATUS_RESPONSE,
-        ),
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_USER}, data=USER_INPUT
-        )
-
-        assert result["type"] is FlowResultType.CREATE_ENTRY
-        assert result["title"] == USER_INPUT[CONF_ADDRESS]
-        assert result["data"][CONF_ADDRESS] == TEST_ADDRESS
-        assert result["data"][CONF_TYPE] == MinecraftServerType.BEDROCK_EDITION
-
-
-async def test_recovery(hass: HomeAssistant) -> None:
-    """Test config flow recovery (successful connection after a failed connection)."""
-    with (
-        patch(
-            "homeassistant.components.minecraft_server.api.BedrockServer.lookup",
-            side_effect=ValueError,
-        ),
-        patch(
-            "homeassistant.components.minecraft_server.api.JavaServer.async_lookup",
-            side_effect=ValueError,
+            side_effect=OSError,
         ),
     ):
         result = await hass.config_entries.flow.async_init(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
1) Move full flow tests to the top.
2) Merge test_show_config_form with full flow tests.
3) Merge connection failure tests to recovery tests.
4) All test cases now end in either CREATE_ENTRY or ABORT.
5) Add Java Edition variant of "service already configured" test.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: n.a.
- This PR is related to issue: n.a.
- Link to documentation pull request: n.a.
- Link to developer documentation pull request: n.a.
- Link to frontend pull request: n.a.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
