### PR TITLE
Bump stookwijzer==1.6.1

### DIFF
--- a/homeassistant/components/stookwijzer/__init__.py
+++ b/homeassistant/components/stookwijzer/__init__.py
@@ -42,12 +42,12 @@ async def async_migrate_entry(
     LOGGER.debug("Migrating from version %s", entry.version)
 
     if entry.version == 1:
-        longitude, latitude = await Stookwijzer.async_transform_coordinates(
+        xy = await Stookwijzer.async_transform_coordinates(
             entry.data[CONF_LOCATION][CONF_LATITUDE],
             entry.data[CONF_LOCATION][CONF_LONGITUDE],
         )
 
-        if not longitude or not latitude:
+        if not xy:
             ir.async_create_issue(
                 hass,
                 DOMAIN,
@@ -65,8 +65,8 @@ async def async_migrate_entry(
             entry,
             version=2,
             data={
-                CONF_LATITUDE: latitude,
-                CONF_LONGITUDE: longitude,
+                CONF_LATITUDE: xy["x"],
+                CONF_LONGITUDE: xy["y"],
             },
         )
 

--- a/homeassistant/components/stookwijzer/config_flow.py
+++ b/homeassistant/components/stookwijzer/config_flow.py
@@ -25,14 +25,14 @@ class StookwijzerFlowHandler(ConfigFlow, domain=DOMAIN):
         """Handle a flow initialized by the user."""
         errors = {}
         if user_input is not None:
-            longitude, latitude = await Stookwijzer.async_transform_coordinates(
+            xy = await Stookwijzer.async_transform_coordinates(
                 user_input[CONF_LOCATION][CONF_LATITUDE],
                 user_input[CONF_LOCATION][CONF_LONGITUDE],
             )
-            if longitude and latitude:
+            if xy:
                 return self.async_create_entry(
                     title="Stookwijzer",
-                    data={CONF_LATITUDE: latitude, CONF_LONGITUDE: longitude},
+                    data={CONF_LATITUDE: xy["x"], CONF_LONGITUDE: xy["y"]},
                 )
             errors["base"] = "unknown"
 

--- a/homeassistant/components/stookwijzer/manifest.json
+++ b/homeassistant/components/stookwijzer/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/stookwijzer",
   "integration_type": "service",
   "iot_class": "cloud_polling",
-  "requirements": ["stookwijzer==1.6.0"]
+  "requirements": ["stookwijzer==1.6.1"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2808,7 +2808,7 @@ statsd==3.2.1
 steamodd==4.21
 
 # homeassistant.components.stookwijzer
-stookwijzer==1.6.0
+stookwijzer==1.6.1
 
 # homeassistant.components.streamlabswater
 streamlabswater==1.0.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2269,7 +2269,7 @@ statsd==3.2.1
 steamodd==4.21
 
 # homeassistant.components.stookwijzer
-stookwijzer==1.6.0
+stookwijzer==1.6.1
 
 # homeassistant.components.streamlabswater
 streamlabswater==1.0.1

--- a/tests/components/stookwijzer/conftest.py
+++ b/tests/components/stookwijzer/conftest.py
@@ -70,10 +70,10 @@ def mock_stookwijzer() -> Generator[MagicMock]:
             new=stookwijzer_mock,
         ),
     ):
-        stookwijzer_mock.async_transform_coordinates.return_value = (
-            450000.123456789,
-            200000.123456789,
-        )
+        stookwijzer_mock.async_transform_coordinates.return_value = {
+            "x": 450000.123456789,
+            "y": 200000.123456789,
+        }
 
         client = stookwijzer_mock.return_value
         client.lki = 2

--- a/tests/components/stookwijzer/test_config_flow.py
+++ b/tests/components/stookwijzer/test_config_flow.py
@@ -32,8 +32,8 @@ async def test_full_user_flow(
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == "Stookwijzer"
     assert result["data"] == {
-        CONF_LATITUDE: 200000.123456789,
-        CONF_LONGITUDE: 450000.123456789,
+        CONF_LATITUDE: 450000.123456789,
+        CONF_LONGITUDE: 200000.123456789,
     }
 
     assert len(mock_setup_entry.mock_calls) == 1
@@ -47,7 +47,7 @@ async def test_connection_error(
 ) -> None:
     """Test user configuration flow while connection fails."""
     original_return_value = mock_stookwijzer.async_transform_coordinates.return_value
-    mock_stookwijzer.async_transform_coordinates.return_value = (None, None)
+    mock_stookwijzer.async_transform_coordinates.return_value = None
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}

--- a/tests/components/stookwijzer/test_init.py
+++ b/tests/components/stookwijzer/test_init.py
@@ -66,8 +66,8 @@ async def test_migrate_entry(
 
     assert mock_v1_config_entry.version == 2
     assert mock_v1_config_entry.data == {
-        CONF_LATITUDE: 200000.123456789,
-        CONF_LONGITUDE: 450000.123456789,
+        CONF_LATITUDE: 450000.123456789,
+        CONF_LONGITUDE: 200000.123456789,
     }
 
 
@@ -81,7 +81,7 @@ async def test_entry_migration_failure(
     assert mock_v1_config_entry.version == 1
 
     # Failed getting the transformed coordinates
-    mock_stookwijzer.async_transform_coordinates.return_value = (None, None)
+    mock_stookwijzer.async_transform_coordinates.return_value = None
 
     mock_v1_config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(mock_v1_config_entry.entry_id)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
https://github.com/fwestenberg/stookwijzer/compare/v1.6.0..v1.6.1
Also, the x and y values were reversed in the tests. This is fixed in this PR.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
