### PR TITLE
Revert "Bump Stookwijzer to 1.5.7"

### DIFF
--- a/homeassistant/components/stookwijzer/__init__.py
+++ b/homeassistant/components/stookwijzer/__init__.py
@@ -9,6 +9,7 @@ from stookwijzer import Stookwijzer
 from homeassistant.const import CONF_LATITUDE, CONF_LOCATION, CONF_LONGITUDE, Platform
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_registry as er, issue_registry as ir
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import DOMAIN, LOGGER
 from .coordinator import StookwijzerConfigEntry, StookwijzerCoordinator
@@ -43,6 +44,7 @@ async def async_migrate_entry(
 
     if entry.version == 1:
         latitude, longitude = await Stookwijzer.async_transform_coordinates(
+            async_get_clientsession(hass),
             entry.data[CONF_LOCATION][CONF_LATITUDE],
             entry.data[CONF_LOCATION][CONF_LONGITUDE],
         )

--- a/homeassistant/components/stookwijzer/config_flow.py
+++ b/homeassistant/components/stookwijzer/config_flow.py
@@ -9,6 +9,7 @@ import voluptuous as vol
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_LATITUDE, CONF_LOCATION, CONF_LONGITUDE
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.selector import LocationSelector
 
 from .const import DOMAIN
@@ -26,6 +27,7 @@ class StookwijzerFlowHandler(ConfigFlow, domain=DOMAIN):
         errors = {}
         if user_input is not None:
             latitude, longitude = await Stookwijzer.async_transform_coordinates(
+                async_get_clientsession(self.hass),
                 user_input[CONF_LOCATION][CONF_LATITUDE],
                 user_input[CONF_LOCATION][CONF_LONGITUDE],
             )

--- a/homeassistant/components/stookwijzer/manifest.json
+++ b/homeassistant/components/stookwijzer/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/stookwijzer",
   "integration_type": "service",
   "iot_class": "cloud_polling",
-  "requirements": ["stookwijzer==1.5.7"]
+  "requirements": ["stookwijzer==1.5.4"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2811,7 +2811,7 @@ statsd==3.2.1
 steamodd==4.21
 
 # homeassistant.components.stookwijzer
-stookwijzer==1.5.7
+stookwijzer==1.5.4
 
 # homeassistant.components.streamlabswater
 streamlabswater==1.0.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2272,7 +2272,7 @@ statsd==3.2.1
 steamodd==4.21
 
 # homeassistant.components.stookwijzer
-stookwijzer==1.5.7
+stookwijzer==1.5.4
 
 # homeassistant.components.streamlabswater
 streamlabswater==1.0.1


### PR DESCRIPTION
@bdraco @thecode @fwestenberg
Reverts home-assistant/core#139063 due the following dependency conflict:

```
#16 1.841 Using Python 3.13.2 environment at: /usr/local
#16 26.24   × No solution found when resolving dependencies:
#16 26.24   ╰─▶ Because pointset==0.1.7 depends on numpy>=1.24.1,<2.0.0 and only
#16 26.24       pointset==0.1.7 is available, we can conclude that all versions of
#16 26.24       pointset depend on numpy>=1.24.1,<2.0.0.
#16 26.24       And because stookwijzer==1.5.7 depends on pointset, we can conclude that
#16 26.24       stookwijzer==1.5.7 depends on numpy>=1.24.1,<2.0.0.
#16 26.24       And because you require numpy==2.2.2 and stookwijzer==1.5.7, we can
#16 26.24       conclude that your requirements are unsatisfiable.
```
See https://github.com/home-assistant/core/actions/runs/13512319712/job/37754885304

Since home-assistant/core#139063 was merged 3 days ago we can't ship nightlies due the conflict above.
