### PR TITLE
Improve calculating supported features in template light

### DIFF
--- a/homeassistant/components/template/light.py
+++ b/homeassistant/components/template/light.py
@@ -1013,7 +1013,7 @@ class LightTemplate(TemplateEntity, LightEntity):
         if render in (None, "None", ""):
             self._supports_transition = False
             return
-        self._attr_supported_features &= LightEntityFeature.EFFECT
+        self._attr_supported_features &= ~LightEntityFeature.TRANSITION
         self._supports_transition = bool(render)
         if self._supports_transition:
             self._attr_supported_features |= LightEntityFeature.TRANSITION

--- a/tests/components/template/test_light.py
+++ b/tests/components/template/test_light.py
@@ -1894,6 +1894,12 @@ async def test_supports_transition_template_updates(
         supported_features == LightEntityFeature.TRANSITION | LightEntityFeature.EFFECT
     )
 
+    hass.states.async_set("sensor.test", 0)
+    await hass.async_block_till_done()
+    state = hass.states.get("light.test_template_light")
+    supported_features = state.attributes.get("supported_features")
+    assert supported_features == LightEntityFeature.EFFECT
+
 
 @pytest.mark.parametrize("count", [1])
 @pytest.mark.parametrize(

--- a/tests/components/template/test_light.py
+++ b/tests/components/template/test_light.py
@@ -1848,6 +1848,54 @@ async def test_supports_transition_template(
 
 
 @pytest.mark.parametrize("count", [1])
+async def test_supports_transition_template_updates(
+    hass: HomeAssistant, count: int
+) -> None:
+    """Test the template for the supports transition dynamically."""
+    light_config = {
+        "test_template_light": {
+            "value_template": "{{ 1 == 1 }}",
+            "turn_on": {"service": "light.turn_on", "entity_id": "light.test_state"},
+            "turn_off": {"service": "light.turn_off", "entity_id": "light.test_state"},
+            "set_temperature": {
+                "service": "light.turn_on",
+                "data_template": {
+                    "entity_id": "light.test_state",
+                    "color_temp": "{{color_temp}}",
+                },
+            },
+            "set_effect": {
+                "service": "test.automation",
+                "data_template": {
+                    "entity_id": "test.test_state",
+                    "effect": "{{effect}}",
+                },
+            },
+            "effect_list_template": "{{ ['Disco', 'Police'] }}",
+            "effect_template": "{{ None }}",
+            "supports_transition_template": "{{ states('sensor.test') }}",
+        }
+    }
+    await async_setup_light(hass, count, light_config)
+    state = hass.states.get("light.test_template_light")
+    assert state is not None
+
+    hass.states.async_set("sensor.test", 0)
+    await hass.async_block_till_done()
+    state = hass.states.get("light.test_template_light")
+    supported_features = state.attributes.get("supported_features")
+    assert supported_features == LightEntityFeature.EFFECT
+
+    hass.states.async_set("sensor.test", 1)
+    await hass.async_block_till_done()
+    state = hass.states.get("light.test_template_light")
+    supported_features = state.attributes.get("supported_features")
+    assert (
+        supported_features == LightEntityFeature.TRANSITION | LightEntityFeature.EFFECT
+    )
+
+
+@pytest.mark.parametrize("count", [1])
 @pytest.mark.parametrize(
     "light_config",
     [


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve calculating supported features in template light when updating the support for `TRANSITION`.

The old code did reset al flags except the `EFFECT` feature flag, which works because template light only supports `EFFECT` and `TRANSITION` but would have caused bugs if template light gained new features, e.g. `FLASH`.
The new code only resets the `TRANSITION` feature flag.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
