### PR TITLE
Bump ZHA to 0.0.50

### DIFF
--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -21,7 +21,7 @@
     "zha",
     "universal_silabs_flasher"
   ],
-  "requirements": ["zha==0.0.49"],
+  "requirements": ["zha==0.0.50"],
   "usb": [
     {
       "vid": "10C4",

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -1044,6 +1044,63 @@
       },
       "valve_duration": {
         "name": "Irrigation duration"
+      },
+      "down_movement": {
+        "name": "Down movement"
+      },
+      "sustain_time": {
+        "name": "Sustain time"
+      },
+      "up_movement": {
+        "name": "Up movement"
+      },
+      "large_motion_detection_sensitivity": {
+        "name": "Motion detection sensitivity"
+      },
+      "large_motion_detection_distance": {
+        "name": "Motion detection distance"
+      },
+      "medium_motion_detection_distance": {
+        "name": "Medium motion detection distance"
+      },
+      "medium_motion_detection_sensitivity": {
+        "name": "Medium motion detection sensitivity"
+      },
+      "small_motion_detection_distance": {
+        "name": "Small motion detection distance"
+      },
+      "small_motion_detection_sensitivity": {
+        "name": "Small motion detection sensitivity"
+      },
+      "static_detection_sensitivity": {
+        "name": "Static detection sensitivity"
+      },
+      "static_detection_distance": {
+        "name": "Static detection distance"
+      },
+      "motion_detection_sensitivity": {
+        "name": "Motion detection sensitivity"
+      },
+      "holiday_temperature": {
+        "name": "Holiday temperature"
+      },
+      "boost_time": {
+        "name": "Boost time"
+      },
+      "antifrost_temperature": {
+        "name": "Antifrost temperature"
+      },
+      "eco_temperature": {
+        "name": "Eco temperature"
+      },
+      "comfort_temperature": {
+        "name": "Comfort temperature"
+      },
+      "valve_state_auto_shutdown": {
+        "name": "Valve state auto shutdown"
+      },
+      "shutdown_timer": {
+        "name": "Shutdown timer"
       }
     },
     "select": {
@@ -1235,6 +1292,33 @@
       },
       "eco_mode": {
         "name": "Eco mode"
+      },
+      "mode": {
+        "name": "Mode"
+      },
+      "reverse": {
+        "name": "Reverse"
+      },
+      "motion_state": {
+        "name": "Motion state"
+      },
+      "motion_detection_mode": {
+        "name": "Motion detection mode"
+      },
+      "screen_orientation": {
+        "name": "Screen orientation"
+      },
+      "motor_thrust": {
+        "name": "Motor thrust"
+      },
+      "display_brightness": {
+        "name": "Display brightness"
+      },
+      "display_orientation": {
+        "name": "Display orientation"
+      },
+      "hysteresis_mode": {
+        "name": "Hysteresis mode"
       }
     },
     "sensor": {
@@ -1561,6 +1645,27 @@
       },
       "error_status": {
         "name": "Error status"
+      },
+      "brightness_level": {
+        "name": "Brightness level"
+      },
+      "average_light_intensity_20mins": {
+        "name": "Average light intensity last 20 min"
+      },
+      "todays_max_light_intensity": {
+        "name": "Today's max light intensity"
+      },
+      "fault_code": {
+        "name": "Fault code"
+      },
+      "water_flow": {
+        "name": "Water flow"
+      },
+      "remaining_watering_time": {
+        "name": "Remaining watering time"
+      },
+      "last_watering_duration": {
+        "name": "Last watering duration"
       }
     },
     "switch": {
@@ -1746,6 +1851,30 @@
       },
       "total_flow_reset_switch": {
         "name": "Total flow reset switch"
+      },
+      "touch_control": {
+        "name": "Touch control"
+      },
+      "sound_enabled": {
+        "name": "Sound enabled"
+      },
+      "invert_relay": {
+        "name": "Invert relay"
+      },
+      "boost_heating": {
+        "name": "Boost heating"
+      },
+      "holiday_mode": {
+        "name": "Holiday mode"
+      },
+      "heating_stop": {
+        "name": "Heating stop"
+      },
+      "schedule_mode": {
+        "name": "Schedule mode"
+      },
+      "auto_clean": {
+        "name": "Auto clean"
       }
     }
   }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3152,7 +3152,7 @@ zeroconf==0.145.1
 zeversolar==0.3.2
 
 # homeassistant.components.zha
-zha==0.0.49
+zha==0.0.50
 
 # homeassistant.components.zhong_hong
 zhong-hong-hvac==1.0.13

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2541,7 +2541,7 @@ zeroconf==0.145.1
 zeversolar==0.3.2
 
 # homeassistant.components.zha
-zha==0.0.49
+zha==0.0.50
 
 # homeassistant.components.zwave_js
 zwave-js-server-python==0.60.1


### PR DESCRIPTION
## Proposed change

This bumps ZHA to [0.0.50](https://github.com/zigpy/zha/releases/tag/0.0.50) (full diff: https://github.com/zigpy/zha/compare/0.0.49...0.0.50). These dependency upgrades are bundled with it: 

- `zha-quirks` [0.0.134](https://github.com/zigpy/zha-device-handlers/releases/tag/0.0.134)
full diff: https://github.com/zigpy/zha-device-handlers/compare/0.0.133...0.0.134

- `zigpy` [0.76.2](https://github.com/zigpy/zigpy/releases/tag/0.76.2)
full diff: https://github.com/zigpy/zigpy/compare/0.76.1...0.76.2

This zha-quirks release also adds a few entities via the quirks v2 API. The entity names are added to `strings.json`.


## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #138627, fixes #138460
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.


To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
