### PR TITLE
Add translations and icon for Twinkly select entity

### DIFF
--- a/homeassistant/components/twinkly/icons.json
+++ b/homeassistant/components/twinkly/icons.json
@@ -4,6 +4,11 @@
       "light": {
         "default": "mdi:string-lights"
       }
+    },
+    "select": {
+      "mode": {
+        "default": "mdi:cogs"
+      }
     }
   }
 }

--- a/homeassistant/components/twinkly/select.py
+++ b/homeassistant/components/twinkly/select.py
@@ -29,7 +29,7 @@ async def async_setup_entry(
 class TwinklyModeSelect(TwinklyEntity, SelectEntity):
     """Twinkly Mode Selection."""
 
-    _attr_name = "Mode"
+    _attr_translation_key = "mode"
     _attr_options = TWINKLY_MODES
 
     def __init__(self, coordinator: TwinklyCoordinator) -> None:

--- a/homeassistant/components/twinkly/strings.json
+++ b/homeassistant/components/twinkly/strings.json
@@ -30,7 +30,7 @@
           "demo": "Demo",
           "effect": "Effect",
           "movie": "Uploaded effect",
-          "off": "[%key:common::state:off%]",
+          "off": "[%key:common::state::off%]",
           "playlist": "Playlist",
           "rt": "Real time"
         }

--- a/homeassistant/components/twinkly/strings.json
+++ b/homeassistant/components/twinkly/strings.json
@@ -30,7 +30,7 @@
           "demo": "Demo",
           "effect": "Effect",
           "movie": "Uploaded effect",
-          "off": "Off",
+          "off": "[%key:common::state:off%]",
           "playlist": "Playlist",
           "rt": "Real time"
         }

--- a/homeassistant/components/twinkly/strings.json
+++ b/homeassistant/components/twinkly/strings.json
@@ -20,5 +20,21 @@
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
     }
+  },
+  "entity": {
+    "select": {
+      "mode": {
+        "name": "Mode",
+        "state": {
+          "color": "Color",
+          "demo": "Demo",
+          "effect": "Effect",
+          "movie": "Uploaded effect",
+          "off": "Off",
+          "playlist": "Playlist",
+          "rt": "Real time"
+        }
+      }
+    }
   }
 }

--- a/tests/components/twinkly/snapshots/test_select.ambr
+++ b/tests/components/twinkly/snapshots/test_select.ambr
@@ -38,7 +38,7 @@
     'platform': 'twinkly',
     'previous_unique_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'mode',
     'unique_id': '00:2d:13:3b:aa:bb_mode',
     'unit_of_measurement': None,
   })


### PR DESCRIPTION
## Proposed change

Add translations and icon for Twinkly select entity

I translated `movie` mode by "Uploaded effect" because `movie` is too technical for end-users and that's how XLED documenation describes it : https://xled-docs.readthedocs.io/en/latest/protocol_details.html#led-operating-modes

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
