### PR TITLE
Fix fetch options error for Home connect

### DIFF
--- a/homeassistant/components/home_connect/coordinator.py
+++ b/homeassistant/components/home_connect/coordinator.py
@@ -440,6 +440,8 @@ class HomeConnectCoordinator(
         self, ha_id: str, program_key: ProgramKey
     ) -> dict[OptionKey, ProgramDefinitionOption]:
         """Get options with constraints for appliance."""
+        if program_key is ProgramKey.UNKNOWN:
+            return {}
         try:
             return {
                 option.key: option
@@ -468,8 +470,7 @@ class HomeConnectCoordinator(
         events = self.data[ha_id].events
         options_to_notify = options.copy()
         options.clear()
-        if program_key is not ProgramKey.UNKNOWN:
-            options.update(await self.get_options_definitions(ha_id, program_key))
+        options.update(await self.get_options_definitions(ha_id, program_key))
 
         for option in options.values():
             option_value = option.constraints.default if option.constraints else None

--- a/homeassistant/components/home_connect/coordinator.py
+++ b/homeassistant/components/home_connect/coordinator.py
@@ -440,13 +440,25 @@ class HomeConnectCoordinator(
         self, ha_id: str, program_key: ProgramKey
     ) -> dict[OptionKey, ProgramDefinitionOption]:
         """Get options with constraints for appliance."""
-        return {
-            option.key: option
-            for option in (
-                await self.client.get_available_program(ha_id, program_key=program_key)
-            ).options
-            or []
-        }
+        try:
+            return {
+                option.key: option
+                for option in (
+                    await self.client.get_available_program(
+                        ha_id, program_key=program_key
+                    )
+                ).options
+                or []
+            }
+        except HomeConnectError as error:
+            _LOGGER.debug(
+                "Error fetching options for %s: %s",
+                ha_id,
+                error
+                if isinstance(error, HomeConnectApiError)
+                else type(error).__name__,
+            )
+            return {}
 
     async def update_options(
         self, ha_id: str, event_key: EventKey, program_key: ProgramKey

--- a/tests/components/home_connect/test_entity.py
+++ b/tests/components/home_connect/test_entity.py
@@ -23,6 +23,7 @@ from aiohomeconnect.model.error import (
     SelectedProgramNotSetError,
 )
 from aiohomeconnect.model.program import (
+    EnumerateProgram,
     ProgramDefinitionConstraints,
     ProgramDefinitionOption,
 )
@@ -232,6 +233,78 @@ async def test_program_options_retrieval(
         )
     for _, entity_id in (option_without_default, option_without_constraints):
         assert hass.states.is_state(entity_id, STATE_UNKNOWN)
+
+
+@pytest.mark.parametrize(
+    ("array_of_programs_program_arg", "event_key"),
+    [
+        (
+            "active",
+            EventKey.BSH_COMMON_ROOT_ACTIVE_PROGRAM,
+        ),
+        (
+            "selected",
+            EventKey.BSH_COMMON_ROOT_SELECTED_PROGRAM,
+        ),
+    ],
+)
+async def test_no_options_retrieval_on_unknown_program(
+    array_of_programs_program_arg: str,
+    event_key: EventKey,
+    appliance_ha_id: str,
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    integration_setup: Callable[[MagicMock], Awaitable[bool]],
+    setup_credentials: None,
+    client: MagicMock,
+) -> None:
+    """Test that no options are retrieved when the program is unknown."""
+
+    async def get_all_programs_with_options_mock(ha_id: str) -> ArrayOfPrograms:
+        return ArrayOfPrograms(
+            **(
+                {
+                    "programs": [
+                        EnumerateProgram(ProgramKey.UNKNOWN, "unknown program")
+                    ],
+                    array_of_programs_program_arg: Program(
+                        ProgramKey.UNKNOWN, options=[]
+                    ),
+                }
+            )
+        )
+
+    client.get_all_programs = AsyncMock(side_effect=get_all_programs_with_options_mock)
+
+    assert config_entry.state == ConfigEntryState.NOT_LOADED
+    assert await integration_setup(client)
+    assert config_entry.state == ConfigEntryState.LOADED
+
+    assert client.get_available_program.call_count == 0
+
+    await client.add_events(
+        [
+            EventMessage(
+                appliance_ha_id,
+                EventType.NOTIFY,
+                data=ArrayOfEvents(
+                    [
+                        Event(
+                            key=event_key,
+                            raw_key=event_key.value,
+                            timestamp=0,
+                            level="",
+                            handling="",
+                            value=ProgramKey.UNKNOWN,
+                        )
+                    ]
+                ),
+            )
+        ]
+    )
+    await hass.async_block_till_done()
+
+    assert client.get_available_program.call_count == 0
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Handle the error that can occur from fetching the options, improve tests to include all the methods that are called at integration setup and don't fetch the program options if the program key is `UNKNOWN`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #139389
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
