### PR TITLE
Add default_db_url flag to WS command recorder/info

### DIFF
--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -149,9 +149,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     commit_interval = conf[CONF_COMMIT_INTERVAL]
     db_max_retries = conf[CONF_DB_MAX_RETRIES]
     db_retry_wait = conf[CONF_DB_RETRY_WAIT]
-    db_url = conf.get(CONF_DB_URL) or DEFAULT_URL.format(
-        hass_config_path=hass.config.path(DEFAULT_DB_FILE)
-    )
+    db_url = conf.get(CONF_DB_URL) or format_default_url(hass)
     exclude = conf[CONF_EXCLUDE]
     exclude_event_types: set[EventType[Any] | str] = set(
         exclude.get(CONF_EVENT_TYPES, [])
@@ -200,3 +198,8 @@ async def _async_setup_integration_platform(
             instance.queue_task(AddRecorderPlatformTask(domain, platform))
 
     await async_process_integration_platforms(hass, DOMAIN, _process_recorder_platform)
+
+
+def format_default_url(hass: HomeAssistant) -> str:
+    """Format the default URL."""
+    return DEFAULT_URL.format(hass_config_path=hass.config.path(DEFAULT_DB_FILE))

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -149,7 +149,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     commit_interval = conf[CONF_COMMIT_INTERVAL]
     db_max_retries = conf[CONF_DB_MAX_RETRIES]
     db_retry_wait = conf[CONF_DB_RETRY_WAIT]
-    db_url = conf.get(CONF_DB_URL) or format_default_url(hass)
+    db_url = conf.get(CONF_DB_URL) or get_default_url(hass)
     exclude = conf[CONF_EXCLUDE]
     exclude_event_types: set[EventType[Any] | str] = set(
         exclude.get(CONF_EVENT_TYPES, [])
@@ -200,6 +200,6 @@ async def _async_setup_integration_platform(
     await async_process_integration_platforms(hass, DOMAIN, _process_recorder_platform)
 
 
-def format_default_url(hass: HomeAssistant) -> str:
-    """Format the default URL."""
+def get_default_url(hass: HomeAssistant) -> str:
+    """Return the default URL."""
     return DEFAULT_URL.format(hass_config_path=hass.config.path(DEFAULT_DB_FILE))

--- a/homeassistant/components/recorder/basic_websocket_api.py
+++ b/homeassistant/components/recorder/basic_websocket_api.py
@@ -10,6 +10,7 @@ from homeassistant.components import websocket_api
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import recorder as recorder_helper
 
+from . import format_default_url
 from .util import get_instance
 
 
@@ -34,6 +35,7 @@ async def ws_info(
     await hass.data[recorder_helper.DATA_RECORDER].db_connected
     instance = get_instance(hass)
     backlog = instance.backlog
+    default_db_url = instance.db_url == format_default_url(hass)
     migration_in_progress = instance.migration_in_progress
     migration_is_live = instance.migration_is_live
     recording = instance.recording
@@ -44,6 +46,7 @@ async def ws_info(
 
     recorder_info = {
         "backlog": backlog,
+        "default_db_url": default_db_url,
         "max_backlog": max_backlog,
         "migration_in_progress": migration_in_progress,
         "migration_is_live": migration_is_live,

--- a/homeassistant/components/recorder/basic_websocket_api.py
+++ b/homeassistant/components/recorder/basic_websocket_api.py
@@ -10,7 +10,7 @@ from homeassistant.components import websocket_api
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import recorder as recorder_helper
 
-from . import format_default_url
+from . import get_default_url
 from .util import get_instance
 
 
@@ -35,7 +35,7 @@ async def ws_info(
     await hass.data[recorder_helper.DATA_RECORDER].db_connected
     instance = get_instance(hass)
     backlog = instance.backlog
-    default_db_url = instance.db_url == format_default_url(hass)
+    db_in_default_location = instance.db_url == get_default_url(hass)
     migration_in_progress = instance.migration_in_progress
     migration_is_live = instance.migration_is_live
     recording = instance.recording
@@ -46,7 +46,7 @@ async def ws_info(
 
     recorder_info = {
         "backlog": backlog,
-        "default_db_url": default_db_url,
+        "db_in_default_location": db_in_default_location,
         "max_backlog": max_backlog,
         "migration_in_progress": migration_in_progress,
         "migration_is_live": migration_is_live,

--- a/tests/components/recorder/test_websocket_api.py
+++ b/tests/components/recorder/test_websocket_api.py
@@ -2562,12 +2562,51 @@ async def test_recorder_info(
     assert response["success"]
     assert response["result"] == {
         "backlog": 0,
+        "default_db_url": False,  # We never use the default URL in tests
         "max_backlog": 65000,
         "migration_in_progress": False,
         "migration_is_live": False,
         "recording": True,
         "thread_running": True,
     }
+
+
+@pytest.mark.parametrize(
+    ("db_url", "default_db_url"),
+    [
+        ("sqlite:///{config_dir}/home-assistant_v2.db", True),
+        ("sqlite:///{config_dir}/custom.db", False),
+        ("mysql://root:root_password@127.0.0.1:3316/homeassistant-test", False),
+    ],
+)
+async def test_recorder_info_default_url(
+    recorder_mock: Recorder,
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    db_url: str,
+    default_db_url: bool,
+) -> None:
+    """Test getting recorder status."""
+    client = await hass_ws_client()
+
+    # Ensure there are no queued events
+    await async_wait_recording_done(hass)
+
+    with patch.object(
+        recorder_mock, "db_url", db_url.format(config_dir=hass.config.config_dir)
+    ):
+        await client.send_json_auto_id({"type": "recorder/info"})
+        response = await client.receive_json()
+        assert response["success"]
+        assert response["result"] == {
+            "backlog": 0,
+            "default_db_url": default_db_url,
+            "max_backlog": 65000,
+            "migration_in_progress": False,
+            "migration_is_live": False,
+            "recording": True,
+            "thread_running": True,
+        }
 
 
 async def test_recorder_info_no_recorder(
@@ -2624,6 +2663,7 @@ async def test_recorder_info_wait_database_connect(
         assert response["success"]
         assert response["result"] == {
             "backlog": ANY,
+            "default_db_url": False,
             "max_backlog": 65000,
             "migration_in_progress": False,
             "migration_is_live": False,

--- a/tests/components/recorder/test_websocket_api.py
+++ b/tests/components/recorder/test_websocket_api.py
@@ -2562,7 +2562,7 @@ async def test_recorder_info(
     assert response["success"]
     assert response["result"] == {
         "backlog": 0,
-        "default_db_url": False,  # We never use the default URL in tests
+        "db_in_default_location": False,  # We never use the default URL in tests
         "max_backlog": 65000,
         "migration_in_progress": False,
         "migration_is_live": False,
@@ -2572,7 +2572,7 @@ async def test_recorder_info(
 
 
 @pytest.mark.parametrize(
-    ("db_url", "default_db_url"),
+    ("db_url", "db_in_default_location"),
     [
         ("sqlite:///{config_dir}/home-assistant_v2.db", True),
         ("sqlite:///{config_dir}/custom.db", False),
@@ -2584,7 +2584,7 @@ async def test_recorder_info_default_url(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     db_url: str,
-    default_db_url: bool,
+    db_in_default_location: bool,
 ) -> None:
     """Test getting recorder status."""
     client = await hass_ws_client()
@@ -2600,7 +2600,7 @@ async def test_recorder_info_default_url(
         assert response["success"]
         assert response["result"] == {
             "backlog": 0,
-            "default_db_url": default_db_url,
+            "db_in_default_location": db_in_default_location,
             "max_backlog": 65000,
             "migration_in_progress": False,
             "migration_is_live": False,
@@ -2663,7 +2663,7 @@ async def test_recorder_info_wait_database_connect(
         assert response["success"]
         assert response["result"] == {
             "backlog": ANY,
-            "default_db_url": False,
+            "db_in_default_location": False,
             "max_backlog": 65000,
             "migration_in_progress": False,
             "migration_is_live": False,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add `default_db_url` flag to WS command `recorder/info`

This is to be used by frontend to hide or disable the option to backup the history database if the database is not in the default location

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
