### PR TITLE
Fix Music Assistant media player entity features

### DIFF
--- a/homeassistant/components/music_assistant/media_player.py
+++ b/homeassistant/components/music_assistant/media_player.py
@@ -89,7 +89,6 @@ SUPPORTED_FEATURES_BASE = (
     | MediaPlayerEntityFeature.REPEAT_SET
     | MediaPlayerEntityFeature.PLAY
     | MediaPlayerEntityFeature.PLAY_MEDIA
-    | MediaPlayerEntityFeature.VOLUME_STEP
     | MediaPlayerEntityFeature.CLEAR_PLAYLIST
     | MediaPlayerEntityFeature.BROWSE_MEDIA
     | MediaPlayerEntityFeature.MEDIA_ENQUEUE

--- a/homeassistant/components/music_assistant/media_player.py
+++ b/homeassistant/components/music_assistant/media_player.py
@@ -234,6 +234,19 @@ class MusicAssistantPlayer(MusicAssistantEntity, MediaPlayerEntity):
             )
         )
 
+        # we subscribe to the player config changed event to update
+        # the supported features of the player
+        async def player_config_changed(event: MassEvent) -> None:
+            self._set_supported_features()
+            await self.async_on_update()
+            self.async_write_ha_state()
+
+        self.async_on_remove(
+            self.mass.subscribe(
+                player_config_changed, EventType.PLAYER_CONFIG_UPDATED, self.player_id
+            )
+        )
+
     @property
     def active_queue(self) -> PlayerQueue | None:
         """Return the active queue for this player (if any)."""

--- a/tests/components/music_assistant/common.py
+++ b/tests/components/music_assistant/common.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
+from music_assistant_models.api import MassEvent
 from music_assistant_models.enums import EventType
 from music_assistant_models.media_items import Album, Artist, Playlist, Radio, Track
 from music_assistant_models.player import Player
@@ -134,15 +136,42 @@ async def trigger_subscription_callback(
     hass: HomeAssistant,
     client: MagicMock,
     event: EventType = EventType.PLAYER_UPDATED,
+    object_id: str | None = None,
     data: Any = None,
 ) -> None:
     """Trigger a subscription callback."""
     # trigger callback on all subscribers
-    for sub in client.subscribe_events.call_args_list:
-        callback = sub.kwargs["callback"]
-        event_filter = sub.kwargs.get("event_filter")
-        if event_filter in (None, event):
-            callback(event, data)
+    for sub in client.subscribe.call_args_list:
+        cb_func = sub.kwargs.get("cb_func", sub.args[0])
+        event_filter = sub.kwargs.get(
+            "event_filter", sub.args[1] if len(sub.args) > 1 else None
+        )
+        id_filter = sub.kwargs.get(
+            "id_filter", sub.args[2] if len(sub.args) > 2 else None
+        )
+        if not (
+            event_filter is None
+            or event == event_filter
+            or (isinstance(event_filter, list) and event in event_filter)
+        ):
+            continue
+        if not (
+            id_filter is None
+            or object_id == id_filter
+            or (isinstance(id_filter, list) and object_id in id_filter)
+        ):
+            continue
+
+        event = MassEvent(
+            event=event,
+            object_id=object_id,
+            data=data,
+        )
+        if asyncio.iscoroutinefunction(cb_func):
+            await cb_func(event)
+        else:
+            cb_func(event)
+
     await hass.async_block_till_done()
 
 

--- a/tests/components/music_assistant/test_media_player.py
+++ b/tests/components/music_assistant/test_media_player.py
@@ -2,7 +2,13 @@
 
 from unittest.mock import MagicMock, call
 
-from music_assistant_models.enums import MediaType, QueueOption
+from music_assistant_models.constants import PLAYER_CONTROL_NONE
+from music_assistant_models.enums import (
+    EventType,
+    MediaType,
+    PlayerFeature,
+    QueueOption,
+)
 from music_assistant_models.media_items import Track
 import pytest
 from syrupy import SnapshotAssertion
@@ -20,6 +26,7 @@ from homeassistant.components.media_player import (
     SERVICE_CLEAR_PLAYLIST,
     SERVICE_JOIN,
     SERVICE_UNJOIN,
+    MediaPlayerEntityFeature,
 )
 from homeassistant.components.music_assistant.const import DOMAIN as MASS_DOMAIN
 from homeassistant.components.music_assistant.media_player import (
@@ -59,7 +66,11 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from .common import setup_integration_from_fixtures, snapshot_music_assistant_entities
+from .common import (
+    setup_integration_from_fixtures,
+    snapshot_music_assistant_entities,
+    trigger_subscription_callback,
+)
 
 from tests.common import AsyncMock
 
@@ -607,3 +618,104 @@ async def test_media_player_get_queue_action(
     # no call is made, this info comes from the cached queue data
     assert music_assistant_client.send_command.call_count == 0
     assert response == snapshot(exclude=paths(f"{entity_id}.elapsed_time"))
+
+
+async def test_media_player_supported_features(
+    hass: HomeAssistant,
+    music_assistant_client: MagicMock,
+) -> None:
+    """Test if media_player entity supported features are cortrectly (re)mapped."""
+    await setup_integration_from_fixtures(hass, music_assistant_client)
+    entity_id = "media_player.test_player_1"
+    mass_player_id = "00:00:00:00:00:01"
+    state = hass.states.get(entity_id)
+    assert state
+    expected_features = (
+        MediaPlayerEntityFeature.STOP
+        | MediaPlayerEntityFeature.PREVIOUS_TRACK
+        | MediaPlayerEntityFeature.NEXT_TRACK
+        | MediaPlayerEntityFeature.SHUFFLE_SET
+        | MediaPlayerEntityFeature.REPEAT_SET
+        | MediaPlayerEntityFeature.PLAY
+        | MediaPlayerEntityFeature.PLAY_MEDIA
+        | MediaPlayerEntityFeature.VOLUME_STEP
+        | MediaPlayerEntityFeature.CLEAR_PLAYLIST
+        | MediaPlayerEntityFeature.BROWSE_MEDIA
+        | MediaPlayerEntityFeature.MEDIA_ENQUEUE
+        | MediaPlayerEntityFeature.MEDIA_ANNOUNCE
+        | MediaPlayerEntityFeature.SEEK
+        | MediaPlayerEntityFeature.PAUSE
+        | MediaPlayerEntityFeature.GROUPING
+        | MediaPlayerEntityFeature.VOLUME_SET
+        | MediaPlayerEntityFeature.VOLUME_STEP
+        | MediaPlayerEntityFeature.VOLUME_MUTE
+        | MediaPlayerEntityFeature.TURN_ON
+        | MediaPlayerEntityFeature.TURN_OFF
+    )
+    assert state.attributes["supported_features"] == expected_features
+    # remove power control capability from player, trigger subscription callback
+    # and check if the supported features got updated
+    music_assistant_client.players._players[
+        mass_player_id
+    ].power_control = PLAYER_CONTROL_NONE
+    await trigger_subscription_callback(
+        hass, music_assistant_client, EventType.PLAYER_CONFIG_UPDATED, mass_player_id
+    )
+    expected_features &= ~MediaPlayerEntityFeature.TURN_ON
+    expected_features &= ~MediaPlayerEntityFeature.TURN_OFF
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.attributes["supported_features"] == expected_features
+
+    # remove volume control capability from player, trigger subscription callback
+    # and check if the supported features got updated
+    music_assistant_client.players._players[
+        mass_player_id
+    ].volume_control = PLAYER_CONTROL_NONE
+    await trigger_subscription_callback(
+        hass, music_assistant_client, EventType.PLAYER_CONFIG_UPDATED, mass_player_id
+    )
+    expected_features &= ~MediaPlayerEntityFeature.VOLUME_SET
+    expected_features &= ~MediaPlayerEntityFeature.VOLUME_STEP
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.attributes["supported_features"] == expected_features
+
+    # remove mute control capability from player, trigger subscription callback
+    # and check if the supported features got updated
+    music_assistant_client.players._players[
+        mass_player_id
+    ].mute_control = PLAYER_CONTROL_NONE
+    await trigger_subscription_callback(
+        hass, music_assistant_client, EventType.PLAYER_CONFIG_UPDATED, mass_player_id
+    )
+    expected_features &= ~MediaPlayerEntityFeature.VOLUME_MUTE
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.attributes["supported_features"] == expected_features
+
+    # remove pause capability from player, trigger subscription callback
+    # and check if the supported features got updated
+    music_assistant_client.players._players[mass_player_id].supported_features.remove(
+        PlayerFeature.PAUSE
+    )
+    await trigger_subscription_callback(
+        hass, music_assistant_client, EventType.PLAYER_CONFIG_UPDATED, mass_player_id
+    )
+    expected_features &= ~MediaPlayerEntityFeature.PAUSE
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.attributes["supported_features"] == expected_features
+
+    # remove grouping capability from player, trigger subscription callback
+    # and check if the supported features got updated
+    music_assistant_client.players._players[mass_player_id].supported_features.remove(
+        PlayerFeature.SET_MEMBERS
+    )
+    await trigger_subscription_callback(
+        hass, music_assistant_client, EventType.PLAYER_CONFIG_UPDATED, mass_player_id
+    )
+    expected_features &= ~MediaPlayerEntityFeature.GROUPING
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.attributes["supported_features"] == expected_features


### PR DESCRIPTION
## Proposed change

The capabilities from a Music Assistant player can change/update based on both the capabilities of the player and user overridden config. This should change the mediaplayer features in Home Assistant as wel, which was not the case, resulting in errors if you e.g. try to turn off a player which does not support that.

This PR fixes that and also handles if the player capabilities may change.


## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
