### PR TITLE
Fix ability to remove orphan device in Music Assistant integration

### DIFF
--- a/homeassistant/components/music_assistant/__init__.py
+++ b/homeassistant/components/music_assistant/__init__.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 from music_assistant_client import MusicAssistantClient
 from music_assistant_client.exceptions import CannotConnect, InvalidServerVersion
 from music_assistant_models.enums import EventType
-from music_assistant_models.errors import MusicAssistantError
+from music_assistant_models.errors import ActionUnavailable, MusicAssistantError
 
 from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.const import CONF_URL, EVENT_HOMEASSISTANT_STOP, Platform
@@ -23,7 +23,7 @@ from homeassistant.helpers.issue_registry import (
     async_delete_issue,
 )
 
-from .actions import register_actions
+from .actions import get_music_assistant_client, register_actions
 from .const import DOMAIN, LOGGER
 
 if TYPE_CHECKING:
@@ -174,3 +174,31 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         await mass_entry_data.mass.disconnect()
 
     return unload_ok
+
+
+async def async_remove_config_entry_device(
+    hass: HomeAssistant, config_entry: ConfigEntry, device_entry: dr.DeviceEntry
+) -> bool:
+    """Remove a config entry from a device."""
+    player_id = next(
+        (
+            identifier[1]
+            for identifier in device_entry.identifiers
+            if identifier[0] == DOMAIN
+        ),
+        None,
+    )
+    if player_id is None:
+        # this should not be possible at all, but guard it anyways
+        return False
+    mass = get_music_assistant_client(hass, config_entry.entry_id)
+    if mass.players.get(player_id) is None:
+        # player is already removed on the server, this is an orphaned device
+        return True
+    # try to remove the player from the server
+    try:
+        await mass.config.remove_player_config(player_id)
+    except ActionUnavailable:
+        return False
+    else:
+        return True

--- a/homeassistant/components/music_assistant/__init__.py
+++ b/homeassistant/components/music_assistant/__init__.py
@@ -137,6 +137,18 @@ async def async_setup_entry(
         mass.subscribe(handle_player_removed, EventType.PLAYER_REMOVED)
     )
 
+    # check if any playerconfigs have been removed while we were disconnected
+    all_player_configs = await mass.config.get_player_configs()
+    player_ids = {player.player_id for player in all_player_configs}
+    dev_reg = dr.async_get(hass)
+    dev_entries = dr.async_entries_for_config_entry(dev_reg, entry.entry_id)
+    for device in dev_entries:
+        for identifier in device.identifiers:
+            if identifier[0] == DOMAIN and identifier[1] not in player_ids:
+                dev_reg.async_update_device(
+                    device.id, remove_config_entry_id=entry.entry_id
+                )
+
     return True
 
 

--- a/tests/components/music_assistant/conftest.py
+++ b/tests/components/music_assistant/conftest.py
@@ -8,6 +8,7 @@ from music_assistant_client.music import Music
 from music_assistant_client.player_queues import PlayerQueues
 from music_assistant_client.players import Players
 from music_assistant_models.api import ServerInfoMessage
+from music_assistant_models.config_entries import PlayerConfig
 import pytest
 
 from homeassistant.components.music_assistant.config_flow import CONF_URL
@@ -68,6 +69,21 @@ async def music_assistant_client_fixture() -> AsyncGenerator[MagicMock]:
         client.music = Music(client)
         client.server_url = client.server_info.base_url
         client.get_media_item_image_url = MagicMock(return_value=None)
+        client.config = MagicMock()
+
+        async def get_player_configs() -> list[PlayerConfig]:
+            """Mock get player configs."""
+            # simply return a mock config for each player
+            return [
+                PlayerConfig(
+                    values={},
+                    provider=player.provider,
+                    player_id=player.player_id,
+                )
+                for player in client.players
+            ]
+
+        client.config.get_player_configs = get_player_configs
 
         yield client
 

--- a/tests/components/music_assistant/test_init.py
+++ b/tests/components/music_assistant/test_init.py
@@ -1,0 +1,70 @@
+"""Test the Music Assistant integration init."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+from music_assistant_models.errors import ActionUnavailable
+
+from homeassistant.components.music_assistant.const import DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.setup import async_setup_component
+
+from .common import setup_integration_from_fixtures
+
+from tests.typing import WebSocketGenerator
+
+
+async def test_remove_config_entry_device(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    music_assistant_client: MagicMock,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test device removal."""
+    assert await async_setup_component(hass, "config", {})
+    await setup_integration_from_fixtures(hass, music_assistant_client)
+    await hass.async_block_till_done()
+    config_entry = hass.config_entries.async_entries(DOMAIN)[0]
+    client = await hass_ws_client(hass)
+
+    # test if the removal should be denied if the device is still in use
+    device_entry = dr.async_entries_for_config_entry(
+        device_registry, config_entry.entry_id
+    )[0]
+    entity_id = "media_player.test_player_1"
+    assert device_entry
+    assert entity_registry.async_get(entity_id)
+    assert hass.states.get(entity_id)
+    music_assistant_client.config.remove_player_config = AsyncMock(
+        side_effect=ActionUnavailable
+    )
+    response = await client.remove_device(device_entry.id, config_entry.entry_id)
+    assert music_assistant_client.config.remove_player_config.call_count == 1
+    assert response["success"] is False
+
+    # test if the removal should be allowed if the device is not in use
+    music_assistant_client.config.remove_player_config = AsyncMock()
+    response = await client.remove_device(device_entry.id, config_entry.entry_id)
+    assert response["success"] is True
+    await hass.async_block_till_done()
+    assert not device_registry.async_get(device_entry.id)
+    assert not entity_registry.async_get(entity_id)
+    assert not hass.states.get(entity_id)
+
+    # test if the removal succeeds if its no longer provided by the server
+    mass_player_id = "00:00:00:00:00:02"
+    music_assistant_client.players._players.pop(mass_player_id)
+    device_entry = dr.async_entries_for_config_entry(
+        device_registry, config_entry.entry_id
+    )[0]
+    entity_id = "media_player.my_super_test_player_2"
+    assert device_entry
+    assert entity_registry.async_get(entity_id)
+    assert hass.states.get(entity_id)
+    music_assistant_client.config.remove_player_config = AsyncMock()
+    response = await client.remove_device(device_entry.id, config_entry.entry_id)
+    assert music_assistant_client.config.remove_player_config.call_count == 0
+    assert response["success"] is True


### PR DESCRIPTION
## Proposed change

If you remove a player(config) on the Music Assistant Server while the Home Assistsant integration is running, it will auto pickup that as an event and remove the device from HA as well. But if you remove a device from MA while HA is not running, you end up with an orphaned device in HA. 

To fix this, this PR implements the "async_remove_config_entry_device" so the user can manually cleanup these orphaned devices if needed. It also supports removing a device from MA which is marked as unavailable. If a device can not be deleted (because its still in use), it will return False and the UI will state that removing is denied.


## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #138937 
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
